### PR TITLE
Extract shared goal measurement helpers

### DIFF
--- a/src/components/AddSessionNoteModal.tsx
+++ b/src/components/AddSessionNoteModal.tsx
@@ -2,8 +2,13 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { X, Calendar, Clock, FileText, CheckCircle } from 'lucide-react';
 import type { Goal, Program, SessionGoalMeasurementEntry, SessionNote, Therapist } from '../types';
+import {
+  buildGoalMeasurementEntry,
+  getGoalMeasurementFieldMeta,
+  mergeGoalMeasurementEntry,
+  mergeUniqueGoalIds,
+} from '../lib/goal-measurements';
 import { useActiveOrganizationId } from '../lib/organization';
-import { normalizeSessionGoalMeasurementEntry } from '../lib/session-notes';
 import { showError } from '../lib/toast';
 import { supabase } from '../lib/supabase';
 
@@ -36,91 +41,6 @@ export interface SessionNoteFormValues {
 }
 
 const MAX_GOAL_NOTE_LENGTH = 5000;
-const GOAL_MEASUREMENT_VERSION = 1;
-
-const mergeUniqueGoalIds = (...goalIdLists: Array<string[] | null | undefined>): string[] => {
-  const merged = new Set<string>();
-
-  goalIdLists.forEach((goalIds) => {
-    goalIds?.forEach((goalId) => {
-      const trimmed = goalId?.trim();
-      if (trimmed) {
-        merged.add(trimmed);
-      }
-    });
-  });
-
-  return Array.from(merged);
-};
-
-interface GoalMeasurementFieldMeta {
-  readonly primaryLabel: string;
-  readonly primaryUnit: string | null;
-  readonly secondaryLabel: string | null;
-  readonly helperText: string;
-  readonly min?: number;
-  readonly max?: number;
-  readonly step: number;
-}
-
-const normalizeMeasurementTypeToken = (value: string | null | undefined): string =>
-  value?.trim().toLowerCase() ?? '';
-
-const getGoalMeasurementFieldMeta = (goal: Goal | undefined): GoalMeasurementFieldMeta => {
-  const measurementType = normalizeMeasurementTypeToken(goal?.measurement_type);
-
-  if (
-    measurementType.includes('percent') ||
-    measurementType.includes('%') ||
-    measurementType.includes('accuracy') ||
-    measurementType.includes('fidelity')
-  ) {
-    return {
-      primaryLabel: 'Percent',
-      primaryUnit: '%',
-      secondaryLabel: 'Opportunities',
-      helperText: 'Capture the observed percentage and, if known, the number of opportunities.',
-      min: 0,
-      max: 100,
-      step: 1,
-    };
-  }
-
-  if (
-    measurementType.includes('duration') ||
-    measurementType.includes('minute') ||
-    measurementType.includes('time')
-  ) {
-    return {
-      primaryLabel: 'Duration',
-      primaryUnit: 'minutes',
-      secondaryLabel: 'Occurrences',
-      helperText: 'Capture how long the skill or behavior was observed during the session.',
-      min: 0,
-      step: 1,
-    };
-  }
-
-  if (measurementType.includes('rate')) {
-    return {
-      primaryLabel: 'Rate',
-      primaryUnit: 'per hour',
-      secondaryLabel: 'Observation minutes',
-      helperText: 'Capture the observed rate and how long the observation window lasted.',
-      min: 0,
-      step: 0.1,
-    };
-  }
-
-  return {
-    primaryLabel: 'Count',
-    primaryUnit: 'responses',
-    secondaryLabel: 'Opportunities',
-    helperText: 'Capture the observed count for this goal during the session.',
-    min: 0,
-    step: 1,
-  };
-};
 
 const toOptionalNumber = (value: string): number | null => {
   if (value.trim().length === 0) {
@@ -134,44 +54,6 @@ const toOptionalNumber = (value: string): number | null => {
 const toOptionalString = (value: string): string | null => {
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
-};
-
-const hasMeaningfulMeasurementEntry = (
-  entry: SessionGoalMeasurementEntry | null | undefined,
-): boolean => {
-  if (!entry) {
-    return false;
-  }
-
-  const { data } = entry;
-  return (
-    (data.metric_value !== null && data.metric_value !== undefined) ||
-    (data.opportunities !== null && data.opportunities !== undefined) ||
-    (data.prompt_level?.trim().length ?? 0) > 0 ||
-    (data.note?.trim().length ?? 0) > 0
-  );
-};
-
-const buildGoalMeasurementEntry = (
-  goal: Goal | undefined,
-  rawValue: unknown,
-): SessionGoalMeasurementEntry | null => {
-  const fieldMeta = getGoalMeasurementFieldMeta(goal);
-  const normalizedExisting = normalizeSessionGoalMeasurementEntry(rawValue);
-  const nextEntry: SessionGoalMeasurementEntry = {
-    version: GOAL_MEASUREMENT_VERSION,
-    data: {
-      measurement_type: goal?.measurement_type ?? normalizedExisting?.data.measurement_type ?? null,
-      metric_label: normalizedExisting?.data.metric_label ?? fieldMeta.primaryLabel,
-      metric_unit: normalizedExisting?.data.metric_unit ?? fieldMeta.primaryUnit,
-      metric_value: normalizedExisting?.data.metric_value ?? null,
-      opportunities: normalizedExisting?.data.opportunities ?? null,
-      prompt_level: normalizedExisting?.data.prompt_level ?? null,
-      note: normalizedExisting?.data.note ?? null,
-    },
-  };
-
-  return hasMeaningfulMeasurementEntry(nextEntry) ? nextEntry : null;
 };
 
 function useMinWidthSm(): boolean {
@@ -406,30 +288,9 @@ export function AddSessionNoteModal({
     updates: Partial<SessionGoalMeasurementEntry['data']>,
   ) => {
     setGoalMeasurements((prev) => {
-      const fieldMeta = getGoalMeasurementFieldMeta(goal);
-      const existing = buildGoalMeasurementEntry(goal, prev[goal.id]);
-      const nextEntry: SessionGoalMeasurementEntry = {
-        version: GOAL_MEASUREMENT_VERSION,
-        data: {
-          measurement_type: goal.measurement_type ?? existing?.data.measurement_type ?? null,
-          metric_label: existing?.data.metric_label ?? fieldMeta.primaryLabel,
-          metric_unit: existing?.data.metric_unit ?? fieldMeta.primaryUnit,
-          metric_value: updates.metric_value !== undefined
-            ? updates.metric_value ?? null
-            : existing?.data.metric_value ?? null,
-          opportunities: updates.opportunities !== undefined
-            ? updates.opportunities ?? null
-            : existing?.data.opportunities ?? null,
-          prompt_level: updates.prompt_level !== undefined
-            ? updates.prompt_level ?? null
-            : existing?.data.prompt_level ?? null,
-          note: updates.note !== undefined
-            ? updates.note ?? null
-            : existing?.data.note ?? null,
-        },
-      };
+      const nextEntry = mergeGoalMeasurementEntry(goal, prev[goal.id], updates);
 
-      if (!hasMeaningfulMeasurementEntry(nextEntry)) {
+      if (!nextEntry) {
         const next = { ...prev };
         delete next[goal.id];
         return next;
@@ -529,6 +390,7 @@ export function AddSessionNoteModal({
       existingNote.goal_ids ?? [],
       Object.keys(hydratedGoalNotes),
       Object.keys(hydratedGoalMeasurements),
+      { trimValues: true },
     );
 
     setDate(existingNote.date ?? new Date().toISOString().split('T')[0]);
@@ -612,6 +474,7 @@ export function AddSessionNoteModal({
       selectedGoalIds,
       Object.keys(goalNotes),
       Object.keys(goalMeasurements),
+      { trimValues: true },
     );
     const selectedTherapist = therapists.find((t) => t.id === therapistId);
     const existingGoalLabelsById = new Map(

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -30,6 +30,12 @@ import {
   toUtcSessionIsoString,
 } from "../features/scheduling/domain/time";
 import { startSessionFromModal } from "../features/scheduling/domain/sessionStart";
+import {
+  getGoalMeasurementFieldMeta,
+  hasMeaningfulGoalMeasurementEntry,
+  mergeUniqueGoalIds,
+  normalizeGoalMeasurementEntry,
+} from '../lib/goal-measurements';
 
 const ENABLE_ALTERNATIVE_TIME_SUGGESTIONS = false;
 
@@ -45,77 +51,6 @@ export interface SessionModalClinicalNotesPayload {
 
 export type SessionModalSubmitData = Partial<Session> & SessionModalClinicalNotesPayload;
 
-const GOAL_MEASUREMENT_VERSION = 1;
-
-interface GoalMeasurementFieldMeta {
-  readonly primaryLabel: string;
-  readonly primaryUnit: string | null;
-  readonly secondaryLabel: string | null;
-  readonly helperText: string;
-  readonly min?: number;
-  readonly max?: number;
-  readonly step: number;
-}
-
-const normalizeMeasurementTypeToken = (value: string | null | undefined): string =>
-  value?.trim().toLowerCase() ?? '';
-
-const getGoalMeasurementFieldMeta = (goal: Goal | undefined): GoalMeasurementFieldMeta => {
-  const measurementType = normalizeMeasurementTypeToken(goal?.measurement_type);
-
-  if (
-    measurementType.includes('percent') ||
-    measurementType.includes('%') ||
-    measurementType.includes('accuracy') ||
-    measurementType.includes('fidelity')
-  ) {
-    return {
-      primaryLabel: 'Percent',
-      primaryUnit: '%',
-      secondaryLabel: 'Opportunities',
-      helperText: 'Capture the observed percentage and, if known, the number of opportunities.',
-      min: 0,
-      max: 100,
-      step: 1,
-    };
-  }
-
-  if (
-    measurementType.includes('duration') ||
-    measurementType.includes('minute') ||
-    measurementType.includes('time')
-  ) {
-    return {
-      primaryLabel: 'Duration',
-      primaryUnit: 'minutes',
-      secondaryLabel: 'Occurrences',
-      helperText: 'Capture how long the skill or behavior was observed during the session.',
-      min: 0,
-      step: 1,
-    };
-  }
-
-  if (measurementType.includes('rate')) {
-    return {
-      primaryLabel: 'Rate',
-      primaryUnit: 'per hour',
-      secondaryLabel: 'Observation minutes',
-      helperText: 'Capture the observed rate and how long the observation window lasted.',
-      min: 0,
-      step: 0.1,
-    };
-  }
-
-  return {
-    primaryLabel: 'Count',
-    primaryUnit: 'responses',
-    secondaryLabel: 'Opportunities',
-    helperText: 'Capture the observed count for this goal during the session.',
-    min: 0,
-    step: 1,
-  };
-};
-
 const toOptionalNumber = (value: unknown): number | null => {
   if (value === null || value === undefined || value === '') {
     return null;
@@ -125,82 +60,10 @@ const toOptionalNumber = (value: unknown): number | null => {
   return Number.isFinite(parsed) ? parsed : null;
 };
 
-const toOptionalString = (value: unknown): string | null => {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-};
-
 const toFormNumber = (value: unknown): number | undefined => {
   const normalized = toOptionalNumber(value);
   return normalized ?? undefined;
 };
-
-const hasMeaningfulMeasurementEntry = (
-  entry: SessionGoalMeasurementEntry | null | undefined,
-): boolean => {
-  if (!entry) {
-    return false;
-  }
-
-  const { data } = entry;
-  return (
-    (data.metric_value !== null && data.metric_value !== undefined) ||
-    (data.opportunities !== null && data.opportunities !== undefined) ||
-    (data.prompt_level?.trim().length ?? 0) > 0 ||
-    (data.note?.trim().length ?? 0) > 0
-  );
-};
-
-const normalizeGoalMeasurementEntry = (
-  goal: Goal | undefined,
-  rawValue: unknown,
-): SessionGoalMeasurementEntry | null => {
-  if (!rawValue || typeof rawValue !== 'object') {
-    return null;
-  }
-
-  const candidate = rawValue as {
-    data?: Record<string, unknown>;
-  } & Record<string, unknown>;
-  const sourceData =
-    candidate.data && typeof candidate.data === 'object'
-      ? candidate.data
-      : candidate;
-  const fieldMeta = getGoalMeasurementFieldMeta(goal);
-  const normalizedEntry: SessionGoalMeasurementEntry = {
-    version: GOAL_MEASUREMENT_VERSION,
-    data: {
-      measurement_type: goal?.measurement_type ?? toOptionalString(sourceData.measurement_type),
-      metric_label: toOptionalString(sourceData.metric_label) ?? fieldMeta.primaryLabel,
-      metric_unit: toOptionalString(sourceData.metric_unit) ?? fieldMeta.primaryUnit,
-      metric_value: toOptionalNumber(
-        sourceData.metric_value ?? sourceData.count ?? sourceData.value,
-      ),
-      opportunities: toOptionalNumber(
-        sourceData.opportunities ?? sourceData.trials,
-      ),
-      prompt_level: toOptionalString(
-        sourceData.prompt_level ?? sourceData.promptLevel,
-      ),
-      note: toOptionalString(sourceData.note ?? sourceData.comment),
-    },
-  };
-
-  return hasMeaningfulMeasurementEntry(normalizedEntry) ? normalizedEntry : null;
-};
-
-const mergeUniqueGoalIds = (...goalIdLists: Array<Array<string | undefined> | undefined>): string[] =>
-  Array.from(
-    new Set(
-      goalIdLists
-        .flatMap((goalIds) => goalIds ?? [])
-        .filter((goalId): goalId is string => typeof goalId === 'string' && goalId.trim().length > 0),
-    ),
-  );
 
 interface SessionModalProps {
   isOpen: boolean;
@@ -836,8 +699,8 @@ export function SessionModal({
         mergedGoalIds
           .map((goalEntryId) => {
             const entry = normalizeGoalMeasurementEntry(
-              goals.find((goal) => goal.id === goalEntryId),
               data.session_note_goal_measurements?.[goalEntryId],
+              goals.find((goal) => goal.id === goalEntryId),
             );
             return entry ? [goalEntryId, entry] : null;
           })
@@ -1025,10 +888,10 @@ export function SessionModal({
       return true;
     }
     return Object.entries(sessionNoteGoalMeasurements ?? {}).some(([goalId, rawValue]) =>
-      hasMeaningfulMeasurementEntry(
+      hasMeaningfulGoalMeasurementEntry(
         normalizeGoalMeasurementEntry(
-          goals.find((goal) => goal.id === goalId),
           rawValue,
+          goals.find((goal) => goal.id === goalId),
         ),
       ),
     );
@@ -1905,8 +1768,8 @@ export function SessionModal({
                       const selectedGoal = goals.find((goal) => goal.id === selectedGoalId);
                       const measurementFieldMeta = getGoalMeasurementFieldMeta(selectedGoal);
                       const existingMeasurementEntry = normalizeGoalMeasurementEntry(
-                        selectedGoal,
                         sessionNoteGoalMeasurements?.[selectedGoalId],
+                        selectedGoal,
                       );
                       const fieldKey = `session_note_goal_notes.${selectedGoalId}` as const;
                       const metricValueFieldKey =

--- a/src/lib/__tests__/goal-measurements.test.ts
+++ b/src/lib/__tests__/goal-measurements.test.ts
@@ -1,0 +1,78 @@
+import {
+  buildGoalMeasurementEntry,
+  getGoalMeasurementFieldMeta,
+  mergeGoalMeasurementEntry,
+  mergeUniqueGoalIds,
+  normalizeGoalMeasurementEntry,
+} from '../goal-measurements';
+
+describe('goal-measurements helpers', () => {
+  it('derives percent-oriented field metadata from measurement_type', () => {
+    expect(getGoalMeasurementFieldMeta({ measurement_type: 'Percent Accuracy' } as any)).toEqual(
+      expect.objectContaining({
+        primaryLabel: 'Percent',
+        primaryUnit: '%',
+        secondaryLabel: 'Opportunities',
+        step: 1,
+      }),
+    );
+  });
+
+  it('normalizes legacy measurement payloads into the versioned envelope', () => {
+    expect(
+      normalizeGoalMeasurementEntry({
+        count: '4',
+        trials: '5',
+        promptLevel: 'Gestural',
+        comment: 'Needed one reminder',
+      }),
+    ).toEqual({
+      version: 1,
+      data: {
+        measurement_type: null,
+        metric_label: 'Count',
+        metric_unit: 'responses',
+        metric_value: 4,
+        opportunities: 5,
+        prompt_level: 'Gestural',
+        note: 'Needed one reminder',
+      },
+    });
+  });
+
+  it('builds a goal-scoped measurement entry with goal defaults', () => {
+    expect(
+      buildGoalMeasurementEntry(
+        { measurement_type: 'duration' } as any,
+        { data: { metric_value: 12 } },
+      ),
+    ).toEqual({
+      version: 1,
+      data: {
+        measurement_type: 'duration',
+        metric_label: 'Duration',
+        metric_unit: 'minutes',
+        metric_value: 12,
+        opportunities: null,
+        prompt_level: null,
+        note: null,
+      },
+    });
+  });
+
+  it('merges entry updates and removes empty payloads', () => {
+    expect(
+      mergeGoalMeasurementEntry(
+        { measurement_type: 'frequency' } as any,
+        { data: { metric_value: 3, opportunities: 4, note: 'Initial' } },
+        { metric_value: null, opportunities: null, note: null, prompt_level: null },
+      ),
+    ).toBeNull();
+  });
+
+  it('merges unique goal ids while trimming blanks', () => {
+    expect(
+      mergeUniqueGoalIds(['goal-1', ' goal-2 '], ['goal-2', '', undefined], null, ['goal-3'], { trimValues: true }),
+    ).toEqual(['goal-1', 'goal-2', 'goal-3']);
+  });
+});

--- a/src/lib/goal-measurements.ts
+++ b/src/lib/goal-measurements.ts
@@ -1,0 +1,231 @@
+import type { Goal, SessionGoalMeasurementEntry } from '../types';
+
+export const GOAL_MEASUREMENT_VERSION = 1 as const;
+
+export interface GoalMeasurementFieldMeta {
+  readonly primaryLabel: string;
+  readonly primaryUnit: string | null;
+  readonly secondaryLabel: string | null;
+  readonly helperText: string;
+  readonly min?: number;
+  readonly max?: number;
+  readonly step: number;
+}
+
+const normalizeMeasurementTypeToken = (value: string | null | undefined): string =>
+  value?.trim().toLowerCase() ?? '';
+
+const toOptionalNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const toOptionalString = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export const getGoalMeasurementFieldMeta = (goal: Goal | undefined): GoalMeasurementFieldMeta => {
+  const measurementType = normalizeMeasurementTypeToken(goal?.measurement_type);
+
+  if (
+    measurementType.includes('percent') ||
+    measurementType.includes('%') ||
+    measurementType.includes('accuracy') ||
+    measurementType.includes('fidelity')
+  ) {
+    return {
+      primaryLabel: 'Percent',
+      primaryUnit: '%',
+      secondaryLabel: 'Opportunities',
+      helperText: 'Capture the observed percentage and, if known, the number of opportunities.',
+      min: 0,
+      max: 100,
+      step: 1,
+    };
+  }
+
+  if (
+    measurementType.includes('duration') ||
+    measurementType.includes('minute') ||
+    measurementType.includes('time')
+  ) {
+    return {
+      primaryLabel: 'Duration',
+      primaryUnit: 'minutes',
+      secondaryLabel: 'Occurrences',
+      helperText: 'Capture how long the skill or behavior was observed during the session.',
+      min: 0,
+      step: 1,
+    };
+  }
+
+  if (measurementType.includes('rate')) {
+    return {
+      primaryLabel: 'Rate',
+      primaryUnit: 'per hour',
+      secondaryLabel: 'Observation minutes',
+      helperText: 'Capture the observed rate and how long the observation window lasted.',
+      min: 0,
+      step: 0.1,
+    };
+  }
+
+  return {
+    primaryLabel: 'Count',
+    primaryUnit: 'responses',
+    secondaryLabel: 'Opportunities',
+    helperText: 'Capture the observed count for this goal during the session.',
+    min: 0,
+    step: 1,
+  };
+};
+
+export const hasMeaningfulGoalMeasurementEntry = (
+  entry: SessionGoalMeasurementEntry | null | undefined,
+): boolean => {
+  if (!entry) {
+    return false;
+  }
+
+  const { data } = entry;
+  return (
+    (data.metric_value !== null && data.metric_value !== undefined) ||
+    (data.opportunities !== null && data.opportunities !== undefined) ||
+    (data.prompt_level?.trim().length ?? 0) > 0 ||
+    (data.note?.trim().length ?? 0) > 0
+  );
+};
+
+export const normalizeGoalMeasurementEntry = (
+  rawValue: unknown,
+  goal?: Goal,
+  options?: {
+    readonly fallbackMetricUnit?: string | null;
+  },
+): SessionGoalMeasurementEntry | null => {
+  if (!rawValue || typeof rawValue !== 'object') {
+    return null;
+  }
+
+  const candidate = rawValue as {
+    data?: Record<string, unknown>;
+  } & Record<string, unknown>;
+  const sourceData =
+    candidate.data && typeof candidate.data === 'object'
+      ? candidate.data
+      : candidate;
+  const fieldMeta = getGoalMeasurementFieldMeta(goal);
+  const fallbackMetricUnit =
+    options && 'fallbackMetricUnit' in options
+      ? options.fallbackMetricUnit
+      : fieldMeta.primaryUnit;
+  const normalizedEntry: SessionGoalMeasurementEntry = {
+    version: GOAL_MEASUREMENT_VERSION,
+    data: {
+      measurement_type: goal?.measurement_type ?? toOptionalString(sourceData.measurement_type),
+      metric_label: toOptionalString(sourceData.metric_label) ?? fieldMeta.primaryLabel,
+      metric_unit: toOptionalString(sourceData.metric_unit) ?? fallbackMetricUnit,
+      metric_value: toOptionalNumber(
+        sourceData.metric_value ?? sourceData.count ?? sourceData.value,
+      ),
+      opportunities: toOptionalNumber(
+        sourceData.opportunities ?? sourceData.trials,
+      ),
+      prompt_level: toOptionalString(
+        sourceData.prompt_level ?? sourceData.promptLevel,
+      ),
+      note: toOptionalString(sourceData.note ?? sourceData.comment),
+    },
+  };
+
+  return hasMeaningfulGoalMeasurementEntry(normalizedEntry) ? normalizedEntry : null;
+};
+
+export const buildGoalMeasurementEntry = (
+  goal: Goal | undefined,
+  rawValue: unknown,
+): SessionGoalMeasurementEntry | null => {
+  const fieldMeta = getGoalMeasurementFieldMeta(goal);
+  const normalizedExisting = normalizeGoalMeasurementEntry(rawValue, goal);
+  const nextEntry: SessionGoalMeasurementEntry = {
+    version: GOAL_MEASUREMENT_VERSION,
+    data: {
+      measurement_type: goal?.measurement_type ?? normalizedExisting?.data.measurement_type ?? null,
+      metric_label: normalizedExisting?.data.metric_label ?? fieldMeta.primaryLabel,
+      metric_unit: normalizedExisting?.data.metric_unit ?? fieldMeta.primaryUnit,
+      metric_value: normalizedExisting?.data.metric_value ?? null,
+      opportunities: normalizedExisting?.data.opportunities ?? null,
+      prompt_level: normalizedExisting?.data.prompt_level ?? null,
+      note: normalizedExisting?.data.note ?? null,
+    },
+  };
+
+  return hasMeaningfulGoalMeasurementEntry(nextEntry) ? nextEntry : null;
+};
+
+export const mergeGoalMeasurementEntry = (
+  goal: Goal | undefined,
+  rawValue: unknown,
+  updates: Partial<SessionGoalMeasurementEntry['data']>,
+): SessionGoalMeasurementEntry | null => {
+  const fieldMeta = getGoalMeasurementFieldMeta(goal);
+  const existing = buildGoalMeasurementEntry(goal, rawValue);
+  const nextEntry: SessionGoalMeasurementEntry = {
+    version: GOAL_MEASUREMENT_VERSION,
+    data: {
+      measurement_type: goal?.measurement_type ?? existing?.data.measurement_type ?? null,
+      metric_label: existing?.data.metric_label ?? fieldMeta.primaryLabel,
+      metric_unit: existing?.data.metric_unit ?? fieldMeta.primaryUnit,
+      metric_value: updates.metric_value !== undefined
+        ? updates.metric_value ?? null
+        : existing?.data.metric_value ?? null,
+      opportunities: updates.opportunities !== undefined
+        ? updates.opportunities ?? null
+        : existing?.data.opportunities ?? null,
+      prompt_level: updates.prompt_level !== undefined
+        ? updates.prompt_level ?? null
+        : existing?.data.prompt_level ?? null,
+      note: updates.note !== undefined
+        ? updates.note ?? null
+        : existing?.data.note ?? null,
+    },
+  };
+
+  return hasMeaningfulGoalMeasurementEntry(nextEntry) ? nextEntry : null;
+};
+
+interface MergeUniqueGoalIdsOptions {
+  readonly trimValues?: boolean;
+}
+
+export const mergeUniqueGoalIds = (
+  ...goalIdListsAndOptions: Array<ReadonlyArray<string | undefined | null> | MergeUniqueGoalIdsOptions | null | undefined>
+): string[] => {
+  const maybeOptions = goalIdListsAndOptions.at(-1);
+  const hasOptions =
+    typeof maybeOptions === 'object' &&
+    maybeOptions !== null &&
+    !Array.isArray(maybeOptions);
+  const options = (hasOptions ? maybeOptions : undefined) as MergeUniqueGoalIdsOptions | undefined;
+  const goalIdLists = (hasOptions ? goalIdListsAndOptions.slice(0, -1) : goalIdListsAndOptions) as Array<
+    ReadonlyArray<string | undefined | null> | null | undefined
+  >;
+
+  return Array.from(
+    new Set(
+      goalIdLists
+        .flatMap((goalIds) => goalIds ?? [])
+        .filter((goalId): goalId is string => typeof goalId === 'string' && goalId.trim().length > 0)
+        .map((goalId) => (options?.trimValues ? goalId.trim() : goalId)),
+    ),
+  );
+};

--- a/src/lib/session-notes.ts
+++ b/src/lib/session-notes.ts
@@ -1,6 +1,7 @@
 import type { PostgrestError } from '@supabase/supabase-js';
 import type { SessionGoalMeasurementEntry, SessionNote } from '../types';
 import type { Database } from './generated/database.types';
+import { normalizeGoalMeasurementEntry } from './goal-measurements';
 import { supabase } from './supabase';
 
 type ClientSessionNoteRow = Database['public']['Tables']['client_session_notes']['Row'];
@@ -11,66 +12,10 @@ interface TherapistSummary {
   readonly title: string | null;
 }
 
-const toOptionalNumber = (value: unknown): number | null => {
-  if (value === null || value === undefined || value === '') {
-    return null;
-  }
-
-  const parsed = typeof value === 'number' ? value : Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-};
-
-const toOptionalString = (value: unknown): string | null => {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-};
-
 export const normalizeSessionGoalMeasurementEntry = (
   rawValue: unknown,
 ): SessionGoalMeasurementEntry | null => {
-  if (!rawValue || typeof rawValue !== 'object') {
-    return null;
-  }
-
-  const candidate = rawValue as {
-    version?: unknown;
-    data?: Record<string, unknown>;
-  } & Record<string, unknown>;
-  const sourceData =
-    candidate.data && typeof candidate.data === 'object'
-      ? candidate.data
-      : candidate;
-  const normalized: SessionGoalMeasurementEntry = {
-    version: 1,
-    data: {
-      measurement_type: toOptionalString(sourceData.measurement_type),
-      metric_label: toOptionalString(sourceData.metric_label) ?? 'Count',
-      metric_unit: toOptionalString(sourceData.metric_unit),
-      metric_value: toOptionalNumber(
-        sourceData.metric_value ?? sourceData.count ?? sourceData.value,
-      ),
-      opportunities: toOptionalNumber(
-        sourceData.opportunities ?? sourceData.trials,
-      ),
-      prompt_level: toOptionalString(
-        sourceData.prompt_level ?? sourceData.promptLevel,
-      ),
-      note: toOptionalString(sourceData.note ?? sourceData.comment),
-    },
-  };
-
-  const { data } = normalized;
-  const hasMeaningfulValue =
-    (data.metric_value !== null && data.metric_value !== undefined) ||
-    (data.opportunities !== null && data.opportunities !== undefined) ||
-    Boolean(data.prompt_level) ||
-    Boolean(data.note);
-
-  return hasMeaningfulValue ? normalized : null;
+  return normalizeGoalMeasurementEntry(rawValue, undefined, { fallbackMetricUnit: null });
 };
 
 export const normalizeSessionGoalMeasurementMap = (


### PR DESCRIPTION
## Summary
- extract shared goal measurement helpers for field metadata, normalization, envelope building, and goal-id dedupe
- refactor `SessionModal` and `AddSessionNoteModal` to use the shared helper without changing their form APIs
- keep `session-notes` legacy DB-read normalization behavior stable and add focused helper tests

## Route Task
- classification: `low-risk autonomous`
- lane: `standard`

## Verification
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm test -- src/lib/__tests__/goal-measurements.test.ts src/components/__tests__/SessionModal.test.tsx src/components/__tests__/AddSessionNoteModal.test.tsx src/lib/__tests__/session-notes.test.ts`
- `npm run build`

## Residual Risk
- No intended product behavior change in this slice; the only deliberate guard is that `session-notes` explicitly preserves its prior legacy-read default of `metric_unit: null` when a stored payload omitted that field.
- `vite build` still emits pre-existing duplicate `aria-label` warnings in settings components outside this diff.
