### PR TITLE
chore: Phone Preview extension + test reliability stamp

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
 {
-  "recommendations": ["denoland.vscode-deno"]
+  "recommendations": [
+    "denoland.vscode-deno",
+    "lirobi.phone-preview"
+  ]
 }

--- a/reports/test-reliability-latest.json
+++ b/reports/test-reliability-latest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-07T01:11:05.162Z",
+  "generatedAt": "2026-04-09T19:32:17.788Z",
   "slo": {
     "suitePassRatePctTarget": 99.5,
     "rollingWindowDays": 14


### PR DESCRIPTION
## Summary
- Recommend **Phone Preview** (\lirobi.phone-preview\) in \.vscode/extensions.json\ for mobile layout work alongside Deno.
- Refresh \eports/test-reliability-latest.json\ \generatedAt\ to match the latest local CI test run timestamp.

## Risk
None — editor recommendations and report metadata only.

Made with [Cursor](https://cursor.com)