### PR TITLE
feat: enforce auto-schedule client caps – 2025-09-18

### DIFF
--- a/src/components/__tests__/AutoScheduleModalWarnings.test.tsx
+++ b/src/components/__tests__/AutoScheduleModalWarnings.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import AutoScheduleModal from '../AutoScheduleModal';
+import type { Therapist, Client, Session } from '../../types';
+import { generateOptimalSchedule } from '../../lib/autoSchedule';
+
+vi.mock('../../lib/autoSchedule', () => ({
+  generateOptimalSchedule: vi.fn()
+}));
+
+const createTherapist = (overrides: Partial<Therapist> = {}): Therapist => ({
+  id: 'therapist-1',
+  email: 'therapist@example.com',
+  full_name: 'Therapist Example',
+  specialties: [],
+  max_clients: 5,
+  service_type: ['ABA'],
+  weekly_hours_min: 0,
+  weekly_hours_max: 30,
+  availability_hours: {
+    monday: { start: '08:00', end: '17:00' },
+    tuesday: { start: '08:00', end: '17:00' },
+    wednesday: { start: '08:00', end: '17:00' },
+    thursday: { start: '08:00', end: '17:00' },
+    friday: { start: '08:00', end: '17:00' },
+    saturday: { start: null, end: null },
+    sunday: { start: null, end: null }
+  },
+  created_at: new Date('2024-01-01T00:00:00Z').toISOString(),
+  ...overrides
+});
+
+const createClient = (overrides: Partial<Client> = {}): Client => ({
+  id: 'client-1',
+  email: 'client@example.com',
+  full_name: 'Client Example',
+  date_of_birth: '2015-01-01',
+  insurance_info: {},
+  service_preference: ['ABA'],
+  one_to_one_units: 0,
+  supervision_units: 0,
+  parent_consult_units: 0,
+  availability_hours: {
+    monday: { start: '08:00', end: '17:00' },
+    tuesday: { start: '08:00', end: '17:00' },
+    wednesday: { start: '08:00', end: '17:00' },
+    thursday: { start: '08:00', end: '17:00' },
+    friday: { start: '08:00', end: '17:00' },
+    saturday: { start: null, end: null },
+    sunday: { start: null, end: null }
+  },
+  created_at: new Date('2024-01-01T00:00:00Z').toISOString(),
+  ...overrides
+});
+
+const mockedGenerateOptimalSchedule = vi.mocked(generateOptimalSchedule);
+
+describe('AutoScheduleModal warnings', () => {
+  beforeEach(() => {
+    mockedGenerateOptimalSchedule.mockReset();
+  });
+
+  it('displays capped client warnings when scheduling results indicate limits', () => {
+    const therapist = createTherapist();
+    const client = createClient();
+    const cappedResult = {
+      slots: [],
+      cappedClients: [
+        {
+          client,
+          remainingMinutes: 0
+        }
+      ]
+    };
+    mockedGenerateOptimalSchedule.mockReturnValue(cappedResult);
+
+    render(
+      <AutoScheduleModal
+        isOpen
+        onClose={() => {}}
+        onSchedule={vi.fn()}
+        therapists={[therapist]}
+        clients={[client]}
+        existingSessions={[] as Session[]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /generate preview/i }));
+
+    expect(mockedGenerateOptimalSchedule).toHaveBeenCalled();
+    expect(
+      screen.getByText('Some clients are at their monthly limits and were skipped.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Client Example')).toBeInTheDocument();
+    expect(screen.getByText('No remaining hours')).toBeInTheDocument();
+    expect(
+      screen.getByText('All eligible clients are already at their authorized limits for the selected range.')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/lib/__tests__/autoSchedule.test.ts
+++ b/src/lib/__tests__/autoSchedule.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateOptimalSchedule,
+  normalizeClientHourCapacity
+} from '../autoSchedule';
+import type { Therapist, Client, Session } from '../../types';
+
+const createTherapist = (overrides: Partial<Therapist> = {}): Therapist => ({
+  id: 'therapist-1',
+  email: 'therapist@example.com',
+  full_name: 'Therapist Example',
+  specialties: [],
+  max_clients: 10,
+  service_type: ['ABA'],
+  weekly_hours_min: 0,
+  weekly_hours_max: 40,
+  availability_hours: {
+    monday: { start: '08:00', end: '17:00' },
+    tuesday: { start: '08:00', end: '17:00' },
+    wednesday: { start: '08:00', end: '17:00' },
+    thursday: { start: '08:00', end: '17:00' },
+    friday: { start: '08:00', end: '17:00' },
+    saturday: { start: null, end: null },
+    sunday: { start: null, end: null }
+  },
+  created_at: new Date('2024-01-01T00:00:00Z').toISOString(),
+  ...overrides
+});
+
+const createClient = (overrides: Partial<Client> = {}): Client => ({
+  id: 'client-1',
+  email: 'client@example.com',
+  full_name: 'Client Example',
+  date_of_birth: '2015-01-01',
+  insurance_info: {},
+  service_preference: ['ABA'],
+  one_to_one_units: 0,
+  supervision_units: 0,
+  parent_consult_units: 0,
+  availability_hours: {
+    monday: { start: '08:00', end: '17:00' },
+    tuesday: { start: '08:00', end: '17:00' },
+    wednesday: { start: '08:00', end: '17:00' },
+    thursday: { start: '08:00', end: '17:00' },
+    friday: { start: '08:00', end: '17:00' },
+    saturday: { start: null, end: null },
+    sunday: { start: null, end: null }
+  },
+  created_at: new Date('2024-01-01T00:00:00Z').toISOString(),
+  ...overrides
+});
+
+describe('normalizeClientHourCapacity', () => {
+  it('uses the smaller of remaining authorized and unscheduled hours', () => {
+    const client = createClient({
+      authorized_hours_per_month: 20,
+      hours_provided_per_month: 5,
+      unscheduled_hours: 3
+    });
+
+    const capacity = normalizeClientHourCapacity(client);
+    expect(capacity.remainingHours).toBe(3);
+    expect(capacity.remainingMinutes).toBe(180);
+  });
+
+  it('falls back to unscheduled hours when no authorization exists', () => {
+    const client = createClient({
+      authorized_hours_per_month: undefined,
+      hours_provided_per_month: undefined,
+      unscheduled_hours: 4
+    });
+
+    const capacity = normalizeClientHourCapacity(client);
+    expect(capacity.remainingHours).toBe(4);
+    expect(capacity.authorizedHours).toBeNull();
+  });
+});
+
+describe('generateOptimalSchedule', () => {
+  const baseTherapist = createTherapist();
+  const schedulingWindow = {
+    start: new Date('2024-06-03T00:00:00Z'),
+    end: new Date('2024-06-07T23:59:59Z')
+  };
+  const sessions: Session[] = [];
+
+  it('skips clients who have no remaining hours for a full session', () => {
+    const cappedClient = createClient({
+      id: 'client-capped',
+      full_name: 'Capped Client',
+      email: 'capped@example.com',
+      authorized_hours_per_month: 10,
+      hours_provided_per_month: 10,
+      unscheduled_hours: 0
+    });
+
+    const result = generateOptimalSchedule(
+      [baseTherapist],
+      [cappedClient],
+      sessions,
+      schedulingWindow.start,
+      schedulingWindow.end
+    );
+
+    expect(result.slots).toHaveLength(0);
+    expect(result.cappedClients.map(info => info.client.id)).toContain('client-capped');
+  });
+
+  it('avoids scheduling clients with insufficient fractional availability', () => {
+    const fractionalClient = createClient({
+      id: 'client-fractional',
+      full_name: 'Fractional Client',
+      email: 'fractional@example.com',
+      authorized_hours_per_month: 1,
+      hours_provided_per_month: 0.75
+    });
+
+    const result = generateOptimalSchedule(
+      [baseTherapist],
+      [fractionalClient],
+      sessions,
+      schedulingWindow.start,
+      schedulingWindow.end
+    );
+
+    expect(result.slots).toHaveLength(0);
+    expect(result.cappedClients.map(info => info.client.id)).toContain('client-fractional');
+  });
+
+  it('prioritizes eligible clients while omitting capped ones', () => {
+    const cappedClient = createClient({
+      id: 'client-capped',
+      full_name: 'Capped Client',
+      email: 'capped@example.com',
+      authorized_hours_per_month: 8,
+      hours_provided_per_month: 8
+    });
+
+    const eligibleClient = createClient({
+      id: 'client-open',
+      full_name: 'Open Client',
+      email: 'open@example.com',
+      authorized_hours_per_month: 12,
+      hours_provided_per_month: 6
+    });
+
+    const result = generateOptimalSchedule(
+      [baseTherapist],
+      [cappedClient, eligibleClient],
+      sessions,
+      schedulingWindow.start,
+      schedulingWindow.end
+    );
+
+    const scheduledClientIds = result.slots.map(slot => slot.client.id);
+    expect(scheduledClientIds).toContain('client-open');
+    expect(scheduledClientIds).not.toContain('client-capped');
+    expect(result.cappedClients.map(info => info.client.id)).toContain('client-capped');
+  });
+});


### PR DESCRIPTION
### Summary
Respect monthly client authorizations during auto scheduling and surface warnings for capped clients.

### Proposed changes
- Normalize client authorization data in the auto-scheduler and stop slot creation once remaining minutes fall below a session.
- Return metadata about capped clients so the auto-schedule modal can render limits messaging during previews.
- Add targeted unit tests for capped client handling and UI alerts around skipped clients.

### Tests added/updated
- src/lib/__tests__/autoSchedule.test.ts
- src/components/__tests__/AutoScheduleModalWarnings.test.tsx

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cba25deed4833280d9e37300c80da1