### PR TITLE
fix: prevent overlapping holds – 2025-07-08

### DIFF
--- a/docs/SESSION_HOLD_CONFLICT_CODES.md
+++ b/docs/SESSION_HOLD_CONFLICT_CODES.md
@@ -1,0 +1,19 @@
+# Session hold conflict codes
+
+The `acquire_session_hold` RPC returns structured error responses when it cannot reserve a slot. The
+`sessions-hold` Edge Function forwards these codes to clients so the front-end can display specific
+messages and retry guidance.
+
+| Code | Description | HTTP status |
+| ---- | ----------- | ----------- |
+| `INVALID_RANGE` | The supplied `end_time` is not after `start_time`. | 400 |
+| `HOLD_EXISTS` | A hold already exists for the same therapist, client, start time pair. | 409 |
+| `THERAPIST_CONFLICT` | The therapist already has a confirmed session that overlaps the requested range. | 409 |
+| `CLIENT_CONFLICT` | The client already has a confirmed session that overlaps the requested range. | 409 |
+| `THERAPIST_HOLD_CONFLICT` | A non-expired hold already reserves the overlapping range for the therapist. | 409 |
+| `CLIENT_HOLD_CONFLICT` | A non-expired hold already reserves the overlapping range for the client. | 409 |
+
+The new `THERAPIST_HOLD_CONFLICT` and `CLIENT_HOLD_CONFLICT` codes are emitted both during the
+pre-insert range check and by the database exclusion constraints. Callers should treat them as
+temporary conflicts and either retry after the existing hold expires or prompt the user to choose a
+different slot.


### PR DESCRIPTION
### Summary
Prevent overlapping session holds by enforcing conflict detection and documenting new error codes.

### Proposed changes
- Block therapist/client hold range overlaps via pre-insert checks and exclusion constraints in the session hold RPC.
- Add a concurrency-focused unit test confirming that overlapping holds are rejected.
- Document the session hold conflict codes for front-end consumers.

### Tests added/updated
- vitest src/lib/__tests__/sessionHolds.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cba06fac7083329d362c5fedfb3fe8