### PR TITLE
fix(ui): SessionModal mobile conflict compaction + footer hierarchy

### DIFF
--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { format, parseISO } from 'date-fns';
 import { 
   X, AlertCircle, Calendar, Clock, User, 
-  FileText, CheckCircle2, AlertTriangle 
+  FileText, CheckCircle2, AlertTriangle, ChevronDown 
 } from 'lucide-react';
 import type { Session, Therapist, Client, Goal, Program } from '../types';
 import { checkSchedulingConflicts, suggestAlternativeTimes, type Conflict, type AlternativeTime } from '../lib/conflicts';
@@ -1064,18 +1064,47 @@ export function SessionModal({
                 id={conflictDescriptionId}
                 role="region"
                 aria-labelledby={conflictHeadingId}
-                className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-900/30 rounded-lg p-3 sm:p-4"
+                className="rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/30 dark:bg-amber-900/20 max-sm:border-l-[3px] max-sm:border-l-amber-500/70 max-sm:bg-amber-50/90 max-sm:p-2 sm:p-4"
               >
-                <div className="flex items-center mb-2">
-                  <AlertTriangle className="w-5 h-5 text-amber-500 dark:text-amber-400 mr-2 flex-shrink-0" />
-                  <h3 id={conflictHeadingId} className="font-medium text-amber-800 dark:text-amber-200">
-                    Scheduling Conflicts
-                  </h3>
+                <div className="mb-2 flex items-center justify-between gap-2 max-sm:mb-1.5">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <AlertTriangle className="h-5 w-5 flex-shrink-0 text-amber-500 dark:text-amber-400 max-sm:h-4 max-sm:w-4" />
+                    <h3
+                      id={conflictHeadingId}
+                      className="font-medium text-amber-800 dark:text-amber-200 max-sm:text-sm max-sm:leading-tight"
+                    >
+                      Scheduling Conflicts
+                    </h3>
+                  </div>
+                  <span className="hidden shrink-0 rounded bg-amber-100/90 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-amber-900 max-sm:inline-flex dark:bg-amber-900/50 dark:text-amber-100">
+                    {conflicts.length}
+                  </span>
                 </div>
-                <ul className="space-y-2 text-sm text-amber-700 dark:text-amber-300">
+                {/* Narrow screens: messages behind disclosure to reduce vertical dominance */}
+                <details className="group sm:hidden">
+                  <summary className="flex cursor-pointer list-none items-center gap-1 text-xs font-medium text-amber-800/95 dark:text-amber-200/95 [&::-webkit-details-marker]:hidden">
+                    <span>View messages</span>
+                    <ChevronDown
+                      className="h-3.5 w-3.5 shrink-0 text-amber-700 transition-transform group-open:rotate-180 dark:text-amber-300"
+                      aria-hidden
+                    />
+                  </summary>
+                  <ul className="mt-1.5 max-h-32 space-y-1.5 overflow-y-auto border-t border-amber-200/40 pt-1.5 text-xs leading-snug text-amber-700 dark:text-amber-300">
+                    {conflicts.map((conflict, index) => (
+                      <li key={index} className="flex items-start gap-1.5">
+                        <AlertCircle
+                          className="mt-0.5 h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400"
+                          aria-hidden
+                        />
+                        <span>{conflict.message}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+                <ul className="hidden space-y-2 text-sm text-amber-700 dark:text-amber-300 sm:block">
                   {conflicts.map((conflict, index) => (
                     <li key={index} className="flex items-start">
-                      <AlertCircle className="w-4 h-4 mr-2 mt-0.5 flex-shrink-0" />
+                      <AlertCircle className="mt-0.5 mr-2 h-4 w-4 flex-shrink-0" />
                       <span>{conflict.message}</span>
                     </li>
                   ))}
@@ -1682,14 +1711,14 @@ export function SessionModal({
         </div>
 
         {/* Footer */}
-        <div className="sticky bottom-0 z-10 border-t bg-white/95 px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] backdrop-blur dark:border-gray-700 dark:bg-dark-lighter/95 sm:px-5 sm:py-4 sm:pb-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
-            <div className="grid grid-cols-1 gap-2 sm:flex sm:flex-wrap sm:justify-end">
+        <div className="sticky bottom-0 z-10 border-t bg-white/95 px-4 py-2.5 pb-[max(1rem,env(safe-area-inset-bottom,0px))] backdrop-blur dark:border-gray-700 dark:bg-dark-lighter/95 max-sm:pt-2 sm:px-5 sm:py-4 sm:pb-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
+            <div className="grid grid-cols-1 gap-1.5 sm:flex sm:flex-wrap sm:justify-end sm:gap-2 max-sm:grid-cols-2 max-sm:gap-2">
             <button
               type="button"
               onClick={handleAttemptClose}
               disabled={isSubmitting}
-              className="min-h-11 w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-dark dark:text-gray-300 dark:hover:bg-gray-800 sm:w-auto"
+              className={`min-h-11 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-none hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-dark dark:text-gray-300 dark:hover:bg-gray-800 sm:w-auto sm:px-4 sm:shadow-sm ${!session?.id ? 'max-sm:col-span-2' : ''}`}
             >
               Cancel
             </button>
@@ -1698,7 +1727,7 @@ export function SessionModal({
                 type="button"
                 onClick={handleStartSession}
                 disabled={!canStartSession || isDependentDataLoading}
-                className="min-h-11 w-full rounded-md border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700 shadow-sm hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-emerald-900/40 dark:bg-emerald-900/20 dark:text-emerald-200 dark:hover:bg-emerald-900/30 sm:w-auto"
+                className="min-h-11 w-full rounded-md border border-emerald-200 bg-emerald-50/90 px-3 py-2 text-sm font-medium text-emerald-800 shadow-none hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-emerald-900/40 dark:bg-emerald-900/25 dark:text-emerald-200 dark:hover:bg-emerald-900/35 sm:w-auto sm:px-4 sm:shadow-sm"
               >
                 Start Session
               </button>
@@ -1708,7 +1737,7 @@ export function SessionModal({
                 type="button"
                 onClick={handleCloseSession}
                 disabled={isSubmitting || isDependentDataLoading || isLoadingAlternatives}
-                className="min-h-11 w-full rounded-md border border-violet-200 bg-violet-50 px-4 py-2 text-sm font-medium text-violet-700 shadow-sm hover:bg-violet-100 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900/40 dark:bg-violet-900/20 dark:text-violet-200 dark:hover:bg-violet-900/30 sm:w-auto"
+                className="min-h-11 w-full rounded-md border border-violet-200 bg-violet-50/90 px-3 py-2 text-sm font-medium text-violet-800 shadow-none hover:bg-violet-100 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900/40 dark:bg-violet-900/25 dark:text-violet-200 dark:hover:bg-violet-900/35 sm:w-auto sm:px-4 sm:shadow-sm max-sm:col-span-2"
               >
                 Close Session
               </button>
@@ -1718,7 +1747,7 @@ export function SessionModal({
               type="submit"
               form="session-form"
               disabled={isSubmitting || isDependentDataLoading || isLoadingAlternatives}
-              className="flex min-h-11 w-full items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:min-w-[12rem]"
+              className="flex min-h-11 w-full items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:min-w-[12rem] sm:font-medium sm:shadow-sm max-sm:shadow-md"
             >
               {isSubmitting ? (
                 <>


### PR DESCRIPTION
## Summary
Mobile-only presentation polish for Schedule → Edit Session modal: reduce visual weight of the scheduling conflict area and clarify primary vs secondary actions on narrow screens.

## Changes
- **Conflict region**: Compact header on narrow screens (left accent, count chip), with conflict messages behind a \details\ disclosure (\View messages\) and scroll cap; full list remains always visible from \sm\ breakpoint up.
- **Footer**: Tighter vertical spacing, two-column layout for secondary actions where applicable, lighter secondary button chrome (\shadow-none\ on mobile), primary submit uses stronger typography/shadow on mobile; bottom padding uses \max(1rem, safe-area)\ for system nav clearance.

## Scope
- \src/components/SessionModal.tsx\ only (no behavior changes to conflict detection, validation, or submit flows).

## Verification
- \
pm run lint\
- \
pm run typecheck\
- \
px vitest run src/components/__tests__/SessionModal.test.tsx\
- \
pm run build\

## Manual check (Android Chrome)
- With conflicts: confirm compact strip + expandable messages.
- Without conflicts: unchanged flow.
- Footer: primary action reads as dominant; safe-area clearance acceptable.

Made with [Cursor](https://cursor.com)