### PR TITLE
feat: unify client schema validation – 2025-09-29

### DIFF
--- a/src/components/__tests__/ClientModal.test.tsx
+++ b/src/components/__tests__/ClientModal.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '../../test/utils';
+import { renderWithProviders } from '../../test/utils';
+import ClientModal from '../ClientModal';
+
+const getInputByName = (name: string) => {
+  const input = document.querySelector<HTMLInputElement>(`input[name="${name}"]`);
+
+  if (!input) {
+    throw new Error(`Input with name attribute "${name}" was not found`);
+  }
+
+  return input;
+};
+
+describe('ClientModal validation', () => {
+  it('shows inline errors and disables submit when required fields are missing', async () => {
+    const handleSubmit = vi.fn();
+
+    renderWithProviders(
+      <ClientModal
+        isOpen
+        onClose={() => {}}
+        onSubmit={handleSubmit}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /create client/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('First name is required')).toBeInTheDocument();
+      expect(screen.getByText('Last name is required')).toBeInTheDocument();
+      expect(screen.getByText('Date of birth is required')).toBeInTheDocument();
+      expect(screen.getByText('Email is required')).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByRole('button', { name: /create client/i });
+    expect(submitButton).toBeDisabled();
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it('shows a JSON validation error when insurance information is invalid', async () => {
+    const handleSubmit = vi.fn();
+
+    renderWithProviders(
+      <ClientModal
+        isOpen
+        onClose={() => {}}
+        onSubmit={handleSubmit}
+      />
+    );
+
+    fireEvent.change(getInputByName('first_name'), { target: { value: 'Jamie' } });
+    fireEvent.change(getInputByName('last_name'), { target: { value: 'Rivera' } });
+    fireEvent.change(getInputByName('date_of_birth'), { target: { value: '2012-05-01' } });
+    fireEvent.change(getInputByName('email'), { target: { value: 'jamie@example.com' } });
+
+    const insuranceField = screen.getByPlaceholderText('Enter insurance information in JSON format');
+    fireEvent.change(insuranceField, { target: { value: 'not-json' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /create client/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Insurance information must be valid JSON')).toBeInTheDocument();
+    });
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it('prevents submission when unit inputs contain negative values', async () => {
+    const handleSubmit = vi.fn();
+
+    renderWithProviders(
+      <ClientModal
+        isOpen
+        onClose={() => {}}
+        onSubmit={handleSubmit}
+      />
+    );
+
+    fireEvent.change(getInputByName('first_name'), { target: { value: 'Jamie' } });
+    fireEvent.change(getInputByName('last_name'), { target: { value: 'Rivera' } });
+    fireEvent.change(getInputByName('date_of_birth'), { target: { value: '2012-05-01' } });
+    fireEvent.change(getInputByName('email'), { target: { value: 'jamie@example.com' } });
+
+    fireEvent.change(getInputByName('one_to_one_units'), { target: { value: -5 } });
+
+    fireEvent.click(screen.getByRole('button', { name: /create client/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('1:1 units must be 0 or greater')).toBeInTheDocument();
+    });
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/ClientOnboarding.test.tsx
+++ b/src/components/__tests__/ClientOnboarding.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { describe, beforeEach, it, expect, vi } from 'vitest';
+import { fireEvent, screen, waitFor, renderWithProviders } from '../../test/utils';
+import ClientOnboarding from '../ClientOnboarding';
+import { supabase } from '../../lib/supabase';
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    rpc: vi.fn(),
+  },
+}));
+
+const rpcMock = supabase.rpc as unknown as ReturnType<typeof vi.fn>;
+
+describe('ClientOnboarding validation', () => {
+  beforeEach(() => {
+    rpcMock.mockReset();
+    rpcMock.mockResolvedValue({ data: false, error: null });
+  });
+
+  it('shows required field errors when attempting to proceed without input', async () => {
+    renderWithProviders(<ClientOnboarding />);
+
+    const nextButton = screen.getByRole('button', { name: /next/i });
+
+    await waitFor(() => {
+      expect(nextButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('First name is required')).toBeInTheDocument();
+      expect(screen.getByText('Last name is required')).toBeInTheDocument();
+      expect(screen.getByText('Date of birth is required')).toBeInTheDocument();
+      expect(screen.getByText('Email is required')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Parent/Guardian Information')).not.toBeInTheDocument();
+  });
+
+  it('disables step progression when email already exists', async () => {
+    rpcMock.mockImplementation(async (fn: string) => {
+      if (fn === 'client_email_exists') {
+        return { data: true, error: null };
+      }
+      return { data: null, error: null };
+    });
+
+    renderWithProviders(<ClientOnboarding />);
+
+    fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: 'Jamie' } });
+    fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: 'Doe' } });
+    fireEvent.change(screen.getByLabelText(/date of birth/i), { target: { value: '2015-01-01' } });
+
+    const emailInput = screen.getByLabelText(/email/i);
+    fireEvent.change(emailInput, { target: { value: 'duplicate@example.com' } });
+    fireEvent.blur(emailInput);
+
+    await waitFor(() => {
+      expect(screen.getByText('A client with this email address already exists')).toBeInTheDocument();
+    });
+
+    const nextButton = screen.getByRole('button', { name: /next/i });
+    expect(nextButton).toBeDisabled();
+  });
+
+  it('advances to the parent information step when required fields are provided', async () => {
+    renderWithProviders(<ClientOnboarding />);
+
+    fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: 'Jamie' } });
+    fireEvent.change(screen.getByLabelText(/last name/i), { target: { value: 'Rivera' } });
+    fireEvent.change(screen.getByLabelText(/date of birth/i), { target: { value: '2012-05-01' } });
+    const emailInput = screen.getByLabelText(/email/i);
+    fireEvent.change(emailInput, { target: { value: 'jamie@example.com' } });
+    fireEvent.blur(emailInput);
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('client_email_exists', { p_email: 'jamie@example.com' });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/checking email availability/i)).not.toBeInTheDocument();
+    });
+
+    const nextButton = screen.getByRole('button', { name: /next/i });
+
+    await waitFor(() => {
+      expect(nextButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Primary Parent/Guardian')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/lib/clientPayload.ts
+++ b/src/lib/clientPayload.ts
@@ -1,5 +1,6 @@
 import type { Client } from '../types';
 import { prepareFormData } from './validation';
+import { clientPayloadSchema } from './validationSchemas';
 
 interface PrepareClientPayloadOptions {
   enforceFullName?: boolean;
@@ -16,7 +17,7 @@ const computeFullName = (client: Partial<Client>): string => {
 export const prepareClientPayload = (
   clientData: Partial<Client>,
   options: PrepareClientPayloadOptions = {}
-): Partial<Client> => {
+) => {
   const prepared = prepareFormData(clientData);
 
   const payload: Partial<Client> = {
@@ -44,7 +45,7 @@ export const prepareClientPayload = (
     }
   }
 
-  return payload;
+  return clientPayloadSchema.parse(payload);
 };
 
 type SupabaseUpdateResponse<T> = Promise<{ data: T | null; error: unknown }>;


### PR DESCRIPTION
### Summary
Share a Zod-backed client validation schema across the client modal and onboarding flows to keep Supabase payloads consistent.

### Proposed changes
- Centralize client form rules in `clientFormSchema`/`clientPayloadSchema` and parse submissions before updates.
- Wire `ClientModal` and onboarding steps through the shared schema with resolver-driven errors, IDs, and step validation, adding targeted unit tests.

### Tests added/updated
- src/components/__tests__/ClientModal.test.tsx
- src/components/__tests__/ClientOnboarding.test.tsx

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68d9ff230fbc833299b6f99e7ab98c3b