### PR TITLE
Therapist read-only schedule, hide client import/onboard, admin-only client onboarding

### DIFF
--- a/scripts/route-audit.cjs
+++ b/scripts/route-audit.cjs
@@ -23,7 +23,7 @@ const ROUTES = [
   { path: '/schedule', component: 'Schedule', roles: ['client', 'therapist', 'admin', 'super_admin'], permissions: [] },
   { path: '/clients', component: 'Clients', roles: ['therapist', 'admin', 'super_admin'], permissions: ['view_clients'] },
   { path: '/clients/:clientId', component: 'ClientDetails', roles: ['therapist', 'admin', 'super_admin'], permissions: ['view_clients'] },
-  { path: '/clients/new', component: 'ClientOnboarding', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
+  { path: '/clients/new', component: 'ClientOnboarding', roles: ['admin', 'super_admin'], permissions: [] },
   { path: '/therapists', component: 'Therapists', roles: ['admin', 'super_admin'], permissions: [] },
   { path: '/therapists/:therapistId', component: 'TherapistDetails', roles: ['client', 'therapist', 'admin', 'super_admin'], permissions: [] },
   { path: '/therapists/new', component: 'TherapistOnboarding', roles: ['admin', 'super_admin'], permissions: [] },

--- a/scripts/route-audit.ts
+++ b/scripts/route-audit.ts
@@ -106,7 +106,7 @@ export const ROUTES: readonly RouteDefinition[] = [
     roles: ['therapist', 'admin', 'super_admin'],
     permissions: ['view_clients'],
   },
-  { path: '/clients/new', component: 'ClientOnboarding', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
+  { path: '/clients/new', component: 'ClientOnboarding', roles: ['admin', 'super_admin'], permissions: [] },
   { path: '/therapists', component: 'Therapists', roles: ['admin', 'super_admin'], permissions: [] },
   {
     path: '/therapists/:therapistId',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,9 +176,9 @@ function App() {
                       </RoleGuard>
                     } />
                     
-                    {/* Client Onboarding - accessible to therapists and above */}
+                    {/* Client Onboarding - admin and super_admin only */}
                     <Route path="clients/new" element={
-                      <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                      <RoleGuard roles={['admin', 'super_admin']}>
                         <ClientOnboardingPage />
                       </RoleGuard>
                     } />

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -387,22 +387,24 @@ const Clients = () => {
       )}
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Clients</h1>
-        <div className="flex space-x-3">
-          <button
-            onClick={() => setIsImportModalOpen(true)}
-            className="px-4 py-2 text-sm font-medium text-white bg-purple-600 rounded-md shadow-sm hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500"
-          >
-            <FileUp className="w-5 h-5 mr-2 inline-block" />
-            Import CSV
-          </button>
-          <button
-            onClick={handleOnboardClient}
-            className="px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-md shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
-          >
-            <UserPlus className="w-5 h-5 mr-2 inline-block" />
-            Onboard Client
-          </button>
-        </div>
+        {!isTherapistViewer ? (
+          <div className="flex space-x-3">
+            <button
+              onClick={() => setIsImportModalOpen(true)}
+              className="px-4 py-2 text-sm font-medium text-white bg-purple-600 rounded-md shadow-sm hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500"
+            >
+              <FileUp className="w-5 h-5 mr-2 inline-block" />
+              Import CSV
+            </button>
+            <button
+              onClick={handleOnboardClient}
+              className="px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-md shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+            >
+              <UserPlus className="w-5 h-5 mr-2 inline-block" />
+              Onboard Client
+            </button>
+          </div>
+        ) : null}
       </div>
 
       <div className="bg-white dark:bg-dark-lighter rounded-lg shadow mb-6">

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -461,6 +461,9 @@ export const Schedule = React.memo(() => {
   );
 
   const openFromPendingSchedule = useCallback((detail: PendingScheduleDetail | null) => {
+    if (effectiveRole === "therapist") {
+      return;
+    }
     const transition = applyPendingScheduleDetail({
       detail,
       lastDetailKeyRef: lastPendingScheduleKeyRef,
@@ -483,7 +486,7 @@ export const Schedule = React.memo(() => {
         startTimeIso: transition.prefill.date.toISOString(),
       });
     }
-  }, [writeModalUrlState]);
+  }, [effectiveRole, writeModalUrlState]);
 
   const consumePendingSchedule = useCallback(() => {
     consumePendingScheduleFromStorage({
@@ -623,9 +626,17 @@ export const Schedule = React.memo(() => {
 
   const therapistScopedView = effectiveRole === "therapist";
 
-  /** Keep the week/day grid when sessions are empty so admins and therapists can create bookings from empty slots. */
-  const showEmptySessionsState =
+  const showOrgDirectoryEmpty =
     displayData.therapists.length === 0 && displayData.clients.length === 0;
+  /** Therapists view assigned work only: show the read-only empty state instead of an empty booking grid. */
+  const showTherapistReadOnlyEmptyPeriod =
+    therapistScopedView && !showOrgDirectoryEmpty && displayData.sessions.length === 0;
+
+  useEffect(() => {
+    if (therapistScopedView) {
+      setView("day");
+    }
+  }, [therapistScopedView]);
 
   useEffect(() => {
     if (selectedTherapist) {
@@ -738,15 +749,6 @@ export const Schedule = React.memo(() => {
     scopedTherapistId,
     therapistLinkedClientIdsQuery.data,
   ]);
-  const scopedTherapistDisplayName = useMemo(() => {
-    const scopedId = selectedTherapist ?? scopedTherapistId;
-    if (!scopedId) {
-      return "Current Therapist";
-    }
-    const match = visibleTherapists.find((therapist) => therapist.id === scopedId);
-    return match?.full_name ?? "Current Therapist";
-  }, [selectedTherapist, scopedTherapistId, visibleTherapists]);
-
   const isScheduleShellNarrow = useSyncExternalStore(
     (onStoreChange) => {
       if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
@@ -762,6 +764,7 @@ export const Schedule = React.memo(() => {
         : false,
     () => false,
   );
+  const scheduleShellUsesCollapsibleFilters = isScheduleShellNarrow || therapistScopedView;
 
   const mobileScheduleOptionsSummary = useMemo(() => {
     const tzShort = recurrenceTimeZone.includes("/")
@@ -770,11 +773,16 @@ export const Schedule = React.memo(() => {
     const parts: string[] = [];
     parts.push(view === "day" ? "Day view" : "Week view");
     parts.push(tzShort);
-    if (recurrenceEnabled) {
+    if (!therapistScopedView && recurrenceEnabled) {
       parts.push("Recurrence on");
     }
     if (therapistScopedView) {
-      parts.push("My clients");
+      parts.push("All therapists");
+      parts.push(
+        selectedClient
+          ? (visibleClients.find((x) => x.id === selectedClient)?.full_name ?? "Client")
+          : "All clients",
+      );
     } else {
       const t = selectedTherapist
         ? (visibleTherapists.find((x) => x.id === selectedTherapist)?.full_name ?? "Therapist")
@@ -967,6 +975,9 @@ export const Schedule = React.memo(() => {
       timeSlot: { date: Date; time: string },
       options?: { syncUrl?: boolean },
     ) => {
+      if (therapistScopedView) {
+        return;
+      }
       const plan = buildScheduleModalOpenResetPlan({
         mode: "create",
         timeSlot,
@@ -1003,7 +1014,7 @@ export const Schedule = React.memo(() => {
         });
       }
     },
-    [writeModalUrlState],
+    [therapistScopedView, writeModalUrlState],
   );
 
   const handleEditSession = useCallback((
@@ -1436,6 +1447,12 @@ export const Schedule = React.memo(() => {
     }
 
     if (parsed.state.mode === "create") {
+      if (therapistScopedView) {
+        const params = clearScheduleModalSearchParams(searchParams);
+        setSearchParams(params, { replace: true });
+        lastAppliedUrlModalKeyRef.current = null;
+        return;
+      }
       const date = parseISO(parsed.state.startTimeIso);
       handleCreateSession(
         {
@@ -1506,6 +1523,7 @@ export const Schedule = React.memo(() => {
     displayData.sessions,
     handleCreateSession,
     handleEditSession,
+    therapistScopedView,
   ]);
 
   if (!activeOrganizationId) {
@@ -1653,48 +1671,7 @@ export const Schedule = React.memo(() => {
     </div>
   );
 
-  const therapistScopeSection =
-    therapistScopedView ? (
-      <section
-        className="bg-white dark:bg-dark-lighter border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-4"
-        aria-label="Therapist schedule scope"
-      >
-        <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-          My Clients
-        </div>
-        <div className="mt-3 grid grid-cols-1 gap-4 md:grid-cols-2">
-          <div>
-            <p className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Therapist</p>
-            <div className="w-full rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-800 dark:border-gray-600 dark:bg-dark dark:text-gray-100">
-              {scopedTherapistDisplayName}
-            </div>
-          </div>
-          <div>
-            <label
-              htmlFor="therapist-client-scope-filter"
-              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              Client
-            </label>
-            <select
-              id="therapist-client-scope-filter"
-              value={selectedClient || ""}
-              onChange={(event) => handleClientFilterChange(event.target.value || null)}
-              className="w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
-            >
-              <option value="">All My Clients ({visibleClients.length})</option>
-              {visibleClients.map((client) => (
-                <option key={client.id} value={client.id}>
-                  {client.full_name} - {(client.service_preference ?? []).join(", ")}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-      </section>
-    ) : null;
-
-  const sessionFiltersBlock = !therapistScopedView ? (
+  const sessionFiltersBlock = (
     <SessionFilters
       therapists={visibleTherapists}
       clients={visibleClients}
@@ -1706,7 +1683,7 @@ export const Schedule = React.memo(() => {
       scopedClientId={scopedClientId}
       therapistLocked={therapistScopedView}
     />
-  ) : null;
+  );
 
   const renderScheduleRecurrenceFieldset = (marginClass: string) => (
     <fieldset
@@ -1855,7 +1832,7 @@ export const Schedule = React.memo(() => {
 
   return (
     <div className="h-full">
-      {isScheduleShellNarrow ? (
+      {scheduleShellUsesCollapsibleFilters ? (
         <>
           <div className="mb-3">{schedulePageHeader}</div>
           <details className="group mb-4 rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-dark-lighter">
@@ -1872,9 +1849,8 @@ export const Schedule = React.memo(() => {
               </div>
             </summary>
             <div className="space-y-4 border-t border-gray-200 px-3 pb-4 pt-3 dark:border-gray-700">
-              {therapistScopeSection}
               {sessionFiltersBlock}
-              {renderScheduleRecurrenceFieldset("")}
+              {!therapistScopedView ? renderScheduleRecurrenceFieldset("") : null}
             </div>
           </details>
         </>
@@ -1882,14 +1858,13 @@ export const Schedule = React.memo(() => {
         <>
           <div className="mb-6 space-y-4">
             {schedulePageHeader}
-            {therapistScopeSection}
           </div>
           {sessionFiltersBlock}
-          {renderScheduleRecurrenceFieldset("mt-6")}
+          {!therapistScopedView ? renderScheduleRecurrenceFieldset("mt-6") : null}
         </>
       )}
 
-      {showEmptySessionsState ? (
+      {showOrgDirectoryEmpty ? (
         <div
           className="mt-6 flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 py-16 text-center dark:border-gray-600 dark:bg-gray-900/40"
           data-testid="schedule-empty-sessions"
@@ -1908,6 +1883,25 @@ export const Schedule = React.memo(() => {
             There are no therapists or clients for this organization. Add team members and clients, then book sessions from the schedule.
           </p>
         </div>
+      ) : showTherapistReadOnlyEmptyPeriod ? (
+        <div
+          className="mt-6 flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 py-16 text-center dark:border-gray-600 dark:bg-gray-900/40"
+          data-testid="schedule-empty-sessions"
+          data-schedule-empty-reason="no-sessions-in-period"
+          role="status"
+          aria-live="polite"
+        >
+          <CalendarX
+            className="h-12 w-12 text-gray-400 dark:text-gray-500"
+            aria-hidden="true"
+          />
+          <h2 className="mt-4 text-base font-medium text-gray-900 dark:text-white">
+            No sessions in this period
+          </h2>
+          <p className="mt-2 max-w-sm text-sm text-gray-500 dark:text-gray-400">
+            There are no sessions for this date range and filters. Try another period or adjust filters.
+          </p>
+        </div>
       ) : (
         <Suspense fallback={<ScheduleViewLoadingState />}>
           {view === "day" ? (
@@ -1917,6 +1911,7 @@ export const Schedule = React.memo(() => {
               sessionSlotIndex={sessionSlotIndex}
               onCreateSession={handleCreateSession}
               onEditSession={handleEditSession}
+              allowCreateInEmptySlot={!therapistScopedView}
             />
           ) : (
             <LazyScheduleWeekView
@@ -1925,6 +1920,7 @@ export const Schedule = React.memo(() => {
               sessionSlotIndex={sessionSlotIndex}
               onCreateSession={handleCreateSession}
               onEditSession={handleEditSession}
+              allowCreateInEmptySlot={!therapistScopedView}
             />
           )}
         </Suspense>

--- a/src/pages/ScheduleCalendarViewShared.tsx
+++ b/src/pages/ScheduleCalendarViewShared.tsx
@@ -15,12 +15,14 @@ export const TimeSlot = React.memo(
     slotSessions,
     onCreateSession,
     onEditSession,
+    allowCreateInEmptySlot = true,
   }: {
     time: string;
     day: Date;
     slotSessions: Session[];
     onCreateSession: ScheduleTimeSlotHandler;
     onEditSession: ScheduleEditSessionHandler;
+    allowCreateInEmptySlot?: boolean;
   }) => {
     const handleTimeSlotClick = useCallback(() => {
       onCreateSession({ date: day, time });
@@ -34,27 +36,45 @@ export const TimeSlot = React.memo(
       [onEditSession],
     );
 
+    const enableSlotCreateChrome = allowCreateInEmptySlot;
+
     return (
       <div
-        className="h-10 border-b border-r p-2 relative group cursor-pointer hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
-        role="button"
-        tabIndex={0}
-        aria-label="Add session"
-        title="Add session"
-        onClick={handleTimeSlotClick}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            handleTimeSlotClick();
-          }
-        }}
+        className={`h-10 border-b border-r p-2 relative group dark:border-gray-700 ${
+          enableSlotCreateChrome
+            ? "cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
+            : "cursor-default"
+        }`}
+        role={enableSlotCreateChrome ? "button" : undefined}
+        tabIndex={enableSlotCreateChrome ? 0 : undefined}
+        aria-label={
+          enableSlotCreateChrome
+            ? "Add session"
+            : slotSessions.length === 0
+              ? "Empty time slot"
+              : undefined
+        }
+        title={enableSlotCreateChrome ? "Add session" : undefined}
+        {...(enableSlotCreateChrome
+          ? {
+              onClick: handleTimeSlotClick,
+              onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  handleTimeSlotClick();
+                }
+              },
+            }
+          : {})}
       >
-        <span
-          aria-hidden="true"
-          className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 p-1 rounded-full text-gray-500 transition-opacity dark:text-gray-400"
-        >
-          <Plus className="w-4 h-4 text-gray-500 dark:text-gray-400" />
-        </span>
+        {enableSlotCreateChrome ? (
+          <span
+            aria-hidden="true"
+            className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 p-1 rounded-full text-gray-500 transition-opacity dark:text-gray-400"
+          >
+            <Plus className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+          </span>
+        ) : null}
 
         {slotSessions.map((session) => {
           const statusStyles = getSessionStatusClasses(session.status);
@@ -103,12 +123,14 @@ export const DayColumn = React.memo(
     sessionSlotIndex,
     onCreateSession,
     onEditSession,
+    allowCreateInEmptySlot = true,
   }: {
     day: Date;
     timeSlots: string[];
     sessionSlotIndex: Map<string, Session[]>;
     onCreateSession: ScheduleTimeSlotHandler;
     onEditSession: ScheduleEditSessionHandler;
+    allowCreateInEmptySlot?: boolean;
   }) => {
     const dayKey = useMemo(() => format(day, 'yyyy-MM-dd'), [day]);
 
@@ -122,6 +144,7 @@ export const DayColumn = React.memo(
             slotSessions={sessionSlotIndex.get(createSessionSlotKey(dayKey, time)) ?? []}
             onCreateSession={onCreateSession}
             onEditSession={onEditSession}
+            allowCreateInEmptySlot={allowCreateInEmptySlot}
           />
         ))}
       </div>

--- a/src/pages/ScheduleDayView.tsx
+++ b/src/pages/ScheduleDayView.tsx
@@ -10,6 +10,7 @@ interface ScheduleDayViewProps {
   sessionSlotIndex: Map<string, Session[]>;
   onCreateSession: ScheduleTimeSlotHandler;
   onEditSession: ScheduleEditSessionHandler;
+  allowCreateInEmptySlot?: boolean;
 }
 
 const ScheduleDayViewComponent: React.FC<ScheduleDayViewProps> = ({
@@ -18,6 +19,7 @@ const ScheduleDayViewComponent: React.FC<ScheduleDayViewProps> = ({
   sessionSlotIndex,
   onCreateSession,
   onEditSession,
+  allowCreateInEmptySlot = true,
 }) => {
   const selectedDateKey = format(selectedDate, 'yyyy-MM-dd');
 
@@ -56,6 +58,7 @@ const ScheduleDayViewComponent: React.FC<ScheduleDayViewProps> = ({
               slotSessions={sessionSlotIndex.get(createSessionSlotKey(selectedDateKey, time)) ?? []}
               onCreateSession={onCreateSession}
               onEditSession={onEditSession}
+              allowCreateInEmptySlot={allowCreateInEmptySlot}
             />
           ))}
         </div>

--- a/src/pages/ScheduleWeekView.tsx
+++ b/src/pages/ScheduleWeekView.tsx
@@ -9,6 +9,7 @@ interface ScheduleWeekViewProps {
   sessionSlotIndex: Map<string, Session[]>;
   onCreateSession: ScheduleTimeSlotHandler;
   onEditSession: ScheduleEditSessionHandler;
+  allowCreateInEmptySlot?: boolean;
 }
 
 const ScheduleWeekViewComponent: React.FC<ScheduleWeekViewProps> = ({
@@ -17,6 +18,7 @@ const ScheduleWeekViewComponent: React.FC<ScheduleWeekViewProps> = ({
   sessionSlotIndex,
   onCreateSession,
   onEditSession,
+  allowCreateInEmptySlot = true,
 }) => {
   return (
     <div className="bg-white dark:bg-dark-lighter rounded-lg shadow overflow-x-auto">
@@ -55,6 +57,7 @@ const ScheduleWeekViewComponent: React.FC<ScheduleWeekViewProps> = ({
             sessionSlotIndex={sessionSlotIndex}
             onCreateSession={onCreateSession}
             onEditSession={onEditSession}
+            allowCreateInEmptySlot={allowCreateInEmptySlot}
           />
         ))}
       </div>

--- a/src/pages/__tests__/AppNavigation.test.tsx
+++ b/src/pages/__tests__/AppNavigation.test.tsx
@@ -158,13 +158,14 @@ describe('App navigation landing', () => {
     expect(payload.metadata).not.toHaveProperty('hash');
   });
 
-  it('allows therapist access to client onboarding route', async () => {
+  it('blocks therapists from client onboarding route', async () => {
     authRole = 'therapist';
     window.history.pushState({}, '', '/clients/new');
     renderApp();
 
-    expect(await screen.findByText('ClientOnboardingPage')).toBeInTheDocument();
-    expect(screen.queryByText('ClientDetailsPage')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/unauthorized');
+    });
   });
 
   it('blocks clients from client onboarding route', async () => {

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -327,15 +327,21 @@ describe("Schedule", () => {
     });
 
     expect(
-      await screen.findByRole("region", { name: /Therapist schedule scope/i }),
+      await screen.findByRole("heading", { name: /^Schedule$/i }),
     ).toBeInTheDocument();
-    // Therapist display may fall back to "Current Therapist" until profile scope resolves; the locked
-    // therapist still appears on session cards, so "Dr. Myles" can exist more than once.
+
+    await userEvent.click(screen.getByText("Filters & schedule options"));
+
     const myles = await screen.findAllByText("Dr. Myles");
     expect(myles.length).toBeGreaterThan(0);
     expect(screen.queryByRole("option", { name: /All Therapists/i })).not.toBeInTheDocument();
     expect(screen.getByRole("option", { name: /Jamie Client/i })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /Riley Client/i })).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("checkbox", { name: /Enable recurrence \(RRULE\)/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryAllByLabelText("Add session")).toHaveLength(0);
   });
 
   it("exposes recurrence toggle and labeled recurrence controls when enabled", async () => {

--- a/src/server/routes/__tests__/guards.test.ts
+++ b/src/server/routes/__tests__/guards.test.ts
@@ -12,8 +12,8 @@ const expectedPaths = [
   '/',
   '/schedule',
   '/clients',
-  '/clients/:clientId',
   '/clients/new',
+  '/clients/:clientId',
   '/therapists',
   '/therapists/:therapistId',
   '/therapists/new',
@@ -56,6 +56,10 @@ describe('route guard matchers', () => {
     const match = findGuardForPath('/therapists/abc123');
     expect(match?.path).toBe('/therapists/:therapistId');
   });
+
+  it('route guard matcher resolves client onboarding before dynamic client id', () => {
+    expect(findGuardForPath('/clients/new')?.path).toBe('/clients/new');
+  });
 });
 
 describe('route guard access controls', () => {
@@ -69,6 +73,12 @@ describe('route guard access controls', () => {
     expect(hasRoleAccess('/therapists', 'admin')).toBe(true);
     expect(hasRoleAccess('/therapists', 'therapist')).toBe(false);
     expect(hasRoleAccess('/therapists/new', 'super_admin')).toBe(true);
+  });
+
+  it('restricts client onboarding to admin roles', () => {
+    expect(hasRoleAccess('/clients/new', 'therapist')).toBe(false);
+    expect(hasRoleAccess('/clients/new', 'admin')).toBe(true);
+    expect(hasRoleAccess('/clients/new', 'super_admin')).toBe(true);
   });
 
   it('route guard allows elevated roles to inherit lower privileges', () => {

--- a/src/server/routes/guards.ts
+++ b/src/server/routes/guards.ts
@@ -39,6 +39,13 @@ const guardDefinitions: readonly GuardWithMatcher[] = [
     requiredPermissions: ['view_clients'],
     supabasePolicies: ['public.clients: role_scoped_select'],
   }),
+  // Static segment must precede `/clients/:clientId` or `new` is treated as a UUID-like id.
+  createGuard({
+    path: '/clients/new',
+    allowedRoles: ['admin', 'super_admin'],
+    requiredPermissions: [],
+    supabasePolicies: ['app.set_client_archive_state: admin_super_admin_execute'],
+  }),
   createGuard({
     path: '/clients/:clientId',
     allowedRoles: ['therapist', 'admin', 'super_admin'],
@@ -47,12 +54,6 @@ const guardDefinitions: readonly GuardWithMatcher[] = [
       'public.clients: role_scoped_select',
       'public.sessions: sessions_scoped_access',
     ],
-  }),
-  createGuard({
-    path: '/clients/new',
-    allowedRoles: ['therapist', 'admin', 'super_admin'],
-    requiredPermissions: [],
-    supabasePolicies: ['app.set_client_archive_state: admin_super_admin_execute'],
   }),
   createGuard({
     path: '/therapists',


### PR DESCRIPTION
## Summary

- **Clients (therapist):** Remove Import CSV and Onboard Client from the header. Therapists remain on the client list and detail routes.
- **Schedule (therapist):** Restore the screenshot-style shell (collapsible Filters & schedule options, day view default), hide recurrence, block creating sessions from empty slots and from URL/pending create flows, and show the dashed empty state when there are no sessions in the period.
- **Routing:** \/clients/new\ is limited to **admin** and **super_admin** in \App.tsx\. Therapists hitting that URL are sent to \/unauthorized\ (same as the therapist-onboarding guard pattern).
- **Server guards:** \/clients/new\ is registered **before** \/clients/:clientId\ so the path is not mistaken for a client id (fixes \hasRoleAccess\ / matcher behavior for \
ew\).

## Verification

- \
px vitest run src/pages/__tests__/AppNavigation.test.tsx src/server/routes/__tests__/guards.test.ts tests/edge/route-audit-policy.test.ts\
- \
px vitest run src/pages/__tests__/Schedule.test.tsx\ (run locally before commit)
- \
pm run typecheck\ / \
pm run build\ (run locally before commit)

## Notes

- Other working-tree changes (session-notes, migrations, netlify, etc.) were **not** included in this commit; they remain uncommitted locally.

Made with [Cursor](https://cursor.com)