### PR TITLE
fix: harden diagnostics and dashboard fallback – 2025-09-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ AllIncompassing delivers therapist scheduling, billing, and operational telemetr
 | Cypress end-to-end suite | `npm run test:e2e` or `npm run test:e2e:open` |
 | Route integrity tests | `npm run test:routes` or `npm run test:routes:open` |
 
+### Supabase connection diagnostics
+
+- Connection diagnostics automatically execute only in Vite development builds so production deployments do not trigger auth, table, or RPC probes on every boot.
+- To force diagnostics in another environment, export `VITE_ENABLE_CONNECTION_DIAGNOSTICS=true` before running the app (e.g., `VITE_ENABLE_CONNECTION_DIAGNOSTICS=true npm run dev`). Set the flag to `false` to explicitly disable the checks.
+- The helper `verifyConnection()` in `src/lib/supabase.ts` can be invoked manually from dev tools or scripts. Each intentional run logs `[supabase] Running connection diagnostics` and `[supabase] Starting connection diagnostics checks` in the console for easy traceability.
+
 ### Supabase migrations & health tooling
 
 - Create a new database branch for experimentation: `npm run db:branch:create`

--- a/src/lib/__tests__/dashboardFallback.test.ts
+++ b/src/lib/__tests__/dashboardFallback.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildRedactedDashboardFallback,
+  fetchBillingAlertsFallback,
+  fetchClientMetricsFallback,
+  fetchIncompleteSessionsFallback,
+  fetchTodaySessionsFallback,
+} from '../dashboardFallback';
+
+const createSessionBuilder = (dataOverride?: unknown[]) => {
+  const rows =
+    dataOverride ??
+    [
+      {
+        id: 'session-1',
+        start_time: '2024-01-01T12:00:00.000Z',
+        status: 'scheduled',
+        therapists: { id: 'therapist-1', full_name: 'Therapist Example' },
+        clients: { id: 'client-1', full_name: 'Client Example' },
+      },
+    ];
+
+  const result = { data: rows, error: null };
+  const builder: any = {};
+  builder.select = vi.fn().mockImplementation(() => builder);
+  builder.gte = vi.fn().mockReturnValue(builder);
+  builder.lte = vi.fn().mockReturnValue(builder);
+  builder.eq = vi.fn().mockReturnValue(builder);
+  builder.is = vi.fn().mockReturnValue(builder);
+  builder.order = vi.fn().mockReturnValue(builder);
+  builder.limit = vi.fn().mockImplementation(() => Promise.resolve(result));
+  return { builder, result };
+};
+
+const createBillingBuilder = () => {
+  const result = {
+    data: [
+      { id: 'billing-1', amount: 42, status: 'pending', created_at: '2024-01-01T00:00:00.000Z' },
+    ],
+    error: null,
+  };
+  const builder: any = {};
+  builder.select = vi.fn().mockImplementation(() => builder);
+  builder.in = vi.fn().mockReturnValue(builder);
+  builder.order = vi.fn().mockReturnValue(builder);
+  builder.limit = vi.fn().mockImplementation(() => Promise.resolve(result));
+  return { builder, result };
+};
+
+const createCountBuilder = (count: number) => {
+  const builder: any = { promise: Promise.resolve({ data: [], error: null, count }) };
+  builder.select = vi.fn().mockImplementation(() => {
+    builder.promise = Promise.resolve({ data: [], error: null, count });
+    return builder;
+  });
+  builder.gte = vi.fn().mockImplementation(() => builder);
+  builder.then = (...args: unknown[]) => builder.promise.then(...args);
+  builder.catch = (...args: unknown[]) => builder.promise.catch(...args);
+  builder.finally = (...args: unknown[]) => builder.promise.finally(...args);
+  return builder;
+};
+
+const createTotalsBuilder = () => {
+  const builder: any = {};
+  builder.select = vi.fn().mockImplementation(() => builder);
+  builder.maybeSingle = vi.fn().mockResolvedValue({
+    data: {
+      total_one_to_one: 12,
+      total_supervision: 4,
+      total_parent: 2,
+    },
+    error: null,
+  });
+  return builder;
+};
+
+describe('dashboard fallback queries', () => {
+  it('limits today sessions fallback query to required columns', async () => {
+    const { builder } = createSessionBuilder();
+    const from = vi.fn().mockReturnValue(builder);
+    const supabaseMock = { from } as any;
+
+    const sessions = await fetchTodaySessionsFallback(supabaseMock, new Date('2024-01-01T09:00:00.000Z'));
+
+    expect(from).toHaveBeenCalledWith('sessions');
+    expect(builder.select).toHaveBeenCalledTimes(1);
+    const selectArg = builder.select.mock.calls[0][0] as string;
+    expect(selectArg).toContain('therapists:therapists!inner');
+    expect(selectArg).toContain('clients:clients!inner');
+    expect(builder.limit).toHaveBeenCalledWith(50);
+    expect(sessions[0]).toMatchObject({
+      id: 'session-1',
+      therapist: { id: 'therapist-1', full_name: 'Therapist Example' },
+      client: { id: 'client-1', full_name: 'Client Example' },
+    });
+  });
+
+  it('limits incomplete sessions fallback query', async () => {
+    const { builder } = createSessionBuilder();
+    const from = vi.fn().mockReturnValue(builder);
+    const supabaseMock = { from } as any;
+
+    await fetchIncompleteSessionsFallback(supabaseMock);
+
+    expect(from).toHaveBeenCalledWith('sessions');
+    expect(builder.eq).toHaveBeenCalledWith('status', 'completed');
+    expect(builder.is).toHaveBeenCalledWith('notes', null);
+    expect(builder.limit).toHaveBeenCalledWith(50);
+  });
+
+  it('limits billing alert fallback query and prunes columns', async () => {
+    const { builder } = createBillingBuilder();
+    const from = vi.fn().mockReturnValue(builder);
+    const supabaseMock = { from } as any;
+
+    const alerts = await fetchBillingAlertsFallback(supabaseMock);
+
+    expect(from).toHaveBeenCalledWith('billing_records');
+    expect(builder.select).toHaveBeenCalledWith('id, amount, status, created_at');
+    expect(builder.limit).toHaveBeenCalledWith(50);
+    expect(alerts[0]).toMatchObject({ id: 'billing-1', amount: 42, status: 'pending' });
+  });
+
+  it('aggregates client metrics without scanning entire table payloads', async () => {
+    const totalBuilder = createCountBuilder(120);
+    const activeBuilder = createCountBuilder(45);
+    const totalsBuilder = createTotalsBuilder();
+    let callIndex = -1;
+    const builders = [totalBuilder, activeBuilder, totalsBuilder];
+    const from = vi.fn().mockImplementation(() => {
+      callIndex += 1;
+      return builders[callIndex] ?? totalsBuilder;
+    });
+
+    const supabaseMock = { from } as any;
+
+    const metrics = await fetchClientMetricsFallback(supabaseMock, new Date('2024-01-31T00:00:00.000Z'));
+
+    expect(from).toHaveBeenCalledWith('clients');
+    expect(totalBuilder.select).toHaveBeenCalledWith('id', { count: 'exact', head: true });
+    expect(activeBuilder.gte).toHaveBeenCalledWith('created_at', expect.stringMatching(/T/));
+    expect(totalsBuilder.select).toHaveBeenCalledTimes(1);
+    const selectArg = totalsBuilder.select.mock.calls[0][0] as string;
+    expect(selectArg).toContain('one_to_one_units.sum()');
+    expect(metrics).toEqual({ total: 120, active: 45, totalUnits: 18 });
+  });
+
+  it('provides redacted placeholders when fallback is blocked', () => {
+    const fallback = buildRedactedDashboardFallback();
+
+    expect(fallback.redacted).toBe(true);
+    expect(fallback.todaySessions[0]?.__redacted).toBe(true);
+    expect(fallback.incompleteSessions[0]?.__redacted).toBe(true);
+    expect(fallback.billingAlerts[0]?.__redacted).toBe(true);
+    expect(fallback.clientMetrics.redacted).toBe(true);
+  });
+});

--- a/src/lib/__tests__/supabase.diagnostics.test.ts
+++ b/src/lib/__tests__/supabase.diagnostics.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.unmock('../supabase');
+
+let supabaseMock: ReturnType<typeof createSupabaseMock>;
+
+vi.mock('../supabaseClient', () => ({
+  get supabase() {
+    return supabaseMock;
+  },
+}));
+
+const createQueryBuilder = () => {
+  const result = { data: [{ count: 0 }], error: null };
+  const builder: any = { promise: Promise.resolve(result) };
+  builder.select = vi.fn().mockImplementation(() => {
+    builder.promise = Promise.resolve(result);
+    return builder;
+  });
+  builder.limit = vi.fn().mockImplementation(() => Promise.resolve(result));
+  builder.order = vi.fn().mockReturnValue(builder);
+  builder.eq = vi.fn().mockReturnValue(builder);
+  builder.is = vi.fn().mockReturnValue(builder);
+  builder.in = vi.fn().mockReturnValue(builder);
+  builder.gte = vi.fn().mockReturnValue(builder);
+  builder.lte = vi.fn().mockReturnValue(builder);
+  builder.then = (...args: unknown[]) => builder.promise.then(...args);
+  builder.catch = (...args: unknown[]) => builder.promise.catch(...args);
+  builder.finally = (...args: unknown[]) => builder.promise.finally(...args);
+  return builder;
+};
+
+const createSupabaseMock = () => {
+  const authGetSession = vi.fn().mockResolvedValue({ data: { session: null }, error: null });
+  const from = vi.fn().mockImplementation(() => createQueryBuilder());
+  const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+
+  return {
+    auth: { getSession: authGetSession },
+    from,
+    rpc,
+  };
+};
+
+const setupModule = async () => {
+  supabaseMock = createSupabaseMock();
+  vi.resetModules();
+  const mod = await import('../supabase');
+  return { mod, supabaseMock };
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe('supabase connection diagnostics guard', () => {
+  it('skips diagnostics when running under test harness', async () => {
+    vi.stubEnv('VITEST', 'true');
+    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { mod, supabaseMock } = await setupModule();
+
+    expect(mod.shouldRunConnectionDiagnostics()).toBe(false);
+    expect(supabaseMock.auth.getSession).not.toHaveBeenCalled();
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Running connection diagnostics'),
+      expect.anything()
+    );
+  });
+
+  it('does not run diagnostics in production builds', async () => {
+    vi.stubEnv('DEV', 'false');
+    vi.stubEnv('VITEST', 'false');
+    vi.stubEnv('VITE_ENABLE_CONNECTION_DIAGNOSTICS', 'false');
+    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { mod, supabaseMock } = await setupModule();
+
+    expect(mod.shouldRunConnectionDiagnostics()).toBe(false);
+    expect(supabaseMock.auth.getSession).not.toHaveBeenCalled();
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      '[supabase] Running connection diagnostics',
+      expect.anything()
+    );
+  });
+
+  it('runs diagnostics automatically in development', async () => {
+    vi.stubEnv('DEV', 'true');
+    vi.stubEnv('VITEST', 'false');
+    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { mod, supabaseMock } = await setupModule();
+
+    expect(mod.shouldRunConnectionDiagnostics()).toBe(true);
+    expect(supabaseMock.auth.getSession).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith('[supabase] Running connection diagnostics', {
+      scope: 'supabase.connectionDiagnostics',
+    });
+  });
+
+  it('respects explicit diagnostics flag overrides', async () => {
+    vi.stubEnv('DEV', 'false');
+    vi.stubEnv('VITEST', 'false');
+    vi.stubEnv('VITE_ENABLE_CONNECTION_DIAGNOSTICS', 'true');
+    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { mod, supabaseMock } = await setupModule();
+
+    expect(mod.shouldRunConnectionDiagnostics()).toBe(true);
+    expect(supabaseMock.auth.getSession).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith('[supabase] Running connection diagnostics', {
+      scope: 'supabase.connectionDiagnostics',
+    });
+  });
+
+  it('disables diagnostics when flag is explicitly false', async () => {
+    vi.stubEnv('DEV', 'true');
+    vi.stubEnv('VITEST', 'false');
+    vi.stubEnv('VITE_ENABLE_CONNECTION_DIAGNOSTICS', 'false');
+    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { mod, supabaseMock } = await setupModule();
+
+    expect(mod.shouldRunConnectionDiagnostics()).toBe(false);
+    expect(supabaseMock.auth.getSession).not.toHaveBeenCalled();
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      '[supabase] Running connection diagnostics',
+      expect.anything()
+    );
+  });
+});

--- a/src/lib/dashboardFallback.ts
+++ b/src/lib/dashboardFallback.ts
@@ -1,0 +1,260 @@
+import { startOfDay, endOfDay, subDays } from 'date-fns';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from './supabase';
+import type { Database } from './generated/database.types';
+
+type TypedSupabaseClient = SupabaseClient<Database>;
+
+export const DASHBOARD_FALLBACK_ALLOWED_ROLES = ['admin', 'super_admin'] as const;
+
+export type DashboardFallbackAllowedRole = typeof DASHBOARD_FALLBACK_ALLOWED_ROLES[number];
+
+export interface DashboardSessionSummary {
+  id: string;
+  start_time: string;
+  status: string | null;
+  therapist: { id: string; full_name: string | null } | null;
+  client: { id: string; full_name: string | null } | null;
+  __redacted?: boolean;
+}
+
+export interface DashboardBillingAlertSummary {
+  id: string;
+  amount: number | string | null;
+  status: string | null;
+  created_at: string | null;
+  __redacted?: boolean;
+}
+
+export interface DashboardClientMetricsSummary {
+  total: number;
+  active: number;
+  totalUnits: number;
+  redacted?: boolean;
+}
+
+const TODAY_SESSION_LIMIT = 50;
+const INCOMPLETE_SESSION_LIMIT = 50;
+const BILLING_ALERT_LIMIT = 50;
+
+type RawSessionRow = {
+  id: string;
+  start_time: string;
+  status: string | null;
+  therapists: { id: string; full_name: string | null } | null;
+  clients: { id: string; full_name: string | null } | null;
+};
+
+type RawBillingRow = {
+  id: string;
+  amount: number | null;
+  status: string | null;
+  created_at: string;
+};
+
+type RawUnitAggregate = {
+  total_one_to_one: number | null;
+  total_supervision: number | null;
+  total_parent: number | null;
+};
+
+export const REDACTED_SESSION_PLACEHOLDER: DashboardSessionSummary = {
+  id: 'redacted',
+  start_time: '1970-01-01T00:00:00.000Z',
+  status: null,
+  therapist: { id: 'redacted', full_name: 'Restricted' },
+  client: { id: 'redacted', full_name: 'Restricted' },
+  __redacted: true,
+};
+
+export const REDACTED_BILLING_ALERT_PLACEHOLDER: DashboardBillingAlertSummary = {
+  id: 'redacted',
+  amount: '****',
+  status: 'restricted',
+  created_at: null,
+  __redacted: true,
+};
+
+export const REDACTED_CLIENT_METRICS: DashboardClientMetricsSummary = {
+  total: 0,
+  active: 0,
+  totalUnits: 0,
+  redacted: true,
+};
+
+const mapSessionRow = (session: RawSessionRow): DashboardSessionSummary => ({
+  id: session.id,
+  start_time: session.start_time,
+  status: session.status,
+  therapist: session.therapists
+    ? { id: session.therapists.id, full_name: session.therapists.full_name }
+    : null,
+  client: session.clients
+    ? { id: session.clients.id, full_name: session.clients.full_name }
+    : null,
+});
+
+export const fetchTodaySessionsFallback = async (
+  client: TypedSupabaseClient = supabase,
+  now: Date = new Date()
+): Promise<DashboardSessionSummary[]> => {
+  const start = startOfDay(now).toISOString();
+  const end = endOfDay(now).toISOString();
+
+  const { data, error } = await client
+    .from('sessions')
+    .select(
+      `
+        id,
+        start_time,
+        status,
+        therapists:therapists!inner (
+          id,
+          full_name
+        ),
+        clients:clients!inner (
+          id,
+          full_name
+        )
+      `
+    )
+    .gte('start_time', start)
+    .lte('start_time', end)
+    .order('start_time', { ascending: true })
+    .limit(TODAY_SESSION_LIMIT);
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = (data ?? []) as RawSessionRow[];
+  return rows.map(mapSessionRow);
+};
+
+export const fetchIncompleteSessionsFallback = async (
+  client: TypedSupabaseClient = supabase
+): Promise<DashboardSessionSummary[]> => {
+  const { data, error } = await client
+    .from('sessions')
+    .select(
+      `
+        id,
+        start_time,
+        status,
+        therapists:therapists!inner (
+          id,
+          full_name
+        ),
+        clients:clients!inner (
+          id,
+          full_name
+        )
+      `
+    )
+    .eq('status', 'completed')
+    .is('notes', null)
+    .order('start_time', { ascending: true })
+    .limit(INCOMPLETE_SESSION_LIMIT);
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = (data ?? []) as RawSessionRow[];
+  return rows.map(mapSessionRow);
+};
+
+export const fetchBillingAlertsFallback = async (
+  client: TypedSupabaseClient = supabase
+): Promise<DashboardBillingAlertSummary[]> => {
+  const { data, error } = await client
+    .from('billing_records')
+    .select('id, amount, status, created_at')
+    .in('status', ['pending', 'rejected'])
+    .order('created_at', { ascending: false })
+    .limit(BILLING_ALERT_LIMIT);
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = (data ?? []) as RawBillingRow[];
+  return rows.map((record) => ({
+    id: record.id,
+    amount: record.amount,
+    status: record.status,
+    created_at: record.created_at,
+  }));
+};
+
+const sumUnit = (value: number | null | undefined): number => (typeof value === 'number' ? value : 0);
+
+export const fetchClientMetricsFallback = async (
+  client: TypedSupabaseClient = supabase,
+  now: Date = new Date()
+): Promise<DashboardClientMetricsSummary> => {
+  const activeSince = subDays(now, 30).toISOString();
+
+  const totalPromise = client
+    .from('clients')
+    .select('id', { count: 'exact', head: true });
+
+  const activePromise = client
+    .from('clients')
+    .select('id', { count: 'exact', head: true })
+    .gte('created_at', activeSince);
+
+  const totalsPromise = client
+    .from('clients')
+    .select(
+      `
+        total_one_to_one:one_to_one_units.sum(),
+        total_supervision:supervision_units.sum(),
+        total_parent:parent_consult_units.sum()
+      `
+    )
+    .maybeSingle();
+
+  const [totalResult, activeResult, totalsResult] = await Promise.all([
+    totalPromise,
+    activePromise,
+    totalsPromise,
+  ]);
+
+  if (totalResult.error) {
+    throw totalResult.error;
+  }
+
+  if (activeResult.error) {
+    throw activeResult.error;
+  }
+
+  if (totalsResult.error) {
+    throw totalsResult.error;
+  }
+
+  const aggregates = (totalsResult.data ?? {
+    total_one_to_one: 0,
+    total_supervision: 0,
+    total_parent: 0,
+  }) as RawUnitAggregate;
+
+  return {
+    total: totalResult.count ?? 0,
+    active: activeResult.count ?? 0,
+    totalUnits:
+      sumUnit(aggregates.total_one_to_one) +
+      sumUnit(aggregates.total_supervision) +
+      sumUnit(aggregates.total_parent),
+  };
+};
+
+export const buildRedactedDashboardFallback = () => ({
+  todaySessions: [REDACTED_SESSION_PLACEHOLDER],
+  incompleteSessions: [REDACTED_SESSION_PLACEHOLDER],
+  billingAlerts: [REDACTED_BILLING_ALERT_PLACEHOLDER],
+  clientMetrics: REDACTED_CLIENT_METRICS,
+  redacted: true as const,
+});
+
+export type RedactedDashboardFallback = ReturnType<typeof buildRedactedDashboardFallback>;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -569,36 +569,38 @@ afterAll(() => {
   consoleGuard.restore();
 });
 
-// Mock window.matchMedia for responsive design tests
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: vi.fn().mockImplementation(query => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(), // deprecated
-    removeListener: vi.fn(), // deprecated
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
+if (typeof window !== 'undefined') {
+  // Mock window.matchMedia for responsive design tests
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(), // deprecated
+      removeListener: vi.fn(), // deprecated
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
 
-// Mock IntersectionObserver for virtual scrolling tests
-const mockIntersectionObserver = vi.fn();
-mockIntersectionObserver.mockReturnValue({
-  observe: () => null,
-  unobserve: () => null,
-  disconnect: () => null,
-});
-window.IntersectionObserver = mockIntersectionObserver; 
+  // Mock IntersectionObserver for virtual scrolling tests
+  const mockIntersectionObserver = vi.fn();
+  mockIntersectionObserver.mockReturnValue({
+    observe: () => null,
+    unobserve: () => null,
+    disconnect: () => null,
+  });
+  window.IntersectionObserver = mockIntersectionObserver;
 
-// Stub browser dialogs for jsdom environment
-Object.defineProperty(window, 'alert', {
-  writable: true,
-  value: vi.fn(),
-});
-Object.defineProperty(window, 'confirm', {
-  writable: true,
-  value: vi.fn(() => true),
-});
+  // Stub browser dialogs for jsdom environment
+  Object.defineProperty(window, 'alert', {
+    writable: true,
+    value: vi.fn(),
+  });
+  Object.defineProperty(window, 'confirm', {
+    writable: true,
+    value: vi.fn(() => true),
+  });
+}


### PR DESCRIPTION
### Summary
Guard Supabase diagnostics behind environment flags and rework dashboard fallback queries for safe, limited access.

### Proposed changes
- Add environment-aware diagnostics helpers and structured logging in `src/lib/supabase.ts`.
- Introduce scoped dashboard fallback queries with role gating and redaction, wiring them into the Dashboard page.
- Document the new diagnostics flag usage and add focused unit coverage for diagnostics and fallback helpers.

### Tests added/updated
- vitest src/lib/__tests__/supabase.diagnostics.test.ts
- vitest src/lib/__tests__/dashboardFallback.test.ts

### Checklist
- [ ] `npm test` passed
- [ ] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d4a6d4f6b883329a35e8bb39bb98b0