### PR TITLE
fix(schedule): show grid when org has therapists/clients but no sessions

### DIFF
--- a/src/components/__tests__/SchedulingIntegration.test.tsx
+++ b/src/components/__tests__/SchedulingIntegration.test.tsx
@@ -89,6 +89,11 @@ const buildProgramGoalQuery = (data: unknown[]) => {
 describe('Scheduling Integration - End-to-End Flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    try {
+      window.localStorage.removeItem('pendingSchedule');
+    } catch {
+      // Ignore environments without localStorage.
+    }
     vi.mocked(supabase.from).mockImplementation((table: string) => {
       if (table === 'programs') {
         return buildProgramGoalQuery([mockProgram]) as ReturnType<typeof baseFrom>;
@@ -197,10 +202,8 @@ describe('Scheduling Integration - End-to-End Flow', () => {
     const start = '2025-07-01T10:00';
     document.dispatchEvent(new CustomEvent('openScheduleModal', { detail: { start_time: start } }));
 
-    // Session modal should open
-    await waitFor(() => {
-      expect(screen.getByText('New Session')).toBeInTheDocument();
-    });
+    // Session modal is lazy-loaded; week grid also lazy-loads now, so allow extra time in CI.
+    expect(await screen.findByText(/New Session/i, {}, { timeout: 20_000 })).toBeInTheDocument();
 
     // Fill out the session form
     const therapistSelect = document.getElementById('therapist-select') as HTMLSelectElement;

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -621,15 +621,11 @@ export const Schedule = React.memo(() => {
     void refetchDropdowns();
   }, [refetchScheduleBatch, refetchSessions, refetchDropdowns]);
 
-  const showEmptySessionsState = displayData.sessions.length === 0;
   const therapistScopedView = effectiveRole === "therapist";
 
-  const scheduleEmptyReason = useMemo(() => {
-    if (displayData.therapists.length === 0 && displayData.clients.length === 0) {
-      return "no-schedule-data" as const;
-    }
-    return "no-sessions-in-period" as const;
-  }, [displayData.therapists.length, displayData.clients.length]);
+  /** Keep the week/day grid when sessions are empty so admins and therapists can create bookings from empty slots. */
+  const showEmptySessionsState =
+    displayData.therapists.length === 0 && displayData.clients.length === 0;
 
   useEffect(() => {
     if (selectedTherapist) {
@@ -1897,7 +1893,7 @@ export const Schedule = React.memo(() => {
         <div
           className="mt-6 flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 py-16 text-center dark:border-gray-600 dark:bg-gray-900/40"
           data-testid="schedule-empty-sessions"
-          data-schedule-empty-reason={scheduleEmptyReason}
+          data-schedule-empty-reason="no-schedule-data"
           role="status"
           aria-live="polite"
         >
@@ -1905,25 +1901,12 @@ export const Schedule = React.memo(() => {
             className="h-12 w-12 text-gray-400 dark:text-gray-500"
             aria-hidden="true"
           />
-          {scheduleEmptyReason === "no-schedule-data" ? (
-            <>
-              <h2 className="mt-4 text-base font-medium text-gray-900 dark:text-white">
-                No schedule data yet
-              </h2>
-              <p className="mt-2 max-w-sm text-sm text-gray-500 dark:text-gray-400">
-                There are no therapists or clients for this organization. Add team members and clients, then book sessions from the schedule.
-              </p>
-            </>
-          ) : (
-            <>
-              <h2 className="mt-4 text-base font-medium text-gray-900 dark:text-white">
-                No sessions in this period
-              </h2>
-              <p className="mt-2 max-w-sm text-sm text-gray-500 dark:text-gray-400">
-                There are no sessions for this date range and filters. Try another period or adjust filters.
-              </p>
-            </>
-          )}
+          <h2 className="mt-4 text-base font-medium text-gray-900 dark:text-white">
+            No schedule data yet
+          </h2>
+          <p className="mt-2 max-w-sm text-sm text-gray-500 dark:text-gray-400">
+            There are no therapists or clients for this organization. Add team members and clients, then book sessions from the schedule.
+          </p>
         </div>
       ) : (
         <Suspense fallback={<ScheduleViewLoadingState />}>

--- a/src/pages/__tests__/Schedule.dataLoadUx.test.tsx
+++ b/src/pages/__tests__/Schedule.dataLoadUx.test.tsx
@@ -178,7 +178,7 @@ describe("Schedule data-load UX", () => {
     expect(screen.getByText(/get_dropdown_data failed/i)).toBeInTheDocument();
   });
 
-  it("shows an explicit empty state when schedule loads successfully but there are no sessions", async () => {
+  it("renders the schedule grid when therapists and clients exist but there are no sessions", async () => {
     mockUseScheduleDataBatch.mockReturnValue({
       data: {
         sessions: [],
@@ -191,10 +191,8 @@ describe("Schedule data-load UX", () => {
 
     renderWithProviders(<Schedule />);
 
-    const empty = await screen.findByTestId("schedule-empty-sessions");
-    expect(empty).toBeInTheDocument();
-    expect(empty).toHaveAttribute("data-schedule-empty-reason", "no-sessions-in-period");
-    expect(screen.getByText(/No sessions in this period/i)).toBeInTheDocument();
+    expect(await screen.findByText(/^Time$/)).toBeInTheDocument();
+    expect(screen.queryByTestId("schedule-empty-sessions")).not.toBeInTheDocument();
     expect(screen.queryByTestId("schedule-data-load-error")).not.toBeInTheDocument();
   });
 
@@ -271,9 +269,8 @@ describe("Schedule data-load UX", () => {
 
     renderWithProviders(<Schedule />);
 
-    const empty = await screen.findByTestId("schedule-empty-sessions");
-    expect(empty).toHaveAttribute("data-schedule-empty-reason", "no-sessions-in-period");
-    expect(screen.getByText(/No sessions in this period/i)).toBeInTheDocument();
+    expect(await screen.findByText(/^Time$/)).toBeInTheDocument();
+    expect(screen.queryByTestId("schedule-empty-sessions")).not.toBeInTheDocument();
   });
 
   it("uses generic copy when sessions query is in error but no error object is present", async () => {
@@ -318,7 +315,8 @@ describe("Schedule data-load UX", () => {
 
     renderWithProviders(<Schedule />);
 
-    expect(await screen.findByTestId("schedule-empty-sessions")).toBeInTheDocument();
+    expect(await screen.findByText(/^Time$/)).toBeInTheDocument();
+    expect(screen.queryByTestId("schedule-empty-sessions")).not.toBeInTheDocument();
     expect(screen.queryByTestId("schedule-data-load-error")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Empty-state previously keyed off zero sessions, which hid LazyScheduleDayView/ LazyScheduleWeekView and blocked slot-based session creation for admins and therapists. Show the dashed empty panel only when both directory lists are empty (no-schedule-data). Update data-load UX tests to assert the grid header.

Made-with: Cursor