### PR TITLE
docs(audit): WIN-34 tracker closure + optional admin_actions audit test

### DIFF
--- a/docs/AUDIT_REMEDIATION_TRACKER.md
+++ b/docs/AUDIT_REMEDIATION_TRACKER.md
@@ -38,7 +38,7 @@ Track remediation work from the executive audit report to close production-readi
 | --- | --- | --- | --- |
 | Security / Tenant Safety | Org-scoped validation missing in critical edge endpoints | Backend | In progress |
 | Security / Data Safety | `ai_guidance_documents` RLS-without-policy exposure fixed via `20260310162000_harden_ai_guidance_documents_rls.sql` | Backend / DB | Completed |
-| Data Integrity | Soft-delete audit triggers for client/therapist archives | Backend / DB | In progress |
+| Data Integrity | Soft-delete audit triggers for client/therapist archives | Backend / DB | Completed — migrations `20260120120000_soft_delete_audit_triggers.sql` and `20260121130000_soft_delete_audit_triggers_refresh.sql`; optional audit read coverage when `TEST_JWT_ORG_A_ADMIN` is set (`tests/admins/archive_soft_delete.spec.ts`) |
 | Reliability | Documented test failures | QA / Eng | In progress |
 | Reliability | Schedule data batch RPC 400s (aggregation ORDER BY) | Backend / DB | Applied migration (verify in prod) |
 | Admin Governance | Admin users + guardian queue RPC access broken | Backend / DB | Applied migrations (verify in prod) |
@@ -182,3 +182,8 @@ Track remediation work from the executive audit report to close production-readi
   - `docs/STAGING_OPERATIONS.md`
   - `docs/ENVIRONMENT_MATRIX.md`
   - Added `docs/PHASE3_EXECUTION_STATUS_2026_03_12.md` for execution evidence and residual risks.
+
+## Documentation change log (2026-04-14, WIN-34 / WIN-38 / WIN-35 triage execution)
+- **WIN-34 (soft-delete audit):** Marked must-have row **Completed** in this tracker. Canonical migrations implement `app.log_soft_delete_action` and `AFTER INSERT OR UPDATE OF deleted_at` triggers on `clients`, `therapists`, and `client_guardians` writing to `public.admin_actions`. `admin_actions` SELECT remains **admin-scoped** (`admin_actions_select_scoped`); integration coverage for audit rows is optional behind `TEST_JWT_ORG_A_ADMIN` in `tests/admins/archive_soft_delete.spec.ts`.
+- **WIN-38 (org-scoped edge):** No change to must-have row status; **programs** edge/API org deny matrix is already covered by `tests/edge/programs.cors.contract.test.ts` (`programs route org-scope deny matrix`) and `src/server/__tests__/programsHandler.test.ts`. Remaining endpoints per `docs/ai/WIN-38I-parity-scenario-execution-index.md` (goals, dashboard, sessions-start, MCP).
+- **WIN-35 (advisor backlog):** No migration in this change set. Next permissive-policy / unused-index batches require a **fresh Supabase advisor export** and table-by-table review before SQL (see advisor backlog section above).

--- a/tests/admins/archive_soft_delete.spec.ts
+++ b/tests/admins/archive_soft_delete.spec.ts
@@ -44,9 +44,30 @@ async function fetchRow(
   });
 
   const json = (await response.json()) as unknown;
-  const row = Array.isArray(json) ? json[0] as { id: string; organization_id: string | null; deleted_at: string | null } : null;
+  const row = Array.isArray(json)
+    ? (json[0] as { id: string; organization_id: string | null; deleted_at: string | null })
+    : null;
 
   return { status: response.status, row };
+}
+
+type AdminActionRow = { action_type: string; action_details: Record<string, unknown> | null };
+
+async function fetchRecentAdminActions(orgId: string, token: string) {
+  const response = await fetch(
+    `${SUPABASE_URL}/rest/v1/admin_actions?select=action_type,action_details,created_at&organization_id=eq.${orgId}&order=created_at.desc&limit=15`,
+    {
+      method: 'GET',
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+    },
+  );
+  const json = (await response.json()) as unknown;
+  const rows = Array.isArray(json) ? (json as AdminActionRow[]) : [];
+  return { status: response.status, rows };
 }
 
 describe('Soft delete archive controls', () => {
@@ -117,5 +138,45 @@ describe('Soft delete archive controls', () => {
 
     const { row: restoredRow } = await fetchRow('therapists', tokenOrgA, `id=eq.${therapist.id}`);
     expect(restoredRow?.deleted_at).toBeNull();
+  });
+
+  it('records client_archived in admin_actions when an org admin JWT can read the audit log', async () => {
+    const adminReadToken = process.env.TEST_JWT_ORG_A_ADMIN as string;
+    if (!adminReadToken || !tokenOrgA) return;
+
+    const { row: client } = await fetchRow('clients', tokenOrgA, 'deleted_at=is.null&limit=1');
+    expect(client).toBeTruthy();
+    if (!client?.organization_id) return;
+
+    const archiveResult = await callRpc('set_client_archive_state', tokenOrgA, {
+      p_client_id: client.id,
+      p_restore: false,
+    });
+    expect([200, 204]).toContain(archiveResult.status);
+
+    const { status, rows } = await fetchRecentAdminActions(client.organization_id, adminReadToken);
+    if (status === 403 || status === 401) {
+      // RLS: reader token is not org admin; skip without failing default CI secrets.
+      await callRpc('set_client_archive_state', tokenOrgA, {
+        p_client_id: client.id,
+        p_restore: true,
+      });
+      return;
+    }
+    expect(status).toBe(200);
+
+    const archivedEvent = rows.find(
+      (r) =>
+        r.action_type === 'client_archived' &&
+        r.action_details &&
+        String((r.action_details as { target_id?: string }).target_id) === client.id,
+    );
+    expect(archivedEvent).toBeTruthy();
+
+    const restoreFinal = await callRpc('set_client_archive_state', tokenOrgA, {
+      p_client_id: client.id,
+      p_restore: true,
+    });
+    expect([200, 204]).toContain(restoreFinal.status);
   });
 });

--- a/tests/admins/archive_soft_delete.spec.ts
+++ b/tests/admins/archive_soft_delete.spec.ts
@@ -51,11 +51,23 @@ async function fetchRow(
   return { status: response.status, row };
 }
 
-type AdminActionRow = { action_type: string; action_details: Record<string, unknown> | null };
+type AdminActionRow = { action_type: string; action_details: Record<string, unknown> | null; created_at: string };
+
+function maxArchivedCreatedAtForClient(rows: AdminActionRow[], clientId: string): number {
+  let maxMs = 0;
+  for (const r of rows) {
+    if (r.action_type !== 'client_archived' || !r.action_details) continue;
+    const tid = (r.action_details as { target_id?: string }).target_id;
+    if (String(tid) !== clientId) continue;
+    const ms = Date.parse(r.created_at);
+    if (Number.isFinite(ms) && ms > maxMs) maxMs = ms;
+  }
+  return maxMs;
+}
 
 async function fetchRecentAdminActions(orgId: string, token: string) {
   const response = await fetch(
-    `${SUPABASE_URL}/rest/v1/admin_actions?select=action_type,action_details,created_at&organization_id=eq.${orgId}&order=created_at.desc&limit=15`,
+    `${SUPABASE_URL}/rest/v1/admin_actions?select=action_type,action_details,created_at&organization_id=eq.${orgId}&order=created_at.desc&limit=50`,
     {
       method: 'GET',
       headers: {
@@ -148,6 +160,16 @@ describe('Soft delete archive controls', () => {
     expect(client).toBeTruthy();
     if (!client?.organization_id) return;
 
+    const { status: preStatus, rows: preRows } = await fetchRecentAdminActions(
+      client.organization_id,
+      adminReadToken,
+    );
+    if (preStatus === 403 || preStatus === 401) {
+      return;
+    }
+    expect(preStatus).toBe(200);
+    const baselineMs = maxArchivedCreatedAtForClient(preRows, client.id);
+
     const archiveResult = await callRpc('set_client_archive_state', tokenOrgA, {
       p_client_id: client.id,
       p_restore: false,
@@ -165,12 +187,12 @@ describe('Soft delete archive controls', () => {
     }
     expect(status).toBe(200);
 
-    const archivedEvent = rows.find(
-      (r) =>
-        r.action_type === 'client_archived' &&
-        r.action_details &&
-        String((r.action_details as { target_id?: string }).target_id) === client.id,
-    );
+    const archivedEvent = rows.find((r) => {
+      if (r.action_type !== 'client_archived' || !r.action_details) return false;
+      if (String((r.action_details as { target_id?: string }).target_id) !== client.id) return false;
+      const rowMs = Date.parse(r.created_at);
+      return Number.isFinite(rowMs) && rowMs > baselineMs;
+    });
     expect(archivedEvent).toBeTruthy();
 
     const restoreFinal = await callRpc('set_client_archive_state', tokenOrgA, {


### PR DESCRIPTION
## Summary

Executes the **WIN-34** reconciliation slice of the WIN-38/35/34 plan: align \docs/AUDIT_REMEDIATION_TRACKER.md\ with canonical migrations already on \main\, and add optional integration coverage for \dmin_actions\ soft-delete audit rows.

## WIN-34

- Must-have row **Soft-delete audit triggers** → **Completed** with evidence: \20260120120000_soft_delete_audit_triggers.sql\, \20260121130000_soft_delete_audit_triggers_refresh.sql\.
- New test in \	ests/admins/archive_soft_delete.spec.ts\: asserts \client_archived\ appears in \dmin_actions\ when \TEST_JWT_ORG_A_ADMIN\ is set and RLS allows read; **skips** read assertion on 401/403 so default CI secrets do not fail.

## WIN-38 / WIN-35 (documentation only this PR)

- Changelog records: programs deny-matrix tests already exist; remaining WIN-38 endpoints per WIN-38I.
- WIN-35: no new migration — next batches need fresh Supabase advisor export.

## Verification

- \
px vitest run\ … \rchive_soft_delete.spec.ts\, \programsHandler.test.ts\, \programs.cors.contract.test.ts\
- \
pm run ci:check-focused\

## Linear

After merge: consider **WIN-34** → **Done**; **WIN-40** child count unchanged until WIN-38/35 ship code.

Made with [Cursor](https://cursor.com)