### PR TITLE
fix: remove hard-coded Supabase secrets – 2025-01-14

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,24 @@ node scripts/cleanup-supabase-branch.js --pattern "^pr-"
 node scripts/cleanup-supabase-branch.js --dry-run --max-age 7
 ```
 
+### `scripts/admin-password-reset.js`
+- Reset a user's password or create the account if it does not exist
+- Requires Supabase service role credentials loaded from your environment (no fallback value is bundled)
+
+#### Usage
+```bash
+# Supply the service role key through the environment (e.g. shell export or .env file)
+export SUPABASE_SERVICE_ROLE_KEY="<your-service-role-key>"
+
+# Optional: override the Supabase project URL if you are using a non-default project
+export SUPABASE_URL="https://your-project.supabase.co"
+
+# Execute the script with the target account details
+node scripts/admin-password-reset.js user@example.com NewPass123 true
+```
+
+> ℹ️  The script reads configuration via `dotenv`, so storing the key in a local `.env` file is supported. Keep the key out of version control and CI logs.
+
 ## 🔧 Configuration
 
 ### Environment Variables

--- a/scripts/reset-password.ps1
+++ b/scripts/reset-password.ps1
@@ -2,8 +2,10 @@
 # Usage: .\scripts\reset-password.ps1
 
 param(
-    [string]$Email = "j_edaurdo622@yahoo.com",
-    [string]$Password = "Nina.6225"
+    [Parameter(Mandatory=$true)]
+    [string]$Email,
+    [Parameter(Mandatory=$true)]
+    [string]$Password
 )
 
 Write-Host "🔐 Admin Password Reset Tool" -ForegroundColor Green

--- a/src/scripts/__tests__/secret-guards.test.ts
+++ b/src/scripts/__tests__/secret-guards.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('resolveSupabaseServiceKey', () => {
+  const originalServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  afterAll(() => {
+    if (originalServiceKey === undefined) {
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    } else {
+      process.env.SUPABASE_SERVICE_ROLE_KEY = originalServiceKey;
+    }
+  });
+
+  it('returns the configured service role key when present', async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+    const module = await import('../../../scripts/admin-password-reset.js');
+
+    expect(module.resolveSupabaseServiceKey()).toBe('test-service-role-key');
+  });
+
+  it('throws a descriptive error when the key is missing', async () => {
+    const module = await import('../../../scripts/admin-password-reset.js');
+
+    expect(() => module.resolveSupabaseServiceKey()).toThrowError(/SUPABASE_SERVICE_ROLE_KEY/);
+  });
+
+  it('supports supplying an explicit environment map', async () => {
+    const module = await import('../../../scripts/admin-password-reset.js');
+
+    expect(
+      module.resolveSupabaseServiceKey({ SUPABASE_SERVICE_ROLE_KEY: 'inline-service-role-key' })
+    ).toBe('inline-service-role-key');
+  });
+});
+
+describe('resolveSupabaseAnonKey and resolveSupabaseUrl', () => {
+  const originalAnonKey = process.env.SUPABASE_ANON_KEY;
+  const originalUrl = process.env.SUPABASE_URL;
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.SUPABASE_ANON_KEY;
+    delete process.env.SUPABASE_URL;
+  });
+
+  afterAll(() => {
+    if (originalAnonKey === undefined) {
+      delete process.env.SUPABASE_ANON_KEY;
+    } else {
+      process.env.SUPABASE_ANON_KEY = originalAnonKey;
+    }
+
+    if (originalUrl === undefined) {
+      delete process.env.SUPABASE_URL;
+    } else {
+      process.env.SUPABASE_URL = originalUrl;
+    }
+  });
+
+  it('reads the anon key from the environment when present', async () => {
+    process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+    const module = await import('../../../scripts/test-transcription.js');
+
+    expect(module.resolveSupabaseAnonKey()).toBe('test-anon-key');
+  });
+
+  it('throws an error when no anon key is provided', async () => {
+    const module = await import('../../../scripts/test-transcription.js');
+
+    expect(() => module.resolveSupabaseAnonKey()).toThrowError(/SUPABASE_ANON_KEY/);
+  });
+
+  it('prefers a provided URL while falling back to the default project when unset', async () => {
+    const module = await import('../../../scripts/test-transcription.js');
+
+    expect(module.resolveSupabaseUrl({ SUPABASE_URL: 'https://custom.supabase.co' })).toBe(
+      'https://custom.supabase.co'
+    );
+    expect(module.resolveSupabaseUrl({})).toBe('https://wnnjeqheqxxyrgsjmygy.supabase.co');
+  });
+});


### PR DESCRIPTION
### Summary
Remove embedded Supabase credentials from admin tooling and require environment-provided secrets.

### Proposed changes
- Guard the admin password reset script behind SUPABASE_SERVICE_ROLE_KEY resolution and reuse a cached client
- Load Supabase credentials from the environment for the transcription test script and stop hard-coded defaults
- Document the required environment configuration, sanitize the PowerShell helper, and add regression tests for the new guards

### Tests added/updated
- src/scripts/__tests__/secret-guards.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68c9d65ca7b0833283c57b238b3170c9