### PR TITLE
WIN-78: schedule batch org gate + client routes audit hardening

### DIFF
--- a/docs/ai/WIN-43-qa-audit-credential-handoff.md
+++ b/docs/ai/WIN-43-qa-audit-credential-handoff.md
@@ -40,6 +40,14 @@ Document ownership and evidence expectations for QA credential bootstrap so brow
 - [ ] Confirm a canonical test client identifier source (reference location only).
 - [ ] Define evidence storage location for audit rerun outputs (screenshots, pass/fail note, timestamp).
 
+## Canonical upload artifact (Programs & Goals extraction re-audit)
+
+For **production** Playwright MCP runs that exercise **assessment upload → extraction → draft/Programs & Goals** flows, use this **tracked, redacted** sample at the repository root:
+
+- `7.21.2025_RoVa_CalOptima_FBA_FINAL (1).Redacted.docx.pdf`
+
+Pick that file from the local workspace when the upload control prompts for a file (absolute path on your machine will match your clone, e.g. `<repo-root>/7.21.2025_RoVa_CalOptima_FBA_FINAL (1).Redacted.docx.pdf`). Do not substitute unrelated PDFs for WIN-43 evidence unless the scenario explicitly requires a negative test.
+
 ## Safe Verification Notes
 
 - Browser re-audit remains blocked until credentials are provided through approved secure channels.

--- a/scripts/playwright-client-routes-audit.ts
+++ b/scripts/playwright-client-routes-audit.ts
@@ -217,6 +217,7 @@ const runRouteChecks = async (
   };
 
   let detailRouteUrl: string | null = null;
+  const clientDetailHrefs: string[] = [];
   try {
     await page.goto(clientsResult.url, { waitUntil: 'networkidle' });
     if (isOnLoginRoute(page.url())) {
@@ -235,13 +236,14 @@ const runRouteChecks = async (
     for (let i = 0; i < count; i += 1) {
       const href = await clientDetailLinks.nth(i).getAttribute('href');
       if (href && /^\/clients\/(?!new$)[^/]+$/i.test(href)) {
-        detailRouteUrl = `${baseUrl}${href}`;
-        break;
+        clientDetailHrefs.push(href);
       }
     }
 
     clientsResult.checks.push(
-      detailRouteUrl ? 'Found at least one client details link' : 'No client details link found (empty state)',
+      clientDetailHrefs.length > 0
+        ? `Found ${clientDetailHrefs.length} client detail link(s) on /clients`
+        : 'No client details link found (empty state)',
     );
     clientsResult.status = 'passed';
   } catch (error) {
@@ -253,26 +255,58 @@ const runRouteChecks = async (
   const detailsResult: RouteAuditResult = {
     route: '/clients/:clientId',
     status: 'skipped',
-    url: detailRouteUrl ?? `${baseUrl}/clients/:clientId`,
+    url: `${baseUrl}/clients/:clientId`,
     checks: [],
     errors: [],
   };
 
-  if (!detailRouteUrl) {
+  if (clientDetailHrefs.length === 0) {
     detailsResult.errors.push('Skipped: no client row/link available from /clients to open details.');
   } else {
     try {
-      await page.goto(detailRouteUrl, { waitUntil: 'networkidle' });
-      if (isOnLoginRoute(page.url())) {
-        throw new Error('Redirected to /login');
+      let opened = false;
+      for (const href of clientDetailHrefs.slice(0, 20)) {
+        const url = `${baseUrl}${href}`;
+        detailsResult.url = url;
+        await page.goto(url, { waitUntil: 'networkidle' });
+        if (isOnLoginRoute(page.url())) {
+          throw new Error('Redirected to /login');
+        }
+
+        const denied = page.getByRole('heading', { name: /you are not assigned to this client/i });
+        const notFound = page.getByRole('heading', { name: /client not found/i });
+        const orgRequired = page.getByRole('heading', { name: /organization context required/i });
+        if (await denied.first().isVisible().catch(() => false)) {
+          detailsResult.checks.push(`Skipped non-owned client: ${href}`);
+          continue;
+        }
+        if (await notFound.first().isVisible().catch(() => false)) {
+          detailsResult.checks.push(`Skipped missing client: ${href}`);
+          continue;
+        }
+        if (await orgRequired.first().isVisible().catch(() => false)) {
+          detailsResult.checks.push('Skipped: organization context required on client details');
+          continue;
+        }
+
+        // ClientDetails kicker: exact text "Client record" (`src/pages/ClientDetails.tsx`).
+        await page.getByText('Client record', { exact: true }).first().waitFor({ state: 'visible', timeout: 12000 });
+        detailRouteUrl = url;
+        detailsResult.checks.push('Client record label is visible');
+        await page.getByRole('button', { name: /profile \/ notes & issues/i }).first().waitFor({ state: 'visible', timeout: 5000 });
+        detailsResult.checks.push('Profile tab is visible');
+        await page.getByRole('button', { name: /session notes \/ physical auth/i }).first().waitFor({ state: 'visible', timeout: 5000 });
+        detailsResult.checks.push('Session Notes tab is visible');
+        detailsResult.status = 'passed';
+        opened = true;
+        break;
       }
-      await page.getByRole('heading', { name: /client records:/i }).first().waitFor({ state: 'visible', timeout: 10000 });
-      detailsResult.checks.push('Client details heading is visible');
-      await page.getByRole('button', { name: /profile \/ notes & issues/i }).first().waitFor({ state: 'visible', timeout: 5000 });
-      detailsResult.checks.push('Profile tab is visible');
-      await page.getByRole('button', { name: /session notes \/ physical auth/i }).first().waitFor({ state: 'visible', timeout: 5000 });
-      detailsResult.checks.push('Session Notes tab is visible');
-      detailsResult.status = 'passed';
+
+      if (!opened) {
+        throw new Error(
+          'No accessible client detail within first 20 list links (assignment, org context, or permissions).',
+        );
+      }
     } catch (error) {
       detailsResult.status = 'failed';
       detailsResult.errors.push(error instanceof Error ? error.message : String(error));

--- a/src/lib/optimizedQueries.ts
+++ b/src/lib/optimizedQueries.ts
@@ -66,7 +66,8 @@ export const useScheduleDataBatch = (
     gcTime: CACHE_STRATEGIES.SESSIONS.schedule_batch * 2,
     refetchOnWindowFocus: false,
     refetchOnReconnect: 'always',
-    enabled: options?.enabled ?? true,
+    // Defense-in-depth: never run batch fetch without a resolved org id, even if a caller mis-sets `enabled`.
+    enabled: (options?.enabled ?? true) && Boolean(options?.organizationId),
   });
 };
 


### PR DESCRIPTION
## Summary

- **WIN-78:** `useScheduleDataBatch` now requires a truthy `organizationId` for the query to run, even if `enabled` is mis-set (defense-in-depth). Schedule already gates hooks when org is missing; see `Schedule.orgGuard.test.tsx`.
- **Playwright:** `playwright-client-routes-audit` matches current **Client record** copy, scans client list links for therapist assignment, avoids using `PW_FOREIGN_CLIENT_ID` for happy path.
- **Docs:** Canonical redacted PDF reference for WIN-43 Programs & Goals re-audit handoff.

## Verification (local)

- `npm run ci:check-focused`
- `npm run lint`, `npm run typecheck`
- `vitest run src/pages/__tests__/Schedule.orgGuard.test.tsx` + prefetch tests
- `npm run build`

## Linear

- Lands hook hardening for **WIN-78** (issue already closed with verification comment).

## Out of scope

- No router, auth policy, server, RLS, or API contract changes beyond the batch `enabled` expression.
