### PR TITLE
feat: enforce phi-safe logging guard – 2025-09-17

### DIFF
--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -57,7 +57,7 @@ describe('logger', () => {
   });
 
   it('sanitizes metadata before logging info', () => {
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info');
 
     try {
       logger.info('Client Name: Jane Doe', {
@@ -74,7 +74,7 @@ describe('logger', () => {
   });
 
   it('forwards sanitized errors to the error tracker', () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error');
     const trackErrorSpy = vi.mocked(errorTracker.trackError);
 
     const originalError = new Error('Client email john@example.com failed validation');
@@ -101,7 +101,7 @@ describe('logger', () => {
   });
 
   it('respects the track=false option', () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error');
     const trackErrorSpy = vi.mocked(errorTracker.trackError);
 
     try {

--- a/src/lib/__tests__/loggerRedaction.test.ts
+++ b/src/lib/__tests__/loggerRedaction.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../errorTracking', () => ({
+  errorTracker: {
+    trackError: vi.fn()
+  }
+}));
+
+import { logger } from '../logger/logger';
+import { REDACTED_VALUE } from '../logger/redactPhi';
+import { getConsoleGuard } from '../../test/utils/consoleGuard';
+import { errorTracker } from '../errorTracking';
+
+const guard = getConsoleGuard();
+
+describe('logger redaction with console guard', () => {
+  beforeEach(() => {
+    guard.resetCapturedLogs();
+    vi.clearAllMocks();
+  });
+
+  it('masks PHI tokens in both message and metadata when using the safe logger', () => {
+    logger.info(
+      'Creating session for jane.doe@example.com with MRN: MRN-778899 and diagnosis: F84.0 at 555-987-6543',
+      {
+        metadata: {
+          email: 'jane.doe@example.com',
+          phone_number: '(555) 987-6543',
+          mrn: 'MRN-778899',
+          diagnosis: 'F84.0',
+          guardian: {
+            contact_email: 'guardian@example.com',
+            mobile: '+1 (555) 222-3333'
+          }
+        }
+      }
+    );
+
+    const captured = guard.getCapturedLogs('info');
+    expect(captured).toHaveLength(1);
+    const combined = captured[0];
+
+    expect(combined).toContain(REDACTED_VALUE);
+    expect(combined).not.toMatch(/jane\.doe@example\.com/i);
+    expect(combined).not.toMatch(/guardian@example\.com/i);
+    expect(combined).not.toMatch(/MRN-778899/i);
+    expect(combined).not.toMatch(/555-987-6543/);
+    expect(combined).not.toMatch(/\bF84\.0\b/);
+    expect(combined).toContain('"email": "****"');
+    expect(combined).toContain('"mrn": "****"');
+    expect(combined).toContain('"phone_number": "****"');
+  });
+
+  it('sanitizes error payloads before forwarding them to the console and tracker', () => {
+    const sensitiveError = new Error('Encountered MRN: 445566 with email leak@example.com');
+
+    logger.error('Failed to process leak@example.com for MRN: 445566', {
+      error: sensitiveError,
+      metadata: {
+        email_address: 'leak@example.com',
+        phone: '415-555-9999',
+        diagnosis: 'F90.2'
+      }
+    });
+
+    const captured = guard.getCapturedLogs('error');
+    expect(captured).toHaveLength(1);
+    const combined = captured[0];
+
+    expect(combined).not.toMatch(/leak@example\.com/);
+    expect(combined).not.toMatch(/445566/);
+    expect(combined).not.toMatch(/415-555-9999/);
+    expect(combined).not.toMatch(/\bF90\.2\b/);
+    expect(combined).toContain(REDACTED_VALUE);
+
+    const trackErrorSpy = vi.mocked(errorTracker.trackError);
+    expect(trackErrorSpy).toHaveBeenCalledTimes(1);
+    const [trackedError, context] = trackErrorSpy.mock.calls[0];
+    expect(trackedError).toBeInstanceOf(Error);
+    expect((trackedError as Error).message).not.toContain('leak@example.com');
+    expect((trackedError as Error).message).toContain(REDACTED_VALUE);
+    expect(JSON.stringify(context)).not.toContain('415-555-9999');
+  });
+
+  it('throws when console output contains unredacted PHI', () => {
+    expect(() => console.warn('Reach client at 212-555-0101 or jane.raw@example.com')).toThrowError(
+      /ConsoleGuard detected potential/,
+    );
+    expect(guard.getCapturedLogs()).toHaveLength(0);
+  });
+});

--- a/src/lib/logger/README.md
+++ b/src/lib/logger/README.md
@@ -1,0 +1,30 @@
+# Logger Redaction Safety
+
+This package provides the PHI-safe logging utilities (`logger` and `redactPhi`) used across the
+application. All logging must flow through the safe logger so that structured metadata and freeform
+messages are sanitized before reaching telemetry, stdout, or the Vitest console.
+
+## Test-time PHI guard
+
+Vitest installs the console guard defined in `src/test/utils/consoleGuard.ts`. The guard wraps
+`console.log`, `console.info`, `console.warn`, `console.error`, and `console.debug` during tests and
+throws if a log message still contains unmasked protected health information (PHI). Guarded logs are
+captured so tests can assert that only the masked value (`****`) appears in output.
+
+If a test needs to extend the detection logic (for example, to cover a new type of identifier), add a
+pattern to the exported `DEFAULT_CONSOLE_GUARD_PATTERNS` array and update any fixtures that rely on
+the new token. The guard clones the patterns at install time, so edits to the defaults will apply to
+all future test runs.
+
+## Extending the redaction rules
+
+When new PHI fields are introduced, make sure that:
+
+1. The key or pattern is covered in `src/lib/logger/redactPhi.ts` by adding to `EXACT_SENSITIVE_KEYS`,
+   `KEYWORD_FRAGMENTS`, `SENSITIVE_SUFFIXES`, or the direct regular-expression patterns.
+2. The same token shape is reflected in `src/test/utils/consoleGuard.ts` so the Vitest console guard
+   can block regressions.
+3. Tests in `src/lib/__tests__/loggerRedaction.test.ts` (or related suites) include a fixture for the
+   new PHI token to prove that the logger redacts it.
+
+Following these steps keeps runtime logging and automated tests aligned whenever the PHI catalog grows.

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,14 @@
-import { vi, beforeAll, afterEach, afterAll } from 'vitest';
+import { vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import '@testing-library/jest-dom';
+import { installConsoleGuard } from './utils/consoleGuard';
+
+const consoleGuard = installConsoleGuard({ passthrough: false });
+
+beforeEach(() => {
+  consoleGuard.resetCapturedLogs();
+});
 
 // Global, deterministic time for tests (fake Date only; keep real timers)
 vi.useFakeTimers({ toFake: ['Date'] });
@@ -467,6 +474,10 @@ afterEach(() => server.resetHandlers());
 
 // Close server after all tests
 afterAll(() => server.close());
+
+afterAll(() => {
+  consoleGuard.restore();
+});
 
 // Mock window.matchMedia for responsive design tests
 Object.defineProperty(window, 'matchMedia', {

--- a/src/test/utils/consoleGuard.ts
+++ b/src/test/utils/consoleGuard.ts
@@ -1,0 +1,204 @@
+export type ConsoleMethodName = 'log' | 'info' | 'warn' | 'error' | 'debug';
+
+export interface GuardPattern {
+  label: string;
+  expression: RegExp;
+  description?: string;
+}
+
+export interface ConsoleGuard {
+  getCapturedLogs(method?: ConsoleMethodName): string[];
+  resetCapturedLogs(): void;
+  restore(): void;
+  getPatterns(): GuardPattern[];
+  addPatterns(...patterns: GuardPattern[]): void;
+}
+
+export interface ConsoleGuardOptions {
+  patterns?: GuardPattern[];
+  passthrough?: boolean;
+}
+
+const DEFAULT_PATTERNS: GuardPattern[] = [
+  {
+    label: 'email address',
+    expression: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i,
+    description: 'Standard RFC5322-like emails'
+  },
+  {
+    label: 'US phone number',
+    expression: /\b(?:\+?1[-.\s]*)?(?:\(\d{3}\)|\d{3})[-.\s]*\d{3}[-.\s]*\d{4}\b/,
+    description: 'North American phone numbers with optional country code'
+  },
+  {
+    label: 'medical record number',
+    expression: /\b(?:mrn|medical\s*record\s*number)\s*(?:[#:=]\s*)?(?!\*{2,})(?=[A-Z0-9-]*\d)[A-Z0-9-]{4,}\b/i,
+    description: 'MRN tokens that are not already redacted'
+  },
+  {
+    label: 'ICD-10 diagnosis code',
+    expression: /\b[ABDEFGHJKLMNPRSTVWXYZ]\d{2}(?:\.\d{1,4})?\b/i,
+    description: 'ICD-10 style diagnosis identifiers (e.g., F84.0)'
+  },
+  {
+    label: 'US social security number',
+    expression: /\b\d{3}-\d{2}-\d{4}\b/,
+    description: 'SSA formatted identifiers'
+  }
+];
+
+const METHOD_NAMES: ConsoleMethodName[] = ['log', 'info', 'warn', 'error', 'debug'];
+
+const clonePattern = (pattern: GuardPattern): GuardPattern => ({
+  label: pattern.label,
+  expression: new RegExp(pattern.expression.source, pattern.expression.flags),
+  description: pattern.description
+});
+
+const maskRedactedValues = (value: string): string => value.replace(/\*{4,}/g, 'MASK');
+
+const buildSerializer = () => {
+  const seen = new WeakSet<object>();
+  return (_key: string, value: unknown): unknown => {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+    if (typeof value === 'function') {
+      return `[Function ${value.name || 'anonymous'}]`;
+    }
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value as object)) {
+        return '[Circular]';
+      }
+      seen.add(value as object);
+    }
+    return value;
+  };
+};
+
+const safeSerialize = (input: unknown): string => {
+  if (input === null || input === undefined) {
+    return '';
+  }
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (typeof input === 'number' || typeof input === 'boolean' || typeof input === 'bigint') {
+    return String(input);
+  }
+  if (typeof input === 'symbol') {
+    return input.toString();
+  }
+  if (input instanceof Error) {
+    const message = input.message ?? input.toString();
+    const stack = typeof input.stack === 'string' ? `\n${input.stack}` : '';
+    return `${input.name}: ${message}${stack}`;
+  }
+  try {
+    return JSON.stringify(input, buildSerializer(), 2);
+  } catch (error) {
+    return `[unserializable:${(error as Error)?.message ?? String(error)}]`;
+  }
+};
+
+const findPhiPattern = (payload: string, patterns: GuardPattern[]): GuardPattern | undefined => {
+  const candidate = maskRedactedValues(payload);
+  return patterns.find((pattern) => pattern.expression.test(candidate));
+};
+
+interface InternalConsoleGuard extends ConsoleGuard {
+  patterns: GuardPattern[];
+  passthrough: boolean;
+  originals: Map<ConsoleMethodName, Console[ConsoleMethodName]>;
+  captured: Map<ConsoleMethodName, string[]>;
+}
+
+let activeGuard: InternalConsoleGuard | undefined;
+
+const installGuardImplementation = (options?: ConsoleGuardOptions): InternalConsoleGuard => {
+  const patterns = (options?.patterns ?? DEFAULT_PATTERNS).map(clonePattern);
+  const originals = new Map<ConsoleMethodName, Console[ConsoleMethodName]>();
+  const captured = new Map<ConsoleMethodName, string[]>(
+    METHOD_NAMES.map((method) => [method, []])
+  );
+  const passthrough = options?.passthrough ?? false;
+
+  const guardedCall = (method: ConsoleMethodName, ...args: unknown[]): void => {
+    const serialized = args.map((value) => safeSerialize(value)).join(' ');
+    const violation = findPhiPattern(serialized, patterns);
+
+    if (violation) {
+      throw new Error(`ConsoleGuard detected potential ${violation.label} in console output: ${serialized}`);
+    }
+
+    captured.get(method)?.push(serialized);
+
+    if (passthrough) {
+      originals.get(method)?.apply(console, args as never);
+    }
+  };
+
+  METHOD_NAMES.forEach((method) => {
+    originals.set(method, console[method].bind(console));
+    Object.defineProperty(console, method, {
+      configurable: true,
+      writable: true,
+      value: (...args: unknown[]) => guardedCall(method, ...args)
+    });
+  });
+
+  return {
+    patterns,
+    passthrough,
+    originals,
+    captured,
+    getCapturedLogs: (method?: ConsoleMethodName) => {
+      if (method) {
+        return [...(captured.get(method) ?? [])];
+      }
+      return METHOD_NAMES.flatMap((name) => captured.get(name) ?? []);
+    },
+    resetCapturedLogs: () => {
+      METHOD_NAMES.forEach((name) => {
+        captured.set(name, []);
+      });
+    },
+    restore: () => {
+      METHOD_NAMES.forEach((method) => {
+        const original = originals.get(method);
+        if (original) {
+          Object.defineProperty(console, method, {
+            configurable: true,
+            writable: true,
+            value: original
+          });
+        }
+      });
+      METHOD_NAMES.forEach((name) => captured.set(name, []));
+      activeGuard = undefined;
+    },
+    getPatterns: () => patterns.map(clonePattern),
+    addPatterns: (...additional: GuardPattern[]) => {
+      additional.forEach((pattern) => {
+        patterns.push(clonePattern(pattern));
+      });
+    }
+  };
+};
+
+export const installConsoleGuard = (options?: ConsoleGuardOptions): ConsoleGuard => {
+  if (activeGuard) {
+    return activeGuard;
+  }
+  activeGuard = installGuardImplementation(options);
+  return activeGuard;
+};
+
+export const getConsoleGuard = (): ConsoleGuard => {
+  if (!activeGuard) {
+    throw new Error('Console guard has not been installed. Ensure installConsoleGuard() runs in setup.');
+  }
+  return activeGuard;
+};
+
+export const DEFAULT_CONSOLE_GUARD_PATTERNS = DEFAULT_PATTERNS.map(clonePattern);


### PR DESCRIPTION
### Summary
Add automated PHI guardrails around console logging to ensure redaction stays enforced during tests.

### Proposed changes
- Introduce a reusable console guard utility that detects PHI patterns and captures sanitized logs.
- Wire the guard into the global Vitest setup and extend logger tests with coverage for redaction failures.
- Document the workflow for extending PHI patterns across the logger and guard implementations.

### Tests added/updated
- src/lib/__tests__/loggerRedaction.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cb1107cf3c833286d8426e54caa9c5