### PR TITLE
feat: route bookings through api – 2025-09-18

### DIFF
--- a/src/components/__tests__/SchedulingIntegration.test.tsx
+++ b/src/components/__tests__/SchedulingIntegration.test.tsx
@@ -87,38 +87,42 @@ describe('Scheduling Integration - End-to-End Flow', () => {
       http.get('*/rest/v1/sessions*', () => {
         return HttpResponse.json([]);
       }),
-      http.post('*/functions/v1/sessions-hold*', () => {
-        return HttpResponse.json({
-          success: true,
-          data: {
-            holdKey: 'test-hold',
-            holdId: 'hold-1',
-            expiresAt: '2025-01-01T00:05:00Z',
-          },
-        });
-      }),
-      http.post('*/functions/v1/sessions-confirm*', () => {
+      http.post('*/api/book', async ({ request }) => {
         sessionCreated = true;
+        const payload = await request.json();
+        const sessionPayload = (payload?.session ?? {}) as Record<string, unknown>;
         return HttpResponse.json({
           success: true,
           data: {
             session: {
-              id: 'new-session-id',
-              client_id: 'client-1',
-              therapist_id: 'therapist-1',
-              start_time: '2024-03-19T10:00:00Z',
-              end_time: '2024-03-19T11:00:00Z',
-              status: 'scheduled',
-              notes: 'Initial ABA therapy session',
+              id: (sessionPayload.id as string) ?? 'new-session-id',
+              client_id: (sessionPayload.client_id as string) ?? 'client-1',
+              therapist_id: (sessionPayload.therapist_id as string) ?? 'therapist-1',
+              start_time: (sessionPayload.start_time as string) ?? '2024-03-19T10:00:00Z',
+              end_time: (sessionPayload.end_time as string) ?? '2024-03-19T11:00:00Z',
+              status: (sessionPayload.status as string) ?? 'scheduled',
+              notes: (sessionPayload.notes as string) ?? 'Initial ABA therapy session',
               created_at: '2024-03-19T09:00:00Z',
               created_by: 'user-1',
               updated_at: '2024-03-19T09:00:00Z',
               updated_by: 'user-1',
               duration_minutes: 60,
-              location_type: null,
-              session_type: null,
+              location_type: (sessionPayload.location_type as string) ?? null,
+              session_type: (sessionPayload.session_type as string) ?? null,
               rate_per_hour: null,
               total_cost: null,
+            },
+            hold: {
+              holdKey: 'test-hold',
+              holdId: 'hold-1',
+              expiresAt: '2025-01-01T00:05:00Z',
+            },
+            cpt: {
+              code: '97153',
+              description: 'Adaptive behavior treatment by protocol',
+              modifiers: [],
+              source: 'fallback',
+              durationMinutes: 60,
             },
           },
         });

--- a/src/server/__tests__/bookHandler.test.ts
+++ b/src/server/__tests__/bookHandler.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { bookHandler } from "../api/book";
+import { bookSession } from "../bookSession";
+
+vi.mock("../bookSession", () => ({
+  bookSession: vi.fn(),
+}));
+
+const mockedBookSession = vi.mocked(bookSession);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("bookHandler", () => {
+  it("returns CORS headers for OPTIONS requests", async () => {
+    const response = await bookHandler(new Request("http://localhost/api/book", { method: "OPTIONS" }));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("rejects non-POST methods", async () => {
+    const response = await bookHandler(new Request("http://localhost/api/book", { method: "GET" }));
+    expect(response.status).toBe(405);
+  });
+
+  it("returns error when JSON payload is invalid", async () => {
+    const response = await bookHandler(new Request("http://localhost/api/book", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/invalid json/i);
+  });
+
+  it("invokes booking service and returns success", async () => {
+    mockedBookSession.mockResolvedValueOnce({
+      session: {
+        id: "session-1",
+        client_id: "client-1",
+        therapist_id: "therapist-1",
+        start_time: "2025-01-01T10:00:00Z",
+        end_time: "2025-01-01T11:00:00Z",
+        status: "scheduled",
+        notes: "",
+        created_at: "2025-01-01T09:00:00Z",
+        created_by: "user-1",
+        updated_at: "2025-01-01T09:00:00Z",
+        updated_by: "user-1",
+        duration_minutes: 60,
+      },
+      hold: { holdKey: "hold", holdId: "1", expiresAt: "2025-01-01T10:05:00Z" },
+      cpt: { code: "97153", description: "Adaptive behavior treatment by protocol", modifiers: [], source: "fallback", durationMinutes: 60 },
+    });
+
+    const response = await bookHandler(new Request("http://localhost/api/book", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": "abc-123",
+      },
+      body: JSON.stringify({
+        session: {
+          therapist_id: "therapist-1",
+          client_id: "client-1",
+          start_time: "2025-01-01T10:00:00Z",
+          end_time: "2025-01-01T11:00:00Z",
+        },
+        startTimeOffsetMinutes: 0,
+        endTimeOffsetMinutes: 0,
+        timeZone: "UTC",
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Idempotency-Key")).toBe("abc-123");
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.session.id).toBe("session-1");
+    expect(mockedBookSession).toHaveBeenCalledWith(expect.objectContaining({ idempotencyKey: "abc-123" }));
+  });
+
+  it("surfaces booking errors", async () => {
+    mockedBookSession.mockRejectedValueOnce(new Error("conflict"));
+
+    const response = await bookHandler(new Request("http://localhost/api/book", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        session: {
+          therapist_id: "therapist-1",
+          client_id: "client-1",
+          start_time: "2025-01-01T10:00:00Z",
+          end_time: "2025-01-01T11:00:00Z",
+        },
+        startTimeOffsetMinutes: 0,
+        endTimeOffsetMinutes: 0,
+        timeZone: "UTC",
+      }),
+    }));
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("conflict");
+  });
+});

--- a/src/server/__tests__/bookSession.test.ts
+++ b/src/server/__tests__/bookSession.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { bookSession } from "../bookSession";
+import {
+  cancelSessionHold,
+  confirmSessionBooking,
+  requestSessionHold,
+} from "../../lib/sessionHolds";
+import type { Session } from "../../types";
+
+vi.mock("../../lib/sessionHolds", () => ({
+  requestSessionHold: vi.fn(),
+  confirmSessionBooking: vi.fn(),
+  cancelSessionHold: vi.fn(),
+}));
+
+const mockedRequestSessionHold = vi.mocked(requestSessionHold);
+const mockedConfirmSessionBooking = vi.mocked(confirmSessionBooking);
+const mockedCancelSessionHold = vi.mocked(cancelSessionHold);
+
+const basePayload = {
+  session: {
+    therapist_id: "therapist-1",
+    client_id: "client-1",
+    start_time: "2025-01-01T10:00:00Z",
+    end_time: "2025-01-01T11:00:00Z",
+    status: "scheduled" as const,
+  },
+  startTimeOffsetMinutes: 0,
+  endTimeOffsetMinutes: 0,
+  timeZone: "UTC",
+} as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("bookSession", () => {
+  it("requests a hold and confirms the session", async () => {
+    mockedRequestSessionHold.mockResolvedValueOnce({
+      holdKey: "hold-key",
+      holdId: "hold-id",
+      expiresAt: "2025-01-01T00:05:00Z",
+    });
+
+    const confirmedSession: Session = {
+      id: "session-1",
+      client_id: basePayload.session.client_id,
+      therapist_id: basePayload.session.therapist_id,
+      start_time: basePayload.session.start_time,
+      end_time: basePayload.session.end_time,
+      status: "scheduled",
+      notes: "",
+      created_at: "2025-01-01T09:00:00Z",
+      created_by: "user-1",
+      updated_at: "2025-01-01T09:00:00Z",
+      updated_by: "user-1",
+      duration_minutes: 60,
+    };
+
+    mockedConfirmSessionBooking.mockResolvedValueOnce(confirmedSession);
+
+    const result = await bookSession(basePayload);
+
+    expect(result.session).toBe(confirmedSession);
+    expect(result.hold.holdKey).toBe("hold-key");
+    expect(result.cpt.code).toBe("97153");
+
+    expect(mockedRequestSessionHold).toHaveBeenCalledWith({
+      therapistId: basePayload.session.therapist_id,
+      clientId: basePayload.session.client_id,
+      startTime: basePayload.session.start_time,
+      endTime: basePayload.session.end_time,
+      sessionId: undefined,
+      holdSeconds: undefined,
+      idempotencyKey: undefined,
+      startTimeOffsetMinutes: 0,
+      endTimeOffsetMinutes: 0,
+      timeZone: "UTC",
+    });
+
+    expect(mockedConfirmSessionBooking).toHaveBeenCalledWith({
+      holdKey: "hold-key",
+      session: expect.objectContaining({
+        therapist_id: basePayload.session.therapist_id,
+        status: "scheduled",
+      }),
+      idempotencyKey: undefined,
+      startTimeOffsetMinutes: 0,
+      endTimeOffsetMinutes: 0,
+      timeZone: "UTC",
+    });
+  });
+
+  it("releases the hold when confirmation fails", async () => {
+    mockedRequestSessionHold.mockResolvedValueOnce({
+      holdKey: "hold-key",
+      holdId: "hold-id",
+      expiresAt: "2025-01-01T00:05:00Z",
+    });
+
+    mockedConfirmSessionBooking.mockRejectedValueOnce(new Error("unable to confirm"));
+
+    await expect(bookSession(basePayload)).rejects.toThrow("unable to confirm");
+    expect(mockedCancelSessionHold).toHaveBeenCalledWith({ holdKey: "hold-key" });
+  });
+
+  it("throws when required session fields are missing", async () => {
+    await expect(
+      bookSession({
+        ...basePayload,
+        session: {
+          ...basePayload.session,
+          therapist_id: "",
+        },
+      }),
+    ).rejects.toThrow(/therapist_id/);
+  });
+});

--- a/src/server/__tests__/deriveCpt.test.ts
+++ b/src/server/__tests__/deriveCpt.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { deriveCptMetadata } from "../deriveCpt";
+
+const baseSession = {
+  therapist_id: "therapist-1",
+  client_id: "client-1",
+  start_time: "2025-01-01T10:00:00Z",
+  end_time: "2025-01-01T11:00:00Z",
+  status: "scheduled" as const,
+};
+
+describe("deriveCptMetadata", () => {
+  it("returns default CPT code for individual sessions", () => {
+    const result = deriveCptMetadata({ session: { ...baseSession, session_type: "Individual" } });
+    expect(result.code).toBe("97153");
+    expect(result.modifiers).toEqual([]);
+    expect(result.source).toBe("session_type");
+    expect(result.durationMinutes).toBe(60);
+  });
+
+  it("adds group modifiers when session type is group", () => {
+    const result = deriveCptMetadata({
+      session: {
+        ...baseSession,
+        session_type: "Group",
+      },
+    });
+    expect(result.code).toBe("97154");
+    expect(result.modifiers).toContain("HQ");
+    expect(result.source).toBe("session_type");
+  });
+
+  it("adds telehealth modifier based on location", () => {
+    const result = deriveCptMetadata({
+      session: {
+        ...baseSession,
+        location_type: "telehealth",
+      },
+    });
+    expect(result.modifiers).toContain("95");
+    expect(result.code).toBe("97153");
+  });
+
+  it("honors CPT overrides", () => {
+    const result = deriveCptMetadata({
+      session: baseSession,
+      overrides: {
+        cptCode: "97155",
+        modifiers: ["gt", " 95 "],
+      },
+    });
+    expect(result.code).toBe("97155");
+    expect(result.source).toBe("override");
+    expect(result.modifiers).toEqual(["GT", "95"]);
+  });
+
+  it("adds long-duration modifier when session exceeds three hours", () => {
+    const result = deriveCptMetadata({
+      session: {
+        ...baseSession,
+        start_time: "2025-01-01T09:00:00Z",
+        end_time: "2025-01-01T13:30:00Z",
+      },
+    });
+    expect(result.modifiers).toContain("KX");
+    expect(result.durationMinutes).toBe(270);
+  });
+});

--- a/src/server/api/book.ts
+++ b/src/server/api/book.ts
@@ -1,0 +1,75 @@
+import { bookSession } from "../bookSession";
+import type {
+  BookSessionApiRequestBody,
+  BookSessionApiResponse,
+  BookSessionRequest,
+} from "../types";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, content-type, idempotency-key",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function jsonResponse(
+  body: BookSessionApiResponse,
+  status = 200,
+  extraHeaders: Record<string, string> = {},
+) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...CORS_HEADERS,
+      ...extraHeaders,
+    },
+  });
+}
+
+function normalizePayload(
+  body: BookSessionApiRequestBody,
+  idempotencyKey?: string,
+): BookSessionRequest {
+  return {
+    ...body,
+    idempotencyKey,
+  };
+}
+
+export async function bookHandler(request: Request): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return new Response("ok", { status: 200, headers: CORS_HEADERS });
+  }
+
+  if (request.method !== "POST") {
+    return jsonResponse({ success: false, error: "Method not allowed" }, 405);
+  }
+
+  let body: BookSessionApiRequestBody;
+  try {
+    body = await request.json();
+  } catch (error) {
+    console.error("Failed to parse booking payload", error);
+    return jsonResponse({ success: false, error: "Invalid JSON body" }, 400);
+  }
+
+  if (!body || typeof body !== "object" || !body.session) {
+    return jsonResponse({ success: false, error: "Missing session payload" }, 400);
+  }
+
+  try {
+    const idempotencyKey = request.headers.get("Idempotency-Key") ?? undefined;
+    const result = await bookSession(normalizePayload(body, idempotencyKey));
+    const headers = idempotencyKey
+      ? { "Idempotency-Key": idempotencyKey }
+      : {};
+    return jsonResponse({ success: true, data: result }, 200, headers);
+  } catch (error) {
+    const status = typeof (error as { status?: number })?.status === "number"
+      ? (error as { status: number }).status
+      : 500;
+    const message = error instanceof Error ? error.message : "Failed to book session";
+    console.error("Session booking failed", error);
+    return jsonResponse({ success: false, error: message }, status);
+  }
+}

--- a/src/server/bookSession.ts
+++ b/src/server/bookSession.ts
@@ -1,0 +1,85 @@
+import {
+  cancelSessionHold,
+  confirmSessionBooking,
+  requestSessionHold,
+} from "../lib/sessionHolds";
+import { deriveCptMetadata } from "./deriveCpt";
+import type {
+  BookSessionRequest,
+  BookSessionResult,
+  BookableSession,
+  RequiredSessionFields,
+} from "./types";
+
+const REQUIRED_SESSION_FIELDS: Array<keyof RequiredSessionFields> = [
+  "therapist_id",
+  "client_id",
+  "start_time",
+  "end_time",
+];
+
+function assertSessionCompleteness(session: BookableSession) {
+  for (const field of REQUIRED_SESSION_FIELDS) {
+    const value = session[field];
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`Missing required session field: ${String(field)}`);
+    }
+  }
+}
+
+export async function bookSession(payload: BookSessionRequest): Promise<BookSessionResult> {
+  if (!payload?.session) {
+    throw new Error("Session payload is required");
+  }
+
+  assertSessionCompleteness(payload.session);
+
+  const cpt = deriveCptMetadata({
+    session: payload.session,
+    overrides: payload.overrides,
+  });
+
+  const sessionId = typeof payload.session.id === "string" ? payload.session.id : undefined;
+
+  const hold = await requestSessionHold({
+    therapistId: payload.session.therapist_id,
+    clientId: payload.session.client_id,
+    startTime: payload.session.start_time,
+    endTime: payload.session.end_time,
+    sessionId,
+    holdSeconds: payload.holdSeconds,
+    idempotencyKey: payload.idempotencyKey,
+    startTimeOffsetMinutes: payload.startTimeOffsetMinutes,
+    endTimeOffsetMinutes: payload.endTimeOffsetMinutes,
+    timeZone: payload.timeZone,
+  });
+
+  const sessionPayload: BookableSession = {
+    ...payload.session,
+    status: payload.session.status ?? "scheduled",
+  };
+
+  try {
+    const confirmed = await confirmSessionBooking({
+      holdKey: hold.holdKey,
+      session: sessionPayload,
+      idempotencyKey: payload.idempotencyKey,
+      startTimeOffsetMinutes: payload.startTimeOffsetMinutes,
+      endTimeOffsetMinutes: payload.endTimeOffsetMinutes,
+      timeZone: payload.timeZone,
+    });
+
+    return {
+      session: confirmed,
+      hold,
+      cpt,
+    };
+  } catch (error) {
+    try {
+      await cancelSessionHold({ holdKey: hold.holdKey });
+    } catch (releaseError) {
+      console.warn("Failed to release session hold after confirmation error", releaseError);
+    }
+    throw error;
+  }
+}

--- a/src/server/deriveCpt.ts
+++ b/src/server/deriveCpt.ts
@@ -1,0 +1,150 @@
+import type { BookableSession, BookingOverrides, DerivedCpt } from "./types";
+
+interface DeriveCptInput {
+  session: BookableSession;
+  overrides?: BookingOverrides;
+}
+
+interface SessionTypeRule {
+  code: string;
+  description: string;
+  defaultModifiers?: string[];
+}
+
+const SESSION_TYPE_RULES: Record<string, SessionTypeRule> = {
+  individual: {
+    code: "97153",
+    description: "Adaptive behavior treatment by protocol",
+  },
+  group: {
+    code: "97154",
+    description: "Group adaptive behavior treatment by protocol",
+    defaultModifiers: ["HQ"],
+  },
+  assessment: {
+    code: "97151",
+    description: "Behavior identification assessment by a physician or other qualified health care professional",
+  },
+  consultation: {
+    code: "97156",
+    description: "Family adaptive behavior guidance and therapy",
+    defaultModifiers: ["HO"],
+  },
+};
+
+const CPT_DESCRIPTIONS: Record<string, string> = Object.values(SESSION_TYPE_RULES).reduce(
+  (acc, rule) => ({ ...acc, [rule.code]: rule.description }),
+  {
+    "97155": "Adaptive behavior treatment with protocol modification",
+    "97158": "Group adaptive behavior treatment with protocol modification",
+  },
+);
+
+const FALLBACK_RULE: SessionTypeRule = {
+  code: "97153",
+  description: "Adaptive behavior treatment by protocol",
+};
+
+function computeDurationMinutes(session: BookableSession): number | null {
+  try {
+    const start = new Date(session.start_time);
+    const end = new Date(session.end_time);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      return null;
+    }
+    const diff = (end.getTime() - start.getTime()) / 60000;
+    if (!Number.isFinite(diff) || diff <= 0) {
+      return null;
+    }
+    return Math.round(diff);
+  } catch (error) {
+    console.warn("Failed to compute session duration", error);
+    return null;
+  }
+}
+
+function normalizeModifier(candidate: unknown): string | null {
+  if (typeof candidate !== "string") {
+    return null;
+  }
+  const trimmed = candidate.trim().toUpperCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function deriveBaseRule(session: BookableSession, overrides?: BookingOverrides): {
+  rule: SessionTypeRule;
+  source: DerivedCpt["source"];
+} {
+  const overrideCode = normalizeModifier(overrides?.cptCode ?? null);
+  if (overrideCode) {
+    const description = CPT_DESCRIPTIONS[overrideCode] ?? "Custom CPT code";
+    return {
+      rule: { code: overrideCode, description },
+      source: "override",
+    };
+  }
+
+  const normalizedType = typeof session.session_type === "string"
+    ? session.session_type.trim().toLowerCase()
+    : "";
+
+  if (normalizedType && SESSION_TYPE_RULES[normalizedType]) {
+    return { rule: SESSION_TYPE_RULES[normalizedType], source: "session_type" };
+  }
+
+  return { rule: FALLBACK_RULE, source: "fallback" };
+}
+
+function appendLocationModifiers(session: BookableSession, modifiers: Set<string>) {
+  const location = typeof session.location_type === "string"
+    ? session.location_type.trim().toLowerCase()
+    : "";
+
+  if (location.length === 0) {
+    return;
+  }
+
+  if (location.includes("tele") || location.includes("virtual") || location.includes("remote")) {
+    modifiers.add("95");
+  }
+
+  if (location.includes("school")) {
+    modifiers.add("HQ");
+  }
+}
+
+export function deriveCptMetadata({ session, overrides }: DeriveCptInput): DerivedCpt {
+  const { rule, source } = deriveBaseRule(session, overrides);
+  const durationMinutes = computeDurationMinutes(session);
+  const modifiers = new Set<string>();
+
+  if (Array.isArray(overrides?.modifiers)) {
+    overrides?.modifiers.forEach((modifier) => {
+      const normalized = normalizeModifier(modifier);
+      if (normalized) {
+        modifiers.add(normalized);
+      }
+    });
+  }
+
+  rule.defaultModifiers?.forEach((modifier) => {
+    const normalized = normalizeModifier(modifier);
+    if (normalized) {
+      modifiers.add(normalized);
+    }
+  });
+
+  appendLocationModifiers(session, modifiers);
+
+  if (typeof durationMinutes === "number" && durationMinutes >= 180) {
+    modifiers.add("KX");
+  }
+
+  return {
+    code: rule.code,
+    description: rule.description,
+    modifiers: [...modifiers],
+    source,
+    durationMinutes,
+  };
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,0 +1,48 @@
+import type { Session } from "../types";
+import type { HoldResponse } from "../lib/sessionHolds";
+
+export interface BookingOverrides {
+  cptCode?: string;
+  modifiers?: string[];
+}
+
+export type RequiredSessionFields = Pick<
+  Session,
+  "therapist_id" | "client_id" | "start_time" | "end_time"
+>;
+
+export type BookableSession = RequiredSessionFields &
+  Partial<Omit<Session, keyof RequiredSessionFields>>;
+
+export interface BookSessionRequest {
+  session: BookableSession;
+  startTimeOffsetMinutes: number;
+  endTimeOffsetMinutes: number;
+  timeZone: string;
+  holdSeconds?: number;
+  idempotencyKey?: string;
+  overrides?: BookingOverrides;
+}
+
+export interface DerivedCpt {
+  code: string;
+  description: string;
+  modifiers: string[];
+  source: "override" | "session_type" | "fallback";
+  durationMinutes: number | null;
+}
+
+export interface BookSessionResult {
+  session: Session;
+  hold: HoldResponse;
+  cpt: DerivedCpt;
+}
+
+export type BookSessionApiRequestBody = Omit<BookSessionRequest, "idempotencyKey">;
+
+export interface BookSessionApiResponse {
+  success: boolean;
+  data?: BookSessionResult;
+  error?: string;
+  code?: string;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -422,6 +422,60 @@ export const server = setupServer(
       }
     ]);
   }),
+  http.post('*/api/book', async ({ request }) => {
+    let body: { session?: Record<string, unknown> } | null = null;
+    try {
+      body = await request.json();
+    } catch (error) {
+      console.error('Failed to parse book API payload in tests', error);
+    }
+
+    const sessionPayload = (body?.session ?? {}) as Record<string, unknown>;
+    const startTime = typeof sessionPayload.start_time === 'string'
+      ? sessionPayload.start_time
+      : '2025-03-18T10:00:00Z';
+    const endTime = typeof sessionPayload.end_time === 'string'
+      ? sessionPayload.end_time
+      : '2025-03-18T11:00:00Z';
+
+    const responseSession = {
+      id: (sessionPayload.id as string) ?? 'new-session-id',
+      client_id: (sessionPayload.client_id as string) ?? 'client-1',
+      therapist_id: (sessionPayload.therapist_id as string) ?? 'therapist-1',
+      start_time: startTime,
+      end_time: endTime,
+      status: (sessionPayload.status as string) ?? 'scheduled',
+      notes: (sessionPayload.notes as string) ?? 'Test session',
+      created_at: '2025-03-18T09:00:00Z',
+      created_by: 'user-1',
+      updated_at: '2025-03-18T09:00:00Z',
+      updated_by: 'user-1',
+      duration_minutes: 60,
+      location_type: (sessionPayload.location_type as string) ?? null,
+      session_type: (sessionPayload.session_type as string) ?? null,
+      rate_per_hour: null,
+      total_cost: null,
+    };
+
+    return HttpResponse.json({
+      success: true,
+      data: {
+        session: responseSession,
+        hold: {
+          holdKey: 'test-hold',
+          holdId: 'hold-1',
+          expiresAt: '2025-01-01T00:05:00Z',
+        },
+        cpt: {
+          code: '97153',
+          description: 'Adaptive behavior treatment by protocol',
+          modifiers: [],
+          source: 'fallback',
+          durationMinutes: 60,
+        },
+      },
+    });
+  }),
   // Mock session hold + confirmation flow
   http.post('*/functions/v1/sessions-hold*', () => {
     return HttpResponse.json({


### PR DESCRIPTION
### Summary
Introduce a server-side booking flow and update the scheduler UI to call it.

### Proposed changes
- add server modules for CPT derivation, booking orchestration, and API handling
- update schedule page and fixtures to call the new /api/book endpoint
- cover booking service and handler with dedicated unit tests

### Tests added/updated
- src/server/__tests__/bookSession.test.ts
- src/server/__tests__/bookHandler.test.ts
- src/server/__tests__/deriveCpt.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cb5b7afe0083328c26d526020a6212