### PR TITLE
fix: ensure sidebar icons stay active – 2025-09-27

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -231,15 +231,21 @@ export default function Sidebar() {
                   }`
                 }
               >
-                <Icon className={`
-                  -ml-1 mr-2 h-5 w-5
-                  ${
-                    path === location.pathname
-                      ? 'text-blue-500 dark:text-blue-400'
-                      : 'text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-400'
-                  }
-                `} />
-                {label}
+                {({ isActive }) => (
+                  <>
+                    <Icon
+                      className={`
+                        -ml-1 mr-2 h-5 w-5
+                        ${
+                          isActive
+                            ? 'text-blue-500 dark:text-blue-400'
+                            : 'text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-400'
+                        }
+                      `}
+                    />
+                    {label}
+                  </>
+                )}
               </NavLink>
             );
           })}

--- a/src/components/__tests__/SidebarNavigation.test.tsx
+++ b/src/components/__tests__/SidebarNavigation.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import Sidebar from "../Sidebar";
+
+const mockUseAuth = vi.fn();
+const mockUseTheme = vi.fn();
+
+vi.mock("../../lib/authContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("../../lib/theme", () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
+vi.mock("../ChatBot", () => ({
+  __esModule: true,
+  default: () => <div data-testid="chatbot-mock" />,
+}));
+
+vi.mock("../ThemeToggle", () => ({
+  __esModule: true,
+  default: () => <div data-testid="theme-toggle-mock" />,
+}));
+
+describe("Sidebar navigation active styling", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    mockUseTheme.mockReset();
+    mockUseAuth.mockReturnValue({
+      signOut: vi.fn(),
+      hasRole: vi.fn(() => true),
+      user: {
+        email: "therapist@example.com",
+        user_metadata: {
+          therapist_id: "therapist-123",
+        },
+      },
+      profile: {
+        role: "therapist",
+      },
+      hasAnyRole: vi.fn(() => true),
+    });
+
+    mockUseTheme.mockReturnValue({
+      isDark: false,
+      toggleTheme: vi.fn(),
+    });
+  });
+
+  it("keeps the clients link icon highlighted for nested routes", () => {
+    render(
+      <MemoryRouter initialEntries={["/clients/123"]}>
+        <Sidebar />
+      </MemoryRouter>
+    );
+
+    const clientsLink = screen.getByRole("link", { name: /clients/i });
+    expect(clientsLink).toHaveClass("border-blue-500");
+    expect(clientsLink).toHaveClass("text-blue-600");
+
+    const icon = clientsLink.querySelector("svg");
+    expect(icon).not.toBeNull();
+    expect(icon).toHaveClass("text-blue-500");
+    expect(icon).toHaveClass("dark:text-blue-400");
+  });
+});


### PR DESCRIPTION
### Summary
Ensure sidebar icons stay highlighted for nested navigation routes and cover the behavior with a focused test.

### Proposed changes
- Derive the sidebar icon styling from the same NavLink active state used for text styling
- Add a router-aware sidebar test verifying icons remain active on nested client routes

### Tests added/updated
- src/components/__tests__/SidebarNavigation.test.tsx

### Checklist
- [ ] `npm test` passed
- [ ] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d7de1ffe708332a7a88916c7200caa