### PR TITLE
fix: tighten schedule batch org scoping – 2025-10-06

### DIFF
--- a/supabase/functions/get-schedule-data-batch/index.ts
+++ b/supabase/functions/get-schedule-data-batch/index.ts
@@ -4,6 +4,8 @@ import { getUserOrThrow } from "../_shared/auth.ts";
 import { corsHeaders } from '../_shared/cors.ts'
 import { errorEnvelope, getRequestId, rateLimit, IsoDateSchema } from '../lib/http/error.ts'
 
+const MAX_BATCH_SIZE = 100
+
 interface BatchScheduleRequest { start_date: string; end_date: string; therapist_ids?: string[]; client_ids?: string[]; batch_size?: number; offset?: number; include_availability?: boolean; include_conflicts?: boolean; }
 interface ScheduleBatch { sessions: Array<{ id: string; start_time: string; end_time: string; status: string; location_type: string; therapist: { id: string; full_name: string; email: string; }; client: { id: string; full_name: string; email: string; }; authorization?: { id: string; sessions_remaining: number; end_date: string; }; }>; availability?: Array<{ therapist_id: string; therapist_name: string; date: string; available_slots: Array<{ start_time: string; end_time: string; duration_minutes: number; }>; }>; conflicts?: Array<{ type: 'double_booking' | 'insufficient_break' | 'authorization_expired'; description: string; session_ids: string[]; suggested_resolution: string; }>; pagination: { total_records: number; batch_size: number; current_offset: number; has_more: boolean; next_offset?: number; }; performance: { query_time_ms: number; cache_hit: boolean; }; }
 
@@ -16,6 +18,13 @@ Deno.serve(async (req: Request) => {
     const db = createRequestClient(req);
     await getUserOrThrow(db);
 
+    const { data: organizationId, error: organizationError } = await db.rpc('current_user_organization_id')
+    if (organizationError) {
+      console.error('Failed to resolve caller organization:', organizationError)
+      return errorEnvelope({ requestId, code: 'internal_error', message: 'Could not resolve organization', status: 500 })
+    }
+    if (!organizationId) return errorEnvelope({ requestId, code: 'forbidden', message: 'Organization context required', status: 403 })
+
     const ip = req.headers.get('x-forwarded-for') || 'unknown';
     const rl = rateLimit(`schedule:${ip}`, 60, 60_000);
     if (!rl.allowed) return errorEnvelope({ requestId, code: 'rate_limited', message: 'Too many requests', status: 429, headers: { 'Retry-After': String(rl.retryAfter ?? 60) } });
@@ -27,31 +36,66 @@ Deno.serve(async (req: Request) => {
       requestData = { start_date: url.searchParams.get('start_date') || new Date().toISOString().split('T')[0], end_date: url.searchParams.get('end_date') || new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0], therapist_ids: url.searchParams.get('therapist_ids')?.split(','), client_ids: url.searchParams.get('client_ids')?.split(','), batch_size: parseInt(url.searchParams.get('batch_size') || '100'), offset: parseInt(url.searchParams.get('offset') || '0'), include_availability: url.searchParams.get('include_availability') === 'true', include_conflicts: url.searchParams.get('include_conflicts') === 'true' };
     }
 
-    const BodySchema = z.object({ start_date: IsoDateSchema, end_date: IsoDateSchema, therapist_ids: z.array(z.string()).optional(), client_ids: z.array(z.string()).optional(), batch_size: z.number().int().positive().max(1000).optional().default(100), offset: z.number().int().nonnegative().optional().default(0), include_availability: z.boolean().optional().default(false), include_conflicts: z.boolean().optional().default(false) });
+    const BodySchema = z.object({ start_date: IsoDateSchema, end_date: IsoDateSchema, therapist_ids: z.array(z.string()).optional(), client_ids: z.array(z.string()).optional(), batch_size: z.number().int().positive().max(MAX_BATCH_SIZE).optional().default(MAX_BATCH_SIZE), offset: z.number().int().nonnegative().optional().default(0), include_availability: z.boolean().optional().default(false), include_conflicts: z.boolean().optional().default(false) });
     const parsedBody = BodySchema.safeParse(requestData);
     if (!parsedBody.success) return errorEnvelope({ requestId, code: 'invalid_body', message: 'Invalid request body', status: 400 });
     const { start_date, end_date, therapist_ids, client_ids, batch_size, offset, include_availability, include_conflicts } = parsedBody.data;
 
+    const sanitizedTherapistIds = therapist_ids?.filter(id => typeof id === 'string' && id.trim().length > 0) ?? []
+    const sanitizedClientIds = client_ids?.filter(id => typeof id === 'string' && id.trim().length > 0) ?? []
+
+    let allowedTherapistIds = sanitizedTherapistIds
+    if (sanitizedTherapistIds.length > 0) {
+      const { data: therapistMatches, error: therapistError } = await db
+        .from('therapists')
+        .select('id')
+        .eq('organization_id', organizationId)
+        .in('id', sanitizedTherapistIds)
+      if (therapistError) throw therapistError
+      const accessibleTherapistIds = (therapistMatches ?? []).map(match => match.id)
+      const unauthorizedTherapists = sanitizedTherapistIds.filter(id => !accessibleTherapistIds.includes(id))
+      if (unauthorizedTherapists.length > 0) return errorEnvelope({ requestId, code: 'forbidden', message: 'Access denied for therapist scope', status: 403 })
+      allowedTherapistIds = accessibleTherapistIds
+    }
+
+    let allowedClientIds = sanitizedClientIds
+    if (sanitizedClientIds.length > 0) {
+      const { data: clientMatches, error: clientError } = await db
+        .from('clients')
+        .select('id')
+        .eq('organization_id', organizationId)
+        .in('id', sanitizedClientIds)
+      if (clientError) throw clientError
+      const accessibleClientIds = (clientMatches ?? []).map(match => match.id)
+      const unauthorizedClients = sanitizedClientIds.filter(id => !accessibleClientIds.includes(id))
+      if (unauthorizedClients.length > 0) return errorEnvelope({ requestId, code: 'forbidden', message: 'Access denied for client scope', status: 403 })
+      allowedClientIds = accessibleClientIds
+    }
+
+    const effectiveBatchSize = Math.min(batch_size, MAX_BATCH_SIZE)
+
     let sessionQuery = db
       .from('sessions')
       .select('id, start_time, end_time, status, location_type, therapist_id, client_id, authorization_id, therapist:therapists!inner(id, full_name, email), client:clients!inner(id, full_name, email), authorization:authorizations(id, authorized_sessions, sessions_used, end_date)', { count: 'exact' })
+      .eq('organization_id', organizationId)
       .gte('start_time', `${start_date}T00:00:00`).lte('start_time', `${end_date}T23:59:59`).order('start_time', { ascending: true });
 
-    if (therapist_ids && therapist_ids.length > 0) sessionQuery = sessionQuery.in('therapist_id', therapist_ids);
-    if (client_ids && client_ids.length > 0) sessionQuery = sessionQuery.in('client_id', client_ids);
+    if (allowedTherapistIds.length > 0) sessionQuery = sessionQuery.in('therapist_id', allowedTherapistIds)
+    if (allowedClientIds.length > 0) sessionQuery = sessionQuery.in('client_id', allowedClientIds)
 
-    sessionQuery = sessionQuery.range(offset, offset + batch_size - 1);
+    sessionQuery = sessionQuery.range(offset, offset + effectiveBatchSize - 1);
 
     const { data: sessions, error: sessionError, count } = await sessionQuery; if (sessionError) throw sessionError;
 
     const formattedSessions = sessions?.map(session => ({ id: session.id, start_time: session.start_time, end_time: session.end_time, status: session.status, location_type: session.location_type, therapist: session.therapist, client: session.client, authorization: session.authorization ? { id: session.authorization.id, sessions_remaining: (session.authorization.authorized_sessions || 0) - (session.authorization.sessions_used || 0), end_date: session.authorization.end_date } : undefined })) || [];
 
     let availability: any[] = [];
-    if (include_availability && therapist_ids && therapist_ids.length > 0) {
+    if (include_availability && allowedTherapistIds.length > 0) {
       const { data: therapists } = await db
         .from('therapists')
         .select('id, full_name, availability_hours')
-        .in('id', therapist_ids)
+        .eq('organization_id', organizationId)
+        .in('id', allowedTherapistIds.slice(0, effectiveBatchSize))
         .is('deleted_at', null);
       availability = therapists?.map(therapist => {
         const availableSlots: Array<{ start_time: string; end_time: string; duration_minutes: number }>= [];
@@ -100,12 +144,17 @@ Deno.serve(async (req: Request) => {
     }
 
     const totalRecords = count || 0;
-    const hasMore = offset + batch_size < totalRecords;
-    const nextOffset = hasMore ? offset + batch_size : undefined;
+    const hasMore = offset + effectiveBatchSize < totalRecords;
+    const nextOffset = hasMore ? offset + effectiveBatchSize : undefined;
 
-    const response: ScheduleBatch = { sessions: formattedSessions, ...(include_availability && { availability }), ...(include_conflicts && { conflicts }), pagination: { total_records: totalRecords, batch_size, current_offset: offset, has_more: hasMore, next_offset: nextOffset }, performance: { query_time_ms: Date.now() - startTime, cache_hit: false } };
+    const truncatedAvailability = include_availability ? availability.slice(0, effectiveBatchSize) : undefined
+    const truncatedConflicts = include_conflicts ? conflicts.slice(0, effectiveBatchSize) : undefined
 
-    return new Response(JSON.stringify({ success: true, data: response, request_parameters: requestData, requestId }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+    const response: ScheduleBatch = { sessions: formattedSessions, ...(include_availability && { availability: truncatedAvailability }), ...(include_conflicts && { conflicts: truncatedConflicts }), pagination: { total_records: totalRecords, batch_size: effectiveBatchSize, current_offset: offset, has_more: hasMore, next_offset: nextOffset }, performance: { query_time_ms: Date.now() - startTime, cache_hit: false } };
+
+    const requestParameters = { ...requestData, therapist_ids: allowedTherapistIds, client_ids: allowedClientIds, batch_size: effectiveBatchSize }
+
+    return new Response(JSON.stringify({ success: true, data: response, request_parameters: requestParameters, requestId }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
   } catch (error) {
     const requestId = getRequestId(new Request('http://local'));
     console.error('Schedule batch data error:', error);

--- a/tests/therapists/org_scope.spec.ts
+++ b/tests/therapists/org_scope.spec.ts
@@ -43,7 +43,7 @@ describe('Therapist RPC organization scoping', () => {
     expect([200, 204]).toContain(allowed.status);
 
     const denied = await callRpc('get_dropdown_data', tokenOrgB);
-    expect([200, 204]).toContain(denied.status);
+    expect([200, 204, 403]).toContain(denied.status);
 
     const therapists = Array.isArray((denied.json as any)?.therapists)
       ? (denied.json as any).therapists
@@ -52,8 +52,18 @@ describe('Therapist RPC organization scoping', () => {
       ? (denied.json as any).clients
       : [];
 
-    expect(therapists.length).toBe(0);
-    expect(clients.length).toBe(0);
+    if (denied.status === 403) {
+      const payload = (denied.json ?? {}) as Record<string, unknown>;
+      const message = typeof payload.error === 'string'
+        ? payload.error
+        : typeof payload.message === 'string'
+          ? payload.message
+          : '';
+      expect(message.toLowerCase()).toContain('denied');
+    } else {
+      expect(therapists.length).toBe(0);
+      expect(clients.length).toBe(0);
+    }
 
     if (Array.isArray((allowed.json as any)?.therapists) && (allowed.json as any).therapists.length > 0) {
       expect((allowed.json as any).therapists.length).toBeGreaterThan(therapists.length);
@@ -77,10 +87,22 @@ describe('Therapist RPC organization scoping', () => {
     expect([200, 204]).toContain(allowed.status);
 
     const denied = await callRpc('get_sessions_optimized', tokenOrgB, payload);
-    expect([200, 204]).toContain(denied.status);
+    expect([200, 204, 403]).toContain(denied.status);
+
+    if (denied.status === 403) {
+      const payloadDenied = (denied.json ?? {}) as Record<string, unknown>;
+      const message = typeof payloadDenied.error === 'string'
+        ? payloadDenied.error
+        : typeof payloadDenied.message === 'string'
+          ? payloadDenied.message
+          : '';
+      expect(message.toLowerCase()).toContain('denied');
+    }
 
     const sessions = Array.isArray(denied.json) ? (denied.json as any[]) : [];
-    expect(sessions.length).toBe(0);
+    if (denied.status !== 403) {
+      expect(sessions.length).toBe(0);
+    }
 
     if (Array.isArray(allowed.json) && (allowed.json as any[]).length > 0) {
       expect((allowed.json as any[]).length).toBeGreaterThan(sessions.length);
@@ -99,7 +121,17 @@ describe('Therapist RPC organization scoping', () => {
     expect([200, 204]).toContain(allowed.status);
 
     const denied = await callRpc('get_schedule_data_batch', tokenOrgB, payload);
-    expect([200, 204]).toContain(denied.status);
+    expect([200, 204, 403]).toContain(denied.status);
+
+    if (denied.status === 403) {
+      const payloadDenied = (denied.json ?? {}) as Record<string, unknown>;
+      const message = typeof payloadDenied.error === 'string'
+        ? payloadDenied.error
+        : typeof payloadDenied.message === 'string'
+          ? payloadDenied.message
+          : '';
+      expect(message.toLowerCase()).toContain('denied');
+    }
 
     const sessions = Array.isArray((denied.json as any)?.sessions)
       ? (denied.json as any).sessions
@@ -111,9 +143,11 @@ describe('Therapist RPC organization scoping', () => {
       ? (denied.json as any).clients
       : [];
 
-    expect(sessions.length).toBe(0);
-    expect(therapists.length).toBe(0);
-    expect(clients.length).toBe(0);
+    if (denied.status !== 403) {
+      expect(sessions.length).toBe(0);
+      expect(therapists.length).toBe(0);
+      expect(clients.length).toBe(0);
+    }
 
     if (Array.isArray((allowed.json as any)?.sessions) && (allowed.json as any).sessions.length > 0) {
       expect((allowed.json as any).sessions.length).toBeGreaterThan(sessions.length);


### PR DESCRIPTION
### Summary
Scope schedule batching to the caller organization and harden pagination safeguards.

### Proposed changes
- Resolve the caller organization inside the schedule batch edge function, validate requested therapist/client scopes, and cap batch responses.
- Update therapist organization scope regression coverage to expect 403 or empty results for cross-tenant access.

### Tests added/updated
- tests/therapists/org_scope.spec.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68e3d1d485a8833292834e054dcddedc