### PR TITLE
Session Data Collection 2.0 Phase 1 — persist per-goal `goal_measurements` on session notes

### DIFF
--- a/docs/ai/session-data-collection-2.0-phase1-handoff.md
+++ b/docs/ai/session-data-collection-2.0-phase1-handoff.md
@@ -1,0 +1,88 @@
+# Session Data Collection 2.0 — Phase 1 (goal_measurements) Handoff
+
+## Route-task
+- classification: high-risk human-reviewed
+- lane: critical
+- why: scope touches `supabase/migrations/**` and tenant-scoped clinical note persistence (`client_session_notes`).
+- triggering paths:
+  - `supabase/migrations/20260409103000_session_data_collection_2_goal_measurements.sql`
+  - `src/lib/session-notes.ts`
+  - `src/components/SessionModal.tsx`
+  - `src/pages/Schedule.tsx`
+- required agents: specification-engineer → software-architect → implementation-engineer → code-review-engineer → test-engineer → security-engineer
+- reviewer required: yes
+- verify-change required: yes
+- linear required: yes (not linked in this local environment)
+
+## Scope lock
+### Allowed files
+- `supabase/migrations/20260409103000_session_data_collection_2_goal_measurements.sql`
+- `src/lib/generated/database.types.ts`
+- `src/lib/session-notes.ts`
+- `src/components/SessionModal.tsx`
+- `src/pages/Schedule.tsx`
+- `src/types/index.ts`
+- `src/lib/__tests__/session-notes.test.ts`
+
+### Non-goals
+- No completion-readiness rule changes (`checkInProgressSessionCloseReadiness` / `sessions-complete`).
+- No therapist-facing UI redesign for entering measurement values.
+- No changes to access for `ai_guidance_documents` / `white_bible_core`.
+
+### Stop conditions
+- If completion authority semantics must change, stop for explicit product/security sign-off.
+- If schema decision must switch from per-goal JSON to separate relational table, stop and produce spec-lock addendum first.
+
+## Implementation summary
+- Added nullable `goal_measurements jsonb` to `client_session_notes` with object-type check constraint.
+- Extended app read/write paths to round-trip `session_note_goal_measurements` through Schedule → SessionModal → `upsertClientSessionNoteForSession`.
+- Updated generated DB types + app session note types.
+- Added/updated unit coverage for `goal_measurements` persistence.
+
+## Tenant boundary and safety statement
+- Read/write boundary remains organization-scoped through existing `client_session_notes` RLS and explicit `.eq('organization_id', activeOrganizationId)` filters.
+- No grants/RLS policy broadening introduced; migration only adds column + check constraint.
+- Cross-tenant access remains impossible under existing org-scoped policies.
+
+## Verification card (verify-change)
+- classification: high-risk human-reviewed
+- lane: critical
+- change type:
+  - database/RLS/migrations/tenant isolation
+  - server/API-adjacent app write path (Schedule session note persistence)
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - pass: `npm run ci:check-focused`
+  - pass: `npm run lint`
+  - pass: `npm run typecheck`
+  - pass: `npm run test:ci`
+  - pass: `npm run validate:tenant`
+  - pass: `npm run build`
+  - fail: `npm run verify:local` (fails at `npm run test:routes:tier0` in this container)
+- blocked checks:
+  - `npm run test:routes:tier0` blocked due missing OS dependency `Xvfb` (Cypress cannot launch browser in this environment).
+- result: pass-with-blocked-checks
+- residual risk:
+  - Browser route/auth regression suite is unverified locally due missing `Xvfb`; rely on CI/browser-enabled environment for this gate.
+
+## Reviewer placeholder
+- reviewer status: pending human review (required by critical lane)
+- requested review focus:
+  - tenant isolation and org-scoped note persistence
+  - migration safety/idempotency
+  - compatibility with session-close authority semantics
+
+## PR hygiene snapshot
+- branch-ready: yes (`codex/session-data-collection-2.0-phase1-schema-persistence`)
+- single-purpose diff: yes
+- protected-path drift: expected (`supabase/migrations/**`), lane remains `critical`
+- verification summary: present
+- linear-ready: no (external linkage needed before merge)
+- pr-ready: no (blocked on Linear linkage + human reviewer sign-off)

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -29,6 +29,7 @@ const ENABLE_ALTERNATIVE_TIME_SUGGESTIONS = false;
 export interface SessionModalClinicalNotesPayload {
   session_note_narrative?: string;
   session_note_goal_notes?: Record<string, string>;
+  session_note_goal_measurements?: Record<string, unknown>;
   session_note_goal_ids?: string[];
   session_note_goals_addressed?: string[];
   session_note_authorization_id?: string;
@@ -135,6 +136,7 @@ export function SessionModal({
       status: session?.status || 'scheduled',
       session_note_narrative: '',
       session_note_goal_notes: {},
+      session_note_goal_measurements: {},
       session_note_goal_ids: [],
       session_note_goals_addressed: [],
       session_note_authorization_id: '',
@@ -281,7 +283,7 @@ export function SessionModal({
       }
       const { data, error } = await supabase
         .from('client_session_notes')
-        .select('id, authorization_id, service_code, narrative, goal_notes, goal_ids, goals_addressed')
+        .select('id, authorization_id, service_code, narrative, goal_notes, goal_measurements, goal_ids, goals_addressed')
         .eq('session_id', session.id)
         .eq('organization_id', activeOrganizationId)
         .order('updated_at', { ascending: false })
@@ -672,6 +674,7 @@ export function SessionModal({
         ...data,
         session_note_narrative: data.session_note_narrative?.trim() ?? '',
         session_note_goal_notes: normalizedGoalNoteMap,
+        session_note_goal_measurements: data.session_note_goal_measurements ?? {},
         session_note_goal_ids: mergedGoalIds,
         session_note_goals_addressed: mergedGoalIds
           .map((goalEntryId) => goals.find((goal) => goal.id === goalEntryId)?.title?.trim())
@@ -949,6 +952,10 @@ export function SessionModal({
     setValue(
       'session_note_goal_notes',
       (linkedSessionNote.goal_notes as Record<string, string> | null) ?? {},
+    );
+    setValue(
+      'session_note_goal_measurements',
+      (linkedSessionNote.goal_measurements as Record<string, unknown> | null) ?? {},
     );
     setValue('session_note_goal_ids', linkedSessionNote.goal_ids ?? []);
     setValue('session_note_goals_addressed', linkedSessionNote.goals_addressed ?? []);

--- a/src/lib/__tests__/session-notes.test.ts
+++ b/src/lib/__tests__/session-notes.test.ts
@@ -42,6 +42,7 @@ const noteRow = {
   session_duration: 60,
   goals_addressed: [],
   goal_ids: [],
+  goal_measurements: null,
   narrative: 'test',
   is_locked: false,
   signed_at: null,
@@ -150,6 +151,32 @@ describe('createClientSessionNote', () => {
     expect(lastInsertPayload?.goal_notes).toEqual({ 'goal-1': 'Good progress on this goal.' });
   });
 
+  it('persists goal_measurements when provided', async () => {
+    setupMocks('approved');
+
+    await createClientSessionNote({
+      authorizationId: authRecord.id,
+      clientId: 'client-1',
+      therapistId: 'therapist-1',
+      organizationId: authRecord.organization_id,
+      createdBy: 'user-1',
+      serviceCode: '97153',
+      sessionDate: '2025-06-01',
+      startTime: '09:00',
+      endTime: '10:00',
+      sessionDuration: 60,
+      goalsAddressed: ['Goal A'],
+      goalIds: ['goal-1'],
+      goalMeasurements: { 'goal-1': { version: 1, data: { count: 4 } } },
+      narrative: '',
+      isLocked: false,
+    });
+
+    expect(lastInsertPayload?.goal_measurements).toEqual({
+      'goal-1': { version: 1, data: { count: 4 } },
+    });
+  });
+
   it('stores goal_notes as null when an empty object is provided', async () => {
     setupMocks('approved');
 
@@ -252,12 +279,14 @@ describe('upsertClientSessionNoteForSession', () => {
       endTime: '10:00:00',
       goalsAddressed: ['Goal A'],
       goalIds: ['goal-1'],
+      goalMeasurements: { 'goal-1': { version: 1, data: { count: 2 } } },
       goalNotes: { 'goal-1': '  Progress captured  ' },
       narrative: '  Narrative text  ',
     });
 
     expect(result.id).toBe('note-existing');
     expect(lastUpdatePayload?.goal_notes).toEqual({ 'goal-1': 'Progress captured' });
+    expect(lastUpdatePayload?.goal_measurements).toEqual({ 'goal-1': { version: 1, data: { count: 2 } } });
     expect(lastUpdatePayload?.narrative).toBe('Narrative text');
   });
 
@@ -294,10 +323,10 @@ describe('upsertClientSessionNoteForSession', () => {
         endTime: '10:00:00',
         goalsAddressed: ['Goal A'],
         goalIds: ['goal-1'],
+        goalMeasurements: { 'goal-1': { version: 1, data: { count: 2 } } },
         goalNotes: { 'goal-1': 'Progress captured' },
         narrative: 'Narrative text',
       }),
     ).rejects.toThrow(/locked/i);
   });
 });
-

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -1820,6 +1820,7 @@ export type Database = {
           created_by: string
           end_time: string
           goal_ids: string[] | null
+          goal_measurements: Record<string, unknown> | null
           goal_notes: Record<string, unknown> | null
           goals_addressed: string[]
           id: string
@@ -1842,6 +1843,7 @@ export type Database = {
           created_by: string
           end_time: string
           goal_ids?: string[] | null
+          goal_measurements?: Record<string, unknown> | null
           goal_notes?: Record<string, unknown> | null
           goals_addressed?: string[]
           id?: string
@@ -1864,6 +1866,7 @@ export type Database = {
           created_by?: string
           end_time?: string
           goal_ids?: string[] | null
+          goal_measurements?: Record<string, unknown> | null
           goal_notes?: Record<string, unknown> | null
           goals_addressed?: string[]
           id?: string

--- a/src/lib/session-notes.ts
+++ b/src/lib/session-notes.ts
@@ -19,6 +19,7 @@ const SESSION_NOTE_SELECT_COLUMNS = `
   created_at,
   end_time,
   goal_ids,
+  goal_measurements,
   goal_notes,
   goals_addressed,
   is_locked,
@@ -55,6 +56,7 @@ const mapRowToSessionNote = (
   therapist_name: therapist?.full_name ?? 'Unknown Therapist',
   goals_addressed: row.goals_addressed ?? [],
   goal_ids: row.goal_ids ?? [],
+  goal_measurements: row.goal_measurements as Record<string, unknown> | null ?? null,
   goal_notes: row.goal_notes as Record<string, string> | null ?? null,
   session_id: row.session_id ?? null,
   narrative: row.narrative,
@@ -121,6 +123,7 @@ export interface CreateClientSessionNoteInput {
   readonly sessionDuration: number;
   readonly goalsAddressed: string[];
   readonly goalIds?: string[];
+  readonly goalMeasurements?: Record<string, unknown> | null;
   readonly goalNotes?: Record<string, string> | null;
   readonly narrative: string;
   readonly isLocked: boolean;
@@ -140,6 +143,7 @@ export interface UpsertClientSessionNoteForSessionInput {
   readonly endTime: string;
   readonly goalsAddressed: string[];
   readonly goalIds: string[];
+  readonly goalMeasurements?: Record<string, unknown> | null;
   readonly goalNotes: Record<string, string>;
   readonly narrative: string;
 }
@@ -194,6 +198,10 @@ export const createClientSessionNote = async (
     payload.goalNotes && Object.keys(payload.goalNotes).length > 0
       ? payload.goalNotes
       : null;
+  const goalMeasurementsValue =
+    payload.goalMeasurements && Object.keys(payload.goalMeasurements).length > 0
+      ? payload.goalMeasurements
+      : null;
 
   const insertPayload: ClientSessionNoteInsert = {
     authorization_id: payload.authorizationId,
@@ -208,6 +216,7 @@ export const createClientSessionNote = async (
     session_duration: payload.sessionDuration,
     goals_addressed: payload.goalsAddressed,
     goal_ids: payload.goalIds ?? null,
+    goal_measurements: goalMeasurementsValue,
     goal_notes: goalNotesValue,
     narrative: payload.narrative,
     is_locked: payload.isLocked,
@@ -240,6 +249,10 @@ export const upsertClientSessionNoteForSession = async (
       .map(([goalId, noteText]) => [goalId, noteText.trim()])
       .filter(([, noteText]) => noteText.length > 0),
   );
+  const cleanedGoalMeasurements =
+    payload.goalMeasurements && Object.keys(payload.goalMeasurements).length > 0
+      ? payload.goalMeasurements
+      : null;
   const sessionDuration = calculateSessionDurationMinutes(payload.startTime, payload.endTime);
   if (sessionDuration <= 0) {
     throw new Error('End time must be later than start time.');
@@ -274,6 +287,7 @@ export const upsertClientSessionNoteForSession = async (
       sessionDuration,
       goalsAddressed: payload.goalsAddressed,
       goalIds: payload.goalIds,
+      goalMeasurements: cleanedGoalMeasurements,
       goalNotes: cleanedGoalNotes,
       narrative: trimmedNarrative,
       isLocked: false,
@@ -293,6 +307,7 @@ export const upsertClientSessionNoteForSession = async (
       session_duration: sessionDuration,
       goals_addressed: payload.goalsAddressed,
       goal_ids: payload.goalIds,
+      goal_measurements: cleanedGoalMeasurements,
       goal_notes: Object.keys(cleanedGoalNotes).length > 0 ? cleanedGoalNotes : null,
       narrative: trimmedNarrative,
       session_id: payload.sessionId,
@@ -336,4 +351,3 @@ export const calculateSessionDurationMinutes = (startTime: string, endTime: stri
 export const isSupabaseError = (error: unknown): error is PostgrestError => {
   return Boolean(error && typeof error === 'object' && 'message' in error && 'code' in error);
 };
-

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -98,6 +98,7 @@ const stripClinicalNoteFields = (data: ScheduleSubmitData): Partial<Session> => 
   const {
     session_note_narrative: _sessionNoteNarrative,
     session_note_goal_notes: _sessionNoteGoalNotes,
+    session_note_goal_measurements: _sessionNoteGoalMeasurements,
     session_note_goal_ids: _sessionNoteGoalIds,
     session_note_goals_addressed: _sessionNoteGoalsAddressed,
     session_note_authorization_id: _sessionNoteAuthorizationId,
@@ -112,6 +113,7 @@ const buildClinicalNoteDraft = (
 ): {
   narrative: string;
   goalNotes: Record<string, string>;
+  goalMeasurements: Record<string, unknown>;
   goalIds: string[];
   goalsAddressed: string[];
   authorizationId: string;
@@ -126,6 +128,10 @@ const buildClinicalNoteDraft = (
   const goalIds = Array.isArray(data.session_note_goal_ids)
     ? data.session_note_goal_ids.filter((goalId) => typeof goalId === "string" && goalId.trim().length > 0)
     : [];
+  const goalMeasurements =
+    data.session_note_goal_measurements && typeof data.session_note_goal_measurements === "object"
+      ? data.session_note_goal_measurements
+      : {};
   const goalsAddressed = Array.isArray(data.session_note_goals_addressed)
     ? data.session_note_goals_addressed
         .map((goalLabel) => goalLabel.trim())
@@ -135,13 +141,15 @@ const buildClinicalNoteDraft = (
   const serviceCode = data.session_note_service_code?.trim() ?? "";
   if (
     narrative.length === 0 &&
-    Object.keys(goalNotes).length === 0
+    Object.keys(goalNotes).length === 0 &&
+    Object.keys(goalMeasurements).length === 0
   ) {
     return null;
   }
   return {
     narrative,
     goalNotes,
+    goalMeasurements,
     goalIds,
     goalsAddressed,
     authorizationId,
@@ -1492,6 +1500,7 @@ export const Schedule = React.memo(() => {
               endTime: format(parseISO(sessionPayload.end_time ?? selectedSession.end_time), "HH:mm:ss"),
               goalsAddressed: clinicalNoteDraft.goalsAddressed,
               goalIds: clinicalNoteDraft.goalIds,
+              goalMeasurements: clinicalNoteDraft.goalMeasurements,
               goalNotes: clinicalNoteDraft.goalNotes,
               narrative: clinicalNoteDraft.narrative,
             });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -335,6 +335,7 @@ export interface SessionNote {
   goals_addressed: string[];
   goal_ids?: string[];
   goal_notes?: Record<string, string> | null;
+  goal_measurements?: Record<string, unknown> | null;
   session_id?: string | null;
   narrative: string;
   is_locked: boolean;

--- a/supabase/migrations/20260409103000_session_data_collection_2_goal_measurements.sql
+++ b/supabase/migrations/20260409103000_session_data_collection_2_goal_measurements.sql
@@ -1,0 +1,19 @@
+-- @migration-intent: Add versioned per-goal session measurement payload storage to client_session_notes for Session Data Collection 2.0.
+-- @migration-dependencies: 20260402182221_repair_goal_notes_and_session_goals_close_notes.sql
+-- @migration-rollback: alter table public.client_session_notes drop constraint if exists client_session_notes_goal_measurements_object_chk; alter table public.client_session_notes drop column if exists goal_measurements;
+
+alter table public.client_session_notes
+  add column if not exists goal_measurements jsonb;
+
+comment on column public.client_session_notes.goal_measurements is
+  'Session Data Collection 2.0: versioned per-goal measurement payload keyed by goal UUID.';
+
+alter table public.client_session_notes
+  drop constraint if exists client_session_notes_goal_measurements_object_chk;
+
+alter table public.client_session_notes
+  add constraint client_session_notes_goal_measurements_object_chk
+  check (
+    goal_measurements is null
+    or jsonb_typeof(goal_measurements) = 'object'
+  );


### PR DESCRIPTION
### Motivation
- Implement Phase 1 of Session Data Collection 2.0 so versioned per-goal measurement payloads persist with tenant-safe scoping on `client_session_notes`.
- This slice must preserve org scoping and RLS patterns used by existing `client_session_notes`/`session_goals` flows and not change completion-readiness semantics.
- Route-task: classification `high-risk human-reviewed`, lane `critical` because the change touches `supabase/migrations/**` and tenant-scoped persistence paths.

### Description
- Add migration `supabase/migrations/20260409103000_session_data_collection_2_goal_measurements.sql` to create `client_session_notes.goal_measurements jsonb` plus an object-type check constraint (idempotent, with rollback hint).
- Extend DB typings and app types (`src/lib/generated/database.types.ts`, `src/types/index.ts`) to include `goal_measurements` for `client_session_notes` and `SessionNote`.
- Wire read/write round-trip: include `goal_measurements` in selects/mapping and in `createClientSessionNote` / `upsertClientSessionNoteForSession` in `src/lib/session-notes.ts`, and pass `session_note_goal_measurements` through `SessionModal` and `Schedule` so Schedule → SessionModal → session-note upsert preserves measurements.
- Add unit coverage and assertions for `goal_measurements` persistence and a short handoff/verification artifact `docs/ai/session-data-collection-2.0-phase1-handoff.md` documenting lane, scope, and verification outcomes.

### Testing
- Ran policy and static checks: `npm run ci:check-focused` — passed.
- Type/lint/unit/CI: `npm ci`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run validate:tenant`, and `npm run build` — all passed in this environment; updated `src/lib/__tests__/session-notes.test.ts` exercises create/update persistence for `goal_measurements` and passed when run (`npx vitest run src/lib/__tests__/session-notes.test.ts`).
- Full local verification attempt: `npm run verify:local` was attempted but blocked on the browser route gate; `npm run test:routes:tier0` failed in this container because Cypress requires `Xvfb` (OS dependency) so the `verify:local` browser gate is blocked; CI must run the tier-0 route suite in a browser-enabled environment to complete that check.
- Result summary: automated checks and unit tests passed; `verify:local` is pass-with-blocked-checks due to missing `Xvfb` for Cypress in this container and requires CI/human review before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d839dfc3048332bf0ffd0edaa5b8de)