### PR TITLE
feat: admin invite edge function – 2025-09-29

### DIFF
--- a/docs/ADMIN_INVITE_CONFIGURATION.md
+++ b/docs/ADMIN_INVITE_CONFIGURATION.md
@@ -1,0 +1,34 @@
+# Admin Invite Configuration Guide
+
+## Email Templates
+- **Template name:** `admin-invite`
+- **Location:** Managed by the notification service addressed by `ADMIN_INVITE_EMAIL_URL`.
+- **Variables passed by the Edge function:**
+  - `invite_url` – Fully qualified acceptance URL containing the one-time token.
+  - `expires_at` – ISO 8601 timestamp for when the invite becomes invalid.
+  - `organization_id` – Used for organization-specific branding or context.
+  - `role` – Role that will be granted upon acceptance (defaults to `admin`).
+
+## Environment Variables
+| Variable | Description |
+| --- | --- |
+| `ADMIN_INVITE_EMAIL_URL` | HTTPS endpoint for the transactional email service handling invite messages. |
+| `ADMIN_PORTAL_URL` | Base URL for the admin application where invites are redeemed (e.g., `https://admin.example.com`). |
+| `SUPABASE_SERVICE_ROLE_KEY` | Required by the Edge function runtime and Supabase CLI for privileged operations. Already provided in platform secrets; **never** log or expose it. |
+| `SUPABASE_URL` / `SUPABASE_ANON_KEY` | Used by the Edge function to scope the caller via `createRequestClient`. |
+
+## Token Storage
+- **Table:** `admin_invite_tokens`
+- **Columns referenced:** `id`, `email`, `organization_id`, `token_hash`, `role`, `expires_at`, `created_by`.
+- Tokens are stored hashed with SHA-256; plaintext tokens only appear in the email payload and response redirect URL.
+- Prior to inserting a new invite, the function prunes any expired record for the same email + organization and aborts with `409` if an active invite already exists.
+
+## Auditing
+- Every invite attempt generates an `admin_actions` row with `action_type = 'admin_invite_sent'`.
+- `action_details` payload includes the invite email, expiration, generated invite ID, role, and email delivery status (`sent` or `failed`).
+- Failed email deliveries still log an action with `email_delivery_status = 'failed'` and the upstream error message.
+
+## Operational Notes
+- Default expiration is 72 hours and can be overridden per request within 1–168 hours.
+- Super admins may invite admins into any organization; standard admins are restricted to their own organization context.
+- Expired invites are automatically replaced on subsequent requests; active invites must be explicitly revoked in the database if re-sending is required before expiration.

--- a/proposals/functions/admins_invite_flow.md
+++ b/proposals/functions/admins_invite_flow.md
@@ -1,0 +1,87 @@
+# Admin Invite Flow – Edge Function Proposal
+
+## Goals
+- Allow authorized administrators to invite new admins into their organization.
+- Ensure every invite is scoped to the caller's organization and properly audited.
+- Provide a tamper-resistant token flow with predictable expiration handling.
+
+## Actors & Entry Point
+- **Caller:** Authenticated admin or super admin hitting the `admin-invite` Edge function.
+- **Target:** Email recipient who will become an admin once the invite is accepted.
+- **Data Sources:**
+  - `admin_invite_tokens` table for invite lifecycle state.
+  - `admin_actions` table for audit logging.
+  - Supabase Auth service (service role) for validating or creating auth users.
+
+## Token Creation
+1. Validate payload with Zod:
+   - `email` (RFC-compliant string).
+   - `organizationId` (UUID). Optional for super admins – falls back to caller org for regular admins.
+   - Optional `expiresInHours` with sane defaults (e.g. 72h, bounded 1-168).
+   - Optional `role` (defaults to `admin` unless super admin is inviting another super admin).
+2. Resolve the caller's organization from Supabase Auth metadata (`organization_id`/`organizationId`). Reject if the caller is not scoped or attempts to invite outside their org (unless `super_admin`).
+3. Normalize email + organization, soft-delete any expired tokens for that tuple, and abort with `409` if an active invite already exists.
+4. Generate a cryptographically strong token (`crypto.randomUUID()` or 32-byte random), hash with SHA-256, and insert into `admin_invite_tokens` with:
+   - `token_hash`
+   - `email`
+   - `organization_id`
+   - `role`
+   - `expires_at`
+   - `created_by`
+   - optional metadata (e.g. `redirect_uri`, `invited_first_name`).
+
+## Email Delivery
+1. Build an invite URL `${ADMIN_PORTAL_URL}/accept-invite?token=<rawToken>`.
+2. POST to an internal notification service (`ADMIN_INVITE_EMAIL_URL`) with template payload:
+   ```json
+   {
+     "template": "admin-invite",
+     "to": "target@example.com",
+     "variables": {
+       "organization_name": "Acme Health",
+       "invite_url": "https://admin.example.com/accept-invite?token=...",
+       "expires_at": "2025-07-01T12:00:00Z"
+     }
+   }
+   ```
+3. Treat non-2xx responses as delivery failures (log + 502) and avoid exposing the raw token in logs.
+4. Include telemetry via `admin_actions` even if the downstream email service fails (so we keep an audit trail of attempted invites).
+
+## Expiration & Acceptance
+- Invites default to 72 hours; allow override within configured min/max bounds.
+- Enforce single-use tokens by deleting/invalidation once redeemed.
+- Periodically clean expired rows (scheduled job) and allow new invites to replace expired entries.
+- When validating a token:
+  - Hash the provided token and match against `token_hash` + `organization_id`.
+  - Ensure `expires_at > now` and `redeemed_at` is null.
+  - On success, create or update the auth user with admin metadata and mark invite as `redeemed_at = now()`.
+
+## Organization Binding & Auditing
+- For non-super-admin callers, `organizationId` must match metadata.
+- Super admins can specify `organizationId` explicitly; fallback to target metadata if an existing user.
+- Every invite insertion logs an `admin_actions` row:
+  ```sql
+  INSERT INTO admin_actions (
+    admin_user_id,
+    target_user_id,
+    organization_id,
+    action_type,
+    action_details
+  ) VALUES (
+    <caller_id>,
+    NULL,
+    <organization_id>,
+    'admin_invite_sent',
+    jsonb_build_object(
+      'email', <target_email>,
+      'expires_at', <timestamp>,
+      'role', <role>
+    )
+  );
+  ```
+- Include optional context such as `email_delivery_status` or request correlation IDs.
+
+## Open Questions
+- Should invites auto-provision auth users ("pre-created" accounts) or wait until acceptance?
+- Do we need SMS fallback or reminders for soon-to-expire invites?
+- How many concurrent invites per email should be permitted (likely 1 active per org)?

--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -1,0 +1,294 @@
+import { z } from "zod";
+import {
+  createProtectedRoute,
+  corsHeaders,
+  logApiAccess,
+  RouteOptions,
+  type UserContext,
+} from "../_shared/auth-middleware.ts";
+import { createRequestClient } from "../_shared/database.ts";
+import { assertAdminOrSuperAdmin } from "../_shared/auth.ts";
+
+const DEFAULT_EXPIRATION_HOURS = 72;
+const MIN_EXPIRATION_HOURS = 1;
+const MAX_EXPIRATION_HOURS = 24 * 7;
+const ADMIN_INVITE_PATH = "/admin/invite";
+
+const InviteRequestSchema = z.object({
+  email: z.string().email(),
+  organizationId: z.string().uuid().optional(),
+  expiresInHours: z
+    .number()
+    .int()
+    .min(MIN_EXPIRATION_HOURS)
+    .max(MAX_EXPIRATION_HOURS)
+    .optional(),
+  role: z.enum(["admin", "super_admin"]).optional(),
+});
+
+type InviteRequest = z.infer<typeof InviteRequestSchema>;
+
+type InviteTokenRecord = {
+  id: string;
+  expires_at: string | null;
+};
+
+type InviteLookupResult = {
+  data: InviteTokenRecord | null;
+  error: { message?: string } | null;
+};
+
+type InsertInviteResult = {
+  data: InviteTokenRecord | null;
+  error: { message?: string } | null;
+};
+
+const jsonResponse = (status: number, body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+const extractOrganizationId = (metadata: Record<string, unknown> | null | undefined): string | null => {
+  if (!metadata) return null;
+  const candidate = metadata.organization_id ?? metadata.organizationId;
+  return typeof candidate === "string" && candidate.length > 0 ? candidate : null;
+};
+
+const normalizeEmail = (email: string) => email.trim().toLowerCase();
+
+const toHex = (bytes: ArrayBuffer) =>
+  Array.from(new Uint8Array(bytes))
+    .map(byte => byte.toString(16).padStart(2, "0"))
+    .join("");
+
+const hashToken = async (token: string) => {
+  const encoded = new TextEncoder().encode(token);
+  const digest = await crypto.subtle.digest("SHA-256", encoded);
+  return toHex(digest);
+};
+
+const ensureEmailServiceConfig = () => {
+  const emailServiceUrl = Deno.env.get("ADMIN_INVITE_EMAIL_URL") ?? "";
+  const portalBaseUrl = Deno.env.get("ADMIN_PORTAL_URL") ?? "";
+  return {
+    emailServiceUrl: emailServiceUrl.trim(),
+    portalBaseUrl: portalBaseUrl.trim(),
+  };
+};
+
+const buildInviteUrl = (baseUrl: string, token: string) => {
+  const trimmed = baseUrl.replace(/\/$/, "");
+  return `${trimmed}/accept-invite?token=${token}`;
+};
+
+async function sendInviteEmail(
+  url: string,
+  payload: {
+    to: string;
+    inviteUrl: string;
+    expiresAt: string;
+    organizationId: string;
+    role: string;
+  },
+): Promise<{ status: "sent" | "failed"; error?: string }> {
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        template: "admin-invite",
+        to: payload.to,
+        variables: {
+          invite_url: payload.inviteUrl,
+          expires_at: payload.expiresAt,
+          organization_id: payload.organizationId,
+          role: payload.role,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      return {
+        status: "failed",
+        error: `Email service responded with status ${response.status}`,
+      };
+    }
+
+    return { status: "sent" };
+  } catch (error) {
+    return {
+      status: "failed",
+      error: error instanceof Error ? error.message : "Unknown email delivery error",
+    };
+  }
+}
+
+async function handleInvite(req: Request, userContext: UserContext) {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { error: "method_not_allowed" });
+  }
+
+  try {
+    const adminClient = createRequestClient(req);
+    await assertAdminOrSuperAdmin(adminClient);
+
+    const payloadResult = InviteRequestSchema.safeParse(await req.json());
+    if (!payloadResult.success) {
+      return jsonResponse(400, {
+        error: "invalid_payload",
+        details: payloadResult.error.flatten(),
+      });
+    }
+
+    const payload: InviteRequest = payloadResult.data;
+
+    const { data: authResult, error: authError } = await adminClient.auth.getUser();
+    if (authError || !authResult?.user) {
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 401);
+      return jsonResponse(401, { error: "unauthorized" });
+    }
+
+    const callerOrganizationId = extractOrganizationId(authResult.user.user_metadata as Record<string, unknown> | undefined);
+    const normalizedEmail = normalizeEmail(payload.email);
+    const targetOrganizationId = payload.organizationId ?? callerOrganizationId;
+
+    if (!targetOrganizationId) {
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
+      return jsonResponse(403, { error: "organization_context_required" });
+    }
+
+    if (userContext.profile.role !== "super_admin" && targetOrganizationId !== callerOrganizationId) {
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
+      return jsonResponse(403, { error: "cross_org_invite_forbidden" });
+    }
+
+    const desiredRole = payload.role ?? "admin";
+    if (desiredRole === "super_admin" && userContext.profile.role !== "super_admin") {
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
+      return jsonResponse(403, { error: "insufficient_role_for_target" });
+    }
+
+    const now = new Date();
+    const expiresInHours = payload.expiresInHours ?? DEFAULT_EXPIRATION_HOURS;
+    const expiresAt = new Date(now.getTime() + expiresInHours * 60 * 60 * 1000);
+
+    const existingInvite = (await adminClient
+      .from("admin_invite_tokens")
+      .select("id, expires_at")
+      .eq("email", normalizedEmail)
+      .eq("organization_id", targetOrganizationId)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle()) as InviteLookupResult;
+
+    if (existingInvite.error) {
+      console.error("Failed to lookup existing invite", existingInvite.error);
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
+      return jsonResponse(500, { error: "invite_lookup_failed" });
+    }
+
+    const activeInvite = existingInvite.data;
+    if (activeInvite?.expires_at) {
+      const expiresAtDate = new Date(activeInvite.expires_at);
+      if (!Number.isNaN(expiresAtDate.getTime()) && expiresAtDate.getTime() > now.getTime()) {
+        logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
+        return jsonResponse(409, { error: "active_invite_exists" });
+      }
+    }
+
+    if (activeInvite?.id) {
+      const { error: deleteError } = await adminClient
+        .from("admin_invite_tokens")
+        .delete()
+        .eq("id", activeInvite.id);
+
+      if (deleteError) {
+        console.error("Failed to prune expired invite", deleteError);
+      }
+    }
+
+    const rawToken = crypto.randomUUID().replace(/-/g, "");
+    const tokenHash = await hashToken(rawToken);
+
+    const insertedInvite = (await adminClient
+      .from("admin_invite_tokens")
+      .insert({
+        email: normalizedEmail,
+        token_hash: tokenHash,
+        organization_id: targetOrganizationId,
+        expires_at: expiresAt.toISOString(),
+        created_by: userContext.user.id,
+        role: desiredRole,
+      })
+      .select("id, expires_at")
+      .single()) as InsertInviteResult;
+
+    if (insertedInvite.error || !insertedInvite.data) {
+      console.error("Failed to insert invite token", insertedInvite.error);
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
+      return jsonResponse(500, { error: "invite_creation_failed" });
+    }
+
+    const { emailServiceUrl, portalBaseUrl } = ensureEmailServiceConfig();
+    if (!emailServiceUrl) {
+      console.error("ADMIN_INVITE_EMAIL_URL is not configured");
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
+      return jsonResponse(500, { error: "email_service_unconfigured" });
+    }
+
+    if (!portalBaseUrl) {
+      console.error("ADMIN_PORTAL_URL is not configured");
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
+      return jsonResponse(500, { error: "portal_url_unconfigured" });
+    }
+
+    const inviteUrl = buildInviteUrl(portalBaseUrl, rawToken);
+
+    const emailResult = await sendInviteEmail(emailServiceUrl, {
+      to: normalizedEmail,
+      inviteUrl,
+      expiresAt: expiresAt.toISOString(),
+      organizationId: targetOrganizationId,
+      role: desiredRole,
+    });
+
+    const { error: actionError } = await adminClient.from("admin_actions").insert({
+      admin_user_id: userContext.user.id,
+      target_user_id: null,
+      organization_id: targetOrganizationId,
+      action_type: "admin_invite_sent",
+      action_details: {
+        email: normalizedEmail,
+        expires_at: expiresAt.toISOString(),
+        invite_id: insertedInvite.data.id,
+        role: desiredRole,
+        email_delivery_status: emailResult.status,
+        ...(emailResult.error ? { email_error: emailResult.error } : {}),
+      },
+    });
+
+    if (actionError) {
+      console.warn("Failed to log admin invite action", actionError);
+    }
+
+    if (emailResult.status === "failed") {
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 502);
+      return jsonResponse(502, { error: "email_delivery_failed" });
+    }
+
+    logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 201);
+    return jsonResponse(201, {
+      inviteId: insertedInvite.data.id,
+      expiresAt: expiresAt.toISOString(),
+    });
+  } catch (error) {
+    console.error("Unexpected admin invite error", error);
+    logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
+    return jsonResponse(500, { error: "internal_server_error" });
+  }
+}
+
+export const handler = createProtectedRoute(handleInvite, RouteOptions.admin);
+
+export default handler;

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type TestRole = 'client' | 'therapist' | 'admin' | 'super_admin';
+
+type TestUser = {
+  id: string;
+  email: string;
+};
+
+type TestProfile = TestUser & {
+  role: TestRole;
+  is_active: boolean;
+};
+
+type TestUserContext = {
+  user: TestUser;
+  profile: TestProfile;
+};
+
+type GlobalWithDeno = typeof globalThis & {
+  Deno?: { env: { get: (key: string) => string } };
+};
+
+interface StoredInviteToken {
+  id: string;
+  email: string;
+  organization_id: string;
+  token_hash: string;
+  expires_at: string;
+  created_by: string;
+  created_at: string;
+  role: string;
+}
+
+const envValues = new Map<string, string>([
+  ['SUPABASE_URL', 'http://localhost'],
+  ['SUPABASE_ANON_KEY', 'anon'],
+  ['ADMIN_INVITE_EMAIL_URL', 'https://mailer.example.com'],
+  ['ADMIN_PORTAL_URL', 'https://admin.example.com'],
+]);
+
+(globalThis as GlobalWithDeno).Deno = {
+  env: {
+    get(key: string) {
+      return envValues.get(key) ?? '';
+    },
+  },
+};
+
+const logApiAccess = vi.fn();
+const assertAdminOrSuperAdmin = vi.fn(async () => {});
+const createRequestClient = vi.fn();
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-Client-Info, apikey',
+  'Access-Control-Max-Age': '86400',
+};
+
+let currentUserContext: TestUserContext = {
+  user: { id: 'admin-1', email: 'admin@example.com' },
+  profile: { id: 'profile-1', email: 'admin@example.com', role: 'admin', is_active: true },
+};
+
+let currentUserMetadata: Record<string, unknown> = { organization_id: 'org-123' };
+
+const inviteTokens: StoredInviteToken[] = [];
+const adminActionRows: Array<Record<string, unknown>> = [];
+
+const createInviteTableClient = () => {
+  const state: { email?: string; organizationId?: string } = {};
+  const builder: any = {
+    select: vi.fn(() => builder),
+    eq: vi.fn((column: string, value: string) => {
+      if (column === 'email') state.email = value;
+      if (column === 'organization_id') state.organizationId = value;
+      return builder;
+    }),
+    order: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+    maybeSingle: vi.fn(async () => {
+      const filtered = inviteTokens
+        .filter(token =>
+          (state.email ? token.email === state.email : true)
+          && (state.organizationId ? token.organization_id === state.organizationId : true),
+        )
+        .sort((a, b) => b.created_at.localeCompare(a.created_at));
+      const record = filtered[0];
+      return { data: record ? { id: record.id, expires_at: record.expires_at } : null, error: null };
+    }),
+    insert: (value: Record<string, unknown>) => {
+      const record = Array.isArray(value) ? value[0] : value;
+      const id = (record.id as string) ?? crypto.randomUUID();
+      const stored: StoredInviteToken = {
+        id,
+        email: record.email as string,
+        organization_id: record.organization_id as string,
+        token_hash: record.token_hash as string,
+        expires_at: record.expires_at as string,
+        created_by: record.created_by as string,
+        created_at: new Date().toISOString(),
+        role: (record.role as string) ?? 'admin',
+      };
+      inviteTokens.push(stored);
+      return {
+        select: () => ({
+          single: async () => ({ data: { id: stored.id, expires_at: stored.expires_at }, error: null }),
+        }),
+      };
+    },
+    delete: () => ({
+      eq: (column: string, value: string) => {
+        if (column !== 'id') throw new Error(`Unexpected delete column ${column}`);
+        const index = inviteTokens.findIndex(token => token.id === value);
+        if (index >= 0) {
+          inviteTokens.splice(index, 1);
+        }
+        return { error: null };
+      },
+    }),
+  };
+  return builder;
+};
+
+const createMockClient = () => ({
+  auth: {
+    getUser: vi.fn(async () => ({
+      data: { user: { id: currentUserContext.user.id, user_metadata: currentUserMetadata } },
+      error: null,
+    })),
+  },
+  from: (table: string) => {
+    if (table === 'admin_invite_tokens') {
+      return createInviteTableClient();
+    }
+    if (table === 'admin_actions') {
+      return {
+        insert: vi.fn(async (payload: Record<string, unknown>) => {
+          adminActionRows.push(payload);
+          return { error: null };
+        }),
+      };
+    }
+    throw new Error(`Unexpected table ${table}`);
+  },
+});
+
+createRequestClient.mockImplementation(() => createMockClient());
+
+vi.mock('../../supabase/functions/_shared/auth-middleware.ts', () => ({
+  corsHeaders,
+  RouteOptions: { admin: {} },
+  logApiAccess,
+  createProtectedRoute: (handler: (req: Request, context: TestUserContext) => Promise<Response>) => {
+    return (req: Request) => handler(req, currentUserContext);
+  },
+}));
+
+vi.mock('../../supabase/functions/_shared/database.ts', () => ({
+  createRequestClient,
+}));
+
+vi.mock('../../supabase/functions/_shared/auth.ts', () => ({
+  assertAdminOrSuperAdmin,
+}));
+
+describe('admin invite edge function', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  const loadHandler = async () => {
+    const module = await import('../../supabase/functions/admin-invite/index.ts');
+    return module.handler as (req: Request) => Promise<Response>;
+  };
+
+  beforeEach(async () => {
+    vi.resetModules();
+    inviteTokens.splice(0, inviteTokens.length);
+    adminActionRows.splice(0, adminActionRows.length);
+    currentUserContext = {
+      user: { id: 'admin-1', email: 'admin@example.com' },
+      profile: { id: 'profile-1', email: 'admin@example.com', role: 'admin', is_active: true },
+    };
+    currentUserMetadata = { organization_id: 'org-123' };
+    envValues.set('ADMIN_INVITE_EMAIL_URL', 'https://mailer.example.com');
+    envValues.set('ADMIN_PORTAL_URL', 'https://admin.example.com');
+    fetchMock = vi.fn(async () => ({ ok: true, status: 202 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    logApiAccess.mockClear();
+    assertAdminOrSuperAdmin.mockClear();
+    createRequestClient.mockClear();
+  });
+
+  it('creates a scoped invite token, sends email, and logs the admin action', async () => {
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'NewAdmin@example.com' }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body).toMatchObject({ inviteId: expect.any(String), expiresAt: expect.any(String) });
+
+    expect(inviteTokens).toHaveLength(1);
+    const storedToken = inviteTokens[0];
+    expect(storedToken.email).toBe('newadmin@example.com');
+    expect(storedToken.token_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(storedToken.organization_id).toBe('org-123');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(requestInit?.method).toBe('POST');
+    const emailPayload = JSON.parse(requestInit?.body as string);
+    expect(emailPayload.template).toBe('admin-invite');
+    expect(emailPayload.to).toBe('newadmin@example.com');
+    expect(emailPayload.variables.invite_url).toContain('?token=');
+
+    expect(adminActionRows).toHaveLength(1);
+    expect(adminActionRows[0]).toMatchObject({
+      admin_user_id: 'admin-1',
+      organization_id: 'org-123',
+      action_type: 'admin_invite_sent',
+    });
+    expect(adminActionRows[0]?.action_details).toMatchObject({
+      email: 'newadmin@example.com',
+      email_delivery_status: 'sent',
+    });
+
+    expect(assertAdminOrSuperAdmin).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces an expired invite token with a new one', async () => {
+    const expiredToken: StoredInviteToken = {
+      id: 'invite-old',
+      email: 'newadmin@example.com',
+      organization_id: 'org-123',
+      token_hash: 'deadbeef',
+      expires_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      created_by: 'admin-1',
+      created_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      role: 'admin',
+    };
+    inviteTokens.push(expiredToken);
+
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'newadmin@example.com', expiresInHours: 4 }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+
+    expect(inviteTokens).toHaveLength(1);
+    const newToken = inviteTokens[0];
+    expect(newToken.id).not.toBe(expiredToken.id);
+    expect(newToken.token_hash).not.toBe(expiredToken.token_hash);
+    expect(newToken.expires_at).not.toBe(expiredToken.expires_at);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(adminActionRows).toHaveLength(1);
+    expect(adminActionRows[0]?.action_details).toMatchObject({
+      email: 'newadmin@example.com',
+      email_delivery_status: 'sent',
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Implement an admin invite edge function with supporting documentation and tests.

### Proposed changes
- Add design proposal for organization-scoped admin invite tokens.
- Implement the `admin-invite` Supabase Edge function with validation, email dispatch, and auditing.
- Add acceptance tests for valid and expired invite token flows and document configuration requirements.

### Tests added/updated
- tests/admins/invite_flow.spec.ts

### Checklist
- [ ] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated


------
https://chatgpt.com/codex/tasks/task_b_68db11e4051883328ce921da3636f2b6