### PR TITLE
fix: reuse callEdge for AI edges – 2025-09-22

### DIFF
--- a/docs/TRANSCRIPTION_TESTING_PLAN.md
+++ b/docs/TRANSCRIPTION_TESTING_PLAN.md
@@ -27,6 +27,22 @@ OPENAI_API_KEY=<openai-key>  # In Supabase secrets
 - **Performance Tests**: Load testing with multiple concurrent sessions
 - **Compliance Tests**: Automated validation against California requirements
 
+### 1.4 Edge Function Invocation Standard
+- ✅ Use the shared `callEdge(path, init, options?)` helper from `src/lib/supabase` for every Supabase Edge request.
+- 🔐 The helper fetches the active session via `supabase.auth.getSession()` and attaches the `Authorization: Bearer <JWT>` header automatically, so tests can assert authenticated behavior without duplicating logic.
+- 🧰 Override tokens only when performing service-to-service calls (`options.accessToken`) or when a specific anon key is required (`options.anonKey`).
+- 🧪 Example (TypeScript):
+  ```ts
+  import { callEdge } from '@/lib/supabase';
+
+  await callEdge('ai-transcription', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ audio: base64Chunk }),
+  });
+  ```
+- 🚫 Do **not** call `fetch(buildSupabaseEdgeUrl(...))` directly—doing so bypasses JWT attachment and can lead to anonymous traffic hitting authenticated functions.
+
 ## 2. Core Functionality Tests
 
 ### 2.1 Audio Transcription Tests

--- a/src/lib/ai-documentation.ts
+++ b/src/lib/ai-documentation.ts
@@ -1,5 +1,4 @@
-import { supabase } from './supabase';
-import { buildSupabaseEdgeUrl, getSupabaseAnonKey } from './runtimeConfig';
+import { callEdge, supabase } from './supabase';
 import { showSuccess, showError } from './toast';
 
 // Types for AI Documentation System
@@ -227,11 +226,10 @@ export class AIDocumentationService {
   private async transcribeAudio(audioBase64: string): Promise<any> {
     try {
       // Call Supabase AI Transcription Edge Function
-      const response = await fetch(buildSupabaseEdgeUrl('ai-transcription'), {
+      const response = await callEdge('ai-transcription', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${getSupabaseAnonKey()}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({
           audio: audioBase64,
@@ -443,11 +441,10 @@ export class AIDocumentationService {
     try {
       const prompt = this.buildSessionNotePrompt(sessionData, transcriptData);
       
-      const response = await fetch(buildSupabaseEdgeUrl('ai-session-note-generator'), {
+      const response = await callEdge('ai-session-note-generator', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${getSupabaseAnonKey()}`
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({
           prompt,


### PR DESCRIPTION
### Summary
Ensure AI documentation flows call the shared Supabase Edge helper so session JWTs are attached automatically.

### Proposed changes
- Refactor `AIDocumentationService` transcription and note generation to invoke `callEdge` instead of manual fetches.
- Expand the Vitest suite to verify bearer tokens are forwarded and align the Supabase mock helper with runtime behavior.
- Document the shared Edge helper in the transcription testing guide so other callers reuse it.

### Tests added/updated
- src/lib/__tests__/ai-documentation.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d190cf8b748332a15102d0ecc8c83d