### PR TITLE
feat: flexible session duration and archive programs/goals

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -166,6 +166,8 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const [noteType, setNoteType] = useState<ProgramNote["note_type"]>("plan_update");
   const [noteContent, setNoteContent] = useState("");
   const [deletingAssessmentId, setDeletingAssessmentId] = useState<string | null>(null);
+  const [archivingProgramId, setArchivingProgramId] = useState<string | null>(null);
+  const [archivingGoalId, setArchivingGoalId] = useState<string | null>(null);
   const [isUploadProcessing, setIsUploadProcessing] = useState(false);
 
   const applyDraftGoal = (goal: ProgramGoalDraftResponse["goals"][number]) => {
@@ -217,10 +219,17 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     retry: false,
   });
 
+  const livePrograms = useMemo(
+    () => programs.filter((program) => program.status !== "archived"),
+    [programs],
+  );
+
   const resolvedProgramId = useMemo(() => {
-    if (selectedProgramId) return selectedProgramId;
-    return programs.find((program) => program.status === "active")?.id ?? programs[0]?.id ?? null;
-  }, [programs, selectedProgramId]);
+    if (selectedProgramId && livePrograms.some((program) => program.id === selectedProgramId)) {
+      return selectedProgramId;
+    }
+    return livePrograms.find((program) => program.status === "active")?.id ?? livePrograms[0]?.id ?? null;
+  }, [livePrograms, selectedProgramId]);
   const programNameValue = programName.trim();
   const goalTitleValue = goalTitle.trim();
   const goalDescriptionValue = goalDescription.trim();
@@ -270,6 +279,11 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     enabled: Boolean(resolvedProgramId),
     retry: false,
   });
+
+  const liveGoals = useMemo(
+    () => goals.filter((goal) => goal.status !== "archived"),
+    [goals],
+  );
 
   const { data: programNotes = [] } = useQuery({
     queryKey: ["program-notes", resolvedProgramId, organizationId ?? "MISSING_ORG"],
@@ -384,7 +398,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const hasRequiredAcceptedGoalMix =
     acceptedDraftChildGoalCount >= MIN_CHILD_GOALS && acceptedDraftParentGoalCount >= MIN_PARENT_GOALS;
   const hasStagedDraftChanges = hasExistingDrafts;
-  const hasDraftsButNoLivePrograms = hasExistingDrafts && programs.length === 0;
+  const hasDraftsButNoLivePrograms = hasExistingDrafts && livePrograms.length === 0;
   const canPromoteAssessment =
     canQuerySelectedAssessment &&
     !hasPendingRequiredChecklistItems &&
@@ -964,6 +978,97 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     onError: showError,
   });
 
+  const archiveProgram = useMutation({
+    mutationFn: async (program: Program) => {
+      const response = await callEdgeWithSupabaseFallback({
+        edgePath: `${PROGRAMS_EDGE_PATH}?program_id=${encodeURIComponent(program.id)}`,
+        fallback: async () => {
+          if (!organizationId) {
+            return jsonResponse({ error: "Organization context is required." }, 400);
+          }
+          const { error } = await supabase
+            .from("programs")
+            .update({ status: "archived" })
+            .eq("id", program.id)
+            .eq("organization_id", organizationId);
+          if (error) {
+            return jsonResponse({ error: error.message }, 500);
+          }
+          return jsonResponse({ ok: true });
+        },
+        init: {
+          method: "PATCH",
+          body: JSON.stringify({ status: "archived" }),
+        },
+        timeoutMs: PROGRAM_CREATE_REQUEST_TIMEOUT_MS,
+        timeoutMessage: "Archive program request timed out. Please retry.",
+      });
+      if (!response.ok) {
+        throw new Error(await parseApiErrorMessage(response, "Failed to remove program."));
+      }
+    },
+    onMutate: (program) => {
+      setArchivingProgramId(program.id);
+    },
+    onSuccess: (_, program) => {
+      showSuccess(`Program "${program.name}" removed from active care plan.`);
+      if (selectedProgramId === program.id) {
+        setSelectedProgramId(null);
+      }
+      queryClient.invalidateQueries({
+        queryKey: ["client-programs", client.id, organizationId ?? "MISSING_ORG"],
+      });
+    },
+    onError: showError,
+    onSettled: () => {
+      setArchivingProgramId(null);
+    },
+  });
+
+  const archiveGoal = useMutation({
+    mutationFn: async (goal: Goal) => {
+      const response = await callEdgeWithSupabaseFallback({
+        edgePath: `${GOALS_EDGE_PATH}?goal_id=${encodeURIComponent(goal.id)}`,
+        fallback: async () => {
+          if (!organizationId) {
+            return jsonResponse({ error: "Organization context is required." }, 400);
+          }
+          const { error } = await supabase
+            .from("goals")
+            .update({ status: "archived" })
+            .eq("id", goal.id)
+            .eq("organization_id", organizationId);
+          if (error) {
+            return jsonResponse({ error: error.message }, 500);
+          }
+          return jsonResponse({ ok: true });
+        },
+        init: {
+          method: "PATCH",
+          body: JSON.stringify({ status: "archived" }),
+        },
+        timeoutMs: GOAL_CREATE_REQUEST_TIMEOUT_MS,
+        timeoutMessage: "Archive goal request timed out. Please retry.",
+      });
+      if (!response.ok) {
+        throw new Error(await parseApiErrorMessage(response, "Failed to remove goal."));
+      }
+    },
+    onMutate: (goal) => {
+      setArchivingGoalId(goal.id);
+    },
+    onSuccess: (_, goal) => {
+      showSuccess(`Goal "${goal.title}" removed from active care plan.`);
+      queryClient.invalidateQueries({
+        queryKey: ["program-goals", goal.program_id, organizationId ?? "MISSING_ORG"],
+      });
+    },
+    onError: showError,
+    onSettled: () => {
+      setArchivingGoalId(null);
+    },
+  });
+
   const createNote = useMutation({
     mutationFn: async () => {
       if (!resolvedProgramId) {
@@ -1070,8 +1175,8 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       <div className="rounded-lg border border-sky-200 bg-sky-50/70 px-4 py-3 text-sm text-sky-900 dark:border-sky-700/60 dark:bg-sky-900/20 dark:text-sky-100">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <p>
-            Live care plan: <span className="font-semibold">{programs.length}</span> program(s) and{" "}
-            <span className="font-semibold">{goals.length}</span> goal(s) in the selected program.
+            Live care plan: <span className="font-semibold">{livePrograms.length}</span> program(s) and{" "}
+            <span className="font-semibold">{liveGoals.length}</span> active goal(s) in the selected program.
           </p>
           {hasDraftsButNoLivePrograms && (
             <button
@@ -1325,25 +1430,46 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
               Live records only. Uploaded assessment drafts appear here after you publish.
             </p>
             <div className="space-y-2">
-              {programs.length === 0 && (
+              {livePrograms.length === 0 && (
                 <p className="text-sm text-gray-500">No programs yet.</p>
               )}
-              {programs.map((program) => (
-                <button
-                  key={program.id}
-                  type="button"
-                  onClick={() => setSelectedProgramId(program.id)}
-                  className={`w-full text-left rounded-md px-3 py-2 text-sm border ${
-                    resolvedProgramId === program.id
-                      ? "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-200"
-                      : "border-transparent hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
-                  }`}
-                >
-                  <div className="font-medium">{program.name}</div>
-                  {program.description && (
-                    <div className="text-xs text-gray-500 mt-1 line-clamp-2">{program.description}</div>
-                  )}
-                </button>
+              {livePrograms.map((program) => (
+                <div key={program.id} className="flex items-stretch gap-1">
+                  <button
+                    type="button"
+                    onClick={() => setSelectedProgramId(program.id)}
+                    className={`min-w-0 flex-1 text-left rounded-md px-3 py-2 text-sm border ${
+                      resolvedProgramId === program.id
+                        ? "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-200"
+                        : "border-transparent hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
+                    }`}
+                  >
+                    <div className="font-medium">{program.name}</div>
+                    {program.description && (
+                      <div className="text-xs text-gray-500 mt-1 line-clamp-2">{program.description}</div>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Remove ${program.name}`}
+                    title="Remove from active care plan"
+                    onClick={() => {
+                      if (typeof window !== "undefined") {
+                        const confirmed = window.confirm(
+                          `Remove "${program.name}" from the active care plan? You can add programs again later.`,
+                        );
+                        if (!confirmed) {
+                          return;
+                        }
+                      }
+                      archiveProgram.mutate(program);
+                    }}
+                    disabled={archivingProgramId === program.id && archiveProgram.isLoading}
+                    className="shrink-0 rounded-md border border-transparent px-2 py-2 text-rose-700 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-900/30 disabled:opacity-50"
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </div>
               ))}
             </div>
           </div>
@@ -1853,16 +1979,40 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
               </div>
             ) : (
               <div className="space-y-3">
-                {goals.length === 0 && (
+                {liveGoals.length === 0 && (
                   <p className="text-sm text-gray-500">No goals in this program yet.</p>
                 )}
-                {goals.map((goal) => (
+                {liveGoals.map((goal) => (
                   <div key={goal.id} className="rounded-md border border-gray-200 dark:border-gray-700 p-3">
-                    <div className="flex items-center justify-between">
-                      <div className="font-medium text-gray-800 dark:text-gray-200">{goal.title}</div>
-                      <span className="text-xs uppercase text-gray-500">{goal.status}</span>
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="font-medium text-gray-800 dark:text-gray-200">{goal.title}</div>
+                          <span className="text-xs uppercase text-gray-500 shrink-0">{goal.status}</span>
+                        </div>
+                        <p className="text-xs text-gray-500 mt-1">{goal.description}</p>
+                      </div>
+                      <button
+                        type="button"
+                        aria-label={`Remove ${goal.title}`}
+                        title="Remove from active care plan"
+                        onClick={() => {
+                          if (typeof window !== "undefined") {
+                            const confirmed = window.confirm(
+                              `Remove goal "${goal.title}" from the active care plan?`,
+                            );
+                            if (!confirmed) {
+                              return;
+                            }
+                          }
+                          archiveGoal.mutate(goal);
+                        }}
+                        disabled={archivingGoalId === goal.id && archiveGoal.isLoading}
+                        className="shrink-0 rounded-md border border-transparent p-1.5 text-rose-700 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-900/30 disabled:opacity-50"
+                      >
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
+                      </button>
                     </div>
-                    <p className="text-xs text-gray-500 mt-1">{goal.description}</p>
                     <div className="mt-2 space-y-1 text-xs text-gray-500">
                       {goal.measurement_type && <p>Measurement: {goal.measurement_type}</p>}
                       {goal.baseline_data && <p>Baseline: {goal.baseline_data}</p>}

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -14,6 +14,8 @@ import { supabase } from '../lib/supabase';
 import { useActiveOrganizationId } from '../lib/organization';
 import { showError, showSuccess } from '../lib/toast';
 import {
+  addMinutesToLocalInput,
+  diffMinutesBetweenLocalInputs,
   formatSessionLocalInput,
   getDefaultSessionEndTime,
   normalizeQuarterHourLocalInput,
@@ -485,12 +487,6 @@ export function SessionModal({
   }, [startTime, therapistId, clientId, onRetryHintDismiss]);
 
   useEffect(() => {
-    if (startTime && therapistId && clientId) {
-      setValue('end_time', getDefaultSessionEndTime(startTime));
-    }
-  }, [startTime, therapistId, clientId, setValue]);
-
-  useEffect(() => {
     const requestId = conflictCheckRequestIdRef.current + 1;
     conflictCheckRequestIdRef.current = requestId;
     let cancelled = false;
@@ -760,12 +756,23 @@ export function SessionModal({
     }
 
     const normalized = normalizeQuarterHourLocalInput(value, resolvedTimeZone);
-    setValue(field, normalized.normalizedStart);
 
-    // If changing start time, also update end time
     if (field === 'start_time') {
-      setValue('end_time', normalized.normalizedEnd);
+      const previousStart = getValues('start_time');
+      const previousEnd = getValues('end_time');
+      setValue('start_time', normalized);
+      let durationMinutes = 60;
+      if (previousStart && previousEnd) {
+        const d = diffMinutesBetweenLocalInputs(previousStart, previousEnd, resolvedTimeZone);
+        if (d != null && d > 0) {
+          durationMinutes = d;
+        }
+      }
+      setValue('end_time', addMinutesToLocalInput(normalized, durationMinutes, resolvedTimeZone));
+      return;
     }
+
+    setValue('end_time', normalized);
   };
 
   const handleSelectAlternativeTime = (newStartTime: string, newEndTime: string) => {

--- a/src/features/scheduling/domain/__tests__/time.test.ts
+++ b/src/features/scheduling/domain/__tests__/time.test.ts
@@ -22,10 +22,9 @@ describe("scheduling time domain helpers", () => {
     expect(endTime).toBe("2026-03-20T11:30");
   });
 
-  it("rounds start input to nearest quarter hour and updates end", () => {
+  it("rounds local input to nearest quarter hour", () => {
     const normalized = normalizeQuarterHourLocalInput("2026-03-20T10:07", "America/New_York");
-    expect(normalized.normalizedStart.endsWith(":00") || normalized.normalizedStart.endsWith(":15")).toBe(true);
-    expect(normalized.normalizedEnd).not.toBe(normalized.normalizedStart);
+    expect(normalized.endsWith(":00") || normalized.endsWith(":15")).toBe(true);
   });
 });
 

--- a/src/features/scheduling/domain/time.ts
+++ b/src/features/scheduling/domain/time.ts
@@ -1,4 +1,4 @@
-import { addMinutes, format, parseISO } from "date-fns";
+import { addMinutes, differenceInMinutes, format, parseISO } from "date-fns";
 import {
   fromZonedTime as zonedTimeToUtc,
   toZonedTime as utcToZonedTime,
@@ -56,10 +56,38 @@ export const getDefaultSessionEndTime = (startTimeStr: string): string => {
   return format(endTime, "yyyy-MM-dd'T'HH:mm");
 };
 
-export const normalizeQuarterHourLocalInput = (
-  value: string,
+/** Minutes between two local datetime-local values in the scheduling timezone; null if invalid. */
+export const diffMinutesBetweenLocalInputs = (
+  startLocal: string,
+  endLocal: string,
   resolvedTimeZone: string,
-): { normalizedStart: string; normalizedEnd: string } => {
+): number | null => {
+  if (!startLocal?.trim() || !endLocal?.trim()) {
+    return null;
+  }
+  try {
+    const startUtc = zonedTimeToUtc(startLocal, resolvedTimeZone);
+    const endUtc = zonedTimeToUtc(endLocal, resolvedTimeZone);
+    const diff = differenceInMinutes(endUtc, startUtc);
+    return Number.isFinite(diff) ? diff : null;
+  } catch {
+    return null;
+  }
+};
+
+export const addMinutesToLocalInput = (
+  localInput: string,
+  minutes: number,
+  resolvedTimeZone: string,
+): string => {
+  const utc = zonedTimeToUtc(localInput, resolvedTimeZone);
+  const shifted = addMinutes(utc, minutes);
+  const local = utcToZonedTime(shifted, resolvedTimeZone);
+  return format(local, "yyyy-MM-dd'T'HH:mm");
+};
+
+/** Rounds a single local datetime-local value to the nearest 15 minutes (scheduling timezone). */
+export const normalizeQuarterHourLocalInput = (value: string, resolvedTimeZone: string): string => {
   const utcDate = zonedTimeToUtc(value, resolvedTimeZone);
   const minutes = utcDate.getUTCMinutes();
   const roundedMinutes = Math.round(minutes / 15) * 15;
@@ -71,12 +99,6 @@ export const normalizeQuarterHourLocalInput = (
   }
 
   const adjustedLocal = utcToZonedTime(adjustedUtc, resolvedTimeZone);
-  const endUtc = addMinutes(adjustedUtc, 60);
-  const endLocal = utcToZonedTime(endUtc, resolvedTimeZone);
-
-  return {
-    normalizedStart: format(adjustedLocal, "yyyy-MM-dd'T'HH:mm"),
-    normalizedEnd: format(endLocal, "yyyy-MM-dd'T'HH:mm"),
-  };
+  return format(adjustedLocal, "yyyy-MM-dd'T'HH:mm");
 };
 


### PR DESCRIPTION
## Summary
- **Session modal:** Editing start time keeps the previous session length (or defaults to 60 minutes when there is no valid prior range). Removed the effect that reset end time to start + 1 hour whenever therapist, client, or start time changed.
- **Scheduling helpers:** \
ormalizeQuarterHourLocalInput\ now returns a single rounded local string; added \diffMinutesBetweenLocalInputs\ and \ddMinutesToLocalInput\ for duration math in the scheduling timezone.
- **Programs & Goals tab:** Trash actions on live programs and goals call PATCH to set \status: archived\; archived rows are hidden from the active lists. Confirmation dialogs before archive.

## Verification
- \
pm run typecheck\
- Vitest: \	ime.test.ts\, \SessionModal.test.tsx\
- Pre-commit: \
pm run ci:check-focused\ (passed locally)

## Notes
- Program/goal removal is a soft archive (no hard delete); aligns with existing edge \PATCH\ APIs.

Made with [Cursor](https://cursor.com)