### PR TITLE
chore(parity): drift manifest + suppress superseded caloptima assessment migration

### DIFF
--- a/config/migration-drift-manifest.json
+++ b/config/migration-drift-manifest.json
@@ -1,12 +1,14 @@
 {
   "meta": {
     "schemaVersion": 1,
-    "classification": "LEDGER_ONLY_DRIFT",
+    "classification": "MIXED",
     "sourceArtifact": "reports/migration-triage-inventory.json",
     "sourceInventoryGeneratedAt": "2026-04-07T16:00:55.714Z",
     "sourceProjectIdExpected": "wnnjeqheqxxyrgsjmygy",
-    "entryCount": 83,
-    "note": "Human-reviewed bulk drift-only suppressions for parity reporting. These versions are not candidates for DDL apply via allowlist; remote ledger filename/version mismatch or substance already present."
+    "entryCount": 84,
+    "ledgerOnlyDriftEntryCount": 83,
+    "supersededDoNotApplyEntryCount": 1,
+    "note": "Human-reviewed parity suppressions: bulk LEDGER_ONLY_DRIFT from migration-triage-inventory.json, plus optional SUPERSEDED_DO_NOT_APPLY entries preserved here (not from inventory regen). These versions are excluded from actionable pending in scripts/report-migration-parity.mjs; they are not DDL allowlist guards. Do not replay superseded historical SQL on main without a new reviewed migration."
   },
   "entries": [
     {
@@ -508,6 +510,16 @@
       "matchRuleSummary": "name_slug_prefix_suffix:20260210151545",
       "nearestRemoteVersion": "20260210151545",
       "nearestRemoteName": "lock_authorization_rpc_search_path_20260210"
+    },
+    {
+      "version": "20260212120000",
+      "filename": "20260212120000_caloptima_assessment_staging.sql",
+      "slug": "caloptima_assessment_staging",
+      "classification": "SUPERSEDED_DO_NOT_APPLY",
+      "reason": "Human-reviewed 2026: main assessment staging exists via applied migrations 20260219181744 (assessment_staging_and_storage_access_hotfix) and 20260220161517 (assessment_extraction_lifecycle_fields); live schema/RLS/policy surface does not match this historical file. Do not replay on main: DROP/CREATE policies on several assessment_* tables would change authz. Parity suppression only — not an allowlist safety gate.",
+      "matchRuleSummary": "none",
+      "nearestRemoteVersion": "20260219181744",
+      "nearestRemoteName": "assessment_staging_and_storage_access_hotfix_20260219"
     },
     {
       "version": "20260219183000",

--- a/scripts/build-migration-drift-manifest.mjs
+++ b/scripts/build-migration-drift-manifest.mjs
@@ -1,6 +1,10 @@
 /**
  * Regenerate config/migration-drift-manifest.json from reports/migration-triage-inventory.json.
- * Only rows with classification LEDGER_ONLY_DRIFT are included (bulk-approved drift-only queue).
+ * Rows with classification LEDGER_ONLY_DRIFT become the bulk of the manifest.
+ *
+ * Preserves existing entries with classification SUPERSEDED_DO_NOT_APPLY (human-reviewed parity
+ * suppressions that are not in the inventory LEDGER_ONLY set). Dedupes by version: superseded
+ * entry wins over a generated LEDGER row if both exist.
  *
  * Usage: node scripts/build-migration-drift-manifest.mjs
  */
@@ -11,6 +15,17 @@ import process from 'process';
 const projectRoot = process.cwd();
 const inventoryPath = path.join(projectRoot, 'reports', 'migration-triage-inventory.json');
 const outPath = path.join(projectRoot, 'config', 'migration-drift-manifest.json');
+
+async function loadPreservedSupersededEntries() {
+  try {
+    const raw = await readFile(outPath, 'utf8');
+    const doc = JSON.parse(raw);
+    if (!Array.isArray(doc.entries)) return [];
+    return doc.entries.filter((e) => e && e.classification === 'SUPERSEDED_DO_NOT_APPLY');
+  } catch {
+    return [];
+  }
+}
 
 async function main() {
   const raw = await readFile(inventoryPath, 'utf8');
@@ -31,27 +46,40 @@ async function main() {
     );
   }
 
+  const preservedSuperseded = await loadPreservedSupersededEntries();
+  const supersededByVersion = new Map(preservedSuperseded.map((e) => [e.version, e]));
+
+  const ledgerEntries = rows.map((r) => ({
+    version: r.version,
+    filename: r.filename,
+    slug: r.slug,
+    classification: 'LEDGER_ONLY_DRIFT',
+    reason: r.reason,
+    matchRuleSummary: r.match_rule_summary,
+    nearestRemoteVersion: r.nearest_remote_version,
+    nearestRemoteName: r.nearest_remote_name,
+  }));
+
+  const ledgerFiltered = ledgerEntries.filter((e) => !supersededByVersion.has(e.version));
+
+  const mergedEntries = [...ledgerFiltered, ...preservedSuperseded].sort((a, b) =>
+    String(a.version).localeCompare(String(b.version)),
+  );
+
   const manifest = {
     meta: {
       schemaVersion: 1,
-      classification: 'LEDGER_ONLY_DRIFT',
+      classification: 'MIXED',
       sourceArtifact: 'reports/migration-triage-inventory.json',
       sourceInventoryGeneratedAt: inv.meta?.generatedAt ?? null,
       sourceProjectIdExpected: inv.meta?.project_id_expected ?? null,
-      entryCount: rows.length,
+      entryCount: mergedEntries.length,
+      ledgerOnlyDriftEntryCount: ledgerFiltered.length,
+      supersededDoNotApplyEntryCount: preservedSuperseded.length,
       note:
-        'Human-reviewed bulk drift-only suppressions for parity reporting. These versions are not candidates for DDL apply via allowlist; remote ledger filename/version mismatch or substance already present.',
+        'Human-reviewed parity suppressions: bulk LEDGER_ONLY_DRIFT from migration-triage-inventory.json, plus optional SUPERSEDED_DO_NOT_APPLY entries preserved here (not from inventory regen). These versions are excluded from actionable pending in scripts/report-migration-parity.mjs; they are not DDL allowlist guards. Do not replay superseded historical SQL on main without a new reviewed migration.',
     },
-    entries: rows.map((r) => ({
-      version: r.version,
-      filename: r.filename,
-      slug: r.slug,
-      classification: 'LEDGER_ONLY_DRIFT',
-      reason: r.reason,
-      matchRuleSummary: r.match_rule_summary,
-      nearestRemoteVersion: r.nearest_remote_version,
-      nearestRemoteName: r.nearest_remote_name,
-    })),
+    entries: mergedEntries,
   };
 
   if (manifest.entries.length !== manifest.meta.entryCount) {
@@ -60,7 +88,9 @@ async function main() {
 
   await mkdir(path.dirname(outPath), { recursive: true });
   await writeFile(outPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
-  console.log(`Wrote ${rows.length} entries to ${path.relative(projectRoot, outPath)}`);
+  console.log(
+    `Wrote ${mergedEntries.length} entries (${ledgerFiltered.length} LEDGER_ONLY_DRIFT + ${preservedSuperseded.length} SUPERSEDED_DO_NOT_APPLY preserved) to ${path.relative(projectRoot, outPath)}`,
+  );
 }
 
 main().catch((e) => {

--- a/scripts/report-migration-parity.mjs
+++ b/scripts/report-migration-parity.mjs
@@ -4,7 +4,8 @@
  * Env: BRANCH_DB_URL | SUPABASE_DB_URL | DIRECT_URL | DATABASE_URL (same resolution as apply-remote-migrations.mjs)
  *
  * Suppression: actionable pending excludes versions listed in config/migration-drift-manifest.json
- * (LEDGER_ONLY_DRIFT — see scripts/build-migration-drift-manifest.mjs). Raw pending count is unchanged.
+ * (bulk LEDGER_ONLY_DRIFT from triage + optional SUPERSEDED_DO_NOT_APPLY preserved entries;
+ * see scripts/build-migration-drift-manifest.mjs). Raw pending count is unchanged.
  */
 import { readdir, readFile } from 'fs/promises';
 import path from 'path';


### PR DESCRIPTION
## Summary
Adds human-reviewed parity suppression for \20260212120000_caloptima_assessment_staging\ as **SUPERSEDED_DO_NOT_APPLY** (main already has assessment staging via applied migrations \20260219181744\ / \20260220161517\; replaying the historical file would rewrite RLS on several \ssessment_*\ tables).

## Changes
- **config/migration-drift-manifest.json**: 84th entry with version, classification, reason, nearest remote references; \meta\ documents **MIXED** manifest (83 LEDGER_ONLY_DRIFT + 1 superseded).
- **scripts/build-migration-drift-manifest.mjs**: preserve \SUPERSEDED_DO_NOT_APPLY\ entries on regen; dedupe by version (superseded wins).
- **scripts/report-migration-parity.mjs**: header comment clarifies suppression is not only LEDGER_ONLY_DRIFT.

## Verification
- \
ode -r dotenv/config scripts/report-migration-parity.mjs\: raw pending **92** unchanged; actionable pending **9 → 8**; \20260212120000\ no longer in actionable sample.
- \
ode scripts/build-migration-drift-manifest.mjs\: confirms 83 + 1 preserved.
- \
pm run lint\, \
pm run typecheck\, pre-commit \ci:check-focused\ passed on commit.

## Risk
Manifest affects **parity reporting only**, not \pply-remote-migrations.mjs\ allowlists. Residual: triage inventory still lists this version under NEEDS_SCHEMA_DIFF_REVIEW until regenerated separately.

Made with [Cursor](https://cursor.com)