### PR TITLE
fix: align super admin sidebar nav – 2025-09-27

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -89,23 +89,23 @@ export default function Sidebar() {
       path: '/schedule',
       roles: [] // accessible to all authenticated users
     },
-    { 
-      icon: Users, 
-      label: 'Clients', 
+    {
+      icon: Users,
+      label: 'Clients',
       path: '/clients',
-      roles: ['admin', 'therapist']
+      roles: ['therapist', 'admin', 'super_admin']
     },
-    { 
-      icon: UserCog, 
-      label: 'Therapists', 
-      path: '/therapists', 
-      roles: ['admin']
+    {
+      icon: UserCog,
+      label: 'Therapists',
+      path: '/therapists',
+      roles: ['admin', 'super_admin']
     },
-    { 
-      icon: FileCheck, 
-      label: 'Authorizations', 
+    {
+      icon: FileCheck,
+      label: 'Authorizations',
       path: '/authorizations',
-      roles: ['admin', 'therapist']
+      roles: ['therapist', 'admin', 'super_admin']
     },
     { 
       icon: FileText, 
@@ -113,29 +113,29 @@ export default function Sidebar() {
       path: '/documentation',
       roles: [] // accessible to all authenticated users
     },
-    { 
-      icon: CreditCard, 
-      label: 'Billing', 
-      path: '/billing', 
-      roles: ['admin']
+    {
+      icon: CreditCard,
+      label: 'Billing',
+      path: '/billing',
+      roles: ['admin', 'super_admin']
     },
-    { 
-      icon: BarChart, 
-      label: 'Reports', 
-      path: '/reports', 
-      roles: ['admin']
+    {
+      icon: BarChart,
+      label: 'Reports',
+      path: '/reports',
+      roles: ['admin', 'super_admin']
     },
-    { 
-      icon: Activity, 
-      label: 'Monitoring', 
-      path: '/monitoring', 
-      roles: ['admin']
+    {
+      icon: Activity,
+      label: 'Monitoring',
+      path: '/monitoring',
+      roles: ['admin', 'super_admin']
     },
-    { 
-      icon: Settings, 
-      label: 'Settings', 
-      path: '/settings', 
-      roles: ['admin']
+    {
+      icon: Settings,
+      label: 'Settings',
+      path: '/settings',
+      roles: ['admin', 'super_admin']
     },
   ];
 

--- a/src/components/__tests__/SidebarNavigation.test.tsx
+++ b/src/components/__tests__/SidebarNavigation.test.tsx
@@ -66,4 +66,38 @@ describe("Sidebar navigation active styling", () => {
     expect(icon).toHaveClass("text-blue-500");
     expect(icon).toHaveClass("dark:text-blue-400");
   });
+
+  it("shows admin navigation items for super admin users", () => {
+    const hasRole = vi.fn(
+      (role: "client" | "therapist" | "admin" | "super_admin") =>
+        ["client", "therapist", "admin", "super_admin"].includes(role)
+    );
+
+    mockUseAuth.mockReturnValue({
+      signOut: vi.fn(),
+      hasRole,
+      user: {
+        email: "superadmin@example.com",
+        user_metadata: {},
+      },
+      profile: {
+        role: "super_admin",
+      },
+      hasAnyRole: vi.fn((roles: ("client" | "therapist" | "admin" | "super_admin")[]) =>
+        roles.some(role => hasRole(role))
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Sidebar />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: /therapists/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /billing/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /reports/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /monitoring/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /settings/i })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
### Summary
Ensure the sidebar exposes admin-only navigation links to super admin users and cover the access rules with automated tests.

### Proposed changes
- Align sidebar role checks so super admin profiles retain access to all admin navigation items
- Add a regression test confirming super admin accounts render billing, reports, monitoring, and settings links

### Tests added/updated
- src/components/__tests__/SidebarNavigation.test.tsx

### Checklist
- [x] `npm test` passed
- [ ] `eslint .` passed *(fails due to pre-existing lint errors under tests/ outside the /src scope)*
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d7dc3983848332b28675849252aaed