### PR TITLE
feat: add cpt billing metadata – 2025-09-18

### DIFF
--- a/supabase/migrations/20250920120000_create_cpt_master_tables.sql
+++ b/supabase/migrations/20250920120000_create_cpt_master_tables.sql
@@ -1,0 +1,94 @@
+/*
+  # Introduce CPT master data
+
+  1. New Tables
+    - `cpt_codes`
+      - Stores CPT code metadata leveraged by scheduling and billing flows
+      - Enforces uniqueness on CPT code values
+
+  2. Security
+    - Enable row level security
+    - Allow authenticated users to read CPT metadata
+    - Allow the service role to manage CPT metadata for administrative tooling
+
+  3. Performance
+    - Adds an index for efficient lookups by CPT code
+
+  4. Seed Data
+    - Inserts common ABA therapy CPT codes with descriptions and duration hints
+*/
+
+CREATE TABLE public.cpt_codes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL,
+  short_description text NOT NULL,
+  long_description text,
+  service_setting text,
+  typical_duration_minutes integer,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT cpt_codes_code_unique UNIQUE (code)
+);
+
+ALTER TABLE public.cpt_codes
+  ADD CONSTRAINT cpt_codes_typical_duration_positive
+  CHECK (
+    typical_duration_minutes IS NULL
+    OR typical_duration_minutes > 0
+  );
+
+CREATE INDEX cpt_codes_code_idx ON public.cpt_codes (code);
+CREATE INDEX cpt_codes_active_idx ON public.cpt_codes (is_active) WHERE is_active;
+
+ALTER TABLE public.cpt_codes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated users can read CPT codes"
+  ON public.cpt_codes
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Service role can manage CPT codes"
+  ON public.cpt_codes
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+INSERT INTO public.cpt_codes (
+  code,
+  short_description,
+  long_description,
+  service_setting,
+  typical_duration_minutes
+) VALUES
+  (
+    '97151',
+    'ABA assessment by BCBA',
+    'Behavior identification assessment administered by a qualified health care professional for ABA services.',
+    'Assessment',
+    120
+  ),
+  (
+    '97153',
+    'Adaptive behavior treatment',
+    'Adaptive behavior treatment with protocol modification delivered by technician under direction of qualified professional.',
+    'Direct treatment',
+    60
+  ),
+  (
+    '97155',
+    'Adaptive treatment w/ protocol modification',
+    'Adaptive behavior treatment with protocol modification administered by qualified professional.',
+    'Supervision',
+    60
+  ),
+  (
+    '97156',
+    'Family adaptive behavior treatment guidance',
+    'Family adaptive behavior treatment guidance performed by qualified health care professional (typically parent training).',
+    'Caregiver training',
+    60
+  )
+ON CONFLICT (code) DO NOTHING;

--- a/supabase/migrations/20250920120100_create_cpt_modifier_associations.sql
+++ b/supabase/migrations/20250920120100_create_cpt_modifier_associations.sql
@@ -1,0 +1,129 @@
+/*
+  # Introduce CPT modifier catalog and associations
+
+  1. New Tables
+    - `billing_modifiers`
+      - Stores modifier metadata
+    - `cpt_modifier_mappings`
+      - Bridges CPT codes to their valid modifiers
+
+  2. Security
+    - Enable RLS across both tables
+    - Allow authenticated users to read modifier metadata
+    - Delegate write access to the service role for administrative tooling
+
+  3. Performance
+    - Adds indexes to accelerate lookups by code and associations
+
+  4. Seed Data
+    - Inserts common ABA billing modifiers and associates them with CPT codes
+*/
+
+CREATE TABLE public.billing_modifiers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL,
+  description text NOT NULL,
+  billing_note text,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT billing_modifiers_code_unique UNIQUE (code)
+);
+
+ALTER TABLE public.billing_modifiers
+  ADD CONSTRAINT billing_modifiers_code_format
+  CHECK (code ~ '^[A-Z0-9]{2,4}$');
+
+CREATE INDEX billing_modifiers_code_idx ON public.billing_modifiers (code);
+CREATE INDEX billing_modifiers_active_idx ON public.billing_modifiers (is_active) WHERE is_active;
+
+ALTER TABLE public.billing_modifiers ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated users can read billing modifiers"
+  ON public.billing_modifiers
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Service role can manage billing modifiers"
+  ON public.billing_modifiers
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE TABLE public.cpt_modifier_mappings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  cpt_code_id uuid NOT NULL REFERENCES public.cpt_codes(id) ON DELETE CASCADE,
+  modifier_id uuid NOT NULL REFERENCES public.billing_modifiers(id) ON DELETE CASCADE,
+  is_required boolean NOT NULL DEFAULT false,
+  is_default boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT cpt_modifier_unique UNIQUE (cpt_code_id, modifier_id)
+);
+
+CREATE INDEX cpt_modifier_mappings_cpt_code_id_idx
+  ON public.cpt_modifier_mappings (cpt_code_id);
+CREATE INDEX cpt_modifier_mappings_modifier_id_idx
+  ON public.cpt_modifier_mappings (modifier_id);
+CREATE UNIQUE INDEX cpt_modifier_default_unique
+  ON public.cpt_modifier_mappings (cpt_code_id)
+  WHERE is_default;
+
+ALTER TABLE public.cpt_modifier_mappings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated users can read CPT modifier mappings"
+  ON public.cpt_modifier_mappings
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Service role can manage CPT modifier mappings"
+  ON public.cpt_modifier_mappings
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+INSERT INTO public.billing_modifiers (code, description, billing_note)
+VALUES
+  ('HO', 'Master''s level clinician', 'Use for services provided by BCBA/BCBA-D.'),
+  ('HN', 'Bachelor''s level clinician', 'Use for services rendered by RBT/technician under supervision.'),
+  ('GT', 'Telehealth via interactive audio and video', 'Indicates service delivered through telehealth platform.'),
+  ('KX', 'Requirements met', 'Indicates that medical necessity and documentation requirements are satisfied.')
+ON CONFLICT (code) DO UPDATE
+  SET description = EXCLUDED.description,
+      billing_note = EXCLUDED.billing_note,
+      is_active = true,
+      updated_at = now();
+
+INSERT INTO public.cpt_modifier_mappings (
+  cpt_code_id,
+  modifier_id,
+  is_required,
+  is_default
+)
+SELECT
+  c.id AS cpt_code_id,
+  m.id AS modifier_id,
+  mapping.is_required,
+  mapping.is_default
+FROM (
+  VALUES
+    ('97151', 'HO', true, true),
+    ('97151', 'GT', false, false),
+    ('97153', 'HN', false, true),
+    ('97153', 'HO', false, false),
+    ('97153', 'GT', false, false),
+    ('97155', 'HO', true, true),
+    ('97155', 'KX', false, false),
+    ('97156', 'HO', false, true),
+    ('97156', 'GT', false, false)
+) AS mapping(cpt_code, modifier_code, is_required, is_default)
+JOIN public.cpt_codes c ON c.code = mapping.cpt_code
+JOIN public.billing_modifiers m ON m.code = mapping.modifier_code
+ON CONFLICT (cpt_code_id, modifier_id) DO UPDATE
+  SET is_required = EXCLUDED.is_required,
+      is_default = EXCLUDED.is_default,
+      updated_at = now();

--- a/supabase/migrations/20250920120200_create_session_cpt_linkages.sql
+++ b/supabase/migrations/20250920120200_create_session_cpt_linkages.sql
@@ -1,0 +1,301 @@
+/*
+  # Link sessions to CPT and modifier selections for billing
+
+  1. New Tables
+    - `session_cpt_entries`
+      - Stores CPT selections, units, and financial metadata per session
+    - `session_cpt_modifiers`
+      - Stores modifiers applied to each session CPT line
+
+  2. Security
+    - RLS enforces that therapists (or admins) only see data for sessions they own
+    - Service role can perform full CRUD for automation and integrations
+
+  3. Performance
+    - Adds indexes for frequent filtering (session, CPT, primary line lookups)
+
+  4. Developer Ergonomics
+    - Provides a view (`session_cpt_details_vw`) that joins CPT metadata and session context
+*/
+
+CREATE TABLE public.session_cpt_entries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES public.sessions(id) ON DELETE CASCADE,
+  cpt_code_id uuid NOT NULL REFERENCES public.cpt_codes(id) ON DELETE RESTRICT,
+  line_number integer NOT NULL DEFAULT 1,
+  units numeric(6,2) NOT NULL DEFAULT 1,
+  billed_minutes integer,
+  rate numeric(10,2),
+  is_primary boolean NOT NULL DEFAULT false,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT session_cpt_entries_line_unique UNIQUE (session_id, line_number)
+);
+
+ALTER TABLE public.session_cpt_entries
+  ADD CONSTRAINT session_cpt_entries_units_positive
+  CHECK (units > 0);
+
+ALTER TABLE public.session_cpt_entries
+  ADD CONSTRAINT session_cpt_entries_minutes_positive
+  CHECK (billed_minutes IS NULL OR billed_minutes > 0);
+
+CREATE INDEX session_cpt_entries_session_id_idx
+  ON public.session_cpt_entries (session_id);
+CREATE INDEX session_cpt_entries_cpt_code_id_idx
+  ON public.session_cpt_entries (cpt_code_id);
+CREATE UNIQUE INDEX session_cpt_entries_primary_unique
+  ON public.session_cpt_entries (session_id)
+  WHERE is_primary;
+
+ALTER TABLE public.session_cpt_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Session CPT entries accessible to therapists"
+  ON public.session_cpt_entries
+  FOR SELECT
+  TO authenticated
+  USING (
+    CASE
+      WHEN app.user_has_role('admin') THEN true
+      WHEN app.user_has_role('therapist') THEN EXISTS (
+        SELECT 1
+        FROM public.sessions s
+        WHERE s.id = session_cpt_entries.session_id
+          AND s.therapist_id = auth.uid()
+      )
+      ELSE false
+    END
+  );
+
+CREATE POLICY "Session CPT entries write access"
+  ON public.session_cpt_entries
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    CASE
+      WHEN app.user_has_role('admin') THEN true
+      WHEN app.user_has_role('therapist') THEN EXISTS (
+        SELECT 1
+        FROM public.sessions s
+        WHERE s.id = session_cpt_entries.session_id
+          AND s.therapist_id = auth.uid()
+      )
+      ELSE false
+    END
+  );
+
+CREATE POLICY "Session CPT entries update access"
+  ON public.session_cpt_entries
+  FOR UPDATE
+  TO authenticated
+  USING (
+    CASE
+      WHEN app.user_has_role('admin') THEN true
+      WHEN app.user_has_role('therapist') THEN EXISTS (
+        SELECT 1
+        FROM public.sessions s
+        WHERE s.id = session_cpt_entries.session_id
+          AND s.therapist_id = auth.uid()
+      )
+      ELSE false
+    END
+  )
+  WITH CHECK (
+    CASE
+      WHEN app.user_has_role('admin') THEN true
+      WHEN app.user_has_role('therapist') THEN EXISTS (
+        SELECT 1
+        FROM public.sessions s
+        WHERE s.id = session_cpt_entries.session_id
+          AND s.therapist_id = auth.uid()
+      )
+      ELSE false
+    END
+  );
+
+CREATE POLICY "Session CPT entries delete access"
+  ON public.session_cpt_entries
+  FOR DELETE
+  TO authenticated
+  USING (
+    CASE
+      WHEN app.user_has_role('admin') THEN true
+      WHEN app.user_has_role('therapist') THEN EXISTS (
+        SELECT 1
+        FROM public.sessions s
+        WHERE s.id = session_cpt_entries.session_id
+          AND s.therapist_id = auth.uid()
+      )
+      ELSE false
+    END
+  );
+
+CREATE POLICY "Service role manages session CPT entries"
+  ON public.session_cpt_entries
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE TABLE public.session_cpt_modifiers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_cpt_entry_id uuid NOT NULL REFERENCES public.session_cpt_entries(id) ON DELETE CASCADE,
+  modifier_id uuid NOT NULL REFERENCES public.billing_modifiers(id) ON DELETE RESTRICT,
+  position smallint NOT NULL DEFAULT 1,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT session_cpt_modifiers_unique UNIQUE (session_cpt_entry_id, modifier_id)
+);
+
+ALTER TABLE public.session_cpt_modifiers
+  ADD CONSTRAINT session_cpt_modifiers_position_positive
+  CHECK (position > 0);
+
+CREATE INDEX session_cpt_modifiers_entry_idx
+  ON public.session_cpt_modifiers (session_cpt_entry_id);
+CREATE INDEX session_cpt_modifiers_modifier_idx
+  ON public.session_cpt_modifiers (modifier_id);
+CREATE UNIQUE INDEX session_cpt_modifiers_primary_idx
+  ON public.session_cpt_modifiers (session_cpt_entry_id, position);
+
+ALTER TABLE public.session_cpt_modifiers ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Session CPT modifiers accessible to therapists"
+  ON public.session_cpt_modifiers
+  FOR SELECT
+  TO authenticated
+  USING (
+    CASE
+      WHEN app.user_has_role('admin') THEN true
+      WHEN app.user_has_role('therapist') THEN EXISTS (
+        SELECT 1
+        FROM public.session_cpt_entries sce
+        JOIN public.sessions s ON s.id = sce.session_id
+        WHERE sce.id = session_cpt_modifiers.session_cpt_entry_id
+          AND s.therapist_id = auth.uid()
+      )
+      ELSE false
+    END
+  );
+
+CREATE POLICY "Session CPT modifiers write access"
+  ON public.session_cpt_modifiers
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    CASE
+      WHEN app.user_has_role('admin') THEN true
+      WHEN app.user_has_role('therapist') THEN EXISTS (
+        SELECT 1
+        FROM public.session_cpt_entries sce
+        JOIN public.sessions s ON s.id = sce.session_id
+        WHERE sce.id = session_cpt_modifiers.session_cpt_entry_id
+          AND s.therapist_id = auth.uid()
+      )
+      ELSE false
+    END
+  );
+
+CREATE POLICY "Session CPT modifiers update access"
+  ON public.session_cpt_modifiers
+  FOR UPDATE
+  TO authenticated
+  USING (
+    CASE
+      WHEN app.user_has_role('admin') THEN true
+      WHEN app.user_has_role('therapist') THEN EXISTS (
+        SELECT 1
+        FROM public.session_cpt_entries sce
+        JOIN public.sessions s ON s.id = sce.session_id
+        WHERE sce.id = session_cpt_modifiers.session_cpt_entry_id
+          AND s.therapist_id = auth.uid()
+      )
+      ELSE false
+    END
+  )
+  WITH CHECK (
+    CASE
+      WHEN app.user_has_role('admin') THEN true
+      WHEN app.user_has_role('therapist') THEN EXISTS (
+        SELECT 1
+        FROM public.session_cpt_entries sce
+        JOIN public.sessions s ON s.id = sce.session_id
+        WHERE sce.id = session_cpt_modifiers.session_cpt_entry_id
+          AND s.therapist_id = auth.uid()
+      )
+      ELSE false
+    END
+  );
+
+CREATE POLICY "Session CPT modifiers delete access"
+  ON public.session_cpt_modifiers
+  FOR DELETE
+  TO authenticated
+  USING (
+    CASE
+      WHEN app.user_has_role('admin') THEN true
+      WHEN app.user_has_role('therapist') THEN EXISTS (
+        SELECT 1
+        FROM public.session_cpt_entries sce
+        JOIN public.sessions s ON s.id = sce.session_id
+        WHERE sce.id = session_cpt_modifiers.session_cpt_entry_id
+          AND s.therapist_id = auth.uid()
+      )
+      ELSE false
+    END
+  );
+
+CREATE POLICY "Service role manages session CPT modifiers"
+  ON public.session_cpt_modifiers
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE OR REPLACE VIEW public.session_cpt_details_vw AS
+SELECT
+  sce.id,
+  sce.session_id,
+  sce.cpt_code_id,
+  c.code AS cpt_code,
+  c.short_description,
+  sce.line_number,
+  sce.units,
+  sce.billed_minutes,
+  sce.rate,
+  sce.is_primary,
+  sce.notes,
+  sce.created_at,
+  sce.updated_at,
+  s.start_time,
+  s.end_time,
+  s.therapist_id,
+  s.client_id,
+  ARRAY_AGG(DISTINCT bm.code ORDER BY scm.position) FILTER (WHERE bm.code IS NOT NULL) AS modifier_codes
+FROM public.session_cpt_entries sce
+JOIN public.sessions s ON s.id = sce.session_id
+JOIN public.cpt_codes c ON c.id = sce.cpt_code_id
+LEFT JOIN public.session_cpt_modifiers scm ON scm.session_cpt_entry_id = sce.id
+LEFT JOIN public.billing_modifiers bm ON bm.id = scm.modifier_id
+GROUP BY
+  sce.id,
+  sce.session_id,
+  sce.cpt_code_id,
+  c.code,
+  c.short_description,
+  sce.line_number,
+  sce.units,
+  sce.billed_minutes,
+  sce.rate,
+  sce.is_primary,
+  sce.notes,
+  sce.created_at,
+  sce.updated_at,
+  s.start_time,
+  s.end_time,
+  s.therapist_id,
+  s.client_id;
+
+GRANT SELECT ON public.session_cpt_details_vw TO authenticated;
+GRANT SELECT ON public.session_cpt_details_vw TO service_role;


### PR DESCRIPTION
### Summary
Introduce CPT, modifier, and session linkage tables so scheduling can resolve billing metadata.

### Proposed changes
- Add `cpt_codes` master data table with seed data, indexes, and RLS policies
- Catalog billing modifiers and CPT associations with row-level security and defaults
- Create session↔CPT linkage tables plus a reporting view with therapist-scoped access controls

### Tests added/updated
- n/a (SQL migrations only)

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cb58b6831c8332a4f806562ac801ad