### PR TITLE
fix: harden admin password reset env guard – 2025-09-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ node scripts/cleanup-supabase-branch.js --dry-run --max-age 7
 
 ### `scripts/admin-password-reset.js`
 - Reset a user's password or create the account if it does not exist
-- Requires Supabase service role credentials loaded from your environment (no fallback value is bundled)
+- Requires Supabase service role credentials loaded from your environment; the script throws if `SUPABASE_SERVICE_ROLE_KEY` is missing or blank
 
 #### Usage
 ```bash
@@ -311,7 +311,7 @@ export SUPABASE_URL="https://your-project.supabase.co"
 node scripts/admin-password-reset.js user@example.com NewPass123 true
 ```
 
-> ℹ️  The script reads configuration via `dotenv`, so storing the key in a local `.env` file is supported. Keep the key out of version control and CI logs.
+> ℹ️  The script reads configuration via `dotenv`, so storing the key in a local `.env` file is supported. Keep the key out of version control and CI logs. The script does not include any fallback key and will exit early if the environment variable is omitted.
 
 ## 🔧 Configuration
 

--- a/docs/AUTH_ROLES.md
+++ b/docs/AUTH_ROLES.md
@@ -305,6 +305,8 @@ SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 ```
 
+> ⚠️ Supply these values through environment variables or your secret manager. Operational scripts (such as `scripts/admin-password-reset.js`) will terminate if `SUPABASE_SERVICE_ROLE_KEY` is unset or blank—no fallback key is bundled with the repository.
+
 ### Migration Application
 ```bash
 # Apply authentication system migration

--- a/docs/DATABASE_PIPELINE.md
+++ b/docs/DATABASE_PIPELINE.md
@@ -78,6 +78,8 @@ NETLIFY_AUTH_TOKEN=your_netlify_auth_token
 NETLIFY_SITE_ID=your_netlify_site_id
 ```
 
+> 🔒 Provide these values via your CI/CD secret store. Scripts that require elevated access, including `scripts/admin-password-reset.js`, will abort if `SUPABASE_SERVICE_ROLE_KEY` is missing or blank; no fallback credentials are embedded.
+
 ### Local Development Setup
 
 1. **Install Supabase CLI**:

--- a/scripts/admin-password-reset.js
+++ b/scripts/admin-password-reset.js
@@ -15,14 +15,22 @@ config();
 
 const SUPABASE_URL_FALLBACK = 'https://wnnjeqheqxxyrgsjmygy.supabase.co';
 
-export function resolveSupabaseServiceKey(env = process.env) {
-  const key = env.SUPABASE_SERVICE_ROLE_KEY;
+function normalizeServiceRoleKey(key) {
+  if (typeof key !== 'string') {
+    return '';
+  }
 
-  if (!key) {
+  return key.trim();
+}
+
+export function resolveSupabaseServiceKey(env = process.env) {
+  const normalizedKey = normalizeServiceRoleKey(env.SUPABASE_SERVICE_ROLE_KEY);
+
+  if (!normalizedKey) {
     throw new Error('SUPABASE_SERVICE_ROLE_KEY environment variable is required to run this script.');
   }
 
-  return key;
+  return normalizedKey;
 }
 
 let cachedSupabaseClient;

--- a/src/scripts/__tests__/secret-guards.test.ts
+++ b/src/scripts/__tests__/secret-guards.test.ts
@@ -29,6 +29,20 @@ describe('resolveSupabaseServiceKey', () => {
     expect(() => module.resolveSupabaseServiceKey()).toThrowError(/SUPABASE_SERVICE_ROLE_KEY/);
   });
 
+  it('throws when the key is only whitespace', async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = '   ';
+    const module = await import('../../../scripts/admin-password-reset.js');
+
+    expect(() => module.resolveSupabaseServiceKey()).toThrowError(/SUPABASE_SERVICE_ROLE_KEY/);
+  });
+
+  it('trims surrounding whitespace from the configured key', async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = '  padded-key  ';
+    const module = await import('../../../scripts/admin-password-reset.js');
+
+    expect(module.resolveSupabaseServiceKey()).toBe('padded-key');
+  });
+
   it('supports supplying an explicit environment map', async () => {
     const module = await import('../../../scripts/admin-password-reset.js');
 


### PR DESCRIPTION
### Summary
Harden the admin password reset flow so it fails fast without an explicitly supplied service role key and document the expectation for operators.

### Proposed changes
- Trim and validate the Supabase service role key in the admin password reset script, throwing if the value is missing or blank
- Extend the secret guard unit tests to cover whitespace-only and padded keys
- Clarify in the README and operations documentation that the service role key must be provided through environment variables because no fallback is bundled

### Tests added/updated
- src/scripts/__tests__/secret-guards.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68c9dec3e8708332b41ca715e4cd903d