### PR TITLE
WIN-97 prefetch lazy route modules from sidebar intent

### DIFF
--- a/docs/ai/WIN-97-sidebar-route-module-prefetch-handoff.md
+++ b/docs/ai/WIN-97-sidebar-route-module-prefetch-handoff.md
@@ -1,0 +1,29 @@
+## Scope
+
+- Prefetch lazy route modules from sidebar hover and focus intent.
+- Limit prefetching to code modules only; do not prefetch route data.
+- Keep navigation semantics and access rules unchanged.
+
+## Files
+
+- `src/components/Sidebar.tsx`
+- `src/lib/routeModulePrefetch.ts`
+- `src/lib/__tests__/routeModulePrefetch.test.ts`
+- `src/components/__tests__/SidebarNavigation.test.tsx`
+
+## Verification
+
+- `npm test -- src/components/__tests__/SidebarNavigation.test.tsx`
+- `npm test -- src/lib/__tests__/routeModulePrefetch.test.ts`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run build`
+
+## Blocked Local Gates
+
+- `npm run verify:local`
+  - Timed out on repo-wide verification and pulled in unrelated global failures/noise outside this diff, so it is not a reliable local gate for this sidebar-only slice.
+
+## Residual Risk
+
+- The helper caches successful preload attempts for the session, but we still rely on CI/browser coverage for broader route-level confirmation.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
 } from 'lucide-react';
 import { useAuth } from '../lib/authContext';
 import { useTheme } from '../lib/theme';
+import { preloadRouteModule } from '../lib/routeModulePrefetch';
 // Theme is toggled directly via context; no hidden proxy button
 import { logger } from '../lib/logger/logger';
 
@@ -208,6 +209,10 @@ export function Sidebar() {
     setIsChatAssistantOpen(true);
   };
 
+  const handleNavIntent = (path: string) => {
+    preloadRouteModule(path);
+  };
+
   useEffect(() => {
     if (!isMobileMenuOpen) {
       return;
@@ -296,6 +301,8 @@ export function Sidebar() {
                 key={path}
                 to={path}
                 onClick={() => setIsMobileMenuOpen(false)}
+                onMouseEnter={() => handleNavIntent(path)}
+                onFocus={() => handleNavIntent(path)}
                 className={({ isActive }) =>
                   `group inline-flex items-center px-6 py-4 border-b-2 font-medium text-sm
                   ${

--- a/src/components/__tests__/SidebarNavigation.test.tsx
+++ b/src/components/__tests__/SidebarNavigation.test.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { render, screen } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Sidebar } from "../Sidebar";
 
 const mockUseAuth = vi.fn();
 const mockUseTheme = vi.fn();
+const mockPreloadRouteModule = vi.fn();
 
 vi.mock("../../lib/authContext", () => ({
   useAuth: () => mockUseAuth(),
@@ -14,6 +16,10 @@ vi.mock("../../lib/authContext", () => ({
 
 vi.mock("../../lib/theme", () => ({
   useTheme: () => mockUseTheme(),
+}));
+
+vi.mock("../../lib/routeModulePrefetch", () => ({
+  preloadRouteModule: (...args: unknown[]) => mockPreloadRouteModule(...args),
 }));
 
 vi.mock("../ChatBot", () => ({
@@ -29,6 +35,7 @@ describe("Sidebar navigation active styling", () => {
   beforeEach(() => {
     mockUseAuth.mockReset();
     mockUseTheme.mockReset();
+    mockPreloadRouteModule.mockReset();
     mockUseAuth.mockReturnValue({
       signOut: vi.fn(),
       hasRole: vi.fn(() => true),
@@ -182,6 +189,33 @@ describe("Sidebar navigation active styling", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /chat assistant/i }));
     expect(await screen.findByTestId("chatbot-mock")).toBeInTheDocument();
+  });
+
+  it("prefetches a route module on hover intent without preloading on initial render", async () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Sidebar />
+      </MemoryRouter>
+    );
+
+    expect(mockPreloadRouteModule).not.toHaveBeenCalled();
+
+    await userEvent.hover(screen.getByRole("link", { name: /schedule/i }));
+
+    expect(mockPreloadRouteModule).toHaveBeenCalledTimes(1);
+    expect(mockPreloadRouteModule).toHaveBeenCalledWith("/schedule");
+  });
+
+  it("prefetches a route module on keyboard focus intent", async () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Sidebar />
+      </MemoryRouter>
+    );
+
+    fireEvent.focus(screen.getByRole("link", { name: /schedule/i }));
+
+    expect(mockPreloadRouteModule).toHaveBeenCalledWith("/schedule");
   });
 
   it("hides family navigation for non-guardian clients", () => {

--- a/src/lib/__tests__/routeModulePrefetch.test.ts
+++ b/src/lib/__tests__/routeModulePrefetch.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRouteModulePrefetcher } from '../routeModulePrefetch';
+
+describe('createRouteModulePrefetcher', () => {
+  it('prefetches each registered route module at most once after a successful load', async () => {
+    const scheduleLoader = vi.fn().mockResolvedValue({});
+    const preloadRouteModule = createRouteModulePrefetcher({
+      '/schedule': scheduleLoader,
+    });
+
+    preloadRouteModule('/schedule');
+    preloadRouteModule('/schedule');
+    await Promise.resolve();
+
+    expect(scheduleLoader).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows retrying a route preload after a failed import', async () => {
+    const scheduleLoader = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error('chunk failed'))
+      .mockResolvedValueOnce({});
+    const preloadRouteModule = createRouteModulePrefetcher({
+      '/schedule': scheduleLoader,
+    });
+
+    preloadRouteModule('/schedule');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    preloadRouteModule('/schedule');
+    await Promise.resolve();
+
+    expect(scheduleLoader).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores paths that do not have a registered route preloader', () => {
+    const scheduleLoader = vi.fn().mockResolvedValue({});
+    const preloadRouteModule = createRouteModulePrefetcher({
+      '/schedule': scheduleLoader,
+    });
+
+    preloadRouteModule('/reports');
+
+    expect(scheduleLoader).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/routeModulePrefetch.ts
+++ b/src/lib/routeModulePrefetch.ts
@@ -1,0 +1,36 @@
+type RouteModulePreloader = () => Promise<unknown>;
+
+const routeModulePreloaders: Record<string, RouteModulePreloader> = {
+  '/': () => import('../pages/Dashboard'),
+  '/schedule': () => import('../pages/Schedule'),
+  '/clients': () => import('../pages/Clients'),
+  '/therapists': () => import('../pages/Therapists'),
+  '/authorizations': () => import('../pages/Authorizations'),
+  '/documentation': () => import('../pages/Documentation'),
+  '/fill-docs': () => import('../pages/FillDocs'),
+  '/billing': () => import('../pages/Billing'),
+  '/reports': () => import('../pages/Reports'),
+  '/monitoring': () => import('../pages/MonitoringDashboard'),
+  '/settings': () => import('../pages/Settings'),
+  '/family': () => import('../pages/FamilyDashboard'),
+};
+
+export const createRouteModulePrefetcher = (
+  preloaders: Record<string, RouteModulePreloader>,
+): ((pathname: string) => void) => {
+  const preloadCache = new Set<string>();
+
+  return (pathname: string): void => {
+    const preloader = preloaders[pathname];
+    if (!preloader || preloadCache.has(pathname)) {
+      return;
+    }
+
+    preloadCache.add(pathname);
+    void preloader().catch(() => {
+      preloadCache.delete(pathname);
+    });
+  };
+};
+
+export const preloadRouteModule = createRouteModulePrefetcher(routeModulePreloaders);


### PR DESCRIPTION
## Summary
- prefetch lazy route modules from sidebar hover and focus intent
- keep prefetch limited to route code, with retry-safe caching in a dedicated helper
- add focused tests for sidebar wiring and preload helper idempotence/reset behavior

## Verification
- npm test -- src/components/__tests__/SidebarNavigation.test.tsx src/lib/__tests__/routeModulePrefetch.test.ts
- npm run lint
- npm run typecheck
- npm run build

## Blocked local gates
- npm run verify:local -> timed out on repo-wide verification and pulled in unrelated global failures/noise outside this diff