### PR TITLE
feat: add super-admin impersonation console – 2025-02-14

### DIFF
--- a/src/components/TherapistModal.tsx
+++ b/src/components/TherapistModal.tsx
@@ -127,7 +127,7 @@ export function TherapistModal({
             <h3 className="text-lg font-medium text-blue-900 dark:text-blue-100 mb-4">General Information</h3>
             <div className="grid grid-cols-3 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-first-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   First Name
                 </label>
                 <input
@@ -149,10 +149,11 @@ export function TherapistModal({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-middle-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Middle Name
                 </label>
                 <input
+                  id="therapist-middle-name"
                   type="text"
                   {...register('middle_name')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
@@ -160,7 +161,7 @@ export function TherapistModal({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-last-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Last Name
                 </label>
                 <input
@@ -184,7 +185,7 @@ export function TherapistModal({
 
             <div className="grid grid-cols-2 gap-4 mt-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Email
                 </label>
                 <input
@@ -206,10 +207,11 @@ export function TherapistModal({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-phone" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Phone
                 </label>
                 <input
+                  id="therapist-phone"
                   type="tel"
                   {...register('phone')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
@@ -219,10 +221,11 @@ export function TherapistModal({
 
             <div className="grid grid-cols-3 gap-4 mt-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-staff-id" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Staff ID
                 </label>
                 <input
+                  id="therapist-staff-id"
                   type="text"
                   {...register('staff_id')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
@@ -230,10 +233,11 @@ export function TherapistModal({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Title
                 </label>
                 <select
+                  id="therapist-title"
                   {...register('title')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                 >
@@ -247,10 +251,11 @@ export function TherapistModal({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-employee-type" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Employee Type
                 </label>
                 <select
+                  id="therapist-employee-type"
                   {...register('employee_type')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                 >
@@ -264,10 +269,11 @@ export function TherapistModal({
 
             <div className="grid grid-cols-2 gap-4 mt-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-status" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Status
                 </label>
                 <select
+                  id="therapist-status"
                   {...register('status')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                 >
@@ -412,7 +418,7 @@ export function TherapistModal({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-license-number" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   License Number
                 </label>
                 <input
@@ -434,10 +440,11 @@ export function TherapistModal({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-practitioner-id" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Practitioner ID
                 </label>
                 <input
+                  id="therapist-practitioner-id"
                   type="text"
                   {...register('practitioner_id')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
@@ -445,10 +452,11 @@ export function TherapistModal({
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="therapist-taxonomy-code" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Taxonomy Code
                 </label>
                 <input
+                  id="therapist-taxonomy-code"
                   type="text"
                   {...register('taxonomy_code')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"

--- a/src/components/TherapistOnboarding.tsx
+++ b/src/components/TherapistOnboarding.tsx
@@ -125,6 +125,7 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
     formState: { errors },
     setFocus,
     trigger,
+    getFieldState,
   } = useForm<OnboardingFormData>({
     resolver: zodResolver(therapistOnboardingSchema),
     defaultValues: {
@@ -288,6 +289,10 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
     if (fieldsToValidate) {
       const isValid = await trigger(fieldsToValidate);
       if (!isValid) {
+        const firstInvalidField = fieldsToValidate.find(field => getFieldState(field).invalid);
+        if (firstInvalidField) {
+          setFocus(firstInvalidField);
+        }
         return;
       }
     }
@@ -308,7 +313,7 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
             
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="onboarding-first-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   First Name
                 </label>
                 <input
@@ -330,10 +335,11 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="onboarding-middle-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Middle Name
                 </label>
                 <input
+                  id="onboarding-middle-name"
                   type="text"
                   {...register('middle_name')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
@@ -341,7 +347,7 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="onboarding-last-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Last Name
                 </label>
                 <input
@@ -365,7 +371,7 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="onboarding-email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Email
                 </label>
                 <input
@@ -387,10 +393,11 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="onboarding-phone" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Phone
                 </label>
                 <input
+                  id="onboarding-phone"
                   type="tel"
                   {...register('phone')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
@@ -398,10 +405,11 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="onboarding-title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Title
                 </label>
                 <select
+                  id="onboarding-title"
                   {...register('title')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                 >
@@ -419,10 +427,11 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="onboarding-employee-type" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Employee Type
                 </label>
                 <select
+                  id="onboarding-employee-type"
                   {...register('employee_type')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                 >
@@ -434,10 +443,11 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="onboarding-staff-id" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Staff ID
                 </label>
                 <input
+                  id="onboarding-staff-id"
                   type="text"
                   {...register('staff_id')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
@@ -445,10 +455,11 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <label htmlFor="onboarding-status" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Status
                 </label>
                 <select
+                  id="onboarding-status"
                   {...register('status')}
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                 >
@@ -470,43 +481,47 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
               <h3 className="text-md font-medium text-blue-800 dark:text-blue-200 mb-2">Credentials & Identifiers</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  <label htmlFor="onboarding-npi-number" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     NPI Number
                   </label>
                   <input
+                    id="onboarding-npi-number"
                     type="text"
                     {...register('npi_number')}
                     className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  <label htmlFor="onboarding-medicaid-id" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     Medicaid ID
                   </label>
                   <input
+                    id="onboarding-medicaid-id"
                     type="text"
                     {...register('medicaid_id')}
                     className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                   />
-                </div>
+                  </div>
               </div>
-              
+
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  <label htmlFor="onboarding-rbt-number" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     RBT Number
                   </label>
                   <input
+                    id="onboarding-rbt-number"
                     type="text"
                     {...register('rbt_number')}
                     className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  <label htmlFor="onboarding-bcba-number" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     BCBA Number
                   </label>
                   <input
+                    id="onboarding-bcba-number"
                     type="text"
                     {...register('bcba_number')}
                     className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
@@ -516,7 +531,7 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  <label htmlFor="onboarding-license-number" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     License Number
                   </label>
                   <input
@@ -540,20 +555,22 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  <label htmlFor="onboarding-practitioner-id" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     Practitioner ID
                   </label>
                   <input
+                    id="onboarding-practitioner-id"
                     type="text"
                     {...register('practitioner_id')}
                     className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  <label htmlFor="onboarding-taxonomy-code" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                     Taxonomy Code
                   </label>
                   <input
+                    id="onboarding-taxonomy-code"
                     type="text"
                     {...register('taxonomy_code')}
                     className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
@@ -841,7 +858,7 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
               </div>
               
               <div className="border border-gray-300 dark:border-gray-600 rounded-lg p-4">
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                <label htmlFor="license" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                   License/Certification
                 </label>
                 <div className="flex items-center">

--- a/src/lib/__tests__/impersonation.test.ts
+++ b/src/lib/__tests__/impersonation.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildImpersonationIssuePayload,
+  clampImpersonationMinutes,
+  DEFAULT_IMPERSONATION_MINUTES,
+  getExpiryCountdownLabel,
+  shouldAutoRevoke,
+  validateImpersonationScope,
+} from '../impersonation';
+
+describe('impersonation helpers', () => {
+  it('validates organization scope and throws for mismatches', () => {
+    expect(() => validateImpersonationScope('org-1', 'org-1')).not.toThrow();
+    expect(() => validateImpersonationScope(null, 'org-1')).toThrow(/Actor organization is required/i);
+    expect(() => validateImpersonationScope('org-1', null)).toThrow(/Target organization is required/i);
+    expect(() => validateImpersonationScope('org-1', 'org-2')).toThrow(/Cross-organization impersonation/i);
+  });
+
+  it('clamps impersonation minutes to configured bounds', () => {
+    expect(clampImpersonationMinutes(undefined)).toBe(DEFAULT_IMPERSONATION_MINUTES);
+    expect(clampImpersonationMinutes(0)).toBe(1);
+    expect(clampImpersonationMinutes(45)).toBe(30);
+    expect(clampImpersonationMinutes(10.6)).toBe(11);
+  });
+
+  it('builds an impersonation payload with a sanitized reason', () => {
+    const fixedNow = new Date('2025-06-01T12:00:00Z');
+    const { body, expiresAt, expiresInMinutes } = buildImpersonationIssuePayload({
+      actorOrganizationId: 'org-1234',
+      targetOrganizationId: 'org-1234',
+      targetUserId: 'user-9999',
+      requestedMinutes: 9,
+      reason: '  Investigating access issue  ',
+      now: fixedNow,
+    });
+
+    expect(body).toEqual({
+      action: 'issue',
+      targetUserId: 'user-9999',
+      targetUserEmail: undefined,
+      expiresInMinutes: 9,
+      reason: 'Investigating access issue',
+    });
+    expect(expiresInMinutes).toBe(9);
+    expect(expiresAt).toBe('2025-06-01T12:09:00.000Z');
+  });
+
+  it('calculates countdown labels and automatic revocation', () => {
+    const now = new Date('2025-06-01T12:00:00Z');
+    const future = '2025-06-01T12:05:30.000Z';
+    expect(getExpiryCountdownLabel(future, now)).toBe('05:30');
+
+    const past = '2025-06-01T11:59:00.000Z';
+    expect(shouldAutoRevoke(past, null, now)).toBe(true);
+    expect(shouldAutoRevoke(future, null, now)).toBe(false);
+    expect(shouldAutoRevoke(future, '2025-06-01T12:01:00.000Z', now)).toBe(false);
+  });
+});

--- a/src/lib/impersonation.ts
+++ b/src/lib/impersonation.ts
@@ -1,0 +1,131 @@
+import { differenceInSeconds } from 'date-fns';
+
+export const MAX_IMPERSONATION_MINUTES = 30;
+export const MIN_IMPERSONATION_MINUTES = 1;
+export const DEFAULT_IMPERSONATION_MINUTES = 15;
+
+export interface ImpersonationAuditRecord {
+  id: string;
+  actor_user_id: string;
+  target_user_id: string;
+  actor_organization_id: string;
+  target_organization_id: string;
+  token_jti: string;
+  issued_at: string;
+  expires_at: string;
+  revoked_at: string | null;
+  reason: string | null;
+}
+
+export interface BuildImpersonationPayloadOptions {
+  actorOrganizationId: string | null | undefined;
+  targetOrganizationId: string | null | undefined;
+  targetUserId?: string;
+  targetUserEmail?: string;
+  requestedMinutes?: number;
+  reason?: string;
+  now?: Date;
+}
+
+export interface ImpersonationIssueBody {
+  action: 'issue';
+  targetUserId?: string;
+  targetUserEmail?: string;
+  expiresInMinutes: number;
+  reason?: string;
+}
+
+export interface ImpersonationIssuePayloadResult {
+  body: ImpersonationIssueBody;
+  expiresAt: string;
+  expiresInMinutes: number;
+}
+
+export const clampImpersonationMinutes = (value?: number): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return DEFAULT_IMPERSONATION_MINUTES;
+  }
+
+  const rounded = Math.round(value);
+  const clamped = Math.max(MIN_IMPERSONATION_MINUTES, Math.min(MAX_IMPERSONATION_MINUTES, rounded));
+  return clamped;
+};
+
+export const validateImpersonationScope = (
+  actorOrganizationId: string | null | undefined,
+  targetOrganizationId: string | null | undefined,
+): void => {
+  if (!actorOrganizationId) {
+    throw new Error('Actor organization is required for impersonation.');
+  }
+
+  if (!targetOrganizationId) {
+    throw new Error('Target organization is required for impersonation.');
+  }
+
+  if (actorOrganizationId !== targetOrganizationId) {
+    throw new Error('Cross-organization impersonation is not permitted.');
+  }
+};
+
+const normaliseReason = (reason?: string): string | undefined => {
+  if (typeof reason !== 'string') {
+    return undefined;
+  }
+  const trimmed = reason.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+export const buildImpersonationIssuePayload = (
+  options: BuildImpersonationPayloadOptions,
+): ImpersonationIssuePayloadResult => {
+  validateImpersonationScope(options.actorOrganizationId, options.targetOrganizationId);
+
+  if (!options.targetUserId && !options.targetUserEmail) {
+    throw new Error('Either target user ID or email must be provided.');
+  }
+
+  const expiresInMinutes = clampImpersonationMinutes(options.requestedMinutes);
+  const issuedAt = options.now ?? new Date();
+  const expiresAtDate = new Date(issuedAt.getTime() + expiresInMinutes * 60_000);
+
+  const body: ImpersonationIssueBody = {
+    action: 'issue',
+    targetUserId: options.targetUserId || undefined,
+    targetUserEmail: options.targetUserEmail || undefined,
+    expiresInMinutes,
+  };
+
+  const reason = normaliseReason(options.reason);
+  if (reason) {
+    body.reason = reason;
+  }
+
+  return {
+    body,
+    expiresAt: expiresAtDate.toISOString(),
+    expiresInMinutes,
+  };
+};
+
+export const getExpiryCountdownLabel = (expiresAtIso: string, now: Date = new Date()): string => {
+  const expiresAt = new Date(expiresAtIso);
+  const totalSeconds = Math.max(0, differenceInSeconds(expiresAt, now));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const paddedMinutes = minutes.toString().padStart(2, '0');
+  const paddedSeconds = seconds.toString().padStart(2, '0');
+  return `${paddedMinutes}:${paddedSeconds}`;
+};
+
+export const shouldAutoRevoke = (
+  expiresAtIso: string,
+  revokedAtIso: string | null,
+  now: Date = new Date(),
+): boolean => {
+  if (revokedAtIso) {
+    return false;
+  }
+  const expiresAt = new Date(expiresAtIso);
+  return expiresAt.getTime() <= now.getTime();
+};

--- a/src/pages/SuperAdminImpersonation.tsx
+++ b/src/pages/SuperAdminImpersonation.tsx
@@ -1,0 +1,395 @@
+import React, { useMemo, useState, useEffect, useRef } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../lib/authContext';
+import { showSuccess, showError } from '../lib/toast';
+import { logger } from '../lib/logger/logger';
+import { toError } from '../lib/logger/normalizeError';
+import {
+  buildImpersonationIssuePayload,
+  DEFAULT_IMPERSONATION_MINUTES,
+  getExpiryCountdownLabel,
+  ImpersonationAuditRecord,
+  MAX_IMPERSONATION_MINUTES,
+  MIN_IMPERSONATION_MINUTES,
+  shouldAutoRevoke,
+  validateImpersonationScope,
+} from '../lib/impersonation';
+
+const resolveOrganizationId = (metadata: Record<string, unknown> | null | undefined): string | null => {
+  if (!metadata) return null;
+  const orgId = metadata.organization_id;
+  if (typeof orgId === 'string' && orgId.length > 0) {
+    return orgId;
+  }
+  const camel = metadata.organizationId;
+  if (typeof camel === 'string' && camel.length > 0) {
+    return camel;
+  }
+  return null;
+};
+
+export const SuperAdminImpersonation: React.FC = () => {
+  const { user, profile } = useAuth();
+  const queryClient = useQueryClient();
+  const [targetUserId, setTargetUserId] = useState('');
+  const [targetUserEmail, setTargetUserEmail] = useState('');
+  const [targetOrganizationId, setTargetOrganizationId] = useState('');
+  const [expiresInMinutes, setExpiresInMinutes] = useState<number>(DEFAULT_IMPERSONATION_MINUTES);
+  const [reason, setReason] = useState('');
+  const [issuedToken, setIssuedToken] = useState<string | null>(null);
+  const [issuedExpiresAt, setIssuedExpiresAt] = useState<string | null>(null);
+  const [now, setNow] = useState(new Date());
+  const autoRevokedRef = useRef<Set<string>>(new Set());
+
+  const actorOrganizationId = useMemo(() => {
+    const metadata = user?.user_metadata as Record<string, unknown> | undefined;
+    return resolveOrganizationId(metadata ?? null);
+  }, [user]);
+
+  useEffect(() => {
+    if (actorOrganizationId && !targetOrganizationId) {
+      setTargetOrganizationId(actorOrganizationId);
+    }
+  }, [actorOrganizationId, targetOrganizationId]);
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const impersonationsQuery = useQuery({
+    queryKey: ['impersonation-audit'],
+    enabled: profile?.role === 'super_admin',
+    refetchInterval: 15000,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('impersonation_audit')
+        .select(`
+          id,
+          actor_user_id,
+          target_user_id,
+          actor_organization_id,
+          target_organization_id,
+          token_jti,
+          issued_at,
+          expires_at,
+          revoked_at,
+          reason
+        `)
+        .order('issued_at', { ascending: false });
+
+      if (error) {
+        logger.error('Failed to load impersonation audit entries', {
+          error: toError(error, 'Impersonation audit fetch failed'),
+        });
+        throw error;
+      }
+
+      return (data ?? []) as ImpersonationAuditRecord[];
+    },
+  });
+
+  const issueMutation = useMutation<
+    { token: string; expiresAt: string; auditId: string; expiresInMinutes: number },
+    Error,
+    void
+  >({
+    mutationFn: async () => {
+      const payload = buildImpersonationIssuePayload({
+        actorOrganizationId,
+        targetOrganizationId,
+        targetUserId: targetUserId.trim() || undefined,
+        targetUserEmail: targetUserEmail.trim() || undefined,
+        requestedMinutes: expiresInMinutes,
+        reason,
+      });
+
+      const { data, error } = await supabase.functions.invoke('super-admin-impersonate', {
+        body: payload.body,
+      });
+
+      if (error) {
+        throw new Error(error.message ?? 'Failed to issue impersonation token');
+      }
+
+      const response = data as { token: string; expiresAt: string; auditId: string; expiresInMinutes: number } | null;
+
+      if (!response || typeof response.token !== 'string' || typeof response.expiresAt !== 'string') {
+        throw new Error('Unexpected response from impersonation service');
+      }
+
+      return response;
+    },
+    onSuccess: data => {
+      setIssuedToken(data.token);
+      setIssuedExpiresAt(data.expiresAt);
+      showSuccess('Impersonation token issued successfully');
+      queryClient.invalidateQueries({ queryKey: ['impersonation-audit'] });
+      setReason('');
+      setTargetUserId('');
+      setTargetUserEmail('');
+    },
+    onError: error => {
+      logger.error('Failed to issue impersonation token', {
+        error: toError(error, 'Impersonation issuance failed'),
+      });
+      showError(error);
+    },
+  });
+
+  const revokeMutation = useMutation<
+    { revoked: boolean; auditId: string },
+    Error,
+    { auditId: string; silent?: boolean }
+  >({
+    mutationFn: async ({ auditId }) => {
+      const { data, error } = await supabase.functions.invoke('super-admin-impersonate', {
+        body: { action: 'revoke', auditId },
+      });
+
+      if (error) {
+        throw new Error(error.message ?? 'Failed to revoke impersonation token');
+      }
+
+      const response = data as { revoked: boolean; auditId: string } | null;
+
+      if (!response || !response.revoked) {
+        throw new Error('Unexpected response when revoking impersonation token');
+      }
+
+      return response;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['impersonation-audit'] });
+      if (!variables.silent) {
+        showSuccess('Impersonation token revoked');
+      }
+    },
+    onError: error => {
+      logger.error('Failed to revoke impersonation token', {
+        error: toError(error, 'Impersonation revoke failed'),
+      });
+      showError(error);
+    },
+  });
+
+  useEffect(() => {
+    if (!impersonationsQuery.data) {
+      autoRevokedRef.current.clear();
+      return;
+    }
+
+    const activeIds = new Set(impersonationsQuery.data.map(entry => entry.id));
+    autoRevokedRef.current.forEach(id => {
+      if (!activeIds.has(id)) {
+        autoRevokedRef.current.delete(id);
+      }
+    });
+
+    impersonationsQuery.data.forEach(entry => {
+      if (shouldAutoRevoke(entry.expires_at, entry.revoked_at, now) && !autoRevokedRef.current.has(entry.id)) {
+        autoRevokedRef.current.add(entry.id);
+        revokeMutation.mutate({ auditId: entry.id, silent: true });
+      }
+    });
+  }, [impersonationsQuery.data, now, revokeMutation]);
+
+  if (profile?.role !== 'super_admin') {
+    return (
+      <div className="p-8">
+        <h1 className="text-2xl font-semibold text-slate-900">Super Admin Impersonation</h1>
+        <p className="mt-4 text-sm text-slate-600">
+          You must be a super admin to issue impersonation tokens.
+        </p>
+      </div>
+    );
+  }
+
+  const handleIssue = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    try {
+      validateImpersonationScope(actorOrganizationId, targetOrganizationId || null);
+    } catch (error) {
+      showError(error);
+      return;
+    }
+
+    if (!targetUserId.trim() && !targetUserEmail.trim()) {
+      showError(new Error('Provide a target user ID or email.'));
+      return;
+    }
+
+    const confirmed = window.confirm('Issue a short-lived impersonation token for the selected user?');
+    if (!confirmed) return;
+
+    try {
+      await issueMutation.mutateAsync();
+    } catch {
+      // Error surfaced via onError handler.
+    }
+  };
+
+  const handleRevoke = (auditId: string) => {
+    const confirmed = window.confirm('Revoke this impersonation token?');
+    if (!confirmed) return;
+    revokeMutation.mutate({ auditId });
+  };
+
+  const impersonations = impersonationsQuery.data ?? [];
+
+  return (
+    <div className="mx-auto max-w-5xl p-8">
+      <h1 className="text-3xl font-semibold text-slate-900">Super Admin Impersonation</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Issue short-lived impersonation tokens for secure troubleshooting. Tokens automatically expire and are revoked within {MAX_IMPERSONATION_MINUTES} minutes.
+      </p>
+
+      <form className="mt-6 rounded-lg border border-slate-200 bg-white p-6 shadow-sm" onSubmit={handleIssue}>
+        <h2 className="text-xl font-semibold text-slate-900">Issue token</h2>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <div className="md:col-span-1">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="target-user-id">Target user ID</label>
+            <input
+              id="target-user-id"
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              value={targetUserId}
+              onChange={event => setTargetUserId(event.target.value)}
+              placeholder="uuid-of-user"
+            />
+            <p className="mt-1 text-xs text-slate-500">Provide either the user ID or email address.</p>
+          </div>
+          <div className="md:col-span-1">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="target-user-email">Target user email</label>
+            <input
+              id="target-user-email"
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              value={targetUserEmail}
+              onChange={event => setTargetUserEmail(event.target.value)}
+              placeholder="user@example.com"
+              type="email"
+            />
+          </div>
+          <div className="md:col-span-1">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="target-org">Target organization ID</label>
+            <input
+              id="target-org"
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              value={targetOrganizationId}
+              onChange={event => setTargetOrganizationId(event.target.value)}
+              placeholder="organization uuid"
+              required
+            />
+          </div>
+          <div className="md:col-span-1">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="expires-minutes">Duration (minutes)</label>
+          <input
+            id="expires-minutes"
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            type="number"
+            min={MIN_IMPERSONATION_MINUTES}
+            max={MAX_IMPERSONATION_MINUTES}
+            value={expiresInMinutes}
+            onChange={event => {
+              const nextValue = Number(event.target.value);
+              setExpiresInMinutes(Number.isNaN(nextValue) ? DEFAULT_IMPERSONATION_MINUTES : nextValue);
+            }}
+          />
+            <p className="mt-1 text-xs text-slate-500">Must be between {MIN_IMPERSONATION_MINUTES} and {MAX_IMPERSONATION_MINUTES} minutes.</p>
+          </div>
+        </div>
+        <div className="mt-4">
+          <label className="block text-sm font-medium text-slate-700" htmlFor="impersonation-reason">Reason</label>
+          <textarea
+            id="impersonation-reason"
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            rows={3}
+            value={reason}
+            onChange={event => setReason(event.target.value)}
+            placeholder="Document the justification for impersonation"
+            required
+          />
+          <p className="mt-1 text-xs text-slate-500">This reason will be recorded in the audit trail.</p>
+        </div>
+        <div className="mt-6 flex items-center gap-3">
+          <button
+            type="submit"
+            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-slate-400"
+            disabled={issueMutation.isPending}
+          >
+            {issueMutation.isPending ? 'Issuing token…' : 'Issue impersonation token'}
+          </button>
+          <span className="text-xs text-slate-500">Token expires automatically after the configured duration.</span>
+        </div>
+      </form>
+
+      {issuedToken && issuedExpiresAt && (
+        <div className="mt-6 rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900">
+          <p className="font-semibold">Token issued</p>
+          <p className="mt-1 break-all font-mono">{issuedToken}</p>
+          <p className="mt-2 text-xs">Expires at {new Date(issuedExpiresAt).toLocaleString()}</p>
+        </div>
+      )}
+
+      <div className="mt-8 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-slate-900">Active impersonation tokens</h2>
+          <span className="text-sm text-slate-500">Auto-refreshing every 15 seconds</span>
+        </div>
+        {impersonationsQuery.isLoading ? (
+          <p className="mt-4 text-sm text-slate-500">Loading impersonation activity…</p>
+        ) : impersonations.length === 0 ? (
+          <p className="mt-4 text-sm text-slate-500">No impersonation activity recorded.</p>
+        ) : (
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200">
+              <thead className="bg-slate-50">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Target user</th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Reason</th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Issued</th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Expires in</th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Status</th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-600">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 bg-white">
+                {impersonations.map(entry => {
+                  const countdown = getExpiryCountdownLabel(entry.expires_at, now);
+                  const isExpired = shouldAutoRevoke(entry.expires_at, entry.revoked_at, now);
+                  const statusColor = entry.revoked_at ? 'text-rose-600' : isExpired ? 'text-amber-600' : 'text-emerald-600';
+                  return (
+                    <tr key={entry.id}>
+                      <td className="whitespace-nowrap px-4 py-2 text-sm text-slate-800">{entry.target_user_id}</td>
+                      <td className="max-w-xs px-4 py-2 text-sm text-slate-600">{entry.reason ?? '—'}</td>
+                      <td className="whitespace-nowrap px-4 py-2 text-sm text-slate-600">{new Date(entry.issued_at).toLocaleString()}</td>
+                      <td className="whitespace-nowrap px-4 py-2 text-sm text-slate-600">{countdown}</td>
+                      <td className={`whitespace-nowrap px-4 py-2 text-sm font-medium ${statusColor}`}>
+                        {entry.revoked_at ? 'Revoked' : isExpired ? 'Expired' : 'Active'}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-2 text-sm text-slate-600">
+                        {entry.revoked_at ? (
+                          <span className="text-xs text-slate-400">—</span>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => handleRevoke(entry.id)}
+                            className="rounded-md border border-rose-200 px-3 py-1 text-xs font-medium text-rose-600 hover:bg-rose-50"
+                            disabled={revokeMutation.isPending}
+                          >
+                            Revoke
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/__tests__/SuperAdminImpersonation.test.tsx
+++ b/src/pages/__tests__/SuperAdminImpersonation.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../test/utils';
+import { SuperAdminImpersonation } from '../SuperAdminImpersonation';
+import { supabase } from '../../lib/supabase';
+import * as authContext from '../../lib/authContext';
+import * as toast from '../../lib/toast';
+import { logger } from '../../lib/logger/logger';
+
+const selectMock = vi.fn();
+const orderMock = vi.fn();
+let invokeSpy: ReturnType<typeof vi.spyOn>;
+let fromSpy: ReturnType<typeof vi.spyOn>;
+let useAuthSpy: ReturnType<typeof vi.spyOn>;
+let showSuccessSpy: ReturnType<typeof vi.spyOn>;
+let showErrorSpy: ReturnType<typeof vi.spyOn>;
+let loggerSpy: ReturnType<typeof vi.spyOn>;
+const originalConfirm = window.confirm;
+
+beforeEach(() => {
+  window.confirm = vi.fn(() => true);
+  selectMock.mockReset();
+  orderMock.mockReset();
+
+  invokeSpy = vi.spyOn(supabase.functions, 'invoke');
+  fromSpy = vi.spyOn(supabase, 'from');
+  orderMock.mockResolvedValue({ data: [], error: null });
+  fromSpy.mockImplementation(() => ({
+    select: (...args: unknown[]) => {
+      selectMock(...args);
+      return { order: orderMock };
+    },
+  }));
+
+  useAuthSpy = vi.spyOn(authContext, 'useAuth');
+  useAuthSpy.mockReturnValue({
+    user: { user_metadata: { organization_id: 'org-123' } },
+    profile: { role: 'super_admin' },
+  } as unknown as ReturnType<typeof authContext.useAuth>);
+
+  showSuccessSpy = vi.spyOn(toast, 'showSuccess').mockImplementation(() => undefined);
+  showErrorSpy = vi.spyOn(toast, 'showError').mockImplementation(() => undefined);
+  loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  window.confirm = originalConfirm;
+  invokeSpy.mockRestore();
+  fromSpy.mockRestore();
+  useAuthSpy.mockRestore();
+  showSuccessSpy.mockRestore();
+  showErrorSpy.mockRestore();
+  loggerSpy.mockRestore();
+  selectMock.mockReset();
+  orderMock.mockReset();
+});
+
+describe('SuperAdminImpersonation page', () => {
+  it('submits impersonation issuance with sanitized payload', async () => {
+    invokeSpy.mockResolvedValue({
+      data: { token: 'token-123', expiresAt: '2025-06-01T12:15:00.000Z', auditId: 'audit-1', expiresInMinutes: 30 },
+      error: null,
+    });
+
+    renderWithProviders(<SuperAdminImpersonation />);
+
+    await userEvent.type(screen.getByLabelText(/Target user ID/i), 'user-456');
+    await userEvent.clear(screen.getByLabelText(/Duration/i));
+    await userEvent.type(screen.getByLabelText(/Duration/i), '45');
+    await userEvent.clear(screen.getByLabelText(/Reason/i));
+    await userEvent.type(screen.getByLabelText(/Reason/i), '  Investigate downtime  ');
+
+    await userEvent.click(screen.getByRole('button', { name: /Issue impersonation token/i }));
+
+    await waitFor(() => {
+      expect(invokeSpy).toHaveBeenCalledWith('super-admin-impersonate', {
+        body: {
+          action: 'issue',
+          targetUserId: 'user-456',
+          targetUserEmail: undefined,
+          expiresInMinutes: 30,
+          reason: 'Investigate downtime',
+        },
+      });
+    });
+
+    expect(showSuccessSpy).toHaveBeenCalled();
+  });
+
+  it('automatically revokes expired impersonation tokens', async () => {
+    const expiredEntry = {
+      id: 'audit-auto',
+      actor_user_id: 'admin-1',
+      target_user_id: 'user-1',
+      actor_organization_id: 'org-123',
+      target_organization_id: 'org-123',
+      token_jti: 'token-jti',
+      issued_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+      expires_at: new Date(Date.now() - 60_000).toISOString(),
+      revoked_at: null,
+      reason: 'Expired automatically',
+    };
+
+    orderMock.mockResolvedValueOnce({ data: [expiredEntry], error: null });
+    invokeSpy.mockResolvedValue({ data: { revoked: true, auditId: 'audit-auto' }, error: null });
+
+    renderWithProviders(<SuperAdminImpersonation />);
+
+    await waitFor(() => {
+      expect(invokeSpy).toHaveBeenCalledWith('super-admin-impersonate', {
+        body: { action: 'revoke', auditId: 'audit-auto' },
+      });
+    });
+
+    expect(showSuccessSpy).not.toHaveBeenCalled();
+    expect(showErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/supabase/functions/super-admin-impersonate/index.ts
+++ b/supabase/functions/super-admin-impersonate/index.ts
@@ -1,0 +1,273 @@
+import { z } from "npm:zod@3.23.8";
+import { SignJWT } from "npm:jose@5.8.0";
+import {
+  createProtectedRoute,
+  corsHeaders,
+  logApiAccess,
+  RouteOptions,
+} from "../_shared/auth-middleware.ts";
+import { createRequestClient, supabaseAdmin } from "../_shared/database.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+const MAX_IMPERSONATION_MINUTES = 30;
+const DEFAULT_IMPERSONATION_MINUTES = 15;
+
+const issueSchema = z
+  .object({
+    action: z.literal("issue").optional(),
+    targetUserId: z.string().uuid().optional(),
+    targetUserEmail: z.string().email().optional(),
+    expiresInMinutes: z
+      .number({ invalid_type_error: "expiresInMinutes must be a number" })
+      .int()
+      .positive()
+      .max(MAX_IMPERSONATION_MINUTES)
+      .optional(),
+    reason: z
+      .string()
+      .trim()
+      .min(1, "Reason cannot be empty")
+      .max(500, "Reason is too long")
+      .optional(),
+  })
+  .refine(
+    payload => Boolean(payload.targetUserId || payload.targetUserEmail),
+    {
+      message: "Either targetUserId or targetUserEmail must be provided",
+      path: ["targetUserId"],
+    },
+  );
+
+const revokeSchema = z.object({
+  action: z.literal("revoke"),
+  auditId: z.string().uuid(),
+});
+
+const resolveOrganizationId = (metadata: JsonRecord | null | undefined): string | null => {
+  if (!metadata) return null;
+  const candidate = ["organization_id", "organizationId"].reduce<string | null>((found, key) => {
+    if (found) return found;
+    const value = metadata[key];
+    return typeof value === "string" && value.length > 0 ? value : null;
+  }, null);
+
+  if (!candidate) return null;
+
+  try {
+    return z.string().uuid().parse(candidate);
+  } catch {
+    return null;
+  }
+};
+
+const sanitizeIpAddress = (value: string | null): string | null => {
+  if (!value) return null;
+  const trimmed = value.split(",")[0]?.trim() ?? "";
+  if (!trimmed) return null;
+  const ipv4Pattern = /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+  const ipv6Pattern = /^([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}$/;
+  return ipv4Pattern.test(trimmed) || ipv6Pattern.test(trimmed) ? trimmed : null;
+};
+
+const toMinutesWithinRange = (value: number | undefined): number => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return DEFAULT_IMPERSONATION_MINUTES;
+  }
+  const minimum = 1;
+  return Math.max(minimum, Math.min(MAX_IMPERSONATION_MINUTES, value));
+};
+
+const buildErrorResponse = (status: number, message: string) =>
+  new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+const getJwtSecret = (): Uint8Array | null => {
+  const secret = Deno.env.get("SUPABASE_JWT_SECRET");
+  if (!secret) {
+    return null;
+  }
+  return new TextEncoder().encode(secret);
+};
+
+const loadTargetUser = async (payload: { targetUserId?: string; targetUserEmail?: string }) => {
+  if (payload.targetUserId) {
+    const { data, error } = await supabaseAdmin.auth.admin.getUserById(payload.targetUserId);
+    return { data, error };
+  }
+
+  if (payload.targetUserEmail) {
+    const { data, error } = await supabaseAdmin.auth.admin.getUserByEmail(payload.targetUserEmail);
+    return { data, error };
+  }
+
+  return { data: { user: null }, error: null };
+};
+
+export default createProtectedRoute(async (req, userContext) => {
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const jwtSecret = getJwtSecret();
+  if (!jwtSecret) {
+    return buildErrorResponse(500, "JWT secret not configured");
+  }
+
+  let rawPayload: unknown;
+  try {
+    rawPayload = await req.json();
+  } catch (error) {
+    console.error("Failed to parse impersonation payload", error);
+    return buildErrorResponse(400, "Invalid JSON payload");
+  }
+
+  const payload = (rawPayload as JsonRecord) ?? {};
+  const action = typeof payload.action === "string" ? payload.action : "issue";
+
+  if (action === "revoke") {
+    const parseResult = revokeSchema.safeParse(payload);
+    if (!parseResult.success) {
+      return buildErrorResponse(400, parseResult.error.issues[0]?.message ?? "Invalid revoke payload");
+    }
+
+    const requestClient = createRequestClient(req);
+    const nowIso = new Date().toISOString();
+    const { data, error } = await requestClient
+      .from("impersonation_audit")
+      .update({ revoked_at: nowIso, revoked_by: userContext.user.id })
+      .eq("id", parseResult.data.auditId)
+      .eq("actor_user_id", userContext.user.id)
+      .is("revoked_at", null)
+      .select("id, revoked_at")
+      .single();
+
+    if (error) {
+      console.error("Failed to revoke impersonation token", error);
+      return buildErrorResponse(400, "Unable to revoke impersonation token");
+    }
+
+    logApiAccess("POST", "/super-admin/impersonate", userContext, 200);
+    return new Response(JSON.stringify({ revoked: true, auditId: data.id, revokedAt: data.revoked_at }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const parseResult = issueSchema.safeParse(payload);
+  if (!parseResult.success) {
+    return buildErrorResponse(400, parseResult.error.issues[0]?.message ?? "Invalid impersonation payload");
+  }
+
+  const requestClient = createRequestClient(req);
+
+  const [{ data: actorData, error: actorError }, { data: targetData, error: targetError }] = await Promise.all([
+    supabaseAdmin.auth.admin.getUserById(userContext.user.id),
+    loadTargetUser(parseResult.data),
+  ]);
+
+  if (actorError || !actorData?.user) {
+    console.error("Failed to load actor metadata", actorError);
+    return buildErrorResponse(500, "Unable to resolve actor metadata");
+  }
+
+  if (targetError || !targetData?.user) {
+    console.error("Failed to load target user", targetError);
+    return buildErrorResponse(404, "Target user not found");
+  }
+
+  const actorMetadata = actorData.user.user_metadata as JsonRecord | undefined;
+  const targetMetadata = targetData.user.user_metadata as JsonRecord | undefined;
+
+  const actorOrganizationId = resolveOrganizationId(actorMetadata);
+  const targetOrganizationId = resolveOrganizationId(targetMetadata);
+
+  if (!actorOrganizationId) {
+    return buildErrorResponse(403, "Actor is missing organization context");
+  }
+
+  if (!targetOrganizationId) {
+    return buildErrorResponse(422, "Target user is missing organization context");
+  }
+
+  if (actorOrganizationId !== targetOrganizationId) {
+    return buildErrorResponse(403, "Cross-organization impersonation is not permitted");
+  }
+
+  const expiresInMinutes = toMinutesWithinRange(parseResult.data.expiresInMinutes);
+  const issuedAt = new Date();
+  const expiresAt = new Date(issuedAt.getTime() + expiresInMinutes * 60_000);
+
+  const tokenJti = crypto.randomUUID();
+  const auditId = crypto.randomUUID();
+  const reason = parseResult.data.reason ?? null;
+
+  const sanitizedIp = sanitizeIpAddress(req.headers.get("x-forwarded-for"));
+  const userAgent = req.headers.get("user-agent") ?? null;
+
+  try {
+    const jwt = await new SignJWT({
+      sub: targetData.user.id,
+      aud: "authenticated",
+      role: targetMetadata?.role ?? "client",
+      impersonation: {
+        actor_user_id: userContext.user.id,
+        audit_id: auditId,
+        actor_role: userContext.profile.role,
+      },
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(Math.floor(issuedAt.getTime() / 1000))
+      .setExpirationTime(`${expiresInMinutes}m`)
+      .setSubject(targetData.user.id)
+      .setJti(tokenJti)
+      .setIssuer("super-admin-impersonate")
+      .sign(jwtSecret);
+
+    const { data: insertedAudit, error: insertError } = await requestClient
+      .from("impersonation_audit")
+      .insert({
+        id: auditId,
+        actor_user_id: userContext.user.id,
+        target_user_id: targetData.user.id,
+        actor_organization_id: actorOrganizationId,
+        target_organization_id: targetOrganizationId,
+        token_jti: tokenJti,
+        issued_at: issuedAt.toISOString(),
+        expires_at: expiresAt.toISOString(),
+        reason,
+        actor_ip: sanitizedIp,
+        actor_user_agent: userAgent,
+      })
+      .select("id, expires_at, token_jti")
+      .single();
+
+    if (insertError || !insertedAudit) {
+      console.error("Failed to persist impersonation audit entry", insertError);
+      return buildErrorResponse(500, "Unable to record impersonation audit");
+    }
+
+    logApiAccess("POST", "/super-admin/impersonate", userContext, 201);
+    return new Response(
+      JSON.stringify({
+        token: jwt,
+        expiresAt: expiresAt.toISOString(),
+        auditId: insertedAudit.id,
+        tokenJti: insertedAudit.token_jti,
+        expiresInMinutes,
+      }),
+      {
+        status: 201,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  } catch (error) {
+    console.error("Failed to issue impersonation token", error);
+    return buildErrorResponse(500, "Failed to create impersonation token");
+  }
+}, RouteOptions.superAdmin);

--- a/supabase/migrations/20251202090000_super_admin_impersonation.sql
+++ b/supabase/migrations/20251202090000_super_admin_impersonation.sql
@@ -1,0 +1,110 @@
+/*
+  # Super Admin Impersonation Audit Log
+
+  1. Changes
+    - Create impersonation_audit table for tracking issued impersonation tokens
+    - Ensure security reviewer role exists for oversight visibility
+    - Enforce RLS so only super admins and security reviewers can read records
+    - Allow super admins to insert and revoke their own tokens with audit metadata
+
+  2. Security
+    - Row Level Security enabled on impersonation_audit
+    - Policies restrict INSERT/UPDATE to the acting super admin (or security reviewers for oversight)
+    - Records capture origin IP/User-Agent and enforce issued/expires timeline integrity
+*/
+
+-- Ensure the security reviewer role exists for oversight access
+INSERT INTO public.roles (name, description)
+VALUES ('security_reviewer', 'Read-only access to impersonation audit trails for security oversight')
+ON CONFLICT (name) DO NOTHING;
+
+-- Create impersonation audit table
+CREATE TABLE IF NOT EXISTS public.impersonation_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  target_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  actor_organization_id uuid NOT NULL,
+  target_organization_id uuid NOT NULL,
+  token_jti uuid NOT NULL UNIQUE,
+  issued_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  reason text,
+  actor_ip inet,
+  actor_user_agent text,
+  revoked_at timestamptz,
+  revoked_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT impersonation_audit_expiry_future CHECK (expires_at > issued_at)
+);
+
+COMMENT ON TABLE public.impersonation_audit IS 'Tracks issuance and revocation of super admin impersonation tokens with audit metadata.';
+COMMENT ON COLUMN public.impersonation_audit.actor_user_id IS 'Super admin issuing the impersonation token.';
+COMMENT ON COLUMN public.impersonation_audit.target_user_id IS 'User account that will be impersonated.';
+COMMENT ON COLUMN public.impersonation_audit.actor_organization_id IS 'Organization scope for the super admin performing the impersonation.';
+COMMENT ON COLUMN public.impersonation_audit.target_organization_id IS 'Organization scope of the impersonated user, used for tenant guardrails.';
+COMMENT ON COLUMN public.impersonation_audit.token_jti IS 'JWT identifier associated with the short-lived impersonation token.';
+COMMENT ON COLUMN public.impersonation_audit.reason IS 'Business justification provided by the super admin.';
+COMMENT ON COLUMN public.impersonation_audit.actor_ip IS 'Origin IP captured from the request headers for audit purposes.';
+COMMENT ON COLUMN public.impersonation_audit.actor_user_agent IS 'Request user agent captured during impersonation issuance.';
+COMMENT ON COLUMN public.impersonation_audit.revoked_at IS 'Timestamp indicating when the impersonation token was revoked.';
+COMMENT ON COLUMN public.impersonation_audit.revoked_by IS 'User responsible for revoking the impersonation token.';
+
+-- Indexes for efficient lookups
+CREATE INDEX IF NOT EXISTS impersonation_audit_actor_idx
+  ON public.impersonation_audit (actor_user_id, expires_at DESC);
+
+CREATE INDEX IF NOT EXISTS impersonation_audit_target_idx
+  ON public.impersonation_audit (target_user_id);
+
+CREATE INDEX IF NOT EXISTS impersonation_audit_active_idx
+  ON public.impersonation_audit (expires_at)
+  WHERE revoked_at IS NULL;
+
+-- Enable row level security and policies
+ALTER TABLE public.impersonation_audit ENABLE ROW LEVEL SECURITY;
+
+-- Read access for oversight roles
+CREATE POLICY impersonation_audit_read
+  ON public.impersonation_audit
+  FOR SELECT
+  TO authenticated
+  USING (
+    auth.user_has_role('super_admin')
+    OR auth.user_has_role('security_reviewer')
+  );
+
+-- Insert limited to the acting super admin so long as org scope matches
+CREATE POLICY impersonation_audit_insert
+  ON public.impersonation_audit
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = actor_user_id
+    AND auth.user_has_role('super_admin')
+    AND actor_organization_id = target_organization_id
+  );
+
+-- Updates only allow revocation metadata adjustments
+CREATE POLICY impersonation_audit_update
+  ON public.impersonation_audit
+  FOR UPDATE
+  TO authenticated
+  USING (
+    auth.uid() = actor_user_id
+    AND auth.user_has_role('super_admin')
+  )
+  WITH CHECK (
+    auth.uid() = actor_user_id
+    AND auth.user_has_role('super_admin')
+    AND auth.uid() = COALESCE(revoked_by, auth.uid())
+  );
+
+-- Prevent deletions from authenticated context to preserve audit history
+CREATE POLICY impersonation_audit_delete
+  ON public.impersonation_audit
+  FOR DELETE
+  TO authenticated
+  USING (false);
+
+-- Ensure service role retains full control for maintenance tasks
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.impersonation_audit TO service_role;


### PR DESCRIPTION
### Summary
Introduce audited impersonation tooling for super administrators.

### Proposed changes
- Add Supabase Edge Function to issue and revoke impersonation tokens with audit logging and JWT expiry enforcement.
- Create an impersonation_audit table migration with RLS limited to super admins and security reviewers.
- Build a Super Admin console page plus supporting utilities/tests to trigger impersonation, display countdowns, and revoke tokens.

### Tests added/updated
- src/lib/__tests__/impersonation.test.ts
- src/pages/__tests__/SuperAdminImpersonation.test.tsx

### Checklist
- [ ] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68dbddd2b2788332a4313da45c1bd96e