### PR TITLE
fix: tighten session cancellation authorization – 2025-09-18

### DIFF
--- a/src/lib/__tests__/sessionCancellation.test.ts
+++ b/src/lib/__tests__/sessionCancellation.test.ts
@@ -104,4 +104,14 @@ describe("cancelSessions", () => {
       /bad request/i,
     );
   });
+
+  it("throws when cancellation is forbidden", async () => {
+    mockedCallEdge.mockResolvedValueOnce(
+      jsonResponse({ success: false, error: "Forbidden" }, 403),
+    );
+
+    await expect(cancelSessions({ sessionIds: ["s1"] })).rejects.toThrow(
+      /forbidden/i,
+    );
+  });
 });


### PR DESCRIPTION
### Summary
Restrict the sessions-cancel edge function to authenticated admins or owning therapists and cover unauthorized client behavior.

### Proposed changes
- Derive the caller role via profile lookup, enforce therapist-only filters on session queries, and return 403 for mismatched targets.
- Update sessionCancellation tests to assert forbidden cancellations bubble up to the caller.

### Tests added/updated
- src/lib/__tests__/sessionCancellation.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cb9ac5fa648332b03dac386fa17b7f