### PR TITLE
WIN-100 reconcile accidental client portal perf branch

### DIFF
--- a/docs/ai/WIN-100-client-portal-reconcile-handoff.md
+++ b/docs/ai/WIN-100-client-portal-reconcile-handoff.md
@@ -1,0 +1,49 @@
+# WIN-100 Client Portal Reconcile
+
+## Scope
+
+- Reconcile accidental branch `codex/client-portal-perf` commit `9b9cb117` onto current `main`.
+- Port only the still-useful route-loading shell, staff-index invalidation guard, and client-mode Documentation fetch split.
+- Keep guardian users on the full Documentation route path; only plain clients use the reduced client-only mode.
+- Preserve and adapt the related regression tests.
+
+## Excluded Drift
+
+- `src/lib/clients/hooks.ts`
+  - The accidental branch disables guardian-query focus refetch without dedicated guardian-hook coverage in that branch.
+  - This reconciliation keeps the diff smaller and avoids mixing in tenant-sensitive guardian cache behavior without stronger evidence.
+
+## Verification
+
+- Lane: `critical`
+- Required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - focused tests for `App`, `Layout`, `Documentation`, and `useRouteQueryRefetch`
+  - `npm run test:ci`
+  - `npm run test:routes:tier0`
+  - `npm run build`
+  - `npm run ci:playwright`
+  - `npm run verify:local` when locally reliable and secret-free
+
+- Executed locally:
+  - `npm ci`
+  - `npm test -- src/pages/__tests__/AppNavigation.test.tsx src/components/__tests__/LayoutSuspense.test.tsx src/pages/__tests__/Documentation.test.tsx src/lib/__tests__/useRouteQueryRefetch.test.tsx`
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+- Blocked locally:
+  - `npm run test:routes:tier0`
+    - Cypress failed to start on this Windows environment with `Cypress.exe: bad option: --smoke-test`
+  - `npm run ci:playwright`
+    - `PW_ADMIN_EMAIL` is not configured for deterministic Playwright execution
+  - `npm run verify:local`
+    - aggregate run is not reliable locally because it fails inside the required `test:routes:tier0` step for the Cypress startup issue above
+
+## Residual Risk
+
+- The reconciled diff still touches `src/App.tsx` and shared route invalidation, so browser/auth CI remains an important backstop.
+- Guardian focus-refetch behavior from the accidental branch remains excluded and should be handled as a separate, explicitly validated slice if still wanted.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { canAccessStaffDashboard } from './lib/dashboardAccess';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { PrivateRoute } from './components/PrivateRoute';
 import { RoleGuard } from './components/RoleGuard';
+import { RouteLoadingSkeleton } from './components/RouteLoadingSkeleton';
 import { logger } from './lib/logger/logger';
 
 // Lazy load components
@@ -73,7 +74,13 @@ const DashboardLanding: React.FC = () => {
   const { user, profile, loading, profileLoading, isGuardian, effectiveRole } = useAuth();
 
   if (loading || (user && profileLoading && !profile)) {
-    return <LoadingSpinner />;
+    return (
+      <div className="flex min-h-[16rem] w-full items-center justify-center p-4">
+        <div className="w-full max-w-2xl">
+          <RouteLoadingSkeleton label="Loading your workspace" />
+        </div>
+      </div>
+    );
   }
 
   if (isGuardian) {
@@ -147,7 +154,9 @@ function App() {
                   {/* Protected Routes */}
                   <Route path="/" element={
                     <PrivateRoute>
-                      <Layout />
+                      <Suspense fallback={<RouteLoadingSkeleton label="Loading app layout" />}>
+                        <Layout />
+                      </Suspense>
                     </PrivateRoute>
                   }>
                     {/* Dashboard - accessible to all authenticated users */}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,30 +1,21 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { useAuth } from '../lib/authContext';
 import { useRouteQueryRefetch } from '../lib/useRouteQueryRefetch';
-
-const RouteContentFallback: React.FC = () => (
-  <div
-    className="rounded-2xl border border-gray-200/80 bg-white/70 p-6 shadow-sm backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/40"
-    role="status"
-    aria-live="polite"
-    aria-label="Loading page content"
-  >
-    <div className="animate-pulse space-y-4">
-      <div className="h-6 w-40 rounded-full bg-gray-200 dark:bg-slate-800" />
-      <div className="grid gap-3 md:grid-cols-2">
-        <div className="h-28 rounded-xl bg-gray-200/80 dark:bg-slate-800/80" />
-        <div className="h-28 rounded-xl bg-gray-200/80 dark:bg-slate-800/80" />
-      </div>
-      <div className="h-56 rounded-2xl bg-gray-200/80 dark:bg-slate-800/80" />
-    </div>
-  </div>
-);
+import { preloadRouteModule } from '../lib/routeModulePrefetch';
+import { RouteLoadingSkeleton } from './RouteLoadingSkeleton';
 
 export function Layout() {
-  const { user, effectiveRole } = useAuth();
-  useRouteQueryRefetch();
+  const { user, effectiveRole, profileLoading, hasAnyRole, isGuardian } = useAuth();
+  const invalidateIndexStaffQueries = !profileLoading && hasAnyRole(['therapist', 'admin', 'super_admin']);
+  useRouteQueryRefetch({ invalidateIndexStaffQueries });
+
+  useEffect(() => {
+    if (isGuardian) {
+      preloadRouteModule('/family');
+    }
+  }, [isGuardian]);
 
   return (
     <div className="flex min-h-dvh bg-gray-50 dark:bg-dark">
@@ -37,7 +28,7 @@ export function Layout() {
             <span className="ml-2 font-medium">Role:</span> {effectiveRole}
           </div>
         )}
-        <Suspense fallback={<RouteContentFallback />}>
+        <Suspense fallback={<RouteLoadingSkeleton />}>
           <div className="min-h-[24rem]">
             <Outlet />
           </div>

--- a/src/components/RouteLoadingSkeleton.tsx
+++ b/src/components/RouteLoadingSkeleton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+/** Shared loading skeleton for route transitions and dashboard landing (matches Layout outlet fallback). */
+export const RouteLoadingSkeleton: React.FC<{ label?: string }> = ({ label }) => (
+  <div
+    className="rounded-2xl border border-gray-200/80 bg-white/70 p-6 shadow-sm backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/40"
+    role="status"
+    aria-live="polite"
+    aria-label={label ?? 'Loading page content'}
+  >
+    <div className="animate-pulse space-y-4">
+      <div className="h-6 w-40 rounded-full bg-gray-200 dark:bg-slate-800" />
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="h-28 rounded-xl bg-gray-200/80 dark:bg-slate-800/80" />
+        <div className="h-28 rounded-xl bg-gray-200/80 dark:bg-slate-800/80" />
+      </div>
+      <div className="h-56 rounded-2xl bg-gray-200/80 dark:bg-slate-800/80" />
+    </div>
+  </div>
+);

--- a/src/components/__tests__/LayoutSuspense.test.tsx
+++ b/src/components/__tests__/LayoutSuspense.test.tsx
@@ -12,6 +12,9 @@ vi.mock('../../lib/authContext', () => ({
   useAuth: () => ({
     user: { email: 'user@example.com' },
     effectiveRole: 'admin',
+    profileLoading: false,
+    hasAnyRole: (roles: string[]) => roles.includes('admin'),
+    isGuardian: false,
   }),
 }));
 

--- a/src/lib/__tests__/useRouteQueryRefetch.test.tsx
+++ b/src/lib/__tests__/useRouteQueryRefetch.test.tsx
@@ -16,8 +16,8 @@ vi.mock("@tanstack/react-query", () => ({
   }),
 }));
 
-const HookHarness: React.FC = () => {
-  useRouteQueryRefetch();
+const HookHarness: React.FC<{ invalidateIndexStaffQueries?: boolean }> = (props) => {
+  useRouteQueryRefetch(props);
   return null;
 };
 
@@ -28,6 +28,10 @@ describe("getRouteInvalidationKeys", () => {
       ["session-metrics"],
       ["dropdowns"],
     ]);
+  });
+
+  it("returns no keys for index when staff index invalidation is disabled", () => {
+    expect(getRouteInvalidationKeys("/", { invalidateIndexStaffQueries: false })).toEqual([]);
   });
 
   it("returns scoped keys for schedule route", () => {
@@ -91,6 +95,13 @@ describe("useRouteQueryRefetch", () => {
     pathname = "/documentation";
 
     render(<HookHarness />);
+
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it("skips dashboard invalidation on index when staff index invalidation is disabled", () => {
+    pathname = "/";
+    render(<HookHarness invalidateIndexStaffQueries={false} />);
 
     expect(invalidateQueries).not.toHaveBeenCalled();
   });

--- a/src/lib/useRouteQueryRefetch.ts
+++ b/src/lib/useRouteQueryRefetch.ts
@@ -24,7 +24,21 @@ const ROUTE_QUERY_KEYS: readonly RouteQueryEntry[] = [
 
 const DEFAULT_ROUTE_QUERY_KEYS: readonly unknown[][] = [];
 
-export const getRouteInvalidationKeys = (pathname: string): readonly unknown[][] => {
+export type UseRouteQueryRefetchOptions = {
+  /**
+   * When false, the index route (`/`) does not invalidate staff dashboard query keys.
+   * Use for client-role users who only pass through `/` before redirect.
+   */
+  readonly invalidateIndexStaffQueries?: boolean;
+};
+
+export const getRouteInvalidationKeys = (
+  pathname: string,
+  options?: UseRouteQueryRefetchOptions,
+): readonly unknown[][] => {
+  if (pathname === '/' && options?.invalidateIndexStaffQueries === false) {
+    return DEFAULT_ROUTE_QUERY_KEYS;
+  }
   for (const routeEntry of ROUTE_QUERY_KEYS) {
     if (routeEntry.matches(pathname)) {
       return routeEntry.keys;
@@ -33,14 +47,15 @@ export const getRouteInvalidationKeys = (pathname: string): readonly unknown[][]
   return DEFAULT_ROUTE_QUERY_KEYS;
 };
 
-export const useRouteQueryRefetch = () => {
+export const useRouteQueryRefetch = (options?: UseRouteQueryRefetchOptions) => {
   const location = useLocation();
   const queryClient = useQueryClient();
+  const invalidateIndexStaffQueries = options?.invalidateIndexStaffQueries;
 
   useEffect(() => {
-    const keys = getRouteInvalidationKeys(location.pathname);
+    const keys = getRouteInvalidationKeys(location.pathname, options);
     for (const queryKey of keys) {
       queryClient.invalidateQueries({ queryKey, refetchType: 'active' });
     }
-  }, [location.pathname, queryClient]);
+  }, [location.pathname, queryClient, invalidateIndexStaffQueries]);
 };

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -41,6 +41,13 @@ interface DocumentationData {
   aiSessionNotes: DocumentEntry[];
 }
 
+const emptyDocumentationData = (): DocumentationData => ({
+  therapistDocuments: [],
+  clientDocuments: [],
+  authorizationDocuments: [],
+  aiSessionNotes: [],
+});
+
 const parseDocumentArray = (value: unknown): StoredDocumentMetadata[] => {
   if (!Array.isArray(value)) {
     return [];
@@ -110,7 +117,67 @@ const buildTherapistDocumentTitle = (objectPath: string, documentKey: string) =>
   return documentKey ? `${documentKey.replace(/_/g, ' ')} • ${filename}` : filename;
 };
 
-const fetchDocumentationData = async (
+const mapClientRowsToDocuments = (
+  rows: ReadonlyArray<{
+    id: string;
+    full_name: string | null;
+    created_at: string | null;
+    documents: unknown;
+  }>,
+): DocumentEntry[] =>
+  rows.flatMap((client) =>
+    parseDocumentArray(client.documents).map((doc) => ({
+      id: `${client.id}-${doc.path}`,
+      title: doc.name,
+      description: client.full_name ? `Client: ${client.full_name}` : `Client ID: ${client.id}`,
+      createdAt: client.created_at,
+      size: doc.size ?? null,
+      fileType: doc.type ?? null,
+      source: 'client_document' as const,
+      bucketId: 'client-documents',
+      objectPath: doc.path,
+    })),
+  );
+
+/** Client / guardian portal: only client-record documents (RLS-scoped); avoids staff-only parallel queries. */
+const fetchDocumentationDataForClientRole = async (
+  userId: string,
+  fallbackEmail?: string | null,
+): Promise<DocumentationData> => {
+  const clientResult = await supabase
+    .from('clients')
+    .select('id, full_name, created_at, documents, created_by, email')
+    .eq('created_by', userId)
+    .order('created_at', { ascending: false });
+
+  if (clientResult.error) {
+    throw clientResult.error instanceof Error
+      ? clientResult.error
+      : new Error('Failed to load documentation data');
+  }
+
+  const clientDocuments = mapClientRowsToDocuments(clientResult.data ?? []);
+
+  if ((!clientDocuments.length || !clientResult.data?.length) && fallbackEmail) {
+    const clientEmailResult = await supabase
+      .from('clients')
+      .select('id, full_name, created_at, documents, email')
+      .eq('email', fallbackEmail)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (!clientEmailResult.error && Array.isArray(clientEmailResult.data)) {
+      clientDocuments.push(...mapClientRowsToDocuments(clientEmailResult.data));
+    }
+  }
+
+  return {
+    ...emptyDocumentationData(),
+    clientDocuments,
+  };
+};
+
+/** Therapist / admin documentation: parallel staff-scoped sources. */
+const fetchDocumentationDataForStaffRoles = async (
   userId: string,
   fallbackEmail?: string | null,
 ): Promise<DocumentationData> => {
@@ -164,19 +231,7 @@ const fetchDocumentationData = async (
     sessionNoteId: note.id,
   }));
 
-  const clientDocuments = (clientResult.data ?? []).flatMap((client) =>
-    parseDocumentArray(client.documents).map((doc) => ({
-      id: `${client.id}-${doc.path}`,
-      title: doc.name,
-      description: client.full_name ? `Client: ${client.full_name}` : `Client ID: ${client.id}`,
-      createdAt: client.created_at,
-      size: doc.size ?? null,
-      fileType: doc.type ?? null,
-      source: 'client_document' as const,
-      bucketId: 'client-documents',
-      objectPath: doc.path,
-    })),
-  );
+  const clientDocuments = mapClientRowsToDocuments(clientResult.data ?? []);
 
   const authorizationDocuments = (authorizationResult.data ?? []).flatMap((authorization) =>
     parseDocumentArray(authorization.documents).map((doc) => ({
@@ -202,20 +257,7 @@ const fetchDocumentationData = async (
       .order('created_at', { ascending: false })
       .limit(1);
     if (!clientEmailResult.error && Array.isArray(clientEmailResult.data)) {
-      const fallbackDocs = clientEmailResult.data.flatMap((client) =>
-        parseDocumentArray(client.documents).map((doc) => ({
-          id: `${client.id}-${doc.path}`,
-          title: doc.name,
-          description: client.full_name ? `Client: ${client.full_name}` : `Client ID: ${client.id}`,
-          createdAt: client.created_at,
-          size: doc.size ?? null,
-          fileType: doc.type ?? null,
-          source: 'client_document' as const,
-          bucketId: 'client-documents',
-          objectPath: doc.path,
-        })),
-      );
-      clientDocuments.push(...fallbackDocs);
+      clientDocuments.push(...mapClientRowsToDocuments(clientEmailResult.data));
     }
   }
 
@@ -228,14 +270,20 @@ const fetchDocumentationData = async (
 };
 
 export function Documentation() {
-  const { user, profile } = useAuth();
+  const { user, profile, profileLoading, isGuardian } = useAuth();
   const [search, setSearch] = useState('');
   const [activeDownloadId, setActiveDownloadId] = useState<string | null>(null);
 
+  const isClientDocumentationMode = profile?.role === 'client' && !isGuardian;
+  const documentationFetchMode = isClientDocumentationMode ? 'client' : 'staff';
+
   const { data, isLoading, error } = useQuery({
-    queryKey: ['documentation', user?.id],
-    enabled: Boolean(user?.id),
-    queryFn: () => fetchDocumentationData(user?.id ?? '', profile?.email ?? null),
+    queryKey: ['documentation', user?.id, documentationFetchMode],
+    enabled: Boolean(user?.id) && !profileLoading,
+    queryFn: () =>
+      isClientDocumentationMode
+        ? fetchDocumentationDataForClientRole(user?.id ?? '', profile?.email ?? null)
+        : fetchDocumentationDataForStaffRoles(user?.id ?? '', profile?.email ?? null),
   });
 
   const sections = useMemo(() => {
@@ -244,13 +292,14 @@ export function Documentation() {
     const therapistDocuments = data?.therapistDocuments ?? [];
     const clientDocuments = data?.clientDocuments ?? [];
     const authorizationDocuments = data?.authorizationDocuments ?? [];
-    return [
+    const allSections = [
       {
         id: 'ai-session-notes',
         title: 'AI Session Notes',
         description: 'AI-generated documentation linked to your sessions.',
         documents: aiSessionNotes.filter((entry) => matchesSearch(entry, query)),
         emptyMessage: buildSectionEmptyMessage('No AI session notes yet.', query, aiSessionNotes.length > 0),
+        clientPortal: false,
       },
       {
         id: 'therapist-uploads',
@@ -262,6 +311,7 @@ export function Documentation() {
           query,
           therapistDocuments.length > 0,
         ),
+        clientPortal: false,
       },
       {
         id: 'client-uploads',
@@ -269,6 +319,7 @@ export function Documentation() {
         description: 'Documents you uploaded during client onboarding.',
         documents: clientDocuments.filter((entry) => matchesSearch(entry, query)),
         emptyMessage: buildSectionEmptyMessage('No client documents found.', query, clientDocuments.length > 0),
+        clientPortal: true,
       },
       {
         id: 'authorization-uploads',
@@ -280,9 +331,15 @@ export function Documentation() {
           query,
           authorizationDocuments.length > 0,
         ),
+        clientPortal: false,
       },
     ];
-  }, [data, search]);
+
+    if (isClientDocumentationMode) {
+      return allSections.filter((s) => s.clientPortal);
+    }
+    return allSections;
+  }, [data, search, isClientDocumentationMode]);
 
   const handleDownload = async (entry: DocumentEntry) => {
     if (activeDownloadId) {
@@ -342,7 +399,9 @@ export function Documentation() {
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">Documentation</h1>
           <p className="text-sm text-gray-600 dark:text-gray-300">
-            All documents you have uploaded or generated, organized by category.
+            {isClientDocumentationMode
+              ? 'Documents from your onboarding and care profile.'
+              : 'All documents you have uploaded or generated, organized by category.'}
           </p>
         </div>
         <div className="w-full lg:max-w-sm">

--- a/src/pages/__tests__/Documentation.test.tsx
+++ b/src/pages/__tests__/Documentation.test.tsx
@@ -81,11 +81,16 @@ const buildQuery = (table: keyof typeof tableData) => {
   return builder;
 };
 
+const authMockState = {
+  user: { id: 'user-1', email: 'user@example.com' },
+  profile: { id: 'user-1', email: 'user@example.com', role: 'admin' as const },
+  profileLoading: false,
+  effectiveRole: 'admin' as const,
+  isGuardian: false,
+};
+
 vi.mock('../../lib/authContext', () => ({
-  useAuth: () => ({
-    user: { id: 'user-1', email: 'user@example.com' },
-    profile: { id: 'user-1', email: 'user@example.com' },
-  }),
+  useAuth: () => authMockState,
 }));
 
 vi.mock('../../lib/supabase', () => ({
@@ -114,6 +119,10 @@ describe('Documentation page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setTableData();
+    authMockState.profile = { id: 'user-1', email: 'user@example.com', role: 'admin' };
+    authMockState.profileLoading = false;
+    authMockState.effectiveRole = 'admin';
+    authMockState.isGuardian = false;
   });
 
   it('renders sections and filters results by search', async () => {
@@ -226,5 +235,38 @@ describe('Documentation page', () => {
     });
 
     expect(screen.getByText('Date unknown • Size unknown')).toBeInTheDocument();
+  });
+
+  it('for client role loads only client uploads section and copy', async () => {
+    authMockState.profile = { id: 'user-1', email: 'user@example.com', role: 'client' };
+    authMockState.effectiveRole = 'client';
+
+    renderWithProviders(<Documentation />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Client Uploads')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Therapist Uploads')).not.toBeInTheDocument();
+    expect(screen.queryByText('AI Session Notes')).not.toBeInTheDocument();
+    expect(screen.getByText('Documents from your onboarding and care profile.')).toBeInTheDocument();
+  });
+
+  it('keeps guardians on the full documentation mode even though their effective role is client', async () => {
+    authMockState.profile = { id: 'user-1', email: 'user@example.com', role: 'client' };
+    authMockState.effectiveRole = 'client';
+    authMockState.isGuardian = true;
+
+    renderWithProviders(<Documentation />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Therapist Uploads')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('AI Session Notes')).toBeInTheDocument();
+    expect(screen.queryByText('Documents from your onboarding and care profile.')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('All documents you have uploaded or generated, organized by category.'),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- salvage the still-useful client portal improvements from accidental branch `codex/client-portal-perf` commit `9b9cb117`
- add shell-safe route loading fallbacks for protected layout entry and dashboard landing
- skip dashboard query invalidation for non-staff users passing through `/`, and split Documentation fetching for client vs staff roles
- preserve the related regression tests and document the excluded guardian hook drift

## Excluded
- `src/lib/clients/hooks.ts` guardian focus-refetch tweak from the accidental branch
- reason: this reconciliation keeps tenant-sensitive guardian cache behavior out of the PR because the accidental branch did not bring dedicated guardian-hook coverage

## Verification
- `npm ci`
- `npm test -- src/pages/__tests__/AppNavigation.test.tsx src/components/__tests__/LayoutSuspense.test.tsx src/pages/__tests__/Documentation.test.tsx src/lib/__tests__/useRouteQueryRefetch.test.tsx`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`

## Blocked locally
- `npm run test:routes:tier0` failed to start Cypress on this Windows environment: `Cypress.exe: bad option: --smoke-test`
- `npm run ci:playwright` blocked because `PW_ADMIN_EMAIL` is not configured
- `npm run verify:local` is not reliable locally because it fails inside the blocked Cypress step above

## Tracking
- Linear: `WIN-100`
- Handoff: `docs/ai/WIN-100-client-portal-reconcile-handoff.md`