### PR TITLE
fix: respect db integration run flags – 2025-02-14

### DIFF
--- a/src/lib/__tests__/DatabaseIntegration.test.ts
+++ b/src/lib/__tests__/DatabaseIntegration.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
+import { shouldRunDbIntegrationTests } from '../testUtils/shouldRunDbIntegrationTests';
 
 // Test configuration
 const SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
@@ -27,7 +28,7 @@ async function isTestEnvironmentValid(): Promise<boolean> {
 }
 
 // Only run these against a real test environment (CI or explicit opt-in)
-const SHOULD_RUN_DB_IT = !!(import.meta.env.CI || (import.meta as any).env?.RUN_DB_IT === '1');
+const SHOULD_RUN_DB_IT = shouldRunDbIntegrationTests();
 
 describe('Database Integration Tests', () => {
   let testEnvironmentValid = false;

--- a/src/lib/__tests__/shouldRunDbIntegrationTests.test.ts
+++ b/src/lib/__tests__/shouldRunDbIntegrationTests.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { shouldRunDbIntegrationTests } from '../testUtils/shouldRunDbIntegrationTests';
+
+const originalCI = process.env.CI;
+const originalRunDbIt = process.env.RUN_DB_IT;
+
+const restoreEnv = (key: 'CI' | 'RUN_DB_IT', value: string | undefined): void => {
+  if (typeof value === 'undefined') {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+};
+
+describe('shouldRunDbIntegrationTests', () => {
+  beforeEach(() => {
+    delete process.env.CI;
+    delete process.env.RUN_DB_IT;
+  });
+
+  afterEach(() => {
+    restoreEnv('CI', originalCI);
+    restoreEnv('RUN_DB_IT', originalRunDbIt);
+  });
+
+  it('returns true when CI is enabled in process.env', () => {
+    process.env.CI = 'true';
+
+    expect(shouldRunDbIntegrationTests()).toBe(true);
+  });
+
+  it('returns true when RUN_DB_IT=1 in process.env', () => {
+    process.env.RUN_DB_IT = '1';
+
+    expect(shouldRunDbIntegrationTests()).toBe(true);
+  });
+
+  it('returns true when CI is enabled via import.meta.env', () => {
+    const result = shouldRunDbIntegrationTests({
+      importMetaEnv: { CI: 'true' },
+      processEnv: {},
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when no CI or RUN_DB_IT flags are present', () => {
+    const result = shouldRunDbIntegrationTests({ processEnv: {}, importMetaEnv: {} });
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/lib/testUtils/shouldRunDbIntegrationTests.ts
+++ b/src/lib/testUtils/shouldRunDbIntegrationTests.ts
@@ -1,0 +1,68 @@
+const TRUTHY_STRINGS = new Set(['1', 'true', 'yes', 'on']);
+
+type ProcessLike = { env?: Record<string, string | undefined> };
+
+type ShouldRunDbIntegrationTestsOptions = {
+  importMetaEnv?: Record<string, unknown>;
+  processEnv?: Record<string, string | undefined>;
+};
+
+const isTruthyFlag = (value: unknown): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized.length === 0) {
+      return false;
+    }
+    return TRUTHY_STRINGS.has(normalized);
+  }
+
+  if (typeof value === 'number') {
+    return value === 1;
+  }
+
+  return false;
+};
+
+const getProcessEnv = (
+  provided?: Record<string, string | undefined>
+): Record<string, string | undefined> | undefined => {
+  if (provided) {
+    return provided;
+  }
+
+  const candidate = globalThis as typeof globalThis & { process?: ProcessLike };
+  return candidate.process?.env;
+};
+
+const getImportMetaEnv = (
+  provided?: Record<string, unknown>
+): Record<string, unknown> | undefined => {
+  if (provided) {
+    return provided;
+  }
+
+  const meta = import.meta as ImportMeta & { env?: Record<string, unknown> };
+  return meta.env;
+};
+
+export const shouldRunDbIntegrationTests = (
+  options: ShouldRunDbIntegrationTestsOptions = {}
+): boolean => {
+  const importMetaEnv = getImportMetaEnv(options.importMetaEnv);
+  const processEnv = getProcessEnv(options.processEnv);
+
+  return (
+    isTruthyFlag(importMetaEnv?.CI) ||
+    isTruthyFlag(processEnv?.CI) ||
+    isTruthyFlag(importMetaEnv?.RUN_DB_IT) ||
+    isTruthyFlag(processEnv?.RUN_DB_IT)
+  );
+};
+
+export const testables = {
+  isTruthyFlag,
+};


### PR DESCRIPTION
### Summary
Ensure database integration tests honor process-level CI flags when deciding to run.

### Proposed changes
- Extract a reusable helper to evaluate CI and RUN_DB_IT flags from process and import.meta environments
- Update the database integration suite to use the helper and cover the flag handling with dedicated unit tests

### Tests added/updated
- src/lib/__tests__/shouldRunDbIntegrationTests.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d2285e8c088332b7b83a640b087830