### PR TITLE
WIN-93: polish protected-route guard loading states

### DIFF
--- a/docs/ai/WIN-93-auth-shell-guard-loading-handoff.md
+++ b/docs/ai/WIN-93-auth-shell-guard-loading-handoff.md
@@ -1,0 +1,47 @@
+# WIN-93 Auth Shell Guard Loading Handoff
+
+## Scope
+
+- Workstream B: authenticated-shell payload and guard responsiveness package
+- Branch: `codex/perf-auth-shell-guards`
+- Route-task classification: `high-risk human-reviewed`
+- Lane: `critical`
+
+## Intent
+
+- Preserve fail-closed protected-route behavior while replacing abrupt full-screen guard spinners with a consistent guarded pending state.
+- Keep chat deferral behavior unchanged on current `main`.
+- Avoid auth-context or route-tree redesign.
+
+## Changed files
+
+- `src/components/PrivateRoute.tsx`
+- `src/components/RoleGuard.tsx`
+- `src/components/RouteGuardPending.tsx`
+- `src/components/__tests__/PrivateRoute.test.tsx`
+- `src/components/__tests__/RoleGuard.test.tsx`
+
+## Verification
+
+- Passed: `npm test -- src/components/__tests__/PrivateRoute.test.tsx src/components/__tests__/RoleGuard.test.tsx src/components/__tests__/SidebarNavigation.test.tsx`
+- Passed: `npm run ci:check-focused`
+- Passed: `npm run lint`
+- Passed: `npm run typecheck`
+- Passed: `npm run build`
+- Blocked by unrelated repo-wide failures outside this diff: `npm run test:ci`
+  - timed out in existing suites under `tests/utils/check-secrets.spec.ts`
+  - timed out in existing suites under `src/components/__tests__/ProgramsGoalsTab.test.tsx`
+  - timed out in existing suites under `src/components/__tests__/SessionModal.test.tsx`
+  - timed out in existing suites under `src/components/__tests__/TherapistOnboarding.test.tsx`
+- Blocked locally by browser toolchain: `npm run test:routes:tier0`
+  - Cypress binary fails startup on this machine with `Cypress.exe: bad option: --smoke-test`
+- Blocked locally by missing deterministic browser creds: `npm run ci:playwright`
+  - `PW_ADMIN_EMAIL is required for deterministic Playwright smoke execution.`
+- `npm run verify:local`
+  - not fully green locally because it bundles the same unrelated `test:ci` failures and the same local Cypress startup failure
+
+## Residual risk
+
+- This remains a `critical` protected-route slice because it changes guard rendering behavior.
+- The branch preserves fail-closed behavior in unit coverage, but authoritative CI browser coverage is still required for final confidence.
+- A truly shell-preserving initial protected-route bootstrap remains out of scope without broader route-tree changes.

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../lib/authContext';
+import { RouteGuardPending } from './RouteGuardPending';
 
 interface PrivateRouteProps {
   children: React.ReactNode;
@@ -21,11 +22,7 @@ export const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
 
   // Show loading while auth is being determined
   if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-      </div>
-    );
+    return <RouteGuardPending fullScreen label="Restoring your secure session..." />;
   }
 
   // Redirect to login if not authenticated

--- a/src/components/RoleGuard.tsx
+++ b/src/components/RoleGuard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../lib/authContext';
 import { logger } from '../lib/logger/logger';
+import { RouteGuardPending } from './RouteGuardPending';
 
 interface RoleGuardProps {
   children: React.ReactNode;
@@ -30,11 +31,7 @@ export const RoleGuard: React.FC<RoleGuardProps> = ({
 
   // Show loading while auth is being determined
   if (loading || (user && profileLoading && !profile)) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-      </div>
-    );
+    return <RouteGuardPending label="Checking role access..." />;
   }
 
   // Redirect to login if not authenticated

--- a/src/components/RouteGuardPending.tsx
+++ b/src/components/RouteGuardPending.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface RouteGuardPendingProps {
+  fullScreen?: boolean;
+  label?: string;
+}
+
+export const RouteGuardPending: React.FC<RouteGuardPendingProps> = ({
+  fullScreen = false,
+  label = 'Checking access...',
+}) => {
+  const containerClassName = fullScreen
+    ? 'min-h-screen flex items-center justify-center px-6'
+    : 'h-full min-h-[16rem] flex items-center justify-center px-6 py-10';
+
+  return (
+    <div className={containerClassName} role="status" aria-live="polite" aria-label={label}>
+      <div className="w-full max-w-md rounded-2xl border border-gray-200/80 bg-white/90 p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900/80">
+        <div className="flex items-center gap-3">
+          <div
+            className="h-8 w-8 animate-spin rounded-full border-2 border-blue-200 border-t-blue-600 dark:border-blue-900 dark:border-t-blue-400"
+            aria-hidden="true"
+          />
+          <div>
+            <p className="text-sm font-medium text-gray-900 dark:text-white">{label}</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Loading protected content without exposing unauthorized data.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/__tests__/PrivateRoute.test.tsx
+++ b/src/components/__tests__/PrivateRoute.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import { PrivateRoute } from '../PrivateRoute';
+
+type MockAuthValue = {
+  readonly user: unknown;
+  readonly loading: boolean;
+  readonly profileLoading?: boolean;
+  readonly profile?: unknown;
+  readonly signOut?: () => Promise<void> | void;
+};
+
+vi.mock('../../lib/authContext', () => ({
+  useAuth: vi.fn<() => MockAuthValue>(),
+}));
+
+import { useAuth } from '../../lib/authContext';
+
+const renderProtectedRoute = (): void => {
+  const LoginRoute = () => {
+    const location = useLocation();
+    return <div data-testid="login-page">{JSON.stringify(location.state ?? null)}</div>;
+  };
+
+  render(
+    <MemoryRouter initialEntries={['/protected']}>
+      <Routes>
+        <Route
+          path="/protected"
+          element={(
+            <PrivateRoute>
+              <div>protected</div>
+            </PrivateRoute>
+          )}
+        />
+        <Route path="/login" element={<LoginRoute />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+};
+
+describe('PrivateRoute access behaviour', () => {
+  it('shows a guarded loading fallback while auth is unresolved', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: true,
+      profileLoading: true,
+      profile: null,
+      signOut: vi.fn(),
+    });
+
+    renderProtectedRoute();
+
+    expect(screen.getByLabelText('Restoring your secure session...')).toBeInTheDocument();
+    expect(screen.queryByText('protected')).not.toBeInTheDocument();
+  });
+
+  it('redirects unauthenticated users to login', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: false,
+      profileLoading: false,
+      profile: null,
+      signOut: vi.fn(),
+    });
+
+    renderProtectedRoute();
+
+    const loginStateNode = await screen.findByTestId('login-page');
+    expect(loginStateNode.textContent).toContain('"pathname":"/protected"');
+  });
+
+  it('renders protected children when the user is authenticated', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 'user-1' },
+      loading: false,
+      profileLoading: false,
+      profile: { is_active: true },
+      signOut: vi.fn(),
+    });
+
+    renderProtectedRoute();
+
+    expect(await screen.findByText('protected')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/RoleGuard.test.tsx
+++ b/src/components/__tests__/RoleGuard.test.tsx
@@ -94,6 +94,7 @@ describe('RoleGuard route guard behaviour', () => {
 
     renderProtectedRoute();
 
+    expect(screen.getByLabelText('Checking role access...')).toBeInTheDocument();
     expect(screen.queryByText('unauthorized-page')).not.toBeInTheDocument();
     expect(screen.queryByText('login-page')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- replace raw guard spinners with a shared guarded pending state for PrivateRoute and RoleGuard
- add focused guard tests for pending, redirect, authorized render, and role denial paths
- document scope, verification, and local browser/test blockers in the WIN-93 handoff

## Verification
- 
pm test -- src/components/__tests__/PrivateRoute.test.tsx src/components/__tests__/RoleGuard.test.tsx src/components/__tests__/SidebarNavigation.test.tsx
- 
pm run ci:check-focused
- 
pm run lint
- 
pm run typecheck
- 
pm run build

## Local blockers
- 
pm run test:ci is red on unrelated existing timeout failures outside this diff
- 
pm run test:routes:tier0 is blocked locally because Cypress fails startup with Cypress.exe: bad option: --smoke-test
- 
pm run ci:playwright is blocked locally because PW_ADMIN_EMAIL is not configured

## Risk
- Critical auth/routing slice. Fail-closed behavior is preserved, but browser validation and human review remain required before merge.