### PR TITLE
fix: document env template – 2025-10-02

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,27 +1,53 @@
 #########################################
-# Supabase Environment (Example)
+# Environment configuration template
 #
-# Copy this file to `.env` or `.env.codex` for local development.
-# Never commit real secrets. Use non-production credentials only.
+# Copy this file to `.env.codex` (preferred) or `.env` before running local
+# scripts. The runtime loader in `src/server/env.ts` defaults to `.env.codex`,
+# so keep that filename when possible.
+#
+# Never commit real secrets. Replace every `****` placeholder with project-
+# specific values stored in Codex Secrets or your local shell exports.
 #########################################
 
-# Server-side (Node/server runtime only)
-SUPABASE_URL="https://YOUR-PROJECT-ref.supabase.co"
-SUPABASE_ANON_KEY="eyJhbGciOi...YOUR-ANON-KEY..."
-# Server key for backend scripts/functions only. Never expose to browsers.
-SUPABASE_SERVICE_ROLE_KEY="service-role-****"
+# ---------------------------------------------------------------------------
+# Client-safe Supabase configuration
+# These values are safe to expose in browser bundles and may also be echoed
+# as Vite `VITE_*` variables when building the front end.
+# ---------------------------------------------------------------------------
+SUPABASE_URL=****
+SUPABASE_ANON_KEY=****
+SUPABASE_EDGE_URL=****
 
-# Supabase CLI management only (PAT)
-# Used for commands like `supabase projects list`. Do not send to REST/RPC.
-SUPABASE_ACCESS_TOKEN="ghp_****"
+# Optional Vite mirrors for the browser bundle (keep in sync with the values
+# above if you surface them through Vite's import.meta.env API).
+VITE_SUPABASE_URL=****
+VITE_SUPABASE_ANON_KEY=****
+VITE_SUPABASE_EDGE_URL=****
 
-# Browser (Vite) – used by the client bundle
-# Keep values non-production for local dev
-VITE_SUPABASE_URL="https://YOUR-PROJECT-ref.supabase.co"
-VITE_SUPABASE_ANON_KEY="eyJhbGciOi...YOUR-ANON-KEY..."
+# ---------------------------------------------------------------------------
+# Server-only Supabase secrets
+# These must remain on the server: do not embed them in front-end bundles or
+# check them into source control.
+# ---------------------------------------------------------------------------
+SUPABASE_SERVICE_ROLE_KEY=****
+SUPABASE_ACCESS_TOKEN=****
 
-# Optional overrides
-# VITE_SUPABASE_EDGE_URL="https://YOUR-PROJECT-ref.supabase.co/functions/v1/"
-# NODE_ENV="development"
+# ---------------------------------------------------------------------------
+# AI + third-party integrations (server-only)
+# Keep these secrets in secure storage; the `.env.codex` loader will surface
+# them to backend utilities only.
+# ---------------------------------------------------------------------------
+OPENAI_API_KEY=****
+OPENAI_ORGANIZATION=****
 
+# AWS / S3 configuration
+AWS_REGION=****
+AWS_S3_BUCKET=****
+AWS_ACCESS_KEY_ID=****
+AWS_SECRET_ACCESS_KEY=****
 
+# Email provider (SMTP) configuration
+SMTP_HOST=****
+SMTP_PORT=****
+SMTP_USERNAME=****
+SMTP_PASSWORD=****

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ AllIncompassing delivers therapist scheduling, billing, and operational telemetr
 - **Node.js 18+** and npm or another package manager supported by the repo (pnpm, yarn).
 - **Supabase CLI** (installed globally or via `npx`) with access to the project reference `wnnjeqheqxxyrgsjmygy`.
 - **Environment variables** available in your shell: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_ACCESS_TOKEN`.
-- **Vite runtime env file** – `.env` should provide `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`. Include `VITE_SUPABASE_EDGE_URL` when targeting a custom Edge Functions domain.
+- **Vite runtime env file** – copy `.env.example` to `.env.codex` (preferred) or `.env`, then replace every `****` placeholder. The runtime loader in `src/server/env.ts` reads `.env.codex` by default, so keeping that filename avoids additional configuration. Provide `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, and `VITE_SUPABASE_EDGE_URL` values that mirror the non-prefixed Supabase settings.
 
 > ℹ️ Run `./scripts/setup.sh` to validate Supabase credentials, generate database types, and create the `.env` file automatically. The script also configures `~/.supabase/config.toml` for non-interactive CLI sessions.
 
 ### Bootstrapping the app
 
 1. Install dependencies: `npm install`
-2. Populate the `.env` file (or rerun `./scripts/setup.sh` after exporting Supabase variables).
+2. Copy `.env.example` to `.env.codex` and populate the placeholders (or rerun `./scripts/setup.sh` after exporting Supabase variables).
 3. Start the development server: `npm run dev`
 4. Optional helpers:
    - `npm run dev:clean` – clear caches before launching Vite.


### PR DESCRIPTION
### Summary
Update environment template guidance and documentation for `.env.codex` usage.

### Proposed changes
- Regenerate `.env.example` with redacted placeholders, section comments, and `.env.codex` loader notes
- Document copying `.env.example` to `.env.codex` in the README bootstrap steps

### Tests added/updated
- None – documentation-only change

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68de7519c0f0833288b78fe055d6a04f