### PR TITLE
feat: transactional session cancellation – 2025-09-17

### DIFF
--- a/src/lib/__tests__/sessionCancellation.test.ts
+++ b/src/lib/__tests__/sessionCancellation.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cancelSessions } from "../sessionCancellation";
+import { callEdge } from "../supabase";
+
+vi.mock("../supabase", () => ({
+  callEdge: vi.fn(),
+}));
+
+const mockedCallEdge = vi.mocked(callEdge);
+
+const jsonResponse = (
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+
+describe("cancelSessions", () => {
+  beforeEach(() => {
+    mockedCallEdge.mockReset();
+  });
+
+  it("cancels sessions by id and returns summary", async () => {
+    mockedCallEdge.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          success: true,
+          data: {
+            cancelledCount: 2,
+            alreadyCancelledCount: 1,
+            totalCount: 3,
+            cancelledSessionIds: ["s1", "s2"],
+            alreadyCancelledSessionIds: ["s3"],
+          },
+        },
+        200,
+        { "Idempotency-Key": "custom-key" },
+      ),
+    );
+
+    const result = await cancelSessions({
+      sessionIds: ["s1", "s2"],
+      idempotencyKey: "custom-key",
+    });
+
+    expect(result).toEqual({
+      cancelledCount: 2,
+      alreadyCancelledCount: 1,
+      totalCount: 3,
+      cancelledSessionIds: ["s1", "s2"],
+      alreadyCancelledSessionIds: ["s3"],
+      idempotencyKey: "custom-key",
+    });
+
+    expect(mockedCallEdge).toHaveBeenCalledWith(
+      "sessions-cancel",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    const requestInit = mockedCallEdge.mock.calls[0][1];
+    const headers = requestInit?.headers as Headers;
+    expect(headers.get("Idempotency-Key")).toBe("custom-key");
+
+    const body = JSON.parse(requestInit?.body as string);
+    expect(body.session_ids).toEqual(["s1", "s2"]);
+  });
+
+  it("generates an idempotency key when not provided", async () => {
+    mockedCallEdge.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          success: true,
+          data: {
+            cancelledCount: 0,
+            alreadyCancelledCount: 0,
+            totalCount: 0,
+            cancelledSessionIds: [],
+            alreadyCancelledSessionIds: [],
+          },
+        },
+        200,
+        {},
+      ),
+    );
+
+    await cancelSessions({ date: "2025-03-18" });
+
+    const requestInit = mockedCallEdge.mock.calls[0][1];
+    const headers = requestInit?.headers as Headers;
+    expect(headers.get("Idempotency-Key")).toBeTruthy();
+    const body = JSON.parse(requestInit?.body as string);
+    expect(body.date).toBe("2025-03-18");
+  });
+
+  it("throws when the API responds with an error", async () => {
+    mockedCallEdge.mockResolvedValueOnce(
+      jsonResponse({ success: false, error: "bad request" }, 400),
+    );
+
+    await expect(cancelSessions({ sessionIds: ["s1"] })).rejects.toThrow(
+      /bad request/i,
+    );
+  });
+});

--- a/src/lib/sessionCancellation.ts
+++ b/src/lib/sessionCancellation.ts
@@ -1,0 +1,116 @@
+import { callEdge } from "./supabase";
+
+export interface CancelSessionsPayload {
+  sessionIds?: string[];
+  date?: string;
+  therapistId?: string;
+  reason?: string | null;
+  idempotencyKey?: string;
+}
+
+export interface CancelSessionsResult {
+  cancelledCount: number;
+  alreadyCancelledCount: number;
+  totalCount: number;
+  cancelledSessionIds: string[];
+  alreadyCancelledSessionIds: string[];
+  idempotencyKey: string;
+}
+
+function createIdempotencyKey(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (typeof item === "number" || typeof item === "bigint") return String(item);
+      return "";
+    })
+    .filter((item): item is string => item.length > 0);
+}
+
+export async function cancelSessions(payload: CancelSessionsPayload): Promise<CancelSessionsResult> {
+  if ((!payload.sessionIds || payload.sessionIds.length === 0) && !payload.date) {
+    throw new Error("Must provide a session id list or date to cancel sessions");
+  }
+
+  const idempotencyKey = (payload.idempotencyKey ?? createIdempotencyKey()).trim();
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (idempotencyKey.length > 0) {
+    headers.set("Idempotency-Key", idempotencyKey);
+  }
+
+  const body: Record<string, unknown> = {};
+  if (payload.sessionIds && payload.sessionIds.length > 0) {
+    body.session_ids = payload.sessionIds;
+  }
+  if (payload.date) {
+    body.date = payload.date;
+  }
+  if (payload.therapistId) {
+    body.therapist_id = payload.therapistId;
+  }
+  if (payload.reason !== undefined) {
+    body.reason = payload.reason;
+  }
+
+  const response = await callEdge("sessions-cancel", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  let responseBody: Record<string, unknown> | null = null;
+  try {
+    responseBody = (await response.json()) as Record<string, unknown>;
+  } catch (error) {
+    console.error("Failed to parse sessions-cancel response", error);
+  }
+
+  if (!responseBody || responseBody.success !== true || !response.ok) {
+    const errorMessage = typeof responseBody?.error === "string"
+      ? responseBody.error
+      : "Failed to cancel sessions";
+    throw new Error(errorMessage);
+  }
+
+  const data = (responseBody.data ?? {}) as Record<string, unknown>;
+
+  const cancelledCount = typeof data.cancelledCount === "number"
+    ? data.cancelledCount
+    : Number(data.cancelled_count ?? 0);
+  const alreadyCancelledCount = typeof data.alreadyCancelledCount === "number"
+    ? data.alreadyCancelledCount
+    : Number(data.already_cancelled_count ?? 0);
+  const totalCount = typeof data.totalCount === "number"
+    ? data.totalCount
+    : Number(data.total_count ?? cancelledCount + alreadyCancelledCount);
+
+  const cancelledSessionIds = normalizeStringArray(
+    data.cancelledSessionIds ?? data.cancelled_session_ids,
+  );
+  const alreadyCancelledSessionIds = normalizeStringArray(
+    data.alreadyCancelledSessionIds ?? data.already_cancelled_session_ids,
+  );
+
+  const usedKey = response.headers.get("Idempotency-Key")?.trim() || idempotencyKey;
+
+  return {
+    cancelledCount: Number.isNaN(cancelledCount) ? 0 : cancelledCount,
+    alreadyCancelledCount: Number.isNaN(alreadyCancelledCount) ? 0 : alreadyCancelledCount,
+    totalCount: Number.isNaN(totalCount) ? cancelledCount + alreadyCancelledCount : totalCount,
+    cancelledSessionIds,
+    alreadyCancelledSessionIds,
+    idempotencyKey: usedKey,
+  };
+}


### PR DESCRIPTION
### Summary
Add an idempotent session cancellation flow and route UI calls through it.

### Proposed changes
- extend the `sessions-cancel` edge function to update sessions inside a transactional request path
- add a shared `cancelSessions` helper used by the Schedule page and ChatBot to drive cancellations
- cover the new flow with unit tests for the helper and ChatBot action handling

### Tests added/updated
- src/lib/__tests__/sessionCancellation.test.ts
- src/components/__tests__/ChatBot.test.tsx

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68ca1323788083329144bd9c51bb5293