### PR TITLE
Ensure VITEST env only set in config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,5 +22,8 @@ export default defineConfig({
     deps: {
       inline: ['@supabase/supabase-js'],
     },
+    env: {
+      VITEST: 'true',
+    },
   },
 });


### PR DESCRIPTION
## Summary
- set `VITEST` environment variable in vitest.config.ts

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_68557505a74c8332acd879b78cd6a5b8