### PR TITLE
fix(session-adhoc): require UUID suffix for ad-hoc session target ids

### DIFF
--- a/src/lib/__tests__/session-adhoc-targets.test.ts
+++ b/src/lib/__tests__/session-adhoc-targets.test.ts
@@ -18,6 +18,14 @@ describe('session-adhoc-targets', () => {
     expect(isValidSessionNoteGoalKey('')).toBe(false);
   });
 
+  it('rejects ad-hoc-looking ids without a UUID suffix', () => {
+    expect(isAdhocSessionTargetId('adhoc-skill-not-a-uuid')).toBe(false);
+    expect(isValidSessionNoteGoalKey('adhoc-skill-not-a-uuid')).toBe(false);
+    expect(getAdhocSessionTargetKind('adhoc-skill-not-a-uuid')).toBe(null);
+    expect(isAdhocSessionTargetId('adhoc-skill-')).toBe(false);
+    expect(isAdhocSessionTargetId('adhoc-wrong-550e8400-e29b-41d4-a716-446655440000')).toBe(false);
+  });
+
   it('detects ad-hoc ids and kind', () => {
     const id = createAdhocSessionTargetId('skill');
     expect(isAdhocSessionTargetId(id)).toBe(true);

--- a/src/lib/session-adhoc-targets.ts
+++ b/src/lib/session-adhoc-targets.ts
@@ -6,13 +6,31 @@ import {
 } from './goal-measurements';
 import { showGoalOnBxTab } from './session-goal-tracks';
 
-const ADHOC_ID_RE = /^adhoc-(skill|bx)-/i;
+/** `adhoc-skill-` / `adhoc-bx-` plus a UUID suffix (same shape as {@link createAdhocSessionTargetId}). */
+const ADHOC_SESSION_TARGET_RE = /^adhoc-(skill|bx)-(.+)$/i;
+
+const parseAdhocSessionTargetSegments = (goalId: string): { kind: 'skill' | 'bx' } | null => {
+  const t = goalId.trim();
+  const m = t.match(ADHOC_SESSION_TARGET_RE);
+  if (!m?.[1] || m[2] === undefined) {
+    return null;
+  }
+  const suffix = m[2];
+  if (!z.string().uuid().safeParse(suffix).success) {
+    return null;
+  }
+  const kindRaw = m[1].toLowerCase();
+  if (kindRaw !== 'skill' && kindRaw !== 'bx') {
+    return null;
+  }
+  return { kind: kindRaw };
+};
 
 export function isAdhocSessionTargetId(goalId: string | undefined | null): boolean {
   if (!goalId || typeof goalId !== 'string') {
     return false;
   }
-  return ADHOC_ID_RE.test(goalId.trim());
+  return parseAdhocSessionTargetSegments(goalId) !== null;
 }
 
 /** Keys allowed on `client_session_notes.goal_ids`, `goal_notes`, and `goal_measurements` maps. */
@@ -29,12 +47,7 @@ export function isValidSessionNoteGoalKey(goalId: string): boolean {
 
 /** Returns kind from id, or null if not an ad-hoc session target id. */
 export function getAdhocSessionTargetKind(goalId: string): 'skill' | 'bx' | null {
-  const m = goalId.trim().match(ADHOC_ID_RE);
-  if (!m?.[1]) {
-    return null;
-  }
-  const k = m[1].toLowerCase();
-  return k === 'skill' || k === 'bx' ? k : null;
+  return parseAdhocSessionTargetSegments(goalId)?.kind ?? null;
 }
 
 export function createAdhocSessionTargetId(kind: 'skill' | 'bx'): string {


### PR DESCRIPTION
## Summary
Tightens ad-hoc session capture id detection so ids must match \dhoc-(skill|bx)-<uuid>\, consistent with \createAdhocSessionTargetId\. \isValidSessionNoteGoalKey\ (used by session-notes upsert) rejects prefix-only strings such as \dhoc-skill-not-a-uuid\.

## Route-task (this slice)
- **classification:** low-risk autonomous
- **lane:** standard
- **triggering paths:** \src/lib/session-adhoc-targets.ts\, \src/lib/__tests__/session-adhoc-targets.test.ts\
- **linear required:** no (bounded hygiene follow-up; no Linear issue linked)

## Verification
- \
px vitest run\ — \session-adhoc-targets.test.ts\, \sessionNotesUpsertHandler.test.ts\ (pass)
- \
pm run lint\ (pass)
- \
pm run typecheck\ (pass)
- \
pm run ci:check-focused\ (pass)
- \
pm run build\ (pass)
- \
pm run verify:local\ — not run here (includes full \	est:ci\ coverage + Cypress tier0; slice validated with targeted vitest + build)

## Residual risk
Any stored legacy rows with malformed ad-hoc keys (unlikely if only UI created) would no longer validate on upsert until corrected.

Made with [Cursor](https://cursor.com)