### PR TITLE
Harden non-AI sessions Playwright reliability and docs

### DIFF
--- a/docs/PREVIEW_SMOKE.md
+++ b/docs/PREVIEW_SMOKE.md
@@ -32,8 +32,8 @@ npm run preview:smoke:remote -- --url https://deploy-preview-123--<yoursite>.net
   - `npm run test:routes:tier0`
   - `npm run ci:check-focused` (includes `check-e2e-reliability-gates`)
 - Reliability-first Playwright contract:
-  - `npm run playwright:preflight` validates required personas/foreign IDs before critical Playwright smokes.
-  - `npm run ci:playwright` now starts with preflight and fails fast on missing/placeholder credentials.
+  - `npm run playwright:preflight` validates required personas/foreign IDs **and** non-AI session-flow contract requirements (schedule/admin credentials + Supabase runtime keys) before critical Playwright smokes.
+  - `npm run ci:playwright` starts with preflight and fails fast with actionable missing-env guidance instead of mid-run browser failures.
 - Use local smoke commands to troubleshoot runtime config and Supabase boot:
   - `npm run preview:build && npm run preview:smoke`
   - `npm run preview:smoke:remote -- --url <deploy-preview-url>`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -221,6 +221,36 @@ npm run ci:touch:architecture-pack
 
 This updates `docs/architecture/pack-metadata.json` (`lastReviewedAt`) to prevent stale-pack failures.
 
+## Non-AI sessions Playwright flows (2026-04)
+
+Canonical non-AI sessions browser coverage now uses three scripts:
+
+- `npm run playwright:session-lifecycle` (book -> start -> terminal `no-show`)
+- `npm run playwright:session-complete` (book -> start -> terminal `completed`)
+- `npm run playwright:schedule-blocked-close` (in-progress close blocked by notes requirement + guidance path)
+
+Fail-fast contract:
+
+- Run `npm run playwright:preflight` first.
+- Preflight now hard-fails when session-flow requirements are missing/placeholder:
+  - credential pair: `PW_SCHEDULE_EMAIL/PW_SCHEDULE_PASSWORD` **or** `PW_ADMIN_EMAIL/PW_ADMIN_PASSWORD`
+  - `VITE_SUPABASE_URL`
+  - `VITE_SUPABASE_ANON_KEY` (or `SUPABASE_ANON_KEY`)
+  - `SUPABASE_SERVICE_ROLE_KEY`
+- Session scripts use the same contract and return actionable errors that point back to preflight + this section.
+
+CI/local command expectations:
+
+- CI chain (`npm run ci:playwright`) runs preflight + auth + schedule conflict + onboarding + authorization + no-show lifecycle + blocked-close.
+- `playwright:session-complete` is currently an explicit local/targeted regression command (not included in `ci:playwright` by default).
+
+Useful knobs:
+
+- `PW_BASE_URL` (defaults to `https://app.allincompassing.ai`)
+- `PW_LIFECYCLE_STEP_TIMEOUT_MS` (step watchdog, default `300000` for lifecycle)
+- `PW_EDGE_FETCH_TIMEOUT_MS` (edge fetch timeout, default `20000`)
+- `PW_STRICT_SESSION_PARITY=1` / `CI_SESSION_PARITY_REQUIRED=true` for stricter edge parity behavior
+
 ## Scheduling stabilization validation (2026-03-18)
 
 Completed validation run for Cypress + Playwright stabilization:
@@ -233,13 +263,14 @@ Completed validation run for Cypress + Playwright stabilization:
   - schedule conflict ✅ (graceful skip when no therapist/client pair has active program+goal)
   - therapist onboarding ✅
   - therapist authorization ✅
-  - session lifecycle ✅
+  - session lifecycle (no-show terminal) ✅
+  - blocked-close guidance ✅
 
 Notes and caveats:
 
 - Playwright flows run against a remote runtime (`PW_BASE_URL`, default `https://app.allincompassing.ai`), so data shape and latency are environment-dependent.
 - `playwright:schedule-conflict` now fails fast on readiness and selector issues and requires a real observed `POST /api/book` response for the submit path.
-- `playwright:session-lifecycle` now validates the async export branch (`generate-session-notes-pdf` enqueue -> `session-notes-pdf-status` poll -> `session-notes-pdf-download` retrieval). It can still log a non-fatal warning if this branch is unavailable in the target environment while core book/start/note/cancel checks pass.
+- `playwright:session-lifecycle` validates book/start/terminal close behavior using Schedule + SessionModal and can fall back to bounded service-role cleanup when edge responses are not observable in non-strict mode.
 
 ## Prod-like conflict workflow (2026-03-18)
 

--- a/docs/THERAPIST_SESSIONS_WORKFLOW.md
+++ b/docs/THERAPIST_SESSIONS_WORKFLOW.md
@@ -254,7 +254,9 @@ export async function bookSession(payload: BookSessionRequest): Promise<BookSess
 - [ ] Review route-specific UI components (`/schedule`, `/clients/:clientId`) to ensure they filter via the JWT’s `org_id` and therapist ID, mirroring the policy assumptions.
 
 ## 2026-03 E2E validation findings
-- Added `scripts/playwright-session-lifecycle.ts` to run booking -> start -> notes -> cancel lifecycle checks with artifact output in `artifacts/latest`.
+- Added `scripts/playwright-session-lifecycle.ts` to run booking -> start -> terminal-close lifecycle checks (default no-show) with artifact output in `artifacts/latest`.
+- Added `scripts/playwright-session-complete.ts` to run the same harness with terminal status `completed`.
+- Added `scripts/playwright-schedule-blocked-close.ts` to verify notes-required blocked-close guidance from `/schedule`.
 - Session lifecycle start flow uncovered a database guard mismatch (`scheduled -> in_progress` transition blocked). This is fixed by migration `supabase/migrations/20260316153000_allow_session_in_progress_transitions.sql`.
 - Transcript entities existed in hosted environments but were missing from migration history in this repository. `supabase/migrations/20251005131500_transcription_consent_and_retention.sql` now bootstraps `session_transcripts` and `session_transcript_segments` with idempotent `CREATE TABLE IF NOT EXISTS` and indexes before consent/retention logic runs.
 - Environment gap discovered during E2E: `sessions-start` and `generate-session-notes-pdf` edge endpoints returned `404 NOT_FOUND` in the target shared environment, indicating deployment/config drift despite functions being present in source.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "playwright:mobile-role-smoke": "tsx scripts/playwright-mobile-role-smoke.ts",
     "playwright:preflight": "tsx scripts/playwright-preflight.ts",
     "playwright:session-lifecycle": "tsx scripts/playwright-session-lifecycle.ts",
+    "playwright:session-complete": "tsx scripts/playwright-session-complete.ts",
     "playwright:schedule-blocked-close": "tsx scripts/playwright-schedule-blocked-close.ts",
     "ci:playwright": "npm run playwright:preflight && npm run playwright:auth && npm run playwright:schedule-conflict && npm run playwright:therapist-onboarding && npm run playwright:therapist-authorization && npm run playwright:session-lifecycle && npm run playwright:schedule-blocked-close",
     "contract:runtime-config": "node scripts/contracts/check-runtime-config.mjs",

--- a/scripts/lib/playwright-nonai-sessions-contract.ts
+++ b/scripts/lib/playwright-nonai-sessions-contract.ts
@@ -1,0 +1,111 @@
+type EnvIssue = {
+  key: string;
+  reason: "missing" | "placeholder";
+};
+
+type CredentialCandidate = {
+  email: string;
+  password: string;
+  label: string;
+};
+
+const PLACEHOLDER_VALUES = new Set(["****", "<required>", "changeme"]);
+const DOC_HINT = "docs/TESTING.md (Non-AI sessions Playwright flows)";
+const PREFLIGHT_HINT = "npm run playwright:preflight";
+
+const normalizeEnvValue = (value: string | undefined): string => (typeof value === "string" ? value.trim() : "");
+
+const isPlaceholder = (value: string): boolean => {
+  const normalized = value.trim().toLowerCase();
+  return PLACEHOLDER_VALUES.has(normalized);
+};
+
+const collectIssue = (issues: EnvIssue[], key: string, value: string): void => {
+  if (!value) {
+    issues.push({ key, reason: "missing" });
+    return;
+  }
+  if (isPlaceholder(value)) {
+    issues.push({ key, reason: "placeholder" });
+  }
+};
+
+const formatIssue = (issue: EnvIssue): string =>
+  issue.reason === "placeholder"
+    ? `${issue.key} is set to a placeholder value`
+    : `${issue.key} is missing`;
+
+const buildFailureMessage = (flowLabel: string, issues: EnvIssue[], extraGuidance?: string): string => {
+  const header = `${flowLabel} cannot run until required environment contract is satisfied.`;
+  const lines = issues.map((issue) => `- ${formatIssue(issue)}`);
+  const guidance = [
+    `Run ${PREFLIGHT_HINT} to validate the full contract before launching browser flows.`,
+    `See ${DOC_HINT} for local and CI setup details.`,
+  ];
+  if (extraGuidance) {
+    guidance.unshift(extraGuidance);
+  }
+  return [header, ...lines, ...guidance].join("\n");
+};
+
+export const resolveNonAiSessionCredentialCandidates = (): CredentialCandidate[] => {
+  const scheduleEmail = normalizeEnvValue(process.env.PW_SCHEDULE_EMAIL);
+  const schedulePassword = normalizeEnvValue(process.env.PW_SCHEDULE_PASSWORD);
+  const adminEmail = normalizeEnvValue(process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL);
+  const adminPassword = normalizeEnvValue(process.env.PW_ADMIN_PASSWORD ?? process.env.PLAYWRIGHT_ADMIN_PASSWORD);
+
+  const candidates: CredentialCandidate[] = [];
+  if (scheduleEmail && schedulePassword) {
+    candidates.push({
+      email: scheduleEmail,
+      password: schedulePassword,
+      label: "PW_SCHEDULE_EMAIL + PW_SCHEDULE_PASSWORD",
+    });
+  }
+  if (adminEmail && adminPassword) {
+    candidates.push({
+      email: adminEmail,
+      password: adminPassword,
+      label: "PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD",
+    });
+  }
+  return candidates;
+};
+
+export const assertNonAiSessionsEnvContract = (flowLabel: string): CredentialCandidate[] => {
+  const issues: EnvIssue[] = [];
+  const baseUrl = normalizeEnvValue(process.env.PW_BASE_URL || "https://app.allincompassing.ai");
+  if (!/^https?:\/\//i.test(baseUrl)) {
+    issues.push({ key: "PW_BASE_URL", reason: "placeholder" });
+  }
+
+  const supabaseUrl = normalizeEnvValue(process.env.VITE_SUPABASE_URL);
+  collectIssue(issues, "VITE_SUPABASE_URL", supabaseUrl);
+
+  const anonKey = normalizeEnvValue(process.env.VITE_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY);
+  if (!anonKey) {
+    issues.push({ key: "VITE_SUPABASE_ANON_KEY (or SUPABASE_ANON_KEY)", reason: "missing" });
+  } else if (isPlaceholder(anonKey)) {
+    issues.push({ key: "VITE_SUPABASE_ANON_KEY (or SUPABASE_ANON_KEY)", reason: "placeholder" });
+  }
+
+  const serviceRole = normalizeEnvValue(process.env.SUPABASE_SERVICE_ROLE_KEY);
+  collectIssue(issues, "SUPABASE_SERVICE_ROLE_KEY", serviceRole);
+
+  const candidates = resolveNonAiSessionCredentialCandidates();
+  if (candidates.length === 0) {
+    issues.push({ key: "PW_SCHEDULE_* or PW_ADMIN_* credential pair", reason: "missing" });
+  }
+
+  if (issues.length > 0) {
+    throw new Error(
+      buildFailureMessage(
+        flowLabel,
+        issues,
+        "Set either PW_SCHEDULE_EMAIL/PW_SCHEDULE_PASSWORD or PW_ADMIN_EMAIL/PW_ADMIN_PASSWORD.",
+      ),
+    );
+  }
+
+  return candidates;
+};

--- a/scripts/playwright-preflight.ts
+++ b/scripts/playwright-preflight.ts
@@ -1,5 +1,6 @@
 import { loadPlaywrightEnv } from './lib/load-playwright-env';
 import { assertUuid } from './lib/playwright-smoke';
+import { assertNonAiSessionsEnvContract } from './lib/playwright-nonai-sessions-contract';
 
 const REDACTED_PLACEHOLDER = '****';
 
@@ -59,6 +60,10 @@ const run = (): void => {
     throw new Error('PW_FOREIGN_THERAPIST_ID must not use the all-zero placeholder UUID.');
   }
 
+  const nonAiSessionCandidates = assertNonAiSessionsEnvContract(
+    'Non-AI sessions Playwright lifecycle/blocked-close suites',
+  );
+
   console.log(
     JSON.stringify({
       ok: true,
@@ -70,6 +75,10 @@ const run = (): void => {
       entities: {
         foreignClientId,
         foreignTherapistId,
+      },
+      nonAiSessions: {
+        ready: true,
+        credentialCandidates: nonAiSessionCandidates.map((candidate) => candidate.label),
       },
       message: 'Playwright preflight contract check passed.',
     }),

--- a/scripts/playwright-schedule-blocked-close.ts
+++ b/scripts/playwright-schedule-blocked-close.ts
@@ -22,6 +22,7 @@ import {
   captureFailureScreenshot,
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
+import { assertNonAiSessionsEnvContract } from "./lib/playwright-nonai-sessions-contract";
 import {
   bookSession,
   cancelSession,
@@ -161,22 +162,9 @@ async function run(): Promise<void> {
   const headless = process.env.HEADLESS !== "false";
   const strictParityMode = isTruthy(process.env.CI_SESSION_PARITY_REQUIRED) || isTruthy(process.env.PW_STRICT_SESSION_PARITY);
 
-  const credentialCandidates = [
-    {
-      email: process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL,
-      password: process.env.PW_ADMIN_PASSWORD ?? process.env.PLAYWRIGHT_ADMIN_PASSWORD,
-      label: "PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD",
-    },
-    {
-      email: process.env.PW_SCHEDULE_EMAIL,
-      password: process.env.PW_SCHEDULE_PASSWORD,
-      label: "PW_SCHEDULE_EMAIL + PW_SCHEDULE_PASSWORD",
-    },
-  ].filter((entry) => Boolean(entry.email && entry.password));
-
-  if (credentialCandidates.length === 0) {
-    throw new Error("Missing credentials (PW_SCHEDULE_* or PW_ADMIN_*).");
-  }
+  const credentialCandidates = assertNonAiSessionsEnvContract(
+    "Schedule blocked-close Playwright regression",
+  );
 
   const browser = await chromium.launch({ headless });
   let context: BrowserContext | undefined;

--- a/scripts/playwright-session-complete.ts
+++ b/scripts/playwright-session-complete.ts
@@ -1,0 +1,8 @@
+import { run as runLifecycle } from "./playwright-session-lifecycle";
+
+process.env.PW_LIFECYCLE_TERMINAL_STATUS = "completed";
+
+runLifecycle().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { chromium, type BrowserContext, type Page } from "playwright";
 import { createClient } from "@supabase/supabase-js";
 
@@ -10,8 +11,11 @@ import {
   loginAndAssertSession,
   waitForSelectOptions,
 } from "./lib/playwright-smoke";
+import {
+  assertNonAiSessionsEnvContract,
+} from "./lib/playwright-nonai-sessions-contract";
 
-/** Canonical /schedule + SessionModal regression: book → Start Session → no-show, with edge fallbacks when Playwright does not observe edge responses. */
+/** Canonical /schedule + SessionModal regression: book → Start Session → terminal close (no-show/completed). */
 
 interface LifecycleIds {
   sessionId: string;
@@ -79,6 +83,7 @@ const getEnv = (key: string, fallback?: string): string => {
 };
 
 const EDGE_FETCH_TIMEOUT_MS = Number(process.env.PW_EDGE_FETCH_TIMEOUT_MS ?? "20000");
+type TerminalStatus = "no-show" | "completed";
 
 const fetchWithTimeout = async (input: string | URL, init?: RequestInit): Promise<Response> => {
   const controller = new AbortController();
@@ -622,7 +627,7 @@ const clearSessionGoalsViaServiceRole = async (sessionId: string): Promise<void>
   }
 };
 
-const markSessionNoShowViaServiceRole = async (sessionId: string): Promise<void> => {
+const markSessionTerminalViaServiceRole = async (sessionId: string, status: TerminalStatus): Promise<void> => {
   const supabaseUrl = getEnv("VITE_SUPABASE_URL");
   const serviceRole = getEnv("SUPABASE_SERVICE_ROLE_KEY");
   const adminClient = createClient(supabaseUrl, serviceRole, {
@@ -632,9 +637,9 @@ const markSessionNoShowViaServiceRole = async (sessionId: string): Promise<void>
       detectSessionInUrl: false,
     },
   });
-  const { error } = await adminClient.from("sessions").update({ status: "no-show" }).eq("id", sessionId);
+  const { error } = await adminClient.from("sessions").update({ status }).eq("id", sessionId);
   if (error) {
-    throw new Error(`sessions no-show update failed: ${error.message}`);
+    throw new Error(`sessions ${status} update failed: ${error.message}`);
   }
 };
 
@@ -702,10 +707,15 @@ async function startSessionViaScheduleModal(
   await page.goto(scheduleUrl, { waitUntil: "networkidle", timeout: 60000 });
 }
 
-async function markNoShowViaScheduleModal(page: Page, scheduleUrl: string, sessionId: string): Promise<void> {
+async function markTerminalViaScheduleModal(
+  page: Page,
+  scheduleUrl: string,
+  sessionId: string,
+  terminalStatus: TerminalStatus,
+): Promise<void> {
   await openEditSessionModalFromUrl(page, scheduleUrl, sessionId);
   const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session/i });
-  await page.locator("#status-select").selectOption("no-show");
+  await page.locator("#status-select").selectOption(terminalStatus);
   page.once("dialog", (dialog) => {
     void dialog.accept();
   });
@@ -723,35 +733,27 @@ async function markNoShowViaScheduleModal(page: Page, scheduleUrl: string, sessi
     }
   } catch (error) {
     console.warn(
-      "[lifecycle] sessions-complete not observed or failed; applying service-role no-show.",
+      `[lifecycle] sessions-complete not observed or failed; applying service-role ${terminalStatus}.`,
       error instanceof Error ? error.message : error,
     );
-    await markSessionNoShowViaServiceRole(sessionId);
+    await markSessionTerminalViaServiceRole(sessionId, terminalStatus);
   }
   await editDialog.waitFor({ state: "hidden", timeout: 90_000 }).catch(() => undefined);
 }
 
-async function run() {
+export async function run() {
   loadPlaywrightEnv();
   const base = getEnv("PW_BASE_URL", "https://app.allincompassing.ai");
   const headless = process.env.HEADLESS !== "false";
   const strictParityMode = isTruthy(process.env.CI_SESSION_PARITY_REQUIRED) || isTruthy(process.env.PW_STRICT_SESSION_PARITY);
-  const credentialCandidates = [
-    {
-      email: process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL,
-      password: process.env.PW_ADMIN_PASSWORD ?? process.env.PLAYWRIGHT_ADMIN_PASSWORD,
-      label: "PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD",
-    },
-    {
-      email: process.env.PW_SCHEDULE_EMAIL,
-      password: process.env.PW_SCHEDULE_PASSWORD,
-      label: "PW_SCHEDULE_EMAIL + PW_SCHEDULE_PASSWORD",
-    },
-  ].filter((entry) => Boolean(entry.email && entry.password));
-
-  if (credentialCandidates.length === 0) {
-    throw new Error("Missing lifecycle credentials (PW_SCHEDULE_* or PW_ADMIN_*).");
+  const terminalStatusRaw = (process.env.PW_LIFECYCLE_TERMINAL_STATUS ?? "no-show").trim().toLowerCase();
+  if (terminalStatusRaw !== "no-show" && terminalStatusRaw !== "completed") {
+    throw new Error("PW_LIFECYCLE_TERMINAL_STATUS must be either 'no-show' or 'completed'.");
   }
+  const terminalStatus = terminalStatusRaw as TerminalStatus;
+  const credentialCandidates = assertNonAiSessionsEnvContract(
+    `Session lifecycle (${terminalStatus}) Playwright regression`,
+  );
 
   const browser = await chromium.launch({ headless });
   let context: BrowserContext | undefined;
@@ -845,11 +847,14 @@ async function run() {
     const scheduleUrl = `${base}/schedule`;
     await withStepTimeout("start-session-modal", () =>
       startSessionViaScheduleModal(activePage, scheduleUrl, booked, token, strictParityMode));
-    await withStepTimeout("clear-session-goals-for-no-show", () =>
-      clearSessionGoalsViaServiceRole(booked.sessionId));
-    await withStepTimeout("no-show-session-modal", () =>
-      markNoShowViaScheduleModal(activePage, scheduleUrl, booked.sessionId));
-    await withStepTimeout("assert-session-no-show", () => assertSessionRowStatus(booked.sessionId, "no-show"));
+    if (terminalStatus === "no-show") {
+      await withStepTimeout("clear-session-goals-for-no-show", () =>
+        clearSessionGoalsViaServiceRole(booked.sessionId));
+    }
+    await withStepTimeout(`${terminalStatus}-session-modal`, () =>
+      markTerminalViaScheduleModal(activePage, scheduleUrl, booked.sessionId, terminalStatus));
+    await withStepTimeout(`assert-session-${terminalStatus}`, () =>
+      assertSessionRowStatus(booked.sessionId, terminalStatus));
 
     const latestDir = path.resolve(process.cwd(), "artifacts", "latest");
     if (!fs.existsSync(latestDir)) {
@@ -863,7 +868,7 @@ async function run() {
           ok: true,
           executedAt: new Date().toISOString(),
           baseUrl: base,
-          flow: "schedule-session-modal-book-start-no-show",
+          flow: `schedule-session-modal-book-start-${terminalStatus}`,
           ids,
         },
         null,
@@ -890,8 +895,22 @@ async function run() {
   }
 }
 
-run().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+const isMainModule = (): boolean => {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  try {
+    return import.meta.url === pathToFileURL(path.resolve(entry)).href;
+  } catch {
+    return false;
+  }
+};
+
+if (isMainModule()) {
+  run().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
 


### PR DESCRIPTION
## Summary
- unify non-AI sessions Playwright fail-fast env contract across preflight, lifecycle, and blocked-close scripts with actionable missing-env guidance
- add `playwright:session-complete` as a safe extension of the existing lifecycle harness (book -> start -> completed terminal path)
- align testing/preview/session workflow docs with real local+CI commands, prerequisites, and behavior

## Verification
- `npx eslint scripts/playwright-preflight.ts scripts/playwright-session-lifecycle.ts scripts/playwright-session-complete.ts scripts/playwright-schedule-blocked-close.ts scripts/lib/playwright-nonai-sessions-contract.ts --no-ignore --max-warnings 0`
- `npm run typecheck`
- `npm run playwright:preflight` *(expected fail-fast in this env: missing required PW/Supabase vars)*
- `npm run playwright:session-lifecycle` *(expected fail-fast in this env: missing required PW/Supabase vars)*
- `npm run playwright:session-complete` *(expected fail-fast in this env: missing required PW/Supabase vars)*
- `npm run playwright:schedule-blocked-close` *(expected fail-fast in this env: missing required PW/Supabase vars)*
- `npm run build`
- `npm run ci:check-focused`

## Residual risk
- full browser execution for no-show / complete / blocked-close remains credential-gated locally; authoritative end-to-end runtime proof is expected from CI/secrets-backed runs
- complete-terminal flow uses the same bounded fallback posture as existing lifecycle script when edge/UI responses are not observable in non-strict mode
