### PR TITLE
fix: tighten CI gates – 2025-10-06

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,18 @@ jobs:
       - name: Run typecheck
         run: npm run typecheck
 
+      - name: Ensure no focused or skipped tests are committed
+        run: npm run ci:check-focused
+
       - name: Run unit tests
-        run: npm test -- --run --reporter=verbose | tee vitest-output.log
+        run: vitest run --coverage --run --reporter=verbose --coverage.reporter=json-summary | tee vitest-output.log
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           RUN_DB_IT: '1'
+
+      - name: Verify coverage threshold
+        run: npm run ci:verify-coverage
 
       - name: Ensure RLS tests executed
         if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -57,11 +57,17 @@ AllIncompassing delivers therapist scheduling, billing, and operational telemetr
 | --- | --- |
 | Lint TypeScript & React files | `npm run lint` |
 | Unit tests (Vitest) | `npm test` |
+| CI-aligned unit tests + coverage | `npm run test:ci` |
 | Coverage report | `npm run test:coverage` |
+| Focused/Skipped test guard | `npm run ci:check-focused` |
+| Coverage threshold verification | `npm run ci:verify-coverage` |
 | Type checking | `npm run typecheck` |
 | UI test runner | `npm run test:ui` |
 | Cypress end-to-end suite | `npm run test:e2e` or `npm run test:e2e:open` |
 | Route integrity tests | `npm run test:routes` or `npm run test:routes:open` |
+
+> CI fails if `.only`/`.skip` usages slip outside `tests/utils/testControls.ts` or if line coverage drops below 85% in
+> `coverage/coverage-summary.json`. Run the focus guard and coverage verification commands locally before opening a PR.
 
 ### Supabase connection diagnostics
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:auth": "vitest run --reporter=verbose --config vitest.config.ts src/lib/__tests__/auth.test.ts",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "test:ci": "vitest run --coverage --run --reporter=verbose --coverage.reporter=json-summary",
     "test:e2e": "cypress run",
     "test:e2e:open": "cypress open",
     "bolt:dev": "vite --host 0.0.0.0",
@@ -37,7 +38,9 @@
     "audit:service-role": "node scripts/audit-service-role-usage.cjs",
     "preview:smoke": "node scripts/preview-smoke.js --url $PREVIEW_URL",
     "typegen": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/lib/db.types.ts",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "ci:check-focused": "node scripts/ci/check-focused-tests.mjs",
+    "ci:verify-coverage": "node scripts/ci/verify-coverage.mjs"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.18",

--- a/scripts/ci/check-focused-tests.mjs
+++ b/scripts/ci/check-focused-tests.mjs
@@ -1,0 +1,83 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const SEARCH_ROOTS = ['src', 'tests'];
+const IGNORED_DIRECTORIES = new Set(['node_modules', '.git', 'dist', 'coverage']);
+const ALLOWED_FILES = new Set([
+  path.join('tests', 'utils', 'testControls.ts'),
+]);
+const FILE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const PATTERN = /\.(?:only|skip)(?:\s*\(|\b)/g;
+
+const violations = [];
+
+const walk = async (directory) => {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if ((error?.code ?? '') === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+
+  await Promise.all(entries.map(async (entry) => {
+    const resolved = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRECTORIES.has(entry.name)) {
+        return;
+      }
+      await walk(resolved);
+      return;
+    }
+
+    if (!entry.isFile()) {
+      return;
+    }
+
+    const extension = path.extname(entry.name);
+    if (!FILE_EXTENSIONS.has(extension)) {
+      return;
+    }
+
+    const relativePath = path.relative(process.cwd(), resolved);
+    if (ALLOWED_FILES.has(relativePath)) {
+      return;
+    }
+
+    const content = await readFile(resolved, 'utf8');
+
+    let match;
+    while ((match = PATTERN.exec(content)) !== null) {
+      const before = content.slice(0, match.index);
+      const line = before.split(/\r?\n/).length;
+      violations.push({
+        file: relativePath,
+        line,
+        match: match[0],
+      });
+    }
+  }));
+};
+
+const run = async () => {
+  await Promise.all(SEARCH_ROOTS.map((root) => walk(path.join(process.cwd(), root))));
+
+  if (violations.length === 0) {
+    return;
+  }
+
+  console.error('Focused or skipped tests detected outside approved helpers:');
+  for (const violation of violations) {
+    console.error(`- ${violation.file}:${violation.line} contains \`${violation.match}\``);
+  }
+  console.error('Use tests/utils/testControls.ts helpers to guard conditional suites or tests.');
+  process.exitCode = 1;
+};
+
+run().catch((error) => {
+  console.error('Failed to verify focused test usage.');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/ci/verify-coverage.mjs
+++ b/scripts/ci/verify-coverage.mjs
@@ -1,0 +1,44 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const COVERAGE_FILE = path.join(process.cwd(), 'coverage', 'coverage-summary.json');
+const MIN_LINE_COVERAGE = 85;
+
+const formatPct = (value) => `${value.toFixed(2)}%`;
+
+const run = async () => {
+  let fileContents;
+  try {
+    fileContents = await readFile(COVERAGE_FILE, 'utf8');
+  } catch (error) {
+    if ((error?.code ?? '') === 'ENOENT') {
+      throw new Error(`Coverage summary not found at ${COVERAGE_FILE}`);
+    }
+    throw error;
+  }
+
+  let summary;
+  try {
+    summary = JSON.parse(fileContents);
+  } catch (error) {
+    throw new Error('Coverage summary JSON is invalid.');
+  }
+
+  const lineCoverage = summary?.total?.lines?.pct;
+  if (typeof lineCoverage !== 'number' || Number.isNaN(lineCoverage)) {
+    throw new Error('Line coverage percentage missing from coverage summary.');
+  }
+
+  if (lineCoverage < MIN_LINE_COVERAGE) {
+    throw new Error(
+      `Line coverage ${formatPct(lineCoverage)} is below the required ${formatPct(MIN_LINE_COVERAGE)} threshold.`,
+    );
+  }
+
+  console.log(`Line coverage ${formatPct(lineCoverage)} meets the required ${formatPct(MIN_LINE_COVERAGE)} threshold.`);
+};
+
+run().catch((error) => {
+  console.error(error.message ?? error);
+  process.exitCode = 1;
+});

--- a/tests/admins/assign_role.spec.ts
+++ b/tests/admins/assign_role.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect } from 'vitest';
+import { selectTest } from '../utils/testControls';
 
 const SUPABASE_URL = process.env.SUPABASE_URL as string;
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY as string;
@@ -31,7 +32,12 @@ async function callRpc(
 describe('Admin role assignments', () => {
   const tokenOrgA = process.env.TEST_JWT_ORG_A as string;
 
-  it.skip('removes admins within the same organization', async () => {
+  const removalTest = selectTest({
+    run: process.env.RUN_ADMIN_ROLE_REMOVAL_TEST === 'true',
+    reason: 'Seeded admin fixtures required. Enable by setting RUN_ADMIN_ROLE_REMOVAL_TEST=true.',
+  });
+
+  removalTest('removes admins within the same organization', async () => {
     if (!tokenOrgA) return;
 
     const { status: orgStatus, json: orgJson } = await callRpc('current_user_organization_id', tokenOrgA);

--- a/tests/admins/domain.verification.spec.ts
+++ b/tests/admins/domain.verification.spec.ts
@@ -1,29 +1,35 @@
 // ENV REQUIREMENTS: set SUPABASE_URL, SUPABASE_ANON_KEY, TEST_JWT_ORG_A, and TEST_JWT_SUPER_ADMIN before enabling RUN_ADMIN_DOMAIN_TESTS.
-import { describe, it, expect } from "vitest";
+import { expect, it } from 'vitest';
+import { selectSuite } from '../utils/testControls';
 
 const runAdminsSuite =
-  process.env.RUN_ADMIN_DOMAIN_TESTS === "true" &&
+  process.env.RUN_ADMIN_DOMAIN_TESTS === 'true' &&
   Boolean(process.env.TEST_JWT_ORG_A) &&
   Boolean(process.env.TEST_JWT_SUPER_ADMIN);
-const suite = runAdminsSuite ? describe : describe.skip;
 
-suite("Admin edge contract expectations", () => {
-  it("describes admin users fetch query parameters", () => {
+const suite = selectSuite({
+  run: runAdminsSuite,
+  reason:
+    'Set RUN_ADMIN_DOMAIN_TESTS=true and supply TEST_JWT_ORG_A plus TEST_JWT_SUPER_ADMIN credentials.',
+});
+
+suite('Admin edge contract expectations', () => {
+  it('describes admin users fetch query parameters', () => {
     const query = new URLSearchParams({
-      organization_id: "uuid",
-      page: "1",
-      limit: "50",
-      search: "smith",
+      organization_id: 'uuid',
+      page: '1',
+      limit: '50',
+      search: 'smith',
     });
 
-    expect(query.get("organization_id")).toMatch(/^[a-z0-9-]{36}$/);
-    expect(Number.parseInt(query.get("limit") ?? "0", 10)).toBeGreaterThan(0);
+    expect(query.get('organization_id')).toMatch(/^[a-z0-9-]{36}$/);
+    expect(Number.parseInt(query.get('limit') ?? '0', 10)).toBeGreaterThan(0);
   });
 
-  it("notes invite payload requirements", () => {
+  it('notes invite payload requirements', () => {
     const payload = {
-      email: "admin@example.com",
-      organizationId: "uuid",
+      email: 'admin@example.com',
+      organizationId: 'uuid',
       expiresInHours: 72,
     } as const;
 

--- a/tests/clients/domain.verification.spec.ts
+++ b/tests/clients/domain.verification.spec.ts
@@ -1,36 +1,40 @@
 // ENV REQUIREMENTS: set SUPABASE_URL, SUPABASE_ANON_KEY, and TEST_JWT_ORG_A with a non-prod client/admin JWT before enabling RUN_CLIENT_DOMAIN_TESTS.
-import { describe, it, expect } from "vitest";
+import { expect, it } from 'vitest';
+import { selectSuite } from '../utils/testControls';
 
-const runClientsSuite =
-  process.env.RUN_CLIENT_DOMAIN_TESTS === "true" && Boolean(process.env.TEST_JWT_ORG_A);
-const suite = runClientsSuite ? describe : describe.skip;
+const runClientsSuite = process.env.RUN_CLIENT_DOMAIN_TESTS === 'true' && Boolean(process.env.TEST_JWT_ORG_A);
 
-suite("Clients domain contract expectations", () => {
-  it("documents booking API header requirements", () => {
+const suite = selectSuite({
+  run: runClientsSuite,
+  reason: 'Set RUN_CLIENT_DOMAIN_TESTS=true and provide TEST_JWT_ORG_A credentials.',
+});
+
+suite('Clients domain contract expectations', () => {
+  it('documents booking API header requirements', () => {
     const requiredHeaders = {
-      Authorization: "Bearer <supabase-jwt>",
-      "Idempotency-Key": "<uuid optional>",
-      "Content-Type": "application/json",
+      Authorization: 'Bearer <supabase-jwt>',
+      'Idempotency-Key': '<uuid optional>',
+      'Content-Type': 'application/json',
     } as const;
 
-    expect(requiredHeaders.Authorization.startsWith("Bearer ")).toBe(true);
-    expect(requiredHeaders["Content-Type"]).toBe("application/json");
+    expect(requiredHeaders.Authorization.startsWith('Bearer ')).toBe(true);
+    expect(requiredHeaders['Content-Type']).toBe('application/json');
   });
 
-  it("notes client details payload structure", () => {
+  it('notes client details payload structure', () => {
     const payloadShape = {
-      clientId: "uuid",
+      clientId: 'uuid',
     } as const;
 
-    expect(typeof payloadShape.clientId).toBe("string");
+    expect(typeof payloadShape.clientId).toBe('string');
   });
 
-  it("records onboarding expectations", () => {
+  it('records onboarding expectations', () => {
     const onboardingRequest = {
-      client_name: "Full Name",
-      client_email: "user@example.com",
+      client_name: 'Full Name',
+      client_email: 'user@example.com',
     } as const;
 
-    expect(onboardingRequest.client_email).toContain("@");
+    expect(onboardingRequest.client_email).toContain('@');
   });
 });

--- a/tests/super_admin/domain.verification.spec.ts
+++ b/tests/super_admin/domain.verification.spec.ts
@@ -1,34 +1,39 @@
 // ENV REQUIREMENTS: set SUPABASE_URL, SUPABASE_ANON_KEY, and TEST_JWT_SUPER_ADMIN before enabling RUN_SUPER_ADMIN_DOMAIN_TESTS.
-import { describe, it, expect } from "vitest";
+import { expect, it } from 'vitest';
+import { selectSuite } from '../utils/testControls';
 
 const runSuperAdminSuite =
-  process.env.RUN_SUPER_ADMIN_DOMAIN_TESTS === "true" && Boolean(process.env.TEST_JWT_SUPER_ADMIN);
-const suite = runSuperAdminSuite ? describe : describe.skip;
+  process.env.RUN_SUPER_ADMIN_DOMAIN_TESTS === 'true' && Boolean(process.env.TEST_JWT_SUPER_ADMIN);
 
-suite("Super admin automation contract expectations", () => {
-  it("captures impersonation header and payload requirements", () => {
+const suite = selectSuite({
+  run: runSuperAdminSuite,
+  reason: 'Set RUN_SUPER_ADMIN_DOMAIN_TESTS=true and provide TEST_JWT_SUPER_ADMIN credentials.',
+});
+
+suite('Super admin automation contract expectations', () => {
+  it('captures impersonation header and payload requirements', () => {
     const headers = {
-      Authorization: "Bearer <super-admin-jwt>",
-      apikey: "<anon-key>",
-      "Content-Type": "application/json",
+      Authorization: 'Bearer <super-admin-jwt>',
+      apikey: '<anon-key>',
+      'Content-Type': 'application/json',
     } as const;
     const payload = {
-      action: "issue",
-      targetUserId: "uuid",
+      action: 'issue',
+      targetUserId: 'uuid',
       expiresInMinutes: 15,
-      reason: "Audit support",
+      reason: 'Audit support',
     } as const;
 
-    expect(headers.Authorization.includes("Bearer ")).toBe(true);
+    expect(headers.Authorization.includes('Bearer ')).toBe(true);
     expect(payload.expiresInMinutes).toBeLessThanOrEqual(30);
   });
 
-  it("describes role mutation contract", () => {
+  it('describes role mutation contract', () => {
     const rolePatch = {
-      role: "admin",
+      role: 'admin',
       is_active: true,
     } as const;
 
-    expect(rolePatch.role === "super_admin" || rolePatch.role === "admin").toBe(true);
+    expect(rolePatch.role === 'super_admin' || rolePatch.role === 'admin').toBe(true);
   });
 });

--- a/tests/therapists/domain.verification.spec.ts
+++ b/tests/therapists/domain.verification.spec.ts
@@ -1,28 +1,33 @@
 // ENV REQUIREMENTS: set SUPABASE_URL, SUPABASE_ANON_KEY, and TEST_JWT_ORG_A (therapist-scoped JWT) before enabling RUN_THERAPIST_DOMAIN_TESTS.
-import { describe, it, expect } from "vitest";
+import { expect, it } from 'vitest';
+import { selectSuite } from '../utils/testControls';
 
 const runTherapistSuite =
-  process.env.RUN_THERAPIST_DOMAIN_TESTS === "true" && Boolean(process.env.TEST_JWT_ORG_A);
-const suite = runTherapistSuite ? describe : describe.skip;
+  process.env.RUN_THERAPIST_DOMAIN_TESTS === 'true' && Boolean(process.env.TEST_JWT_ORG_A);
 
-suite("Therapist schedule and mutation expectations", () => {
-  it("documents required headers for session confirmation", () => {
+const suite = selectSuite({
+  run: runTherapistSuite,
+  reason: 'Set RUN_THERAPIST_DOMAIN_TESTS=true and configure TEST_JWT_ORG_A credentials.',
+});
+
+suite('Therapist schedule and mutation expectations', () => {
+  it('documents required headers for session confirmation', () => {
     const headers = {
-      Authorization: "Bearer <supabase-jwt>",
-      "Idempotency-Key": "uuid-v4",
-      "Content-Type": "application/json",
+      Authorization: 'Bearer <supabase-jwt>',
+      'Idempotency-Key': 'uuid-v4',
+      'Content-Type': 'application/json',
     } as const;
 
-    expect(headers.Authorization.startsWith("Bearer ")).toBe(true);
-    expect(headers["Idempotency-Key"].split("-").length).toBe(5);
+    expect(headers.Authorization.startsWith('Bearer ')).toBe(true);
+    expect(headers['Idempotency-Key'].split('-').length).toBe(5);
   });
 
-  it("tracks filter contract for optimized sessions", () => {
+  it('tracks filter contract for optimized sessions', () => {
     const filterParams = {
-      therapist_id: "uuid",
-      status: "scheduled",
-      start_date: "2025-01-01",
-      end_date: "2025-01-31",
+      therapist_id: 'uuid',
+      status: 'scheduled',
+      start_date: '2025-01-01',
+      end_date: '2025-01-31',
     } as const;
 
     expect(filterParams.start_date).toMatch(/\d{4}-\d{2}-\d{2}/);

--- a/tests/utils/testControls.ts
+++ b/tests/utils/testControls.ts
@@ -1,0 +1,55 @@
+import { describe, it } from 'vitest';
+
+type SuiteSelectorOptions = {
+  run: boolean;
+  reason?: string;
+};
+
+type TestSelectorOptions = SuiteSelectorOptions;
+
+type SuiteFn = typeof describe;
+type TestFn = typeof it;
+
+const appendReason = (title: string, reason?: string) => {
+  if (!reason) {
+    return title;
+  }
+
+  return `${title} (skipped: ${reason})`;
+};
+
+const cloneSuite = (source: SuiteFn, target: SuiteFn) => {
+  Object.assign(target, source);
+};
+
+const cloneTest = (source: TestFn, target: TestFn) => {
+  Object.assign(target, source);
+};
+
+export const selectSuite = ({ run, reason }: SuiteSelectorOptions): SuiteFn => {
+  if (run) {
+    return describe;
+  }
+
+  const skipped: SuiteFn = ((title, ...rest) => {
+    return describe.skip(appendReason(title, reason), ...rest);
+  }) as SuiteFn;
+
+  cloneSuite(describe, skipped);
+
+  return skipped;
+};
+
+export const selectTest = ({ run, reason }: TestSelectorOptions): TestFn => {
+  if (run) {
+    return it;
+  }
+
+  const skipped: TestFn = ((title, ...rest) => {
+    return it.skip(appendReason(title, reason), ...rest);
+  }) as TestFn;
+
+  cloneTest(it, skipped);
+
+  return skipped;
+};


### PR DESCRIPTION
### Summary
Add CI checks for focused tests and minimum coverage while updating tests and docs to use the new helpers.

### Proposed changes
- replace the CI test runner with a coverage-producing Vitest command and enforce 85% line coverage
- add a focused-test guard script and helper utilities for conditional suites/tests
- document the new CI gates and expose supporting npm scripts for local execution

### Tests added/updated
- tests/admins/domain.verification.spec.ts
- tests/clients/domain.verification.spec.ts
- tests/super_admin/domain.verification.spec.ts
- tests/therapists/domain.verification.spec.ts
- tests/admins/assign_role.spec.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68e3ed00285883328db75cb4834ee512