### PR TITLE
Make ProgramsGoalsTab tests deterministic

### DIFF
--- a/docs/SESSION_DATA_COLLECTION_2.0_RESEARCH_ONE_PAGER.md
+++ b/docs/SESSION_DATA_COLLECTION_2.0_RESEARCH_ONE_PAGER.md
@@ -2,7 +2,7 @@
 
 **Status:** Research complete — Track 1 and Track 1b shipped on `main` (see **Implementation status** below). Further phases follow product and Phase 0 doc.  
 **Audience:** Implementing agents, tech lead, clinical/product reviewer  
-**Last updated:** 2026-04-09  
+**Last updated:** 2026-04-10  
 **Related:** `AGENTS.md`, `docs/ai/high-risk-paths.md`, `docs/ai/verification-matrix.md`, `docs/THERAPIST_SESSIONS_WORKFLOW.md`, `docs/SESSION_START_NOTES_UPDATES_2026_02.md`, `docs/SESSION_DATA_COLLECTION_2.0_PHASE_0_SPEC_LOCK.md`
 
 ---
@@ -15,12 +15,13 @@
 |-------|-----|----------------|
 | **Track 1** | [#402](https://github.com/Jeduardo622/AllIincompassing/pull/402) | **SessionModal:** per-goal measurement snapshot UI; normalized `session_note_goal_measurements` → **`client_session_notes.goal_measurements`**. **SessionNotesTab:** read/display of saved measurements; **`session-notes`** normalization on fetch. |
 | **Track 1b** | [#403](https://github.com/Jeduardo622/AllIincompassing/pull/403) | **AddSessionNoteModal:** create + **edit** parity for `goal_measurements` (hydrate, submit). **`updateClientSessionNote`** in `src/lib/session-notes.ts`. **SessionNotesTab** wires edits through update path. **ProgramsGoalsTab** test: scoped **15s** timeout for CI stability (hygiene guard, not a root async fix). |
+| **Track 1c** | [#405](https://github.com/Jeduardo622/AllIincompassing/pull/405) | Shared goal measurement helpers extracted into `src/lib/goal-measurements.ts`; `SessionModal`, `AddSessionNoteModal`, and `session-notes` now share envelope/meta normalization without intended behavior change. |
 
 **Schema reference:** `client_session_notes.goal_measurements` (jsonb, object check) — migration `supabase/migrations/20260409103000_session_data_collection_2_goal_measurements.sql`.
 
 **Unchanged (per Phase 0 lock):** In-progress session **completion** still requires **non-empty `goal_notes`** text for each `session_goals` goal; structured measurements **supplement** notes, they do not replace that gate.
 
-**Suggested follow-ups (not committed here):** Extract shared measurement-field helpers used by **SessionModal** and **AddSessionNoteModal** to avoid drift; replace ProgramsGoalsTab timeout band-aid with faster deterministic setup when prioritized; optional Playwright smoke: Schedule save → Client Session Notes → measurement visible.
+**Suggested follow-ups (not committed here):** Replace ProgramsGoalsTab timeout band-aid with faster deterministic setup when prioritized; optional Playwright smoke: Schedule save → Client Session Notes → measurement visible.
 
 ---
 

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
+import { fireEvent, renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
 import { ProgramsGoalsTab } from "../ClientDetails/ProgramsGoalsTab";
 import { generateProgramGoalDraft } from "../../lib/ai";
 import { showError, showInfo, showSuccess } from "../../lib/toast";
@@ -447,16 +447,16 @@ describe("ProgramsGoalsTab", () => {
     });
 
     const programNameInput = await screen.findByPlaceholderText("Program name");
-    await userEvent.type(programNameInput, "Communication Program");
+    fireEvent.change(programNameInput, { target: { value: "Communication Program" } });
     await userEvent.click(screen.getByRole("button", { name: "Create Program" }));
 
     await waitFor(() => {
       expect(showSuccess).toHaveBeenCalledWith("Program created");
     });
 
-    await userEvent.type(await screen.findByPlaceholderText("Goal title"), "Goal A");
-    await userEvent.type(await screen.findByPlaceholderText("Goal description"), "Goal description");
-    await userEvent.type(await screen.findByPlaceholderText("Original clinical wording"), "Original wording");
+    fireEvent.change(await screen.findByPlaceholderText("Goal title"), { target: { value: "Goal A" } });
+    fireEvent.change(await screen.findByPlaceholderText("Goal description"), { target: { value: "Goal description" } });
+    fireEvent.change(await screen.findByPlaceholderText("Original clinical wording"), { target: { value: "Original wording" } });
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Create Goal" })).toBeEnabled();
@@ -473,7 +473,7 @@ describe("ProgramsGoalsTab", () => {
       );
     });
     expect(showSuccess).toHaveBeenCalledWith("Goal created");
-  }, 15000);
+  });
 
   it("falls back to same-origin API when program edge calls time out", async () => {
     let hasProgram = false;
@@ -648,10 +648,11 @@ describe("ProgramsGoalsTab", () => {
     const assessmentInput = await screen.findByPlaceholderText(
       /Paste assessment summary or White Bible-aligned notes/i,
     );
-    await userEvent.type(
-      assessmentInput,
-      "Assessment shows deficits in functional communication and WH-question responding with moderate prompt dependence.",
-    );
+    fireEvent.change(assessmentInput, {
+      target: {
+        value: "Assessment shows deficits in functional communication and WH-question responding with moderate prompt dependence.",
+      },
+    });
     await userEvent.click(screen.getByRole("button", { name: /Generate AI Proposal Program \+ Goals/i }));
 
     await waitFor(() => {
@@ -670,7 +671,7 @@ describe("ProgramsGoalsTab", () => {
       );
     });
     expect(showSuccess).toHaveBeenCalledWith("AI proposal saved to assessment queue for review.");
-  }, 15000);
+  });
 
   it("uses canonical programs array values when generating a draft proposal", async () => {
     vi.mocked(generateProgramGoalDraft).mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- remove the `ProgramsGoalsTab` per-test 15s timeout overrides
- make the slow setup deterministic by replacing typing-heavy input setup with direct change events in the affected tests
- sync the Session Data Collection one-pager to add PR #405 and remove the now-obsolete shared-helper follow-up

## Route Task
- classification: `low-risk autonomous`
- lane: `standard`

## Verification
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm test -- src/components/__tests__/ProgramsGoalsTab.test.tsx`
- `npm run test:ci`
- `npm run build`

## Residual Risk
- No production logic changed in this slice.
- `test:ci` and the whole `ProgramsGoalsTab` file are green locally without the 15s overrides, so the timeout band-aid appears unnecessary.
- `vite build` and `test:ci` still emit pre-existing duplicate `aria-label` warnings in settings components outside this diff.
