### PR TITLE
perf(authorizations): therapist-scoped queries on /authorizations

### DIFF
--- a/src/pages/Authorizations.tsx
+++ b/src/pages/Authorizations.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 import { 
@@ -10,12 +10,42 @@ import {
   Calendar
 } from 'lucide-react';
 import { supabase } from '../lib/supabase';
-import type { Authorization, AuthorizationService } from '../types';
+import type { Authorization, AuthorizationService, Client } from '../types';
 import { AuthorizationModal } from '../components/AuthorizationModal';
 import { showSuccess, showError } from '../lib/toast';
 import { logger } from '../lib/logger/logger';
 import { fetchClients } from '../lib/clients/fetchers';
 import { createAuthorizationWithServices, updateAuthorizationWithServices } from '../lib/authorizations/mutations';
+import { useAuth } from '../lib/authContext';
+import { useActiveOrganizationId } from '../lib/organization';
+
+const emptyAvailabilityHours = (): Client['availability_hours'] => ({
+  monday: { start: null, end: null },
+  tuesday: { start: null, end: null },
+  wednesday: { start: null, end: null },
+  thursday: { start: null, end: null },
+  friday: { start: null, end: null },
+  saturday: { start: null, end: null },
+  sunday: { start: null, end: null },
+});
+
+/** Picker-only stub when editing a row whose client is outside the scoped therapist caseload list. */
+const minimalClientForPicker = (row: { id: string; full_name: string }): Client => ({
+  id: row.id,
+  full_name: row.full_name,
+  email: '',
+  date_of_birth: '',
+  insurance_info: {},
+  service_preference: [],
+  one_to_one_units: 0,
+  supervision_units: 0,
+  parent_consult_units: 0,
+  assessment_units: 0,
+  auth_units: 0,
+  availability_hours: emptyAvailabilityHours(),
+  created_at: '',
+  updated_at: '',
+});
 
 export function Authorizations() {
   const [searchQuery, setSearchQuery] = useState('');
@@ -23,6 +53,9 @@ export function Authorizations() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedAuthorization, setSelectedAuthorization] = useState<Authorization | undefined>();
   const queryClient = useQueryClient();
+  const { effectiveRole, profile } = useAuth();
+  const resolvedOrganizationId = useActiveOrganizationId();
+  const isTherapistViewer = effectiveRole === 'therapist';
 
   const { data: authorizations = [], isLoading } = useQuery({
     queryKey: ['authorizations'],
@@ -46,22 +79,79 @@ export function Authorizations() {
     },
   });
 
-  const { data: clients = [] } = useQuery({
-    queryKey: ['clients', 'authorizations'],
-    queryFn: () => fetchClients({ allowAll: true }),
+  const { data: clientsFromQuery = [] } = useQuery({
+    queryKey: isTherapistViewer
+      ? ['clients', 'authorizations', 'scoped', resolvedOrganizationId ?? 'MISSING_ORG', profile?.id ?? 'MISSING_PROFILE']
+      : ['clients', 'authorizations'],
+    queryFn: () =>
+      isTherapistViewer
+        ? fetchClients({
+            organizationId: resolvedOrganizationId ?? undefined,
+            therapistId: profile?.id ?? null,
+            allowAll: false,
+          })
+        : fetchClients({ allowAll: true }),
+    enabled: isTherapistViewer ? Boolean(resolvedOrganizationId && profile?.id) : true,
   });
 
+  const therapistProviderIds = useMemo(() => {
+    if (!isTherapistViewer || !profile?.id) {
+      return null;
+    }
+    const ids = new Set<string>([profile.id]);
+    for (const row of authorizations) {
+      if (typeof row.provider_id === 'string' && row.provider_id.length > 0) {
+        ids.add(row.provider_id);
+      }
+    }
+    return Array.from(ids).sort();
+  }, [isTherapistViewer, profile?.id, authorizations]);
+
+  const clientsForModal = useMemo(() => {
+    if (!isTherapistViewer) {
+      return clientsFromQuery;
+    }
+    const byId = new Map(clientsFromQuery.map((c) => [c.id, c]));
+    if (selectedAuthorization) {
+      const embedded = selectedAuthorization.client;
+      if (
+        embedded &&
+        typeof embedded.id === 'string' &&
+        typeof embedded.full_name === 'string' &&
+        !byId.has(embedded.id)
+      ) {
+        byId.set(embedded.id, minimalClientForPicker({ id: embedded.id, full_name: embedded.full_name }));
+      }
+    }
+    return [...byId.values()];
+  }, [isTherapistViewer, clientsFromQuery, selectedAuthorization]);
+
   const { data: providers = [] } = useQuery({
-    queryKey: ['therapists'],
+    queryKey:
+      isTherapistViewer && therapistProviderIds
+        ? ['therapists', 'authorizations', 'scoped', ...therapistProviderIds]
+        : ['therapists'],
     queryFn: async () => {
+      if (isTherapistViewer && therapistProviderIds && therapistProviderIds.length > 0) {
+        const { data, error } = await supabase
+          .from('therapists')
+          .select('*')
+          .in('id', therapistProviderIds)
+          .order('full_name');
+
+        if (error) throw error;
+        return data ?? [];
+      }
+
       const { data, error } = await supabase
         .from('therapists')
         .select('*')
         .order('full_name');
-      
+
       if (error) throw error;
       return data;
     },
+    enabled: !isTherapistViewer || Boolean(therapistProviderIds?.length),
   });
 
   const createAuthorizationMutation = useMutation({
@@ -463,7 +553,7 @@ export function Authorizations() {
           }}
           onSubmit={handleSubmit}
           authorization={selectedAuthorization}
-          clients={clients}
+          clients={clientsForModal}
           providers={providers}
         />
       )}

--- a/src/pages/__tests__/Authorizations.test.tsx
+++ b/src/pages/__tests__/Authorizations.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderWithProviders, screen, waitFor } from '../../test/utils';
+import { Authorizations } from '../Authorizations';
+import type { UserProfile } from '../../lib/authContext';
+
+const { useAuthMock } = vi.hoisted(() => ({ useAuthMock: vi.fn() }));
+
+vi.mock('../../lib/authContext', () => ({
+  useAuth: () => useAuthMock(),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const emptyAuthRow = {
+  id: 'auth-1',
+  authorization_number: 'AUTH-1',
+  client_id: 'client-x',
+  provider_id: 'therapist-b',
+  insurance_provider_id: 'ins-1',
+  diagnosis_code: 'F84.0',
+  diagnosis_description: 'Autistic disorder',
+  start_date: '2025-01-01',
+  end_date: '2025-12-31',
+  status: 'pending' as const,
+  created_at: '2025-01-01T00:00:00.000Z',
+  updated_at: '2025-01-01T00:00:00.000Z',
+  client: { id: 'client-x', full_name: 'Extra Client' },
+  provider: { id: 'therapist-b', full_name: 'Other Therapist' },
+  services: [] as unknown[],
+};
+
+const {
+  fetchClientsMock,
+  supabaseFromMock,
+  therapistsSelectMock,
+  therapistsInMock,
+  therapistsOrderAfterInMock,
+  therapistsOrderFullMock,
+} = vi.hoisted(() => {
+  const fetchClientsMock = vi.fn();
+  const therapistsSelectMock = vi.fn();
+  const therapistsInMock = vi.fn();
+  const therapistsOrderAfterInMock = vi.fn();
+  const therapistsOrderFullMock = vi.fn();
+
+  const supabaseFromMock = vi.fn((table: string) => {
+    if (table === 'authorizations') {
+      return {
+        select: vi.fn(() => ({
+          order: vi.fn(() =>
+            Promise.resolve({
+              data: [emptyAuthRow],
+              error: null,
+            }),
+          ),
+        })),
+      };
+    }
+    if (table === 'therapists') {
+      therapistsSelectMock.mockReturnValue({
+        in: therapistsInMock.mockImplementation(() => ({
+          order: therapistsOrderAfterInMock.mockImplementation(() =>
+            Promise.resolve({ data: [{ id: 'therapist-b', full_name: 'Other Therapist' }], error: null }),
+          ),
+        })),
+        order: therapistsOrderFullMock.mockImplementation(() =>
+          Promise.resolve({ data: [{ id: 't-all', full_name: 'Everyone' }], error: null }),
+        ),
+      });
+      return {
+        select: therapistsSelectMock,
+      };
+    }
+    return {
+      select: vi.fn(() => ({
+        order: vi.fn(() => Promise.resolve({ data: [], error: null })),
+      })),
+    };
+  });
+
+  return {
+    fetchClientsMock,
+    supabaseFromMock,
+    therapistsSelectMock,
+    therapistsInMock,
+    therapistsOrderAfterInMock,
+    therapistsOrderFullMock,
+  };
+});
+
+vi.mock('../../lib/clients/fetchers', () => ({
+  fetchClients: (...args: unknown[]) => fetchClientsMock(...args),
+}));
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: { from: supabaseFromMock },
+}));
+
+vi.mock('../../components/AuthorizationModal', () => ({
+  AuthorizationModal: () => null,
+}));
+
+vi.mock('../../lib/authorizations/mutations', () => ({
+  createAuthorizationWithServices: vi.fn(),
+  updateAuthorizationWithServices: vi.fn(),
+}));
+
+const baseProfile = (overrides: Partial<UserProfile>): UserProfile => ({
+  id: 'user-id',
+  email: 'user@example.com',
+  role: 'therapist',
+  organization_id: 'org-1',
+  is_active: true,
+  created_at: '2025-01-01T00:00:00.000Z',
+  updated_at: '2025-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('Authorizations page query scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchClientsMock.mockResolvedValue([
+      {
+        id: 'client-1',
+        full_name: 'Scoped Client',
+        email: 'c@example.com',
+        date_of_birth: '2010-01-01',
+        insurance_info: {},
+        service_preference: [],
+        one_to_one_units: 0,
+        supervision_units: 0,
+        parent_consult_units: 0,
+        assessment_units: 0,
+        auth_units: 0,
+        availability_hours: {
+          monday: { start: null, end: null },
+          tuesday: { start: null, end: null },
+          wednesday: { start: null, end: null },
+          thursday: { start: null, end: null },
+          friday: { start: null, end: null },
+          saturday: { start: null, end: null },
+          sunday: { start: null, end: null },
+        },
+        created_at: '2025-01-01T00:00:00.000Z',
+        updated_at: '2025-01-01T00:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('uses scoped client fetch and bounded therapist fetch for therapist role', async () => {
+    const therapistUserId = 'therapist-user-uuid';
+
+    useAuthMock.mockReturnValue({
+      user: null,
+      effectiveRole: 'therapist',
+      profile: baseProfile({
+        id: therapistUserId,
+        role: 'therapist',
+        organization_id: 'org-therapist-1',
+      }),
+    });
+
+    renderWithProviders(<Authorizations />, { auth: false });
+
+    await waitFor(() => {
+      expect(fetchClientsMock).toHaveBeenCalled();
+    });
+
+    expect(fetchClientsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: 'org-therapist-1',
+        therapistId: therapistUserId,
+        allowAll: false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(therapistsInMock).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      const lastCall = therapistsInMock.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe('id');
+      const idList = lastCall?.[1] as string[];
+      expect(idList).toContain(therapistUserId);
+      expect(idList).toContain('therapist-b');
+    });
+
+    expect(therapistsOrderFullMock).not.toHaveBeenCalled();
+  });
+
+  it('uses allowAll clients and full therapist list query for admin role', async () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      effectiveRole: 'admin',
+      profile: baseProfile({
+        id: 'admin-user',
+        role: 'admin',
+        organization_id: 'org-admin-1',
+      }),
+    });
+
+    renderWithProviders(<Authorizations />, { auth: false });
+
+    await waitFor(() => {
+      expect(fetchClientsMock).toHaveBeenCalledWith({ allowAll: true });
+    });
+
+    await waitFor(() => {
+      expect(therapistsOrderFullMock).toHaveBeenCalled();
+    });
+
+    expect(therapistsInMock).not.toHaveBeenCalled();
+    expect(screen.getByText('Authorizations')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
Reduce app-layer query fan-out for \ffectiveRole === 'therapist'\ on \/authorizations\ by reusing the same \etchClients\ contract as \Clients.tsx\ (org + therapist, no \llowAll\) and by loading therapist rows with \.in('id', …)\ limited to the signed-in therapist plus provider ids already present on returned authorization rows. Admin/super_admin behavior is unchanged.

## Route-task
- **classification:** low-risk autonomous  
- **lane:** standard (page-level data fetching + tests; no auth/RLS/migration edits)

## Verification
- \
pm test -- src/pages/__tests__/Authorizations.test.tsx\
- \
pm run lint\, \
pm run typecheck\, \
pm run build\
- \
pm run ci:check-focused\
- \
pm run verify:local\ (passed in this workspace)

## Residual risk
Authorizations list query unchanged (RLS-defined); create flow uses scoped client list only; edit flow adds a minimal picker stub when the row client is outside caseload. Backend create rules unchanged.