### PR TITLE
feat: tighten session hold RLS – 2025-09-19

### DIFF
--- a/supabase/migrations/20250720121500_secure_session_holds_rls.sql
+++ b/supabase/migrations/20250720121500_secure_session_holds_rls.sql
@@ -1,0 +1,47 @@
+-- Adjust session_holds RLS to allow admins full access and therapists scoped to their holds
+set search_path = public;
+
+drop policy if exists "session_holds_disallow_select" on session_holds;
+drop policy if exists "session_holds_disallow_insert" on session_holds;
+drop policy if exists "session_holds_disallow_update" on session_holds;
+drop policy if exists "session_holds_disallow_delete" on session_holds;
+
+create policy "session_holds_select_access"
+  on session_holds
+  for select
+  to authenticated
+  using (
+    auth.user_has_role('admin')
+    or (auth.user_has_role('therapist') and therapist_id = auth.uid())
+  );
+
+create policy "session_holds_insert_access"
+  on session_holds
+  for insert
+  to authenticated
+  with check (
+    auth.user_has_role('admin')
+    or (auth.user_has_role('therapist') and therapist_id = auth.uid())
+  );
+
+create policy "session_holds_update_access"
+  on session_holds
+  for update
+  to authenticated
+  using (
+    auth.user_has_role('admin')
+    or (auth.user_has_role('therapist') and therapist_id = auth.uid())
+  )
+  with check (
+    auth.user_has_role('admin')
+    or (auth.user_has_role('therapist') and therapist_id = auth.uid())
+  );
+
+create policy "session_holds_delete_access"
+  on session_holds
+  for delete
+  to authenticated
+  using (
+    auth.user_has_role('admin')
+    or (auth.user_has_role('therapist') and therapist_id = auth.uid())
+  );


### PR DESCRIPTION
### Summary
Tighten the `session_holds` row-level security rules while expanding the security integration tests.

### Proposed changes
- Replace the `session_holds` policies with authenticated admin/therapist rules that enforce `WITH CHECK` guards.
- Extend the RLS integration suite to cover admin success paths, therapist denials, and admin visibility of existing `session_holds` rows.

### Tests added/updated
- src/tests/security/rls.spec.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68ccab8f7c8483329635d8e87bdddb5e