### PR TITLE
feat: pseudonymize AI scheduling prompts – 2025-09-22

### DIFF
--- a/src/lib/__tests__/aiDocumentationPrompt.test.ts
+++ b/src/lib/__tests__/aiDocumentationPrompt.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { AIDocumentationService } from '../ai-documentation';
+import { createPseudonym } from '../phi/pseudonym';
+
+describe('buildSessionNotePrompt', () => {
+  it('replaces PHI with deterministic pseudonyms', () => {
+    const service = new AIDocumentationService() as unknown as {
+      buildSessionNotePrompt: (sessionData: any, transcriptData: any) => string;
+    };
+
+    const sessionData = {
+      session_date: '2024-05-01',
+      duration: 60,
+      location: 'Clinic Office - Room 3',
+      client_id: 'client-123',
+      client_name: 'Alice Smith',
+      client_email: 'alice.smith@example.com',
+      therapist_id: 'therapist-456',
+      therapist_name: 'Robert Jones',
+      therapist_email: 'rjones@example.com',
+      participants: ['Parent One', { full_name: 'Sibling Smith', email: 'sibling@example.com', participant_id: 'participant-789' }]
+    };
+
+    const transcriptData = {
+      processed_transcript:
+        'During the session Alice discussed progress with Robert. Email alice.smith@example.com for follow up details.',
+      behavioral_markers: [
+        {
+          type: 'positive_behavior',
+          description: 'Alice Smith independently requested a break and Robert Jones honored the request.',
+          timestamp: 32,
+          confidence: 0.92
+        }
+      ]
+    };
+
+    const promptBuilder = service as unknown as {
+      buildSessionNotePrompt: (sessionData: any, transcriptData: any) => string;
+    };
+
+    const prompt = promptBuilder.buildSessionNotePrompt(sessionData, transcriptData);
+
+    const clientAlias = createPseudonym('Client', sessionData.client_id);
+    const therapistAlias = createPseudonym('Therapist', sessionData.therapist_id);
+    const firstParticipantAlias = createPseudonym('Participant', sessionData.participants[0] as string);
+    const secondParticipantAlias = createPseudonym('Participant', 'participant-789');
+
+    expect(prompt).toContain(clientAlias);
+    expect(prompt).toContain(therapistAlias);
+    expect(prompt).toContain(firstParticipantAlias);
+    expect(prompt).toContain(secondParticipantAlias);
+
+    expect(prompt).not.toContain('Alice Smith');
+    expect(prompt).not.toContain('Robert Jones');
+    expect(prompt).not.toContain('alice.smith@example.com');
+    expect(prompt).not.toContain('rjones@example.com');
+
+    expect(prompt).toContain(`${clientAlias} discussed progress with ${therapistAlias}`);
+    expect(prompt).not.toMatch(/Alice\b/);
+    expect(prompt).not.toMatch(/Robert\b/);
+  });
+});
+

--- a/src/lib/phi/pseudonym.ts
+++ b/src/lib/phi/pseudonym.ts
@@ -1,0 +1,75 @@
+import { redactPhi } from '../logger/redactPhi.ts';
+
+export type PseudonymMap = Record<string, string>;
+
+const FNV_OFFSET_BASIS = 2166136261;
+const FNV_PRIME = 16777619;
+
+const normalizeSource = (value: string): string => value.trim().toLowerCase();
+
+export const hashIdentifier = (value: string): string => {
+  const normalized = normalizeSource(value || '');
+  let hash = FNV_OFFSET_BASIS;
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    hash ^= normalized.charCodeAt(index);
+    hash = Math.imul(hash, FNV_PRIME);
+  }
+
+  return (hash >>> 0).toString(36);
+};
+
+export const createPseudonym = (prefix: string, identifier?: string | null): string => {
+  const source = identifier && identifier.trim().length > 0 ? identifier : `${prefix}-unknown`;
+  const hashed = hashIdentifier(source);
+  return `${prefix}-${hashed}`;
+};
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, (match) => `\\${match}`);
+
+export const applyPseudonymMap = (input: string, map: PseudonymMap): string => {
+  const validEntries = Object.entries(map).filter(([target, alias]) => Boolean(target) && Boolean(alias));
+
+  if (validEntries.length === 0) {
+    return input;
+  }
+
+  return validEntries
+    .sort((a, b) => b[0].length - a[0].length)
+    .reduce((acc, [target, alias]) => acc.replace(new RegExp(escapeRegExp(target), 'gi'), alias), input);
+};
+
+export const redactAndPseudonymize = (input: string, map: PseudonymMap): string => {
+  const withPseudonyms = applyPseudonymMap(input, map);
+  return (redactPhi(withPseudonyms) as string) ?? '';
+};
+
+export const registerPseudonym = (map: PseudonymMap, value: string | null | undefined, alias: string): void => {
+  if (!value) {
+    return;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return;
+  }
+  if (map[trimmed] && map[trimmed] !== alias) {
+    return;
+  }
+  map[trimmed] = alias;
+};
+
+export const registerNamePseudonym = (map: PseudonymMap, value: string | null | undefined, alias: string): void => {
+  if (!value) {
+    return;
+  }
+  registerPseudonym(map, value, alias);
+  value
+    .split(/[\s,]+/)
+    .map(part => part.trim())
+    .filter(part => part.length > 1)
+    .forEach(part => {
+      registerPseudonym(map, part, alias);
+    });
+};
+


### PR DESCRIPTION
### Summary
Introduce pseudonymization for scheduling prompts to protect PHI before sending requests to OpenAI.

### Proposed changes
- Add shared pseudonymization utilities and apply them to AI session note prompt construction.
- Sanitize the suggest-alternative-times function to redact PHI, use pseudonyms, and restrict OpenAI metadata to hashed scheduling attributes.
- Add unit coverage ensuring session note prompts mask PHI tokens.

### Tests added/updated
- vitest src/lib/__tests__/aiDocumentationPrompt.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d19959229483329ab210097fb23490