### PR TITLE
fix: harden CI workflow – 2025-09-23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,28 @@
-name: CI (minimal)
+name: CI
 on:
   pull_request:
   push:
-    branches: [ main, develop ]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20 }
-      - run: npm ci
+        with:
+          node-version: 20
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - uses: supabase/setup-cli@v1
         with:
           access-token: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
@@ -26,10 +38,27 @@ jobs:
           SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_PROJECT_ID }}
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
-      - name: Typecheck (conditional)
-        if: ${{ vars.SUPABASE_PROJECT_ID != '' }}
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run typecheck
         run: npm run typecheck
 
-      - name: Skipped typegen/typecheck (repo var missing)
+      - name: Run unit tests
+        run: npm test -- --run --reporter=verbose | tee vitest-output.log
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          RUN_DB_IT: '1'
+
+      - name: Ensure RLS tests executed
+        if: ${{ always() }}
+        run: |
+          if grep -q "Skipping RLS policy test - environment not available" vitest-output.log; then
+            echo "::error::RLS policy tests were skipped. Ensure Supabase environment variables are configured."
+            exit 1
+          fi
+
+      - name: Skipped typegen (repo var missing)
         if: ${{ vars.SUPABASE_PROJECT_ID == '' }}
-        run: echo "SUPABASE_PROJECT_ID repo variable not set; skipping typegen/typecheck."
+        run: echo "SUPABASE_PROJECT_ID repo variable not set; skipping typegen."


### PR DESCRIPTION
### Summary
Ensure the CI workflow enforces linting, type checking, and tests with RLS coverage guards.

### Proposed changes
- Cache npm dependencies and install only on cache misses.
- Run lint, typecheck, and vitest suites with required Supabase env vars in CI.
- Fail the job when the RLS policy tests are skipped to surface misconfiguration.

### Tests added/updated
- n/a

### Checklist
- [ ] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d1ff7c150c83329725a83ef68f8293