### PR TITLE
feat: improve onboarding accessibility – 2025-06-25

### DIFF
--- a/src/components/ClientOnboarding.tsx
+++ b/src/components/ClientOnboarding.tsx
@@ -1,15 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { 
-  User, Mail, Calendar, Phone, MapPin, 
-  FileText, CheckCircle, ArrowRight, ArrowLeft,
-  Upload, Shield, AlertCircle, RefreshCw
+import {
+  CheckCircle,
+  ArrowRight,
+  ArrowLeft,
+  Upload,
+  AlertCircle,
+  RefreshCw,
 } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { showSuccess, showError } from '../lib/toast';
 import AvailabilityEditor from './AvailabilityEditor';
+import { OnboardingSteps } from './OnboardingSteps';
 import type { Client } from '../types';
 import { prepareFormData } from '../lib/validation';
 
@@ -50,7 +54,7 @@ interface OnboardingFormData {
 
   // Service Information
   service_preference: string[];
-  insurance_info?: Record<string, any>;
+  insurance_info?: Record<string, unknown>;
   referral_source?: string;
   one_to_one_units?: number;
   supervision_units?: number;
@@ -91,7 +95,7 @@ export default function ClientOnboarding({ onComplete }: ClientOnboardingProps) 
   // Parse query parameters
   const queryParams = new URLSearchParams(location.search);
   
-  const { register, handleSubmit, control, setValue, watch, formState: { errors } } = useForm<OnboardingFormData>({
+  const { register, handleSubmit, control, formState: { errors } } = useForm<OnboardingFormData>({
     defaultValues: {
       email: queryParams.get('email') || '',
       first_name: queryParams.get('first_name') || '',
@@ -888,36 +892,16 @@ export default function ClientOnboarding({ onComplete }: ClientOnboardingProps) 
       <div className="bg-white dark:bg-dark-lighter shadow rounded-lg p-6 mb-6">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">Client Onboarding</h1>
         
-        {/* Progress Steps */}
-        <div className="mb-8">
-          <div className="flex items-center justify-between">
-            {[1, 2, 3, 4, 5].map(step => (
-              <div 
-                key={step}
-                className={`flex items-center justify-center w-10 h-10 rounded-full ${
-                  step < currentStep
-                    ? 'bg-blue-600 text-white'
-                    : step === currentStep
-                      ? 'bg-blue-100 dark:bg-blue-900/20 text-blue-800 dark:text-blue-200 border-2 border-blue-600'
-                      : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'
-                }`}
-              >
-                {step < currentStep ? (
-                  <CheckCircle className="w-6 h-6" />
-                ) : (
-                  <span>{step}</span>
-                )}
-              </div>
-            ))}
-          </div>
-          <div className="flex justify-between mt-2 text-xs text-gray-500 dark:text-gray-400">
-            <span>Basic Info</span>
-            <span>Parent/Guardian</span>
-            <span>Address</span>
-            <span>Services</span>
-            <span>Documents</span>
-          </div>
-        </div>
+        <OnboardingSteps
+          labels={[
+            'Basic Info',
+            'Parent/Guardian',
+            'Address',
+            'Services',
+            'Documents',
+          ]}
+          currentStep={currentStep}
+        />
         
         <form onSubmit={handleSubmit(handleFormSubmit)}>
           {renderStepContent()}

--- a/src/components/OnboardingSteps.tsx
+++ b/src/components/OnboardingSteps.tsx
@@ -1,0 +1,47 @@
+import { CheckCircle } from 'lucide-react';
+
+interface OnboardingStepsProps {
+  labels: string[];
+  currentStep: number;
+}
+
+export function OnboardingSteps({ labels, currentStep }: OnboardingStepsProps) {
+  return (
+    <div className="mb-8">
+      <ol className="flex items-center justify-between" aria-label="Onboarding steps">
+        {labels.map((label, index) => {
+          const step = index + 1;
+          let stepClass = '';
+          if (step < currentStep) {
+            stepClass = 'bg-blue-600 text-white';
+          } else if (step === currentStep) {
+            stepClass =
+              'bg-blue-100 dark:bg-blue-900/20 text-blue-800 dark:text-blue-200 border-2 border-blue-600';
+          } else {
+            stepClass =
+              'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400';
+          }
+          return (
+            <li
+              key={step}
+              aria-current={step === currentStep ? 'step' : undefined}
+              aria-label={label}
+              className={`flex items-center justify-center w-10 h-10 rounded-full ${stepClass}`}
+            >
+              {step < currentStep ? (
+                <CheckCircle className="w-6 h-6" />
+              ) : (
+                <span>{step}</span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+      <div className="flex justify-between mt-2 text-xs text-gray-500 dark:text-gray-400">
+        {labels.map((label) => (
+          <span key={label}>{label}</span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TherapistOnboarding.tsx
+++ b/src/components/TherapistOnboarding.tsx
@@ -1,16 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { 
-  User, Mail, Calendar, Phone, MapPin, 
-  FileText, CheckCircle, ArrowRight, ArrowLeft,
-  Upload, Shield, AlertCircle, RefreshCw,
-  Briefcase, Award, Building2
+import {
+  CheckCircle,
+  ArrowRight,
+  ArrowLeft,
+  Upload,
+  AlertCircle,
+  RefreshCw,
 } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { showSuccess, showError } from '../lib/toast';
 import AvailabilityEditor from './AvailabilityEditor';
+import { OnboardingSteps } from './OnboardingSteps';
 import type { Therapist } from '../types';
 import { prepareFormData } from '../lib/validation';
 
@@ -92,7 +95,7 @@ export default function TherapistOnboarding({ onComplete }: TherapistOnboardingP
   // Parse query parameters
   const queryParams = new URLSearchParams(location.search);
   
-  const { register, handleSubmit, control, setValue, watch, formState: { errors } } = useForm<OnboardingFormData>({
+  const { register, handleSubmit, control, formState: { errors } } = useForm<OnboardingFormData>({
     defaultValues: {
       email: queryParams.get('email') || '',
       first_name: queryParams.get('first_name') || '',
@@ -790,36 +793,10 @@ export default function TherapistOnboarding({ onComplete }: TherapistOnboardingP
       <div className="bg-white dark:bg-dark-lighter shadow rounded-lg p-6 mb-6">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">Therapist Onboarding</h1>
         
-        {/* Progress Steps */}
-        <div className="mb-8">
-          <div className="flex items-center justify-between">
-            {[1, 2, 3, 4, 5].map(step => (
-              <div 
-                key={step}
-                className={`flex items-center justify-center w-10 h-10 rounded-full ${
-                  step < currentStep
-                    ? 'bg-blue-600 text-white'
-                    : step === currentStep
-                      ? 'bg-blue-100 dark:bg-blue-900/20 text-blue-800 dark:text-blue-200 border-2 border-blue-600'
-                      : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'
-                }`}
-              >
-                {step < currentStep ? (
-                  <CheckCircle className="w-6 h-6" />
-                ) : (
-                  <span>{step}</span>
-                )}
-              </div>
-            ))}
-          </div>
-          <div className="flex justify-between mt-2 text-xs text-gray-500 dark:text-gray-400">
-            <span>Basic Info</span>
-            <span>Professional</span>
-            <span>Address</span>
-            <span>Services</span>
-            <span>Documents</span>
-          </div>
-        </div>
+        <OnboardingSteps
+          labels={['Basic Info', 'Professional', 'Address', 'Services', 'Documents']}
+          currentStep={currentStep}
+        />
         
         <form onSubmit={handleSubmit(handleFormSubmit)}>
           {renderStepContent()}

--- a/src/components/__tests__/OnboardingSteps.test.tsx
+++ b/src/components/__tests__/OnboardingSteps.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OnboardingSteps } from '../OnboardingSteps';
+
+describe('OnboardingSteps', () => {
+  it('renders labels and highlights current step', () => {
+    render(<OnboardingSteps labels={['A', 'B', 'C']} currentStep={2} />);
+
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('C')).toBeInTheDocument();
+
+    // active step should show number 2
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Summary
Add aria attributes to shared onboarding progress bar

### Proposed changes
- replace div list with accessible `ol`
- add `aria-current` and `aria-label` for steps

### Tests added/updated
- src/components/__tests__/OnboardingSteps.test.tsx

### Checklist
- [ ] `npm test` passed
- [ ] `eslint .` passed
- [ ] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_685c4a722d488332a73e6707e1a0efe1