### PR TITLE
fix: enforce CSV import validation – 2025-09-29

### DIFF
--- a/src/lib/__tests__/importProcessing.test.ts
+++ b/src/lib/__tests__/importProcessing.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { applyExistingDuplicateErrors, prepareRecordsForImport } from '../importProcessing';
+
+const clientHeaderMap: Record<string, string> = {
+  '0': 'first_name',
+  '1': 'last_name',
+  '2': 'email',
+  '3': 'date_of_birth',
+  '4': 'client_id',
+};
+
+describe('importProcessing', () => {
+  it('prepares and sanitizes client records for import (happy path)', () => {
+    const rows = [[
+      ' John ',
+      ' Doe ',
+      'JOHN@EXAMPLE.COM',
+      '01/02/2010',
+      ' ABC123 ',
+    ]];
+
+    const { records, uniqueEmails, uniqueClientIds } = prepareRecordsForImport(rows, clientHeaderMap, 'client');
+
+    expect(records).toHaveLength(1);
+    const [record] = records;
+
+    expect(record.errors).toHaveLength(0);
+    expect(record.data?.email).toBe('john@example.com');
+    expect(record.data?.full_name).toBe('John Doe');
+    expect(record.data?.date_of_birth).toBe('2010-01-02');
+    expect(record.data?.client_id).toBe('ABC123');
+    expect(uniqueEmails).toEqual(['john@example.com']);
+    expect(uniqueClientIds).toEqual(['ABC123']);
+  });
+
+  it('flags missing required fields for invalid rows', () => {
+    const rows = [[
+      'Jane',
+      'Smith',
+      '',
+      '02/03/2011',
+      '',
+    ]];
+
+    const { records } = prepareRecordsForImport(rows, clientHeaderMap, 'client');
+
+    expect(records[0].errors).toContain('Missing required field: email');
+    expect(records[0].errors).not.toContain('Missing required field: client_id');
+  });
+
+  it('detects duplicate identifiers within the same import batch', () => {
+    const rows = [
+      ['Amy', 'Adams', 'amy@example.com', '03/04/2012', 'ID1'],
+      ['Anna', 'Adams', 'amy@example.com', '03/04/2012', 'ID1'],
+    ];
+
+    const { records } = prepareRecordsForImport(rows, clientHeaderMap, 'client');
+
+    expect(records[0].errors).toHaveLength(0);
+    expect(records[1].errors).toContain('Duplicate email in import file: amy@example.com');
+    expect(records[1].errors).toContain('Duplicate client ID in import file: ID1');
+  });
+
+  it('adds errors when duplicates already exist in the database', () => {
+    const rows = [['Eve', 'Stone', 'eve@example.com', '05/06/2013', 'ID2']];
+    const { records } = prepareRecordsForImport(rows, clientHeaderMap, 'client');
+
+    const updated = applyExistingDuplicateErrors(records, {
+      entityType: 'client',
+      existingEmails: new Set(['eve@example.com']),
+      existingClientIds: new Set(['ID2']),
+    });
+
+    const [record] = updated;
+    expect(record.errors).toContain('Email eve@example.com already exists');
+    expect(record.errors).toContain('Client ID ID2 already exists');
+  });
+});

--- a/src/lib/importProcessing.ts
+++ b/src/lib/importProcessing.ts
@@ -1,0 +1,213 @@
+import type { Client, Therapist } from '../types';
+import { prepareFormData } from './validation';
+
+export type ImportEntity = Partial<Client> | Partial<Therapist>;
+export type ImportEntityType = 'client' | 'therapist';
+
+export interface CsvMappedRecord {
+  rowIndex: number;
+  data?: ImportEntity;
+  errors: string[];
+}
+
+export interface PrepareRecordsResult {
+  records: CsvMappedRecord[];
+  uniqueEmails: string[];
+  uniqueClientIds: string[];
+}
+
+type HeaderMap = Record<string, string>;
+
+type RequiredFieldConfig = Record<ImportEntityType, string[]>;
+
+const requiredFields: RequiredFieldConfig = {
+  client: ['first_name', 'last_name', 'email', 'date_of_birth'],
+  therapist: ['first_name', 'last_name', 'email'],
+};
+
+const isValuePresent = (value: unknown): boolean => {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+
+  return value !== undefined && value !== null;
+};
+
+const pushUniqueError = (errors: string[], message: string): void => {
+  if (!errors.includes(message)) {
+    errors.push(message);
+  }
+};
+
+const formatDateOfBirth = (value: string): string => {
+  if (!value) {
+    return value;
+  }
+
+  if (value.includes('/')) {
+    const parts = value.split('/').map(part => part.trim());
+    if (parts.length === 3) {
+      const [month, day, year] = parts;
+      if (year.length === 4) {
+        return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+      }
+    }
+  }
+
+  return value;
+};
+
+const mapRowToEntity = (
+  row: string[],
+  headerMap: HeaderMap,
+  entityType: ImportEntityType
+): ImportEntity => {
+  const entityData: Record<string, unknown> = {};
+
+  Object.entries(headerMap).forEach(([index, field]) => {
+    if (!field) {
+      return;
+    }
+
+    const cellValue = row[Number(index)];
+    if (cellValue === undefined) {
+      return;
+    }
+
+    let value = cellValue.trim();
+
+    if (entityType === 'client' && field === 'date_of_birth') {
+      value = formatDateOfBirth(value);
+    }
+
+    if (['service_preference', 'service_type', 'specialties', 'preferred_areas'].includes(field)) {
+      entityData[field] = value
+        ? value
+            .split(',')
+            .map(item => item.trim())
+            .filter(item => item.length > 0)
+        : [];
+      return;
+    }
+
+    entityData[field] = value || null;
+  });
+
+  const prepared = prepareFormData(entityData);
+
+  if (
+    (typeof prepared.first_name === 'string' && prepared.first_name.length > 0) ||
+    (typeof prepared.last_name === 'string' && prepared.last_name.length > 0)
+  ) {
+    const names = [prepared.first_name, prepared.middle_name, prepared.last_name]
+      .map(part => (typeof part === 'string' ? part.trim() : ''))
+      .filter(part => part.length > 0);
+    prepared.full_name = names.join(' ');
+  }
+
+  return prepared;
+};
+
+export const prepareRecordsForImport = (
+  rows: string[][],
+  headerMap: HeaderMap,
+  entityType: ImportEntityType
+): PrepareRecordsResult => {
+  const records: CsvMappedRecord[] = [];
+  const seenEmails = new Set<string>();
+  const seenClientIds = new Set<string>();
+  const uniqueEmails = new Set<string>();
+  const uniqueClientIds = new Set<string>();
+
+  rows.forEach((row, rowIndex) => {
+    const data = mapRowToEntity(row, headerMap, entityType);
+    const errors: string[] = [];
+
+    const required = requiredFields[entityType];
+    required.forEach(field => {
+      const value = (data as Record<string, unknown>)[field];
+      if (!isValuePresent(value)) {
+        pushUniqueError(errors, `Missing required field: ${field}`);
+      }
+    });
+
+    const email = typeof (data as Record<string, unknown>).email === 'string'
+      ? ((data as Record<string, unknown>).email as string)
+      : undefined;
+    if (email) {
+      uniqueEmails.add(email);
+      if (seenEmails.has(email)) {
+        pushUniqueError(errors, `Duplicate email in import file: ${email}`);
+      } else {
+        seenEmails.add(email);
+      }
+    }
+
+    if (entityType === 'client') {
+      const clientId = typeof (data as Record<string, unknown>).client_id === 'string'
+        ? ((data as Record<string, unknown>).client_id as string)
+        : undefined;
+      if (clientId) {
+        uniqueClientIds.add(clientId);
+        if (seenClientIds.has(clientId)) {
+          pushUniqueError(errors, `Duplicate client ID in import file: ${clientId}`);
+        } else {
+          seenClientIds.add(clientId);
+        }
+      }
+    }
+
+    records.push({ rowIndex, data, errors });
+  });
+
+  return {
+    records,
+    uniqueEmails: Array.from(uniqueEmails),
+    uniqueClientIds: Array.from(uniqueClientIds),
+  };
+};
+
+interface ExistingDuplicateOptions {
+  entityType: ImportEntityType;
+  existingEmails?: Set<string>;
+  existingClientIds?: Set<string>;
+}
+
+export const applyExistingDuplicateErrors = (
+  records: CsvMappedRecord[],
+  { entityType, existingEmails, existingClientIds }: ExistingDuplicateOptions
+): CsvMappedRecord[] => {
+  const emailSet = existingEmails ?? new Set<string>();
+  const clientIdSet = existingClientIds ?? new Set<string>();
+
+  records.forEach(record => {
+    if (!record.data) {
+      return;
+    }
+
+    const email = typeof record.data.email === 'string' ? record.data.email : undefined;
+    if (email && emailSet.has(email)) {
+      pushUniqueError(record.errors, `Email ${email} already exists`);
+    }
+
+    if (entityType === 'client') {
+      const clientId = typeof record.data.client_id === 'string' ? record.data.client_id : undefined;
+      if (clientId && clientIdSet.has(clientId)) {
+        pushUniqueError(record.errors, `Client ID ${clientId} already exists`);
+      }
+    }
+  });
+
+  return records;
+};
+
+export const __testing = {
+  mapRowToEntity,
+  isValuePresent,
+  formatDateOfBirth,
+  requiredFields,
+};


### PR DESCRIPTION
### Summary
Ensure CSV imports sanitize mapped rows, enforce required fields, and block duplicate records before insertion.

### Proposed changes
- Centralize CSV row mapping and sanitization with `prepareRecordsForImport`, enforcing required fields and detecting in-file duplicates before inserts.【F:src/lib/importProcessing.ts†L4-L205】【F:src/components/CSVImport.tsx†L181-L352】
- Query Supabase for existing email and client ID conflicts, surfacing validation failures in the import progress UI.【F:src/components/CSVImport.tsx†L183-L352】
- Add unit tests covering happy path, invalid rows, and duplicate detection for the import preparation workflow.【F:src/lib/__tests__/importProcessing.test.ts†L13-L77】

### Tests added/updated
- vitest src/lib/__tests__/importProcessing.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d9edcf5008833296e74ffa1657206c