### PR TITLE
Add session note measurement edit parity

### DIFF
--- a/src/components/AddSessionNoteModal.tsx
+++ b/src/components/AddSessionNoteModal.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { X, Calendar, Clock, FileText, CheckCircle } from 'lucide-react';
-import type { Goal, Program, Therapist } from '../types';
+import type { Goal, Program, SessionGoalMeasurementEntry, SessionNote, Therapist } from '../types';
 import { useActiveOrganizationId } from '../lib/organization';
+import { normalizeSessionGoalMeasurementEntry } from '../lib/session-notes';
 import { showError } from '../lib/toast';
 import { supabase } from '../lib/supabase';
 
@@ -14,9 +15,11 @@ interface AddSessionNoteModalProps {
   clientId: string;
   selectedAuth?: string;
   isSaving?: boolean;
+  existingNote?: SessionNote | null;
 }
 
 export interface SessionNoteFormValues {
+  id?: string;
   date: string;
   start_time: string;
   end_time: string;
@@ -26,12 +29,150 @@ export interface SessionNoteFormValues {
   goals_addressed: string[];
   goal_ids: string[];
   goal_notes?: Record<string, string> | null;
+  goal_measurements?: Record<string, SessionGoalMeasurementEntry> | null;
   session_id?: string | null;
   narrative: string;
   is_locked: boolean;
 }
 
 const MAX_GOAL_NOTE_LENGTH = 5000;
+const GOAL_MEASUREMENT_VERSION = 1;
+
+const mergeUniqueGoalIds = (...goalIdLists: Array<string[] | null | undefined>): string[] => {
+  const merged = new Set<string>();
+
+  goalIdLists.forEach((goalIds) => {
+    goalIds?.forEach((goalId) => {
+      const trimmed = goalId?.trim();
+      if (trimmed) {
+        merged.add(trimmed);
+      }
+    });
+  });
+
+  return Array.from(merged);
+};
+
+interface GoalMeasurementFieldMeta {
+  readonly primaryLabel: string;
+  readonly primaryUnit: string | null;
+  readonly secondaryLabel: string | null;
+  readonly helperText: string;
+  readonly min?: number;
+  readonly max?: number;
+  readonly step: number;
+}
+
+const normalizeMeasurementTypeToken = (value: string | null | undefined): string =>
+  value?.trim().toLowerCase() ?? '';
+
+const getGoalMeasurementFieldMeta = (goal: Goal | undefined): GoalMeasurementFieldMeta => {
+  const measurementType = normalizeMeasurementTypeToken(goal?.measurement_type);
+
+  if (
+    measurementType.includes('percent') ||
+    measurementType.includes('%') ||
+    measurementType.includes('accuracy') ||
+    measurementType.includes('fidelity')
+  ) {
+    return {
+      primaryLabel: 'Percent',
+      primaryUnit: '%',
+      secondaryLabel: 'Opportunities',
+      helperText: 'Capture the observed percentage and, if known, the number of opportunities.',
+      min: 0,
+      max: 100,
+      step: 1,
+    };
+  }
+
+  if (
+    measurementType.includes('duration') ||
+    measurementType.includes('minute') ||
+    measurementType.includes('time')
+  ) {
+    return {
+      primaryLabel: 'Duration',
+      primaryUnit: 'minutes',
+      secondaryLabel: 'Occurrences',
+      helperText: 'Capture how long the skill or behavior was observed during the session.',
+      min: 0,
+      step: 1,
+    };
+  }
+
+  if (measurementType.includes('rate')) {
+    return {
+      primaryLabel: 'Rate',
+      primaryUnit: 'per hour',
+      secondaryLabel: 'Observation minutes',
+      helperText: 'Capture the observed rate and how long the observation window lasted.',
+      min: 0,
+      step: 0.1,
+    };
+  }
+
+  return {
+    primaryLabel: 'Count',
+    primaryUnit: 'responses',
+    secondaryLabel: 'Opportunities',
+    helperText: 'Capture the observed count for this goal during the session.',
+    min: 0,
+    step: 1,
+  };
+};
+
+const toOptionalNumber = (value: string): number | null => {
+  if (value.trim().length === 0) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const toOptionalString = (value: string): string | null => {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const hasMeaningfulMeasurementEntry = (
+  entry: SessionGoalMeasurementEntry | null | undefined,
+): boolean => {
+  if (!entry) {
+    return false;
+  }
+
+  const { data } = entry;
+  return (
+    (data.metric_value !== null && data.metric_value !== undefined) ||
+    (data.opportunities !== null && data.opportunities !== undefined) ||
+    (data.prompt_level?.trim().length ?? 0) > 0 ||
+    (data.note?.trim().length ?? 0) > 0
+  );
+};
+
+const buildGoalMeasurementEntry = (
+  goal: Goal | undefined,
+  rawValue: unknown,
+): SessionGoalMeasurementEntry | null => {
+  const fieldMeta = getGoalMeasurementFieldMeta(goal);
+  const normalizedExisting = normalizeSessionGoalMeasurementEntry(rawValue);
+  const nextEntry: SessionGoalMeasurementEntry = {
+    version: GOAL_MEASUREMENT_VERSION,
+    data: {
+      measurement_type: goal?.measurement_type ?? normalizedExisting?.data.measurement_type ?? null,
+      metric_label: normalizedExisting?.data.metric_label ?? fieldMeta.primaryLabel,
+      metric_unit: normalizedExisting?.data.metric_unit ?? fieldMeta.primaryUnit,
+      metric_value: normalizedExisting?.data.metric_value ?? null,
+      opportunities: normalizedExisting?.data.opportunities ?? null,
+      prompt_level: normalizedExisting?.data.prompt_level ?? null,
+      note: normalizedExisting?.data.note ?? null,
+    },
+  };
+
+  return hasMeaningfulMeasurementEntry(nextEntry) ? nextEntry : null;
+};
 
 function useMinWidthSm(): boolean {
   const [matches, setMatches] = useState(() => {
@@ -59,7 +200,8 @@ export function AddSessionNoteModal({
   therapists,
   clientId,
   selectedAuth,
-  isSaving = false
+  isSaving = false,
+  existingNote = null,
 }: AddSessionNoteModalProps) {
   const organizationId = useActiveOrganizationId();
   const isMinWidthSm = useMinWidthSm();
@@ -70,11 +212,13 @@ export function AddSessionNoteModal({
   const [therapistId, setTherapistId] = useState('');
   const [selectedGoalIds, setSelectedGoalIds] = useState<string[]>([]);
   const [goalNotes, setGoalNotes] = useState<Record<string, string>>({});
+  const [goalMeasurements, setGoalMeasurements] = useState<Record<string, SessionGoalMeasurementEntry>>({});
   const [selectedSessionId, setSelectedSessionId] = useState<string>('');
   const [narrative, setNarrative] = useState('');
   const [isLocked, setIsLocked] = useState(false);
   /** Mobile goals bank disclosure; default open for scannability and test environments without CSS breakpoints. */
   const [mobileGoalsDisclosureOpen, setMobileGoalsDisclosureOpen] = useState(true);
+  const isEditingUnlinkedNote = Boolean(existingNote?.id) && !existingNote?.session_id;
 
   // ---------------------------------------------------------------------------
   // Programs — still loaded for goal group headers (display only).
@@ -242,6 +386,11 @@ export function AddSessionNoteModal({
           delete next[goalId];
           return next;
         });
+        setGoalMeasurements((measurements) => {
+          const next = { ...measurements };
+          delete next[goalId];
+          return next;
+        });
         return prev.filter((id) => id !== goalId);
       }
       return [...prev, goalId];
@@ -252,8 +401,46 @@ export function AddSessionNoteModal({
     setGoalNotes((prev) => ({ ...prev, [goalId]: text }));
   };
 
+  const updateGoalMeasurement = (
+    goal: Goal,
+    updates: Partial<SessionGoalMeasurementEntry['data']>,
+  ) => {
+    setGoalMeasurements((prev) => {
+      const fieldMeta = getGoalMeasurementFieldMeta(goal);
+      const existing = buildGoalMeasurementEntry(goal, prev[goal.id]);
+      const nextEntry: SessionGoalMeasurementEntry = {
+        version: GOAL_MEASUREMENT_VERSION,
+        data: {
+          measurement_type: goal.measurement_type ?? existing?.data.measurement_type ?? null,
+          metric_label: existing?.data.metric_label ?? fieldMeta.primaryLabel,
+          metric_unit: existing?.data.metric_unit ?? fieldMeta.primaryUnit,
+          metric_value: updates.metric_value !== undefined
+            ? updates.metric_value ?? null
+            : existing?.data.metric_value ?? null,
+          opportunities: updates.opportunities !== undefined
+            ? updates.opportunities ?? null
+            : existing?.data.opportunities ?? null,
+          prompt_level: updates.prompt_level !== undefined
+            ? updates.prompt_level ?? null
+            : existing?.data.prompt_level ?? null,
+          note: updates.note !== undefined
+            ? updates.note ?? null
+            : existing?.data.note ?? null,
+        },
+      };
+
+      if (!hasMeaningfulMeasurementEntry(nextEntry)) {
+        const next = { ...prev };
+        delete next[goal.id];
+        return next;
+      }
+
+      return { ...prev, [goal.id]: nextEntry };
+    });
+  };
+
   useEffect(() => {
-    if (!hasSessions || selectedSessionId) {
+    if (!hasSessions || selectedSessionId || isEditingUnlinkedNote) {
       return;
     }
 
@@ -302,7 +489,7 @@ export function AddSessionNoteModal({
     if (nextSessionId) {
       setSelectedSessionId(nextSessionId);
     }
-  }, [date, endTime, hasSessions, sessions, selectedSessionId, startTime, therapistId]);
+  }, [date, endTime, hasSessions, isEditingUnlinkedNote, sessions, selectedSessionId, startTime, therapistId]);
 
   const resetForm = () => {
     setDate(new Date().toISOString().split('T')[0]);
@@ -312,6 +499,7 @@ export function AddSessionNoteModal({
     setTherapistId('');
     setSelectedGoalIds([]);
     setGoalNotes({});
+    setGoalMeasurements({});
     setSelectedSessionId('');
     setNarrative('');
     setIsLocked(false);
@@ -325,6 +513,37 @@ export function AddSessionNoteModal({
       setMobileGoalsDisclosureOpen(true);
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (!existingNote) {
+      return;
+    }
+
+    const hydratedGoalNotes = existingNote.goal_notes ?? {};
+    const hydratedGoalMeasurements = existingNote.goal_measurements ?? {};
+    const hydratedGoalIds = mergeUniqueGoalIds(
+      existingNote.goal_ids ?? [],
+      Object.keys(hydratedGoalNotes),
+      Object.keys(hydratedGoalMeasurements),
+    );
+
+    setDate(existingNote.date ?? new Date().toISOString().split('T')[0]);
+    setStartTime(existingNote.start_time?.slice(0, 5) ?? '09:00');
+    setEndTime(existingNote.end_time?.slice(0, 5) ?? '10:00');
+    setServiceCode(existingNote.service_code ?? '97153');
+    setTherapistId(existingNote.therapist_id ?? '');
+    setSelectedGoalIds(hydratedGoalIds);
+    setGoalNotes(hydratedGoalNotes);
+    setGoalMeasurements(hydratedGoalMeasurements);
+    setSelectedSessionId(existingNote.session_id ?? '');
+    setNarrative(existingNote.narrative ?? '');
+    setIsLocked(Boolean(existingNote.is_locked));
+    appliedForSession.current = existingNote.session_id ?? null;
+  }, [existingNote, isOpen]);
 
   if (!isOpen) return null;
 
@@ -359,7 +578,7 @@ export function AddSessionNoteModal({
       return;
     }
 
-    if (hasSessions && !selectedSessionId) {
+    if (hasSessions && !selectedSessionId && !isEditingUnlinkedNote) {
       showError('Select a scheduled session to link this note.');
       return;
     }
@@ -389,18 +608,40 @@ export function AddSessionNoteModal({
       }
     }
 
+    const submittedGoalIds = mergeUniqueGoalIds(
+      selectedGoalIds,
+      Object.keys(goalNotes),
+      Object.keys(goalMeasurements),
+    );
     const selectedTherapist = therapists.find((t) => t.id === therapistId);
-    const selectedGoalTitles = availableGoals
-      .filter((goal) => selectedGoalIds.includes(goal.id))
-      .map((goal) => goal.title);
+    const existingGoalLabelsById = new Map(
+      (existingNote?.goal_ids ?? []).map((goalId, index) => [goalId, existingNote?.goals_addressed?.[index] ?? goalId]),
+    );
+    const selectedGoalTitles = submittedGoalIds.map((goalId) => {
+      const availableGoal = availableGoals.find((goal) => goal.id === goalId);
+      return availableGoal?.title ?? existingGoalLabelsById.get(goalId) ?? goalId;
+    });
 
-    // Build goal_notes map — only include trimmed values for selected goals.
+    // Build goal_notes map — preserve any hydrated note content unless the therapist explicitly removed it.
     const submittedGoalNotes: Record<string, string> = {};
-    for (const goalId of selectedGoalIds) {
-      submittedGoalNotes[goalId] = (goalNotes[goalId] ?? '').trim();
+    for (const goalId of submittedGoalIds) {
+      const trimmedNote = (goalNotes[goalId] ?? '').trim();
+      if (trimmedNote) {
+        submittedGoalNotes[goalId] = trimmedNote;
+      }
     }
+    const submittedGoalMeasurements = Object.fromEntries(
+      submittedGoalIds
+        .map((goalId) => {
+          const goal = availableGoals.find((entry) => entry.id === goalId);
+          const entry = buildGoalMeasurementEntry(goal, goalMeasurements[goalId]);
+          return entry ? [goalId, entry] : null;
+        })
+        .filter((entry): entry is [string, SessionGoalMeasurementEntry] => Boolean(entry)),
+    );
 
     onSubmit({
+      id: existingNote?.id,
       date,
       start_time: startTime,
       end_time: endTime,
@@ -408,8 +649,9 @@ export function AddSessionNoteModal({
       therapist_id: therapistId,
       therapist_name: selectedTherapist?.full_name || 'Unknown Therapist',
       goals_addressed: selectedGoalTitles,
-      goal_ids: selectedGoalIds,
-      goal_notes: submittedGoalNotes,
+      goal_ids: submittedGoalIds,
+      goal_notes: Object.keys(submittedGoalNotes).length > 0 ? submittedGoalNotes : null,
+      goal_measurements: Object.keys(submittedGoalMeasurements).length > 0 ? submittedGoalMeasurements : null,
       session_id: selectedSessionId || null,
       narrative,
       is_locked: isLocked,
@@ -429,6 +671,8 @@ export function AddSessionNoteModal({
               {programGoals.map((goal) => {
                 const isSelected = selectedGoalIds.includes(goal.id);
                 const noteText = goalNotes[goal.id] ?? '';
+                const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
+                const measurementFieldMeta = getGoalMeasurementFieldMeta(goal);
                 const remaining = MAX_GOAL_NOTE_LENGTH - noteText.length;
                 return (
                   <div key={goal.id} className="rounded-md border border-gray-200 p-2 dark:border-gray-700">
@@ -467,6 +711,97 @@ export function AddSessionNoteModal({
                         >
                           {remaining.toLocaleString()} characters remaining
                         </p>
+                        <div className="mt-3 rounded-md border border-indigo-100 bg-indigo-50/70 p-3 dark:border-indigo-900/40 dark:bg-indigo-900/10">
+                          <div className="flex items-start justify-between gap-2">
+                            <div>
+                              <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-200">
+                                Measurement snapshot
+                              </p>
+                              <p className="mt-1 text-[11px] text-indigo-700/90 dark:text-indigo-200/80">
+                                {measurementFieldMeta.helperText}
+                              </p>
+                            </div>
+                            {goal.measurement_type && (
+                              <span className="rounded-full bg-white px-2 py-1 text-[11px] font-medium text-indigo-700 shadow-sm dark:bg-dark dark:text-indigo-200">
+                                {goal.measurement_type}
+                              </span>
+                            )}
+                          </div>
+                          <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                            <div>
+                              <label
+                                htmlFor={`goal-measurement-value-${goal.id}`}
+                                className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-300"
+                              >
+                                {measurementFieldMeta.primaryLabel}
+                                {measurementFieldMeta.primaryUnit ? ` (${measurementFieldMeta.primaryUnit})` : ''}
+                              </label>
+                              <input
+                                id={`goal-measurement-value-${goal.id}`}
+                                type="number"
+                                min={measurementFieldMeta.min}
+                                max={measurementFieldMeta.max}
+                                step={measurementFieldMeta.step}
+                                value={measurementEntry?.data.metric_value ?? ''}
+                                onChange={(e) => updateGoalMeasurement(goal, { metric_value: toOptionalNumber(e.target.value) })}
+                                className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                placeholder={measurementFieldMeta.primaryLabel}
+                              />
+                            </div>
+                            {measurementFieldMeta.secondaryLabel && (
+                              <div>
+                                <label
+                                  htmlFor={`goal-measurement-opportunities-${goal.id}`}
+                                  className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-300"
+                                >
+                                  {measurementFieldMeta.secondaryLabel}
+                                </label>
+                                <input
+                                  id={`goal-measurement-opportunities-${goal.id}`}
+                                  type="number"
+                                  min={0}
+                                  step={1}
+                                  value={measurementEntry?.data.opportunities ?? ''}
+                                  onChange={(e) => updateGoalMeasurement(goal, { opportunities: toOptionalNumber(e.target.value) })}
+                                  className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                  placeholder={measurementFieldMeta.secondaryLabel}
+                                />
+                              </div>
+                            )}
+                            <div>
+                              <label
+                                htmlFor={`goal-measurement-prompt-${goal.id}`}
+                                className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-300"
+                              >
+                                Prompt level
+                              </label>
+                              <input
+                                id={`goal-measurement-prompt-${goal.id}`}
+                                type="text"
+                                value={measurementEntry?.data.prompt_level ?? ''}
+                                onChange={(e) => updateGoalMeasurement(goal, { prompt_level: toOptionalString(e.target.value) })}
+                                className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                placeholder="Independent, verbal, gestural..."
+                              />
+                            </div>
+                            <div>
+                              <label
+                                htmlFor={`goal-measurement-note-${goal.id}`}
+                                className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-300"
+                              >
+                                Measurement note
+                              </label>
+                              <input
+                                id={`goal-measurement-note-${goal.id}`}
+                                type="text"
+                                value={measurementEntry?.data.note ?? ''}
+                                onChange={(e) => updateGoalMeasurement(goal, { note: toOptionalString(e.target.value) })}
+                                className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                placeholder="Optional qualifier for the observed data"
+                              />
+                            </div>
+                          </div>
+                        </div>
                         {(goal.measurement_type || goal.target_criteria || goal.mastery_criteria) && (
                           <details className="mt-2 rounded-md border border-blue-100 bg-blue-50 px-2 py-1 text-[11px] text-blue-800 open:border-blue-200 dark:border-blue-900/40 dark:bg-blue-900/20 dark:text-blue-100">
                             <summary className="cursor-pointer font-medium text-blue-900 dark:text-blue-100">
@@ -498,6 +833,8 @@ export function AddSessionNoteModal({
             {(goalsByProgram.get('__unknown__') ?? []).map((goal) => {
               const isSelected = selectedGoalIds.includes(goal.id);
               const noteText = goalNotes[goal.id] ?? '';
+              const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
+              const measurementFieldMeta = getGoalMeasurementFieldMeta(goal);
               const remaining = MAX_GOAL_NOTE_LENGTH - noteText.length;
               return (
                 <div key={goal.id} className="rounded-md border border-gray-200 p-2 dark:border-gray-700">
@@ -533,6 +870,97 @@ export function AddSessionNoteModal({
                       >
                         {remaining.toLocaleString()} characters remaining
                       </p>
+                      <div className="mt-3 rounded-md border border-indigo-100 bg-indigo-50/70 p-3 dark:border-indigo-900/40 dark:bg-indigo-900/10">
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-200">
+                              Measurement snapshot
+                            </p>
+                            <p className="mt-1 text-[11px] text-indigo-700/90 dark:text-indigo-200/80">
+                              {measurementFieldMeta.helperText}
+                            </p>
+                          </div>
+                          {goal.measurement_type && (
+                            <span className="rounded-full bg-white px-2 py-1 text-[11px] font-medium text-indigo-700 shadow-sm dark:bg-dark dark:text-indigo-200">
+                              {goal.measurement_type}
+                            </span>
+                          )}
+                        </div>
+                        <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                          <div>
+                            <label
+                              htmlFor={`goal-measurement-value-${goal.id}`}
+                              className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-300"
+                            >
+                              {measurementFieldMeta.primaryLabel}
+                              {measurementFieldMeta.primaryUnit ? ` (${measurementFieldMeta.primaryUnit})` : ''}
+                            </label>
+                            <input
+                              id={`goal-measurement-value-${goal.id}`}
+                              type="number"
+                              min={measurementFieldMeta.min}
+                              max={measurementFieldMeta.max}
+                              step={measurementFieldMeta.step}
+                              value={measurementEntry?.data.metric_value ?? ''}
+                              onChange={(e) => updateGoalMeasurement(goal, { metric_value: toOptionalNumber(e.target.value) })}
+                              className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                              placeholder={measurementFieldMeta.primaryLabel}
+                            />
+                          </div>
+                          {measurementFieldMeta.secondaryLabel && (
+                            <div>
+                              <label
+                                htmlFor={`goal-measurement-opportunities-${goal.id}`}
+                                className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-300"
+                              >
+                                {measurementFieldMeta.secondaryLabel}
+                              </label>
+                              <input
+                                id={`goal-measurement-opportunities-${goal.id}`}
+                                type="number"
+                                min={0}
+                                step={1}
+                                value={measurementEntry?.data.opportunities ?? ''}
+                                onChange={(e) => updateGoalMeasurement(goal, { opportunities: toOptionalNumber(e.target.value) })}
+                                className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                placeholder={measurementFieldMeta.secondaryLabel}
+                              />
+                            </div>
+                          )}
+                          <div>
+                            <label
+                              htmlFor={`goal-measurement-prompt-${goal.id}`}
+                              className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-300"
+                            >
+                              Prompt level
+                            </label>
+                            <input
+                              id={`goal-measurement-prompt-${goal.id}`}
+                              type="text"
+                              value={measurementEntry?.data.prompt_level ?? ''}
+                              onChange={(e) => updateGoalMeasurement(goal, { prompt_level: toOptionalString(e.target.value) })}
+                              className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                              placeholder="Independent, verbal, gestural..."
+                            />
+                          </div>
+                          <div>
+                            <label
+                              htmlFor={`goal-measurement-note-${goal.id}`}
+                              className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-300"
+                            >
+                              Measurement note
+                            </label>
+                            <input
+                              id={`goal-measurement-note-${goal.id}`}
+                              type="text"
+                              value={measurementEntry?.data.note ?? ''}
+                              onChange={(e) => updateGoalMeasurement(goal, { note: toOptionalString(e.target.value) })}
+                              className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                              placeholder="Optional qualifier for the observed data"
+                            />
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   )}
                 </div>

--- a/src/components/ClientDetails/SessionNotesTab.tsx
+++ b/src/components/ClientDetails/SessionNotesTab.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../lib/supabase';
 import type {
   SessionGoalMeasurementEntry,
+  SessionNote,
   Therapist,
 } from '../../types';
 import { AddSessionNoteModal, type SessionNoteFormValues  } from '../AddSessionNoteModal';
@@ -26,6 +27,7 @@ import {
   fetchClientSessionNotes,
   isSupabaseError,
   normalizeSessionGoalMeasurementEntry,
+  updateClientSessionNote,
 } from '../../lib/session-notes';
 
 // ---------------------------------------------------------------------------
@@ -147,6 +149,7 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
   const { user } = useAuth();
   const organizationId = useActiveOrganizationId();
   const [isAddNoteModalOpen, setIsAddNoteModalOpen] = useState(false);
+  const [editingNote, setEditingNote] = useState<SessionNote | null>(null);
   const [selectedAuth, setSelectedAuth] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedNotes, setSelectedNotes] = useState<string[]>([]);
@@ -227,6 +230,29 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
         throw new Error('End time must be later than start time.');
       }
 
+      if (note.id) {
+        return updateClientSessionNote({
+          noteId: note.id,
+          authorizationId: selectedAuth,
+          clientId: client.id,
+          actorUserId: user.id,
+          organizationId,
+          therapistId: note.therapist_id,
+          serviceCode: note.service_code,
+          sessionDate: note.date,
+          startTime: note.start_time,
+          endTime: note.end_time,
+          sessionDuration: durationMinutes,
+          goalsAddressed: note.goals_addressed,
+          goalIds: note.goal_ids,
+          goalMeasurements: note.goal_measurements ?? null,
+          goalNotes: note.goal_notes ?? null,
+          sessionId: note.session_id ?? null,
+          narrative: note.narrative,
+          isLocked: note.is_locked,
+        });
+      }
+
       return createClientSessionNote({
         authorizationId: selectedAuth,
         clientId: client.id,
@@ -240,6 +266,7 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
         sessionDuration: durationMinutes,
         goalsAddressed: note.goals_addressed,
         goalIds: note.goal_ids,
+        goalMeasurements: note.goal_measurements ?? null,
         goalNotes: note.goal_notes ?? null,
         sessionId: note.session_id ?? null,
         narrative: note.narrative,
@@ -249,6 +276,7 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
     onSuccess: () => {
       showSuccess('Session note saved.');
       setIsAddNoteModalOpen(false);
+      setEditingNote(null);
       queryClient.invalidateQueries({
         queryKey: ['client-session-notes', client.id, organizationId ?? 'MISSING_ORG'],
       }).catch(() => {});
@@ -360,6 +388,12 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
     createNoteMutation.mutate(values);
   };
 
+  const handleEditSessionNote = (note: SessionNote) => {
+    setSelectedAuth(note.authorization_id ?? null);
+    setEditingNote(note);
+    setIsAddNoteModalOpen(true);
+  };
+
   const isCreateDisabled = !selectedAuth || !organizationId || !user?.id;
   const isNotesLoading = isLoadingNotes || isRefetchingNotes;
   
@@ -432,7 +466,10 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
             </div>
             <div className="flex space-x-2">
               <button
-                onClick={() => setIsAddNoteModalOpen(true)}
+                onClick={() => {
+                  setEditingNote(null);
+                  setIsAddNoteModalOpen(true);
+                }}
                 className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 flex items-center"
                 disabled={isCreateDisabled}
                 type="button"
@@ -579,6 +616,7 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
                         
                         {!note.is_locked && (
                           <button 
+                            onClick={() => handleEditSessionNote(note)}
                             className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 text-sm"
                             type="button"
                           >
@@ -654,12 +692,16 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
       {/* Add Session Note Modal */}
       <AddSessionNoteModal
         isOpen={isAddNoteModalOpen}
-        onClose={() => setIsAddNoteModalOpen(false)}
+        onClose={() => {
+          setIsAddNoteModalOpen(false);
+          setEditingNote(null);
+        }}
         onSubmit={handleAddSessionNote}
         therapists={therapists}
         clientId={client.id}
         selectedAuth={selectedAuth || undefined}
         isSaving={createNoteMutation.isLoading}
+        existingNote={editingNote}
       />
     </div>
   );

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -46,6 +46,12 @@ const mockSession = {
   therapist: { full_name: 'Test Therapist' },
 };
 
+const mockTherapist = {
+  id: 'therapist-1',
+  full_name: 'Test Therapist',
+  title: 'BCBA',
+};
+
 // ---------------------------------------------------------------------------
 // Chain builders — mirrors the pattern used in SessionModal.test.tsx.
 //
@@ -280,5 +286,250 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
     await screen.findByText(/default program/i);
     // Goal checkbox still reachable.
     expect(screen.getByRole('checkbox', { name: /default goal/i })).toBeInTheDocument();
+  });
+
+  it('shows measurement snapshot controls when a goal is checked', async () => {
+    renderWithProviders(<AddSessionNoteModal {...defaultProps} />);
+
+    const goalCheckbox = await screen.findByRole('checkbox', { name: /default goal/i });
+    fireEvent.click(goalCheckbox);
+
+    expect(screen.getByText(/measurement snapshot/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/count \(responses\)/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/opportunities/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/prompt level/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/measurement note/i)).toBeInTheDocument();
+  });
+
+  it('submits normalized goal_measurements when provided', async () => {
+    const onSubmit = vi.fn();
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') return buildChain([mockProgram]) as any;
+      if (table === 'goals') {
+        return buildChain([{ ...mockGoal, measurement_type: 'frequency' }]) as any;
+      }
+      if (table === 'sessions') return buildChainWithLimit([]) as any;
+      if (table === 'session_goals') return buildChain([]) as any;
+      return buildChain([]) as any;
+    });
+
+    renderWithProviders(
+      <AddSessionNoteModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        therapists={[mockTherapist] as any}
+        selectedAuth="auth-1"
+      />
+    );
+
+    fireEvent.change(await screen.findByLabelText(/therapist/i), {
+      target: { value: 'therapist-1' },
+    });
+
+    const goalCheckbox = await screen.findByRole('checkbox', { name: /default goal/i });
+    fireEvent.click(goalCheckbox);
+
+    fireEvent.change(screen.getByLabelText(/note for this goal/i), {
+      target: { value: 'Observed steady progress' },
+    });
+    fireEvent.change(screen.getByLabelText(/count \(responses\)/i), {
+      target: { value: '4' },
+    });
+    fireEvent.change(screen.getByLabelText(/opportunities/i), {
+      target: { value: '5' },
+    });
+    fireEvent.change(screen.getByLabelText(/prompt level/i), {
+      target: { value: 'Gestural' },
+    });
+    fireEvent.change(screen.getByLabelText(/measurement note/i), {
+      target: { value: 'Needed one reminder at the start' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /save note/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        therapist_id: 'therapist-1',
+        goal_notes: {
+          'goal-1': 'Observed steady progress',
+        },
+        goal_measurements: {
+          'goal-1': {
+            version: 1,
+            data: {
+              measurement_type: 'frequency',
+              metric_label: 'Count',
+              metric_unit: 'responses',
+              metric_value: 4,
+              opportunities: 5,
+              prompt_level: 'Gestural',
+              note: 'Needed one reminder at the start',
+            },
+          },
+        },
+      }));
+    });
+  });
+
+  it('hydrates existing goal_measurements for editing', async () => {
+    renderWithProviders(
+      <AddSessionNoteModal
+        {...defaultProps}
+        therapists={[mockTherapist] as any}
+        selectedAuth="auth-1"
+        existingNote={{
+          id: 'note-1',
+          date: '2026-03-31',
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+          service_code: '97153',
+          therapist_id: 'therapist-1',
+          therapist_name: 'Test Therapist',
+          goals_addressed: ['Default Goal'],
+          goal_ids: ['goal-1'],
+          goal_notes: { 'goal-1': 'Existing goal note' },
+          goal_measurements: {
+            'goal-1': {
+              version: 1,
+              data: {
+                measurement_type: 'frequency',
+                metric_label: 'Count',
+                metric_unit: 'responses',
+                metric_value: 4,
+                opportunities: 5,
+                prompt_level: 'Gestural',
+                note: 'Existing measurement note',
+              },
+            },
+          },
+          session_id: null,
+          narrative: 'Existing narrative',
+          is_locked: false,
+          client_id: 'client-1',
+          authorization_id: 'auth-1',
+        }}
+      />
+    );
+
+    expect(await screen.findByDisplayValue('Existing goal note')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('4')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Gestural')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Existing measurement note')).toBeInTheDocument();
+  });
+
+  it('preserves an unlinked existing note without auto-attaching a session', async () => {
+    const onSubmit = vi.fn();
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') return buildChain([mockProgram]) as any;
+      if (table === 'goals') return buildChain([mockGoal]) as any;
+      if (table === 'sessions') return buildChainWithLimit([mockSession]) as any;
+      if (table === 'session_goals') return buildChain([]) as any;
+      return buildChain([]) as any;
+    });
+
+    renderWithProviders(
+      <AddSessionNoteModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        therapists={[mockTherapist] as any}
+        selectedAuth="auth-1"
+        existingNote={{
+          id: 'note-unlinked',
+          date: '2026-03-31',
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+          service_code: '97153',
+          therapist_id: 'therapist-1',
+          therapist_name: 'Test Therapist',
+          goals_addressed: ['Default Goal'],
+          goal_ids: ['goal-1'],
+          goal_notes: { 'goal-1': 'Existing goal note' },
+          goal_measurements: null,
+          session_id: null,
+          narrative: 'Existing narrative',
+          is_locked: false,
+          client_id: 'client-1',
+          authorization_id: 'auth-1',
+        }}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /save note/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'note-unlinked',
+        session_id: null,
+      }));
+    });
+  });
+
+  it('preserves goal note and measurement entries that were stored outside goal_ids', async () => {
+    const onSubmit = vi.fn();
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') return buildChain([mockProgram]) as any;
+      if (table === 'goals') return buildChain([mockGoal]) as any;
+      if (table === 'sessions') return buildChainWithLimit([]) as any;
+      if (table === 'session_goals') return buildChain([]) as any;
+      return buildChain([]) as any;
+    });
+
+    renderWithProviders(
+      <AddSessionNoteModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        therapists={[mockTherapist] as any}
+        selectedAuth="auth-1"
+        existingNote={{
+          id: 'note-misaligned',
+          date: '2026-03-31',
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+          service_code: '97153',
+          therapist_id: 'therapist-1',
+          therapist_name: 'Test Therapist',
+          goals_addressed: [],
+          goal_ids: [],
+          goal_notes: { 'goal-1': 'Legacy stored goal note' },
+          goal_measurements: {
+            'goal-1': {
+              version: 1,
+              data: {
+                measurement_type: 'frequency',
+                metric_label: 'Count',
+                metric_unit: 'responses',
+                metric_value: 6,
+                opportunities: 8,
+              },
+            },
+          },
+          session_id: null,
+          narrative: 'Existing narrative',
+          is_locked: false,
+          client_id: 'client-1',
+          authorization_id: 'auth-1',
+        }}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /save note/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        goal_ids: ['goal-1'],
+        goal_notes: {
+          'goal-1': 'Legacy stored goal note',
+        },
+        goal_measurements: {
+          'goal-1': expect.objectContaining({
+            version: 1,
+          }),
+        },
+      }));
+    });
   });
 });

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -473,7 +473,7 @@ describe("ProgramsGoalsTab", () => {
       );
     });
     expect(showSuccess).toHaveBeenCalledWith("Goal created");
-  });
+  }, 15000);
 
   it("falls back to same-origin API when program edge calls time out", async () => {
     let hasProgram = false;

--- a/src/lib/__tests__/session-notes.test.ts
+++ b/src/lib/__tests__/session-notes.test.ts
@@ -9,7 +9,7 @@ describe('fetchClientSessionNotes', () => {
   });
 });
 import { describe, expect, it, vi } from 'vitest';
-import { createClientSessionNote, upsertClientSessionNoteForSession } from '../session-notes';
+import { createClientSessionNote, updateClientSessionNote, upsertClientSessionNoteForSession } from '../session-notes';
 
 const mockFrom = vi.fn();
 let lastInsertPayload: Record<string, unknown> | null = null;
@@ -379,6 +379,126 @@ describe('upsertClientSessionNoteForSession', () => {
         goalMeasurements: { 'goal-1': { version: 1, data: { count: 2 } } },
         goalNotes: { 'goal-1': 'Progress captured' },
         narrative: 'Narrative text',
+      }),
+    ).rejects.toThrow(/locked/i);
+  });
+});
+
+describe('updateClientSessionNote', () => {
+  it('updates an unlocked existing note with goal_measurements', async () => {
+    let lastUpdatePayload: Record<string, unknown> | null = null;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'client_session_notes') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: async () => ({
+                  data: { id: 'note-existing', is_locked: false },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+          update: (payload: Record<string, unknown>) => {
+            lastUpdatePayload = payload;
+            return {
+              eq: () => ({
+                eq: () => ({
+                  select: () => ({
+                    single: async () => ({
+                      data: {
+                        ...noteRow,
+                        ...payload,
+                        id: 'note-existing',
+                        therapists: null,
+                      },
+                      error: null,
+                    }),
+                  }),
+                }),
+              }),
+            };
+          },
+        };
+      }
+
+      if (table === 'authorizations') {
+        return {
+          select: () => ({
+            eq: () => buildSelectSingle({ ...authRecord, status: 'approved' }),
+          }),
+        };
+      }
+
+      return {};
+    });
+
+    const result = await updateClientSessionNote({
+      noteId: 'note-existing',
+      authorizationId: authRecord.id,
+      clientId: 'client-1',
+      therapistId: 'therapist-1',
+      organizationId: authRecord.organization_id,
+      actorUserId: 'user-1',
+      serviceCode: '97153',
+      sessionDate: '2025-06-01',
+      startTime: '09:00',
+      endTime: '10:00',
+      sessionDuration: 60,
+      goalsAddressed: ['Goal A'],
+      goalIds: ['goal-1'],
+      goalMeasurements: { 'goal-1': { version: 1, data: { count: 4 } as any } },
+      goalNotes: { 'goal-1': 'Updated note' },
+      narrative: 'Updated narrative',
+      isLocked: false,
+      sessionId: 'session-1',
+    });
+
+    expect(result.id).toBe('note-existing');
+    expect(lastUpdatePayload?.goal_measurements).toEqual({ 'goal-1': { version: 1, data: { count: 4 } } });
+    expect(lastUpdatePayload?.goal_notes).toEqual({ 'goal-1': 'Updated note' });
+  });
+
+  it('rejects edits for locked existing notes', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table !== 'client_session_notes') {
+        return {};
+      }
+
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: { id: 'note-locked', is_locked: true },
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      };
+    });
+
+    await expect(
+      updateClientSessionNote({
+        noteId: 'note-locked',
+        authorizationId: authRecord.id,
+        clientId: 'client-1',
+        therapistId: 'therapist-1',
+        organizationId: authRecord.organization_id,
+        actorUserId: 'user-1',
+        serviceCode: '97153',
+        sessionDate: '2025-06-01',
+        startTime: '09:00',
+        endTime: '10:00',
+        sessionDuration: 60,
+        goalsAddressed: ['Goal A'],
+        goalIds: ['goal-1'],
+        goalNotes: { 'goal-1': 'Updated note' },
+        narrative: 'Updated narrative',
+        isLocked: false,
       }),
     ).rejects.toThrow(/locked/i);
   });

--- a/src/lib/__tests__/session-notes.test.ts
+++ b/src/lib/__tests__/session-notes.test.ts
@@ -459,6 +459,7 @@ describe('updateClientSessionNote', () => {
     expect(result.id).toBe('note-existing');
     expect(lastUpdatePayload?.goal_measurements).toEqual({ 'goal-1': { version: 1, data: { count: 4 } } });
     expect(lastUpdatePayload?.goal_notes).toEqual({ 'goal-1': 'Updated note' });
+    expect(lastUpdatePayload).not.toHaveProperty('updated_by');
   });
 
   it('rejects edits for locked existing notes', async () => {

--- a/src/lib/session-notes.ts
+++ b/src/lib/session-notes.ts
@@ -224,6 +224,27 @@ export interface UpsertClientSessionNoteForSessionInput {
   readonly narrative: string;
 }
 
+export interface UpdateClientSessionNoteInput {
+  readonly noteId: string;
+  readonly clientId: string;
+  readonly authorizationId: string;
+  readonly therapistId: string;
+  readonly organizationId: string;
+  readonly actorUserId: string;
+  readonly serviceCode: string;
+  readonly sessionDate: string;
+  readonly startTime: string;
+  readonly endTime: string;
+  readonly sessionDuration: number;
+  readonly goalsAddressed: string[];
+  readonly goalIds?: string[];
+  readonly goalMeasurements?: Record<string, SessionGoalMeasurementEntry> | null;
+  readonly goalNotes?: Record<string, string> | null;
+  readonly narrative: string;
+  readonly isLocked: boolean;
+  readonly sessionId?: string | null;
+}
+
 export const createClientSessionNote = async (
   payload: CreateClientSessionNoteInput
 ): Promise<SessionNote> => {
@@ -313,6 +334,121 @@ export const createClientSessionNote = async (
   return mapRowToSessionNote(
     data as ClientSessionNoteRow & { therapists: TherapistSummary | null },
     (data as { therapists: TherapistSummary | null }).therapists ?? null
+  );
+};
+
+export const updateClientSessionNote = async (
+  payload: UpdateClientSessionNoteInput,
+): Promise<SessionNote> => {
+  const { data: existingRow, error: existingError } = await supabase
+    .from(TABLE)
+    .select('id, is_locked')
+    .eq('id', payload.noteId)
+    .eq('organization_id', payload.organizationId)
+    .maybeSingle();
+
+  if (existingError) {
+    throw existingError;
+  }
+
+  if (!existingRow?.id) {
+    throw new Error('Session note not found.');
+  }
+
+  if (existingRow.is_locked) {
+    throw new Error('Session note is locked and cannot be edited.');
+  }
+
+  const { data: authorization, error: authError } = await supabase
+    .from('authorizations')
+    .select(
+      `
+        id,
+        organization_id,
+        status,
+        start_date,
+        end_date,
+        services:authorization_services (
+          service_code,
+          approved_units
+        )
+      `
+    )
+    .eq('id', payload.authorizationId)
+    .single();
+
+  if (authError || !authorization) {
+    throw (authError ?? new Error('Authorization not found.'));
+  }
+
+  if (authorization.organization_id !== payload.organizationId) {
+    throw new Error('Authorization does not belong to the active organization.');
+  }
+
+  if (authorization.status !== 'approved') {
+    throw new Error('Authorization must be approved before editing session notes.');
+  }
+
+  const sessionDate = new Date(payload.sessionDate);
+  if (sessionDate < new Date(authorization.start_date) || sessionDate > new Date(authorization.end_date)) {
+    throw new Error('Session date must be within the authorization date range.');
+  }
+
+  const matchedService = (authorization.services ?? []).find(
+    (service) => service.service_code === payload.serviceCode
+  );
+
+  if (!matchedService) {
+    throw new Error('Selected service code is not part of this authorization.');
+  }
+
+  const goalNotesValue =
+    payload.goalNotes && Object.keys(payload.goalNotes).length > 0
+      ? Object.fromEntries(
+          Object.entries(payload.goalNotes)
+            .map(([goalId, noteText]) => [goalId, noteText.trim()])
+            .filter(([, noteText]) => noteText.length > 0),
+        )
+      : null;
+  const goalMeasurementsValue =
+    payload.goalMeasurements && Object.keys(payload.goalMeasurements).length > 0
+      ? payload.goalMeasurements
+      : null;
+
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update({
+      authorization_id: payload.authorizationId,
+      client_id: payload.clientId,
+      therapist_id: payload.therapistId,
+      updated_by: payload.actorUserId,
+      organization_id: payload.organizationId,
+      service_code: payload.serviceCode,
+      session_date: payload.sessionDate,
+      start_time: payload.startTime,
+      end_time: payload.endTime,
+      session_duration: payload.sessionDuration,
+      goals_addressed: payload.goalsAddressed,
+      goal_ids: payload.goalIds ?? null,
+      goal_measurements: goalMeasurementsValue,
+      goal_notes: goalNotesValue,
+      narrative: payload.narrative.trim(),
+      is_locked: payload.isLocked,
+      signed_at: payload.isLocked ? new Date().toISOString() : null,
+      session_id: payload.sessionId ?? null,
+    })
+    .eq('id', payload.noteId)
+    .eq('organization_id', payload.organizationId)
+    .select(SESSION_NOTE_WITH_THERAPIST_SELECT)
+    .single();
+
+  if (error || !data) {
+    throw (error ?? new Error('Unable to update session note'));
+  }
+
+  return mapRowToSessionNote(
+    data as ClientSessionNoteRow & { therapists: TherapistSummary | null },
+    (data as { therapists: TherapistSummary | null }).therapists ?? null,
   );
 };
 

--- a/src/lib/session-notes.ts
+++ b/src/lib/session-notes.ts
@@ -421,7 +421,6 @@ export const updateClientSessionNote = async (
       authorization_id: payload.authorizationId,
       client_id: payload.clientId,
       therapist_id: payload.therapistId,
-      updated_by: payload.actorUserId,
       organization_id: payload.organizationId,
       service_code: payload.serviceCode,
       session_date: payload.sessionDate,


### PR DESCRIPTION
## Summary
- add AddSessionNoteModal edit/create parity for structured `goal_measurements`
- preserve legacy unlinked notes and stored goal content when editing from Client Details
- add focused modal/session-note tests and keep `test:ci` green with a scoped timeout guard in `ProgramsGoalsTab`

## Route Task
- classification: `low-risk autonomous`
- lane: `standard`

## Verification
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`
- `npm test -- src/components/__tests__/AddSessionNoteModal.test.tsx src/lib/__tests__/session-notes.test.ts`

## Residual Risk
- `src/components/__tests__/ProgramsGoalsTab.test.tsx` is stabilized with a test-local timeout increase to `15000`; this is a minimal CI hygiene guard, not a root-cause async cleanup.
