### PR TITLE
fix: enforce secret verification in ci – 2025-10-06

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           access-token: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
+      - name: Validate secrets configuration
+        run: npm run ci:secrets
+
       # Always run the SERVICE_ROLE audit
       - run: npm run audit:service-role
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ AllIncompassing delivers therapist scheduling, billing, and operational telemetr
 | Unit tests (Vitest) | `npm test` |
 | CI-aligned unit tests + coverage | `npm run test:ci` |
 | Coverage report | `npm run test:coverage` |
+| Secrets preflight | `npm run ci:secrets` |
 | Focused/Skipped test guard | `npm run ci:check-focused` |
 | Coverage threshold verification | `npm run ci:verify-coverage` |
 | Type checking | `npm run typecheck` |

--- a/docs/SECRET_ROTATION_RUNBOOK.md
+++ b/docs/SECRET_ROTATION_RUNBOOK.md
@@ -1,0 +1,67 @@
+# Secret Rotation Runbook
+
+This runbook documents where critical secrets are stored, who owns each system, and how to rotate credentials without breaking CI/CD.
+
+## Supabase
+
+- **Source of truth:** Supabase project secrets.
+- **Managed by:** Platform engineering.
+- **Secrets covered:**
+  - `SUPABASE_URL`
+  - `SUPABASE_EDGE_URL`
+  - `SUPABASE_ANON_KEY`
+  - `SUPABASE_SERVICE_ROLE_KEY`
+  - `SUPABASE_ACCESS_TOKEN`
+- **Rotation steps:**
+  1. Generate new credentials in the Supabase dashboard (Project Settings → API).
+  2. Update the secrets in GitHub (`Settings → Secrets and variables → Actions`).
+  3. Mirror the values into Netlify environment variables for preview builds.
+  4. Notify developers to refresh their local `.env.codex` via `npm run ci:secrets`.
+
+## OpenAI
+
+- **Source of truth:** OpenAI dashboard (organization admins).
+- **Managed by:** AI integrations team.
+- **Secrets covered:** `OPENAI_API_KEY`, `OPENAI_ORGANIZATION`.
+- **Rotation steps:**
+  1. Create a replacement API key in OpenAI.
+  2. Update GitHub secrets and Netlify build environment variables.
+  3. Sync the new key into the Supabase secret store for edge functions.
+  4. Announce the cutover and ensure local validation passes with `npm run ci:secrets`.
+
+## AWS (S3)
+
+- **Source of truth:** AWS IAM.
+- **Managed by:** Infrastructure team.
+- **Secrets covered:** `AWS_REGION`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`.
+- **Rotation steps:**
+  1. Create a new IAM access key pair for the automation user.
+  2. Update GitHub secrets and Netlify environment variables.
+  3. Rotate the Supabase storage integration if applicable.
+  4. Revoke the old IAM keys once builds succeed.
+
+## SMTP
+
+- **Source of truth:** Email provider dashboard.
+- **Managed by:** Communications team.
+- **Secrets covered:** `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`.
+- **Rotation steps:**
+  1. Generate new SMTP credentials.
+  2. Update GitHub secrets and Netlify environment variables.
+  3. Ensure Supabase Edge Functions referencing SMTP pick up the new credentials.
+  4. Send a smoke-test email to confirm delivery.
+
+## Test JWTs
+
+- **Source of truth:** Supabase authentication (non-production tenants).
+- **Managed by:** QA engineering.
+- **Secrets covered:** `TEST_JWT_ORG_A`, `TEST_JWT_ORG_B`, `TEST_JWT_SUPER_ADMIN`.
+- **Rotation steps:**
+  1. Issue fresh JWTs for the designated test users.
+  2. Store the tokens in GitHub secrets and Netlify (for preview QA runs).
+  3. Update the Supabase branch secrets when running integration tests.
+  4. Trigger `npm run ci:secrets` locally to confirm availability.
+
+## Local validation
+
+Developers can run `npm run ci:secrets` to confirm their environment has all required secrets before pushing changes. The CI workflow calls the same script before running linting or tests, ensuring missing secrets fail fast.

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "postcss": "^8.4.35",
         "supabase": "^1.99.10",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.8.1",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
         "vite": "^6.3.5",
@@ -5037,6 +5038,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/getos": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
@@ -7313,6 +7327,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -8370,6 +8394,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "preview:smoke": "node scripts/preview-smoke.js --url $PREVIEW_URL",
     "typegen": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/lib/db.types.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "ci:secrets": "tsx scripts/check-secrets.ts",
     "ci:check-focused": "node scripts/ci/check-focused-tests.mjs",
     "ci:verify-coverage": "node scripts/ci/verify-coverage.mjs"
   },
@@ -89,6 +90,7 @@
     "supabase": "^1.99.10",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
+    "tsx": "^4.8.1",
     "typescript-eslint": "^8.3.0",
     "vite": "^6.3.5",
     "vitest": "^3.2.4"

--- a/scripts/check-secrets.ts
+++ b/scripts/check-secrets.ts
@@ -1,0 +1,88 @@
+import { pathToFileURL } from 'node:url';
+
+type EnvGroup = {
+  readonly name: string;
+  readonly keys: readonly string[];
+};
+
+export const REQUIRED_ENV_GROUPS: readonly EnvGroup[] = [
+  {
+    name: 'Supabase',
+    keys: [
+      'SUPABASE_URL',
+      'SUPABASE_ANON_KEY',
+      'SUPABASE_EDGE_URL',
+      'SUPABASE_SERVICE_ROLE_KEY',
+      'SUPABASE_ACCESS_TOKEN',
+    ],
+  },
+  {
+    name: 'OpenAI',
+    keys: ['OPENAI_API_KEY', 'OPENAI_ORGANIZATION'],
+  },
+  {
+    name: 'AWS',
+    keys: ['AWS_REGION', 'AWS_S3_BUCKET', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
+  },
+  {
+    name: 'SMTP',
+    keys: ['SMTP_HOST', 'SMTP_PORT', 'SMTP_USERNAME', 'SMTP_PASSWORD'],
+  },
+  {
+    name: 'Test JWTs',
+    keys: ['TEST_JWT_ORG_A', 'TEST_JWT_ORG_B', 'TEST_JWT_SUPER_ADMIN'],
+  },
+];
+
+export function collectMissingEnvVars(env: NodeJS.ProcessEnv): string[] {
+  return REQUIRED_ENV_GROUPS.flatMap((group) =>
+    group.keys.filter((key) => {
+      const value = env[key];
+      if (value === undefined) {
+        return true;
+      }
+
+      if (typeof value === 'string' && value.trim() === '') {
+        return true;
+      }
+
+      return false;
+    }),
+  );
+}
+
+export function formatMissingMessage(missingKeys: string[]): string {
+  if (missingKeys.length === 0) {
+    return '✅ All required secrets are configured.';
+  }
+
+  const header = '❌ Missing required secrets:';
+  const details = missingKeys.map((key) => `  - ${key}`).join('\n');
+  const footer = '\nPopulate these values via your local environment or secrets manager before running CI checks.';
+
+  return `${header}\n${details}${footer}`;
+}
+
+export function checkSecretsAndReport(env: NodeJS.ProcessEnv): { missing: string[]; exitCode: number } {
+  const missing = collectMissingEnvVars(env);
+  const exitCode = missing.length === 0 ? 0 : 1;
+  const message = formatMissingMessage(missing);
+  const output = exitCode === 0 ? console.log : console.error;
+  output(message);
+
+  return { missing, exitCode };
+}
+
+const isExecutedDirectly = (() => {
+  const executedFile = process.argv[1];
+  if (!executedFile) {
+    return false;
+  }
+
+  return import.meta.url === pathToFileURL(executedFile).href;
+})();
+
+if (isExecutedDirectly) {
+  const { exitCode } = checkSecretsAndReport(process.env);
+  process.exit(exitCode);
+}

--- a/tests/utils/check-secrets.spec.ts
+++ b/tests/utils/check-secrets.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { checkSecretsAndReport, collectMissingEnvVars, formatMissingMessage, REQUIRED_ENV_GROUPS } from '../../scripts/check-secrets';
+
+describe('check-secrets script', () => {
+  const allKeys = REQUIRED_ENV_GROUPS.flatMap((group) => group.keys);
+
+  it('identifies when all secrets are present', () => {
+    const env: NodeJS.ProcessEnv = Object.fromEntries(
+      allKeys.map((key) => [key, 'value']),
+    );
+
+    const missing = collectMissingEnvVars(env);
+
+    expect(missing).toEqual([]);
+    expect(formatMissingMessage(missing)).toContain('All required secrets');
+  });
+
+  it('lists missing secrets and exits with failure code', () => {
+    const env: NodeJS.ProcessEnv = { ...Object.fromEntries(allKeys.map((key) => [key, 'value'])) };
+    delete env.SUPABASE_URL;
+    env.OPENAI_API_KEY = '   ';
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { missing, exitCode } = checkSecretsAndReport(env);
+
+    expect(exitCode).toBe(1);
+    expect(missing).toContain('SUPABASE_URL');
+    expect(missing).toContain('OPENAI_API_KEY');
+    expect(formatMissingMessage(missing)).toMatch(/Missing required secrets/);
+
+    consoleError.mockRestore();
+  });
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -18,5 +18,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "scripts/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
### Summary
Ensure CI fails fast when required secrets are missing and document the new preflight tooling.

### Proposed changes
- add a TypeScript check that validates Supabase, OpenAI, AWS, SMTP, and test JWT secrets
- wire the secret audit into package scripts, CI, and developer documentation
- document secret rotation sources and provide unit coverage for the new CLI helper

### Tests added/updated
- tests/utils/check-secrets.spec.ts

### Checklist
- [x] `npm test` passed
- [x] `eslint .` passed
- [x] `tsc --noEmit` passed
- [ ] Supabase types regenerated

------
https://chatgpt.com/codex/tasks/task_b_68e3f261ea888332a93c5953314b3266