### PR TITLE
fix: secure runtime env loading – 2025-09-19

### DIFF
--- a/src/server/__tests__/env.test.ts
+++ b/src/server/__tests__/env.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ensureServerEnv,
+  getOptionalServerEnv,
+  getRequiredServerEnv,
+  resetEnvCacheForTests,
+} from '../env';
+
+const ORIGINAL_ENV = { ...process.env } as NodeJS.ProcessEnv;
+
+describe('server/env', () => {
+  let tempDir = '';
+  let envPath = '';
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV } as NodeJS.ProcessEnv;
+    resetEnvCacheForTests();
+    tempDir = mkdtempSync(join(tmpdir(), 'env-tests-'));
+    envPath = join(tempDir, '.env.codex');
+  });
+
+  afterEach(() => {
+    resetEnvCacheForTests();
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(() => {
+    process.env = { ...ORIGINAL_ENV } as NodeJS.ProcessEnv;
+  });
+
+  it('loads missing keys from the configured env file', () => {
+    writeFileSync(envPath, 'SUPABASE_URL=https://example.supabase.co\n');
+
+    const value = getRequiredServerEnv('SUPABASE_URL', { envPath });
+
+    expect(value).toBe('https://example.supabase.co');
+    expect(process.env.SUPABASE_URL).toBe('https://example.supabase.co');
+  });
+
+  it('prefers existing process env values over file entries', () => {
+    process.env.SUPABASE_URL = 'https://process.supabase.co';
+    writeFileSync(envPath, 'SUPABASE_URL=https://file.supabase.co\n');
+
+    const value = getRequiredServerEnv('SUPABASE_URL', { envPath });
+
+    expect(value).toBe('https://process.supabase.co');
+    expect(process.env.SUPABASE_URL).toBe('https://process.supabase.co');
+  });
+
+  it('throws when a required key is missing from both process env and the file', () => {
+    writeFileSync(envPath, 'SUPABASE_ANON_KEY=anon-key\n');
+
+    expect(() => getRequiredServerEnv('SUPABASE_URL', { envPath })).toThrow(/SUPABASE_URL/);
+  });
+
+  it('strips inline comments and surrounding quotes', () => {
+    writeFileSync(envPath, 'SUPABASE_ANON_KEY="anon-key" # comment\n');
+
+    const value = getRequiredServerEnv('SUPABASE_ANON_KEY', { envPath });
+
+    expect(value).toBe('anon-key');
+  });
+
+  it('supports loading multiple keys at once', () => {
+    writeFileSync(
+      envPath,
+      [
+        'SUPABASE_URL=https://batched.supabase.co',
+        'SUPABASE_ANON_KEY=anon-key',
+        'SUPABASE_SERVICE_ROLE_KEY=service-role',
+      ].join('\n'),
+    );
+
+    ensureServerEnv(
+      ['SUPABASE_URL', 'SUPABASE_ANON_KEY', 'SUPABASE_SERVICE_ROLE_KEY'],
+      { envPath },
+    );
+
+    expect(process.env.SUPABASE_URL).toBe('https://batched.supabase.co');
+    expect(process.env.SUPABASE_ANON_KEY).toBe('anon-key');
+    expect(process.env.SUPABASE_SERVICE_ROLE_KEY).toBe('service-role');
+  });
+
+  it('returns undefined for optional keys that remain unset', () => {
+    writeFileSync(envPath, 'SUPABASE_URL=https://example.supabase.co\n');
+
+    const value = getOptionalServerEnv('OPENAI_API_KEY', { envPath });
+
+    expect(value).toBeUndefined();
+  });
+});

--- a/src/server/__tests__/runtimeConfigHandler.test.ts
+++ b/src/server/__tests__/runtimeConfigHandler.test.ts
@@ -1,15 +1,20 @@
-import { describe, expect, it, beforeEach, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 import { runtimeConfigHandler } from '../api/runtime-config';
+import { resetEnvCacheForTests } from '../env';
 
 const originalEnv = { ...process.env };
 
 describe('runtimeConfigHandler', () => {
   beforeEach(() => {
     process.env = { ...originalEnv } as NodeJS.ProcessEnv;
+    resetEnvCacheForTests();
   });
 
   afterAll(() => {
-    process.env = originalEnv as NodeJS.ProcessEnv;
+    process.env = { ...originalEnv } as NodeJS.ProcessEnv;
   });
 
   it('returns runtime config when env vars are present', async () => {
@@ -23,6 +28,31 @@ describe('runtimeConfigHandler', () => {
     expect(payload.supabaseAnonKey).toBe('anon-key');
   });
 
+  it('loads config values from .env.codex when process env is unset', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'runtime-config-tests-'));
+    const envPath = join(tempDir, '.env.codex');
+    writeFileSync(envPath, [
+      'SUPABASE_URL=https://file.supabase.co',
+      'SUPABASE_ANON_KEY=file-anon',
+    ].join('\n'));
+
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_ANON_KEY;
+    process.env.CODEX_ENV_PATH = envPath;
+    resetEnvCacheForTests();
+
+    try {
+      const response = await runtimeConfigHandler(new Request('http://localhost/api/runtime-config'));
+      expect(response.status).toBe(200);
+      const payload = await response.json();
+      expect(payload.supabaseUrl).toBe('https://file.supabase.co');
+      expect(payload.supabaseAnonKey).toBe('file-anon');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+      delete process.env.CODEX_ENV_PATH;
+    }
+  });
+
   it('fails with 500 when env vars are missing', async () => {
     delete process.env.SUPABASE_URL;
     delete process.env.SUPABASE_ANON_KEY;
@@ -30,7 +60,7 @@ describe('runtimeConfigHandler', () => {
     const response = await runtimeConfigHandler(new Request('http://localhost/api/runtime-config'));
     expect(response.status).toBe(500);
     const payload = await response.json();
-    expect(payload.error).toMatch(/Missing required Supabase environment variable/);
+    expect(payload.error).toMatch(/Missing required environment variable SUPABASE_URL/);
   });
 
   it('rejects unsupported methods', async () => {

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -1,0 +1,210 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type EnvMap = Record<string, string>;
+
+interface EnvLoadOptions {
+  readonly envPath?: string;
+}
+
+const DEFAULT_ENV_FILENAME = '.env.codex';
+const envCache = new Map<string, EnvMap>();
+
+const stripInlineComments = (value: string): string => {
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    const previous = index > 0 ? value[index - 1] : undefined;
+
+    if (character === "'" && previous !== '\\' && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+
+    if (character === '"' && previous !== '\\' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+
+    if (character === '#' && !inSingleQuote && !inDoubleQuote) {
+      return value.slice(0, index);
+    }
+  }
+
+  return value;
+};
+
+const unquoteValue = (value: string): string => {
+  if (value.length < 2) {
+    return value;
+  }
+
+  const first = value[0];
+  const last = value[value.length - 1];
+
+  if (first !== last || (first !== '"' && first !== "'")) {
+    return value;
+  }
+
+  const inner = value.slice(1, -1);
+
+  if (first === '"') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return inner
+        .replace(/\\n/g, '\n')
+        .replace(/\\r/g, '\r')
+        .replace(/\\t/g, '\t')
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, '\\');
+    }
+  }
+
+  if (first === "'") {
+    return inner
+      .replace(/\\n/g, '\n')
+      .replace(/\\r/g, '\r')
+      .replace(/\\t/g, '\t')
+      .replace(/\\'/g, "'")
+      .replace(/\\\\/g, '\\');
+  }
+
+  return inner;
+};
+
+const sanitizeValue = (raw: string | undefined | null): string | undefined => {
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+
+  const withoutComments = stripInlineComments(raw);
+  const trimmed = withoutComments.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const unquoted = unquoteValue(trimmed);
+  const normalized = unquoted.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const parseEnvContent = (content: string): EnvMap => {
+  const result: EnvMap = {};
+
+  content.split(/\r?\n/).forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      return;
+    }
+
+    const withoutExport = trimmed.startsWith('export ')
+      ? trimmed.slice('export '.length).trim()
+      : trimmed;
+
+    const equalsIndex = withoutExport.indexOf('=');
+    if (equalsIndex === -1) {
+      return;
+    }
+
+    const key = withoutExport.slice(0, equalsIndex).trim();
+    if (!key) {
+      return;
+    }
+
+    const value = sanitizeValue(withoutExport.slice(equalsIndex + 1));
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  });
+
+  return result;
+};
+
+const getEnvFilePath = (explicitPath?: string): string => {
+  const configuredPath = explicitPath ?? process.env.CODEX_ENV_PATH ?? DEFAULT_ENV_FILENAME;
+  return resolve(process.cwd(), configuredPath);
+};
+
+const getCachedEnv = (envPath: string): EnvMap => {
+  const cached = envCache.get(envPath);
+  if (cached) {
+    return cached;
+  }
+
+  if (!existsSync(envPath)) {
+    const empty: EnvMap = {};
+    envCache.set(envPath, empty);
+    return empty;
+  }
+
+  try {
+    const content = readFileSync(envPath, 'utf8');
+    const parsed = parseEnvContent(content);
+    envCache.set(envPath, parsed);
+    return parsed;
+  } catch (error) {
+    throw new Error(
+      `Failed to read ${envPath}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    );
+  }
+};
+
+const getProcessEnvValue = (key: string): string | undefined => {
+  const raw = process.env[key];
+  const normalized = sanitizeValue(raw);
+  if (normalized && raw !== normalized) {
+    process.env[key] = normalized;
+  }
+  return normalized;
+};
+
+const loadFromCodex = (keys: string[], { envPath }: EnvLoadOptions = {}): void => {
+  const filteredKeys = keys
+    .map((key) => key?.trim())
+    .filter((key): key is string => typeof key === 'string' && key.length > 0);
+
+  if (filteredKeys.length === 0) {
+    return;
+  }
+
+  const missingKeys = filteredKeys.filter((key) => !getProcessEnvValue(key));
+  if (missingKeys.length === 0) {
+    return;
+  }
+
+  const resolvedPath = getEnvFilePath(envPath);
+  const parsed = getCachedEnv(resolvedPath);
+
+  missingKeys.forEach((key) => {
+    const value = parsed[key];
+    if (value !== undefined) {
+      process.env[key] = value;
+    }
+  });
+};
+
+export const ensureServerEnv = (keys: string[], options?: EnvLoadOptions): void => {
+  loadFromCodex(keys, options);
+};
+
+export const getOptionalServerEnv = (key: string, options?: EnvLoadOptions): string | undefined => {
+  loadFromCodex([key], options);
+  return getProcessEnvValue(key);
+};
+
+export const getRequiredServerEnv = (key: string, options?: EnvLoadOptions): string => {
+  const value = getOptionalServerEnv(key, options);
+  if (value) {
+    return value;
+  }
+
+  const resolvedPath = getEnvFilePath(options?.envPath);
+  throw new Error(`Missing required environment variable ${key}. Provide it via process.env or set it in ${resolvedPath}.`);
+};
+
+export const resetEnvCacheForTests = (): void => {
+  envCache.clear();
+};

--- a/src/server/runtimeConfig.ts
+++ b/src/server/runtimeConfig.ts
@@ -1,25 +1,15 @@
 import type { RuntimeSupabaseConfig } from '../lib/runtimeConfig';
-
-type RequiredEnvKey = 'SUPABASE_URL' | 'SUPABASE_ANON_KEY';
-
-const requireEnv = (key: RequiredEnvKey): string => {
-  const value = process.env[key];
-  if (!value || value.trim().length === 0) {
-    throw new Error(`Missing required Supabase environment variable: ${key}`);
-  }
-  return value;
-};
+import { getOptionalServerEnv, getRequiredServerEnv } from './env';
 
 export const getRuntimeSupabaseConfig = (): RuntimeSupabaseConfig => {
-  const supabaseUrl = requireEnv('SUPABASE_URL');
-  const supabaseAnonKey = requireEnv('SUPABASE_ANON_KEY');
-
-  const supabaseEdgeUrl = process.env.SUPABASE_EDGE_URL?.trim();
+  const supabaseUrl = getRequiredServerEnv('SUPABASE_URL');
+  const supabaseAnonKey = getRequiredServerEnv('SUPABASE_ANON_KEY');
+  const supabaseEdgeUrl = getOptionalServerEnv('SUPABASE_EDGE_URL');
 
   return {
     supabaseUrl,
     supabaseAnonKey,
-    supabaseEdgeUrl: supabaseEdgeUrl?.length ? supabaseEdgeUrl : undefined,
+    supabaseEdgeUrl: supabaseEdgeUrl ?? undefined,
   };
 };
 

--- a/src/server/sessionCptPersistence.ts
+++ b/src/server/sessionCptPersistence.ts
@@ -1,4 +1,5 @@
 import { createClient, type PostgrestError, type SupabaseClient } from "@supabase/supabase-js";
+import { getRequiredServerEnv } from "./env";
 import type { DerivedCpt } from "./types";
 
 type Database = {
@@ -58,36 +59,13 @@ type BillingMetrics = {
 
 let cachedClient: SupabaseClient<Database> | null = null;
 
-function resolveEnvValue(key: string): string | undefined {
-  const processValue = typeof process !== "undefined" ? process.env?.[key] : undefined;
-  if (typeof processValue === "string" && processValue.trim().length > 0) {
-    return processValue.trim();
-  }
-
-  const meta = (import.meta as unknown as { env?: Record<string, string | undefined> }).env;
-  const metaValue = meta?.[key] ?? meta?.[`VITE_${key}`];
-  if (typeof metaValue === "string" && metaValue.trim().length > 0) {
-    return metaValue.trim();
-  }
-
-  return undefined;
-}
-
-function requireEnvValue(key: string): string {
-  const value = resolveEnvValue(key);
-  if (!value) {
-    throw new Error(`${key} environment variable is required to persist session CPT metadata`);
-  }
-  return value;
-}
-
 function getServiceClient(): SupabaseClient<Database> {
   if (cachedClient) {
     return cachedClient;
   }
 
-  const url = requireEnvValue("SUPABASE_URL");
-  const serviceRoleKey = requireEnvValue("SUPABASE_SERVICE_ROLE_KEY");
+  const url = getRequiredServerEnv("SUPABASE_URL");
+  const serviceRoleKey = getRequiredServerEnv("SUPABASE_SERVICE_ROLE_KEY");
 
   cachedClient = createClient<Database>(url, serviceRoleKey, {
     auth: {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_OPENAI_API_KEY: string;
+  readonly VITE_DEV_DIAGNOSTICS?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
### Summary
Secure runtime configuration by sourcing secrets on the server and tightening client env typings.

### Proposed changes
- Add a reusable `.env.codex` loader that hydrates required keys into `process.env` and exposes helpers for optional/required lookups.
- Update runtime configuration and server persistence to rely on the loader instead of client-side env access, and adjust runtime-config tests accordingly.

### Tests added/updated
- src/server/__tests__/env.test.ts
- src/server/__tests__/runtimeConfigHandler.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cca744d65c83329704acb309b18fa9