### PR TITLE
fix: redact error tracking payloads – 2025-09-24

### DIFF
--- a/src/lib/__tests__/errorTrackingRedaction.test.ts
+++ b/src/lib/__tests__/errorTrackingRedaction.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { REDACTED_VALUE } from '../logger/redactPhi';
+
+const rpcMock = vi.fn<
+  Promise<{ data: unknown; error: null }>,
+  [string, Record<string, unknown> | undefined]
+>();
+
+vi.mock('../supabase', () => ({
+  supabase: {
+    rpc: rpcMock
+  }
+}));
+
+const loggerMock = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn()
+};
+
+vi.mock('../logger/logger', () => ({
+  logger: loggerMock
+}));
+
+const setNavigatorProperty = (key: keyof Navigator, value: unknown) => {
+  Object.defineProperty(window.navigator, key, {
+    configurable: true,
+    get: () => value
+  });
+};
+
+const loadTracker = async () => {
+  const module = await import('../errorTracking');
+  module.errorTracker.clearErrorData();
+  return module.errorTracker;
+};
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  rpcMock.mockResolvedValue({ data: null, error: null });
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    value: true
+  });
+  setNavigatorProperty('userAgent', 'test-agent patient@example.com');
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  const module = await import('../errorTracking');
+  module.errorTracker.clearErrorData();
+});
+
+afterAll(async () => {
+  const module = await import('../errorTracking');
+  module.errorTracker.destroy();
+});
+
+describe('ErrorTracker PHI redaction', () => {
+  it('redacts sensitive data before enqueuing general errors', async () => {
+    const tracker = await loadTracker();
+    const error = new Error('Patient email patient@example.com');
+    error.stack = 'at handler (patient@example.com:1)';
+
+    tracker.trackError(error, {
+      component: 'PatientView',
+      function: 'loadPatient',
+      url: 'https://app.local/context/patient@example.com',
+      userAgent: 'custom-agent patient@example.com',
+      sessionId: 'session patient@example.com'
+    });
+
+    const queue = (tracker as unknown as { errorQueue: any[] }).errorQueue;
+    expect(queue).toHaveLength(1);
+    const queued = queue[0];
+
+    expect(queued.message).not.toContain('patient@example.com');
+    expect(queued.message).toContain(REDACTED_VALUE);
+    expect(queued.stack).toContain(REDACTED_VALUE);
+    expect(queued.context.userAgent).toContain(REDACTED_VALUE);
+    expect(queued.context.sessionId).toContain(REDACTED_VALUE);
+  });
+
+  it('redacts AI error payloads and RPC submissions', async () => {
+    const tracker = await loadTracker();
+    const error = new Error('AI failure for patient@example.com');
+    error.stack = 'stack patient@example.com';
+
+    await tracker.trackAIError(
+      error,
+      {
+        functionCalled: 'callPatient patient@example.com',
+        tokenUsage: 123,
+        responseTime: 456,
+        cacheAttempted: true,
+        errorType: 'function_error'
+      },
+      {
+        component: 'AIService',
+        function: 'callPatient'
+      }
+    );
+
+    const queue = (tracker as unknown as { errorQueue: any[] }).errorQueue;
+    expect(queue).toHaveLength(1);
+    const queued = queue[0];
+
+    expect(queued.message).toContain(REDACTED_VALUE);
+    expect(queued.stack).toContain(REDACTED_VALUE);
+    expect(queued.details.functionCalled).toContain(REDACTED_VALUE);
+    expect(queued.context.userAgent).toContain(REDACTED_VALUE);
+
+    const performanceCall = rpcMock.mock.calls.find(([fn]) => fn === 'log_ai_performance');
+    expect(performanceCall).toBeDefined();
+    const performanceArgs = performanceCall?.[1] as Record<string, unknown>;
+    expect(performanceArgs.p_function_called).toContain(REDACTED_VALUE);
+    expect(String(performanceArgs.p_function_called)).not.toContain('patient@example.com');
+
+    rpcMock.mockClear();
+    rpcMock.mockResolvedValue({ data: null, error: null });
+
+    await (tracker as unknown as { flushErrorQueue: () => Promise<void> }).flushErrorQueue();
+
+    const flushCall = rpcMock.mock.calls.find(([fn]) => fn === 'log_error_event');
+    expect(flushCall).toBeDefined();
+    const flushArgs = flushCall?.[1] as Record<string, unknown>;
+    expect(flushArgs.p_message).toContain(REDACTED_VALUE);
+    expect(String(flushArgs.p_message)).not.toContain('patient@example.com');
+    expect(flushArgs.p_stack_trace).toContain(REDACTED_VALUE);
+
+    const context = flushArgs.p_context as { userAgent?: string } | null;
+    expect(context).toBeTruthy();
+    expect(context?.userAgent).toContain(REDACTED_VALUE);
+
+    const details = flushArgs.p_details as { functionCalled?: string } | null;
+    expect(details).toBeTruthy();
+    expect(details?.functionCalled).toContain(REDACTED_VALUE);
+  });
+});


### PR DESCRIPTION
### Summary
Ensure error tracking pipelines redact PHI before logging or persisting data.

### Proposed changes
- sanitize AI and application error payloads (messages, stacks, context, details) via redactPhi before queueing or RPC submission
- redact function identifiers in AI performance metrics and sanitize stored queue entries and Supabase payloads
- add regression tests covering PHI redaction for trackError, trackAIError, and Supabase RPC interactions

### Tests added/updated
- src/lib/__tests__/errorTrackingRedaction.test.ts

### Checklist
- [ ] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d33c38c6b88332909965ec9e9b2c62