### PR TITLE
fix: correct bootstrap import destructuring – 2025-10-04

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -53,7 +53,7 @@ const RuntimeConfigError: React.FC<{ message: string }> = ({ message }) => (
 
 const bootstrap = async (): Promise<void> => {
   try {
-    const [{ default: App }] = await Promise.all([ensureRuntimeSupabaseConfig(), import('./App.tsx')]);
+    const [, { default: App }] = await Promise.all([ensureRuntimeSupabaseConfig(), import('./App.tsx')]);
     root.render(
       <React.StrictMode>
         <DevErrorBoundary>


### PR DESCRIPTION
### Summary
Fix the bootstrap sequence to load the App component after ensuring runtime configuration succeeds.

### Proposed changes
- Correctly destructure the Promise.all result to wait for runtime config before rendering the App component.
- Rebuild and preview the production bundle to confirm the React app boots without error #130.

### Tests added/updated
- n/a (no test changes required)

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68e11035a8488332827c6888c6df19d0