### PR TITLE
fix(dashboard): runtime config + apikey parity for /api/dashboard

### DIFF
--- a/src/lib/__tests__/optimizedQueries.dashboard.test.ts
+++ b/src/lib/__tests__/optimizedQueries.dashboard.test.ts
@@ -43,6 +43,7 @@ describe("useDashboardData dashboard route fetch", () => {
     const headers = init?.headers as Headers | undefined;
     expect(init?.method).toBe("GET");
     expect(headers?.get("Authorization")).toBe("Bearer token");
+    expect(headers?.get("apikey")).toBe("test-anon-key");
   });
 
   it("refreshes an expired access token before calling /api/dashboard", async () => {
@@ -66,6 +67,7 @@ describe("useDashboardData dashboard route fetch", () => {
     const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
     const headers = init?.headers as Headers | undefined;
     expect(headers?.get("Authorization")).toBe("Bearer fresh-token");
+    expect(headers?.get("apikey")).toBe("test-anon-key");
   });
 
   it("surfaces 401 when no access token can be resolved for dashboard route", async () => {

--- a/src/lib/optimizedQueries.ts
+++ b/src/lib/optimizedQueries.ts
@@ -7,6 +7,7 @@ import { logger } from './logger/logger';
 import { toError } from './logger/normalizeError';
 import { useDashboardLiveRefresh } from './dashboardLiveRefresh';
 import { callApi } from './api';
+import { ensureRuntimeSupabaseConfig, getSupabaseAnonKey } from './runtimeConfig';
 
 // ============================================================================
 // BATCHED SCHEDULE QUERIES (Replaces N+1 queries)
@@ -164,9 +165,14 @@ export const fetchDashboardData = async () => {
   const DASHBOARD_REQUEST_TIMEOUT_MS = 10000;
 
   const dashboardRouteFallback = async () => {
-    // Use callApi + getCurrentAccessToken (see ./api) so we send a non-expired JWT:
-    // raw getSession() can return a stale access_token while the UI still looks signed-in,
-    // which makes /api/dashboard and the edge auth middleware return 401.
+    // Same-origin GET /api/dashboard (no browser CORS). Wait for runtime config so URL/key
+    // match the live Supabase project; forward anon apikey so Netlify can proxy to the
+    // same project even if server env keys drift (edgeAuthority prefers request apikey).
+    await ensureRuntimeSupabaseConfig();
+    const anonKey = getSupabaseAnonKey();
+
+    // callApi + getCurrentAccessToken (see ./api): non-expired JWT; stale getSession()
+    // alone can 401 the edge auth middleware.
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(() => {
@@ -177,7 +183,12 @@ export const fetchDashboardData = async () => {
     });
 
     const response = await Promise.race([
-      callApi('/api/dashboard', { method: 'GET' }),
+      callApi('/api/dashboard', {
+        method: 'GET',
+        headers: {
+          apikey: anonKey,
+        },
+      }),
       timeoutPromise,
     ]).finally(() => {
       if (timeoutId) {


### PR DESCRIPTION
## Team fix (same-origin dashboard)

- Keep **GET `/api/dashboard`** via **`callApi`** (avoids browser CORS to `*.supabase.co`).
- **`await ensureRuntimeSupabaseConfig()`** before the request so bootstrap/runtime-config is loaded (green path).
- **`apikey: getSupabaseAnonKey()`** on the request so **`proxyToEdgeAuthority`** (`edgeAuthority.ts`) uses the **same publishable key as the browser** when forwarding to `get-dashboard-data`, reducing 401s when Netlify server env drifts from the live project.

## Tests

- `src/lib/__tests__/optimizedQueries.dashboard.test.ts` asserts **Authorization** + **apikey** headers.

## Ops

- Still verify Netlify **`SUPABASE_URL`** / anon key env for long-term parity.
