### PR TITLE
fix: restrict ai cache access – 2025-09-18

### DIFF
--- a/supabase/migrations/20250715103000_secure_ai_cache_rls.sql
+++ b/supabase/migrations/20250715103000_secure_ai_cache_rls.sql
@@ -1,0 +1,66 @@
+/*
+  # Harden AI cache and performance log access
+
+  ## Security
+  - Enable row level security for ai_response_cache and function_performance_logs
+  - Restrict table access to admins (including super_admins) and the service role
+*/
+
+-- Ensure row level security is enforced on ai_response_cache
+ALTER TABLE IF EXISTS public.ai_response_cache ENABLE ROW LEVEL SECURITY;
+
+-- Replace any prior policies with admin/service-role specific ones
+DROP POLICY IF EXISTS ai_response_cache_admin_manage ON public.ai_response_cache;
+DROP POLICY IF EXISTS "Admins manage ai response cache" ON public.ai_response_cache;
+DROP POLICY IF EXISTS ai_response_cache_admin_select ON public.ai_response_cache;
+DROP POLICY IF EXISTS ai_response_cache_service_role_manage ON public.ai_response_cache;
+DROP POLICY IF EXISTS "Service role manages ai response cache" ON public.ai_response_cache;
+
+CREATE POLICY ai_response_cache_admin_manage
+  ON public.ai_response_cache
+  FOR ALL
+  TO authenticated
+  USING (
+    auth.user_has_role('admin')
+    OR auth.user_has_role('super_admin')
+  )
+  WITH CHECK (
+    auth.user_has_role('admin')
+    OR auth.user_has_role('super_admin')
+  );
+
+CREATE POLICY ai_response_cache_service_role_manage
+  ON public.ai_response_cache
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Ensure row level security is enforced on function_performance_logs
+ALTER TABLE IF EXISTS public.function_performance_logs ENABLE ROW LEVEL SECURITY;
+
+-- Replace existing telemetry policies with admin/service-role only access
+DROP POLICY IF EXISTS function_performance_logs_admin_manage ON public.function_performance_logs;
+DROP POLICY IF EXISTS "function_performance_logs_admin_manage" ON public.function_performance_logs;
+DROP POLICY IF EXISTS function_performance_logs_admin_read ON public.function_performance_logs;
+DROP POLICY IF EXISTS function_performance_logs_service_role_manage ON public.function_performance_logs;
+
+CREATE POLICY function_performance_logs_admin_manage
+  ON public.function_performance_logs
+  FOR ALL
+  TO authenticated
+  USING (
+    auth.user_has_role('admin')
+    OR auth.user_has_role('super_admin')
+  )
+  WITH CHECK (
+    auth.user_has_role('admin')
+    OR auth.user_has_role('super_admin')
+  );
+
+CREATE POLICY function_performance_logs_service_role_manage
+  ON public.function_performance_logs
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
### Summary
Lock down AI caching and telemetry data so only admins or the service role can interact with it.

### Proposed changes
- Enable RLS and install admin/service-role policies on `ai_response_cache` and `function_performance_logs`.
- Update the AI edge function to execute cache RPCs with the service-role client after validating the caller.
- Extend security tests to assert standard users cannot read or write the hardened tables.

### Tests added/updated
- src/tests/security/rls.spec.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cc98030d8083329d3b5d9c2458c552