### PR TITLE
feat: refine therapist status filtering – 2025-09-29

### DIFF
--- a/src/pages/Therapists.tsx
+++ b/src/pages/Therapists.tsx
@@ -21,6 +21,18 @@ import { showSuccess, showError } from '../lib/toast';
 import { logger } from '../lib/logger/logger';
 import { toError } from '../lib/logger/normalizeError';
 
+export const matchesStatusFilter = (
+  status: Therapist['status'] | null | undefined,
+  selectedStatus: string,
+) => {
+  if (selectedStatus === 'all') {
+    return true;
+  }
+
+  const normalizedStatus = (status ?? 'active').toLowerCase();
+  return normalizedStatus === selectedStatus.toLowerCase();
+};
+
 const Therapists = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
@@ -214,7 +226,7 @@ const Therapists = () => {
     navigate('/therapists/new');
   };
 
-  const filteredTherapists = therapists.filter(therapist => {
+  const filteredTherapists = therapists.filter((therapist) => {
     const matchesSearch = (
       (therapist.full_name?.toLowerCase() || '').includes(searchQuery.toLowerCase()) ||
       (therapist.email?.toLowerCase() || '').includes(searchQuery.toLowerCase())
@@ -222,7 +234,7 @@ const Therapists = () => {
 
     const matchesLocation = filterLocation === 'all' || therapist.service_type?.includes(filterLocation);
     const matchesServiceLine = filterServiceLine === 'all' || therapist.specialties?.includes(filterServiceLine);
-    const matchesStatus = filterStatus === 'all'; // Add more status conditions as needed
+    const matchesStatus = matchesStatusFilter(therapist.status, filterStatus);
 
     return matchesSearch && matchesLocation && matchesServiceLine && matchesStatus;
   });
@@ -290,7 +302,7 @@ const Therapists = () => {
               onChange={(e) => setFilterStatus(e.target.value)}
               className="border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200 py-2 px-3"
             >
-              <option value="all">All Active</option>
+              <option value="all">All Statuses</option>
               <option value="active">Active</option>
               <option value="inactive">Inactive</option>
             </select>
@@ -380,9 +392,22 @@ const Therapists = () => {
                       </div>
                     </td>
                     <td className="px-6 py-4">
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200">
-                        Active
-                      </span>
+                      {(() => {
+                        const status = (therapist.status ?? 'active').toLowerCase();
+                        const isActive = status === 'active';
+
+                        return (
+                          <span
+                            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                              isActive
+                                ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200'
+                                : 'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200'
+                            }`}
+                          >
+                            {isActive ? 'Active' : 'Inactive'}
+                          </span>
+                        );
+                      })()}
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex items-center space-x-3">

--- a/src/pages/__tests__/Therapists.test.tsx
+++ b/src/pages/__tests__/Therapists.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from '../../test/utils';
+import Therapists, { matchesStatusFilter } from '../Therapists';
+
+const invalidateQueries = vi.fn();
+const useQueryMock = vi.fn();
+const mutationHandlers: Array<{ options: any; mutateAsync: ReturnType<typeof vi.fn> }> = [];
+const useMutationMock = vi.fn();
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+
+  return {
+    ...actual,
+    useQuery: (options: unknown) => useQueryMock(options),
+    useMutation: (options: unknown) => useMutationMock(options),
+    useQueryClient: () => ({
+      invalidateQueries,
+    }),
+  };
+});
+
+const mockTherapists = [
+  {
+    id: 'therapist-1',
+    full_name: 'Active Therapist',
+    email: 'active@example.com',
+    status: 'active',
+    service_type: 'In clinic',
+    specialties: ['ABA Therapy'],
+  },
+  {
+    id: 'therapist-2',
+    full_name: 'Inactive Therapist',
+    email: 'inactive@example.com',
+    status: 'inactive',
+    service_type: 'In clinic',
+    specialties: ['ABA Therapy'],
+  },
+];
+
+beforeEach(() => {
+  invalidateQueries.mockClear();
+  useQueryMock.mockReset();
+  useMutationMock.mockReset();
+  mutationHandlers.length = 0;
+
+  useQueryMock.mockReturnValue({ data: mockTherapists, isLoading: false });
+  useMutationMock.mockImplementation((options: any) => {
+    const mutateAsync = vi.fn();
+    mutationHandlers.push({ options, mutateAsync });
+    return { mutateAsync, isPending: false, isSuccess: false };
+  });
+});
+
+describe('matchesStatusFilter', () => {
+  it('returns true when all statuses are selected', () => {
+    expect(matchesStatusFilter('inactive', 'all')).toBe(true);
+  });
+
+  it('treats missing statuses as active', () => {
+    expect(matchesStatusFilter(null, 'active')).toBe(true);
+  });
+
+  it('compares statuses case-insensitively', () => {
+    expect(matchesStatusFilter('Inactive', 'inactive')).toBe(true);
+  });
+});
+
+describe('Therapists page filtering', () => {
+  it('hides active therapists when the Inactive filter is selected', async () => {
+    renderWithProviders(<Therapists />);
+
+    const statusSelect = screen.getAllByRole('combobox')[2];
+    await userEvent.selectOptions(statusSelect, 'inactive');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Active Therapist')).not.toBeInTheDocument();
+    });
+
+    const inactiveRow = screen.getByText('Inactive Therapist').closest('tr');
+    expect(inactiveRow).not.toBeNull();
+    expect(within(inactiveRow as HTMLTableRowElement).getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('invalidates the therapists query after successful mutations', () => {
+    renderWithProviders(<Therapists />);
+
+    expect(mutationHandlers).toHaveLength(3);
+
+    mutationHandlers.forEach(({ options }) => {
+      invalidateQueries.mockClear();
+      options.onSuccess?.();
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['therapists'] });
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Align the therapist directory filters with therapist status data and extend automated coverage for the page.

### Proposed changes
- Normalize therapist statuses before comparing them to the active filter option.
- Update the status dropdown label and badge rendering to reflect the stored status value.
- Add unit and component tests for the status filter helper and UI interactions, including cache invalidation hooks.

### Tests added/updated
- src/pages/__tests__/Therapists.test.tsx

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68da93fc9c8083328b755a2e844be2dc