### PR TITLE
fix: allow super admin admin-guard coverage – 2025-09-29

### DIFF
--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,11 +1,41 @@
 import type { SupabaseClient } from "npm:@supabase/supabase-js@2.50.0";
+
 export async function getUserOrThrow(db: SupabaseClient) {
   const { data, error } = await db.auth.getUser();
   if (error || !data?.user) throw new Response("Unauthorized", { status: 401 });
   return data.user;
 }
-export async function assertAdmin(db: SupabaseClient) {
-  const { data, error } = await db.rpc("is_admin");
-  if (error) throw new Response("Admin check failed", { status: 500 });
-  if (!data) throw new Response("Forbidden", { status: 403 });
+
+export async function assertAdminOrSuperAdmin(db: SupabaseClient) {
+  const { data, error } = await db.rpc("get_user_roles");
+
+  if (error) throw new Response("Role check failed", { status: 500 });
+
+  const roles = Array.isArray(data)
+    ? data.flatMap(entry => {
+        if (!entry) return [] as string[];
+        if (Array.isArray((entry as { roles?: unknown }).roles)) {
+          return (entry as { roles: unknown[] }).roles.filter(
+            (role): role is string => typeof role === "string",
+          );
+        }
+        const roleValue = (entry as { roles?: unknown }).roles;
+        if (typeof roleValue === "string" && roleValue.length > 0) {
+          try {
+            const parsed = JSON.parse(roleValue) as unknown;
+            if (Array.isArray(parsed)) {
+              return parsed.filter((role): role is string => typeof role === "string");
+            }
+          } catch (parseError) {
+            // Fall through to handle comma separated values
+          }
+          return roleValue.split(",").map(role => role.trim()).filter(Boolean);
+        }
+        return [] as string[];
+      })
+    : [];
+
+  const hasAdminAccess = roles.some(role => role === "admin" || role === "super_admin");
+
+  if (!hasAdminAccess) throw new Response("Forbidden", { status: 403 });
 }

--- a/supabase/functions/admin-users-roles/index.ts
+++ b/supabase/functions/admin-users-roles/index.ts
@@ -1,6 +1,6 @@
 import { createProtectedRoute, corsHeaders, logApiAccess, RouteOptions } from "../_shared/auth-middleware.ts";
 import { createRequestClient } from "../_shared/database.ts";
-import { assertAdmin } from "../_shared/auth.ts";
+import { assertAdminOrSuperAdmin } from "../_shared/auth.ts";
 
 interface RoleUpdateRequest { role: 'client' | 'therapist' | 'admin' | 'super_admin'; is_active?: boolean; }
 
@@ -8,7 +8,7 @@ export default createProtectedRoute(async (req: Request, userContext) => {
   if (req.method !== 'PATCH') return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   try {
     const adminClient = createRequestClient(req);
-    await assertAdmin(adminClient);
+    await assertAdminOrSuperAdmin(adminClient);
 
     const url = new URL(req.url);
     const pathSegments = url.pathname.split('/');

--- a/supabase/functions/admin-users/index.ts
+++ b/supabase/functions/admin-users/index.ts
@@ -1,6 +1,6 @@
 import { createProtectedRoute, corsHeaders, logApiAccess, RouteOptions } from "../_shared/auth-middleware.ts";
 import { createRequestClient } from "../_shared/database.ts";
-import { assertAdmin } from "../_shared/auth.ts";
+import { assertAdminOrSuperAdmin } from "../_shared/auth.ts";
 
 interface AdminUsersError extends Error {
   status?: number;
@@ -21,7 +21,7 @@ export default createProtectedRoute(async (req: Request, userContext) => {
 
   try {
     const adminClient = createRequestClient(req);
-    await assertAdmin(adminClient);
+    await assertAdminOrSuperAdmin(adminClient);
 
     const url = new URL(req.url);
     const organizationId = url.searchParams.get("organization_id")?.trim();

--- a/supabase/functions/assign-therapist-user/index.ts
+++ b/supabase/functions/assign-therapist-user/index.ts
@@ -1,6 +1,6 @@
 import { createProtectedRoute, corsHeaders, logApiAccess, RouteOptions } from "../_shared/auth-middleware.ts";
 import { supabaseAdmin, createRequestClient } from "../_shared/database.ts";
-import { assertAdmin } from "../_shared/auth.ts";
+import { assertAdminOrSuperAdmin } from "../_shared/auth.ts";
 
 interface AssignTherapistRequest { userId: string; therapistId: string; }
 
@@ -20,7 +20,7 @@ export default createProtectedRoute(async (req: Request, userContext) => {
   if (req.method !== 'POST') return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   try {
     const adminClient = createRequestClient(req);
-    await assertAdmin(adminClient);
+    await assertAdminOrSuperAdmin(adminClient);
 
     const { userId, therapistId }: AssignTherapistRequest = await req.json();
     if (!userId || !therapistId) return new Response(JSON.stringify({ error: 'User ID and therapist ID are required' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });

--- a/supabase/functions/generate-report/index.ts
+++ b/supabase/functions/generate-report/index.ts
@@ -1,6 +1,6 @@
 import { createProtectedRoute, corsHeaders, logApiAccess, RouteOptions, UserContext } from "../_shared/auth-middleware.ts";
 import { supabaseAdmin, createRequestClient } from "../_shared/database.ts";
-import { assertAdmin } from "../_shared/auth.ts";
+import { assertAdminOrSuperAdmin } from "../_shared/auth.ts";
 
 const supabase = supabaseAdmin;
 
@@ -29,7 +29,7 @@ export default createProtectedRoute(async (req: Request, userContext) => {
 
     const callerRole = userContext.profile.role;
     if (callerRole === 'admin' || callerRole === 'super_admin') {
-      await assertAdmin(caller);
+      await assertAdminOrSuperAdmin(caller);
     }
 
     if (callerRole === 'client') {
@@ -257,7 +257,7 @@ async function generateClientsReport(startDate: string, endDate: string, userCon
 }
 
 async function generateTherapistsReport(startDate: string, endDate: string, userContext: UserContext) {
-  // Only admins can generate therapist reports (enforced by assertAdmin)
+  // Only admins can generate therapist reports (enforced by assertAdminOrSuperAdmin)
   const { data, error } = await supabase
     .from("therapists")
     .select("*")
@@ -285,7 +285,7 @@ async function generateBillingReport(
   userContext: UserContext,
   therapistScope: string[]
 ) {
-  // Only admins can generate billing reports (enforced by assertAdmin)
+  // Only admins can generate billing reports (enforced by assertAdminOrSuperAdmin)
   let query = supabase
     .from("sessions")
     .select(`

--- a/tests/admin-users-roles.access.spec.ts
+++ b/tests/admin-users-roles.access.spec.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const envValues = new Map<string, string>([
+  ['SUPABASE_URL', 'http://localhost'],
+  ['SUPABASE_SERVICE_ROLE_KEY', 'service-role-key'],
+  ['SUPABASE_ANON_KEY', 'anon-key'],
+]);
+
+type TestRole = 'client' | 'therapist' | 'admin' | 'super_admin';
+
+type TestUser = {
+  id: string;
+  email: string;
+};
+
+type TestProfile = TestUser & {
+  role: TestRole;
+  is_active: boolean;
+};
+
+type TestUserContext = {
+  user: TestUser;
+  profile: TestProfile;
+};
+
+type GlobalWithDeno = typeof globalThis & {
+  Deno?: {
+    env: {
+      get: (key: string) => string;
+    };
+  };
+};
+
+(globalThis as GlobalWithDeno).Deno = {
+  env: {
+    get(key: string) {
+      return envValues.get(key) ?? '';
+    },
+  },
+};
+
+const logApiAccess = vi.fn();
+const userContexts = new Map<string, TestUserContext>();
+
+let rpcRoles: string[] = [];
+let fetchedUserId: string | null = null;
+let latestUpdatePayload: Record<string, unknown> | null = null;
+let existingProfile: TestProfile & {
+  first_name: string;
+  last_name: string;
+  full_name: string;
+  updated_at: string;
+};
+
+vi.mock('../supabase/functions/_shared/auth-middleware.ts', () => ({
+  corsHeaders: {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-Client-Info, apikey',
+    'Access-Control-Max-Age': '86400',
+  },
+  RouteOptions: {
+    superAdmin: {},
+  },
+  logApiAccess,
+  createProtectedRoute: (handler: (req: Request, userContext: TestUserContext) => Promise<Response>) => {
+    return async (req: Request) => {
+      const contextKey = req.headers.get('x-test-user') ?? 'default';
+      const context = userContexts.get(contextKey);
+      if (!context) {
+        return new Response(
+          JSON.stringify({ error: 'Authentication required' }),
+          { status: 401, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return handler(req, context);
+    };
+  },
+}));
+
+vi.mock('../supabase/functions/_shared/database.ts', () => {
+  const createProfilesQuery = () => {
+    const builder = {
+      select: vi.fn(() => builder),
+      eq: vi.fn((column: string, value: string) => {
+        if (column === 'id') {
+          fetchedUserId = value;
+        }
+        return builder;
+      }),
+      single: vi.fn(async () => {
+        if (fetchedUserId === existingProfile.id) {
+          return { data: { ...existingProfile }, error: null };
+        }
+        return { data: null, error: { message: 'User not found' } };
+      }),
+      update: vi.fn((values: Record<string, unknown>) => {
+        latestUpdatePayload = values;
+        const updatedUser = {
+          ...existingProfile,
+          ...values,
+          updated_at: '2025-07-01T00:00:00Z',
+        };
+        return {
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(async () => ({ data: updatedUser, error: null })),
+            })),
+          })),
+        };
+      }),
+    };
+    return builder;
+  };
+
+  return {
+    supabaseAdmin: {} as never,
+    createRequestClient: () => ({
+      rpc: vi.fn(async (functionName: string) => {
+        if (functionName === 'get_user_roles') {
+          return { data: [{ roles: rpcRoles }], error: null };
+        }
+        return { data: null, error: { message: `Unexpected RPC ${functionName}` } };
+      }),
+      from: vi.fn((table: string) => {
+        if (table !== 'profiles') {
+          throw new Error(`Unexpected table: ${table}`);
+        }
+        return createProfilesQuery();
+      }),
+    }),
+  };
+});
+
+describe('admin-users-roles access control', () => {
+  beforeEach(() => {
+    userContexts.clear();
+    logApiAccess.mockClear();
+    rpcRoles = [];
+    fetchedUserId = null;
+    latestUpdatePayload = null;
+    existingProfile = {
+      id: '11111111-1111-1111-1111-111111111111',
+      email: 'target@example.com',
+      role: 'admin',
+      is_active: true,
+      first_name: 'Target',
+      last_name: 'User',
+      full_name: 'Target User',
+      updated_at: '2025-06-01T00:00:00Z',
+    };
+  });
+
+  it('allows a super admin to demote another admin user', async () => {
+    rpcRoles = ['super_admin'];
+
+    const superAdminContext: TestUserContext = {
+      user: { id: 'super-admin-1', email: 'super@example.com' },
+      profile: {
+        id: 'super-admin-profile-1',
+        email: 'super@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    };
+
+    userContexts.set('super', superAdminContext);
+
+    const { default: handler } = await import('../supabase/functions/admin-users-roles/index.ts');
+
+    const response = await handler(
+      new Request('http://localhost/functions/v1/admin/users/11111111-1111-1111-1111-111111111111/roles', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+          'x-test-user': 'super',
+        },
+        body: JSON.stringify({ role: 'therapist' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.user.role).toBe('therapist');
+    expect(latestUpdatePayload).toEqual({ role: 'therapist' });
+    expect(logApiAccess).toHaveBeenCalledWith('PATCH', '/admin/users/11111111-1111-1111-1111-111111111111/roles', superAdminContext, 200);
+  });
+});

--- a/tests/generate-report.access.spec.ts
+++ b/tests/generate-report.access.spec.ts
@@ -45,7 +45,7 @@ const logApiAccess = vi.fn();
 const userContexts = new Map<string, TestUserContext>();
 const recordedClientQueries: URL[] = [];
 const recordedSessionQueries: URL[] = [];
-let isAdminResponse = false;
+let roleResponse: string[] = [];
 
 const clientsData = [
   {
@@ -249,8 +249,8 @@ vi.mock('../supabase/functions/_shared/database.ts', () => {
 // generate-report specific handlers for each test run.
 function registerAccessHandlers() {
   server.use(
-    http.post('http://localhost/rest/v1/rpc/is_admin', () => {
-      return HttpResponse.json({ data: isAdminResponse });
+    http.post('http://localhost/rest/v1/rpc/get_user_roles', () => {
+      return HttpResponse.json({ data: [{ roles: roleResponse }] });
     }),
     http.get('http://localhost/rest/v1/user_therapist_links', ({ request }) => {
       const url = new URL(request.url);
@@ -344,7 +344,7 @@ afterEach(() => {
   recordedClientQueries.length = 0;
   recordedSessionQueries.length = 0;
   userContexts.clear();
-  isAdminResponse = false;
+  roleResponse = [];
   logApiAccess.mockClear();
 });
 
@@ -431,7 +431,7 @@ describe('generate-report access control', () => {
       user: { id: 'admin-user-1', email: 'admin@example.com' },
       profile: { id: 'admin-profile-1', email: 'admin@example.com', role: 'admin', is_active: true },
     });
-    isAdminResponse = true;
+    roleResponse = ['admin'];
 
     const handler = (await import('../supabase/functions/generate-report/index.ts')).default;
     const response = await handler(buildRequest({
@@ -453,7 +453,7 @@ describe('generate-report access control', () => {
       user: { id: 'admin-user-1', email: 'admin@example.com' },
       profile: { id: 'admin-profile-1', email: 'admin@example.com', role: 'admin', is_active: true },
     });
-    isAdminResponse = true;
+    roleResponse = ['admin'];
 
     const handler = (await import('../supabase/functions/generate-report/index.ts')).default;
     const response = await handler(buildRequest({


### PR DESCRIPTION
### Summary
Ensure admin role checks allow super admins across edge functions and cover the regression with targeted tests.

### Proposed changes
- Replace the admin assertion helper with an `is_admin`/`is_super_admin` role check via `get_user_roles`.
- Update admin-protected edge functions to rely on the new helper and align accompanying comments.
- Adjust report access tests and add a regression spec confirming super admins can demote administrators.

### Tests added/updated
- tests/admin-users-roles.access.spec.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68dac61223dc833284c4121b71742965