### PR TITLE
fix(session-notes-upsert): align goal_ids with maps on write

### DIFF
--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -172,6 +172,79 @@ describe("sessionNotesUpsertHandler", () => {
     expect(payload.goal_notes).toEqual({ "44444444-4444-4444-8444-444444444444": "covered" });
   });
 
+  it("merges goal_ids from goal_notes keys omitted in goalIds and pads goals_addressed", async () => {
+    const adhocId = "adhoc-skill-550e8400-e29b-41d4-a716-446655440000";
+    const fetchJsonMock = vi.mocked(fetchJson);
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        const parsedBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+        expect(parsedBody.goal_ids).toEqual(["44444444-4444-4444-8444-444444444444", adhocId]);
+        expect(parsedBody.goal_notes).toEqual({
+          "44444444-4444-4444-8444-444444444444": "covered",
+          [adhocId]: "adhoc only",
+        });
+        expect(parsedBody.goals_addressed).toEqual(["Goal A", "Session target"]);
+        return { ok: true, status: 201, data: [{ id: "note-merge" }] };
+      }
+      if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes("id=eq.note-merge")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              ...buildSessionNoteRow("note-merge"),
+              goal_ids: ["44444444-4444-4444-8444-444444444444", adhocId],
+              goal_notes: {
+                "44444444-4444-4444-8444-444444444444": "covered",
+                [adhocId]: "adhoc only",
+              },
+              goals_addressed: ["Goal A", "Session target"],
+            },
+          ],
+        };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          goalIds: ["44444444-4444-4444-8444-444444444444"],
+          goalsAddressed: ["Goal A"],
+          goalNotes: {
+            "44444444-4444-4444-8444-444444444444": "covered",
+            [adhocId]: "adhoc only",
+          },
+          goalMeasurements: {},
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   it("creates a session note with ad-hoc goal ids alongside plan goal uuids", async () => {
     const adhocId = "adhoc-skill-550e8400-e29b-41d4-a716-446655440000";
     const fetchJsonMock = vi.mocked(fetchJson);

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { SessionGoalMeasurementEntry, SessionNote } from "../../types";
-import { normalizeGoalMeasurementEntry } from "../../lib/goal-measurements";
-import { isValidSessionNoteGoalKey } from "../../lib/session-adhoc-targets";
+import { mergeUniqueGoalIds, normalizeGoalMeasurementEntry } from "../../lib/goal-measurements";
+import { isAdhocSessionTargetId, isValidSessionNoteGoalKey } from "../../lib/session-adhoc-targets";
 import {
   corsHeadersForRequest,
   errorResponse,
@@ -132,6 +132,74 @@ const normalizeGoalMeasurements = (
     .filter((entry): entry is readonly [string, SessionGoalMeasurementEntry] => Boolean(entry));
 
   return entries.length > 0 ? Object.fromEntries(entries) : null;
+};
+
+/**
+ * Keeps `goal_ids` and `goals_addressed` aligned with trimmed `goal_notes` / normalized `goal_measurements`
+ * (same merge semantics as SessionModal / AddSessionNoteModal): any goal key present only in maps is
+ * appended to `goal_ids`, and `goals_addressed` gains stable labels for new ids.
+ */
+const alignSessionNoteGoalPayload = (input: {
+  goalIds: readonly string[];
+  goalsAddressed: readonly string[] | undefined;
+  goalNotes: Record<string, string> | null;
+  goalMeasurements: Record<string, SessionGoalMeasurementEntry> | null;
+}): {
+  goalIds: string[];
+  goalsAddressed: string[];
+  goalNotes: Record<string, string> | null;
+  goalMeasurements: Record<string, SessionGoalMeasurementEntry> | null;
+} => {
+  const notes = input.goalNotes ?? {};
+  const measurements = input.goalMeasurements ?? {};
+  const mergedGoalIds = mergeUniqueGoalIds(
+    [...input.goalIds],
+    Object.keys(notes),
+    Object.keys(measurements),
+  ).filter((id) => isValidSessionNoteGoalKey(id));
+
+  const addressedById = new Map<string, string>();
+  input.goalIds.forEach((rawId, index) => {
+    const id = rawId.trim();
+    const label = input.goalsAddressed?.[index]?.trim() ?? "";
+    if (label.length > 0) {
+      addressedById.set(id, label);
+    }
+  });
+
+  const goalsAddressed = mergedGoalIds.map((id) => {
+    const prior = addressedById.get(id);
+    if (prior && prior.length > 0) {
+      return prior;
+    }
+    if (isAdhocSessionTargetId(id)) {
+      return "Session target";
+    }
+    return id;
+  });
+
+  const goalNotes: Record<string, string> = {};
+  for (const id of mergedGoalIds) {
+    const text = notes[id]?.trim() ?? "";
+    if (text.length > 0) {
+      goalNotes[id] = text;
+    }
+  }
+
+  const goalMeasurements: Record<string, SessionGoalMeasurementEntry> = {};
+  for (const id of mergedGoalIds) {
+    const row = measurements[id];
+    if (row) {
+      goalMeasurements[id] = row;
+    }
+  }
+
+  return {
+    goalIds: mergedGoalIds,
+    goalsAddressed,
+    goalNotes: Object.keys(goalNotes).length > 0 ? goalNotes : null,
+    goalMeasurements: Object.keys(goalMeasurements).length > 0 ? goalMeasurements : null,
+  };
 };
 
 const mapRowToSessionNote = (row: SessionNoteRow): SessionNote => ({
@@ -327,6 +395,13 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
     return errorResponse(request, "conflict", "Session note is locked and cannot be edited.", { status: 409 });
   }
 
+  const alignedGoals = alignSessionNoteGoalPayload({
+    goalIds: payload.goalIds,
+    goalsAddressed: payload.goalsAddressed,
+    goalNotes: normalizedGoalNotes,
+    goalMeasurements: normalizedGoalMeasurements,
+  });
+
   const writePayload = {
     authorization_id: payload.authorizationId,
     client_id: payload.clientId,
@@ -337,10 +412,10 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
     start_time: payload.startTime,
     end_time: payload.endTime,
     session_duration: sessionDuration,
-    goals_addressed: payload.goalsAddressed ?? [],
-    goal_ids: payload.goalIds.length > 0 ? payload.goalIds : null,
-    goal_measurements: normalizedGoalMeasurements,
-    goal_notes: normalizedGoalNotes,
+    goals_addressed: alignedGoals.goalsAddressed,
+    goal_ids: alignedGoals.goalIds.length > 0 ? alignedGoals.goalIds : null,
+    goal_measurements: alignedGoals.goalMeasurements,
+    goal_notes: alignedGoals.goalNotes,
     narrative: payload.narrative.trim(),
     is_locked: payload.isLocked,
     signed_at: payload.isLocked ? new Date().toISOString() : null,


### PR DESCRIPTION
## Route-task (Workstream B)
- **classification:** high-risk human-reviewed  
- **lane:** critical  
- **triggering paths:** \src/server/api/session-notes-upsert.ts\, tests

## Summary
After trimming notes and normalizing measurements, merge \goal_ids\ with \mergeUniqueGoalIds\ using keys from both maps (matches SessionModal / AddSessionNoteModal). Extend \goals_addressed\ with \Session target\ for appended ad-hoc ids.

## Evidence
- SessionModal \handleFormSubmit\ already merges \storedGoalIds\, note keys, and measurement keys before submit; Schedule \uildClinicalNoteDraft\ reads \session_note_goal_ids\ from that payload. Server now enforces the same invariant for non-UI callers.

## Verification
- \
px vitest run src/server/__tests__/sessionNotesUpsertHandler.test.ts\ (pass)
- \
pm run lint\, \
pm run typecheck\, \
pm run build\ (pass)

## Residual
- Keys only in \goal_measurements\ without notes still require product rules elsewhere; this change does not add new narrative requirements.

Made with [Cursor](https://cursor.com)