### PR TITLE
WIN-101 Stream A: session note write-path parity inventory + guard

### DIFF
--- a/docs/ai/WIN-101-stream-a-session-notes-write-inventory.md
+++ b/docs/ai/WIN-101-stream-a-session-notes-write-inventory.md
@@ -1,0 +1,54 @@
+# WIN-101 Stream A — `client_session_notes` write-path inventory
+
+Issue: **WIN-101** (Linear) — Session Data Collection 2.0 production-readiness (Stream A: server-authoritative session note writes).
+
+**Merge order:** Stream A (this document) → Stream B (Playwright measurement roundtrip + CI wiring).
+
+## Route-task (this slice)
+
+- **classification:** `low-risk autonomous`
+- **lane:** `standard`
+- **Rationale:** Stream A verification found **no remaining browser direct mutations** on `client_session_notes` in app code; this slice adds documentation, a regression guard test, and an inline contract comment. It does **not** change server handlers, Netlify routing, or auth.
+- **Original WIN-101 Stream A intent** (server/API parity) was **`critical` + `high-risk human-reviewed`**; that classification applies when **changing** `src/server/api/session-notes-upsert.ts`, the Netlify function, or client write routing. This PR does not do those edits.
+
+## Goal
+
+Ensure all **therapist/app** writes to `client_session_notes` go through the server-authoritative **`POST /api/session-notes/upsert`** path (`invokeSessionNoteUpsertApi` → `upsertClientSessionNoteForSession` / `createClientSessionNote` / `updateClientSessionNote` in `src/lib/session-notes.ts`), with **no** parallel direct Supabase `insert` / `update` / `upsert` / `delete` on that table from product code under `src/`.
+
+## Scope
+
+- **In scope:** `src/` application and shared lib (excluding `src/server/**`, `src/tests/**`, `src/**/__tests__/**`, `src/lib/generated/**`).
+- **Out of scope:** RLS harness (`src/tests/security/rls.spec.ts` uses service client inserts/deletes), server REST usage in `src/server/api/**`, Stream B (Playwright/CI).
+
+## Writes (mutations)
+
+| Location | Kind | Routing |
+|----------|------|---------|
+| `src/lib/session-notes.ts` | Upsert (create/update) | **`callApi('/api/session-notes/upsert', …)`** via `invokeSessionNoteUpsertApi` — **authoritative** |
+
+No other files under scoped `src/` perform `insert` / `update` / `upsert` / `delete` on `client_session_notes` (verified by manual grep and `client-session-notes-direct-write-guard.test.ts`).
+
+## Reads (not Stream A writes)
+
+| Location | Kind | Notes |
+|----------|------|--------|
+| `src/lib/session-notes.ts` | `select` | List/detail reads for UI; still uses Supabase client for **read** |
+| `src/components/SessionModal.tsx` | `select` | Hydrate linked session note for modal |
+| `src/components/ClientDetails/PreAuthTab.tsx` | `select` | Pre-auth usage stats |
+| `src/features/scheduling/domain/sessionComplete.ts` | `select` | `goal_notes` for close-readiness check; session completion uses **`/api/sessions-complete`** |
+| `src/server/api/sessions-complete.ts` | GET (server) | Server-side read of `goal_notes` |
+
+## Exceptions
+
+- **RLS / security tests** (`src/tests/security/rls.spec.ts`): service-role `insert` / `delete` for policy verification — **test harness only**, not product writes.
+- **Reads** via Supabase client on `client_session_notes` remain **out of Stream A**; parity target here is **write** routing only.
+
+## Stream B (not in this PR)
+
+- Playwright measurement roundtrip script: `scripts/playwright-session-note-measurement-roundtrip.ts`
+- CI reliability wiring per WIN-101 plan
+
+## Residual risk
+
+- Guard test follows PostgREST-style method chains; unusual formatting could theoretically evade detection — keep writes centralized in `session-notes.ts`.
+- Future direct mutations would fail CI if added in scoped `src/` paths.

--- a/src/lib/__tests__/client-session-notes-direct-write-guard.test.ts
+++ b/src/lib/__tests__/client-session-notes-direct-write-guard.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression guard: chained `.from('client_session_notes').insert|update|…` in product `src/`.
+ * Intentionally not exhaustive: non-chained builders, alternate table identifiers, comments/strings
+ * that resemble code, or unusual `.from(...)` shapes may evade detection — see inventory doc.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** src/ root (this file lives in src/lib/__tests__). */
+const SRC_ROOT = join(__dirname, '..', '..');
+
+const MUTATION_METHODS = new Set(['insert', 'update', 'upsert', 'delete']);
+
+/**
+ * After `.from('client_session_notes')`, walk a PostgREST-style chain of `.method(...)` calls.
+ * Returns true if a mutation method appears before the chain ends.
+ */
+function hasMutationAfterFromLiteralTable(source: string, fromMatch: RegExpExecArray): boolean {
+  let i = fromMatch.index + fromMatch[0].length;
+  while (i < source.length) {
+    const rest = source.slice(i);
+    const chain = /^(\s*\.\s*)(\w+)\s*\(/.exec(rest);
+    if (!chain) {
+      break;
+    }
+    const method = chain[2];
+    if (MUTATION_METHODS.has(method)) {
+      return true;
+    }
+    i += chain[0].length;
+    let depth = 1;
+    while (i < source.length && depth > 0) {
+      const ch = source[i];
+      if (ch === '(') {
+        depth += 1;
+      } else if (ch === ')') {
+        depth -= 1;
+      }
+      i += 1;
+    }
+  }
+  return false;
+}
+
+function fileDefinesClientSessionNotesTableConst(source: string): boolean {
+  return /const\s+TABLE\s*=\s*['"]client_session_notes['"]/.test(source);
+}
+
+function scanFileForViolations(path: string, source: string): string[] {
+  const violations: string[] = [];
+  const fromLiteral = /\.from\(\s*['"]client_session_notes['"]\s*\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = fromLiteral.exec(source)) !== null) {
+    if (hasMutationAfterFromLiteralTable(source, m)) {
+      violations.push(`${path}: direct PostgREST mutation after .from('client_session_notes')`);
+    }
+  }
+
+  if (fileDefinesClientSessionNotesTableConst(source)) {
+    const fromTable = /\.from\(\s*TABLE\s*\)/g;
+    while ((m = fromTable.exec(source)) !== null) {
+      if (hasMutationAfterFromLiteralTable(source, m)) {
+        violations.push(`${path}: direct PostgREST mutation after .from(TABLE) (client_session_notes)`);
+      }
+    }
+  }
+
+  return violations;
+}
+
+function walkSrcTsFiles(dir: string, out: string[]): void {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const rel = relative(SRC_ROOT, p).replace(/\\/g, '/');
+    if (statSync(p).isDirectory()) {
+      if (name === '__tests__') {
+        continue;
+      }
+      if (rel === 'server' || rel === 'tests') {
+        continue;
+      }
+      if (rel === 'lib/generated' || rel.startsWith('lib/generated/')) {
+        continue;
+      }
+      walkSrcTsFiles(p, out);
+    } else if (/\.(ts|tsx)$/.test(name) && !name.endsWith('.d.ts')) {
+      out.push(p);
+    }
+  }
+}
+
+describe('client_session_notes direct write guard', () => {
+  it('does not use Supabase client mutations on client_session_notes in scoped app src', () => {
+    const files: string[] = [];
+    walkSrcTsFiles(SRC_ROOT, files);
+
+    const allViolations: string[] = [];
+    for (const abs of files) {
+      const source = readFileSync(abs, 'utf8');
+      const rel = relative(join(SRC_ROOT, '..'), abs).replace(/\\/g, '/');
+      allViolations.push(...scanFileForViolations(rel, source));
+    }
+
+    expect(allViolations, allViolations.join('\n')).toEqual([]);
+  });
+});

--- a/src/lib/session-notes.ts
+++ b/src/lib/session-notes.ts
@@ -208,6 +208,11 @@ export interface SessionNoteUpsertApiPayload {
   readonly isLocked: boolean;
 }
 
+/**
+ * Single writer path for therapist-facing persistence of `client_session_notes` rows:
+ * server `POST /api/session-notes/upsert` (see `src/server/api/session-notes-upsert.ts`).
+ * Do not add parallel Supabase insert/update/upsert/delete call sites on this table in app code.
+ */
 const invokeSessionNoteUpsertApi = async (
   payload: SessionNoteUpsertApiPayload,
 ): Promise<SessionNote> => {


### PR DESCRIPTION
## Summary
Stream A for WIN-101: confirm server-authoritative writes via \POST /api/session-notes/upsert\ and lock in parity with a documented inventory + regression test.

## Changes
- **Doc:** \docs/ai/WIN-101-stream-a-session-notes-write-inventory.md\ — full write vs read inventory, route-task for this slice, exceptions (RLS tests), Stream B pointer.
- **Contract:** JSDoc on \invokeSessionNoteUpsertApi\ in \src/lib/session-notes.ts\.
- **Guard:** Vitest test rejects chained PostgREST mutations on \client_session_notes\ in scoped product \src/\ (excludes server, tests, \__tests__\, generated).

## Verification (local)
- \
pm run ci:check-focused\ — pass
- \
pm run lint\ — pass
- \
pm run typecheck\ — pass
- \
px vitest run src/lib/__tests__/client-session-notes-direct-write-guard.test.ts src/lib/__tests__/session-notes.test.ts\ — pass
- \
pm run test:ci\ — **failed**: unrelated flake in \SessionNotesTab.measurementMutation.test.tsx\ (Edit button waitFor); not caused by this PR.

## Linear
WIN-101 — Stream A only; Stream B (Playwright/CI) remains separate.

cc @Jeduardo622

Made with [Cursor](https://cursor.com)