### PR TITLE
WIN-94: defer schedule modal and prefetch safely

### DIFF
--- a/docs/ai/WIN-94-schedule-firstload-prefetch-handoff.md
+++ b/docs/ai/WIN-94-schedule-firstload-prefetch-handoff.md
@@ -1,0 +1,50 @@
+# WIN-94 Schedule First-Load Prefetch Handoff
+
+## Scope
+
+- Workstream C: heavy route first-load reduction for Schedule and predictive prefetch
+- Branch: `codex/perf-schedule-firstload-prefetch`
+- Route-task classification: `low-risk autonomous`
+- Lane: `standard`
+
+## Intent
+
+- Remove the Session editor from the initial Schedule route payload.
+- Warm only the adjacent schedule batch when the user shows clear next-navigation intent.
+- Keep organization scoping explicit and avoid changing scheduling semantics.
+
+## Changed files
+
+- `src/lib/optimizedQueries.ts`
+- `src/lib/__tests__/optimizedQueries.prefetch.test.tsx`
+- `src/pages/Schedule.tsx`
+- `src/pages/__tests__/Schedule.test.tsx`
+- `src/pages/__tests__/Schedule.lazyModal.test.tsx`
+- `src/pages/__tests__/Schedule.event.test.tsx`
+- `src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
+- `src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx`
+- `src/pages/__tests__/Schedule.dataLoadUx.test.tsx`
+- `src/pages/__tests__/Schedule.orgGuard.test.tsx`
+- `src/pages/__tests__/Schedule.urlEditDeepLink.test.tsx`
+
+## Verification
+
+- Passed: `npm test -- src/pages/__tests__/Schedule.event.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx src/pages/__tests__/Schedule.test.tsx src/pages/__tests__/Schedule.lazyModal.test.tsx src/pages/__tests__/Schedule.dataLoadUx.test.tsx src/pages/__tests__/Schedule.orgGuard.test.tsx src/pages/__tests__/Schedule.urlEditDeepLink.test.tsx`
+- Passed: `npm test -- src/lib/__tests__/optimizedQueries.prefetch.test.tsx src/pages/__tests__/Schedule.event.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx src/pages/__tests__/Schedule.test.tsx src/pages/__tests__/Schedule.lazyModal.test.tsx src/pages/__tests__/Schedule.dataLoadUx.test.tsx src/pages/__tests__/Schedule.orgGuard.test.tsx src/pages/__tests__/Schedule.urlEditDeepLink.test.tsx`
+- Passed: `npm run ci:check-focused`
+- Passed: `npm run lint`
+- Passed: `npm run typecheck`
+- Passed: `npm run build`
+- `npm run verify:local`
+  - blocked by unrelated repo-wide failures outside this diff in the aggregate `npm run test:ci` phase
+  - after fixing Schedule-specific fallout, the remaining `test:ci` red state is in existing non-schedule suites
+- `npm run test:routes:tier0`
+  - not required by the verification matrix for this standard-lane page performance slice
+- `npm run ci:playwright`
+  - not required locally because this slice does not change auth/session routing flows; authoritative PR CI remains the final browser gate if branch protection requires it
+
+## Residual risk
+
+- Prefetch remains bounded to adjacent week navigation and now uses org-scoped cache identity in the touched query layer.
+- Lazy modal loading now sits behind a local Suspense boundary; focused tests cover create, edit, URL-deep-link, pending-schedule, and session-close flows.
+- The full aggregate suite still has unrelated timeout noise, so authoritative CI remains the source of truth for repo-wide merge readiness.

--- a/src/lib/__tests__/optimizedQueries.prefetch.test.tsx
+++ b/src/lib/__tests__/optimizedQueries.prefetch.test.tsx
@@ -1,0 +1,96 @@
+import { useEffect } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSmartPrefetch } from "../optimizedQueries";
+
+vi.mock("../supabase", () => ({
+  supabase: {
+    rpc: vi.fn(async () => ({ data: { sessions: [] }, error: null })),
+  },
+}));
+
+function SchedulePrefetchProbe({
+  queryFn,
+  organizationId,
+}: {
+  queryFn: (prefetch: ReturnType<typeof useSmartPrefetch>) => void;
+  organizationId?: string | null;
+}) {
+  const prefetch = useSmartPrefetch();
+
+  useEffect(() => {
+    queryFn(prefetch);
+  }, [prefetch, queryFn, organizationId]);
+
+  return null;
+}
+
+describe("useSmartPrefetch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses org-scoped schedule batch keys when prefetching adjacent schedule data", async () => {
+    const queryClient = new QueryClient();
+    const prefetchQuerySpy = vi
+      .spyOn(queryClient, "prefetchQuery")
+      .mockResolvedValue(undefined);
+    const startDate = new Date("2025-07-07T00:00:00.000Z");
+    const endDate = new Date("2025-07-13T23:59:59.999Z");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SchedulePrefetchProbe
+          organizationId="org-123"
+          queryFn={({ prefetchScheduleRange }) => {
+            void prefetchScheduleRange(startDate, endDate, {
+              organizationId: "org-123",
+            });
+          }}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(prefetchQuerySpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(prefetchQuerySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [
+          "sessions-batch",
+          "org-123",
+          startDate.toISOString(),
+          endDate.toISOString(),
+        ],
+      }),
+    );
+  });
+
+  it("skips schedule prefetch when organization context is absent", async () => {
+    const queryClient = new QueryClient();
+    const prefetchQuerySpy = vi
+      .spyOn(queryClient, "prefetchQuery")
+      .mockResolvedValue(undefined);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SchedulePrefetchProbe
+          organizationId={null}
+          queryFn={({ prefetchScheduleRange }) => {
+            void prefetchScheduleRange(
+              new Date("2025-07-07T00:00:00.000Z"),
+              new Date("2025-07-13T23:59:59.999Z"),
+              { organizationId: null },
+            );
+          }}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(prefetchQuerySpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/optimizedQueries.ts
+++ b/src/lib/optimizedQueries.ts
@@ -9,6 +9,17 @@ import { useDashboardLiveRefresh } from './dashboardLiveRefresh';
 import { callApi } from './api';
 import { ensureRuntimeSupabaseConfig, getSupabaseAnonKey } from './runtimeConfig';
 
+const buildOrgScopedScheduleBatchKey = (
+  startDateIso: string,
+  endDateIso: string,
+  organizationId?: string | null,
+) => [
+  'sessions-batch',
+  organizationId || 'org:none',
+  startDateIso,
+  endDateIso,
+];
+
 // ============================================================================
 // BATCHED SCHEDULE QUERIES (Replaces N+1 queries)
 // ============================================================================
@@ -17,28 +28,39 @@ import { ensureRuntimeSupabaseConfig, getSupabaseAnonKey } from './runtimeConfig
  * Optimized schedule data fetching - replaces 3 separate queries with 1 RPC call
  * Reduces API calls by ~60% on Schedule page
  */
-export const useScheduleDataBatch = (startDate: Date, endDate: Date, options?: { enabled?: boolean }) => {
-  return useQuery({
-    queryKey: generateCacheKey.sessionsBatch(startDate.toISOString(), endDate.toISOString()),
-    queryFn: async () => {
-      const { data, error } = await supabase.rpc('get_schedule_data_batch', {
-        p_start_date: startDate.toISOString(),
-        p_end_date: endDate.toISOString()
-      });
+const fetchScheduleDataBatch = async (startDate: Date, endDate: Date) => {
+  const { data, error } = await supabase.rpc('get_schedule_data_batch', {
+    p_start_date: startDate.toISOString(),
+    p_end_date: endDate.toISOString()
+  });
 
-      if (error) {
-        // Gracefully fall back to the non-batched queries when the RPC is unavailable/misconfigured.
-        logger.warn('Schedule batch RPC failed; falling back to individual queries', {
-          metadata: {
-            rpc: 'get_schedule_data_batch',
-            code: (error as { code?: string }).code ?? null,
-            message: (error as { message?: string }).message ?? 'Unknown RPC error',
-          },
-        });
-        return null;
-      }
-      return data;
-    },
+  if (error) {
+    // Gracefully fall back to the non-batched queries when the RPC is unavailable/misconfigured.
+    logger.warn('Schedule batch RPC failed; falling back to individual queries', {
+      metadata: {
+        rpc: 'get_schedule_data_batch',
+        code: (error as { code?: string }).code ?? null,
+        message: (error as { message?: string }).message ?? 'Unknown RPC error',
+      },
+    });
+    return null;
+  }
+
+  return data;
+};
+
+export const useScheduleDataBatch = (
+  startDate: Date,
+  endDate: Date,
+  options?: { enabled?: boolean; organizationId?: string | null },
+) => {
+  return useQuery({
+    queryKey: buildOrgScopedScheduleBatchKey(
+      startDate.toISOString(),
+      endDate.toISOString(),
+      options?.organizationId,
+    ),
+    queryFn: () => fetchScheduleDataBatch(startDate, endDate),
     retry: false,
     staleTime: CACHE_STRATEGIES.SESSIONS.schedule_batch,
     gcTime: CACHE_STRATEGIES.SESSIONS.schedule_batch * 2,
@@ -454,42 +476,79 @@ export const useQueryPerformanceMonitor = () => {
  */
 export const useSmartPrefetch = () => {
   const queryClient = useQueryClient();
-  
-  const prefetchNextWeek = async (currentWeekStart: Date) => {
-    const nextWeekStart = new Date(currentWeekStart);
-    nextWeekStart.setDate(nextWeekStart.getDate() + 7);
-    
-    const nextWeekEnd = new Date(nextWeekStart);
-    nextWeekEnd.setDate(nextWeekEnd.getDate() + 6);
-    
+  const canPrefetch = (options?: { enabled?: boolean; organizationId?: string | null }) =>
+    (options?.enabled ?? true) && typeof options?.organizationId === 'string' && options.organizationId.length > 0;
+
+  const prefetchScheduleRange = async (
+    startDate: Date,
+    endDate: Date,
+    options?: { enabled?: boolean; organizationId?: string | null },
+  ) => {
+    if (!canPrefetch(options)) {
+      return;
+    }
+
     try {
       await queryClient.prefetchQuery({
-        queryKey: generateCacheKey.sessionsBatch(
-          nextWeekStart.toISOString(),
-          nextWeekEnd.toISOString()
+        queryKey: buildOrgScopedScheduleBatchKey(
+          startDate.toISOString(),
+          endDate.toISOString(),
+          options?.organizationId,
         ),
+        queryFn: () => fetchScheduleDataBatch(startDate, endDate),
         staleTime: CACHE_STRATEGIES.SESSIONS.future_weeks,
       });
     } catch (error) {
-      logger.warn('Failed to prefetch next week data', {
+      logger.warn('Failed to prefetch schedule range data', {
         metadata: {
-          scope: 'smartPrefetch.nextWeek',
-          failure: toError(error, 'Next week prefetch failed').message,
+          scope: 'smartPrefetch.scheduleRange',
+          failure: toError(error, 'Schedule range prefetch failed').message,
+          startDate: startDate.toISOString(),
+          endDate: endDate.toISOString(),
         },
       });
     }
   };
   
-  const prefetchReportData = async (currentMonth: Date) => {
+  const prefetchNextWeek = async (
+    currentWeekStart: Date,
+    options?: { enabled?: boolean; organizationId?: string | null },
+  ) => {
+    const nextWeekStart = new Date(currentWeekStart);
+    nextWeekStart.setDate(nextWeekStart.getDate() + 7);
+    
+    const nextWeekEnd = new Date(nextWeekStart);
+    nextWeekEnd.setDate(nextWeekEnd.getDate() + 6);
+    await prefetchScheduleRange(nextWeekStart, nextWeekEnd, options);
+  };
+  
+  const prefetchReportData = async (
+    currentMonth: Date,
+    options?: { enabled?: boolean; organizationId?: string | null },
+  ) => {
+    if (!canPrefetch(options)) {
+      return;
+    }
+
     const nextMonth = new Date(currentMonth);
     nextMonth.setMonth(nextMonth.getMonth() + 1);
+    const startDate = nextMonth.toISOString().split('T')[0];
+    const endDate = new Date(nextMonth.getFullYear(), nextMonth.getMonth() + 1, 0).toISOString().split('T')[0];
     
     try {
       await queryClient.prefetchQuery({
-        queryKey: generateCacheKey.sessionMetrics(
-          nextMonth.toISOString().split('T')[0],
-          new Date(nextMonth.getFullYear(), nextMonth.getMonth() + 1, 0).toISOString().split('T')[0]
-        ),
+        queryKey: generateCacheKey.sessionMetrics(startDate, endDate),
+        queryFn: async () => {
+          const { data, error } = await supabase.rpc('get_session_metrics', {
+            p_start_date: startDate,
+            p_end_date: endDate,
+            p_therapist_id: null,
+            p_client_id: null
+          });
+
+          if (error) throw error;
+          return data;
+        },
         staleTime: CACHE_STRATEGIES.REPORTS.past_months,
       });
     } catch (error) {
@@ -502,5 +561,5 @@ export const useSmartPrefetch = () => {
     }
   };
   
-  return { prefetchNextWeek, prefetchReportData };
+  return { prefetchScheduleRange, prefetchNextWeek, prefetchReportData };
 };

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useRef,
   useSyncExternalStore,
+  Suspense,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { format, parseISO, startOfWeek, addDays, endOfWeek } from "date-fns";
@@ -24,7 +25,6 @@ import {
 } from "lucide-react";
 import type { Session, SessionGoalMeasurementEntry, Client } from "../types";
 import {
-  SessionModal,
   type SessionModalSubmitData,
   type SessionModalClinicalNotesPayload,
 } from "../components/SessionModal";
@@ -34,6 +34,7 @@ import {
   useScheduleDataBatch,
   useSessionsOptimized,
   useDropdownData,
+  useSmartPrefetch,
 } from "../lib/optimizedQueries";
 import { cancelSessions } from "../lib/sessionCancellation";
 import { showError, showSuccess } from "../lib/toast";
@@ -91,6 +92,9 @@ const MISSING_NOTES_RETRY_HINT =
   "Before closing this in-progress session, complete a linked clinical session note for this session and add per-goal note text for each worked goal. You can add these in Schedule > Edit Session > Clinical Session Notes, or in Client Details > Session Notes.";
 const AUTO_SCHEDULE_CONCURRENCY = 3;
 const _scheduleBoundedConcurrencyMarker = AUTO_SCHEDULE_CONCURRENCY;
+const LazySessionModal = React.lazy(() =>
+  import("../components/SessionModal").then((module) => ({ default: module.SessionModal })),
+);
 
 type ScheduleSubmitData = SessionModalSubmitData;
 
@@ -272,6 +276,31 @@ function mergeScheduleDirectoryLists<T extends { id?: string }>(
     return rich ? ({ ...row, ...rich } as T) : row;
   });
 }
+
+const ScheduleModalLoadingState: React.FC = () => (
+  <div
+    className="fixed inset-0 z-50 flex items-center justify-center bg-gray-950/30 px-4 backdrop-blur-[1px]"
+    role="status"
+    aria-live="polite"
+    aria-label="Loading session editor..."
+    data-testid="schedule-modal-loading"
+  >
+    <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-5 shadow-xl dark:border-gray-700 dark:bg-dark-lighter">
+      <div className="flex items-center gap-3">
+        <div
+          className="h-8 w-8 animate-spin rounded-full border-2 border-blue-200 border-t-blue-600 dark:border-blue-900 dark:border-t-blue-400"
+          aria-hidden="true"
+        />
+        <div>
+          <p className="text-sm font-medium text-gray-900 dark:text-white">Loading session editor...</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Preparing scheduling tools without blocking the rest of the page.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+);
 
 // Memoized time slot component
 const TimeSlot = React.memo(
@@ -572,6 +601,7 @@ export const Schedule = React.memo(() => {
   }, []);
 
   const queryClient = useQueryClient();
+  const { prefetchScheduleRange } = useSmartPrefetch();
   const scheduleResetSetters = useMemo(
     () => ({
       setIsModalOpen,
@@ -761,7 +791,10 @@ export const Schedule = React.memo(() => {
     data: batchedData,
     isLoading: isLoadingBatch,
     refetch: refetchScheduleBatch,
-  } = useScheduleDataBatch(weekStart, weekEnd, { enabled: !!activeOrganizationId });
+  } = useScheduleDataBatch(weekStart, weekEnd, {
+    enabled: !!activeOrganizationId,
+    organizationId: activeOrganizationId,
+  });
 
   const hasBatchedSessions = Array.isArray(batchedData?.sessions);
   const enableFallbackSessionsQuery =
@@ -1549,6 +1582,49 @@ export const Schedule = React.memo(() => {
     setView(newView);
   }, []);
 
+  const prefetchAdjacentScheduleRange = useCallback(
+    (direction: "prev" | "next") => {
+      if (!activeOrganizationId) {
+        return;
+      }
+
+      const daysToAdd = view === "day" ? 1 : 7;
+      const targetDate = addDays(
+        selectedDate,
+        direction === "prev" ? -daysToAdd : daysToAdd,
+      );
+      const targetWeekStart = startOfWeek(targetDate, { weekStartsOn: 1 });
+      const targetWeekEnd = endOfWeek(targetDate, { weekStartsOn: 1 });
+
+      if (
+        targetWeekStart.getTime() === weekStart.getTime() &&
+        targetWeekEnd.getTime() === weekEnd.getTime()
+      ) {
+        return;
+      }
+
+      void prefetchScheduleRange(targetWeekStart, targetWeekEnd, {
+        organizationId: activeOrganizationId,
+      });
+    },
+    [
+      activeOrganizationId,
+      prefetchScheduleRange,
+      selectedDate,
+      view,
+      weekEnd,
+      weekStart,
+    ],
+  );
+
+  const handlePrefetchPreviousPeriod = useCallback(() => {
+    prefetchAdjacentScheduleRange("prev");
+  }, [prefetchAdjacentScheduleRange]);
+
+  const handlePrefetchNextPeriod = useCallback(() => {
+    prefetchAdjacentScheduleRange("next");
+  }, [prefetchAdjacentScheduleRange]);
+
   // Memoized time slots generation
   const timeSlots = useMemo(() => {
     const slots = [];
@@ -1588,6 +1664,29 @@ export const Schedule = React.memo(() => {
 
   const hasBatchedData = Boolean(batchedData);
   const isLoading = isLoadingBatch || (!hasBatchedData && (isLoadingSessions || isLoadingDropdowns));
+  const sessionModal = isModalOpen ? (
+    <Suspense fallback={<ScheduleModalLoadingState />}>
+      <LazySessionModal
+        isOpen={isModalOpen}
+        onClose={handleCloseSessionModal}
+        onSubmit={handleSubmit}
+        session={selectedSession}
+        selectedDate={selectedTimeSlot?.date}
+        selectedTime={selectedTimeSlot?.time}
+        therapists={visibleTherapists}
+        clients={visibleClients}
+        existingSessions={displayData.sessions}
+        timeZone={userTimeZone}
+        defaultTherapistId={selectedTherapist}
+        defaultClientId={selectedClient}
+        retryHint={retryHint}
+        onRetryHintDismiss={dismissRetryHint}
+        retryActionLabel={retryActionLabel}
+        onRetryAction={retryActionLabel ? handleOpenLinkedSessionDocumentation : undefined}
+        onSessionStarted={handleSessionStarted}
+      />
+    </Suspense>
+  ) : null;
 
   useEffect(() => {
     const parsed = parseScheduleModalSearchParams(searchParams);
@@ -1714,27 +1813,7 @@ export const Schedule = React.memo(() => {
             aria-hidden="true"
           />
         </div>
-        {isModalOpen && (
-          <SessionModal
-            isOpen={isModalOpen}
-            onClose={handleCloseSessionModal}
-            onSubmit={handleSubmit}
-            session={selectedSession}
-            selectedDate={selectedTimeSlot?.date}
-            selectedTime={selectedTimeSlot?.time}
-            therapists={visibleTherapists}
-            clients={visibleClients}
-            existingSessions={displayData.sessions}
-            timeZone={userTimeZone}
-            defaultTherapistId={selectedTherapist}
-            defaultClientId={selectedClient}
-            retryHint={retryHint}
-            onRetryHintDismiss={dismissRetryHint}
-            retryActionLabel={retryActionLabel}
-            onRetryAction={retryActionLabel ? handleOpenLinkedSessionDocumentation : undefined}
-            onSessionStarted={handleSessionStarted}
-          />
-        )}
+        {sessionModal}
       </div>
     );
   }
@@ -1775,27 +1854,7 @@ export const Schedule = React.memo(() => {
             </button>
           </div>
         </div>
-        {isModalOpen && (
-          <SessionModal
-            isOpen={isModalOpen}
-            onClose={handleCloseSessionModal}
-            onSubmit={handleSubmit}
-            session={selectedSession}
-            selectedDate={selectedTimeSlot?.date}
-            selectedTime={selectedTimeSlot?.time}
-            therapists={visibleTherapists}
-            clients={visibleClients}
-            existingSessions={displayData.sessions}
-            timeZone={userTimeZone}
-            defaultTherapistId={selectedTherapist}
-            defaultClientId={selectedClient}
-            retryHint={retryHint}
-            onRetryHintDismiss={dismissRetryHint}
-            retryActionLabel={retryActionLabel}
-            onRetryAction={retryActionLabel ? handleOpenLinkedSessionDocumentation : undefined}
-            onSessionStarted={handleSessionStarted}
-          />
-        )}
+        {sessionModal}
       </div>
     );
   }
@@ -1808,6 +1867,8 @@ export const Schedule = React.memo(() => {
           <button
             aria-label="Previous period"
             onClick={() => handleDateNavigation("prev")}
+            onFocus={handlePrefetchPreviousPeriod}
+            onMouseEnter={handlePrefetchPreviousPeriod}
             className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
           >
             <ChevronLeft aria-hidden="true" className="w-5 h-5" />
@@ -1823,6 +1884,8 @@ export const Schedule = React.memo(() => {
           <button
             aria-label="Next period"
             onClick={() => handleDateNavigation("next")}
+            onFocus={handlePrefetchNextPeriod}
+            onMouseEnter={handlePrefetchNextPeriod}
             className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
           >
             <ChevronRight aria-hidden="true" className="w-5 h-5" />
@@ -2147,27 +2210,7 @@ export const Schedule = React.memo(() => {
         />
       )}
 
-      {isModalOpen && (
-        <SessionModal
-          isOpen={isModalOpen}
-          onClose={handleCloseSessionModal}
-          onSubmit={handleSubmit}
-          session={selectedSession}
-          selectedDate={selectedTimeSlot?.date}
-          selectedTime={selectedTimeSlot?.time}
-          therapists={visibleTherapists}
-          clients={visibleClients}
-          existingSessions={displayData.sessions}
-          timeZone={userTimeZone}
-          defaultTherapistId={selectedTherapist}
-          defaultClientId={selectedClient}
-          retryHint={retryHint}
-          onRetryHintDismiss={dismissRetryHint}
-          retryActionLabel={retryActionLabel}
-          onRetryAction={retryActionLabel ? handleOpenLinkedSessionDocumentation : undefined}
-          onSessionStarted={handleSessionStarted}
-        />
-      )}
+      {sessionModal}
 
     </div>
   );

--- a/src/pages/__tests__/Schedule.dataLoadUx.test.tsx
+++ b/src/pages/__tests__/Schedule.dataLoadUx.test.tsx
@@ -49,6 +49,11 @@ vi.mock("../../lib/optimizedQueries", () => ({
   useScheduleDataBatch: (...args: unknown[]) => mockUseScheduleDataBatch(...args),
   useSessionsOptimized: (...args: unknown[]) => mockUseSessionsOptimized(...args),
   useDropdownData: (...args: unknown[]) => mockUseDropdownData(...args),
+  useSmartPrefetch: () => ({
+    prefetchScheduleRange: vi.fn(),
+    prefetchNextWeek: vi.fn(),
+    prefetchReportData: vi.fn(),
+  }),
 }));
 
 vi.mock("../../lib/organization", () => ({

--- a/src/pages/__tests__/Schedule.event.test.tsx
+++ b/src/pages/__tests__/Schedule.event.test.tsx
@@ -1,6 +1,44 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useLocation } from "react-router-dom";
 import { renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
+
+vi.mock("../../lib/optimizedQueries", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../lib/optimizedQueries")>();
+  return {
+    ...actual,
+    useSmartPrefetch: () => ({
+      prefetchScheduleRange: vi.fn(),
+      prefetchNextWeek: vi.fn(),
+      prefetchReportData: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("../../components/SessionModal", () => ({
+  SessionModal: ({
+    isOpen,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="event-session-modal">
+        <h2>New Session</h2>
+        <label htmlFor="event-session-start-time">Start Time</label>
+        <input
+          id="event-session-start-time"
+          aria-label="Start Time"
+          defaultValue="10:00"
+        />
+        <button aria-label="Close session modal" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
 import { Schedule } from "../Schedule";
 
 // Integration test for event-based scheduling
@@ -10,6 +48,10 @@ function SearchProbe() {
 }
 
 describe("Schedule page event listener", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   beforeEach(() => {
     localStorage.clear();
   });
@@ -36,10 +78,12 @@ describe("Schedule page event listener", () => {
       end_time: "2025-03-18T11:00:00Z",
     };
 
-    document.dispatchEvent(new CustomEvent("openScheduleModal", { detail }));
+    await waitFor(() => {
+      window.dispatchEvent(new CustomEvent("openScheduleModal", { detail }));
+      expect(screen.getByText(/New Session/i)).toBeInTheDocument();
+    });
 
     // Modal should open with default start time populated
-    expect(await screen.findByText(/New Session/i)).toBeInTheDocument();
     const input = screen.getByLabelText(/Start Time/i) as HTMLInputElement;
     expect(input.value).not.toBe("");
   });

--- a/src/pages/__tests__/Schedule.lazyModal.test.tsx
+++ b/src/pages/__tests__/Schedule.lazyModal.test.tsx
@@ -1,0 +1,115 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { renderWithProviders, screen } from "../../test/utils";
+import userEvent from "@testing-library/user-event";
+
+const mockUseScheduleDataBatch = vi.fn();
+const mockUseSessionsOptimized = vi.fn();
+const mockUseDropdownData = vi.fn();
+const mockUseActiveOrganizationId = vi.fn(() => "org-1");
+let sessionModalLoadCount = 0;
+
+vi.mock("../../lib/optimizedQueries", () => ({
+  useScheduleDataBatch: (...args: unknown[]) => mockUseScheduleDataBatch(...args),
+  useSessionsOptimized: (...args: unknown[]) => mockUseSessionsOptimized(...args),
+  useDropdownData: (...args: unknown[]) => mockUseDropdownData(...args),
+  useSmartPrefetch: () => ({
+    prefetchScheduleRange: vi.fn(),
+    prefetchNextWeek: vi.fn(),
+    prefetchReportData: vi.fn(),
+  }),
+}));
+
+vi.mock("../../lib/organization", () => ({
+  useActiveOrganizationId: () => mockUseActiveOrganizationId(),
+}));
+
+vi.mock("../../components/SessionModal", () => {
+  sessionModalLoadCount += 1;
+  return {
+    SessionModal: ({
+      isOpen,
+      selectedTime,
+    }: {
+      isOpen: boolean;
+      selectedTime?: string;
+    }) => (isOpen ? <div data-testid="session-modal">Session modal for {selectedTime}</div> : null),
+  };
+});
+
+import { Schedule } from "../Schedule";
+
+const scheduleFixtures = {
+  sessions: [
+    {
+      id: "session-1",
+      therapist_id: "therapist-1",
+      client_id: "client-1",
+      program_id: "program-1",
+      goal_id: "goal-1",
+      start_time: "2025-07-01T10:00:00Z",
+      end_time: "2025-07-01T11:00:00Z",
+      status: "scheduled" as const,
+      notes: "",
+      created_at: "2025-06-01T00:00:00Z",
+      updated_at: "2025-06-01T00:00:00Z",
+      therapist: { id: "therapist-1", full_name: "Dr. Myles" },
+      client: { id: "client-1", full_name: "Jamie Client" },
+    },
+  ],
+  therapists: [
+    {
+      id: "therapist-1",
+      full_name: "Dr. Myles",
+      email: "myles@example.com",
+      availability_hours: {},
+    },
+  ],
+  clients: [
+    {
+      id: "client-1",
+      full_name: "Jamie Client",
+      email: "jamie@example.com",
+      availability_hours: {},
+      service_preference: [],
+    },
+  ],
+};
+
+describe("Schedule lazy session modal", () => {
+  beforeEach(() => {
+    sessionModalLoadCount = 0;
+    mockUseActiveOrganizationId.mockReturnValue("org-1");
+    mockUseScheduleDataBatch.mockReturnValue({
+      data: scheduleFixtures,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+    mockUseSessionsOptimized.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockUseDropdownData.mockReturnValue({
+      data: { therapists: scheduleFixtures.therapists, clients: scheduleFixtures.clients },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it("defers loading the session editor module until a modal open path is requested", async () => {
+    renderWithProviders(<Schedule />);
+
+    await screen.findByRole("heading", { name: /Schedule/i });
+    expect(sessionModalLoadCount).toBe(0);
+
+    const addButtons = await screen.findAllByLabelText("Add session");
+    await userEvent.click(addButtons[0]);
+
+    expect(await screen.findByTestId("session-modal")).toHaveTextContent("Session modal for 08:00");
+    expect(sessionModalLoadCount).toBe(1);
+  });
+});

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -54,6 +54,11 @@ vi.mock("../../lib/optimizedQueries", () => ({
     data: { therapists: scheduleFixtures.therapists, clients: scheduleFixtures.clients },
     isLoading: false,
   }),
+  useSmartPrefetch: () => ({
+    prefetchScheduleRange: vi.fn(),
+    prefetchNextWeek: vi.fn(),
+    prefetchReportData: vi.fn(),
+  }),
 }));
 
 vi.mock("../../features/scheduling/domain/booking", () => ({

--- a/src/pages/__tests__/Schedule.orgGuard.test.tsx
+++ b/src/pages/__tests__/Schedule.orgGuard.test.tsx
@@ -18,6 +18,11 @@ vi.mock("../../lib/optimizedQueries", () => ({
   useScheduleDataBatch: vi.fn(() => ({ data: null, isLoading: false })),
   useSessionsOptimized: vi.fn(() => ({ data: [], isLoading: false })),
   useDropdownData: vi.fn(() => ({ data: null, isLoading: false })),
+  useSmartPrefetch: vi.fn(() => ({
+    prefetchScheduleRange: vi.fn(),
+    prefetchNextWeek: vi.fn(),
+    prefetchReportData: vi.fn(),
+  })),
 }));
 
 const batchMock = vi.mocked(useScheduleDataBatch);
@@ -58,7 +63,7 @@ describe("Schedule org-context guard", () => {
       expect(batchMock).toHaveBeenCalledWith(
         expect.any(Date),
         expect.any(Date),
-        { enabled: false },
+        { enabled: false, organizationId: null },
       );
     });
 
@@ -99,7 +104,7 @@ describe("Schedule org-context guard", () => {
       expect(batchMock).toHaveBeenCalledWith(
         expect.any(Date),
         expect.any(Date),
-        { enabled: true },
+        { enabled: true, organizationId: "org-abc-123" },
       );
     });
 

--- a/src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx
+++ b/src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx
@@ -112,6 +112,11 @@ vi.mock("../../lib/optimizedQueries", () => ({
       isLoading: false,
     };
   },
+  useSmartPrefetch: () => ({
+    prefetchScheduleRange: vi.fn(),
+    prefetchNextWeek: vi.fn(),
+    prefetchReportData: vi.fn(),
+  }),
 }));
 
 vi.mock("../../components/SessionModal", () => ({
@@ -185,7 +190,7 @@ describe("Schedule session-close readiness precheck", { timeout: 15_000 }, () =>
     renderWithProviders(<Schedule />);
 
     fireEvent.click(await screen.findByText("Jamie Client"));
-    fireEvent.click(screen.getByRole("button", { name: "Submit terminal" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Submit terminal" }));
 
     await waitFor(() => {
       expect(checkInProgressSessionCloseReadinessMock).toHaveBeenCalledWith({
@@ -214,7 +219,7 @@ describe("Schedule session-close readiness precheck", { timeout: 15_000 }, () =>
     renderWithProviders(<Schedule />);
 
     fireEvent.click(await screen.findByText("Jamie Client"));
-    fireEvent.click(screen.getByRole("button", { name: "Submit terminal" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Submit terminal" }));
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Open Client Details" })).toBeInTheDocument();
@@ -229,7 +234,7 @@ describe("Schedule session-close readiness precheck", { timeout: 15_000 }, () =>
     renderWithProviders(<Schedule />);
 
     fireEvent.click(await screen.findByText("Jamie Client"));
-    fireEvent.click(screen.getByRole("button", { name: "Submit terminal" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Submit terminal" }));
 
     await waitFor(() => {
       expect(checkInProgressSessionCloseReadinessMock).toHaveBeenCalledTimes(1);
@@ -247,7 +252,7 @@ describe("Schedule session-close readiness precheck", { timeout: 15_000 }, () =>
     renderWithProviders(<Schedule />);
 
     fireEvent.click(await screen.findByText("Jamie Client"));
-    fireEvent.click(screen.getByRole("button", { name: "Submit terminal" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Submit terminal" }));
 
     await waitFor(() => {
       expect(completeSessionFromModalMock).toHaveBeenCalledWith({

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { http, HttpResponse } from "msw";
+import { addDays, endOfWeek, startOfWeek } from "date-fns";
 import { renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
 import { fireEvent } from "@testing-library/react";
 import { server } from "../../test/setup";
@@ -12,6 +13,8 @@ const mockUseDropdownData = vi.fn(() => ({
   isLoading: false,
 }));
 const mockUseActiveOrganizationId = vi.fn(() => "org-1");
+const mockPrefetchScheduleRange = vi.fn();
+let sessionModalModuleLoads = 0;
 
 const scheduleFixtures = {
   sessions: [
@@ -112,6 +115,11 @@ vi.mock("../../lib/optimizedQueries", () => ({
   useScheduleDataBatch: (...args: unknown[]) => mockUseScheduleDataBatch(...args),
   useSessionsOptimized: (...args: unknown[]) => mockUseSessionsOptimized(...args),
   useDropdownData: (...args: unknown[]) => mockUseDropdownData(...args),
+  useSmartPrefetch: () => ({
+    prefetchScheduleRange: mockPrefetchScheduleRange,
+    prefetchNextWeek: vi.fn(),
+    prefetchReportData: vi.fn(),
+  }),
 }));
 
 vi.mock("../../lib/organization", () => ({
@@ -119,6 +127,7 @@ vi.mock("../../lib/organization", () => ({
 }));
 
 vi.mock("../../components/SessionModal", () => ({
+  ...(sessionModalModuleLoads++, {}),
   SessionModal: ({
     isOpen,
     existingSessions,
@@ -138,7 +147,9 @@ const defaultRpcImplementation = vi.mocked(supabase.rpc as any).getMockImplement
 
 describe("Schedule", () => {
   beforeEach(() => {
+    sessionModalModuleLoads = 0;
     mockUseActiveOrganizationId.mockReturnValue("org-1");
+    mockPrefetchScheduleRange.mockReset();
     mockUseScheduleDataBatch.mockReset();
     mockUseScheduleDataBatch.mockReturnValue({ data: scheduleFixtures, isLoading: false });
     mockUseSessionsOptimized.mockReset();
@@ -233,7 +244,7 @@ describe("Schedule", () => {
     expect(mockUseScheduleDataBatch).toHaveBeenCalledWith(
       expect.any(Date),
       expect.any(Date),
-      { enabled: false },
+      { enabled: false, organizationId: null },
     );
     expect(mockUseSessionsOptimized).toHaveBeenCalledWith(
       expect.any(Date),
@@ -243,6 +254,44 @@ describe("Schedule", () => {
       false,
     );
     expect(mockUseDropdownData).toHaveBeenCalledWith({ enabled: false });
+  });
+
+  it("lazy-loads the session modal only when the user opens it", async () => {
+    renderWithProviders(<Schedule />);
+
+    await screen.findByRole("heading", { name: /Schedule/i });
+    expect(sessionModalModuleLoads).toBe(0);
+
+    const addButtons = await screen.findAllByLabelText("Add session");
+    fireEvent.click(addButtons[0]);
+
+    await waitFor(() => {
+      expect(sessionModalModuleLoads).toBe(1);
+    });
+    expect(await screen.findByTestId("session-modal-sessions")).toHaveTextContent("session-1");
+  });
+
+  it("prefetches the next schedule batch when the next-period control is hovered", async () => {
+    renderWithProviders(<Schedule />);
+
+    await screen.findByRole("heading", { name: /Schedule/i });
+
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /Next period/i }));
+
+    await waitFor(() => {
+      expect(mockPrefetchScheduleRange).toHaveBeenCalledTimes(1);
+    });
+
+    const [targetStart, targetEnd, options] = mockPrefetchScheduleRange.mock.calls[0];
+    const currentWeekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+    const expectedStart = addDays(currentWeekStart, 7);
+    const expectedEnd = endOfWeek(expectedStart, { weekStartsOn: 1 });
+
+    expect(targetStart).toBeInstanceOf(Date);
+    expect(targetEnd).toBeInstanceOf(Date);
+    expect((targetStart as Date).toISOString()).toBe(expectedStart.toISOString());
+    expect((targetEnd as Date).toISOString()).toBe(expectedEnd.toISOString());
+    expect(options).toEqual({ organizationId: "org-1" });
   });
 
   it("applies therapist filters to batched sessions", async () => {

--- a/src/pages/__tests__/Schedule.urlEditDeepLink.test.tsx
+++ b/src/pages/__tests__/Schedule.urlEditDeepLink.test.tsx
@@ -75,6 +75,16 @@ vi.mock("../../lib/optimizedQueries", () => ({
     },
     isLoading: false,
   }),
+  useSmartPrefetch: () => ({
+    prefetchScheduleRange: vi.fn(),
+    prefetchNextWeek: vi.fn(),
+    prefetchReportData: vi.fn(),
+  }),
+}));
+
+vi.mock("../../components/SessionModal", () => ({
+  SessionModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div>Edit Session</div> : null,
 }));
 
 describe("Schedule URL edit deep links", () => {


### PR DESCRIPTION
## Summary
- lazy-load the Schedule session editor behind a local Suspense boundary so the heavy modal code stays out of the initial Schedule route chunk
- prefetch only the adjacent schedule batch on clear next/previous period intent
- keep the touched schedule-batch cache identity org-scoped and add focused regression coverage

## Verification
- 
pm test -- src/lib/__tests__/optimizedQueries.prefetch.test.tsx src/pages/__tests__/Schedule.event.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx src/pages/__tests__/Schedule.test.tsx src/pages/__tests__/Schedule.lazyModal.test.tsx src/pages/__tests__/Schedule.dataLoadUx.test.tsx src/pages/__tests__/Schedule.orgGuard.test.tsx src/pages/__tests__/Schedule.urlEditDeepLink.test.tsx
- 
pm run ci:check-focused
- 
pm run lint
- 
pm run typecheck
- 
pm run build

## Local blockers
- 
pm run verify:local is not fully green locally because repo-wide 
pm run test:ci still has unrelated timeout failures outside this diff

## Notes
- 
pm run test:routes:tier0 and 
pm run ci:playwright were not required locally for this standard-lane page-performance slice; authoritative PR CI remains the final merge gate.