### PR TITLE
feat: persist scheduling – 2025-06-25

### DIFF
--- a/src/components/__tests__/ChatBot.test.tsx
+++ b/src/components/__tests__/ChatBot.test.tsx
@@ -1,46 +1,73 @@
-import { describe, it, expect, vi } from 'vitest';
-import { renderWithProviders, screen, userEvent } from '../../test/utils';
-import ChatBot from '../ChatBot';
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen, userEvent } from "../../test/utils";
+import ChatBot from "../ChatBot";
 
 beforeAll(() => {
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
-vi.mock('../../lib/ai', () => ({
+vi.mock("../../lib/ai", () => ({
   processMessage: vi.fn().mockResolvedValue({
-    response: 'Sure thing',
+    response: "Sure thing",
     action: {
-      type: 'schedule_session',
+      type: "schedule_session",
       data: {
-        therapist_id: 't1',
-        client_id: 'c1',
-        start_time: '2025-03-18T10:00:00Z',
-        end_time: '2025-03-18T11:00:00Z',
-        location_type: 'in_clinic'
-      }
-    }
-  })
+        therapist_id: "t1",
+        client_id: "c1",
+        start_time: "2025-03-18T10:00:00Z",
+        end_time: "2025-03-18T11:00:00Z",
+        location_type: "in_clinic",
+      },
+    },
+  }),
 }));
 
-describe('ChatBot scheduling', () => {
-  it('dispatches openScheduleModal when scheduling action returned', async () => {
+describe("ChatBot scheduling", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+  it("dispatches openScheduleModal when scheduling action returned", async () => {
     const handler = vi.fn();
-    document.addEventListener('openScheduleModal', handler as EventListener);
+    document.addEventListener("openScheduleModal", handler as EventListener);
 
     renderWithProviders(<ChatBot />);
-    await userEvent.click(document.getElementById('chat-trigger')!);
+    await userEvent.click(document.getElementById("chat-trigger")!);
 
     const input = screen.getByPlaceholderText(/Type your message/);
-    await userEvent.type(input, 'schedule a session');
-    const sendBtn = input.closest('form')!.querySelector('button[type="submit"]') as HTMLButtonElement;
+    await userEvent.type(input, "schedule a session");
+    const sendBtn = input
+      .closest("form")!
+      .querySelector('button[type="submit"]') as HTMLButtonElement;
     await userEvent.click(sendBtn);
 
-    await screen.findByText('Sure thing');
+    await screen.findByText("Sure thing");
 
     expect(handler).toHaveBeenCalled();
     const event = handler.mock.calls[0][0] as CustomEvent;
-    expect(event.detail.therapist_id).toBe('t1');
+    expect(event.detail.therapist_id).toBe("t1");
 
-    document.removeEventListener('openScheduleModal', handler as EventListener);
+    document.removeEventListener("openScheduleModal", handler as EventListener);
+  });
+
+  it("stores pending schedule in localStorage", async () => {
+    renderWithProviders(<ChatBot />);
+    await userEvent.click(document.getElementById("chat-trigger")!);
+
+    const input = screen.getByPlaceholderText(/Type your message/);
+    await userEvent.type(input, "schedule a session");
+    const sendBtn = input
+      .closest("form")!
+      .querySelector('button[type="submit"]') as HTMLButtonElement;
+    await userEvent.click(sendBtn);
+
+    await screen.findByText("Sure thing");
+
+    const stored = localStorage.getItem("pendingSchedule");
+    expect(stored).not.toBeNull();
+    const detail = JSON.parse(stored as string);
+    expect(detail.therapist_id).toBe("t1");
   });
 });

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,350 +1,408 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { format, parseISO, startOfWeek, addDays, endOfWeek } from 'date-fns';
-import { 
-  Calendar as CalendarIcon, 
-  ChevronLeft, 
-  ChevronRight, 
-  Clock, 
-  Plus, 
-  Edit2, 
+import React, { useState, useMemo, useCallback, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { format, parseISO, startOfWeek, addDays, endOfWeek } from "date-fns";
+import {
+  Calendar as CalendarIcon,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Plus,
+  Edit2,
   Trash2,
-  Wand2 
-} from 'lucide-react';
-import { supabase } from '../lib/supabase';
-import type { Session, Therapist, Client } from '../types';
-import SessionModal from '../components/SessionModal';
-import AutoScheduleModal from '../components/AutoScheduleModal';
-import AvailabilityOverlay from '../components/AvailabilityOverlay';
-import SessionFilters from '../components/SessionFilters';
-import SchedulingMatrix from '../components/SchedulingMatrix';
-import { useDebounce } from '../lib/performance';
-import { useScheduleDataBatch, useSessionsOptimized, useDropdownData } from '../lib/optimizedQueries';
+  Wand2,
+} from "lucide-react";
+import { supabase } from "../lib/supabase";
+import type { Session, Therapist, Client } from "../types";
+import SessionModal from "../components/SessionModal";
+import AutoScheduleModal from "../components/AutoScheduleModal";
+import AvailabilityOverlay from "../components/AvailabilityOverlay";
+import SessionFilters from "../components/SessionFilters";
+import SchedulingMatrix from "../components/SchedulingMatrix";
+import { useDebounce } from "../lib/performance";
+import {
+  useScheduleDataBatch,
+  useSessionsOptimized,
+  useDropdownData,
+} from "../lib/optimizedQueries";
 
 // Memoized time slot component
-const TimeSlot = React.memo(({ 
-  time, 
-  day, 
-  sessions, 
-  onCreateSession, 
-  onEditSession 
-}: {
-  time: string;
-  day: Date;
-  sessions: Session[];
-  onCreateSession: (timeSlot: { date: Date; time: string }) => void;
-  onEditSession: (session: Session) => void;
-}) => {
-  const handleTimeSlotClick = useCallback(() => {
-    onCreateSession({ date: day, time });
-  }, [day, time, onCreateSession]);
+const TimeSlot = React.memo(
+  ({
+    time,
+    day,
+    sessions,
+    onCreateSession,
+    onEditSession,
+  }: {
+    time: string;
+    day: Date;
+    sessions: Session[];
+    onCreateSession: (timeSlot: { date: Date; time: string }) => void;
+    onEditSession: (session: Session) => void;
+  }) => {
+    const handleTimeSlotClick = useCallback(() => {
+      onCreateSession({ date: day, time });
+    }, [day, time, onCreateSession]);
 
-  const handleSessionClick = useCallback((e: React.MouseEvent, session: Session) => {
-    e.stopPropagation();
-    onEditSession(session);
-  }, [onEditSession]);
+    const handleSessionClick = useCallback(
+      (e: React.MouseEvent, session: Session) => {
+        e.stopPropagation();
+        onEditSession(session);
+      },
+      [onEditSession],
+    );
 
-  // Filter sessions for this time slot
-  const daySessions = useMemo(() => 
-    sessions.filter(session => 
-      format(parseISO(session.start_time), 'yyyy-MM-dd HH:mm') === 
-      `${format(day, 'yyyy-MM-dd')} ${time}`
-    ), [sessions, day, time]
-  );
+    // Filter sessions for this time slot
+    const daySessions = useMemo(
+      () =>
+        sessions.filter(
+          (session) =>
+            format(parseISO(session.start_time), "yyyy-MM-dd HH:mm") ===
+            `${format(day, "yyyy-MM-dd")} ${time}`,
+        ),
+      [sessions, day, time],
+    );
 
-  return (
-    <div
-      className="h-10 border-b dark:border-gray-700 border-r dark:border-gray-700 p-2 relative group cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
-      onClick={handleTimeSlotClick}
-    >
-      <button className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-opacity">
-        <Plus className="w-4 h-4 text-gray-500 dark:text-gray-400" />
-      </button>
+    return (
+      <div
+        className="h-10 border-b dark:border-gray-700 border-r dark:border-gray-700 p-2 relative group cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
+        onClick={handleTimeSlotClick}
+      >
+        <button className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-opacity">
+          <Plus className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+        </button>
 
-      {daySessions.map(session => (
-        <div
-          key={session.id}
-          className="bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 rounded p-1 text-xs mb-1 group/session relative cursor-pointer hover:bg-blue-200 dark:hover:bg-blue-900/50 transition-colors"
-          onClick={(e) => handleSessionClick(e, session)}
-        >
-          <div className="font-medium truncate">
-            {session.client?.full_name}
-          </div>
-          <div className="text-blue-600 dark:text-blue-300 truncate">
-            {session.therapist?.full_name}
-          </div>
-          <div className="flex items-center text-blue-500 dark:text-blue-400">
-            <Clock className="w-3 h-3 mr-1" />
-            {format(parseISO(session.start_time), 'h:mm a')}
-          </div>
-          
-          <div className="absolute top-1 right-1 opacity-0 group-hover/session:opacity-100 flex space-x-1">
-            <button 
-              className="p-1 rounded hover:bg-blue-300 dark:hover:bg-blue-800"
-              onClick={(e) => {
-                e.stopPropagation();
-                onEditSession(session);
-              }}
-            >
-              <Edit2 className="w-3 h-3" />
-            </button>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-});
-
-TimeSlot.displayName = 'TimeSlot';
-
-// Memoized day column component
-const DayColumn = React.memo(({ 
-  day, 
-  timeSlots, 
-  sessions, 
-  onCreateSession, 
-  onEditSession,
-  showAvailability,
-  therapists,
-  clients 
-}: {
-  day: Date;
-  timeSlots: string[];
-  sessions: Session[];
-  onCreateSession: (timeSlot: { date: Date; time: string }) => void;
-  onEditSession: (session: Session) => void;
-  showAvailability: boolean;
-  therapists: Therapist[];
-  clients: Client[];
-}) => {
-  return (
-    <div className="relative">
-      {showAvailability && (
-        <AvailabilityOverlay
-          therapists={therapists}
-          clients={clients}
-          selectedDate={day}
-          timeSlots={timeSlots}
-        />
-      )}
-      
-      {timeSlots.map(time => (
-        <TimeSlot
-          key={time}
-          time={time}
-          day={day}
-          sessions={sessions}
-          onCreateSession={onCreateSession}
-          onEditSession={onEditSession}
-        />
-      ))}
-    </div>
-  );
-});
-
-DayColumn.displayName = 'DayColumn';
-
-// Memoized week view component
-const WeekView = React.memo(({ 
-  weekDays, 
-  timeSlots, 
-  sessions, 
-  onCreateSession, 
-  onEditSession,
-  showAvailability,
-  therapists,
-  clients 
-}: {
-  weekDays: Date[];
-  timeSlots: string[];
-  sessions: Session[];
-  onCreateSession: (timeSlot: { date: Date; time: string }) => void;
-  onEditSession: (session: Session) => void;
-  showAvailability: boolean;
-  therapists: Therapist[];
-  clients: Client[];
-}) => {
-  return (
-    <div className="bg-white dark:bg-dark-lighter rounded-lg shadow overflow-x-auto">
-      <div className="grid grid-cols-7 border-b dark:border-gray-700 min-w-[800px]">
-        <div className="py-2 px-2 text-center text-sm font-medium text-gray-500 dark:text-gray-400 border-r dark:border-gray-700">
-          Time
-        </div>
-        {weekDays.map(day => (
+        {daySessions.map((session) => (
           <div
-            key={day.toISOString()}
-            className="py-2 px-2 text-center text-sm font-medium text-gray-900 dark:text-white"
+            key={session.id}
+            className="bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 rounded p-1 text-xs mb-1 group/session relative cursor-pointer hover:bg-blue-200 dark:hover:bg-blue-900/50 transition-colors"
+            onClick={(e) => handleSessionClick(e, session)}
           >
-            {format(day, 'EEE MMM d')}
+            <div className="font-medium truncate">
+              {session.client?.full_name}
+            </div>
+            <div className="text-blue-600 dark:text-blue-300 truncate">
+              {session.therapist?.full_name}
+            </div>
+            <div className="flex items-center text-blue-500 dark:text-blue-400">
+              <Clock className="w-3 h-3 mr-1" />
+              {format(parseISO(session.start_time), "h:mm a")}
+            </div>
+
+            <div className="absolute top-1 right-1 opacity-0 group-hover/session:opacity-100 flex space-x-1">
+              <button
+                className="p-1 rounded hover:bg-blue-300 dark:hover:bg-blue-800"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEditSession(session);
+                }}
+              >
+                <Edit2 className="w-3 h-3" />
+              </button>
+            </div>
           </div>
         ))}
       </div>
+    );
+  },
+);
 
-      <div className="grid grid-cols-7 min-w-[800px]">
-        <div className="border-r dark:border-gray-700">
-          {timeSlots.map(time => (
-            <div
-              key={time}
-              className="h-10 border-b dark:border-gray-700 p-2 text-sm text-gray-500 dark:text-gray-400 flex items-center"
-            >
-              {time}
-            </div>
-          ))}
-        </div>
+TimeSlot.displayName = "TimeSlot";
 
-        {weekDays.map(day => (
-          <DayColumn
-            key={day.toISOString()}
-            day={day}
+// Memoized day column component
+const DayColumn = React.memo(
+  ({
+    day,
+    timeSlots,
+    sessions,
+    onCreateSession,
+    onEditSession,
+    showAvailability,
+    therapists,
+    clients,
+  }: {
+    day: Date;
+    timeSlots: string[];
+    sessions: Session[];
+    onCreateSession: (timeSlot: { date: Date; time: string }) => void;
+    onEditSession: (session: Session) => void;
+    showAvailability: boolean;
+    therapists: Therapist[];
+    clients: Client[];
+  }) => {
+    return (
+      <div className="relative">
+        {showAvailability && (
+          <AvailabilityOverlay
+            therapists={therapists}
+            clients={clients}
+            selectedDate={day}
             timeSlots={timeSlots}
+          />
+        )}
+
+        {timeSlots.map((time) => (
+          <TimeSlot
+            key={time}
+            time={time}
+            day={day}
             sessions={sessions}
             onCreateSession={onCreateSession}
             onEditSession={onEditSession}
-            showAvailability={showAvailability}
-            therapists={therapists}
-            clients={clients}
           />
         ))}
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
-WeekView.displayName = 'WeekView';
+DayColumn.displayName = "DayColumn";
 
-// Memoized day view component
-const DayView = React.memo(({ 
-  selectedDate, 
-  timeSlots, 
-  sessions, 
-  onCreateSession, 
-  onEditSession,
-  showAvailability,
-  therapists,
-  clients 
-}: {
-  selectedDate: Date;
-  timeSlots: string[];
-  sessions: Session[];
-  onCreateSession: (timeSlot: { date: Date; time: string }) => void;
-  onEditSession: (session: Session) => void;
-  showAvailability: boolean;
-  therapists: Therapist[];
-  clients: Client[];
-}) => {
-  return (
-    <div className="bg-white dark:bg-dark-lighter rounded-lg shadow overflow-x-auto" data-testid="day-view">
-      <div className="grid grid-cols-2 border-b dark:border-gray-700">
-        <div className="py-4 px-2 text-center text-sm font-medium text-gray-500 dark:text-gray-400 border-r dark:border-gray-700">
-          Time
-        </div>
-        <div className="py-4 px-2 text-center text-sm font-medium text-gray-900 dark:text-white">
-          {format(selectedDate, 'EEEE, MMMM d, yyyy')}
-        </div>
-      </div>
-
-      <div className="grid grid-cols-2">
-        <div className="border-r dark:border-gray-700">
-          {timeSlots.map(time => (
+// Memoized week view component
+const WeekView = React.memo(
+  ({
+    weekDays,
+    timeSlots,
+    sessions,
+    onCreateSession,
+    onEditSession,
+    showAvailability,
+    therapists,
+    clients,
+  }: {
+    weekDays: Date[];
+    timeSlots: string[];
+    sessions: Session[];
+    onCreateSession: (timeSlot: { date: Date; time: string }) => void;
+    onEditSession: (session: Session) => void;
+    showAvailability: boolean;
+    therapists: Therapist[];
+    clients: Client[];
+  }) => {
+    return (
+      <div className="bg-white dark:bg-dark-lighter rounded-lg shadow overflow-x-auto">
+        <div className="grid grid-cols-7 border-b dark:border-gray-700 min-w-[800px]">
+          <div className="py-2 px-2 text-center text-sm font-medium text-gray-500 dark:text-gray-400 border-r dark:border-gray-700">
+            Time
+          </div>
+          {weekDays.map((day) => (
             <div
-              key={time}
-              className="h-10 border-b dark:border-gray-700 p-2 text-sm text-gray-500 dark:text-gray-400 flex items-center"
+              key={day.toISOString()}
+              className="py-2 px-2 text-center text-sm font-medium text-gray-900 dark:text-white"
             >
-              {time}
+              {format(day, "EEE MMM d")}
             </div>
           ))}
         </div>
 
-        <div className="relative">
-          {showAvailability && (
-            <AvailabilityOverlay
-              therapists={therapists}
-              clients={clients}
-              selectedDate={selectedDate}
+        <div className="grid grid-cols-7 min-w-[800px]">
+          <div className="border-r dark:border-gray-700">
+            {timeSlots.map((time) => (
+              <div
+                key={time}
+                className="h-10 border-b dark:border-gray-700 p-2 text-sm text-gray-500 dark:text-gray-400 flex items-center"
+              >
+                {time}
+              </div>
+            ))}
+          </div>
+
+          {weekDays.map((day) => (
+            <DayColumn
+              key={day.toISOString()}
+              day={day}
               timeSlots={timeSlots}
-            />
-          )}
-          
-          {timeSlots.map(time => (
-            <TimeSlot
-              key={time}
-              time={time}
-              day={selectedDate}
               sessions={sessions}
               onCreateSession={onCreateSession}
               onEditSession={onEditSession}
+              showAvailability={showAvailability}
+              therapists={therapists}
+              clients={clients}
             />
           ))}
         </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
-DayView.displayName = 'DayView';
+WeekView.displayName = "WeekView";
+
+// Memoized day view component
+const DayView = React.memo(
+  ({
+    selectedDate,
+    timeSlots,
+    sessions,
+    onCreateSession,
+    onEditSession,
+    showAvailability,
+    therapists,
+    clients,
+  }: {
+    selectedDate: Date;
+    timeSlots: string[];
+    sessions: Session[];
+    onCreateSession: (timeSlot: { date: Date; time: string }) => void;
+    onEditSession: (session: Session) => void;
+    showAvailability: boolean;
+    therapists: Therapist[];
+    clients: Client[];
+  }) => {
+    return (
+      <div
+        className="bg-white dark:bg-dark-lighter rounded-lg shadow overflow-x-auto"
+        data-testid="day-view"
+      >
+        <div className="grid grid-cols-2 border-b dark:border-gray-700">
+          <div className="py-4 px-2 text-center text-sm font-medium text-gray-500 dark:text-gray-400 border-r dark:border-gray-700">
+            Time
+          </div>
+          <div className="py-4 px-2 text-center text-sm font-medium text-gray-900 dark:text-white">
+            {format(selectedDate, "EEEE, MMMM d, yyyy")}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2">
+          <div className="border-r dark:border-gray-700">
+            {timeSlots.map((time) => (
+              <div
+                key={time}
+                className="h-10 border-b dark:border-gray-700 p-2 text-sm text-gray-500 dark:text-gray-400 flex items-center"
+              >
+                {time}
+              </div>
+            ))}
+          </div>
+
+          <div className="relative">
+            {showAvailability && (
+              <AvailabilityOverlay
+                therapists={therapists}
+                clients={clients}
+                selectedDate={selectedDate}
+                timeSlots={timeSlots}
+              />
+            )}
+
+            {timeSlots.map((time) => (
+              <TimeSlot
+                key={time}
+                time={time}
+                day={selectedDate}
+                sessions={sessions}
+                onCreateSession={onCreateSession}
+                onEditSession={onEditSession}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+DayView.displayName = "DayView";
 
 const Schedule = React.memo(() => {
   const [selectedDate, setSelectedDate] = useState(new Date());
-  const [view, setView] = useState<'day' | 'week' | 'matrix'>('week');
+  const [view, setView] = useState<"day" | "week" | "matrix">("week");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isAutoScheduleModalOpen, setIsAutoScheduleModalOpen] = useState(false);
   const [selectedSession, setSelectedSession] = useState<Session | undefined>();
-  const [selectedTimeSlot, setSelectedTimeSlot] = useState<{ date: Date; time: string } | undefined>();
+  const [selectedTimeSlot, setSelectedTimeSlot] = useState<
+    { date: Date; time: string } | undefined
+  >();
   const [showAvailability, setShowAvailability] = useState(true);
-  const [selectedTherapist, setSelectedTherapist] = useState<string | null>(null);
+  const [selectedTherapist, setSelectedTherapist] = useState<string | null>(
+    null,
+  );
   const [selectedClient, setSelectedClient] = useState<string | null>(null);
-  
+
   const queryClient = useQueryClient();
 
   useEffect(() => {
+    const pending = localStorage.getItem("pendingSchedule");
+    if (pending) {
+      try {
+        const detail = JSON.parse(pending);
+        if (detail.start_time) {
+          const date = parseISO(detail.start_time);
+          setSelectedDate(date);
+          setSelectedTimeSlot({ date, time: format(date, "HH:mm") });
+        }
+        setSelectedSession(undefined);
+        setIsModalOpen(true);
+      } catch {
+        // ignore malformed data
+      } finally {
+        localStorage.removeItem("pendingSchedule");
+      }
+    }
+
     const handler = (e: Event) => {
       const detail = (e as CustomEvent).detail || {};
       if (detail.start_time) {
         const date = parseISO(detail.start_time);
         setSelectedDate(date);
-        setSelectedTimeSlot({ date, time: format(date, 'HH:mm') });
+        setSelectedTimeSlot({ date, time: format(date, "HH:mm") });
       }
       setSelectedSession(undefined);
       setIsModalOpen(true);
     };
-    document.addEventListener('openScheduleModal', handler as EventListener);
-    return () => document.removeEventListener('openScheduleModal', handler as EventListener);
+    document.addEventListener("openScheduleModal", handler as EventListener);
+    return () =>
+      document.removeEventListener(
+        "openScheduleModal",
+        handler as EventListener,
+      );
   }, []);
 
   // Memoized date calculations
-  const weekStart = useMemo(() => startOfWeek(selectedDate, { weekStartsOn: 1 }), [selectedDate]);
-  const weekEnd = useMemo(() => endOfWeek(selectedDate, { weekStartsOn: 1 }), [selectedDate]);
+  const weekStart = useMemo(
+    () => startOfWeek(selectedDate, { weekStartsOn: 1 }),
+    [selectedDate],
+  );
+  const weekEnd = useMemo(
+    () => endOfWeek(selectedDate, { weekStartsOn: 1 }),
+    [selectedDate],
+  );
 
   // Debounce filter changes
   const debouncedTherapist = useDebounce(selectedTherapist, 300);
   const debouncedClient = useDebounce(selectedClient, 300);
 
   // PHASE 3 OPTIMIZATION: Use batched schedule data
-  const { data: batchedData, isLoading: isLoadingBatch } = useScheduleDataBatch(weekStart, weekEnd);
-
-  // Fallback to individual queries if batched data is not available
-  const { data: sessions = [], isLoading: isLoadingSessions } = useSessionsOptimized(
+  const { data: batchedData, isLoading: isLoadingBatch } = useScheduleDataBatch(
     weekStart,
     weekEnd,
-    debouncedTherapist,
-    debouncedClient
   );
 
+  // Fallback to individual queries if batched data is not available
+  const { data: sessions = [], isLoading: isLoadingSessions } =
+    useSessionsOptimized(
+      weekStart,
+      weekEnd,
+      debouncedTherapist,
+      debouncedClient,
+    );
+
   // Use dropdown data hook for therapists and clients
-  const { data: dropdownData, isLoading: isLoadingDropdowns } = useDropdownData();
+  const { data: dropdownData, isLoading: isLoadingDropdowns } =
+    useDropdownData();
 
   // Use batched data if available, otherwise use individual query results
   const displayData = {
     sessions: batchedData?.sessions || sessions,
     therapists: batchedData?.therapists || dropdownData?.therapists || [],
-    clients: batchedData?.clients || dropdownData?.clients || []
+    clients: batchedData?.clients || dropdownData?.clients || [],
   };
 
   // Optimized mutations with proper error handling
   const createSessionMutation = useMutation({
     mutationFn: async (newSession: Partial<Session>) => {
       const { data, error } = await supabase
-        .from('sessions')
+        .from("sessions")
         .insert([newSession])
         .select()
         .single();
@@ -353,8 +411,8 @@ const Schedule = React.memo(() => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sessions'] });
-      queryClient.invalidateQueries({ queryKey: ['sessions-batch'] });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      queryClient.invalidateQueries({ queryKey: ["sessions-batch"] });
       setIsModalOpen(false);
       setSelectedSession(undefined);
       setSelectedTimeSlot(undefined);
@@ -364,7 +422,7 @@ const Schedule = React.memo(() => {
   const createMultipleSessionsMutation = useMutation({
     mutationFn: async (newSessions: Partial<Session>[]) => {
       const { data, error } = await supabase
-        .from('sessions')
+        .from("sessions")
         .insert(newSessions)
         .select();
 
@@ -372,8 +430,8 @@ const Schedule = React.memo(() => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sessions'] });
-      queryClient.invalidateQueries({ queryKey: ['sessions-batch'] });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      queryClient.invalidateQueries({ queryKey: ["sessions-batch"] });
       setIsAutoScheduleModalOpen(false);
     },
   });
@@ -381,9 +439,9 @@ const Schedule = React.memo(() => {
   const updateSessionMutation = useMutation({
     mutationFn: async (updatedSession: Partial<Session>) => {
       const { data, error } = await supabase
-        .from('sessions')
+        .from("sessions")
         .update(updatedSession)
-        .eq('id', selectedSession?.id)
+        .eq("id", selectedSession?.id)
         .select()
         .single();
 
@@ -391,8 +449,8 @@ const Schedule = React.memo(() => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sessions'] });
-      queryClient.invalidateQueries({ queryKey: ['sessions-batch'] });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      queryClient.invalidateQueries({ queryKey: ["sessions-batch"] });
       setIsModalOpen(false);
       setSelectedSession(undefined);
     },
@@ -401,24 +459,27 @@ const Schedule = React.memo(() => {
   const deleteSessionMutation = useMutation({
     mutationFn: async (sessionId: string) => {
       const { error } = await supabase
-        .from('sessions')
+        .from("sessions")
         .delete()
-        .eq('id', sessionId);
+        .eq("id", sessionId);
 
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sessions'] });
-      queryClient.invalidateQueries({ queryKey: ['sessions-batch'] });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      queryClient.invalidateQueries({ queryKey: ["sessions-batch"] });
     },
   });
 
   // Memoized callbacks
-  const handleCreateSession = useCallback((timeSlot: { date: Date; time: string }) => {
-    setSelectedTimeSlot(timeSlot);
-    setSelectedSession(undefined);
-    setIsModalOpen(true);
-  }, []);
+  const handleCreateSession = useCallback(
+    (timeSlot: { date: Date; time: string }) => {
+      setSelectedTimeSlot(timeSlot);
+      setSelectedSession(undefined);
+      setIsModalOpen(true);
+    },
+    [],
+  );
 
   const handleEditSession = useCallback((session: Session) => {
     setSelectedSession(session);
@@ -426,38 +487,50 @@ const Schedule = React.memo(() => {
     setIsModalOpen(true);
   }, []);
 
-  const handleDeleteSession = useCallback(async (sessionId: string) => {
-    if (window.confirm('Are you sure you want to delete this session?')) {
-      await deleteSessionMutation.mutateAsync(sessionId);
-    }
-  }, [deleteSessionMutation]);
+  const handleDeleteSession = useCallback(
+    async (sessionId: string) => {
+      if (window.confirm("Are you sure you want to delete this session?")) {
+        await deleteSessionMutation.mutateAsync(sessionId);
+      }
+    },
+    [deleteSessionMutation],
+  );
 
-  const handleSubmit = useCallback(async (data: Partial<Session>) => {
-    if (selectedSession) {
-      await updateSessionMutation.mutateAsync(data);
-    } else {
-      await createSessionMutation.mutateAsync(data);
-    }
-  }, [selectedSession, updateSessionMutation, createSessionMutation]);
+  const handleSubmit = useCallback(
+    async (data: Partial<Session>) => {
+      if (selectedSession) {
+        await updateSessionMutation.mutateAsync(data);
+      } else {
+        await createSessionMutation.mutateAsync(data);
+      }
+    },
+    [selectedSession, updateSessionMutation, createSessionMutation],
+  );
 
-  const handleAutoSchedule = useCallback(async (sessions: Partial<Session>[]) => {
-    await createMultipleSessionsMutation.mutateAsync(sessions);
-  }, [createMultipleSessionsMutation]);
+  const handleAutoSchedule = useCallback(
+    async (sessions: Partial<Session>[]) => {
+      await createMultipleSessionsMutation.mutateAsync(sessions);
+    },
+    [createMultipleSessionsMutation],
+  );
 
-  const handleDateNavigation = useCallback((direction: 'prev' | 'next') => {
-    setSelectedDate(d => {
-      // If in day view, move by 1 day; otherwise, move by 7 days (week)
-      const daysToAdd = view === 'day' ? 1 : 7;
-      return addDays(d, direction === 'prev' ? -daysToAdd : daysToAdd);
-    });
-  }, [view]);
+  const handleDateNavigation = useCallback(
+    (direction: "prev" | "next") => {
+      setSelectedDate((d) => {
+        // If in day view, move by 1 day; otherwise, move by 7 days (week)
+        const daysToAdd = view === "day" ? 1 : 7;
+        return addDays(d, direction === "prev" ? -daysToAdd : daysToAdd);
+      });
+    },
+    [view],
+  );
 
-  const handleViewChange = useCallback((newView: 'day' | 'week' | 'matrix') => {
+  const handleViewChange = useCallback((newView: "day" | "week" | "matrix") => {
     setView(newView);
   }, []);
 
   const toggleAvailability = useCallback(() => {
-    setShowAvailability(prev => !prev);
+    setShowAvailability((prev) => !prev);
   }, []);
 
   // Memoized time slots generation
@@ -465,8 +538,8 @@ const Schedule = React.memo(() => {
     const slots = [];
     for (let hour = 8; hour < 18; hour++) {
       for (let minute = 0; minute < 60; minute += 15) {
-        const hourStr = hour.toString().padStart(2, '0');
-        const minuteStr = minute.toString().padStart(2, '0');
+        const hourStr = hour.toString().padStart(2, "0");
+        const minuteStr = minute.toString().padStart(2, "0");
         slots.push(`${hourStr}:${minuteStr}`);
       }
     }
@@ -475,17 +548,21 @@ const Schedule = React.memo(() => {
 
   // Memoized week days generation
   const weekDays = useMemo(() => {
-    return Array.from({ length: 6 }, (_, i) => // Monday to Saturday
-      addDays(weekStart, i)
+    return Array.from(
+      { length: 6 },
+      (
+        _,
+        i, // Monday to Saturday
+      ) => addDays(weekStart, i),
     );
   }, [weekStart]);
 
   // Memoized date range display
   const dateRangeDisplay = useMemo(() => {
-    if (view === 'day') {
-      return format(selectedDate, 'MMMM d, yyyy');
+    if (view === "day") {
+      return format(selectedDate, "MMMM d, yyyy");
     }
-    return `${format(weekStart, 'MMM d')} - ${format(addDays(weekStart, 5), 'MMM d, yyyy')}`;
+    return `${format(weekStart, "MMM d")} - ${format(addDays(weekStart, 5), "MMM d, yyyy")}`;
   }, [weekStart, selectedDate, view]);
 
   const isLoading = isLoadingBatch || isLoadingSessions || isLoadingDropdowns;
@@ -501,8 +578,10 @@ const Schedule = React.memo(() => {
   return (
     <div className="h-full">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Schedule</h1>
-        
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          Schedule
+        </h1>
+
         <div className="flex items-center space-x-4">
           <button
             onClick={() => setIsAutoScheduleModalOpen(true)}
@@ -514,12 +593,12 @@ const Schedule = React.memo(() => {
 
           <div className="flex items-center space-x-2">
             <button
-              onClick={() => handleDateNavigation('prev')}
+              onClick={() => handleDateNavigation("prev")}
               className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
             >
               <ChevronLeft className="w-5 h-5" />
             </button>
-            
+
             <div className="flex items-center space-x-2">
               <CalendarIcon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
               <span className="font-medium text-gray-900 dark:text-white min-w-[200px] text-center">
@@ -528,7 +607,7 @@ const Schedule = React.memo(() => {
             </div>
 
             <button
-              onClick={() => handleDateNavigation('next')}
+              onClick={() => handleDateNavigation("next")}
               className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
             >
               <ChevronRight className="w-5 h-5" />
@@ -537,31 +616,31 @@ const Schedule = React.memo(() => {
 
           <div className="flex rounded-lg shadow-sm">
             <button
-              onClick={() => handleViewChange('day')}
+              onClick={() => handleViewChange("day")}
               className={`px-4 py-2 text-sm font-medium transition-colors ${
-                view === 'day'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-white dark:bg-dark-lighter text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
+                view === "day"
+                  ? "bg-blue-600 text-white"
+                  : "bg-white dark:bg-dark-lighter text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
               } border border-gray-300 dark:border-gray-600 rounded-l-lg`}
             >
               Day
             </button>
             <button
-              onClick={() => handleViewChange('week')}
+              onClick={() => handleViewChange("week")}
               className={`px-4 py-2 text-sm font-medium transition-colors ${
-                view === 'week'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-white dark:bg-dark-lighter text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
+                view === "week"
+                  ? "bg-blue-600 text-white"
+                  : "bg-white dark:bg-dark-lighter text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
               } border-t border-b border-gray-300 dark:border-gray-600`}
             >
               Week
             </button>
             <button
-              onClick={() => handleViewChange('matrix')}
+              onClick={() => handleViewChange("matrix")}
               className={`px-4 py-2 text-sm font-medium transition-colors ${
-                view === 'matrix'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-white dark:bg-dark-lighter text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
+                view === "matrix"
+                  ? "bg-blue-600 text-white"
+                  : "bg-white dark:bg-dark-lighter text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
               } border border-gray-300 dark:border-gray-600 rounded-r-lg`}
             >
               Matrix
@@ -572,8 +651,8 @@ const Schedule = React.memo(() => {
             onClick={toggleAvailability}
             className={`px-4 py-2 text-sm font-medium transition-colors ${
               showAvailability
-                ? 'bg-green-600 text-white'
-                : 'bg-white dark:bg-dark-lighter text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800'
+                ? "bg-green-600 text-white"
+                : "bg-white dark:bg-dark-lighter text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
             } border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm`}
           >
             Show Availability
@@ -590,19 +669,23 @@ const Schedule = React.memo(() => {
         onClientChange={setSelectedClient}
       />
 
-      {view === 'matrix' ? (
+      {view === "matrix" ? (
         <SchedulingMatrix
           therapists={displayData.therapists}
           clients={displayData.clients}
           selectedDate={selectedDate}
-          onTimeSlotClick={(time) => handleCreateSession({ date: selectedDate, time })}
+          onTimeSlotClick={(time) =>
+            handleCreateSession({ date: selectedDate, time })
+          }
         />
-      ) : view === 'day' ? (
+      ) : view === "day" ? (
         <DayView
           selectedDate={selectedDate}
           timeSlots={timeSlots}
-          sessions={displayData.sessions.filter(session => 
-            format(parseISO(session.start_time), 'yyyy-MM-dd') === format(selectedDate, 'yyyy-MM-dd')
+          sessions={displayData.sessions.filter(
+            (session) =>
+              format(parseISO(session.start_time), "yyyy-MM-dd") ===
+              format(selectedDate, "yyyy-MM-dd"),
           )}
           onCreateSession={handleCreateSession}
           onEditSession={handleEditSession}
@@ -651,6 +734,6 @@ const Schedule = React.memo(() => {
   );
 });
 
-Schedule.displayName = 'Schedule';
+Schedule.displayName = "Schedule";
 
 export default Schedule;

--- a/src/pages/__tests__/Schedule.event.test.tsx
+++ b/src/pages/__tests__/Schedule.event.test.tsx
@@ -1,28 +1,50 @@
-import { describe, it, expect } from 'vitest';
-import { renderWithProviders, screen } from '../../test/utils';
-import Schedule from '../Schedule';
+import { describe, it, expect } from "vitest";
+import { renderWithProviders, screen } from "../../test/utils";
+import Schedule from "../Schedule";
 
 // Integration test for event-based scheduling
 
-describe('Schedule page event listener', () => {
-  it('opens session modal when openScheduleModal event is dispatched', async () => {
+describe("Schedule page event listener", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+  it("opens session modal when openScheduleModal event is dispatched", async () => {
     renderWithProviders(<Schedule />);
 
     // Wait for the page to finish loading
-    await screen.findByRole('heading', { name: /Schedule/i });
+    await screen.findByRole("heading", { name: /Schedule/i });
 
     const detail = {
-      therapist_id: 't1',
-      client_id: 'c1',
-      start_time: '2025-03-18T10:00:00Z',
-      end_time: '2025-03-18T11:00:00Z',
+      therapist_id: "t1",
+      client_id: "c1",
+      start_time: "2025-03-18T10:00:00Z",
+      end_time: "2025-03-18T11:00:00Z",
     };
 
-    document.dispatchEvent(new CustomEvent('openScheduleModal', { detail }));
+    document.dispatchEvent(new CustomEvent("openScheduleModal", { detail }));
 
     // Modal should open with default start time populated
     expect(await screen.findByText(/New Session/i)).toBeInTheDocument();
     const input = screen.getByLabelText(/Start Time/i) as HTMLInputElement;
-    expect(input.value).not.toBe('');
+    expect(input.value).not.toBe("");
+  });
+
+  it("opens modal based on pendingSchedule in localStorage", async () => {
+    const detail = {
+      therapist_id: "t1",
+      client_id: "c1",
+      start_time: "2025-03-18T10:00:00Z",
+      end_time: "2025-03-18T11:00:00Z",
+    };
+    localStorage.setItem("pendingSchedule", JSON.stringify(detail));
+
+    renderWithProviders(<Schedule />);
+    await screen.findByRole("heading", { name: /Schedule/i });
+
+    expect(await screen.findByText(/New Session/i)).toBeInTheDocument();
+    expect(localStorage.getItem("pendingSchedule")).toBeNull();
   });
 });

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -1,70 +1,78 @@
-import { describe, it, expect, vi } from 'vitest';
-import { renderWithProviders, screen, userEvent } from '../../test/utils';
-import Schedule from '../Schedule';
-import { server } from '../../test/setup';
-import { http, HttpResponse } from 'msw';
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen, userEvent } from "../../test/utils";
+import Schedule from "../Schedule";
+import { server } from "../../test/setup";
+import { http, HttpResponse } from "msw";
 
-describe('Schedule', () => {
-  it('renders schedule page with calendar', async () => {
+describe("Schedule", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+  it("renders schedule page with calendar", async () => {
     renderWithProviders(<Schedule />);
-    
+
     // Check for main elements
     expect(await screen.findByText(/Schedule/i)).toBeInTheDocument();
     expect(await screen.findByText(/Auto Schedule/i)).toBeInTheDocument();
   });
 
-  it('displays sessions from API', async () => {
+  it("displays sessions from API", async () => {
     // Mock session data
     server.use(
-      http.get('*/rest/v1/sessions*', () => {
+      http.get("*/rest/v1/sessions*", () => {
         return HttpResponse.json([
           {
-            id: 'test-session-1',
-            client: { full_name: 'Test Client' },
-            therapist: { full_name: 'Test Therapist' },
-            start_time: '2025-03-18T10:00:00Z',
-            end_time: '2025-03-18T11:00:00Z',
-            status: 'scheduled',
+            id: "test-session-1",
+            client: { full_name: "Test Client" },
+            therapist: { full_name: "Test Therapist" },
+            start_time: "2025-03-18T10:00:00Z",
+            end_time: "2025-03-18T11:00:00Z",
+            status: "scheduled",
           },
         ]);
-      })
+      }),
     );
 
     renderWithProviders(<Schedule />);
 
     // Wait for session data to load
-    expect(await screen.findByText('Test Client')).toBeInTheDocument();
-    expect(screen.getByText('Test Therapist')).toBeInTheDocument();
+    expect(await screen.findByText("Test Client")).toBeInTheDocument();
+    expect(screen.getByText("Test Therapist")).toBeInTheDocument();
   });
 
-  it('allows switching between views', async () => {
+  it("allows switching between views", async () => {
     renderWithProviders(<Schedule />);
-    
+
     // Test view switches
-    const dayButton = screen.getByRole('button', { name: /Day/i });
-    const weekButton = screen.getByRole('button', { name: /Week/i });
-    const matrixButton = screen.getByRole('button', { name: /Matrix/i });
+    const dayButton = screen.getByRole("button", { name: /Day/i });
+    const weekButton = screen.getByRole("button", { name: /Week/i });
+    const matrixButton = screen.getByRole("button", { name: /Matrix/i });
 
     await userEvent.click(dayButton);
     await userEvent.click(weekButton);
     await userEvent.click(matrixButton);
 
-    expect(screen.getByRole('button', { name: /Matrix/i })).toHaveClass('bg-blue-600');
+    expect(screen.getByRole("button", { name: /Matrix/i })).toHaveClass(
+      "bg-blue-600",
+    );
   });
 
-  it('handles session filtering', async () => {
+  it("handles session filtering", async () => {
     renderWithProviders(<Schedule />);
 
     // Wait for data to load
-    await screen.findByText('Test Client');
+    await screen.findByText("Test Client");
 
     // Find and interact with filters
     const therapistFilter = await screen.findByLabelText(/Therapist/i);
     const clientFilter = await screen.findByLabelText(/Client/i);
 
-    await userEvent.selectOptions(therapistFilter, ['']);
-    await userEvent.selectOptions(clientFilter, ['']);
+    await userEvent.selectOptions(therapistFilter, [""]);
+    await userEvent.selectOptions(clientFilter, [""]);
 
-    expect(screen.getByText('Test Client')).toBeInTheDocument();
+    expect(screen.getByText("Test Client")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Summary
Persist schedule requests via localStorage and auto-open modal on navigation

### Proposed changes
- store pending schedule details when chat agent triggers scheduling
- navigate to Schedule page after storing
- auto-open schedule modal on mount if pending info exists
- test coverage for new localStorage handling

### Tests added/updated
- src/components/__tests__/ChatBot.test.tsx
- src/pages/__tests__/Schedule.event.test.tsx
- src/pages/__tests__/Schedule.test.tsx

### Checklist
- [ ] `npm test` passed
- [ ] `eslint .` passed
- [ ] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_685c44bfad148332b2b8f209cde1aa64