### PR TITLE
fix(routes): clients/new before clients/:clientId

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,17 +176,17 @@ function App() {
                       </RoleGuard>
                     } />
                     
-                    {/* Client Details - accessible to therapists and above */}
-                    <Route path="clients/:clientId" element={
-                      <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
-                        <ClientDetails />
-                      </RoleGuard>
-                    } />
-
                     {/* Client Onboarding - accessible to therapists and above */}
                     <Route path="clients/new" element={
                       <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
                         <ClientOnboardingPage />
+                      </RoleGuard>
+                    } />
+
+                    {/* Client Details - accessible to therapists and above */}
+                    <Route path="clients/:clientId" element={
+                      <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                        <ClientDetails />
                       </RoleGuard>
                     } />
 
@@ -319,4 +319,3 @@ function App() {
 }
 
 export { App };
-

--- a/src/pages/__tests__/AppNavigation.test.tsx
+++ b/src/pages/__tests__/AppNavigation.test.tsx
@@ -65,6 +65,10 @@ vi.mock('../../pages/ClientOnboardingPage', () => ({
   ClientOnboardingPage: () => <div>ClientOnboardingPage</div>,
 }));
 
+vi.mock('../../pages/ClientDetails', () => ({
+  ClientDetails: () => <div>ClientDetailsPage</div>,
+}));
+
 vi.mock('../../pages/TherapistOnboardingPage', () => ({
   TherapistOnboardingPage: () => <div>TherapistOnboardingPage</div>,
 }));
@@ -160,6 +164,7 @@ describe('App navigation landing', () => {
     renderApp();
 
     expect(await screen.findByText('ClientOnboardingPage')).toBeInTheDocument();
+    expect(screen.queryByText('ClientDetailsPage')).not.toBeInTheDocument();
   });
 
   it('blocks clients from client onboarding route', async () => {


### PR DESCRIPTION
## Summary

Declare the static \clients/new\ route before the dynamic \clients/:clientId\ route so React Router does not treat \
ew\ as a client id.

## Verification
- \
pm test -- src/pages/__tests__/AppNavigation.test.tsx\
- \
pm run lint\, \
pm run typecheck\, \
pm run build\
- \
pm run test:routes:tier0\ (Cypress routes_integrity, role_access, auth-roles)
- \
pm run verify:local\ **failed** in this workspace: unrelated \Schedule.orchestration.integration.test.tsx\ (\getAllByLabelText('Add session')\). Full \	est:ci\ should be confirmed on CI.

## Risk
Low: route declaration order and regression test only; RoleGuard lists unchanged.