### PR TITLE
fix(edge): sessions-book success envelope matches bookSessionEnvelopeSchema

### DIFF
--- a/supabase/functions/sessions-book/index.ts
+++ b/supabase/functions/sessions-book/index.ts
@@ -78,6 +78,12 @@ const parseEdgeJson = async (response: Response): Promise<Record<string, unknown
   }
 };
 
+/** Plain objects for bookSessionEnvelopeSchema (z.record); never null — matches legacy bookSession shape. */
+const asBookingRecord = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { status: 200, headers: corsHeadersForRequest(req) });
@@ -176,13 +182,18 @@ Deno.serve(async (req) => {
   }
 
   const confirmData = (confirmBody.data as Record<string, unknown> | undefined) ?? {};
+  const sessionsRaw = confirmData["sessions"];
+  const sessionsNormalized = Array.isArray(sessionsRaw)
+    ? sessionsRaw.map((row) => asBookingRecord(row))
+    : [];
+
   return json(req, 200, {
     success: true,
     data: {
-      session: confirmData.session ?? null,
-      sessions: confirmData.sessions ?? [],
-      hold: holdBody.data ?? null,
-      cpt: payload.overrides ?? null,
+      session: asBookingRecord(confirmData["session"]),
+      sessions: sessionsNormalized,
+      hold: asBookingRecord(holdBody.data),
+      cpt: asBookingRecord(payload.overrides),
     },
   });
 });

--- a/tests/edge/sessions-book.success-envelope.contract.test.ts
+++ b/tests/edge/sessions-book.success-envelope.contract.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { bookSessionEnvelopeSchema } from '../../src/lib/contracts/scheduling';
+import { stubDenoEnv } from '../utils/stubDeno';
+
+const envValues = new Map<string, string>([
+  ['CORS_ALLOWED_ORIGINS', 'https://app.example.com,https://preview.example.com'],
+  ['SUPABASE_URL', 'https://example.supabase.co'],
+  ['SUPABASE_ANON_KEY', 'anon-key'],
+]);
+
+stubDenoEnv((key) => envValues.get(key) ?? '');
+
+const fetchMock = vi.fn<typeof fetch>();
+
+async function loadHandler() {
+  let serveHandler: ((req: Request) => Promise<Response>) | undefined;
+  const denoObject = (globalThis as typeof globalThis & { Deno?: Record<string, unknown> }).Deno ?? {};
+
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('Deno', {
+    ...denoObject,
+    env: {
+      get: (key: string) => envValues.get(key) ?? '',
+    },
+    serve: vi.fn((handler: (req: Request) => Promise<Response>) => {
+      serveHandler = handler;
+      return {};
+    }),
+  });
+
+  await import('../../supabase/functions/sessions-book/index.ts');
+
+  if (!serveHandler) {
+    throw new Error('Expected sessions-book to register a Deno.serve handler');
+  }
+
+  return serveHandler;
+}
+
+describe('sessions-book success envelope vs bookSessionEnvelopeSchema', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns data.cpt as {} when overrides are omitted so client Zod parse succeeds', async () => {
+    const sessionRow = {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      therapist_id: '11111111-1111-1111-1111-111111111111',
+      client_id: '22222222-2222-2222-2222-222222222222',
+      program_id: '33333333-3333-3333-3333-333333333333',
+      goal_id: '44444444-4444-4444-4444-444444444444',
+      start_time: '2026-03-30T05:00:00.000Z',
+      end_time: '2026-03-30T05:30:00.000Z',
+      status: 'scheduled',
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              holdKey: 'hold-ok',
+              holdId: 'hold-id-ok',
+              expiresAt: '2026-03-30T05:05:00.000Z',
+              holds: [],
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              session: sessionRow,
+              sessions: [sessionRow],
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/functions/v1/sessions-book', {
+        method: 'POST',
+        headers: {
+          Origin: 'https://preview.example.com',
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          session: {
+            therapist_id: '11111111-1111-1111-1111-111111111111',
+            client_id: '22222222-2222-2222-2222-222222222222',
+            program_id: '33333333-3333-3333-3333-333333333333',
+            goal_id: '44444444-4444-4444-4444-444444444444',
+            start_time: '2026-03-30T05:00:00.000Z',
+            end_time: '2026-03-30T05:30:00.000Z',
+          },
+          startTimeOffsetMinutes: -420,
+          endTimeOffsetMinutes: -420,
+          timeZone: 'America/Los_Angeles',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.data.cpt).toEqual({});
+    expect(payload.data.hold).toMatchObject({ holdKey: 'hold-ok' });
+
+    const parsed = bookSessionEnvelopeSchema.safeParse(payload);
+    expect(parsed.success, parsed.success ? '' : JSON.stringify(parsed.error.format())).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Aligns `sessions-book` HTTP 200 success JSON with the client `bookSessionEnvelopeSchema`: `data.cpt`, `data.session`, `data.hold`, and `data.sessions[]` entries are always plain objects (never `null`), so Zod parsing in `bookSessionViaApi` does not fail after a successful book when CPT overrides are omitted.

## Root cause

`bookSessionResultSchema` requires `cpt` as `z.record(z.unknown())`. The edge function previously returned `cpt: null` when `overrides` were absent, causing client parse failure and a misleading "Failed to book session" on 200 responses.

## Changes

- `supabase/functions/sessions-book/index.ts`: `asBookingRecord()` helper; normalize success payload fields.
- `tests/edge/sessions-book.success-envelope.contract.test.ts`: regression — `bookSessionEnvelopeSchema.safeParse` passes without overrides.

## Verification

- `npm run ci:check-focused`
- `npm run lint` / `npm run typecheck`
- `npm run test:ci` (1260 tests passed)
- `npm run build`
- `npm run validate:tenant`

## Deploy note

Deploy the `sessions-book` Edge Function so production receives the fix.

## Residual risk

Empty `{}` for CPT when overrides are absent is schema-safe; UI that expected legacy-derived CPT shape only from this field should verify behavior. Non-200 `/api/book` paths (e.g. 409) are unchanged.

## Linear

Link a critical-lane issue before merge per AGENTS.md (create in Linear if not already filed).
