### PR TITLE
feat: add booking billing integration spec – 2025-09-18

### DIFF
--- a/tests/booking.billing.spec.ts
+++ b/tests/booking.billing.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { bookSession } from "../src/server/bookSession";
+import {
+  createBookingRequest,
+  seedBookingBillingFixture,
+} from "./fixtures/bookingBilling";
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+  if (value && typeof value === "object") {
+    return value as Record<string, unknown>;
+  }
+  return {};
+};
+
+describe("booking billing integration", () => {
+  it("derives CPT metadata using session type, location, and overrides", async () => {
+    const request = createBookingRequest({
+      session: {
+        session_type: "Group",
+        location_type: "Telehealth - school campus",
+        start_time: "2025-07-01T15:00:00Z",
+        end_time: "2025-07-01T18:15:00Z",
+      },
+      overrides: {
+        modifiers: ["gt"],
+      },
+      idempotencyKey: "billing-e2e-group",
+      holdSeconds: 420,
+    });
+
+    const seeded = seedBookingBillingFixture({
+      request,
+      hold: {
+        holdKey: "group-hold-key",
+        holdId: "group-hold-id",
+        expiresAt: "2025-07-01T15:10:00Z",
+      },
+      confirm: {
+        sessionOverrides: {
+          id: "group-session-id",
+          notes: "Group telehealth session",
+        },
+      },
+    });
+
+    const result = await bookSession(request);
+
+    expect(result.hold).toMatchObject({
+      holdKey: "group-hold-key",
+      holdId: "group-hold-id",
+      expiresAt: "2025-07-01T15:10:00Z",
+    });
+
+    expect(result.session).toMatchObject({
+      id: "group-session-id",
+      therapist_id: request.session.therapist_id,
+      client_id: request.session.client_id,
+      start_time: request.session.start_time,
+      end_time: request.session.end_time,
+      duration_minutes: 195,
+    });
+
+    expect(result.cpt).toEqual({
+      code: "97154",
+      description: "Group adaptive behavior treatment by protocol",
+      modifiers: ["GT", "HQ", "95", "KX"],
+      source: "session_type",
+      durationMinutes: 195,
+    });
+
+    expect(seeded.holdRequests).toHaveLength(1);
+    expect(seeded.holdRequests[0]).toMatchObject({
+      therapist_id: request.session.therapist_id,
+      client_id: request.session.client_id,
+      start_time: request.session.start_time,
+      end_time: request.session.end_time,
+      session_id: null,
+      hold_seconds: 420,
+      start_time_offset_minutes: request.startTimeOffsetMinutes,
+      end_time_offset_minutes: request.endTimeOffsetMinutes,
+      time_zone: request.timeZone,
+    });
+
+    expect(seeded.confirmRequests).toHaveLength(1);
+    const confirmPayload = asRecord(seeded.confirmRequests[0]);
+    expect(confirmPayload).toMatchObject({
+      hold_key: "group-hold-key",
+      time_zone: request.timeZone,
+      start_time_offset_minutes: request.startTimeOffsetMinutes,
+      end_time_offset_minutes: request.endTimeOffsetMinutes,
+    });
+
+    const confirmedSessionPayload = asRecord(confirmPayload.session);
+    expect(confirmedSessionPayload).toMatchObject({
+      therapist_id: request.session.therapist_id,
+      client_id: request.session.client_id,
+      session_type: request.session.session_type,
+      location_type: request.session.location_type,
+      status: "scheduled",
+    });
+  });
+
+  it("honors explicit CPT overrides and normalizes modifiers", async () => {
+    const request = createBookingRequest({
+      session: {
+        session_type: "Consultation",
+        location_type: "Remote home visit",
+        start_time: "2025-07-02T09:00:00Z",
+        end_time: "2025-07-02T09:50:00Z",
+      },
+      overrides: {
+        cptCode: "97155",
+        modifiers: [" tz ", "95"],
+      },
+    });
+
+    const seeded = seedBookingBillingFixture({
+      request,
+      hold: {
+        holdKey: "override-hold-key",
+      },
+      confirm: {
+        sessionOverrides: {
+          id: "override-session-id",
+          duration_minutes: 50,
+        },
+        roundedDurationMinutes: 50,
+      },
+    });
+
+    const result = await bookSession(request);
+
+    expect(result.cpt).toEqual({
+      code: "97155",
+      description: "Adaptive behavior treatment with protocol modification",
+      modifiers: ["TZ", "95"],
+      source: "override",
+      durationMinutes: 50,
+    });
+
+    expect(result.session).toMatchObject({
+      id: "override-session-id",
+      duration_minutes: 50,
+    });
+
+    expect(seeded.holdRequests).toHaveLength(1);
+    expect(seeded.holdRequests[0]).toMatchObject({
+      hold_seconds: 300,
+    });
+
+    const confirmPayload = asRecord(seeded.confirmRequests[0]);
+    expect(confirmPayload).toMatchObject({
+      hold_key: "override-hold-key",
+      time_zone: request.timeZone,
+    });
+
+    const sessionPayload = asRecord(confirmPayload.session);
+    expect(sessionPayload).toMatchObject({
+      session_type: request.session.session_type,
+      location_type: request.session.location_type,
+    });
+  });
+});

--- a/tests/fixtures/bookingBilling.ts
+++ b/tests/fixtures/bookingBilling.ts
@@ -1,0 +1,143 @@
+import { http, HttpResponse } from "msw";
+import type { HoldResponse } from "../../src/lib/sessionHolds";
+import type { BookSessionRequest } from "../../src/server/types";
+import type { Session } from "../../src/types";
+import { server } from "../../src/test/setup";
+
+export type BookingRequestOverrides = Partial<Omit<BookSessionRequest, "session">> & {
+  session?: Partial<BookSessionRequest["session"]>;
+};
+
+const DEFAULT_SESSION: BookSessionRequest["session"] = {
+  therapist_id: "therapist-fixture-1",
+  client_id: "client-fixture-1",
+  start_time: "2025-07-01T15:00:00Z",
+  end_time: "2025-07-01T16:00:00Z",
+  status: "scheduled",
+  notes: "Fixture session notes",
+  session_type: "Individual",
+  location_type: "clinic",
+};
+
+export function createBookingRequest(
+  overrides?: BookingRequestOverrides,
+): BookSessionRequest {
+  return {
+    session: {
+      ...DEFAULT_SESSION,
+      ...(overrides?.session ?? {}),
+    },
+    startTimeOffsetMinutes: overrides?.startTimeOffsetMinutes ?? 0,
+    endTimeOffsetMinutes: overrides?.endTimeOffsetMinutes ?? 0,
+    timeZone: overrides?.timeZone ?? "UTC",
+    holdSeconds: overrides?.holdSeconds,
+    idempotencyKey: overrides?.idempotencyKey,
+    overrides: overrides?.overrides,
+  };
+}
+
+const DEFAULT_HOLD: HoldResponse = {
+  holdKey: "fixture-hold-key",
+  holdId: "fixture-hold-id",
+  expiresAt: "2025-07-01T15:05:00Z",
+};
+
+function computeDurationMinutes(request: BookSessionRequest): number | null {
+  try {
+    const start = new Date(request.session.start_time);
+    const end = new Date(request.session.end_time);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      return null;
+    }
+    const diffMinutes = Math.round((end.getTime() - start.getTime()) / 60000);
+    return diffMinutes > 0 ? diffMinutes : null;
+  } catch {
+    return null;
+  }
+}
+
+export function createConfirmedSessionFromRequest(
+  request: BookSessionRequest,
+  overrides?: Partial<Session>,
+): Session {
+  const computedDuration = overrides?.duration_minutes ?? computeDurationMinutes(request) ?? null;
+
+  const base: Session = {
+    id: overrides?.id ?? "fixture-session-id",
+    therapist_id: request.session.therapist_id,
+    client_id: request.session.client_id,
+    start_time: request.session.start_time,
+    end_time: request.session.end_time,
+    status: (request.session.status as Session["status"]) ?? "scheduled",
+    notes:
+      typeof request.session.notes === "string" && request.session.notes.length > 0
+        ? request.session.notes
+        : "Fixture session notes",
+    created_at: overrides?.created_at ?? "2025-07-01T14:55:00Z",
+    created_by: overrides?.created_by ?? "fixture-user",
+    updated_at: overrides?.updated_at ?? "2025-07-01T14:55:00Z",
+    updated_by: overrides?.updated_by ?? "fixture-user",
+    duration_minutes: computedDuration,
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    duration_minutes: overrides?.duration_minutes ?? computedDuration,
+  };
+}
+
+export interface BookingBillingSeedInput {
+  request: BookSessionRequest;
+  hold?: Partial<HoldResponse>;
+  confirm?: {
+    sessionOverrides?: Partial<Session>;
+    roundedDurationMinutes?: number | null;
+  };
+}
+
+export interface SeededBookingBilling {
+  holdRequests: Array<Record<string, unknown>>;
+  confirmRequests: Array<Record<string, unknown>>;
+  hold: HoldResponse;
+  confirmedSession: Session;
+}
+
+export function seedBookingBillingFixture(input: BookingBillingSeedInput): SeededBookingBilling {
+  const hold: HoldResponse = {
+    ...DEFAULT_HOLD,
+    ...(input.hold ?? {}),
+  };
+
+  const confirmedSession = createConfirmedSessionFromRequest(
+    input.request,
+    input.confirm?.sessionOverrides,
+  );
+
+  const roundedDurationMinutes =
+    input.confirm?.roundedDurationMinutes ?? confirmedSession.duration_minutes ?? null;
+
+  const holdRequests: Array<Record<string, unknown>> = [];
+  const confirmRequests: Array<Record<string, unknown>> = [];
+
+  server.use(
+    http.post("*/functions/v1/sessions-hold*", async ({ request }) => {
+      const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+      holdRequests.push(body);
+      return HttpResponse.json({ success: true, data: hold });
+    }),
+    http.post("*/functions/v1/sessions-confirm*", async ({ request }) => {
+      const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+      confirmRequests.push(body);
+      return HttpResponse.json({
+        success: true,
+        data: {
+          session: confirmedSession,
+          roundedDurationMinutes,
+        },
+      });
+    }),
+  );
+
+  return { holdRequests, confirmRequests, hold, confirmedSession };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,11 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
-    include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}', 'src/**/*Integration*.test.{js,jsx,ts,tsx}'],
+    include: [
+      'src/**/*.{test,spec}.{js,jsx,ts,tsx}',
+      'src/**/*Integration*.test.{js,jsx,ts,tsx}',
+      'tests/**/*.{test,spec}.{js,jsx,ts,tsx}',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
## Summary
- add reusable booking billing fixture utilities backed by MSW for deterministic CPT assertions
- cover CPT- and modifier-derived booking flows in a new end-to-end spec
- ensure Vitest picks up the tests directory so `npm test` runs the new suite

## Testing
- `CI=1 npm test`
- `eslint . --max-warnings=0`
- `tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68cb650bd2ec833291ec1ccb63a07844