### PR TITLE
feat(schedule): URL-addressable modal state + CI parity test stabilization

### DIFF
--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useCallback, useLayoutEffect, useEffect, useR
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { format, parseISO, startOfWeek, addDays, endOfWeek } from "date-fns";
 import { getTimezoneOffset } from "date-fns-tz";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   Calendar as CalendarIcon,
   ChevronLeft,
@@ -66,6 +66,12 @@ import {
   applyPendingScheduleDetail,
   type PendingScheduleTransitionRecorder,
 } from "../features/scheduling/domain/pendingScheduleApply";
+import {
+  applyScheduleModalSearchParams,
+  clearScheduleModalSearchParams,
+  parseScheduleModalSearchParams,
+  SCHEDULE_MODAL_URL_TTL_MS,
+} from "./schedule-modal-url-state";
 
 const AUTO_SCHEDULE_CONCURRENCY = 3;
 const MISSING_NOTES_RETRY_HINT =
@@ -450,6 +456,7 @@ DayView.displayName = "DayView";
 
 export const Schedule = React.memo(() => {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   useCapturePendingScheduleEvent();
   const { user, profile, effectiveRole } = useAuth();
   const activeOrganizationId = useActiveOrganizationId();
@@ -475,6 +482,8 @@ export const Schedule = React.memo(() => {
   const [pendingTraceCorrelationId, setPendingTraceCorrelationId] = useState<string | null>(null);
   const [retryActionLabel, setRetryActionLabel] = useState<string | null>(null);
   const lastPendingScheduleKeyRef = useRef<string | null>(null);
+  const lastAppliedUrlModalKeyRef = useRef<string | null>(null);
+  const wasModalOpenRef = useRef(false);
 
   const queryClient = useQueryClient();
   const scheduleResetSetters = useMemo(
@@ -589,8 +598,21 @@ export const Schedule = React.memo(() => {
     [userTimeZone],
   );
 
+  const writeModalUrlState = useCallback(
+    (state: { mode: "create"; startTimeIso: string } | { mode: "edit"; sessionId: string }) => {
+      const params = applyScheduleModalSearchParams(searchParams, {
+        ...state,
+        expiresAtMs: Date.now() + SCHEDULE_MODAL_URL_TTL_MS,
+      });
+      setSearchParams(params, { replace: true });
+      const parsed = parseScheduleModalSearchParams(params);
+      lastAppliedUrlModalKeyRef.current = parsed.kind === "ready" ? parsed.key : null;
+    },
+    [searchParams, setSearchParams],
+  );
+
   const openFromPendingSchedule = useCallback((detail: PendingScheduleDetail | null) => {
-    applyPendingScheduleDetail({
+    const transition = applyPendingScheduleDetail({
       detail,
       lastDetailKeyRef: lastPendingScheduleKeyRef,
       setters: {
@@ -605,7 +627,14 @@ export const Schedule = React.memo(() => {
         setIsModalOpen,
       },
     });
-  }, []);
+
+    if (transition.decision === "apply" && transition.prefill) {
+      writeModalUrlState({
+        mode: "create",
+        startTimeIso: transition.prefill.date.toISOString(),
+      });
+    }
+  }, [writeModalUrlState]);
 
   const consumePendingSchedule = useCallback(() => {
     consumePendingScheduleFromStorage({
@@ -943,7 +972,10 @@ export const Schedule = React.memo(() => {
 
   // Memoized callbacks
   const handleCreateSession = useCallback(
-    (timeSlot: { date: Date; time: string }) => {
+    (
+      timeSlot: { date: Date; time: string },
+      options?: { syncUrl?: boolean },
+    ) => {
       const plan = buildScheduleModalOpenResetPlan({
         mode: "create",
         timeSlot,
@@ -964,11 +996,29 @@ export const Schedule = React.memo(() => {
         },
       });
       setRetryActionLabel(null);
+
+      const [hours, minutes] = timeSlot.time.split(":").map((part) => Number(part));
+      const startTime = new Date(timeSlot.date);
+      startTime.setHours(
+        Number.isFinite(hours) ? hours : 0,
+        Number.isFinite(minutes) ? minutes : 0,
+        0,
+        0,
+      );
+      if (options?.syncUrl !== false) {
+        writeModalUrlState({
+          mode: "create",
+          startTimeIso: startTime.toISOString(),
+        });
+      }
     },
-    [],
+    [writeModalUrlState],
   );
 
-  const handleEditSession = useCallback((session: Session) => {
+  const handleEditSession = useCallback((
+    session: Session,
+    options?: { syncUrl?: boolean },
+  ) => {
     const plan = buildScheduleModalOpenResetPlan({
       mode: "edit",
       session,
@@ -989,7 +1039,13 @@ export const Schedule = React.memo(() => {
       },
     });
     setRetryActionLabel(null);
-  }, []);
+    if (options?.syncUrl !== false) {
+      writeModalUrlState({
+        mode: "edit",
+        sessionId: session.id,
+      });
+    }
+  }, [writeModalUrlState]);
 
   const handleAddRecurrenceException = useCallback(() => {
     setRecurrenceExceptions((prev) => [...prev, ""]);
@@ -1017,6 +1073,15 @@ export const Schedule = React.memo(() => {
       scheduleResetSetters,
     );
   }, [scheduleResetSetters]);
+
+  useEffect(() => {
+    if (wasModalOpenRef.current && !isModalOpen) {
+      const params = clearScheduleModalSearchParams(searchParams);
+      setSearchParams(params, { replace: true });
+      lastAppliedUrlModalKeyRef.current = null;
+    }
+    wasModalOpenRef.current = isModalOpen;
+  }, [isModalOpen, searchParams, setSearchParams]);
 
   const handleSessionStarted = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["sessions"] });
@@ -1236,6 +1301,62 @@ export const Schedule = React.memo(() => {
 
   const hasBatchedData = Boolean(batchedData);
   const isLoading = isLoadingBatch || (!hasBatchedData && (isLoadingSessions || isLoadingDropdowns));
+
+  useEffect(() => {
+    const parsed = parseScheduleModalSearchParams(searchParams);
+    if (parsed.kind === "none") {
+      lastAppliedUrlModalKeyRef.current = null;
+      return;
+    }
+
+    if (parsed.kind === "expired" || parsed.kind === "invalid") {
+      const params = clearScheduleModalSearchParams(searchParams);
+      setSearchParams(params, { replace: true });
+      lastAppliedUrlModalKeyRef.current = null;
+      return;
+    }
+
+    if (lastAppliedUrlModalKeyRef.current === parsed.key) {
+      return;
+    }
+
+    if (parsed.state.mode === "create") {
+      const date = parseISO(parsed.state.startTimeIso);
+      handleCreateSession(
+        {
+          date,
+          time: format(date, "HH:mm"),
+        },
+        { syncUrl: false },
+      );
+      lastAppliedUrlModalKeyRef.current = parsed.key;
+      return;
+    }
+
+    if (isLoading) {
+      return;
+    }
+
+    const sessionPool = Array.isArray(batchedData?.sessions) ? batchedData.sessions : displayData.sessions;
+    const session = sessionPool.find((item) => item.id === parsed.state.sessionId);
+    if (!session) {
+      const params = clearScheduleModalSearchParams(searchParams);
+      setSearchParams(params, { replace: true });
+      lastAppliedUrlModalKeyRef.current = null;
+      return;
+    }
+
+    handleEditSession(session, { syncUrl: false });
+    lastAppliedUrlModalKeyRef.current = parsed.key;
+  }, [
+    searchParams,
+    setSearchParams,
+    isLoading,
+    batchedData?.sessions,
+    displayData.sessions,
+    handleCreateSession,
+    handleEditSession,
+  ]);
 
   if (!activeOrganizationId) {
     return (

--- a/src/pages/__tests__/Schedule.event.test.tsx
+++ b/src/pages/__tests__/Schedule.event.test.tsx
@@ -1,8 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { renderWithProviders, screen, waitFor } from "../../test/utils";
+import { useLocation } from "react-router-dom";
+import { renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
 import { Schedule } from "../Schedule";
 
 // Integration test for event-based scheduling
+function SearchProbe() {
+  const location = useLocation();
+  return <output data-testid="schedule-search">{location.search}</output>;
+}
 
 describe("Schedule page event listener", () => {
   beforeEach(() => {
@@ -12,7 +17,12 @@ describe("Schedule page event listener", () => {
     localStorage.clear();
   });
   it("opens session modal when openScheduleModal event is dispatched", async () => {
-    renderWithProviders(<Schedule />);
+    renderWithProviders(
+      <>
+        <Schedule />
+        <SearchProbe />
+      </>,
+    );
 
     // Wait for the page to finish loading
     await screen.findByRole("heading", { name: /Schedule/i });
@@ -45,12 +55,87 @@ describe("Schedule page event listener", () => {
     };
     localStorage.setItem("pendingSchedule", JSON.stringify(detail));
 
-    renderWithProviders(<Schedule />);
+    renderWithProviders(
+      <>
+        <Schedule />
+        <SearchProbe />
+      </>,
+    );
     await screen.findByRole("heading", { name: /Schedule/i });
 
     await waitFor(async () => {
       expect(await screen.findByText(/New Session/i)).toBeInTheDocument();
       expect(localStorage.getItem("pendingSchedule")).toBeNull();
+    });
+  });
+
+  it("opens create modal when query params request URL-addressable schedule state", async () => {
+    const expiresAtMs = Date.now() + 60_000;
+    const startTime = encodeURIComponent("2025-03-18T10:00:00.000Z");
+    renderWithProviders(
+      <>
+        <Schedule />
+        <SearchProbe />
+      </>,
+      {
+        router: {
+          initialEntries: [
+            `/?scheduleModal=create&scheduleStart=${startTime}&scheduleExp=${expiresAtMs}`,
+          ],
+        },
+      },
+    );
+
+    await screen.findByRole("heading", { name: /Schedule/i });
+    expect(await screen.findByText(/New Session/i)).toBeInTheDocument();
+  });
+
+  it("clears expired URL modal params without opening the modal", async () => {
+    const expiresAtMs = Date.now() - 1_000;
+    const startTime = encodeURIComponent("2025-03-18T10:00:00.000Z");
+    renderWithProviders(
+      <>
+        <Schedule />
+        <SearchProbe />
+      </>,
+      {
+        router: {
+          initialEntries: [
+            `/?scheduleModal=create&scheduleStart=${startTime}&scheduleExp=${expiresAtMs}`,
+          ],
+        },
+      },
+    );
+
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitFor(() => {
+      expect(screen.getByTestId("schedule-search").textContent).toBe("");
+    });
+    expect(screen.queryByText(/New Session/i)).not.toBeInTheDocument();
+  });
+
+  it("removes URL modal params when modal closes", async () => {
+    const expiresAtMs = Date.now() + 60_000;
+    const startTime = encodeURIComponent("2025-03-18T10:00:00.000Z");
+    renderWithProviders(
+      <>
+        <Schedule />
+        <SearchProbe />
+      </>,
+      {
+        router: {
+          initialEntries: [
+            `/?scheduleModal=create&scheduleStart=${startTime}&scheduleExp=${expiresAtMs}`,
+          ],
+        },
+      },
+    );
+
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await screen.findByText(/New Session/i);
+    await userEvent.click(screen.getByLabelText(/Close session modal/i));
+    await waitFor(() => {
+      expect(screen.getByTestId("schedule-search").textContent).toBe("");
     });
   });
 });

--- a/src/pages/__tests__/schedule-modal-url-state.test.ts
+++ b/src/pages/__tests__/schedule-modal-url-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyScheduleModalSearchParams,
+  clearScheduleModalSearchParams,
+  parseScheduleModalSearchParams,
+} from "../schedule-modal-url-state";
+
+describe("schedule modal url state", () => {
+  it("parses valid create state", () => {
+    const params = new URLSearchParams();
+    const next = applyScheduleModalSearchParams(params, {
+      mode: "create",
+      startTimeIso: "2025-03-18T10:00:00.000Z",
+      expiresAtMs: 1000,
+    });
+
+    expect(parseScheduleModalSearchParams(next, 999)).toEqual({
+      kind: "ready",
+      key: "create|2025-03-18T10:00:00.000Z|1000",
+      state: {
+        mode: "create",
+        startTimeIso: "2025-03-18T10:00:00.000Z",
+        expiresAtMs: 1000,
+      },
+    });
+  });
+
+  it("treats expired state as expired", () => {
+    const params = new URLSearchParams(
+      "scheduleModal=create&scheduleStart=2025-03-18T10:00:00.000Z&scheduleExp=1000",
+    );
+    expect(parseScheduleModalSearchParams(params, 1000)).toEqual({
+      kind: "expired",
+    });
+  });
+
+  it("parses valid edit state", () => {
+    const params = applyScheduleModalSearchParams(new URLSearchParams(), {
+      mode: "edit",
+      sessionId: "session-123",
+      expiresAtMs: 10_000,
+    });
+    expect(parseScheduleModalSearchParams(params, 9_999)).toEqual({
+      kind: "ready",
+      key: "edit|session-123|10000",
+      state: {
+        mode: "edit",
+        sessionId: "session-123",
+        expiresAtMs: 10_000,
+      },
+    });
+  });
+
+  it("marks malformed modal params as invalid", () => {
+    const params = new URLSearchParams("scheduleModal=create&scheduleExp=2000");
+    expect(parseScheduleModalSearchParams(params, 1000)).toEqual({
+      kind: "invalid",
+    });
+  });
+
+  it("clears modal-specific keys only", () => {
+    const params = new URLSearchParams(
+      "foo=1&scheduleModal=edit&scheduleSessionId=session-1&scheduleExp=9999",
+    );
+    const next = clearScheduleModalSearchParams(params);
+    expect(next.toString()).toBe("foo=1");
+  });
+});

--- a/src/pages/schedule-modal-url-state.ts
+++ b/src/pages/schedule-modal-url-state.ts
@@ -1,0 +1,128 @@
+const MODAL_MODE_QUERY_KEY = "scheduleModal";
+const MODAL_START_QUERY_KEY = "scheduleStart";
+const MODAL_SESSION_QUERY_KEY = "scheduleSessionId";
+const MODAL_EXPIRY_QUERY_KEY = "scheduleExp";
+
+export const SCHEDULE_MODAL_URL_TTL_MS = 30 * 60 * 1000;
+
+export type ScheduleModalUrlState =
+  | {
+      mode: "create";
+      startTimeIso: string;
+      expiresAtMs: number;
+    }
+  | {
+      mode: "edit";
+      sessionId: string;
+      expiresAtMs: number;
+    };
+
+export type ParsedScheduleModalUrlState =
+  | {
+      kind: "none";
+    }
+  | {
+      kind: "expired";
+    }
+  | {
+      kind: "invalid";
+    }
+  | {
+      kind: "ready";
+      state: ScheduleModalUrlState;
+      key: string;
+    };
+
+export function clearScheduleModalSearchParams(params: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(params);
+  next.delete(MODAL_MODE_QUERY_KEY);
+  next.delete(MODAL_START_QUERY_KEY);
+  next.delete(MODAL_SESSION_QUERY_KEY);
+  next.delete(MODAL_EXPIRY_QUERY_KEY);
+  return next;
+}
+
+export function applyScheduleModalSearchParams(
+  params: URLSearchParams,
+  state: ScheduleModalUrlState,
+): URLSearchParams {
+  const next = clearScheduleModalSearchParams(params);
+  next.set(MODAL_MODE_QUERY_KEY, state.mode);
+  next.set(MODAL_EXPIRY_QUERY_KEY, String(state.expiresAtMs));
+
+  if (state.mode === "create") {
+    next.set(MODAL_START_QUERY_KEY, state.startTimeIso);
+  } else {
+    next.set(MODAL_SESSION_QUERY_KEY, state.sessionId);
+  }
+
+  return next;
+}
+
+function normalizeExpiresAt(raw: string | null): number | null {
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return Math.trunc(parsed);
+}
+
+function isValidIsoDate(value: string | null): value is string {
+  if (!value) {
+    return false;
+  }
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime());
+}
+
+function toModalKey(state: ScheduleModalUrlState): string {
+  return state.mode === "create"
+    ? `create|${state.startTimeIso}|${state.expiresAtMs}`
+    : `edit|${state.sessionId}|${state.expiresAtMs}`;
+}
+
+export function parseScheduleModalSearchParams(
+  params: URLSearchParams,
+  nowMs: number = Date.now(),
+): ParsedScheduleModalUrlState {
+  const mode = params.get(MODAL_MODE_QUERY_KEY);
+  if (!mode) {
+    return { kind: "none" };
+  }
+
+  if (mode !== "create" && mode !== "edit") {
+    return { kind: "invalid" };
+  }
+
+  const expiresAtMs = normalizeExpiresAt(params.get(MODAL_EXPIRY_QUERY_KEY));
+  if (expiresAtMs === null) {
+    return { kind: "invalid" };
+  }
+  if (expiresAtMs <= nowMs) {
+    return { kind: "expired" };
+  }
+
+  if (mode === "create") {
+    const startTimeIso = params.get(MODAL_START_QUERY_KEY);
+    if (!isValidIsoDate(startTimeIso)) {
+      return { kind: "invalid" };
+    }
+    const state: ScheduleModalUrlState = { mode, startTimeIso, expiresAtMs };
+    return { kind: "ready", state, key: toModalKey(state) };
+  }
+
+  const sessionId = params.get(MODAL_SESSION_QUERY_KEY);
+  if (!sessionId || sessionId.trim().length === 0) {
+    return { kind: "invalid" };
+  }
+
+  const state: ScheduleModalUrlState = {
+    mode,
+    sessionId,
+    expiresAtMs,
+  };
+  return { kind: "ready", state, key: toModalKey(state) };
+}

--- a/tests/runtime-migration-parity.test.ts
+++ b/tests/runtime-migration-parity.test.ts
@@ -48,7 +48,7 @@ describe("runtime migration parity helpers", () => {
     } finally {
       rmSync(repoDir, { recursive: true, force: true });
     }
-  });
+  }, 20_000);
 
   it("returns an empty list when all required versions are present", () => {
     const missing = resolveMissingVersions(


### PR DESCRIPTION
## Summary
- Add URL-addressable schedule modal state for create/edit flows on `Schedule` using query params with expiry-based cleanup and normalized open/close synchronization.
- Expand schedule tests for URL-driven modal open/close behavior and add unit coverage for modal URL state parsing/validation.
- Stabilize CI gate flakiness for `tests/runtime-migration-parity.test.ts::collects added migration versions from a git merge range` with a narrow per-test timeout override only.

## Verification performed
- `npm run test:ci` ✅ (passed after stabilization)
- `npm run ci:playwright` ✅
- `npm run ci:check-focused` ✅
- `npm run typecheck` ✅
- `npm run build` ✅ (passes with unchanged pre-existing duplicate `aria-label` warnings)

## Remaining blocker (unrelated / out-of-scope)
- `npm run lint` fails due pre-existing issues under `.claude/worktrees/**` paths.
- This branch does not modify those paths and does not attempt to fix that unrelated lint noise.

## Residual risk
- The parity test timeout change is intentionally narrow and test-only; if CI host contention increases significantly, this test may still need follow-up tuning.
- No sessions product/server/Supabase behavior changes were added as part of gate stabilization.
