### PR TITLE
feat: tighten transcript org scope – 2025-09-22

### DIFF
--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -464,6 +464,7 @@ export type Database = {
           created_by: string | null
           id: string
           is_active: boolean | null
+          organization_id: string | null
           pattern_name: string
           pattern_type: string
           regex_pattern: string
@@ -476,6 +477,7 @@ export type Database = {
           created_by?: string | null
           id?: string
           is_active?: boolean | null
+          organization_id?: string | null
           pattern_name: string
           pattern_type: string
           regex_pattern: string
@@ -488,6 +490,7 @@ export type Database = {
           created_by?: string | null
           id?: string
           is_active?: boolean | null
+          organization_id?: string | null
           pattern_name?: string
           pattern_type?: string
           regex_pattern?: string
@@ -1508,6 +1511,7 @@ export type Database = {
           description: string | null
           id: string
           is_california_compliant: boolean | null
+          organization_id: string | null
           template_name: string
           template_structure: Json
           template_type: string
@@ -1520,6 +1524,7 @@ export type Database = {
           description?: string | null
           id?: string
           is_california_compliant?: boolean | null
+          organization_id?: string | null
           template_name: string
           template_structure: Json
           template_type: string
@@ -1532,6 +1537,7 @@ export type Database = {
           description?: string | null
           id?: string
           is_california_compliant?: boolean | null
+          organization_id?: string | null
           template_name?: string
           template_structure?: Json
           template_type?: string
@@ -1558,6 +1564,7 @@ export type Database = {
           speaker: string
           start_time: number
           text: string
+          organization_id: string | null
         }
         Insert: {
           behavioral_markers?: Json | null
@@ -1569,6 +1576,7 @@ export type Database = {
           speaker: string
           start_time: number
           text: string
+          organization_id?: string | null
         }
         Update: {
           behavioral_markers?: Json | null
@@ -1580,6 +1588,7 @@ export type Database = {
           speaker?: string
           start_time?: number
           text?: string
+          organization_id?: string | null
         }
         Relationships: [
           {
@@ -1600,6 +1609,7 @@ export type Database = {
           raw_transcript: string
           session_id: string
           updated_at: string | null
+          organization_id: string | null
         }
         Insert: {
           confidence_score?: number | null
@@ -1609,6 +1619,7 @@ export type Database = {
           raw_transcript: string
           session_id: string
           updated_at?: string | null
+          organization_id?: string | null
         }
         Update: {
           confidence_score?: number | null
@@ -1618,6 +1629,7 @@ export type Database = {
           raw_transcript?: string
           session_id?: string
           updated_at?: string | null
+          organization_id?: string | null
         }
         Relationships: [
           {

--- a/supabase/migrations/20250923121500_enforce_org_scope.sql
+++ b/supabase/migrations/20250923121500_enforce_org_scope.sql
@@ -27,6 +27,18 @@ ALTER TABLE public.billing_records
 ALTER TABLE public.session_cpt_entries
   ADD COLUMN IF NOT EXISTS organization_id uuid;
 
+ALTER TABLE public.session_transcripts
+  ADD COLUMN IF NOT EXISTS organization_id uuid;
+
+ALTER TABLE public.session_transcript_segments
+  ADD COLUMN IF NOT EXISTS organization_id uuid;
+
+ALTER TABLE public.session_note_templates
+  ADD COLUMN IF NOT EXISTS organization_id uuid;
+
+ALTER TABLE public.behavioral_patterns
+  ADD COLUMN IF NOT EXISTS organization_id uuid;
+
 -- 2. Data backfill helpers
 WITH therapist_orgs AS (
   SELECT
@@ -109,6 +121,88 @@ FROM public.sessions s
 WHERE s.id = sce.session_id
   AND s.organization_id IS NOT NULL
   AND sce.organization_id IS DISTINCT FROM s.organization_id;
+
+WITH transcript_orgs AS (
+  SELECT
+    st.id,
+    COALESCE(
+      st.organization_id,
+      s.organization_id,
+      t.organization_id,
+      get_organization_id_from_metadata(au.raw_user_meta_data)
+    ) AS resolved_org
+  FROM public.session_transcripts st
+  LEFT JOIN public.sessions s ON s.id = st.session_id
+  LEFT JOIN public.therapists t ON t.id = s.therapist_id
+  LEFT JOIN auth.users au ON au.id = s.therapist_id
+)
+UPDATE public.session_transcripts st
+SET organization_id = transcript_orgs.resolved_org
+FROM transcript_orgs
+WHERE transcript_orgs.id = st.id
+  AND transcript_orgs.resolved_org IS NOT NULL
+  AND st.organization_id IS DISTINCT FROM transcript_orgs.resolved_org;
+
+WITH transcript_segment_orgs AS (
+  SELECT
+    sts.id,
+    COALESCE(
+      sts.organization_id,
+      st.organization_id,
+      s.organization_id,
+      t.organization_id,
+      get_organization_id_from_metadata(au.raw_user_meta_data)
+    ) AS resolved_org
+  FROM public.session_transcript_segments sts
+  LEFT JOIN public.session_transcripts st ON st.id = sts.session_id
+  LEFT JOIN public.sessions s ON s.id = COALESCE(st.session_id, sts.session_id)
+  LEFT JOIN public.therapists t ON t.id = s.therapist_id
+  LEFT JOIN auth.users au ON au.id = s.therapist_id
+)
+UPDATE public.session_transcript_segments sts
+SET organization_id = transcript_segment_orgs.resolved_org
+FROM transcript_segment_orgs
+WHERE transcript_segment_orgs.id = sts.id
+  AND transcript_segment_orgs.resolved_org IS NOT NULL
+  AND sts.organization_id IS DISTINCT FROM transcript_segment_orgs.resolved_org;
+
+WITH template_orgs AS (
+  SELECT
+    snt.id,
+    COALESCE(
+      snt.organization_id,
+      t.organization_id,
+      get_organization_id_from_metadata(au.raw_user_meta_data)
+    ) AS resolved_org
+  FROM public.session_note_templates snt
+  LEFT JOIN public.therapists t ON t.id = snt.created_by
+  LEFT JOIN auth.users au ON au.id = snt.created_by
+)
+UPDATE public.session_note_templates snt
+SET organization_id = template_orgs.resolved_org
+FROM template_orgs
+WHERE template_orgs.id = snt.id
+  AND template_orgs.resolved_org IS NOT NULL
+  AND snt.organization_id IS DISTINCT FROM template_orgs.resolved_org;
+
+WITH pattern_orgs AS (
+  SELECT
+    bp.id,
+    COALESCE(
+      bp.organization_id,
+      t.organization_id,
+      get_organization_id_from_metadata(au.raw_user_meta_data)
+    ) AS resolved_org
+  FROM public.behavioral_patterns bp
+  LEFT JOIN public.therapists t ON t.id = bp.created_by
+  LEFT JOIN auth.users au ON au.id = bp.created_by
+)
+UPDATE public.behavioral_patterns bp
+SET organization_id = pattern_orgs.resolved_org
+FROM pattern_orgs
+WHERE pattern_orgs.id = bp.id
+  AND pattern_orgs.resolved_org IS NOT NULL
+  AND bp.organization_id IS DISTINCT FROM pattern_orgs.resolved_org;
 
 -- 3. Helper functions for organization-aware role checks
 CREATE OR REPLACE FUNCTION app.current_user_organization_id()
@@ -376,6 +470,179 @@ CREATE TRIGGER set_session_cpt_entry_organization
   BEFORE INSERT OR UPDATE ON public.session_cpt_entries
   FOR EACH ROW
   EXECUTE FUNCTION app.set_session_cpt_entry_organization();
+
+CREATE OR REPLACE FUNCTION app.set_session_transcript_organization()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  resolved_org uuid := NEW.organization_id;
+BEGIN
+  IF resolved_org IS NULL AND NEW.session_id IS NOT NULL THEN
+    SELECT COALESCE(
+      s.organization_id,
+      t.organization_id,
+      get_organization_id_from_metadata(au.raw_user_meta_data)
+    )
+    INTO resolved_org
+    FROM public.sessions s
+    LEFT JOIN public.therapists t ON t.id = s.therapist_id
+    LEFT JOIN auth.users au ON au.id = s.therapist_id
+    WHERE s.id = NEW.session_id;
+  END IF;
+
+  IF resolved_org IS NULL THEN
+    resolved_org := app.current_user_organization_id();
+  END IF;
+
+  NEW.organization_id := resolved_org;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_session_transcript_organization ON public.session_transcripts;
+CREATE TRIGGER set_session_transcript_organization
+  BEFORE INSERT OR UPDATE ON public.session_transcripts
+  FOR EACH ROW
+  EXECUTE FUNCTION app.set_session_transcript_organization();
+
+CREATE OR REPLACE FUNCTION app.set_session_transcript_segment_organization()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  resolved_org uuid := NEW.organization_id;
+  target_session uuid := NULL;
+  transcript_org uuid := NULL;
+BEGIN
+  IF NEW.session_id IS NOT NULL THEN
+    SELECT st.session_id, st.organization_id
+    INTO target_session, transcript_org
+    FROM public.session_transcripts st
+    WHERE st.id = NEW.session_id;
+  END IF;
+
+  IF target_session IS NULL THEN
+    target_session := NEW.session_id;
+  END IF;
+
+  IF resolved_org IS NULL THEN
+    resolved_org := transcript_org;
+  END IF;
+
+  IF resolved_org IS NULL AND target_session IS NOT NULL THEN
+    SELECT COALESCE(
+      s.organization_id,
+      t.organization_id,
+      get_organization_id_from_metadata(au.raw_user_meta_data)
+    )
+    INTO resolved_org
+    FROM public.sessions s
+    LEFT JOIN public.therapists t ON t.id = s.therapist_id
+    LEFT JOIN auth.users au ON au.id = s.therapist_id
+    WHERE s.id = target_session;
+  END IF;
+
+  IF resolved_org IS NULL THEN
+    resolved_org := app.current_user_organization_id();
+  END IF;
+
+  NEW.organization_id := resolved_org;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_session_transcript_segment_organization ON public.session_transcript_segments;
+CREATE TRIGGER set_session_transcript_segment_organization
+  BEFORE INSERT OR UPDATE ON public.session_transcript_segments
+  FOR EACH ROW
+  EXECUTE FUNCTION app.set_session_transcript_segment_organization();
+
+CREATE OR REPLACE FUNCTION app.set_session_note_template_organization()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  resolved_org uuid := NEW.organization_id;
+BEGIN
+  IF resolved_org IS NULL AND NEW.created_by IS NOT NULL THEN
+    SELECT COALESCE(
+      t.organization_id,
+      get_organization_id_from_metadata(au.raw_user_meta_data)
+    )
+    INTO resolved_org
+    FROM public.therapists t
+    LEFT JOIN auth.users au ON au.id = t.id
+    WHERE t.id = NEW.created_by;
+  END IF;
+
+  IF resolved_org IS NULL THEN
+    resolved_org := app.current_user_organization_id();
+  END IF;
+
+  NEW.organization_id := resolved_org;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_session_note_template_organization ON public.session_note_templates;
+CREATE TRIGGER set_session_note_template_organization
+  BEFORE INSERT OR UPDATE ON public.session_note_templates
+  FOR EACH ROW
+  EXECUTE FUNCTION app.set_session_note_template_organization();
+
+CREATE OR REPLACE FUNCTION app.set_behavioral_pattern_organization()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  resolved_org uuid := NEW.organization_id;
+BEGIN
+  IF resolved_org IS NULL AND NEW.created_by IS NOT NULL THEN
+    SELECT COALESCE(
+      t.organization_id,
+      get_organization_id_from_metadata(au.raw_user_meta_data)
+    )
+    INTO resolved_org
+    FROM public.therapists t
+    LEFT JOIN auth.users au ON au.id = t.id
+    WHERE t.id = NEW.created_by;
+  END IF;
+
+  IF resolved_org IS NULL THEN
+    resolved_org := app.current_user_organization_id();
+  END IF;
+
+  NEW.organization_id := resolved_org;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_behavioral_pattern_organization ON public.behavioral_patterns;
+CREATE TRIGGER set_behavioral_pattern_organization
+  BEFORE INSERT OR UPDATE ON public.behavioral_patterns
+  FOR EACH ROW
+  EXECUTE FUNCTION app.set_behavioral_pattern_organization();
+
+ALTER TABLE public.session_transcripts
+  ALTER COLUMN organization_id SET DEFAULT app.current_user_organization_id();
+
+ALTER TABLE public.session_transcript_segments
+  ALTER COLUMN organization_id SET DEFAULT app.current_user_organization_id();
+
+ALTER TABLE public.session_note_templates
+  ALTER COLUMN organization_id SET DEFAULT app.current_user_organization_id();
+
+ALTER TABLE public.behavioral_patterns
+  ALTER COLUMN organization_id SET DEFAULT app.current_user_organization_id();
 
 -- 4. Update RLS policies with organization-aware checks
 -- Therapists


### PR DESCRIPTION
### Summary
Ensure transcript-related tables inherit session organizations and enforce org-aware access controls.

### Proposed changes
- Add organization defaults, backfills, and triggers for transcripts, transcript segments, note templates, and behavioral patterns.
- Update RLS policies to use `app.user_has_role_for_org` for the newly scoped tables.
- Extend RLS integration tests to cover cross-organization admin access and update generated Supabase types.

### Tests added/updated
- src/tests/security/rls.spec.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [x] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d15807c8e4833289c269facf734c5e