### PR TITLE
feat: add deterministic geocoding cache – 2025-02-14

### DIFF
--- a/src/lib/__tests__/geocoding.test.ts
+++ b/src/lib/__tests__/geocoding.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  configureGeocoding,
+  geocodeAddress,
+  resetGeocodingConfig,
+} from '../geocoding';
+
+describe('geocoding utilities', () => {
+  afterEach(() => {
+    resetGeocodingConfig();
+  });
+
+  it('returns deterministic coordinates for the same address', () => {
+    const address = '123 Main Street, New York, NY';
+    const first = geocodeAddress(address);
+    const second = geocodeAddress(address);
+
+    expect(first).not.toBeNull();
+    expect(second).toEqual(first);
+  });
+
+  it('caches results per normalized address and avoids repeated provider calls', () => {
+    const provider = vi.fn(() => ({ latitude: 10, longitude: 20 }));
+    configureGeocoding({ provider });
+
+    const address = '500 Elm Street, Boston, MA';
+    const first = geocodeAddress(address);
+    const second = geocodeAddress(address.toUpperCase());
+
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(first?.latitude).toBeCloseTo(second?.latitude ?? 0, 6);
+    expect(first?.longitude).toBeCloseTo(second?.longitude ?? 0, 6);
+  });
+
+  it('supports disabling geocoding via configuration', () => {
+    configureGeocoding({ enabled: false });
+    expect(geocodeAddress('987 Maple Avenue, Albany, NY')).toBeNull();
+  });
+});

--- a/src/lib/geocoding.ts
+++ b/src/lib/geocoding.ts
@@ -1,0 +1,152 @@
+import type { Location } from '../types';
+
+export type GeocodedLocation = Pick<Location, 'latitude' | 'longitude' | 'address'>;
+
+export type GeocodingProvider = (address: string) => GeocodedLocation | null;
+
+interface GeocodeCacheEntry {
+  latitude: number;
+  longitude: number;
+}
+
+interface GeocodingState {
+  enabled: boolean;
+  provider: GeocodingProvider;
+}
+
+const DEFAULT_BASE_COORDINATES = {
+  latitude: 40.7128,
+  longitude: -74.006,
+};
+
+const HASH_OFFSET_RANGE = 0.1;
+
+const geocodeCache = new Map<string, GeocodeCacheEntry | null>();
+
+const FNV_OFFSET_BASIS = 2166136261;
+const FNV_PRIME = 16777619;
+
+const normalizeAddress = (address: string | null | undefined): string => {
+  if (!address) {
+    return '';
+  }
+  return address.trim().replace(/\s+/g, ' ').toLowerCase();
+};
+
+const hashString = (value: string): number => {
+  let hash = FNV_OFFSET_BASIS;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, FNV_PRIME) >>> 0;
+  }
+  return hash >>> 0;
+};
+
+const toUnitRange = (hash: number): number => hash / 0xffffffff;
+
+const computeOffset = (normalizedAddress: string, axis: 'lat' | 'lon'): number => {
+  const ratio = toUnitRange(hashString(`${axis}:${normalizedAddress}`));
+  return (ratio * 2 - 1) * HASH_OFFSET_RANGE;
+};
+
+const truncateCoordinate = (value: number): number => Number(value.toFixed(6));
+
+const deterministicGeocoder: GeocodingProvider = (address: string) => {
+  const normalized = normalizeAddress(address);
+  if (!normalized) {
+    return null;
+  }
+
+  const latitude = truncateCoordinate(
+    DEFAULT_BASE_COORDINATES.latitude + computeOffset(normalized, 'lat')
+  );
+  const longitude = truncateCoordinate(
+    DEFAULT_BASE_COORDINATES.longitude + computeOffset(normalized, 'lon')
+  );
+
+  return {
+    latitude,
+    longitude,
+    address: address.trim(),
+  };
+};
+
+let geocodingState: GeocodingState = {
+  enabled: true,
+  provider: deterministicGeocoder,
+};
+
+const getCacheKey = (address: string): string => normalizeAddress(address);
+
+export const geocodeAddress = (address?: string | null): GeocodedLocation | null => {
+  const trimmed = typeof address === 'string' ? address.trim() : '';
+  if (!trimmed) {
+    return null;
+  }
+
+  if (!geocodingState.enabled) {
+    return null;
+  }
+
+  const cacheKey = getCacheKey(trimmed);
+  if (geocodeCache.has(cacheKey)) {
+    const cached = geocodeCache.get(cacheKey);
+    if (!cached) {
+      return null;
+    }
+    return {
+      latitude: cached.latitude,
+      longitude: cached.longitude,
+      address: trimmed,
+    };
+  }
+
+  const result = geocodingState.provider(trimmed);
+  if (!result) {
+    geocodeCache.set(cacheKey, null);
+    return null;
+  }
+
+  const entry: GeocodeCacheEntry = {
+    latitude: truncateCoordinate(result.latitude),
+    longitude: truncateCoordinate(result.longitude),
+  };
+  geocodeCache.set(cacheKey, entry);
+
+  return {
+    latitude: entry.latitude,
+    longitude: entry.longitude,
+    address: result.address ?? trimmed,
+  };
+};
+
+export interface GeocodingConfigurationOptions {
+  enabled?: boolean;
+  provider?: GeocodingProvider;
+}
+
+export const configureGeocoding = (options: GeocodingConfigurationOptions): void => {
+  if (typeof options.enabled === 'boolean') {
+    geocodingState.enabled = options.enabled;
+  }
+  if (options.provider) {
+    geocodingState.provider = options.provider;
+  }
+  clearGeocodingCache();
+};
+
+export const clearGeocodingCache = (): void => {
+  geocodeCache.clear();
+};
+
+export const resetGeocodingConfig = (): void => {
+  geocodingState = {
+    enabled: true,
+    provider: deterministicGeocoder,
+  };
+  clearGeocodingCache();
+};
+
+export const getGeocodingCacheSize = (): number => geocodeCache.size;
+
+export const getDeterministicGeocodingProvider = (): GeocodingProvider => deterministicGeocoder;


### PR DESCRIPTION
### Summary
Implement deterministic geocoding and caching to stabilize travel scoring in the scheduling engine.

### Proposed changes
- Add a configurable geocoding service with deterministic hashing, caching, and feature flag support.
- Integrate the geocoder into auto scheduling travel calculations and extend unit tests for repeatability and injection scenarios.

### Tests added/updated
- vitest src/lib/__tests__/geocoding.test.ts
- vitest src/lib/__tests__/autoSchedule.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d1f0f5439c8332afad7edbb1598224