### PR TITLE
feat: enforce feature flag metadata history – 2025-10-06

### DIFF
--- a/src/lib/featureFlags/organizationMetadataSchema.builder.ts
+++ b/src/lib/featureFlags/organizationMetadataSchema.builder.ts
@@ -1,0 +1,71 @@
+type ZodModule = typeof import("zod");
+type ZodNamespace = ZodModule extends { z: infer Namespace } ? Namespace : never;
+
+export const buildOrganizationMetadataSchema = (zLib: ZodNamespace) => {
+  const contactSchema = zLib
+    .object({
+      name: zLib.string().trim().min(1, "Billing contact name is required").max(120),
+      email: zLib
+        .string()
+        .trim()
+        .email("Billing contact email must be valid")
+        .max(320),
+      phone: zLib
+        .string()
+        .trim()
+        .regex(/^[+0-9().\-\s]*$/, "Phone numbers may contain digits and basic symbols only")
+        .max(40)
+        .optional(),
+    })
+    .strict();
+
+  const rolloutSchema = zLib
+    .object({
+      cohort: zLib.string().trim().min(1, "Rollout cohort is required").max(100),
+      startAt: zLib.string().trim().datetime({ offset: true }),
+      flags: zLib.array(zLib.string().trim().min(2).max(100)).max(20).optional(),
+    })
+    .partial()
+    .refine(
+      value => !value || Object.values(value).some(field => field !== undefined),
+      {
+        message: "Rollout details cannot be empty",
+      },
+    );
+
+  return zLib
+    .object({
+      billing: zLib
+        .object({
+          contact: contactSchema.optional(),
+          cycle: zLib.enum(["monthly", "quarterly", "annual"]).optional(),
+          poNumber: zLib.string().trim().max(50).optional(),
+        })
+        .optional(),
+      seats: zLib
+        .object({
+          licensed: zLib.number().int().min(0).max(100000).optional(),
+          active: zLib.number().int().min(0).max(100000).optional(),
+        })
+        .superRefine((value, ctx) => {
+          if (!value || value.licensed === undefined || value.active === undefined) {
+            return;
+          }
+
+          if (value.active > value.licensed) {
+            ctx.addIssue({
+              code: "custom",
+              message: "Active seats cannot exceed licensed seats",
+              path: ["active"],
+            });
+          }
+        })
+        .optional(),
+      rollout: rolloutSchema.optional(),
+      tags: zLib.array(zLib.string().trim().min(1).max(50)).max(10).optional(),
+      notes: zLib.string().trim().max(1000).optional(),
+    })
+    .strict();
+};
+
+export type OrganizationMetadataSchema = ReturnType<typeof buildOrganizationMetadataSchema>;

--- a/src/lib/featureFlags/organizationMetadataSchema.ts
+++ b/src/lib/featureFlags/organizationMetadataSchema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+import { buildOrganizationMetadataSchema } from "./organizationMetadataSchema.builder";
+
+export const organizationMetadataSchema = buildOrganizationMetadataSchema(z);
+export type OrganizationMetadata = z.infer<typeof organizationMetadataSchema>;

--- a/supabase/functions/feature-flags/schema.ts
+++ b/supabase/functions/feature-flags/schema.ts
@@ -1,0 +1,5 @@
+import { z } from "npm:zod@3.23.8";
+import { buildOrganizationMetadataSchema } from "../../../src/lib/featureFlags/organizationMetadataSchema.builder.ts";
+
+export const organizationMetadataSchema = buildOrganizationMetadataSchema(z);
+export type OrganizationMetadata = z.infer<typeof organizationMetadataSchema>;

--- a/supabase/migrations/20251222113000_feature_flag_plan_history.sql
+++ b/supabase/migrations/20251222113000_feature_flag_plan_history.sql
@@ -1,0 +1,197 @@
+/*
+  # Feature flag plan history
+
+  - Create immutable `feature_flag_plan_history` table for plan + flag transitions
+  - Add triggers on `organization_feature_flags` and `organization_plans` to capture state changes
+  - Enforce immutability and RLS policies for super admin visibility
+*/
+
+CREATE TABLE IF NOT EXISTS public.feature_flag_plan_history (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid REFERENCES public.organizations(id) ON DELETE CASCADE,
+  feature_flag_id uuid REFERENCES public.feature_flags(id) ON DELETE SET NULL,
+  plan_code text REFERENCES public.plans(code) ON DELETE SET NULL,
+  action text NOT NULL,
+  change_context text NOT NULL,
+  previous_state jsonb,
+  new_state jsonb,
+  actor_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  occurred_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+ALTER TABLE public.feature_flag_plan_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Super admins can read feature flag history"
+ON public.feature_flag_plan_history
+FOR SELECT
+TO authenticated
+USING (app.current_user_is_super_admin());
+
+CREATE POLICY "Super admins can insert feature flag history"
+ON public.feature_flag_plan_history
+FOR INSERT
+TO authenticated
+WITH CHECK (app.current_user_is_super_admin());
+
+CREATE OR REPLACE FUNCTION public.prevent_feature_flag_plan_history_mutations()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'feature_flag_plan_history is immutable';
+END;
+$$;
+
+CREATE TRIGGER feature_flag_plan_history_prevent_update
+BEFORE UPDATE ON public.feature_flag_plan_history
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_feature_flag_plan_history_mutations();
+
+CREATE TRIGGER feature_flag_plan_history_prevent_delete
+BEFORE DELETE ON public.feature_flag_plan_history
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_feature_flag_plan_history_mutations();
+
+CREATE OR REPLACE FUNCTION public.log_organization_flag_history()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_actor uuid;
+  v_action text;
+  v_previous jsonb;
+  v_new jsonb;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    v_actor := COALESCE(NEW.updated_by, NEW.created_by);
+    v_action := CASE WHEN NEW.is_enabled THEN 'flag_enabled' ELSE 'flag_disabled' END;
+    v_previous := NULL;
+    v_new := jsonb_strip_nulls(to_jsonb(NEW));
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF NEW.is_enabled IS NOT DISTINCT FROM OLD.is_enabled THEN
+      RETURN NEW;
+    END IF;
+    v_actor := COALESCE(NEW.updated_by, NEW.created_by, OLD.updated_by, OLD.created_by);
+    v_action := CASE WHEN NEW.is_enabled THEN 'flag_enabled' ELSE 'flag_disabled' END;
+    v_previous := jsonb_strip_nulls(to_jsonb(OLD));
+    v_new := jsonb_strip_nulls(to_jsonb(NEW));
+  ELSIF TG_OP = 'DELETE' THEN
+    v_actor := COALESCE(OLD.updated_by, OLD.created_by);
+    v_action := 'flag_override_removed';
+    v_previous := jsonb_strip_nulls(to_jsonb(OLD));
+    v_new := NULL;
+  ELSE
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO public.feature_flag_plan_history (
+    organization_id,
+    feature_flag_id,
+    plan_code,
+    action,
+    change_context,
+    previous_state,
+    new_state,
+    actor_id
+  )
+  VALUES (
+    COALESCE(NEW.organization_id, OLD.organization_id),
+    COALESCE(NEW.feature_flag_id, OLD.feature_flag_id),
+    NULL,
+    v_action,
+    'organization_feature_flag',
+    v_previous,
+    v_new,
+    v_actor
+  );
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER organization_feature_flags_history_aiud
+AFTER INSERT OR UPDATE OR DELETE ON public.organization_feature_flags
+FOR EACH ROW
+EXECUTE FUNCTION public.log_organization_flag_history();
+
+CREATE OR REPLACE FUNCTION public.log_organization_plan_history()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_actor uuid;
+  v_action text;
+  v_previous jsonb;
+  v_new jsonb;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    v_actor := NEW.assigned_by;
+    v_action := 'plan_assigned';
+    v_previous := NULL;
+    v_new := jsonb_strip_nulls(to_jsonb(NEW));
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF NEW.plan_code IS NOT DISTINCT FROM OLD.plan_code AND NEW.notes IS NOT DISTINCT FROM OLD.notes THEN
+      RETURN NEW;
+    END IF;
+    v_actor := COALESCE(NEW.assigned_by, OLD.assigned_by);
+    v_action := CASE
+      WHEN NEW.plan_code IS DISTINCT FROM OLD.plan_code THEN 'plan_changed'
+      ELSE 'plan_updated'
+    END;
+    v_previous := jsonb_strip_nulls(to_jsonb(OLD));
+    v_new := jsonb_strip_nulls(to_jsonb(NEW));
+  ELSIF TG_OP = 'DELETE' THEN
+    v_actor := OLD.assigned_by;
+    v_action := 'plan_removed';
+    v_previous := jsonb_strip_nulls(to_jsonb(OLD));
+    v_new := NULL;
+  ELSE
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO public.feature_flag_plan_history (
+    organization_id,
+    feature_flag_id,
+    plan_code,
+    action,
+    change_context,
+    previous_state,
+    new_state,
+    actor_id
+  )
+  VALUES (
+    COALESCE(NEW.organization_id, OLD.organization_id),
+    NULL,
+    COALESCE(NEW.plan_code, OLD.plan_code),
+    v_action,
+    'organization_plan',
+    v_previous,
+    v_new,
+    v_actor
+  );
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER organization_plans_history_aiud
+AFTER INSERT OR UPDATE OR DELETE ON public.organization_plans
+FOR EACH ROW
+EXECUTE FUNCTION public.log_organization_plan_history();
+
+CREATE INDEX IF NOT EXISTS feature_flag_plan_history_org_idx
+ON public.feature_flag_plan_history (organization_id);
+
+CREATE INDEX IF NOT EXISTS feature_flag_plan_history_flag_idx
+ON public.feature_flag_plan_history (feature_flag_id);
+
+CREATE INDEX IF NOT EXISTS feature_flag_plan_history_context_idx
+ON public.feature_flag_plan_history (change_context, occurred_at);

--- a/tests/super_admin/feature_flags.spec.ts
+++ b/tests/super_admin/feature_flags.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { organizationMetadataSchema } from "../../src/lib/featureFlags/organizationMetadataSchema";
+
+describe("organization metadata schema", () => {
+  it("accepts valid structured metadata", () => {
+    const metadata = {
+      billing: {
+        contact: {
+          name: "Alicia Ops",
+          email: "alicia.ops@example.com",
+          phone: "+1 (555) 000-2222",
+        },
+        cycle: "annual",
+        poNumber: "PO-8821",
+      },
+      seats: {
+        licensed: 120,
+        active: 95,
+      },
+      rollout: {
+        cohort: "beta-2025-q1",
+        startAt: new Date("2025-01-15T12:00:00Z").toISOString(),
+        flags: ["beta-dashboard", "automation-suite"],
+      },
+      tags: ["beta", "priority"],
+      notes: "Key account with contractual automation add-on.",
+    } as const;
+
+    const parsed = organizationMetadataSchema.parse(metadata);
+
+    expect(parsed.rollout?.flags?.length).toBe(2);
+    expect(parsed.billing?.contact?.name).toBe("Alicia Ops");
+    expect(parsed.seats?.active).toBe(95);
+  });
+
+  it("rejects invalid seat allocations", () => {
+    expect(() =>
+      organizationMetadataSchema.parse({
+        seats: {
+          licensed: 5,
+          active: 9,
+        },
+      }),
+    ).toThrowError(/Active seats cannot exceed licensed seats/);
+  });
+});
+
+describe("feature flag plan history migration", () => {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  const migrationPath = resolve(
+    currentDir,
+    "..",
+    "..",
+    "supabase",
+    "migrations",
+    "20251222113000_feature_flag_plan_history.sql",
+  );
+  const migrationSql = readFileSync(migrationPath, "utf8");
+
+  it("creates the immutable history table", () => {
+    expect(migrationSql).toContain("CREATE TABLE IF NOT EXISTS public.feature_flag_plan_history");
+    expect(migrationSql).toContain("feature_flag_plan_history_prevent_update");
+    expect(migrationSql).toContain("feature_flag_plan_history_prevent_delete");
+  });
+
+  it("adds triggers for plan and flag transitions", () => {
+    expect(migrationSql).toMatch(/organization_feature_flags_history_aiud/i);
+    expect(migrationSql).toMatch(/organization_plans_history_aiud/i);
+    expect(migrationSql).toContain("log_organization_flag_history");
+    expect(migrationSql).toContain("log_organization_plan_history");
+  });
+});


### PR DESCRIPTION
### Summary
Introduce schema validation and auditing improvements for super admin feature-flag governance.

### Proposed changes
- Add shared organization metadata schema with validation across edge functions and tests
- Capture feature flag and plan transitions via immutable history table and stricter audit handling
- Extend super admin tests to cover metadata validation failures and migration expectations

### Tests added/updated
- tests/super_admin/feature_flags.spec.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68e3d5787c8c8332a789c8dabea7639f