### PR TITLE
feat: tighten storage rls – 2025-09-18

### DIFF
--- a/supabase/migrations/20250920120500_remove_generic_storage_policies.sql
+++ b/supabase/migrations/20250920120500_remove_generic_storage_policies.sql
@@ -1,0 +1,39 @@
+/*
+  # Remove generic storage policies
+
+  1. Cleanup
+    - Drop legacy "Allow authenticated users..." policies on storage.objects
+
+  2. Security
+    - Enforce role-aware policies from 20250630220728_tender_shrine.sql
+    - Allow clients to read documents stored in their own folders
+*/
+
+-- Drop legacy generic policies so role-aware rules can take effect
+DROP POLICY IF EXISTS "Allow authenticated users to upload client documents" ON storage.objects;
+DROP POLICY IF EXISTS "Allow authenticated users to download client documents" ON storage.objects;
+DROP POLICY IF EXISTS "Allow authenticated users to update client documents" ON storage.objects;
+DROP POLICY IF EXISTS "Allow authenticated users to delete client documents" ON storage.objects;
+
+-- Ensure clients can read their own documents without reintroducing broad access
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Clients can view their own documents'
+  ) THEN
+    CREATE POLICY "Clients can view their own documents"
+    ON storage.objects
+    FOR SELECT
+    TO authenticated
+    USING (
+      bucket_id = 'client-documents'
+      AND auth.user_has_role('client'::text)
+      AND (storage.foldername(name))[2] = auth.uid()::text
+    );
+  END IF;
+END
+$$;


### PR DESCRIPTION
### Summary
Drop broad storage policies so role-aware rules govern client documents.

### Proposed changes
- Remove generic "Allow authenticated users" storage policies and add a client read policy.
- Expand storage RLS integration tests to cover admin, therapist, client, and unauthorized access flows.

### Tests added/updated
- src/tests/security/rls.spec.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cc867dc9a08332bc4988b536963a62