### PR TITLE
feat: enforce transcription consent – 2025-10-05

### DIFF
--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -1651,6 +1651,7 @@ export type Database = {
           location_type: string | null
           notes: string | null
           organization_id: string | null
+          has_transcription_consent: boolean
           rate_per_hour: number | null
           session_type: string | null
           start_time: string
@@ -1667,6 +1668,7 @@ export type Database = {
           location_type?: string | null
           notes?: string | null
           organization_id?: string | null
+          has_transcription_consent?: boolean
           rate_per_hour?: number | null
           session_type?: string | null
           start_time: string
@@ -1683,6 +1685,7 @@ export type Database = {
           location_type?: string | null
           notes?: string | null
           organization_id?: string | null
+          has_transcription_consent?: boolean
           rate_per_hour?: number | null
           session_type?: string | null
           start_time?: string
@@ -2598,6 +2601,13 @@ export type Database = {
           p_file_type: string
         }
         Returns: Json
+      }
+      prune_session_transcripts: {
+        Args: { retention_days?: number }
+        Returns: {
+          deleted_transcripts: number
+          deleted_segments: number
+        }[]
       }
       remove_user_role: {
         Args: { removed_by_uuid?: string; role_name: string; user_uuid: string }

--- a/supabase/functions/transcription-retention/index.ts
+++ b/supabase/functions/transcription-retention/index.ts
@@ -1,0 +1,115 @@
+import { supabaseAdmin } from "../_shared/database.ts";
+import { errorEnvelope, getRequestId } from "../ai-transcription/lib/http/error.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+const parseRetentionDays = (value: unknown, fallback: number): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.floor(value));
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      return Math.max(0, parsed);
+    }
+  }
+  return fallback;
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  const requestId = getRequestId(req);
+
+  if (req.method !== "POST") {
+    return errorEnvelope({
+      requestId,
+      code: "method_not_allowed",
+      message: `Method ${req.method} not allowed`,
+      status: 405,
+      headers: corsHeaders,
+    });
+  }
+
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!serviceKey) {
+    console.error("Retention job misconfigured: missing SUPABASE_SERVICE_ROLE_KEY");
+    return errorEnvelope({
+      requestId,
+      code: "server_error",
+      message: "Service role credentials not configured",
+      status: 500,
+      headers: corsHeaders,
+    });
+  }
+
+  const authHeader = req.headers.get("authorization") ?? "";
+  if (authHeader !== `Bearer ${serviceKey}`) {
+    return errorEnvelope({
+      requestId,
+      code: "unauthorized",
+      message: "Service authorization required",
+      status: 401,
+      headers: corsHeaders,
+    });
+  }
+
+  const envRetention = Number.parseInt(Deno.env.get("TRANSCRIPTION_RETENTION_DAYS") ?? "", 10);
+  const defaultRetention = Number.isFinite(envRetention) && envRetention >= 0 ? envRetention : 30;
+
+  const url = new URL(req.url);
+  let retentionDays = parseRetentionDays(url.searchParams.get("retention_days"), defaultRetention);
+
+  const contentType = req.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      const body = await req.json();
+      if (body && typeof body === "object" && !Array.isArray(body)) {
+        const candidate = (body as Record<string, unknown>).retention_days;
+        retentionDays = parseRetentionDays(candidate, retentionDays);
+      }
+    } catch (error) {
+      console.warn("Failed to parse retention request body:", error);
+      return errorEnvelope({
+        requestId,
+        code: "invalid_body",
+        message: "Invalid retention request payload",
+        status: 400,
+        headers: corsHeaders,
+      });
+    }
+  }
+
+  const { data, error } = await supabaseAdmin.rpc("prune_session_transcripts", { retention_days: retentionDays });
+  if (error) {
+    console.error("Failed to prune transcripts:", error);
+    return errorEnvelope({
+      requestId,
+      code: "retention_failed",
+      message: "Unable to prune transcript history",
+      status: 500,
+      headers: corsHeaders,
+    });
+  }
+
+  const summary = Array.isArray(data) ? data[0] : data;
+  const deletedTranscripts = summary?.deleted_transcripts ?? 0;
+  const deletedSegments = summary?.deleted_segments ?? 0;
+
+  return new Response(
+    JSON.stringify({
+      requestId,
+      retention_days: retentionDays,
+      deleted_transcripts: deletedTranscripts,
+      deleted_segments: deletedSegments,
+      pruned_at: new Date().toISOString(),
+    }),
+    { status: 200, headers: { "Content-Type": "application/json", ...corsHeaders } },
+  );
+});

--- a/supabase/migrations/20251005131500_transcription_consent_and_retention.sql
+++ b/supabase/migrations/20251005131500_transcription_consent_and_retention.sql
@@ -1,0 +1,115 @@
+/*
+  # Enforce transcription consent and retention
+
+  1. Schema changes
+    - Add has_transcription_consent flag to sessions
+  2. Data updates
+    - Backfill consent for sessions with existing transcript data
+  3. Security
+    - Prevent transcript writes when consent is missing
+  4. Maintenance
+    - Provide a retention helper for scheduled pruning
+*/
+
+ALTER TABLE public.sessions
+  ADD COLUMN IF NOT EXISTS has_transcription_consent boolean NOT NULL DEFAULT false;
+
+UPDATE public.sessions s
+SET has_transcription_consent = true
+WHERE s.has_transcription_consent = false
+  AND (
+    EXISTS (SELECT 1 FROM public.session_transcripts st WHERE st.session_id = s.id)
+    OR EXISTS (SELECT 1 FROM public.session_transcript_segments sts WHERE sts.session_id = s.id)
+  );
+
+COMMENT ON COLUMN public.sessions.has_transcription_consent IS
+  'Indicates that the client has granted consent for audio transcription and storage.';
+
+CREATE OR REPLACE FUNCTION app.ensure_session_transcription_consent()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_session_id uuid;
+  v_has_consent boolean;
+BEGIN
+  IF TG_ARGV[0] = 'segment' THEN
+    SELECT COALESCE(
+      (SELECT st.session_id FROM public.session_transcripts st WHERE st.id = NEW.session_id),
+      NEW.session_id
+    )
+    INTO v_session_id;
+  ELSE
+    v_session_id := NEW.session_id;
+  END IF;
+
+  IF v_session_id IS NULL THEN
+    RAISE EXCEPTION 'Unable to resolve session for transcription record';
+  END IF;
+
+  SELECT has_transcription_consent
+  INTO v_has_consent
+  FROM public.sessions
+  WHERE id = v_session_id;
+
+  IF NOT COALESCE(v_has_consent, false) THEN
+    RAISE EXCEPTION 'Transcription consent is required for session %', v_session_id
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ensure_session_transcript_consent ON public.session_transcripts;
+CREATE TRIGGER ensure_session_transcript_consent
+  BEFORE INSERT OR UPDATE ON public.session_transcripts
+  FOR EACH ROW
+  EXECUTE FUNCTION app.ensure_session_transcription_consent('transcript');
+
+DROP TRIGGER IF EXISTS ensure_session_transcript_segment_consent ON public.session_transcript_segments;
+CREATE TRIGGER ensure_session_transcript_segment_consent
+  BEFORE INSERT OR UPDATE ON public.session_transcript_segments
+  FOR EACH ROW
+  EXECUTE FUNCTION app.ensure_session_transcription_consent('segment');
+
+CREATE OR REPLACE FUNCTION public.prune_session_transcripts(retention_days integer DEFAULT 30)
+RETURNS TABLE(deleted_transcripts integer, deleted_segments integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_retention_days integer := GREATEST(COALESCE(retention_days, 30), 0);
+  v_cutoff timestamptz := NOW() - (v_retention_days || ' days')::interval;
+  v_deleted_segments integer := 0;
+  v_deleted_transcripts integer := 0;
+BEGIN
+  DELETE FROM public.session_transcript_segments AS sts
+  USING public.sessions AS s
+  LEFT JOIN public.session_transcripts AS st ON st.id = sts.session_id
+  WHERE s.id = COALESCE(st.session_id, sts.session_id)
+    AND (
+      NOT COALESCE(s.has_transcription_consent, false)
+      OR COALESCE(sts.created_at, 'epoch'::timestamptz) < v_cutoff
+    );
+
+  GET DIAGNOSTICS v_deleted_segments = ROW_COUNT;
+
+  DELETE FROM public.session_transcripts AS st
+  USING public.sessions AS s
+  WHERE s.id = st.session_id
+    AND (
+      NOT COALESCE(s.has_transcription_consent, false)
+      OR COALESCE(st.created_at, 'epoch'::timestamptz) < v_cutoff
+    );
+
+  GET DIAGNOSTICS v_deleted_transcripts = ROW_COUNT;
+
+  RETURN QUERY SELECT v_deleted_transcripts, v_deleted_segments;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.prune_session_transcripts(integer) TO service_role;


### PR DESCRIPTION
### Summary
Ensure AI transcription respects client consent and retention policies.

### Proposed changes
- Validate session consent before persisting AI transcription segments and insert via the service role client.
- Add a retention edge function and migration to prune transcript data lacking consent or past the retention window.
- Update generated types and security tests to cover consent enforcement and retention behaviour.

### Tests added/updated
- src/tests/security/rls.spec.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [x] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d15e4058208332ab27ec37b9f7c2cf