### PR TITLE
WIN-101 Stream B: session-note measurement Playwright roundtrip hardening

### DIFF
--- a/docs/ai/WIN-101-stream-b-playwright-roundtrip.md
+++ b/docs/ai/WIN-101-stream-b-playwright-roundtrip.md
@@ -1,0 +1,36 @@
+# WIN-101 Stream B — Session note measurement Playwright roundtrip
+
+Parent: **WIN-101** (Session Data Collection 2.0). Stream A (server write parity) landed in PR `#435` / merge `c961e561`.
+
+## Route-task (this slice)
+
+- **classification:** `low-risk autonomous`
+- **lane:** `standard`
+- **why:** Tightens Playwright assertions and a stable DOM hook for the existing measurement roundtrip; does not change auth, deploy, or `/api/session-notes/upsert` semantics.
+
+## Audit: how the roundtrip runs today
+
+| Surface | Behavior |
+|--------|----------|
+| **npm script** | `playwright:session-note-measurement-roundtrip` → `tsx scripts/playwright-session-note-measurement-roundtrip.ts` |
+| **`ci:playwright`** | Runs **after** `playwright:schedule-blocked-close` and **includes** `playwright:session-note-measurement-roundtrip` (order enforced by `scripts/ci/check-e2e-reliability-gates.mjs` and `npm run ci:check-focused`) |
+| **GitHub Actions `auth-browser-smoke`** | Runs preflight → auth → session-lifecycle → session-complete → schedule-blocked-close → **session-note-measurement-roundtrip**, with `CI_SESSION_PARITY_REQUIRED=true` |
+
+## PR vs push caveat (important)
+
+In `.github/workflows/ci.yml`, the **auth-browser-smoke** step checks required secrets. On **`pull_request`**, if any secret is missing, the step **exits 0** and **does not run Playwright** (warning only). **Push** / merge-queue runs with secrets are the authoritative path that exercises the full gate. A green PR check is **not** proof the roundtrip ran unless secrets were present.
+
+## Stream B changes (this work)
+
+1. **API contract checks:** After each `/api/session-notes/upsert` response, assert `goal_measurements[goalId].data.metric_value` matches the saved value (initial and updated).
+2. **Stable selector:** `data-testid="session-note-edit-button"` on the session note **Edit** control; Playwright and `SessionNotesTab.measurementMutation` unit test use it instead of role-only matching.
+
+## Verification
+
+- Local (no cloud secrets): `npm run ci:check-focused` (includes e2e wiring gate), `npm run lint`, `npm run typecheck`, `npx vitest run src/components/__tests__/SessionNotesTab.measurementMutation.test.tsx`
+- With full Playwright env: `npm run playwright:session-note-measurement-roundtrip` (or chain after `playwright:schedule-blocked-close` as in CI)
+
+## Residual risk
+
+- Static guard does not prove a given PR executed Playwright; rely on merge/push runs with secrets.
+- Non-chained Supabase patterns are out of scope for this script (unchanged).

--- a/scripts/playwright-session-note-measurement-roundtrip.ts
+++ b/scripts/playwright-session-note-measurement-roundtrip.ts
@@ -46,6 +46,25 @@ const isTruthy = (value: string | undefined): boolean => /^(1|true|yes)$/i.test(
 
 const STEP_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_STEP_TIMEOUT_MS ?? "300000");
 
+/** Assert server upsert JSON includes per-goal metric_value (Session Data Collection 2.0 contract). */
+const assertUpsertResponseMetric = (
+  body: unknown,
+  goalId: string,
+  expectedMetric: number,
+  label: string,
+): void => {
+  const note = body as {
+    goal_measurements?: Record<string, { data?: { metric_value?: number | null } }> | null;
+    id?: string;
+  };
+  const val = note.goal_measurements?.[goalId]?.data?.metric_value;
+  assert.equal(
+    val,
+    expectedMetric,
+    `${label}: expected goal_measurements[${goalId}].data.metric_value=${expectedMetric}, got ${String(val)}`,
+  );
+};
+
 const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): Promise<T> => {
   console.log(`[session-note-measurement] start ${label}`);
   let rejectTimeout: (error: Error) => void = () => {};
@@ -205,6 +224,7 @@ async function run(): Promise<void> {
       }
     }
     Object.assign(ids, booked);
+    assert.ok(booked.goalId, "bookSession must return goalId for measurement roundtrip assertions");
 
     await withStepTimeout("start-session", () => startSession(activePage, token, booked, strictParityMode));
     await withStepTimeout("wait-in-progress", () => waitForSessionStatus(booked.sessionId, "in_progress"));
@@ -257,9 +277,12 @@ async function run(): Promise<void> {
       await activePage.getByRole("button", { name: /Save Session Details/i }).click();
       const res = await upsertPromise;
       assert.equal(res.ok(), true, `session-notes upsert failed: HTTP ${res.status()}`);
-      const body = (await res.json().catch(() => null)) as { id?: string } | null;
-      if (body?.id && typeof body.id === "string") {
-        savedNoteId = body.id;
+      const body = (await res.json()) as unknown;
+      assert.ok(body && typeof body === "object", "session-notes upsert must return a JSON object");
+      assertUpsertResponseMetric(body, booked.goalId, initialMetric, "save-clinical-from-schedule");
+      const noteId = (body as { id?: string }).id;
+      if (noteId && typeof noteId === "string") {
+        savedNoteId = noteId;
       }
     });
 
@@ -292,7 +315,7 @@ async function run(): Promise<void> {
       const card = savedNoteId
         ? activePage.locator(`[data-testid="session-note-card"][data-note-id="${savedNoteId}"]`)
         : activePage.getByTestId("session-note-card").first();
-      await card.getByRole("button", { name: /^Edit$/i }).click();
+      await card.getByTestId("session-note-edit-button").click();
       await activePage.getByRole("dialog").filter({ hasText: /Add Session Note/i }).waitFor({ state: "visible", timeout: 30_000 });
       const goalId = booked.goalId;
       const valueInput = activePage.locator(`#goal-measurement-value-${goalId}`);
@@ -306,6 +329,9 @@ async function run(): Promise<void> {
       await activePage.getByRole("button", { name: /Save Note/i }).click();
       const res = await upsertPromise;
       assert.equal(res.ok(), true, `edit upsert failed: HTTP ${res.status()}`);
+      const editBody = (await res.json()) as unknown;
+      assert.ok(editBody && typeof editBody === "object", "edit upsert must return a JSON object");
+      assertUpsertResponseMetric(editBody, booked.goalId, updatedMetric, "edit-via-add-session-note-modal");
       await activePage.getByLabel(/Close add session note modal/i).click().catch(() => undefined);
     });
 

--- a/src/components/ClientDetails/SessionNotesTab.tsx
+++ b/src/components/ClientDetails/SessionNotesTab.tsx
@@ -617,7 +617,8 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
                         </div>
                         
                         {!note.is_locked && (
-                          <button 
+                          <button
+                            data-testid="session-note-edit-button"
                             onClick={() => handleEditSessionNote(note)}
                             className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 text-sm"
                             type="button"

--- a/src/components/__tests__/SessionNotesTab.measurementMutation.test.tsx
+++ b/src/components/__tests__/SessionNotesTab.measurementMutation.test.tsx
@@ -117,10 +117,10 @@ describe('SessionNotesTab — edit mutation sends goal_measurements', () => {
     renderWithProviders(<SessionNotesTab client={CLIENT} />, AUTH_OPTS);
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /^Edit$/i })).toBeInTheDocument();
+      expect(screen.getByTestId('session-note-edit-button')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /^Edit$/i }));
+    fireEvent.click(screen.getByTestId('session-note-edit-button'));
     await waitFor(() => {
       expect(screen.getByTestId('stub-session-note-submit')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary (WIN-101 Stream B only)

Tightens the existing session-note measurement roundtrip Playwright script and documents CI wiring. Does not change Stream A server upsert routing.

## Changes

- Playwright: assert JSON from `/api/session-notes/upsert` includes `goal_measurements[goalId].data.metric_value` after save and edit; require `goalId` from booking; use `data-testid="session-note-edit-button"` for Edit.
- SessionNotesTab: add `data-testid="session-note-edit-button"` on Edit.
- Vitest: SessionNotesTab.measurementMutation uses the same test id.
- Doc: `docs/ai/WIN-101-stream-b-playwright-roundtrip.md` (audit, ci:playwright, PR secret skip caveat).

## Verification (local)

- npm run ci:check-focused, npm run lint, npm run typecheck
- node scripts/ci/check-e2e-reliability-gates.mjs
- npx vitest run src/components/__tests__/SessionNotesTab.measurementMutation.test.tsx

Full Playwright roundtrip not run in this environment (needs PW_* / Supabase secrets).

## Linear

WIN-101 — Stream B slice.
