### PR TITLE
feat: enforce session idempotency – 2025-09-17

### DIFF
--- a/src/lib/__tests__/idempotencyService.test.ts
+++ b/src/lib/__tests__/idempotencyService.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInMemoryIdempotencyService,
+  hashResponse,
+  IdempotencyConflictError,
+} from "../../../supabase/functions/_shared/idempotency.ts";
+
+const ENDPOINT = "sessions-hold";
+
+describe("hashResponse", () => {
+  it("produces a stable hash for identical payloads", async () => {
+    const first = await hashResponse({ success: true }, 200);
+    const second = await hashResponse({ success: true }, 200);
+    expect(first).toEqual(second);
+  });
+
+  it("changes hash when payload or status differ", async () => {
+    const hashA = await hashResponse({ success: true }, 200);
+    const hashB = await hashResponse({ success: true }, 201);
+    const hashC = await hashResponse({ success: false }, 200);
+
+    expect(hashA).not.toEqual(hashB);
+    expect(hashA).not.toEqual(hashC);
+  });
+});
+
+describe("IdempotencyService", () => {
+  it("stores and retrieves responses", async () => {
+    const service = createInMemoryIdempotencyService();
+
+    const body = { success: true, data: { value: 1 } };
+    const stored = await service.persist("key-1", ENDPOINT, body, 200);
+    expect(stored.responseBody).toEqual(body);
+    expect(stored.statusCode).toBe(200);
+
+    const fetched = await service.find("key-1", ENDPOINT);
+    expect(fetched).toEqual(stored);
+  });
+
+  it("returns existing record when same payload is persisted", async () => {
+    const service = createInMemoryIdempotencyService();
+    const body = { success: true };
+
+    const first = await service.persist("key-2", ENDPOINT, body, 200);
+    const second = await service.persist("key-2", ENDPOINT, body, 200);
+
+    expect(second).toEqual(first);
+  });
+
+  it("throws when payload differs for the same key", async () => {
+    const service = createInMemoryIdempotencyService();
+    await service.persist("key-3", ENDPOINT, { success: true }, 200);
+
+    await expect(
+      service.persist("key-3", ENDPOINT, { success: false }, 200),
+    ).rejects.toBeInstanceOf(IdempotencyConflictError);
+  });
+});

--- a/supabase/functions/_shared/idempotency.ts
+++ b/supabase/functions/_shared/idempotency.ts
@@ -1,0 +1,220 @@
+import type { PostgrestError, SupabaseClient } from "npm:@supabase/supabase-js@2.50.0";
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[];
+
+export interface StoredIdempotencyResponse<T extends Json = Json> {
+  key: string;
+  endpoint: string;
+  responseHash: string;
+  responseBody: T;
+  statusCode: number;
+}
+
+export interface IdempotencyAdapter<T extends Json = Json> {
+  get(key: string, endpoint: string): Promise<StoredIdempotencyResponse<T> | null>;
+  set(record: StoredIdempotencyResponse<T>): Promise<StoredIdempotencyResponse<T>>;
+}
+
+export class IdempotencyConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IdempotencyConflictError";
+  }
+}
+
+function normalize(value: Json): Json {
+  if (Array.isArray(value)) {
+    return value.map(item => normalize(item));
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, Json>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, val]) => [key, normalize(val)] as const);
+
+    return entries.reduce<Record<string, Json>>((acc, [key, val]) => {
+      acc[key] = val;
+      return acc;
+    }, {});
+  }
+
+  return value;
+}
+
+function cloneJson<T extends Json>(value: T): T {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export async function hashResponse(body: Json, statusCode: number): Promise<string> {
+  const encoder = new TextEncoder();
+  const canonical = normalize({ body, statusCode });
+  const payload = encoder.encode(JSON.stringify(canonical));
+  const digest = await crypto.subtle.digest("SHA-256", payload);
+  return Array.from(new Uint8Array(digest))
+    .map(byte => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+class SupabaseIdempotencyAdapter implements IdempotencyAdapter {
+  private static readonly TABLE = "function_idempotency_keys";
+
+  constructor(private readonly client: SupabaseClient) {}
+
+  async get(key: string, endpoint: string): Promise<StoredIdempotencyResponse | null> {
+    const { data, error } = await this.client
+      .from(SupabaseIdempotencyAdapter.TABLE)
+      .select("endpoint, idempotency_key, response_hash, response_body, status_code")
+      .eq("idempotency_key", key)
+      .eq("endpoint", endpoint)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(error.message ?? "Failed to fetch idempotency record");
+    }
+
+    if (!data) {
+      return null;
+    }
+
+    return {
+      key: data.idempotency_key as string,
+      endpoint: data.endpoint as string,
+      responseHash: data.response_hash as string,
+      responseBody: data.response_body as Json,
+      statusCode: data.status_code as number,
+    };
+  }
+
+  async set(record: StoredIdempotencyResponse): Promise<StoredIdempotencyResponse> {
+    const row = {
+      idempotency_key: record.key,
+      endpoint: record.endpoint,
+      response_hash: record.responseHash,
+      response_body: cloneJson(record.responseBody),
+      status_code: record.statusCode,
+    };
+
+    const { data, error } = await this.client
+      .from(SupabaseIdempotencyAdapter.TABLE)
+      .insert(row)
+      .select("endpoint, idempotency_key, response_hash, response_body, status_code")
+      .single();
+
+    if (error) {
+      if ((error as PostgrestError).code === "23505") {
+        const existing = await this.get(record.key, record.endpoint);
+        if (existing && existing.responseHash === record.responseHash) {
+          return existing;
+        }
+        throw new IdempotencyConflictError("Idempotency key already used with a different response");
+      }
+      throw new Error(error.message ?? "Failed to store idempotency response");
+    }
+
+    return {
+      key: data.idempotency_key as string,
+      endpoint: data.endpoint as string,
+      responseHash: data.response_hash as string,
+      responseBody: data.response_body as Json,
+      statusCode: data.status_code as number,
+    };
+  }
+}
+
+class MemoryIdempotencyAdapter implements IdempotencyAdapter {
+  private readonly store = new Map<string, StoredIdempotencyResponse>();
+
+  constructor(initial?: StoredIdempotencyResponse[]) {
+    initial?.forEach(record => {
+      const key = this.composeKey(record.key, record.endpoint);
+      this.store.set(key, {
+        ...record,
+        responseBody: cloneJson(record.responseBody),
+      });
+    });
+  }
+
+  async get(key: string, endpoint: string): Promise<StoredIdempotencyResponse | null> {
+    const record = this.store.get(this.composeKey(key, endpoint));
+    if (!record) {
+      return null;
+    }
+
+    return {
+      ...record,
+      responseBody: cloneJson(record.responseBody),
+    };
+  }
+
+  async set(record: StoredIdempotencyResponse): Promise<StoredIdempotencyResponse> {
+    const key = this.composeKey(record.key, record.endpoint);
+    const existing = this.store.get(key);
+
+    if (existing) {
+      if (existing.responseHash !== record.responseHash) {
+        throw new IdempotencyConflictError("Idempotency key already used with a different response");
+      }
+      return {
+        ...existing,
+        responseBody: cloneJson(existing.responseBody),
+      };
+    }
+
+    const copy: StoredIdempotencyResponse = {
+      ...record,
+      responseBody: cloneJson(record.responseBody),
+    };
+    this.store.set(key, copy);
+
+    return {
+      ...copy,
+      responseBody: cloneJson(copy.responseBody),
+    };
+  }
+
+  private composeKey(key: string, endpoint: string): string {
+    return `${endpoint}::${key}`;
+  }
+}
+
+export class IdempotencyService<T extends Json = Json> {
+  constructor(private readonly adapter: IdempotencyAdapter<T>) {}
+
+  async find(key: string, endpoint: string): Promise<StoredIdempotencyResponse<T> | null> {
+    return this.adapter.get(key, endpoint);
+  }
+
+  async persist(
+    key: string,
+    endpoint: string,
+    responseBody: T,
+    statusCode: number,
+  ): Promise<StoredIdempotencyResponse<T>> {
+    const responseHash = await hashResponse(responseBody, statusCode);
+    return this.adapter.set({
+      key,
+      endpoint,
+      responseHash,
+      responseBody,
+      statusCode,
+    });
+  }
+}
+
+export function createSupabaseIdempotencyService(client: SupabaseClient): IdempotencyService {
+  return new IdempotencyService(new SupabaseIdempotencyAdapter(client));
+}
+
+export function createInMemoryIdempotencyService(initial?: StoredIdempotencyResponse[]): IdempotencyService {
+  return new IdempotencyService(new MemoryIdempotencyAdapter(initial));
+}

--- a/supabase/migrations/20250910T_idempotency_store.sql
+++ b/supabase/migrations/20250910T_idempotency_store.sql
@@ -1,0 +1,24 @@
+-- Idempotency key store for edge functions
+set search_path = public;
+
+create table if not exists function_idempotency_keys (
+  id uuid primary key default gen_random_uuid(),
+  endpoint text not null,
+  idempotency_key text not null,
+  response_hash text not null,
+  response_body jsonb not null,
+  status_code integer not null default 200,
+  created_at timestamptz not null default timezone('utc', now()),
+  unique(endpoint, idempotency_key)
+);
+
+alter table function_idempotency_keys enable row level security;
+
+create policy if not exists "function_idempotency_keys_disallow_all"
+  on function_idempotency_keys
+  for all
+  using (false)
+  with check (false);
+
+create index if not exists function_idempotency_keys_endpoint_created_idx
+  on function_idempotency_keys (endpoint, created_at desc);


### PR DESCRIPTION
### Summary
Add persistent idempotency handling to the session scheduling edge functions and client helpers.

### Proposed changes
- Introduce a reusable Supabase idempotency service with backing table storage and hashed responses.
- Update sessions-hold, sessions-confirm, and new sessions-cancel edge functions to honor the `Idempotency-Key` header and replay stored results.
- Extend client helpers, tests, and documentation to cover idempotent hold/confirm/cancel flows.

### Tests added/updated
- src/lib/__tests__/idempotencyService.test.ts
- src/lib/__tests__/sessionHolds.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68ca0126d5b48332b95fdb11c54b2fee