### PR TITLE
fix(schedule): invalidate clinical session note queries after session update

### DIFF
--- a/src/features/scheduling/domain/__tests__/sessionNoteQueryInvalidation.test.ts
+++ b/src/features/scheduling/domain/__tests__/sessionNoteQueryInvalidation.test.ts
@@ -1,0 +1,41 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { invalidateSessionNoteCachesAfterSessionWrite } from "../sessionNoteQueryInvalidation";
+
+describe("invalidateSessionNoteCachesAfterSessionWrite", () => {
+  it("invalidates session-note-linked and client-session-notes with MISSING_ORG when org is absent", () => {
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+
+    invalidateSessionNoteCachesAfterSessionWrite(queryClient, {
+      sessionId: "session-a",
+      clientId: "client-b",
+      organizationId: null,
+    });
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ["session-note-linked", "session-a", "MISSING_ORG"],
+    });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ["client-session-notes", "client-b", "MISSING_ORG"],
+    });
+  });
+
+  it("uses concrete organization id when provided", () => {
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+
+    invalidateSessionNoteCachesAfterSessionWrite(queryClient, {
+      sessionId: "session-a",
+      clientId: "client-b",
+      organizationId: "org-uuid",
+    });
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ["session-note-linked", "session-a", "org-uuid"],
+    });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ["client-session-notes", "client-b", "org-uuid"],
+    });
+  });
+});

--- a/src/features/scheduling/domain/sessionNoteQueryInvalidation.ts
+++ b/src/features/scheduling/domain/sessionNoteQueryInvalidation.ts
@@ -1,0 +1,21 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+/**
+ * Invalidates React Query caches used when hydrating clinical session notes:
+ * - SessionModal: `['session-note-linked', sessionId, orgKey]`
+ * - ClientDetails SessionNotesTab: `['client-session-notes', clientId, orgKey]`
+ *
+ * `orgKey` must match `activeOrganizationId ?? 'MISSING_ORG'` where those queries are built.
+ */
+export function invalidateSessionNoteCachesAfterSessionWrite(
+  queryClient: QueryClient,
+  params: { sessionId: string; clientId: string; organizationId: string | null | undefined },
+): void {
+  const orgKey = params.organizationId ?? "MISSING_ORG";
+  void queryClient.invalidateQueries({
+    queryKey: ["session-note-linked", params.sessionId, orgKey],
+  });
+  void queryClient.invalidateQueries({
+    queryKey: ["client-session-notes", params.clientId, orgKey],
+  });
+}

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -60,6 +60,7 @@ import { applyScheduleResetBranch } from "../features/scheduling/domain/schedule
 import { decideScheduleSubmitBranch } from "../features/scheduling/domain/submitBranchDecision";
 import { adaptScheduleMutationError } from "../features/scheduling/domain/mutationErrorAdapter";
 import { applyScheduleMutationSuccessLifecycle } from "../features/scheduling/domain/mutationSuccessLifecycle";
+import { invalidateSessionNoteCachesAfterSessionWrite } from "../features/scheduling/domain/sessionNoteQueryInvalidation";
 import {
   checkInProgressSessionCloseReadiness,
   completeSessionFromModal,
@@ -1041,6 +1042,13 @@ export const Schedule = React.memo(() => {
       return bookingResult.session;
     },
     onSuccess: () => {
+      if (selectedSession?.id && selectedSession.client_id) {
+        invalidateSessionNoteCachesAfterSessionWrite(queryClient, {
+          sessionId: selectedSession.id,
+          clientId: selectedSession.client_id,
+          organizationId: activeOrganizationId,
+        });
+      }
       applyScheduleMutationSuccessLifecycle({
         kind: "update-success",
         invalidateQuery: (queryKey) => {


### PR DESCRIPTION
## Summary
Invalidate React Query caches for clinical session notes after a successful Schedule → Edit Session update so saved notes show on close/reopen without a hard refresh.

## Changes
- Add `invalidateSessionNoteCachesAfterSessionWrite` to invalidate `session-note-linked` and `client-session-notes` keys (org key matches MISSING_ORG sentinel used by consumers).
- Call from `updateSessionMutation.onSuccess` in `Schedule.tsx`.
- Unit tests for org absent vs present.

## Verification (local)
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npx vitest run src/features/scheduling/domain/__tests__/sessionNoteQueryInvalidation.test.ts`
- `npm run build`

## Risk
Low: extra refetches on successful session update; query keys aligned with SessionModal / SessionNotesTab.
