### PR TITLE
feat: tighten therapist validation – 2025-09-29

### DIFF
--- a/src/components/TherapistDetails/ProfileTab.tsx
+++ b/src/components/TherapistDetails/ProfileTab.tsx
@@ -8,7 +8,7 @@ import {
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../lib/authContext';
 import { showSuccess, showError } from '../../lib/toast';
-import TherapistModal from '../TherapistModal';
+import { TherapistModal } from '../TherapistModal';
 
 interface ProfileTabProps {
   therapist: { id: string; full_name: string; title?: string; email?: string; phone?: string; specialties?: string[]; street?: string; city?: string; state?: string; zip_code?: string; facility?: string; employee_type?: string; availability_hours?: Record<string, { start: string | null; end: string | null }>; };

--- a/src/components/__tests__/TherapistModal.test.tsx
+++ b/src/components/__tests__/TherapistModal.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, waitFor, userEvent } from '../../test/utils';
+import { TherapistModal } from '../TherapistModal';
+
+describe('TherapistModal validation', () => {
+  const renderModal = () => {
+    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <TherapistModal
+        isOpen
+        onClose={() => {}}
+        onSubmit={handleSubmit}
+      />
+    );
+
+    return { handleSubmit };
+  };
+
+  it('shows errors and focuses the first invalid field on submit', async () => {
+    renderModal();
+
+    await userEvent.click(screen.getByRole('button', { name: /create therapist/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('First name is required')).toBeInTheDocument();
+      expect(screen.getByText('Last name is required')).toBeInTheDocument();
+      expect(screen.getByText('Email is required')).toBeInTheDocument();
+      expect(screen.getByText('License number is required')).toBeInTheDocument();
+    });
+
+    const firstNameInput = screen.getByLabelText(/first name/i);
+    expect(firstNameInput).toHaveAttribute('aria-invalid', 'true');
+    expect(document.activeElement).toBe(firstNameInput);
+  });
+
+  it('prevents submission when license number is missing and focuses the field', async () => {
+    const { handleSubmit } = renderModal();
+
+    await userEvent.type(screen.getByLabelText(/first name/i), 'Casey');
+    await userEvent.type(screen.getByLabelText(/last name/i), 'Morgan');
+    await userEvent.type(screen.getByLabelText(/email/i), 'casey@example.com');
+
+    await userEvent.click(screen.getByRole('button', { name: /create therapist/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('License number is required')).toBeInTheDocument();
+    });
+
+    const licenseInput = screen.getByLabelText(/license number/i);
+    expect(document.activeElement).toBe(licenseInput);
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/TherapistOnboarding.test.tsx
+++ b/src/components/__tests__/TherapistOnboarding.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, waitFor, userEvent } from '../../test/utils';
+import { TherapistOnboarding } from '../TherapistOnboarding';
+
+describe('TherapistOnboarding validation', () => {
+  const renderOnboarding = () => {
+    const handleComplete = vi.fn();
+    renderWithProviders(<TherapistOnboarding onComplete={handleComplete} />);
+    return { handleComplete };
+  };
+
+  it('validates basic information before advancing', async () => {
+    renderOnboarding();
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('First name is required')).toBeInTheDocument();
+    });
+
+    const firstNameInput = screen.getByLabelText(/first name/i);
+    expect(firstNameInput).toHaveAttribute('aria-invalid', 'true');
+    expect(document.activeElement).toBe(firstNameInput);
+  });
+
+  it('requires a license number on the professional step', async () => {
+    renderOnboarding();
+
+    await userEvent.type(screen.getByLabelText(/first name/i), 'Jordan');
+    await userEvent.type(screen.getByLabelText(/last name/i), 'Lee');
+    await userEvent.type(screen.getByLabelText(/email/i), 'jordan@example.com');
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByText(/professional information/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('License number is required')).toBeInTheDocument();
+    });
+
+    const licenseNumberInput = screen.getByLabelText(/license number/i);
+    expect(document.activeElement).toBe(licenseNumberInput);
+  });
+
+  it('requires a license document before submission', async () => {
+    renderOnboarding();
+
+    await userEvent.type(screen.getByLabelText(/first name/i), 'Avery');
+    await userEvent.type(screen.getByLabelText(/last name/i), 'Blake');
+    await userEvent.type(screen.getByLabelText(/email/i), 'avery@example.com');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await userEvent.type(screen.getByLabelText(/license number/i), 'LIC-12345');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(screen.getByText(/documents & certifications/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /complete onboarding/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Professional license document is required')).toBeInTheDocument();
+    });
+
+    const licenseInput = screen.getByLabelText(/license document upload/i);
+    expect(document.activeElement).toBe(licenseInput);
+  });
+});

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -135,6 +135,7 @@ export const prepareFormData = <T extends Record<string, any>>(data: T): T => {
     'parent2_last_name', 'parent2_phone', 'parent2_relationship',
     'middle_name', 'staff_id', 'supervisor', 'npi_number', 'medicaid_id',
     'practitioner_id', 'taxonomy_code', 'rbt_number', 'bcba_number',
+    'license_number',
     'facility', 'street', 'title', 'employee_type'
   ];
   

--- a/src/pages/TherapistOnboardingPage.tsx
+++ b/src/pages/TherapistOnboardingPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
-import TherapistOnboarding from '../components/TherapistOnboarding';
+import { TherapistOnboarding } from '../components/TherapistOnboarding';
 
 export default function TherapistOnboardingPage() {
   const navigate = useNavigate();

--- a/src/pages/Therapists.tsx
+++ b/src/pages/Therapists.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import type { Therapist } from '../types';
-import TherapistModal from '../components/TherapistModal';
+import { TherapistModal } from '../components/TherapistModal';
 import CSVImport from '../components/CSVImport';
 import { prepareFormData } from '../lib/validation';
 import { showSuccess, showError } from '../lib/toast';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,7 @@ export interface Therapist {
   medicaid_id?: string;
   practitioner_id?: string;
   taxonomy_code?: string;
+  license_number?: string;
   time_zone?: string;
   phone?: string;
   street?: string;


### PR DESCRIPTION
### Summary
Add schema-backed validation and accessibility improvements to therapist forms.

### Proposed changes
- Wire TherapistModal and TherapistOnboarding to zod resolvers with required name/email/license rules and focus management.
- Extend shared therapist data utilities to handle license numbers and sanitize persisted payloads.
- Add unit tests that cover invalid submission flows and accessibility cues for therapist forms.

### Tests added/updated
- src/components/__tests__/TherapistModal.test.tsx
- src/components/__tests__/TherapistOnboarding.test.tsx

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68da96b2c9148332b921db1d79fecfea