### PR TITLE
fix: clarify supabase cli env exports – 2025-10-04

### DIFF
--- a/src/lib/__tests__/supabaseCliAuthInstructions.test.ts
+++ b/src/lib/__tests__/supabaseCliAuthInstructions.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SUPABASE_CLI_ENV_INSTRUCTIONS,
+  formatSupabaseCliEnvInstructions,
+} from '../supabaseCliAuthInstructions';
+
+describe('supabaseCliAuthInstructions', () => {
+  it('includes the access token export command with masking placeholder', () => {
+    const accessTokenInstruction = SUPABASE_CLI_ENV_INSTRUCTIONS.find(
+      (instruction) => instruction.varName === 'SUPABASE_ACCESS_TOKEN',
+    );
+
+    expect(accessTokenInstruction).toBeDefined();
+    expect(accessTokenInstruction?.command).toBe('export SUPABASE_ACCESS_TOKEN="****"');
+  });
+
+  it('formats instructions into a readable block', () => {
+    const formatted = formatSupabaseCliEnvInstructions([
+      {
+        varName: 'SUPABASE_ACCESS_TOKEN',
+        command: 'export SUPABASE_ACCESS_TOKEN="****"',
+        description: 'Set the access token for the CLI.',
+      },
+    ]);
+
+    expect(formatted).toContain('# SUPABASE_ACCESS_TOKEN');
+    expect(formatted).toContain('Set the access token for the CLI.');
+    expect(formatted).toContain('Command: export SUPABASE_ACCESS_TOKEN="****"');
+  });
+});

--- a/src/lib/supabaseCliAuthInstructions.ts
+++ b/src/lib/supabaseCliAuthInstructions.ts
@@ -1,0 +1,40 @@
+export type SupabaseCliEnvInstruction = {
+  readonly varName: string;
+  readonly command: string;
+  readonly description: string;
+};
+
+export const SUPABASE_CLI_ENV_INSTRUCTIONS: readonly SupabaseCliEnvInstruction[] = [
+  {
+    varName: 'SUPABASE_ACCESS_TOKEN',
+    command: 'export SUPABASE_ACCESS_TOKEN="****"',
+    description:
+      'Exports the Supabase access token in the current shell session so CLI commands authenticate without prompts. Replace **** with your actual token before running the command.',
+  },
+  {
+    varName: 'SUPABASE_URL',
+    command: 'export SUPABASE_URL="https://<project-ref>.supabase.co"',
+    description:
+      'Optional but recommended when scripting; points the CLI to your project URL and avoids interactive selection prompts.',
+  },
+  {
+    varName: 'SUPABASE_ANON_KEY',
+    command: 'export SUPABASE_ANON_KEY="****"',
+    description:
+      'Provides the anon key for local tooling that needs client credentials. Only export if the command requires it.',
+  },
+];
+
+export const formatSupabaseCliEnvInstructions = (
+  instructions: readonly SupabaseCliEnvInstruction[] = SUPABASE_CLI_ENV_INSTRUCTIONS,
+): string =>
+  instructions
+    .map((instruction) =>
+      [
+        `# ${instruction.varName}`,
+        instruction.description,
+        '',
+        `Command: ${instruction.command}`,
+      ].join('\n'),
+    )
+    .join('\n\n');


### PR DESCRIPTION
### Summary
Provide a reusable helper describing how to export Supabase CLI environment variables.

### Proposed changes
- Add typed list of Supabase CLI environment export commands with descriptions.
- Add unit test verifying the helper content and formatting.

### Tests added/updated
- src/lib/__tests__/supabaseCliAuthInstructions.test.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68e06c3f1c048332a4f3f1a61a3bceb7