### PR TITLE
WIN-88 Preserve shell during lazy route transitions

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,8 +1,26 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { useAuth } from '../lib/authContext';
 import { useRouteQueryRefetch } from '../lib/useRouteQueryRefetch';
+
+const RouteContentFallback: React.FC = () => (
+  <div
+    className="rounded-2xl border border-gray-200/80 bg-white/70 p-6 shadow-sm backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/40"
+    role="status"
+    aria-live="polite"
+    aria-label="Loading page content"
+  >
+    <div className="animate-pulse space-y-4">
+      <div className="h-6 w-40 rounded-full bg-gray-200 dark:bg-slate-800" />
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="h-28 rounded-xl bg-gray-200/80 dark:bg-slate-800/80" />
+        <div className="h-28 rounded-xl bg-gray-200/80 dark:bg-slate-800/80" />
+      </div>
+      <div className="h-56 rounded-2xl bg-gray-200/80 dark:bg-slate-800/80" />
+    </div>
+  </div>
+);
 
 export function Layout() {
   const { user, effectiveRole } = useAuth();
@@ -19,7 +37,11 @@ export function Layout() {
             <span className="ml-2 font-medium">Role:</span> {effectiveRole}
           </div>
         )}
-        <Outlet />
+        <Suspense fallback={<RouteContentFallback />}>
+          <div className="min-h-[24rem]">
+            <Outlet />
+          </div>
+        </Suspense>
       </main>
     </div>
   );

--- a/src/components/__tests__/LayoutSuspense.test.tsx
+++ b/src/components/__tests__/LayoutSuspense.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { Layout } from '../Layout';
+
+vi.mock('../Sidebar', () => ({
+  Sidebar: () => <div data-testid="sidebar-shell">Sidebar shell</div>,
+}));
+
+vi.mock('../../lib/authContext', () => ({
+  useAuth: () => ({
+    user: { email: 'user@example.com' },
+    effectiveRole: 'admin',
+  }),
+}));
+
+vi.mock('../../lib/useRouteQueryRefetch', () => ({
+  useRouteQueryRefetch: vi.fn(),
+}));
+
+const pendingRouteLoad = new Promise<never>(() => {});
+
+const SuspendedChildRoute: React.FC = () => {
+  throw pendingRouteLoad;
+};
+
+describe('Layout suspense boundary', () => {
+  it('keeps the app shell visible while routed content is still loading', async () => {
+    render(
+      <MemoryRouter initialEntries={['/clients']}>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route path="clients" element={<SuspendedChildRoute />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('sidebar-shell')).toBeInTheDocument();
+    const roleIndicator = screen.getByText('Logged in as:').closest('div');
+    expect(roleIndicator).toHaveTextContent('user@example.com');
+    expect(roleIndicator).toHaveTextContent('Role: admin');
+
+    const fallback = await screen.findByLabelText('Loading page content');
+    expect(fallback).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add an `Outlet`-scoped `Suspense` boundary in `Layout` so lazy child route transitions preserve the authenticated shell
- use a lightweight in-shell fallback instead of replacing the whole routed UI after the layout is mounted
- add a focused regression test that verifies the shell remains visible while routed content is suspended

## Route Task
- classification: `low-risk autonomous`
- lane: `standard`

## Scope
- allowed files only: `src/components/Layout.tsx` and `src/components/__tests__/LayoutSuspense.test.tsx`
- non-goals preserved: no auth/session/guard/runtime/server/CI/query-cache/ChatBot changes

## Verification
- `npx vitest run src/components/__tests__/LayoutSuspense.test.tsx` ✅
- `npm run ci:playwright` ✅
- `npm run verify:local` ⚠️ blocked at final `npm run test:routes:tier0` step due local Windows Cypress startup failure: `Cypress.exe: bad option: --smoke-test`
- `npm run ci:check-focused` ✅ (within `verify:local` and commit hook)
- `npm run lint` ✅ (within `verify:local`)
- `npm run typecheck` ✅ (within `verify:local`)
- `npm run test:ci` ✅ (within `verify:local`)
- `npm run ci:verify-coverage` ✅ (within `verify:local`)
- `npm run build` ✅ (within `verify:local`)

## Residual Risk
- local Cypress tier-0 route smoke could not run because the Cypress Windows binary failed to start even after cache clear and reinstall; CI or another working environment should provide that exact route gate before merge

## Linear
- WIN-88
