### PR TITLE
Improve scheduling chat integration

### DIFF
--- a/src/components/__tests__/ChatBot.test.tsx
+++ b/src/components/__tests__/ChatBot.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '../../test/utils';
+import ChatBot from '../ChatBot';
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+vi.mock('../../lib/ai', () => ({
+  processMessage: vi.fn().mockResolvedValue({
+    response: 'Sure thing',
+    action: {
+      type: 'schedule_session',
+      data: {
+        therapist_id: 't1',
+        client_id: 'c1',
+        start_time: '2025-03-18T10:00:00Z',
+        end_time: '2025-03-18T11:00:00Z',
+        location_type: 'in_clinic'
+      }
+    }
+  })
+}));
+
+describe('ChatBot scheduling', () => {
+  it('dispatches openScheduleModal when scheduling action returned', async () => {
+    const handler = vi.fn();
+    document.addEventListener('openScheduleModal', handler as EventListener);
+
+    renderWithProviders(<ChatBot />);
+    await userEvent.click(document.getElementById('chat-trigger')!);
+
+    const input = screen.getByPlaceholderText(/Type your message/);
+    await userEvent.type(input, 'schedule a session');
+    const sendBtn = input.closest('form')!.querySelector('button[type="submit"]') as HTMLButtonElement;
+    await userEvent.click(sendBtn);
+
+    await screen.findByText('Sure thing');
+
+    expect(handler).toHaveBeenCalled();
+    const event = handler.mock.calls[0][0] as CustomEvent;
+    expect(event.detail.therapist_id).toBe('t1');
+
+    document.removeEventListener('openScheduleModal', handler as EventListener);
+  });
+});

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase';
+import { errorTracker } from './errorTracking';
 import type { Therapist, Client, Session } from '../types';
 
 interface Message {
@@ -53,6 +54,12 @@ export async function processMessage(
     return data;
   } catch (error) {
     console.error('Error processing message:', error);
+    if (error instanceof Error) {
+      errorTracker.trackAIError(error, {
+        functionCalled: 'processMessage',
+        errorType: 'network_error',
+      });
+    }
     return {
       response: "I apologize, but I'm having trouble processing your request right now. " +
         "Please try again in a moment or use the manual interface instead."

--- a/src/lib/errorTracking.ts
+++ b/src/lib/errorTracking.ts
@@ -472,13 +472,13 @@ export const withErrorTracking = <P extends object>(
         return () => window.removeEventListener('error', handleError);
       }, []);
 
-      return <>{children}</>;
+      return React.createElement(React.Fragment, null, children);
     };
 
-    return (
-      <ErrorBoundary>
-        <WrappedComponent ref={ref} {...props} />
-      </ErrorBoundary>
+    return React.createElement(
+      ErrorBoundary,
+      null,
+      React.createElement(WrappedComponent, { ...props, ref })
     );
   });
 };

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { format, parseISO, startOfWeek, addDays, endOfWeek } from 'date-fns';
 import { 
@@ -295,6 +295,21 @@ const Schedule = React.memo(() => {
   const [selectedClient, setSelectedClient] = useState<string | null>(null);
   
   const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail || {};
+      if (detail.start_time) {
+        const date = parseISO(detail.start_time);
+        setSelectedDate(date);
+        setSelectedTimeSlot({ date, time: format(date, 'HH:mm') });
+      }
+      setSelectedSession(undefined);
+      setIsModalOpen(true);
+    };
+    document.addEventListener('openScheduleModal', handler as EventListener);
+    return () => document.removeEventListener('openScheduleModal', handler as EventListener);
+  }, []);
 
   // Memoized date calculations
   const weekStart = useMemo(() => startOfWeek(selectedDate, { weekStartsOn: 1 }), [selectedDate]);

--- a/src/pages/__tests__/Schedule.event.test.tsx
+++ b/src/pages/__tests__/Schedule.event.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders, screen } from '../../test/utils';
+import Schedule from '../Schedule';
+
+// Integration test for event-based scheduling
+
+describe('Schedule page event listener', () => {
+  it('opens session modal when openScheduleModal event is dispatched', async () => {
+    renderWithProviders(<Schedule />);
+
+    // Wait for the page to finish loading
+    await screen.findByRole('heading', { name: /Schedule/i });
+
+    const detail = {
+      therapist_id: 't1',
+      client_id: 'c1',
+      start_time: '2025-03-18T10:00:00Z',
+      end_time: '2025-03-18T11:00:00Z',
+    };
+
+    document.dispatchEvent(new CustomEvent('openScheduleModal', { detail }));
+
+    // Modal should open with default start time populated
+    expect(await screen.findByText(/New Session/i)).toBeInTheDocument();
+    const input = screen.getByLabelText(/Start Time/i) as HTMLInputElement;
+    expect(input.value).not.toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add ErrorTracker to ChatBot for better action diagnostics
- handle ChatBot errors via ErrorTracker
- adjust errorTracking React helper to avoid JSX issues
- add Schedule.event.test to verify openScheduleModal integration

## Testing
- `npx vitest run src/components/__tests__/ChatBot.test.tsx src/pages/__tests__/Schedule.event.test.tsx --silent`
- `npx vitest run --silent` *(fails: Schedule tests cannot load data)*

------
https://chatgpt.com/codex/tasks/task_b_6855584be32c8332a12db285611cf073