### PR TITLE
fix: bootstrap server supabase config – 2025-09-24

### DIFF
--- a/src/server/__tests__/bookHandler.integration.test.ts
+++ b/src/server/__tests__/bookHandler.integration.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { bookHandler } from "../api/book";
 
 const { callEdgeMock, persistSessionCptMetadataMock } = vi.hoisted(() => ({
   callEdgeMock: vi.fn(),
@@ -8,7 +7,7 @@ const { callEdgeMock, persistSessionCptMetadataMock } = vi.hoisted(() => ({
     .mockResolvedValue({ entryId: "entry-id", modifierIds: [] }),
 }));
 
-vi.mock("../../lib/supabase", async () => {
+const supabaseModuleFactory = vi.hoisted(() => async () => {
   const actual = await vi.importActual<typeof import("../../lib/supabase")>("../../lib/supabase");
   return {
     ...actual,
@@ -16,9 +15,26 @@ vi.mock("../../lib/supabase", async () => {
   };
 });
 
+vi.mock("../../lib/supabase", supabaseModuleFactory);
+
 vi.mock("../sessionCptPersistence", () => ({
   persistSessionCptMetadata: persistSessionCptMetadataMock,
 }));
+
+const importBookHandler = async () => {
+  const module = await import("../api/book");
+  return module.bookHandler;
+};
+
+const TEST_SUPABASE_URL = "https://testing.supabase.co";
+const TEST_SUPABASE_ANON_KEY = "testing-anon-key";
+const TEST_SUPABASE_EDGE_URL = "https://testing.supabase.co/functions/v1/";
+
+const ORIGINAL_ENV = {
+  SUPABASE_URL: process.env.SUPABASE_URL,
+  SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY,
+  SUPABASE_EDGE_URL: process.env.SUPABASE_EDGE_URL,
+};
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -40,8 +56,13 @@ describe("bookHandler integration", () => {
     timeZone: "UTC",
   } as const;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    const runtimeConfig = await import("../../lib/runtimeConfig");
+    runtimeConfig.resetRuntimeSupabaseConfigForTests();
+    process.env.SUPABASE_URL = TEST_SUPABASE_URL;
+    process.env.SUPABASE_ANON_KEY = TEST_SUPABASE_ANON_KEY;
+    process.env.SUPABASE_EDGE_URL = TEST_SUPABASE_EDGE_URL;
   });
 
   it("calls edge functions with the bearer token from the request", async () => {
@@ -105,6 +126,8 @@ describe("bookHandler integration", () => {
         }),
       );
 
+    const bookHandler = await importBookHandler();
+
     const response = await bookHandler(
       new Request("http://localhost/api/book", {
         method: "POST",
@@ -139,6 +162,8 @@ describe("bookHandler integration", () => {
   });
 
   it("rejects unauthorized requests before invoking edge functions", async () => {
+    const bookHandler = await importBookHandler();
+
     const response = await bookHandler(
       new Request("http://localhost/api/book", {
         method: "POST",
@@ -151,4 +176,169 @@ describe("bookHandler integration", () => {
     expect(callEdgeMock).not.toHaveBeenCalled();
     expect(persistSessionCptMetadataMock).not.toHaveBeenCalled();
   });
+
+  it("bootstraps Supabase runtime config for server handlers", async () => {
+    vi.resetModules();
+    vi.doUnmock("../../lib/supabase");
+    persistSessionCptMetadataMock.mockClear();
+
+    const runtimeConfig = await import("../../lib/runtimeConfig");
+    runtimeConfig.resetRuntimeSupabaseConfigForTests();
+
+    const originalEnv = {
+      SUPABASE_URL: process.env.SUPABASE_URL,
+      SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY,
+      SUPABASE_EDGE_URL: process.env.SUPABASE_EDGE_URL,
+    };
+
+    const supabaseUrl = "https://runtime.example.supabase.co";
+    const supabaseAnonKey = "test-anon-key";
+    const supabaseEdgeUrl = "https://runtime.example.supabase.co/functions/v1/";
+
+    process.env.SUPABASE_URL = supabaseUrl;
+    process.env.SUPABASE_ANON_KEY = supabaseAnonKey;
+    process.env.SUPABASE_EDGE_URL = supabaseEdgeUrl;
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn<typeof fetch>();
+    const holdResponsePayload = {
+      success: true,
+      data: {
+        holdKey: "hold-key",
+        holdId: "hold-id",
+        expiresAt: "2025-01-01T09:05:00Z",
+        holds: [
+          {
+            holdKey: "hold-key",
+            holdId: "hold-id",
+            startTime: payload.session.start_time,
+            endTime: payload.session.end_time,
+            expiresAt: "2025-01-01T09:05:00Z",
+          },
+        ],
+      },
+    } as const;
+
+    const confirmResponsePayload = {
+      success: true,
+      data: {
+        session: {
+          id: "session-1",
+          therapist_id: payload.session.therapist_id,
+          client_id: payload.session.client_id,
+          start_time: payload.session.start_time,
+          end_time: payload.session.end_time,
+          status: "scheduled",
+          notes: "",
+          created_at: "2025-01-01T09:00:00Z",
+          created_by: "user-1",
+          updated_at: "2025-01-01T09:00:00Z",
+          updated_by: "user-1",
+          duration_minutes: 60,
+        },
+        sessions: [
+          {
+            id: "session-1",
+            therapist_id: payload.session.therapist_id,
+            client_id: payload.session.client_id,
+            start_time: payload.session.start_time,
+            end_time: payload.session.end_time,
+            status: "scheduled",
+            notes: "",
+            created_at: "2025-01-01T09:00:00Z",
+            created_by: "user-1",
+            updated_at: "2025-01-01T09:00:00Z",
+            updated_by: "user-1",
+            duration_minutes: 60,
+          },
+        ],
+        roundedDurationMinutes: 60,
+      },
+    } as const;
+
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(holdResponsePayload), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(confirmResponsePayload), { status: 200 }));
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const accessToken = "bootstrap-token";
+
+    try {
+      await import("../bootstrapSupabase");
+      const { bookHandler } = await import("../api/book");
+
+      const response = await bookHandler(
+        new Request("http://localhost/api/book", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify(payload),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.data.session.id).toBe("session-1");
+
+      expect(runtimeConfig.getRuntimeSupabaseConfig()).toEqual({
+        supabaseUrl,
+        supabaseAnonKey,
+        supabaseEdgeUrl,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const expectedBaseUrl = supabaseEdgeUrl.endsWith("/")
+        ? supabaseEdgeUrl
+        : `${supabaseEdgeUrl}/`;
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(`${expectedBaseUrl}sessions-hold`);
+      expect(fetchMock.mock.calls[1]?.[0]).toBe(`${expectedBaseUrl}sessions-confirm`);
+
+      expect(persistSessionCptMetadataMock).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: "session-1" }),
+      );
+      expect(callEdgeMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+      runtimeConfig.resetRuntimeSupabaseConfigForTests();
+      if (typeof originalEnv.SUPABASE_URL === "string") {
+        process.env.SUPABASE_URL = originalEnv.SUPABASE_URL;
+      } else {
+        delete process.env.SUPABASE_URL;
+      }
+      if (typeof originalEnv.SUPABASE_ANON_KEY === "string") {
+        process.env.SUPABASE_ANON_KEY = originalEnv.SUPABASE_ANON_KEY;
+      } else {
+        delete process.env.SUPABASE_ANON_KEY;
+      }
+      if (typeof originalEnv.SUPABASE_EDGE_URL === "string") {
+        process.env.SUPABASE_EDGE_URL = originalEnv.SUPABASE_EDGE_URL;
+      } else {
+        delete process.env.SUPABASE_EDGE_URL;
+      }
+      vi.doMock("../../lib/supabase", supabaseModuleFactory);
+      vi.resetModules();
+    }
+  });
+});
+
+afterAll(() => {
+  if (typeof ORIGINAL_ENV.SUPABASE_URL === "string") {
+    process.env.SUPABASE_URL = ORIGINAL_ENV.SUPABASE_URL;
+  } else {
+    delete process.env.SUPABASE_URL;
+  }
+  if (typeof ORIGINAL_ENV.SUPABASE_ANON_KEY === "string") {
+    process.env.SUPABASE_ANON_KEY = ORIGINAL_ENV.SUPABASE_ANON_KEY;
+  } else {
+    delete process.env.SUPABASE_ANON_KEY;
+  }
+  if (typeof ORIGINAL_ENV.SUPABASE_EDGE_URL === "string") {
+    process.env.SUPABASE_EDGE_URL = ORIGINAL_ENV.SUPABASE_EDGE_URL;
+  } else {
+    delete process.env.SUPABASE_EDGE_URL;
+  }
 });

--- a/src/server/api/book.ts
+++ b/src/server/api/book.ts
@@ -1,3 +1,4 @@
+import "../bootstrapSupabase";
 import { bookSession } from "../bookSession";
 import type {
   BookSessionApiRequestBody,

--- a/src/server/bookSession.ts
+++ b/src/server/bookSession.ts
@@ -1,3 +1,4 @@
+import "./bootstrapSupabase";
 import { addDays } from "date-fns";
 import { formatInTimeZone, zonedTimeToUtc } from "date-fns-tz";
 import {

--- a/src/server/bootstrapSupabase.ts
+++ b/src/server/bootstrapSupabase.ts
@@ -1,0 +1,8 @@
+import { setRuntimeSupabaseConfig } from "../lib/runtimeConfig";
+import { getRuntimeSupabaseConfig } from "./runtimeConfig";
+
+export const bootstrapSupabase = (): void => {
+  setRuntimeSupabaseConfig(getRuntimeSupabaseConfig());
+};
+
+bootstrapSupabase();


### PR DESCRIPTION
### Summary
Ensure server handlers configure the Supabase runtime client before executing session booking logic.

### Proposed changes
- add a bootstrap module that sets the runtime Supabase config from server environment variables
- import the bootstrap module in server entrypoints and refresh related tests to manage env state and cover the new bootstrap flow

### Tests added/updated
- src/server/__tests__/bookHandler.integration.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d33c30ee5c833287d762f17ff8ac36