### PR TITLE
WIN-95 preserve shell frame during auth bootstrap

### DIFF
--- a/docs/ai/WIN-95-protected-bootstrap-shell-handoff.md
+++ b/docs/ai/WIN-95-protected-bootstrap-shell-handoff.md
@@ -1,0 +1,35 @@
+## Scope
+
+- Preserve a shell frame during protected-route auth bootstrap.
+- Keep fail-closed behavior intact while auth is unresolved.
+- Avoid rendering account-specific shell content before auth state is trustworthy.
+
+## Files
+
+- `src/components/PrivateRoute.tsx`
+- `src/components/ProtectedShellPending.tsx`
+- `src/components/__tests__/PrivateRoute.test.tsx`
+
+## Verification
+
+- `npm test -- src/components/__tests__/PrivateRoute.test.tsx src/components/__tests__/RoleGuard.test.tsx src/lib/__tests__/authContext.initializeAuth.test.tsx src/components/__tests__/LayoutSuspense.test.tsx src/pages/__tests__/AppNavigation.test.tsx`
+- `npm run ci:check-focused`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run build`
+
+## Blocked Local Gates
+
+- `npm run test:ci`
+  - Local repo-wide coverage run fails with `ENOENT` writing `coverage/.tmp/coverage-44.json`, outside this diff.
+- `npm run test:routes:tier0`
+  - Local Cypress binary fails to start with `Cypress.exe: bad option: --smoke-test`.
+- `npm run ci:playwright`
+  - Playwright preflight fails because `PW_ADMIN_EMAIL` is not configured in this environment.
+- `npm run verify:local`
+  - Not reliable locally because it rolls up the same blocked `test:ci`, Cypress startup, and Playwright env gates above.
+
+## Residual Risk
+
+- This preserves a shell frame, not the real authenticated sidebar, while bootstrap is unresolved.
+- Runtime config bootstrap in `src/main.tsx` still happens before app render and remains unchanged.

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../lib/authContext';
-import { RouteGuardPending } from './RouteGuardPending';
+import { ProtectedShellPending } from './ProtectedShellPending';
 
 interface PrivateRouteProps {
   children: React.ReactNode;
@@ -22,7 +22,7 @@ export const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
 
   // Show loading while auth is being determined
   if (loading) {
-    return <RouteGuardPending fullScreen label="Restoring your secure session..." />;
+    return <ProtectedShellPending label="Restoring your secure session..." />;
   }
 
   // Redirect to login if not authenticated

--- a/src/components/ProtectedShellPending.tsx
+++ b/src/components/ProtectedShellPending.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+interface ProtectedShellPendingProps {
+  label?: string;
+}
+
+export const ProtectedShellPending: React.FC<ProtectedShellPendingProps> = ({
+  label = 'Restoring your secure session...',
+}) => {
+  return (
+    <div className="flex min-h-dvh bg-gray-50 dark:bg-dark" data-testid="protected-shell-pending">
+      <aside
+        className="hidden w-64 shrink-0 border-r border-gray-200 bg-white/90 px-6 py-6 shadow-sm dark:border-dark-border dark:bg-dark-lighter/90 lg:block"
+        aria-hidden="true"
+      >
+        <div className="flex items-center gap-3">
+          <div className="h-8 w-8 rounded-2xl bg-blue-100 dark:bg-blue-900/40" />
+          <div className="h-5 w-36 rounded-full bg-gray-200 dark:bg-gray-700" />
+        </div>
+        <div className="mt-8 space-y-3">
+          <div className="h-11 rounded-xl bg-gray-200/80 dark:bg-gray-700/80" />
+          <div className="h-11 rounded-xl bg-gray-200/70 dark:bg-gray-800/70" />
+          <div className="h-11 rounded-xl bg-gray-200/70 dark:bg-gray-800/70" />
+          <div className="h-11 rounded-xl bg-gray-200/70 dark:bg-gray-800/70" />
+        </div>
+      </aside>
+      <main className="flex-1 px-4 pt-14 pb-6 lg:px-8 lg:pt-8">
+        <div
+          className="rounded-2xl border border-gray-200/80 bg-white/90 p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900/80"
+          role="status"
+          aria-live="polite"
+          aria-label={label}
+        >
+          <div className="flex items-center gap-3">
+            <div
+              className="h-8 w-8 animate-spin rounded-full border-2 border-blue-200 border-t-blue-600 dark:border-blue-900 dark:border-t-blue-400"
+              aria-hidden="true"
+            />
+            <div>
+              <p className="text-sm font-medium text-gray-900 dark:text-white">{label}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Loading the protected workspace without rendering account-specific content.
+              </p>
+            </div>
+          </div>
+          <div className="mt-6 animate-pulse space-y-4">
+            <div className="h-5 w-48 rounded-full bg-gray-200 dark:bg-gray-700" />
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="h-28 rounded-2xl bg-gray-200/80 dark:bg-gray-800/80" />
+              <div className="h-28 rounded-2xl bg-gray-200/80 dark:bg-gray-800/80" />
+            </div>
+            <div className="h-64 rounded-3xl bg-gray-200/80 dark:bg-gray-800/80" />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};

--- a/src/components/__tests__/PrivateRoute.test.tsx
+++ b/src/components/__tests__/PrivateRoute.test.tsx
@@ -54,7 +54,10 @@ describe('PrivateRoute access behaviour', () => {
     renderProtectedRoute();
 
     expect(screen.getByLabelText('Restoring your secure session...')).toBeInTheDocument();
+    expect(screen.getByTestId('protected-shell-pending')).toBeInTheDocument();
     expect(screen.queryByText('protected')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('login-page')).not.toBeInTheDocument();
+    expect(screen.getByTestId('protected-shell-pending').querySelector('main')).not.toHaveClass('lg:ml-64');
   });
 
   it('redirects unauthenticated users to login', async () => {


### PR DESCRIPTION
## Summary
- replace the fullscreen protected-route spinner with a shell-frame pending state during auth restore
- keep fail-closed behavior and avoid rendering account-specific shell content before auth is resolved
- add focused coverage for the protected bootstrap frame path

## Verification
- npm test -- src/components/__tests__/PrivateRoute.test.tsx src/components/__tests__/RoleGuard.test.tsx src/lib/__tests__/authContext.initializeAuth.test.tsx src/components/__tests__/LayoutSuspense.test.tsx src/pages/__tests__/AppNavigation.test.tsx
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run build

## Blocked local gates
- npm run test:ci -> repo-wide coverage run fails locally with ENOENT writing coverage/.tmp/coverage-44.json
- npm run test:routes:tier0 -> local Cypress binary fails to start with bad option --smoke-test
- npm run ci:playwright -> PW_ADMIN_EMAIL missing in local environment
- npm run verify:local -> rolls up the blocked local gates above and is not reliable on this machine