### PR TITLE
fix: propagate booking tokens – 2025-09-19

### DIFF
--- a/src/components/__tests__/SchedulingFlow.test.tsx
+++ b/src/components/__tests__/SchedulingFlow.test.tsx
@@ -194,7 +194,7 @@ describe('Scheduling Flow - Client with Therapist', () => {
       // Should show matrix view; allow multiple matches
       expect(screen.getAllByText(/therapists/i).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/clients/i).length).toBeGreaterThan(0);
-    });
+    }, 10000);
   });
 
   describe('Session Modal - Creating New Session', () => {

--- a/src/lib/__tests__/sessionHolds.test.ts
+++ b/src/lib/__tests__/sessionHolds.test.ts
@@ -11,6 +11,7 @@ vi.mock("../supabase", () => ({
 }));
 
 const mockedCallEdge = vi.mocked(callEdge);
+const ACCESS_TOKEN = "edge-access-token";
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -37,6 +38,7 @@ describe("session holds API helpers", () => {
       startTimeOffsetMinutes: 0,
       endTimeOffsetMinutes: 0,
       timeZone: "UTC",
+      accessToken: ACCESS_TOKEN,
     });
 
     expect(result).toEqual({ holdKey: "hold-key", holdId: "1", expiresAt: "2025-01-01T00:05:00Z" });
@@ -56,6 +58,7 @@ describe("session holds API helpers", () => {
           time_zone: "UTC",
         }),
       }),
+      { accessToken: ACCESS_TOKEN },
     );
   });
 
@@ -73,6 +76,7 @@ describe("session holds API helpers", () => {
       startTimeOffsetMinutes: 0,
       endTimeOffsetMinutes: 0,
       timeZone: "UTC",
+      accessToken: ACCESS_TOKEN,
     });
 
     expect(mockedCallEdge).toHaveBeenCalledWith(
@@ -80,6 +84,7 @@ describe("session holds API helpers", () => {
       expect.objectContaining({
         headers: expect.objectContaining({ "Idempotency-Key": "unique-key" }),
       }),
+      { accessToken: ACCESS_TOKEN },
     );
   });
 
@@ -97,6 +102,7 @@ describe("session holds API helpers", () => {
         startTimeOffsetMinutes: 0,
         endTimeOffsetMinutes: 0,
         timeZone: "UTC",
+        accessToken: ACCESS_TOKEN,
       }),
     ).rejects.toThrow(/Therapist already booked/);
   });
@@ -128,6 +134,7 @@ describe("session holds API helpers", () => {
       startTimeOffsetMinutes: 0,
       endTimeOffsetMinutes: 0,
       timeZone: "UTC",
+      accessToken: ACCESS_TOKEN,
     } as const;
 
     const [firstResult, secondResult] = await Promise.allSettled([
@@ -188,6 +195,7 @@ describe("session holds API helpers", () => {
       startTimeOffsetMinutes: 0,
       endTimeOffsetMinutes: 0,
       timeZone: "UTC",
+      accessToken: ACCESS_TOKEN,
     });
 
     expect(session.id).toBe("session-1");
@@ -195,6 +203,7 @@ describe("session holds API helpers", () => {
     expect(mockedCallEdge).toHaveBeenCalledWith(
       "sessions-confirm",
       expect.objectContaining({ method: "POST" }),
+      { accessToken: ACCESS_TOKEN },
     );
   });
 
@@ -234,6 +243,7 @@ describe("session holds API helpers", () => {
       startTimeOffsetMinutes: 0,
       endTimeOffsetMinutes: 0,
       timeZone: "UTC",
+      accessToken: ACCESS_TOKEN,
     });
 
     expect(session.duration_minutes).toBe(45);
@@ -314,6 +324,7 @@ describe("session holds API helpers", () => {
           startTimeOffsetMinutes: 0,
           endTimeOffsetMinutes: 0,
           timeZone: "UTC",
+          accessToken: ACCESS_TOKEN,
         });
 
         expect(session.duration_minutes).toBe(roundedDuration);
@@ -347,6 +358,7 @@ describe("session holds API helpers", () => {
         startTimeOffsetMinutes: 0,
         endTimeOffsetMinutes: 0,
         timeZone: "UTC",
+        accessToken: ACCESS_TOKEN,
       }),
     ).rejects.toThrow(/Hold has expired/);
   });
@@ -381,6 +393,7 @@ describe("session holds API helpers", () => {
       startTimeOffsetMinutes: 0,
       endTimeOffsetMinutes: 0,
       timeZone: "UTC",
+      accessToken: ACCESS_TOKEN,
     });
 
     expect(mockedCallEdge).toHaveBeenCalledWith(
@@ -388,6 +401,7 @@ describe("session holds API helpers", () => {
       expect.objectContaining({
         headers: expect.objectContaining({ "Idempotency-Key": "confirm-key" }),
       }),
+      { accessToken: ACCESS_TOKEN },
     );
   });
 
@@ -410,7 +424,7 @@ describe("session holds API helpers", () => {
       }),
     );
 
-    const result = await cancelSessionHold({ holdKey: "hold-key" });
+    const result = await cancelSessionHold({ holdKey: "hold-key", accessToken: ACCESS_TOKEN });
 
     expect(result).toEqual({
       released: true,
@@ -427,19 +441,25 @@ describe("session holds API helpers", () => {
     expect(mockedCallEdge).toHaveBeenCalledWith(
       "sessions-cancel",
       expect.objectContaining({ method: "POST" }),
+      { accessToken: ACCESS_TOKEN },
     );
   });
 
   it("passes idempotency key when cancelling a hold", async () => {
     mockedCallEdge.mockResolvedValueOnce(jsonResponse({ success: true, data: { released: false } }));
 
-    await cancelSessionHold({ holdKey: "hold-key", idempotencyKey: "cancel-key" });
+    await cancelSessionHold({
+      holdKey: "hold-key",
+      idempotencyKey: "cancel-key",
+      accessToken: ACCESS_TOKEN,
+    });
 
     expect(mockedCallEdge).toHaveBeenCalledWith(
       "sessions-cancel",
       expect.objectContaining({
         headers: expect.objectContaining({ "Idempotency-Key": "cancel-key" }),
       }),
+      { accessToken: ACCESS_TOKEN },
     );
   });
 
@@ -448,6 +468,8 @@ describe("session holds API helpers", () => {
       jsonResponse({ success: false, error: "Hold not found" }, 404),
     );
 
-    await expect(cancelSessionHold({ holdKey: "missing" })).rejects.toThrow(/Hold not found/);
+    await expect(
+      cancelSessionHold({ holdKey: "missing", accessToken: ACCESS_TOKEN }),
+    ).rejects.toThrow(/Hold not found/);
   });
 });

--- a/src/lib/__tests__/supabase.edge.test.ts
+++ b/src/lib/__tests__/supabase.edge.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+vi.mock("../supabaseClient", () => ({
+  supabase: {
+    auth: {
+      getSession: getSessionMock,
+    },
+  },
+}));
+
+vi.mock("../runtimeConfig", () => ({
+  buildSupabaseEdgeUrl: (path: string) => `https://edge.test/${path}`,
+}));
+
+const { callEdge: actualCallEdge } = await vi.importActual<typeof import("../supabase")>("../supabase");
+
+describe("callEdge", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    getSessionMock.mockReset();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("uses a provided bearer token without consulting the auth client", async () => {
+    fetchMock.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await actualCallEdge("sessions-test", { method: "GET" }, { accessToken: "token-123" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://edge.test/sessions-test",
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    const headers = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer token-123");
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("attaches the anon apikey when supplied", async () => {
+    fetchMock.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await actualCallEdge(
+      "sessions-test",
+      { method: "POST", headers: new Headers({ "Content-Type": "application/json" }) },
+      { accessToken: "token-456", anonKey: "anon-key" },
+    );
+
+    const headers = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer token-456");
+    expect(headers.get("apikey")).toBe("anon-key");
+  });
+
+  it("falls back to the active session when no token is provided", async () => {
+    fetchMock.mockResolvedValue(new Response("{}", { status: 200 }));
+    getSessionMock.mockResolvedValue({ data: { session: { access_token: "session-token" } } });
+
+    await actualCallEdge("sessions-test");
+
+    const headers = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer session-token");
+    expect(getSessionMock).toHaveBeenCalled();
+  });
+});

--- a/src/lib/sessionHolds.ts
+++ b/src/lib/sessionHolds.ts
@@ -12,6 +12,7 @@ export interface HoldRequest {
   startTimeOffsetMinutes: number;
   endTimeOffsetMinutes: number;
   timeZone: string;
+  accessToken?: string;
 }
 
 export interface HoldResponse {
@@ -43,24 +44,28 @@ function toError(message: string | undefined, fallback: string) {
 }
 
 export async function requestSessionHold(payload: HoldRequest): Promise<HoldResponse> {
-  const response = await callEdge("sessions-hold", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(payload.idempotencyKey ? { "Idempotency-Key": payload.idempotencyKey } : {}),
+  const response = await callEdge(
+    "sessions-hold",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(payload.idempotencyKey ? { "Idempotency-Key": payload.idempotencyKey } : {}),
+      },
+      body: JSON.stringify({
+        therapist_id: payload.therapistId,
+        client_id: payload.clientId,
+        start_time: payload.startTime,
+        end_time: payload.endTime,
+        session_id: payload.sessionId ?? null,
+        hold_seconds: payload.holdSeconds ?? 300,
+        start_time_offset_minutes: payload.startTimeOffsetMinutes,
+        end_time_offset_minutes: payload.endTimeOffsetMinutes,
+        time_zone: payload.timeZone,
+      }),
     },
-    body: JSON.stringify({
-      therapist_id: payload.therapistId,
-      client_id: payload.clientId,
-      start_time: payload.startTime,
-      end_time: payload.endTime,
-      session_id: payload.sessionId ?? null,
-      hold_seconds: payload.holdSeconds ?? 300,
-      start_time_offset_minutes: payload.startTimeOffsetMinutes,
-      end_time_offset_minutes: payload.endTimeOffsetMinutes,
-      time_zone: payload.timeZone,
-    }),
-  });
+    { accessToken: payload.accessToken },
+  );
 
   let body: HoldEdgeResponse | null = null;
   try {
@@ -83,23 +88,28 @@ export interface ConfirmRequest {
   startTimeOffsetMinutes: number;
   endTimeOffsetMinutes: number;
   timeZone: string;
+  accessToken?: string;
 }
 
 export async function confirmSessionBooking(payload: ConfirmRequest): Promise<Session> {
-  const response = await callEdge("sessions-confirm", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(payload.idempotencyKey ? { "Idempotency-Key": payload.idempotencyKey } : {}),
+  const response = await callEdge(
+    "sessions-confirm",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(payload.idempotencyKey ? { "Idempotency-Key": payload.idempotencyKey } : {}),
+      },
+      body: JSON.stringify({
+        hold_key: payload.holdKey,
+        session: payload.session,
+        start_time_offset_minutes: payload.startTimeOffsetMinutes,
+        end_time_offset_minutes: payload.endTimeOffsetMinutes,
+        time_zone: payload.timeZone,
+      }),
     },
-    body: JSON.stringify({
-      hold_key: payload.holdKey,
-      session: payload.session,
-      start_time_offset_minutes: payload.startTimeOffsetMinutes,
-      end_time_offset_minutes: payload.endTimeOffsetMinutes,
-      time_zone: payload.timeZone,
-    }),
-  });
+    { accessToken: payload.accessToken },
+  );
 
   let body: ConfirmEdgeResponse | null = null;
   try {
@@ -129,6 +139,7 @@ export async function confirmSessionBooking(payload: ConfirmRequest): Promise<Se
 export interface CancelHoldRequest {
   holdKey: string;
   idempotencyKey?: string;
+  accessToken?: string;
 }
 
 export interface CancelHoldResponse {
@@ -145,14 +156,18 @@ export interface CancelHoldResponse {
 }
 
 export async function cancelSessionHold(payload: CancelHoldRequest): Promise<CancelHoldResponse> {
-  const response = await callEdge("sessions-cancel", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(payload.idempotencyKey ? { "Idempotency-Key": payload.idempotencyKey } : {}),
+  const response = await callEdge(
+    "sessions-cancel",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(payload.idempotencyKey ? { "Idempotency-Key": payload.idempotencyKey } : {}),
+      },
+      body: JSON.stringify({ hold_key: payload.holdKey }),
     },
-    body: JSON.stringify({ hold_key: payload.holdKey }),
-  });
+    { accessToken: payload.accessToken },
+  );
 
   let body: EdgeSuccess<{ released: boolean; hold?: CancelHoldResponse["hold"] }> | EdgeError | null = null;
   try {

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -24,6 +24,7 @@ import {
   useDropdownData,
 } from "../lib/optimizedQueries";
 import { cancelSessions } from "../lib/sessionCancellation";
+import { supabase } from "../lib/supabase";
 import { showError, showSuccess } from "../lib/toast";
 import type {
   BookSessionApiRequestBody,
@@ -137,6 +138,17 @@ async function callBookSessionApi(
   if (idempotencyKey) {
     headers["Idempotency-Key"] = idempotencyKey;
   }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const accessToken = session?.access_token?.trim();
+
+  if (!accessToken) {
+    throw new Error("Authentication is required to book sessions");
+  }
+
+  headers.Authorization = `Bearer ${accessToken}`;
 
   let response: Response;
   try {

--- a/src/server/__tests__/bookHandler.integration.test.ts
+++ b/src/server/__tests__/bookHandler.integration.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { bookHandler } from "../api/book";
+
+const { callEdgeMock, persistSessionCptMetadataMock } = vi.hoisted(() => ({
+  callEdgeMock: vi.fn(),
+  persistSessionCptMetadataMock: vi
+    .fn()
+    .mockResolvedValue({ entryId: "entry-id", modifierIds: [] }),
+}));
+
+vi.mock("../../lib/supabase", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/supabase")>("../../lib/supabase");
+  return {
+    ...actual,
+    callEdge: callEdgeMock,
+  };
+});
+
+vi.mock("../sessionCptPersistence", () => ({
+  persistSessionCptMetadata: persistSessionCptMetadataMock,
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("bookHandler integration", () => {
+  const payload = {
+    session: {
+      therapist_id: "therapist-1",
+      client_id: "client-1",
+      start_time: "2025-01-01T10:00:00Z",
+      end_time: "2025-01-01T11:00:00Z",
+    },
+    startTimeOffsetMinutes: 0,
+    endTimeOffsetMinutes: 0,
+    timeZone: "UTC",
+  } as const;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls edge functions with the bearer token from the request", async () => {
+    const accessToken = "integration-token";
+    callEdgeMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: { holdKey: "hold-key", holdId: "hold-id", expiresAt: "2025-01-01T09:05:00Z" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: {
+            session: {
+              id: "session-1",
+              therapist_id: payload.session.therapist_id,
+              client_id: payload.session.client_id,
+              start_time: payload.session.start_time,
+              end_time: payload.session.end_time,
+              status: "scheduled",
+              notes: "",
+              created_at: "2025-01-01T09:00:00Z",
+              created_by: "user-1",
+              updated_at: "2025-01-01T09:00:00Z",
+              updated_by: "user-1",
+              duration_minutes: 60,
+            },
+            roundedDurationMinutes: 60,
+          },
+        }),
+      );
+
+    const response = await bookHandler(
+      new Request("http://localhost/api/book", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify(payload),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.session.id).toBe("session-1");
+    expect(callEdgeMock).toHaveBeenCalledTimes(2);
+    expect(callEdgeMock).toHaveBeenNthCalledWith(
+      1,
+      "sessions-hold",
+      expect.any(Object),
+      { accessToken },
+    );
+    expect(callEdgeMock).toHaveBeenNthCalledWith(
+      2,
+      "sessions-confirm",
+      expect.any(Object),
+      { accessToken },
+    );
+    expect(persistSessionCptMetadataMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "session-1" }),
+    );
+  });
+
+  it("rejects unauthorized requests before invoking edge functions", async () => {
+    const response = await bookHandler(
+      new Request("http://localhost/api/book", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(callEdgeMock).not.toHaveBeenCalled();
+    expect(persistSessionCptMetadataMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/__tests__/bookSession.test.ts
+++ b/src/server/__tests__/bookSession.test.ts
@@ -35,6 +35,7 @@ const basePayload = {
   startTimeOffsetMinutes: 0,
   endTimeOffsetMinutes: 0,
   timeZone: "UTC",
+  accessToken: "test-access-token",
 } as const;
 
 beforeEach(() => {
@@ -84,6 +85,7 @@ describe("bookSession", () => {
       startTimeOffsetMinutes: 0,
       endTimeOffsetMinutes: 0,
       timeZone: "UTC",
+      accessToken: basePayload.accessToken,
     });
 
     expect(mockedConfirmSessionBooking).toHaveBeenCalledWith({
@@ -96,6 +98,7 @@ describe("bookSession", () => {
       startTimeOffsetMinutes: 0,
       endTimeOffsetMinutes: 0,
       timeZone: "UTC",
+      accessToken: basePayload.accessToken,
     });
 
     expect(mockedPersistSessionCptMetadata).toHaveBeenCalledWith({
@@ -115,7 +118,10 @@ describe("bookSession", () => {
     mockedConfirmSessionBooking.mockRejectedValueOnce(new Error("unable to confirm"));
 
     await expect(bookSession(basePayload)).rejects.toThrow("unable to confirm");
-    expect(mockedCancelSessionHold).toHaveBeenCalledWith({ holdKey: "hold-key" });
+    expect(mockedCancelSessionHold).toHaveBeenCalledWith({
+      holdKey: "hold-key",
+      accessToken: basePayload.accessToken,
+    });
     expect(mockedPersistSessionCptMetadata).not.toHaveBeenCalled();
   });
 
@@ -209,6 +215,7 @@ describe("bookSession", () => {
       expect.objectContaining({
         holdKey: "hold-key",
         idempotencyKey,
+        accessToken: basePayload.accessToken,
       }),
     );
 
@@ -313,7 +320,10 @@ describe("bookSession", () => {
 
     if (losingHold) {
       expect(cancelledHoldKeys).toContain(losingHold.holdKey);
-      expect(mockedCancelSessionHold).toHaveBeenCalledWith({ holdKey: losingHold.holdKey });
+      expect(mockedCancelSessionHold).toHaveBeenCalledWith({
+        holdKey: losingHold.holdKey,
+        accessToken: basePayload.accessToken,
+      });
     }
 
     expect(mockedPersistSessionCptMetadata).toHaveBeenCalledTimes(1);

--- a/src/server/bookSession.ts
+++ b/src/server/bookSession.ts
@@ -53,6 +53,7 @@ export async function bookSession(payload: BookSessionRequest): Promise<BookSess
     startTimeOffsetMinutes: payload.startTimeOffsetMinutes,
     endTimeOffsetMinutes: payload.endTimeOffsetMinutes,
     timeZone: payload.timeZone,
+    accessToken: payload.accessToken,
   });
 
   const sessionPayload: BookableSession = {
@@ -69,10 +70,11 @@ export async function bookSession(payload: BookSessionRequest): Promise<BookSess
       startTimeOffsetMinutes: payload.startTimeOffsetMinutes,
       endTimeOffsetMinutes: payload.endTimeOffsetMinutes,
       timeZone: payload.timeZone,
+      accessToken: payload.accessToken,
     });
   } catch (error) {
     try {
-      await cancelSessionHold({ holdKey: hold.holdKey });
+      await cancelSessionHold({ holdKey: hold.holdKey, accessToken: payload.accessToken });
     } catch (releaseError) {
       console.warn("Failed to release session hold after confirmation error", releaseError);
     }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -22,6 +22,7 @@ export interface BookSessionRequest {
   holdSeconds?: number;
   idempotencyKey?: string;
   overrides?: BookingOverrides;
+  accessToken: string;
 }
 
 export interface DerivedCpt {
@@ -38,7 +39,7 @@ export interface BookSessionResult {
   cpt: DerivedCpt;
 }
 
-export type BookSessionApiRequestBody = Omit<BookSessionRequest, "idempotencyKey">;
+export type BookSessionApiRequestBody = Omit<BookSessionRequest, "idempotencyKey" | "accessToken">;
 
 export interface BookSessionApiResponse {
   success: boolean;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -204,11 +204,24 @@ vi.mock('../lib/supabase', () => {
             error: null,
           }),
         ),
+        getSession: vi.fn(() =>
+          Promise.resolve({
+            data: { session: { access_token: 'test-access-token' } },
+            error: null,
+          }),
+        ),
       },
     },
-    callEdge: vi.fn((path: string, init?: RequestInit) => {
+    callEdge: vi.fn((path: string, init?: RequestInit, options?: { accessToken?: string; anonKey?: string }) => {
+      const headers = new Headers(init?.headers ?? {});
+      if (options?.accessToken) {
+        headers.set('Authorization', `Bearer ${options.accessToken}`);
+      }
+      if (options?.anonKey) {
+        headers.set('apikey', options.anonKey);
+      }
       const url = `http://localhost/functions/v1/${path}`;
-      return fetch(url, init);
+      return fetch(url, { ...init, headers });
     }),
   };
 });


### PR DESCRIPTION
### Summary
Propagate authenticated Supabase access tokens through the booking flow so edge functions receive the caller context.

### Proposed changes
- Require bearer tokens in the `/api/book` handler and thread them through `bookSession`
- Extend session hold helpers and `callEdge` to accept explicit access tokens and optional anon keys
- Update scheduling client fetch logic and expand unit/integration coverage for token handling

### Tests added/updated
- src/lib/__tests__/supabase.edge.test.ts
- src/server/__tests__/bookHandler.integration.test.ts
- src/lib/__tests__/sessionHolds.test.ts
- src/server/__tests__/bookHandler.test.ts
- src/server/__tests__/bookSession.test.ts
- src/test/setup.ts
- src/components/__tests__/SchedulingFlow.test.tsx

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68cd7da48d40833296b733b5680a7859