### PR TITLE
feat: add env example and docs – 2025-06-21

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+OPENAI_API_KEY=your_openai_key

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ npm install
 npm run dev
 ```
 
+Copy `.env.example` to `.env` and fill in real Supabase and OpenAI keys before running
+Supabase CLI commands or starting the app.
+
 ## 🏗️ **Architecture Overview**
 
 ### **Phase 1: Foundation**


### PR DESCRIPTION
## Summary
- add `.env.example` template for local development
- update README with instructions to copy the file before using Supabase CLI or starting the app

## Testing
- `npm test` *(fails: 3 failed, 7 passed)*
- `eslint . --max-warnings=0` *(fails: 190 errors)*
- `tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_6858373f00dc8332bddd20fedcb7b87a