### PR TITLE
fix(mobile): safe-area menu button, dvh shell, main inset padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link rel="preload" as="fetch" href="/api/runtime-config" crossorigin="anonymous" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#1a1b1e" />
     <meta name="application-name" content="AllIncompassing" />
     <title>AllIncompassing</title>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,7 +133,7 @@ function App() {
     <ErrorBoundary>
       <QueryClientProvider client={appQueryClient}>
         <AuthProvider>
-          <div className="min-h-screen bg-gray-50 dark:bg-dark text-gray-900 dark:text-gray-100 transition-colors">
+          <div className="min-h-dvh bg-gray-50 dark:bg-dark text-gray-900 dark:text-gray-100 transition-colors">
             <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
               <RouteTelemetry />
               <Suspense fallback={<LoadingSpinner />}>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,9 +9,9 @@ export function Layout() {
   useRouteQueryRefetch();
 
   return (
-    <div className="flex min-h-screen bg-gray-50 dark:bg-dark">
+    <div className="flex min-h-dvh bg-gray-50 dark:bg-dark">
       <Sidebar />
-      <main className="flex-1 p-4 lg:p-8 w-full lg:ml-64">
+      <main className="flex-1 min-w-0 w-full lg:ml-64 p-4 pt-14 pb-[max(1rem,env(safe-area-inset-bottom))] lg:p-8 lg:pt-8">
         {/* User role indicator */}
         {user && (
           <div className="mb-4 p-2 bg-blue-50 dark:bg-blue-900/20 rounded-lg text-sm">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -169,7 +169,7 @@ export function Sidebar() {
     <button
       type="button"
       onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-      className="lg:hidden fixed top-4 left-4 z-50 p-2 rounded-lg bg-white dark:bg-dark-lighter shadow-lg border border-gray-200 dark:border-gray-700"
+      className="lg:hidden fixed z-50 flex min-h-11 min-w-11 items-center justify-center rounded-lg border border-gray-200 bg-white p-2 shadow-lg dark:border-gray-700 dark:bg-dark-lighter top-[max(0.75rem,env(safe-area-inset-top))] left-[max(0.75rem,env(safe-area-inset-left))]"
       aria-label={isMobileMenuOpen ? 'Close navigation' : 'Open navigation'}
       aria-expanded={isMobileMenuOpen}
       aria-controls="app-sidebar"
@@ -213,7 +213,7 @@ export function Sidebar() {
         w-64 bg-white dark:bg-dark-lighter border-r border-gray-200 dark:border-dark-border
         transform lg:transform-none transition-transform duration-200 ease-in-out
         ${isMobileMenuOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
-        flex flex-col h-dvh lg:h-screen overflow-y-auto overscroll-contain
+        flex flex-col h-dvh lg:h-dvh overflow-y-auto overscroll-contain
       `}>
         <div className="flex items-center p-6">
           <Calendar aria-hidden="true" className="h-8 w-8 text-blue-600" />


### PR DESCRIPTION
## Summary
- Use \min-h-dvh\ on the app shell and layout to reduce mobile viewport dead space (vs \100vh\).
- Add \iewport-fit=cover\ so safe-area env vars apply on notched devices.
- Position the mobile nav button with safe-area insets and a 44px min touch target; add main top padding so content clears the fixed control; bottom padding respects safe-area.

## Verification
- \
pm run lint\, \
pm run typecheck\, \
pm run build\, \
pm run test:ci\ passed locally on the branch.

## Risk
Low — layout/CSS only; no auth or data paths.

Made with [Cursor](https://cursor.com)