### PR TITLE
feat: runtime Supabase config bootstrap – 2025-09-19

### DIFF
--- a/src/lib/__tests__/DatabaseIntegration.test.ts
+++ b/src/lib/__tests__/DatabaseIntegration.test.ts
@@ -9,8 +9,8 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
 
 // Test configuration
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || 'http://localhost:54321';
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || 'test-key';
+const SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'test-key';
 
 // Initialize Supabase client for testing
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/src/lib/__tests__/ai-documentation.test.ts
+++ b/src/lib/__tests__/ai-documentation.test.ts
@@ -2,12 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AIDocumentationService } from '../ai-documentation';
 import { server } from '../../test/setup';
 import { http, HttpResponse } from 'msw';
-
-// Mock environment variables
-vi.mock('import.meta.env', () => ({
-  VITE_SUPABASE_URL: 'https://test-project.supabase.co',
-  VITE_SUPABASE_ANON_KEY: 'test-anon-key'
-}));
+import { setRuntimeSupabaseConfig, resetRuntimeSupabaseConfigForTests } from '../runtimeConfig';
 
 // Mock MediaRecorder
 class MockMediaRecorder {
@@ -48,6 +43,11 @@ describe('AIDocumentationService', () => {
   let service: AIDocumentationService;
 
   beforeEach(() => {
+    resetRuntimeSupabaseConfigForTests();
+    setRuntimeSupabaseConfig({
+      supabaseUrl: 'https://test-project.supabase.co',
+      supabaseAnonKey: 'test-anon-key',
+    });
     service = AIDocumentationService.getInstance();
     vi.clearAllMocks();
   });

--- a/src/lib/__tests__/conflicts.test.ts
+++ b/src/lib/__tests__/conflicts.test.ts
@@ -2,16 +2,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { checkSchedulingConflicts, suggestAlternativeTimes } from '../conflicts';
 import { parseISO, addHours } from 'date-fns';
 import { fromZonedTime } from 'date-fns-tz';
-import { supabase } from '../supabase';
-
 // Mock supabase
 vi.mock('../supabase', () => ({
   supabase: {
     functions: {
-      invoke: vi.fn()
-    }
-  }
+      invoke: vi.fn(),
+    },
+  },
 }));
+
+let supabase: { functions: { invoke: ReturnType<typeof vi.fn> } };
+
+beforeEach(async () => {
+  ({ supabase } = await import('../supabase'));
+  vi.mocked(supabase.functions.invoke).mockReset();
+});
 
 describe('checkSchedulingConflicts', () => {
   const mockTherapist = {

--- a/src/lib/__tests__/multiTenantAccess.test.ts
+++ b/src/lib/__tests__/multiTenantAccess.test.ts
@@ -15,8 +15,8 @@ interface TestUserContext {
   organizationId: string;
 }
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL ?? '';
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ?? '';
+const SUPABASE_URL = process.env.SUPABASE_URL ?? '';
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY ?? '';
 const SERVICE_ROLE_KEY =
   process.env.SUPABASE_SERVICE_ROLE_KEY ??
   ((import.meta as unknown as { env?: Record<string, string | undefined> }).env?.SUPABASE_SERVICE_ROLE_KEY ?? '');

--- a/src/lib/__tests__/runtimeConfig.test.ts
+++ b/src/lib/__tests__/runtimeConfig.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ensureRuntimeSupabaseConfig,
+  getRuntimeSupabaseConfig,
+  resetRuntimeSupabaseConfigForTests,
+  setRuntimeSupabaseConfig,
+} from '../runtimeConfig';
+
+const mockConfig = {
+  supabaseUrl: 'https://project.supabase.co',
+  supabaseAnonKey: 'anon-key',
+};
+
+describe('runtimeConfig', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resetRuntimeSupabaseConfigForTests();
+  });
+
+  afterEach(() => {
+    resetRuntimeSupabaseConfigForTests();
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns config once set manually', () => {
+    setRuntimeSupabaseConfig(mockConfig);
+    expect(getRuntimeSupabaseConfig()).toMatchObject(mockConfig);
+  });
+
+  it('fetches config when not initialised', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockConfig),
+    } satisfies Partial<Response>);
+
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const config = await ensureRuntimeSupabaseConfig();
+    expect(config).toMatchObject(mockConfig);
+    expect(getRuntimeSupabaseConfig()).toMatchObject(mockConfig);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails fast when runtime endpoint returns an error', async () => {
+    const failureResponse = {
+      ok: false,
+      statusText: 'Not Found',
+      json: () => Promise.resolve({ error: 'Not configured' }),
+    } satisfies Partial<Response>;
+
+    globalThis.fetch = vi.fn().mockResolvedValue(failureResponse) as unknown as typeof fetch;
+
+    await expect(ensureRuntimeSupabaseConfig()).rejects.toThrow(/Failed to load Supabase runtime config/i);
+    await expect(async () => getRuntimeSupabaseConfig()).rejects.toThrow(/has not been initialised/i);
+  });
+});
+

--- a/src/lib/__tests__/supabase.client.test.ts
+++ b/src/lib/__tests__/supabase.client.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setRuntimeSupabaseConfig, resetRuntimeSupabaseConfigForTests } from '../runtimeConfig';
 
 const makeChain = () => {
   const self: any = {
@@ -13,6 +14,18 @@ const makeChain = () => {
 };
 
 describe('supabase client singleton', () => {
+  beforeEach(() => {
+    resetRuntimeSupabaseConfigForTests();
+    setRuntimeSupabaseConfig({
+      supabaseUrl: 'https://test-project.supabase.co',
+      supabaseAnonKey: 'anon-key',
+    });
+  });
+
+  afterEach(() => {
+    resetRuntimeSupabaseConfigForTests();
+  });
+
   it('returns the same instance across imports', async () => {
     const mod1 = await import('../supabase');
     const mod2 = await import('../supabase');
@@ -31,6 +44,12 @@ describe('supabase client singleton', () => {
       .single();
     expect(error).toBeNull();
     expect(data).toBeNull();
+  });
+
+  it('throws a descriptive error when runtime config is missing', async () => {
+    resetRuntimeSupabaseConfigForTests();
+    vi.resetModules();
+    await expect(import('../supabaseClient')).rejects.toThrow(/Failed to initialise client/);
   });
 });
 

--- a/src/lib/ai-documentation.ts
+++ b/src/lib/ai-documentation.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase';
+import { buildSupabaseEdgeUrl, getSupabaseAnonKey } from './runtimeConfig';
 import { showSuccess, showError } from './toast';
 
 // Types for AI Documentation System
@@ -226,11 +227,11 @@ export class AIDocumentationService {
   private async transcribeAudio(audioBase64: string): Promise<any> {
     try {
       // Call Supabase AI Transcription Edge Function
-      const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ai-transcription`, {
+      const response = await fetch(buildSupabaseEdgeUrl('ai-transcription'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`
+          'Authorization': `Bearer ${getSupabaseAnonKey()}`
         },
         body: JSON.stringify({
           audio: audioBase64,
@@ -442,11 +443,11 @@ export class AIDocumentationService {
     try {
       const prompt = this.buildSessionNotePrompt(sessionData, transcriptData);
       
-      const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ai-session-note-generator`, {
+      const response = await fetch(buildSupabaseEdgeUrl('ai-session-note-generator'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`
+          'Authorization': `Bearer ${getSupabaseAnonKey()}`
         },
         body: JSON.stringify({
           prompt,

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,5 +1,6 @@
 // import { supabase } from './supabase';
 import { errorTracker } from './errorTracking';
+import { buildSupabaseEdgeUrl, getSupabaseAnonKey } from './runtimeConfig';
 
 interface AIResponse {
   response: string;
@@ -20,12 +21,12 @@ export async function processMessage(
 ): Promise<AIResponse> {
   try {
     // First try the optimized ai-agent endpoint
-    const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/ai-agent-optimized`;
+    const apiUrl = buildSupabaseEdgeUrl('ai-agent-optimized');
     const response = await fetch(apiUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`
+        'Authorization': `Bearer ${getSupabaseAnonKey()}`
       },
       body: JSON.stringify({ message, context }),
     });
@@ -33,12 +34,12 @@ export async function processMessage(
     if (!response.ok) {
       console.warn(`Optimized AI agent failed with status: ${response.status}, falling back to process-message`);
       // Fall back to the original process-message function
-      const fallbackUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/process-message`;
+      const fallbackUrl = buildSupabaseEdgeUrl('process-message');
       const fallbackResponse = await fetch(fallbackUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+          'Authorization': `Bearer ${getSupabaseAnonKey()}`,
         },
         body: JSON.stringify({ message, context }),
       });
@@ -72,12 +73,12 @@ export async function processMessage(
 // Function to get client details
 export async function getClientDetails(clientId: string): Promise<any> {
   try {
-    const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/get-client-details`;
+    const apiUrl = buildSupabaseEdgeUrl('get-client-details');
     const response = await fetch(apiUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+        'Authorization': `Bearer ${getSupabaseAnonKey()}`,
       },
       body: JSON.stringify({ clientId }),
     });
@@ -97,12 +98,12 @@ export async function getClientDetails(clientId: string): Promise<any> {
 // Function to get therapist details
 export async function getTherapistDetails(therapistId: string): Promise<any> {
   try {
-    const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/get-therapist-details`;
+    const apiUrl = buildSupabaseEdgeUrl('get-therapist-details');
     const response = await fetch(apiUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+        'Authorization': `Bearer ${getSupabaseAnonKey()}`,
       },
       body: JSON.stringify({ therapistId }),
     });
@@ -122,12 +123,12 @@ export async function getTherapistDetails(therapistId: string): Promise<any> {
 // Function to get authorization details
 export async function getAuthorizationDetails(authorizationId: string): Promise<any> {
   try {
-    const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/get-authorization-details`;
+    const apiUrl = buildSupabaseEdgeUrl('get-authorization-details');
     const response = await fetch(apiUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+        'Authorization': `Bearer ${getSupabaseAnonKey()}`,
       },
       body: JSON.stringify({ authorizationId }),
     });

--- a/src/lib/runtimeConfig.ts
+++ b/src/lib/runtimeConfig.ts
@@ -1,0 +1,107 @@
+export interface RuntimeSupabaseConfig {
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  supabaseEdgeUrl?: string;
+}
+
+const RUNTIME_CONFIG_SYMBOL = '__SUPABASE_RUNTIME_CONFIG__';
+
+type RuntimeConfigContainer = typeof globalThis & {
+  [RUNTIME_CONFIG_SYMBOL]?: RuntimeSupabaseConfig;
+};
+
+const getContainer = (): RuntimeConfigContainer => globalThis as RuntimeConfigContainer;
+
+const validateConfig = (config: RuntimeSupabaseConfig): void => {
+  if (!config || typeof config !== 'object') {
+    throw new Error('Invalid Supabase runtime configuration payload');
+  }
+  if (!config.supabaseUrl) {
+    throw new Error('Supabase runtime config missing `supabaseUrl`');
+  }
+  if (!config.supabaseAnonKey) {
+    throw new Error('Supabase runtime config missing `supabaseAnonKey`');
+  }
+};
+
+let fetchPromise: Promise<RuntimeSupabaseConfig> | null = null;
+
+export const setRuntimeSupabaseConfig = (config: RuntimeSupabaseConfig): void => {
+  validateConfig(config);
+  getContainer()[RUNTIME_CONFIG_SYMBOL] = {
+    supabaseUrl: config.supabaseUrl,
+    supabaseAnonKey: config.supabaseAnonKey,
+    supabaseEdgeUrl: config.supabaseEdgeUrl,
+  };
+};
+
+export const getRuntimeSupabaseConfig = (): RuntimeSupabaseConfig => {
+  const config = getContainer()[RUNTIME_CONFIG_SYMBOL];
+  if (!config) {
+    throw new Error('Supabase runtime configuration has not been initialised');
+  }
+  return config;
+};
+
+export const ensureRuntimeSupabaseConfig = async (): Promise<RuntimeSupabaseConfig> => {
+  try {
+    return getRuntimeSupabaseConfig();
+  } catch {
+    // Ignore and fetch below
+  }
+
+  if (!fetchPromise) {
+    if (typeof fetch !== 'function') {
+      throw new Error('Supabase runtime configuration unavailable and fetch is not supported');
+    }
+
+    fetchPromise = fetch('/api/runtime-config', {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}));
+          const detail = typeof payload.error === 'string' ? payload.error : response.statusText;
+          throw new Error(`Failed to load Supabase runtime config: ${detail}`);
+        }
+        return response.json() as Promise<RuntimeSupabaseConfig>;
+      })
+      .then((config) => {
+        setRuntimeSupabaseConfig(config);
+        return config;
+      })
+      .catch((error) => {
+        fetchPromise = null;
+        throw error;
+      });
+  }
+
+  return fetchPromise;
+};
+
+export const getSupabaseUrl = (): string => getRuntimeSupabaseConfig().supabaseUrl;
+
+export const getSupabaseAnonKey = (): string => getRuntimeSupabaseConfig().supabaseAnonKey;
+
+export const getSupabaseEdgeBaseUrl = (): string => {
+  const config = getRuntimeSupabaseConfig();
+  if (config.supabaseEdgeUrl && config.supabaseEdgeUrl.trim().length > 0) {
+    return config.supabaseEdgeUrl;
+  }
+  const normalized = config.supabaseUrl.endsWith('/')
+    ? config.supabaseUrl
+    : `${config.supabaseUrl}/`;
+  return `${normalized}functions/v1/`;
+};
+
+export const buildSupabaseEdgeUrl = (path: string): string => {
+  const base = getSupabaseEdgeBaseUrl();
+  return new URL(path, base).toString();
+};
+
+export const resetRuntimeSupabaseConfigForTests = (): void => {
+  delete getContainer()[RUNTIME_CONFIG_SYMBOL];
+  fetchPromise = null;
+};
+

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -2,6 +2,7 @@
 // multiple GoTrue instances (which can cause session/cookie conflicts).
 // Re-use the canonical client from supabaseClient.ts.
 import { supabase } from './supabaseClient';
+import { buildSupabaseEdgeUrl } from './runtimeConfig';
 // Re-export for modules importing from './supabase'
 export { supabase };
 
@@ -194,10 +195,7 @@ export async function callEdge(path: string, init: RequestInit = {}) {
   const headers = new Headers(init.headers || {});
   if (session?.access_token) headers.set('Authorization', `Bearer ${session.access_token}`);
 
-  type ViteEnv = { VITE_SUPABASE_EDGE_URL?: string; VITE_SUPABASE_URL?: string };
-  const env = (import.meta.env as unknown as ViteEnv) || {};
-  const base = env.VITE_SUPABASE_EDGE_URL ?? `${env.VITE_SUPABASE_URL}/functions/v1/`;
-  const url = new URL(path, base).toString();
+  const url = buildSupabaseEdgeUrl(path);
   return fetch(url, { ...init, headers });
 }
 

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,18 +1,18 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './generated/database.types';
+import { getRuntimeSupabaseConfig } from './runtimeConfig';
 
-const requireEnv = (k: string): string => {
-  const envRecord: Record<string, string | undefined> = (import.meta as unknown as { env?: Record<string, string | undefined> }).env ?? {};
-  const v = envRecord[k];
-  if (!v) {
-    // Fail fast in dev; surface clearly in diagnostics as well
-    throw new Error(`[ENV] Missing required ${k}; set it in .env.local`);
+const resolveSupabaseConfig = (): { supabaseUrl: string; supabaseAnonKey: string } => {
+  try {
+    const { supabaseUrl, supabaseAnonKey } = getRuntimeSupabaseConfig();
+    return { supabaseUrl, supabaseAnonKey };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown runtime configuration error';
+    throw new Error(`[Supabase] Failed to initialise client: ${message}`);
   }
-  return v as string;
 };
 
-const supabaseUrl = requireEnv('VITE_SUPABASE_URL');
-const supabaseAnonKey = requireEnv('VITE_SUPABASE_ANON_KEY');
+const { supabaseUrl, supabaseAnonKey } = resolveSupabaseConfig();
 
 // Browser singleton client. Typed with generated Database.
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
@@ -22,5 +22,3 @@ export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
     detectSessionInUrl: true,
   },
 });
-
-export default supabase;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,18 +1,56 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.tsx';
 import './index.css';
 import BootDiagnostics from './dev/BootDiagnostics';
 import DevErrorBoundary from './dev/ErrorBoundary';
+import { ensureRuntimeSupabaseConfig } from './lib/runtimeConfig';
 
 const devEnabled = import.meta.env.DEV && (import.meta.env.VITE_DEV_DIAGNOSTICS ?? '1') === '1';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <DevErrorBoundary>
-      <BootDiagnostics enabled={devEnabled}>
-        <App />
-      </BootDiagnostics>
-    </DevErrorBoundary>
-  </React.StrictMode>
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+const root = ReactDOM.createRoot(rootElement);
+
+const RuntimeConfigError: React.FC<{ message: string }> = ({ message }) => (
+  <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif', color: '#ef4444' }}>
+    <h1 style={{ fontSize: 24, marginBottom: 16 }}>Configuration error</h1>
+    <p style={{ marginBottom: 12 }}>The application failed to load the Supabase runtime configuration.</p>
+    <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', background: '#111827', color: '#f3f4f6', padding: 16, borderRadius: 8 }}>
+      {message}
+    </pre>
+  </div>
 );
+
+const bootstrap = async (): Promise<void> => {
+  try {
+    await ensureRuntimeSupabaseConfig();
+    const { default: App } = await import('./App.tsx');
+    root.render(
+      <React.StrictMode>
+        <DevErrorBoundary>
+          <BootDiagnostics enabled={devEnabled}>
+            <App />
+          </BootDiagnostics>
+        </DevErrorBoundary>
+      </React.StrictMode>,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown runtime configuration failure';
+    console.error('[Bootstrap] Failed to initialise Supabase runtime config', error);
+    root.render(
+      <React.StrictMode>
+        <DevErrorBoundary>
+          <BootDiagnostics enabled={devEnabled}>
+            <RuntimeConfigError message={message} />
+          </BootDiagnostics>
+        </DevErrorBoundary>
+      </React.StrictMode>,
+    );
+  }
+};
+
+void bootstrap();

--- a/src/server/__tests__/runtimeConfigHandler.test.ts
+++ b/src/server/__tests__/runtimeConfigHandler.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, beforeEach, afterAll } from 'vitest';
+import { runtimeConfigHandler } from '../api/runtime-config';
+
+const originalEnv = { ...process.env };
+
+describe('runtimeConfigHandler', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv } as NodeJS.ProcessEnv;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv as NodeJS.ProcessEnv;
+  });
+
+  it('returns runtime config when env vars are present', async () => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon-key';
+
+    const response = await runtimeConfigHandler(new Request('http://localhost/api/runtime-config'));
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.supabaseUrl).toBe('https://example.supabase.co');
+    expect(payload.supabaseAnonKey).toBe('anon-key');
+  });
+
+  it('fails with 500 when env vars are missing', async () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_ANON_KEY;
+
+    const response = await runtimeConfigHandler(new Request('http://localhost/api/runtime-config'));
+    expect(response.status).toBe(500);
+    const payload = await response.json();
+    expect(payload.error).toMatch(/Missing required Supabase environment variable/);
+  });
+
+  it('rejects unsupported methods', async () => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon-key';
+
+    const response = await runtimeConfigHandler(new Request('http://localhost/api/runtime-config', { method: 'POST' }));
+    expect(response.status).toBe(405);
+    const payload = await response.json();
+    expect(payload.error).toBe('Method not allowed');
+  });
+
+  it('responds to OPTIONS preflight', async () => {
+    const response = await runtimeConfigHandler(new Request('http://localhost/api/runtime-config', { method: 'OPTIONS' }));
+    expect(response.status).toBe(200);
+  });
+});
+

--- a/src/server/api/runtime-config.ts
+++ b/src/server/api/runtime-config.ts
@@ -1,0 +1,28 @@
+import { getRuntimeSupabaseConfig } from '../runtimeConfig';
+
+const JSON_HEADERS: Record<string, string> = {
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store',
+};
+
+export const runtimeConfigHandler = async (request: Request): Promise<Response> => {
+  if (request.method === 'OPTIONS') {
+    return new Response('ok', { status: 200, headers: JSON_HEADERS });
+  }
+
+  if (request.method !== 'GET') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: JSON_HEADERS,
+    });
+  }
+
+  try {
+    const config = getRuntimeSupabaseConfig();
+    return new Response(JSON.stringify(config), { status: 200, headers: JSON_HEADERS });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load runtime config';
+    return new Response(JSON.stringify({ error: message }), { status: 500, headers: JSON_HEADERS });
+  }
+};
+

--- a/src/server/runtimeConfig.ts
+++ b/src/server/runtimeConfig.ts
@@ -1,0 +1,25 @@
+import type { RuntimeSupabaseConfig } from '../lib/runtimeConfig';
+
+type RequiredEnvKey = 'SUPABASE_URL' | 'SUPABASE_ANON_KEY';
+
+const requireEnv = (key: RequiredEnvKey): string => {
+  const value = process.env[key];
+  if (!value || value.trim().length === 0) {
+    throw new Error(`Missing required Supabase environment variable: ${key}`);
+  }
+  return value;
+};
+
+export const getRuntimeSupabaseConfig = (): RuntimeSupabaseConfig => {
+  const supabaseUrl = requireEnv('SUPABASE_URL');
+  const supabaseAnonKey = requireEnv('SUPABASE_ANON_KEY');
+
+  const supabaseEdgeUrl = process.env.SUPABASE_EDGE_URL?.trim();
+
+  return {
+    supabaseUrl,
+    supabaseAnonKey,
+    supabaseEdgeUrl: supabaseEdgeUrl?.length ? supabaseEdgeUrl : undefined,
+  };
+};
+

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,8 +3,14 @@ import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import '@testing-library/jest-dom';
 import { installConsoleGuard } from './utils/consoleGuard';
+import { setRuntimeSupabaseConfig } from '../lib/runtimeConfig';
 
 const consoleGuard = installConsoleGuard({ passthrough: false });
+
+setRuntimeSupabaseConfig({
+  supabaseUrl: 'https://test-project.supabase.co',
+  supabaseAnonKey: 'test-anon-key',
+});
 
 beforeEach(() => {
   consoleGuard.resetCapturedLogs();

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -24,8 +24,8 @@ interface AdminContext {
   userId: string;
 }
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL ?? '';
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ?? '';
+const SUPABASE_URL = process.env.SUPABASE_URL ?? '';
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY ?? '';
 const SERVICE_ROLE_KEY =
   process.env.SUPABASE_SERVICE_ROLE_KEY ??
   ((import.meta as unknown as { env?: Record<string, string | undefined> }).env?.SUPABASE_SERVICE_ROLE_KEY ?? '');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'import.meta.env.VITE_SUPABASE_URL': 'undefined',
+    'import.meta.env.VITE_SUPABASE_ANON_KEY': 'undefined',
+    'import.meta.env.VITE_SUPABASE_EDGE_URL': 'undefined',
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
### Summary
Load Supabase credentials from a runtime endpoint so the browser bundle no longer embeds secrets.

### Proposed changes
- Serve Supabase URL/anon key through a server runtime-config handler and consume it via a shared runtimeConfig helper.
- Defer client bootstrap until runtime config is fetched and update Supabase helpers/tests to rely on the injected values instead of `import.meta.env`.
- Add regression coverage for runtime config fetching failures and the new server handler.

### Tests added/updated
- src/lib/__tests__/runtimeConfig.test.ts
- src/server/__tests__/runtimeConfigHandler.test.ts
- src/lib/__tests__/supabase.client.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cc9c622de08332808445676b8bde45