### PR TITLE
Update Supabase edge dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ npm run dev
 - 70+ database migrations
 - Row Level Security (RLS)
 - 16 Edge Functions with OpenAI
+- Updated to `@supabase/supabase-js@2.50.0` and `openai@5.5.1` for full edge compatibility
+- Use a Supabase personal access token for CLI commands. Run `supabase login --token YOUR_TOKEN` or set `SUPABASE_ACCESS_TOKEN`.
+
+### **Database Setup**
+Run migrations with a superuser (e.g. `supabase admin` or `postgres`) because the
+SQL scripts create functions in the `auth` schema. Without these privileges the
+migrations will fail with `permission denied for schema auth`.
 
 ### **Testing & Monitoring**
 - Vitest for unit testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@headlessui/react": "^1.7.18",
         "@supabase/auth-ui-react": "^0.4.7",
         "@supabase/auth-ui-shared": "^0.1.8",
-        "@supabase/supabase-js": "^2.39.7",
+        "@supabase/supabase-js": "^2.50.0",
         "@tanstack/react-query": "^5.24.1",
         "date-fns": "^3.3.1",
         "dotenv": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@headlessui/react": "^1.7.18",
     "@supabase/auth-ui-react": "^0.4.7",
     "@supabase/auth-ui-shared": "^0.1.8",
-    "@supabase/supabase-js": "^2.39.7",
+    "@supabase/supabase-js": "^2.50.0",
     "@tanstack/react-query": "^5.24.1",
     "date-fns": "^3.3.1",
     "dotenv": "^16.5.0",

--- a/supabase/functions/ai-agent-optimized/index.ts
+++ b/supabase/functions/ai-agent-optimized/index.ts
@@ -1,5 +1,5 @@
-import { OpenAI } from "npm:openai@4.28.0";
-import { createClient } from "npm:@supabase/supabase-js@2.39.7";
+import { OpenAI } from "npm:openai@5.5.1";
+import { createClient } from "npm:@supabase/supabase-js@2.50.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/generate-report/index.ts
+++ b/supabase/functions/generate-report/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "npm:@supabase/supabase-js@2.39.7";
+import { createClient } from "npm:@supabase/supabase-js@2.50.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/get-authorization-details/index.ts
+++ b/supabase/functions/get-authorization-details/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "npm:@supabase/supabase-js@2.39.7";
+import { createClient } from "npm:@supabase/supabase-js@2.50.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/get-client-details/index.ts
+++ b/supabase/functions/get-client-details/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "npm:@supabase/supabase-js@2.39.7";
+import { createClient } from "npm:@supabase/supabase-js@2.50.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/get-therapist-details/index.ts
+++ b/supabase/functions/get-therapist-details/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "npm:@supabase/supabase-js@2.39.7";
+import { createClient } from "npm:@supabase/supabase-js@2.50.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/initiate-client-onboarding/index.ts
+++ b/supabase/functions/initiate-client-onboarding/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "npm:@supabase/supabase-js@2.39.7";
+import { createClient } from "npm:@supabase/supabase-js@2.50.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/process-message/index.ts
+++ b/supabase/functions/process-message/index.ts
@@ -1,5 +1,5 @@
-import { OpenAI } from "npm:openai@4.28.0";
-import { createClient } from "npm:@supabase/supabase-js@2.39.7";
+import { OpenAI } from "npm:openai@5.5.1";
+import { createClient } from "npm:@supabase/supabase-js@2.50.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/suggest-alternative-times/index.ts
+++ b/supabase/functions/suggest-alternative-times/index.ts
@@ -1,5 +1,5 @@
-import { createClient } from "npm:@supabase/supabase-js@2.39.7";
-import { OpenAI } from "npm:openai@4.28.0";
+import { createClient } from "npm:@supabase/supabase-js@2.50.0";
+import { OpenAI } from "npm:openai@5.5.1";
 
 const openai = new OpenAI({
   apiKey: Deno.env.get("OPENAI_API_KEY"),


### PR DESCRIPTION
## Summary
- update Supabase edge function deps to supabase-js 2.50.0 and openai 5.5.1
- document updated packages in README
- note that migrations touching the `auth` schema require a superuser
- remind developers to log in with a Supabase personal access token

## Testing
- `npm install`
- `npx vitest run` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_b_68557aa82920833293353f556f9d9c47