### PR TITLE
feat: soft delete archive controls – 2025-09-30

### DIFF
--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -645,6 +645,8 @@ export type Database = {
           client_id: string | null
           created_at: string | null
           created_by: string | null
+          deleted_at: string | null
+          deleted_by: string | null
           date_of_birth: string | null
           daycare_after_school: boolean | null
           diagnosis: string[] | null
@@ -703,6 +705,8 @@ export type Database = {
           client_id?: string | null
           created_at?: string | null
           created_by?: string | null
+          deleted_at?: string | null
+          deleted_by?: string | null
           date_of_birth?: string | null
           daycare_after_school?: boolean | null
           diagnosis?: string[] | null
@@ -761,6 +765,8 @@ export type Database = {
           client_id?: string | null
           created_at?: string | null
           created_by?: string | null
+          deleted_at?: string | null
+          deleted_by?: string | null
           date_of_birth?: string | null
           daycare_after_school?: boolean | null
           diagnosis?: string[] | null
@@ -1255,6 +1261,8 @@ export type Database = {
         Row: {
           avatar_url: string | null
           created_at: string | null
+          deleted_at: string | null
+          deleted_by: string | null
           email: string
           first_name: string | null
           full_name: string | null
@@ -1271,6 +1279,8 @@ export type Database = {
         Insert: {
           avatar_url?: string | null
           created_at?: string | null
+          deleted_at?: string | null
+          deleted_by?: string | null
           email: string
           first_name?: string | null
           full_name?: string | null
@@ -1287,6 +1297,8 @@ export type Database = {
         Update: {
           avatar_url?: string | null
           created_at?: string | null
+          deleted_at?: string | null
+          deleted_by?: string | null
           email?: string
           first_name?: string | null
           full_name?: string | null
@@ -1859,6 +1871,8 @@ export type Database = {
           bcba_number: string | null
           city: string | null
           created_at: string | null
+          deleted_at: string | null
+          deleted_by: string | null
           email: string
           employee_type: string | null
           facility: string | null
@@ -1899,6 +1913,8 @@ export type Database = {
           bcba_number?: string | null
           city?: string | null
           created_at?: string | null
+          deleted_at?: string | null
+          deleted_by?: string | null
           email: string
           employee_type?: string | null
           facility?: string | null
@@ -1939,6 +1955,8 @@ export type Database = {
           bcba_number?: string | null
           city?: string | null
           created_at?: string | null
+          deleted_at?: string | null
+          deleted_by?: string | null
           email?: string
           employee_type?: string | null
           facility?: string | null

--- a/src/pages/__tests__/Clients.test.tsx
+++ b/src/pages/__tests__/Clients.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../test/utils';
+import Clients from '../Clients';
+
+const invalidateQueries = vi.fn();
+const useQueryMock = vi.fn();
+const mutationHandlers: Array<{ options: any; mutateAsync: ReturnType<typeof vi.fn> }> = [];
+const useMutationMock = vi.fn();
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+
+  return {
+    ...actual,
+    useQuery: (options: unknown) => useQueryMock(options),
+    useMutation: (options: unknown) => useMutationMock(options),
+    useQueryClient: () => ({ invalidateQueries }),
+  };
+});
+
+const mockClients = [
+  {
+    id: 'client-1',
+    full_name: 'Active Client',
+    email: 'active@example.com',
+    client_id: 'AC-001',
+    date_of_birth: null,
+    service_preference: [],
+    one_to_one_units: 10,
+    supervision_units: 5,
+    parent_consult_units: 3,
+    availability_hours: {},
+    created_at: '2025-01-01T00:00:00.000Z',
+    deleted_at: null,
+  },
+  {
+    id: 'client-2',
+    full_name: 'Archived Client',
+    email: 'archived@example.com',
+    client_id: 'AC-002',
+    date_of_birth: null,
+    service_preference: [],
+    one_to_one_units: 8,
+    supervision_units: 2,
+    parent_consult_units: 1,
+    availability_hours: {},
+    created_at: '2025-01-01T00:00:00.000Z',
+    deleted_at: '2025-01-10T00:00:00.000Z',
+  },
+];
+
+beforeEach(() => {
+  invalidateQueries.mockClear();
+  useQueryMock.mockReset();
+  useMutationMock.mockReset();
+  mutationHandlers.length = 0;
+
+  useQueryMock.mockReturnValue({ data: mockClients, isLoading: false });
+  useMutationMock.mockImplementation((options: any) => {
+    const mutateAsync = vi.fn();
+    mutationHandlers.push({ options, mutateAsync });
+    return { mutateAsync, isPending: false, isSuccess: false };
+  });
+});
+
+describe('Clients page filtering', () => {
+  it('shows only archived clients when the archived filter is selected', async () => {
+    renderWithProviders(<Clients />);
+
+    const archivedSelect = screen.getAllByRole('combobox')[3];
+    await userEvent.selectOptions(archivedSelect, 'archived');
+
+    await waitFor(() => {
+      expect(screen.getByText('Archived Client')).toBeInTheDocument();
+      expect(screen.queryByText('Active Client')).not.toBeInTheDocument();
+    });
+  });
+
+  it('invalidates the clients query after successful mutations', () => {
+    renderWithProviders(<Clients />);
+
+    expect(mutationHandlers).toHaveLength(3);
+
+    mutationHandlers.forEach(({ options }) => {
+      invalidateQueries.mockClear();
+      options.onSuccess?.({}, { restore: false });
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['clients'] });
+    });
+  });
+});

--- a/src/pages/__tests__/Therapists.test.tsx
+++ b/src/pages/__tests__/Therapists.test.tsx
@@ -43,6 +43,15 @@ const mockTherapists = [
     service_type: 'In clinic',
     specialties: ['ABA Therapy'],
   },
+  {
+    id: 'therapist-3',
+    full_name: 'Archived Therapist',
+    email: 'archived@example.com',
+    status: 'inactive',
+    service_type: 'Telehealth',
+    specialties: ['Speech Therapy'],
+    deleted_at: '2025-01-01T00:00:00.000Z',
+  },
 ];
 
 beforeEach(() => {
@@ -98,6 +107,19 @@ describe('Therapists page filtering', () => {
       invalidateQueries.mockClear();
       options.onSuccess?.();
       expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['therapists'] });
+    });
+  });
+
+  it('shows only archived therapists when the archived filter is selected', async () => {
+    renderWithProviders(<Therapists />);
+
+    const archivedSelect = screen.getAllByRole('combobox')[3];
+    await userEvent.selectOptions(archivedSelect, 'archived');
+
+    await waitFor(() => {
+      expect(screen.getByText('Archived Therapist')).toBeInTheDocument();
+      expect(screen.queryByText('Active Therapist')).not.toBeInTheDocument();
+      expect(screen.queryByText('Inactive Therapist')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,8 @@ export interface Therapist {
     };
   };
   created_at: string;
+  deleted_at?: string | null;
+  deleted_by?: string | null;
   latitude?: number;
   longitude?: number;
   service_radius_km?: number;
@@ -102,6 +104,8 @@ export interface Client {
   updated_at?: string;
   updated_by?: string | null;
   organization_id?: string | null;
+  deleted_at?: string | null;
+  deleted_by?: string | null;
   latitude?: number;
   longitude?: number;
   preferred_radius_km?: number;

--- a/supabase/functions/ai-agent-optimized/index.ts
+++ b/supabase/functions/ai-agent-optimized/index.ts
@@ -368,8 +368,8 @@ async function getCompressedContextData(): Promise<ContextData> {
     const db = createRequestClient((globalThis as any).currentRequest);
     await getUserOrThrow(db);
     const [therapists, clients, sessions] = await Promise.all([
-      db.from('therapists').select('id').eq('status', 'active'),
-      db.from('clients').select('id'),
+      db.from('therapists').select('id').eq('status', 'active').is('deleted_at', null),
+      db.from('clients').select('id').is('deleted_at', null),
       db.from('sessions').select('id').gte('start_time', new Date().toISOString().split('T')[0])
     ]);
 

--- a/supabase/functions/get-client-details/index.ts
+++ b/supabase/functions/get-client-details/index.ts
@@ -153,6 +153,12 @@ export async function handleGetClientDetails({
       return jsonResponse(404, { error: "Client not found or access denied" });
     }
 
+    const isArchived = Boolean((data as { deleted_at?: string | null }).deleted_at);
+    if (isArchived && !isAdmin) {
+      logApiAccess("POST", "/get-client-details", userContext, 404);
+      return jsonResponse(404, { error: "Client not found or archived" });
+    }
+
     logApiAccess("POST", "/get-client-details", userContext, 200);
     return jsonResponse(200, { client: data });
   } catch (error) {

--- a/supabase/functions/get-dashboard-data/index.ts
+++ b/supabase/functions/get-dashboard-data/index.ts
@@ -67,11 +67,17 @@ Deno.serve(async (req: Request) => {
     if (weekError) throw weekError;
 
     const { count: activeClientsCount, error: clientError } = await db
-      .from('clients').select('id', { count: 'exact', head: true }).eq('status', 'active');
+      .from('clients')
+      .select('id', { count: 'exact', head: true })
+      .is('deleted_at', null)
+      .eq('status', 'active');
     if (clientError) throw clientError;
 
     const { count: activeTherapistsCount, error: therapistError } = await db
-      .from('therapists').select('id', { count: 'exact', head: true }).eq('status', 'active');
+      .from('therapists')
+      .select('id', { count: 'exact', head: true })
+      .is('deleted_at', null)
+      .eq('status', 'active');
     if (therapistError) throw therapistError;
 
     const thirtyDaysFromNow = new Date();

--- a/supabase/functions/get-dropdown-data/index.ts
+++ b/supabase/functions/get-dropdown-data/index.ts
@@ -17,7 +17,10 @@ Deno.serve(async (req: Request) => {
     const dropdownData: Partial<DropdownData> = {};
 
     if (dataTypes.includes('therapists') || dataTypes.includes('all')) {
-      let therapistQuery = db.from('therapists').select('id, full_name, email, status, specialties');
+      let therapistQuery = db
+        .from('therapists')
+        .select('id, full_name, email, status, specialties')
+        .is('deleted_at', null);
       if (!includeInactive) therapistQuery = therapistQuery.eq('status', 'active');
       const { data: therapists, error: therapistError } = await therapistQuery.order('full_name');
       if (therapistError) throw therapistError;
@@ -25,7 +28,10 @@ Deno.serve(async (req: Request) => {
     }
 
     if (dataTypes.includes('clients') || dataTypes.includes('all')) {
-      let clientQuery = db.from('clients').select('id, full_name, email, status');
+      let clientQuery = db
+        .from('clients')
+        .select('id, full_name, email, status')
+        .is('deleted_at', null);
       if (!includeInactive) clientQuery = clientQuery.eq('status', 'active');
       const { data: clients, error: clientError } = await clientQuery.order('full_name');
       if (clientError) throw clientError;

--- a/supabase/functions/get-schedule-data-batch/index.ts
+++ b/supabase/functions/get-schedule-data-batch/index.ts
@@ -48,7 +48,11 @@ Deno.serve(async (req: Request) => {
 
     let availability: any[] = [];
     if (include_availability && therapist_ids && therapist_ids.length > 0) {
-      const { data: therapists } = await db.from('therapists').select('id, full_name, availability_hours').in('id', therapist_ids);
+      const { data: therapists } = await db
+        .from('therapists')
+        .select('id, full_name, availability_hours')
+        .in('id', therapist_ids)
+        .is('deleted_at', null);
       availability = therapists?.map(therapist => {
         const availableSlots: Array<{ start_time: string; end_time: string; duration_minutes: number }>= [];
         const currentDate = new Date(start_date);

--- a/supabase/migrations/20251101100000_soft_delete_archival.sql
+++ b/supabase/migrations/20251101100000_soft_delete_archival.sql
@@ -1,0 +1,267 @@
+BEGIN;
+
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz,
+  ADD COLUMN IF NOT EXISTS deleted_by uuid REFERENCES auth.users(id);
+
+ALTER TABLE public.therapists
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz,
+  ADD COLUMN IF NOT EXISTS deleted_by uuid REFERENCES auth.users(id);
+
+CREATE INDEX IF NOT EXISTS clients_organization_deleted_idx
+  ON public.clients (organization_id, deleted_at)
+  WHERE deleted_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS therapists_organization_deleted_idx
+  ON public.therapists (organization_id, deleted_at)
+  WHERE deleted_at IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION app.enforce_soft_delete_admin()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_org uuid := COALESCE(NEW.organization_id, OLD.organization_id);
+  v_requires_admin boolean := false;
+  v_target uuid := COALESCE(NEW.id, OLD.id);
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.deleted_at IS NOT NULL OR NEW.deleted_by IS NOT NULL THEN
+      v_requires_admin := true;
+    END IF;
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF NEW.deleted_at IS DISTINCT FROM OLD.deleted_at
+       OR NEW.deleted_by IS DISTINCT FROM OLD.deleted_by THEN
+      v_requires_admin := true;
+    END IF;
+  END IF;
+
+  IF v_requires_admin THEN
+    IF v_actor IS NULL THEN
+      RAISE EXCEPTION 'Authentication required to manage archive state'
+        USING ERRCODE = 'P0001';
+    END IF;
+
+    IF NOT (
+      app.user_has_role_for_org(
+        'admin',
+        v_org,
+        CASE WHEN TG_TABLE_NAME = 'therapists' THEN v_target ELSE NULL END,
+        CASE WHEN TG_TABLE_NAME = 'clients' THEN v_target ELSE NULL END
+      )
+      OR app.user_has_role_for_org(
+        'super_admin',
+        v_org,
+        CASE WHEN TG_TABLE_NAME = 'therapists' THEN v_target ELSE NULL END,
+        CASE WHEN TG_TABLE_NAME = 'clients' THEN v_target ELSE NULL END
+      )
+    ) THEN
+      RAISE EXCEPTION 'Only organization admins may manage archive state'
+        USING ERRCODE = 'P0001';
+    END IF;
+
+    IF TG_OP = 'UPDATE' THEN
+      IF NEW.deleted_at IS NULL THEN
+        NEW.deleted_by := NULL;
+      ELSE
+        NEW.deleted_at := timezone('utc', now());
+        NEW.deleted_by := COALESCE(NEW.deleted_by, v_actor);
+      END IF;
+    ELSE
+      IF NEW.deleted_at IS NULL THEN
+        NEW.deleted_by := NULL;
+      ELSE
+        NEW.deleted_at := timezone('utc', now());
+        NEW.deleted_by := COALESCE(NEW.deleted_by, v_actor);
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS clients_enforce_soft_delete_admin ON public.clients;
+CREATE TRIGGER clients_enforce_soft_delete_admin
+  BEFORE INSERT OR UPDATE ON public.clients
+  FOR EACH ROW
+  EXECUTE FUNCTION app.enforce_soft_delete_admin();
+
+DROP TRIGGER IF EXISTS therapists_enforce_soft_delete_admin ON public.therapists;
+CREATE TRIGGER therapists_enforce_soft_delete_admin
+  BEFORE INSERT OR UPDATE ON public.therapists
+  FOR EACH ROW
+  EXECUTE FUNCTION app.enforce_soft_delete_admin();
+
+ALTER POLICY "Therapists scoped access"
+  ON public.therapists
+  USING (
+    CASE
+      WHEN app.user_has_role_for_org('admin', organization_id, id) THEN true
+      WHEN app.user_has_role_for_org('super_admin', organization_id, id) THEN true
+      WHEN app.user_has_role_for_org('therapist', organization_id, id) THEN id = auth.uid() AND deleted_at IS NULL
+      ELSE false
+    END
+  )
+  WITH CHECK (
+    CASE
+      WHEN app.user_has_role_for_org('admin', organization_id, id) THEN true
+      WHEN app.user_has_role_for_org('super_admin', organization_id, id) THEN true
+      WHEN app.user_has_role_for_org('therapist', organization_id, id) THEN id = auth.uid() AND deleted_at IS NULL
+      ELSE false
+    END
+  );
+
+ALTER POLICY "Clients scoped access"
+  ON public.clients
+  USING (
+    CASE
+      WHEN app.user_has_role_for_org('admin', organization_id, NULL, id) THEN true
+      WHEN app.user_has_role_for_org('super_admin', organization_id, NULL, id) THEN true
+      WHEN app.user_has_role_for_org('therapist', organization_id, NULL, id) THEN (
+        EXISTS (
+          SELECT 1
+          FROM public.sessions s
+          WHERE s.client_id = public.clients.id
+            AND s.therapist_id = auth.uid()
+        )
+        AND public.clients.deleted_at IS NULL
+      )
+      ELSE false
+    END
+  )
+  WITH CHECK (
+    CASE
+      WHEN app.user_has_role_for_org('admin', organization_id, NULL, id) THEN true
+      WHEN app.user_has_role_for_org('super_admin', organization_id, NULL, id) THEN true
+      WHEN app.user_has_role_for_org('therapist', organization_id, NULL, id) THEN (
+        EXISTS (
+          SELECT 1
+          FROM public.sessions s
+          WHERE s.client_id = public.clients.id
+            AND s.therapist_id = auth.uid()
+        )
+        AND public.clients.deleted_at IS NULL
+      )
+      ELSE false
+    END
+  );
+
+CREATE OR REPLACE FUNCTION app.set_client_archive_state(
+  p_client_id uuid,
+  p_restore boolean DEFAULT false
+)
+RETURNS public.clients
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_client public.clients;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+  INTO v_client
+  FROM public.clients
+  WHERE id = p_client_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Client not found' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NOT (
+    app.user_has_role_for_org('admin', v_client.organization_id, NULL, v_client.id)
+    OR app.user_has_role_for_org('super_admin', v_client.organization_id, NULL, v_client.id)
+  ) THEN
+    RAISE EXCEPTION 'Only organization admins may update archive state'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF p_restore THEN
+    UPDATE public.clients
+    SET deleted_at = NULL,
+        deleted_by = NULL,
+        updated_at = timezone('utc', now()),
+        updated_by = v_actor
+    WHERE id = p_client_id
+    RETURNING * INTO v_client;
+  ELSE
+    UPDATE public.clients
+    SET deleted_at = timezone('utc', now()),
+        deleted_by = v_actor,
+        updated_at = timezone('utc', now()),
+        updated_by = v_actor
+    WHERE id = p_client_id
+    RETURNING * INTO v_client;
+  END IF;
+
+  RETURN v_client;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION app.set_client_archive_state(uuid, boolean) TO authenticated;
+
+CREATE OR REPLACE FUNCTION app.set_therapist_archive_state(
+  p_therapist_id uuid,
+  p_restore boolean DEFAULT false
+)
+RETURNS public.therapists
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_therapist public.therapists;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+  INTO v_therapist
+  FROM public.therapists
+  WHERE id = p_therapist_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Therapist not found' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NOT (
+    app.user_has_role_for_org('admin', v_therapist.organization_id, v_therapist.id)
+    OR app.user_has_role_for_org('super_admin', v_therapist.organization_id, v_therapist.id)
+  ) THEN
+    RAISE EXCEPTION 'Only organization admins may update archive state'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF p_restore THEN
+    UPDATE public.therapists
+    SET deleted_at = NULL,
+        deleted_by = NULL
+    WHERE id = p_therapist_id
+    RETURNING * INTO v_therapist;
+  ELSE
+    UPDATE public.therapists
+    SET deleted_at = timezone('utc', now()),
+        deleted_by = v_actor
+    WHERE id = p_therapist_id
+    RETURNING * INTO v_therapist;
+  END IF;
+
+  RETURN v_therapist;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION app.set_therapist_archive_state(uuid, boolean) TO authenticated;
+
+COMMIT;

--- a/tests/admins/archive_soft_delete.spec.ts
+++ b/tests/admins/archive_soft_delete.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+
+const SUPABASE_URL = process.env.SUPABASE_URL as string;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY as string;
+
+async function callRpc(
+  functionName: string,
+  token: string,
+  payload: Record<string, unknown>,
+) {
+  const response = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${functionName}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  let json: unknown = null;
+  try {
+    json = await response.json();
+  } catch (error) {
+    // Some RPCs can return 204 with no content
+  }
+
+  return { status: response.status, json };
+}
+
+async function fetchRow(
+  table: 'clients' | 'therapists',
+  token: string,
+  filters: string,
+) {
+  const response = await fetch(`${SUPABASE_URL}/rest/v1/${table}?select=id,organization_id,deleted_at&${filters}`, {
+    method: 'GET',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+      Prefer: 'return=representation',
+    },
+  });
+
+  const json = (await response.json()) as unknown;
+  const row = Array.isArray(json) ? json[0] as { id: string; organization_id: string | null; deleted_at: string | null } : null;
+
+  return { status: response.status, row };
+}
+
+describe('Soft delete archive controls', () => {
+  const tokenOrgA = process.env.TEST_JWT_ORG_A as string;
+  const tokenOrgB = process.env.TEST_JWT_ORG_B as string;
+
+  it('enforces organization scoped archive controls for clients', async () => {
+    if (!tokenOrgA || !tokenOrgB) return;
+
+    const { row: client } = await fetchRow('clients', tokenOrgA, 'deleted_at=is.null&limit=1');
+    expect(client).toBeTruthy();
+    if (!client) return;
+
+    const archiveResult = await callRpc('set_client_archive_state', tokenOrgA, {
+      p_client_id: client.id,
+      p_restore: false,
+    });
+    expect([200, 204]).toContain(archiveResult.status);
+    expect((archiveResult.json as { deleted_at?: string | null } | null)?.deleted_at).toBeTruthy();
+
+    const crossOrg = await callRpc('set_client_archive_state', tokenOrgB, {
+      p_client_id: client.id,
+      p_restore: true,
+    });
+    expect([401, 403, 400]).toContain(crossOrg.status);
+
+    const { row: archivedRow } = await fetchRow('clients', tokenOrgA, `id=eq.${client.id}`);
+    expect(archivedRow?.deleted_at).toBeTruthy();
+
+    const restoreResult = await callRpc('set_client_archive_state', tokenOrgA, {
+      p_client_id: client.id,
+      p_restore: true,
+    });
+    expect([200, 204]).toContain(restoreResult.status);
+
+    const { row: restoredRow } = await fetchRow('clients', tokenOrgA, `id=eq.${client.id}`);
+    expect(restoredRow?.deleted_at).toBeNull();
+  });
+
+  it('enforces organization scoped archive controls for therapists', async () => {
+    if (!tokenOrgA || !tokenOrgB) return;
+
+    const { row: therapist } = await fetchRow('therapists', tokenOrgA, 'deleted_at=is.null&limit=1');
+    expect(therapist).toBeTruthy();
+    if (!therapist) return;
+
+    const archiveResult = await callRpc('set_therapist_archive_state', tokenOrgA, {
+      p_therapist_id: therapist.id,
+      p_restore: false,
+    });
+    expect([200, 204]).toContain(archiveResult.status);
+    expect((archiveResult.json as { deleted_at?: string | null } | null)?.deleted_at).toBeTruthy();
+
+    const crossOrg = await callRpc('set_therapist_archive_state', tokenOrgB, {
+      p_therapist_id: therapist.id,
+      p_restore: true,
+    });
+    expect([401, 403, 400]).toContain(crossOrg.status);
+
+    const { row: archivedRow } = await fetchRow('therapists', tokenOrgA, `id=eq.${therapist.id}`);
+    expect(archivedRow?.deleted_at).toBeTruthy();
+
+    const restoreResult = await callRpc('set_therapist_archive_state', tokenOrgA, {
+      p_therapist_id: therapist.id,
+      p_restore: true,
+    });
+    expect([200, 204]).toContain(restoreResult.status);
+
+    const { row: restoredRow } = await fetchRow('therapists', tokenOrgA, `id=eq.${therapist.id}`);
+    expect(restoredRow?.deleted_at).toBeNull();
+  });
+});


### PR DESCRIPTION
### Summary
Add soft-delete enforcement for clients and therapists across database, API, and UI flows.

### Proposed changes
- Extend clients/therapists tables with archive metadata, RLS triggers, and RPC helpers for toggling state.
- Update Supabase edge functions and React pages to respect archived records, including restore actions and filters.
- Add regression and unit tests covering archive filtering and org-scoped permissions.

### Tests added/updated
- src/pages/__tests__/Clients.test.tsx
- src/pages/__tests__/Therapists.test.tsx
- tests/admins/archive_soft_delete.spec.ts

### Checklist
- [ ] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [x] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68dbd41a6a108332890b755d9488f97a