### PR TITLE
fix(migrations): Postgres-safe goal_ids text[] conversion + repair

### DIFF
--- a/supabase/migrations/20260415143000_client_session_notes_goal_ids_text_array.sql
+++ b/supabase/migrations/20260415143000_client_session_notes_goal_ids_text_array.sql
@@ -2,22 +2,38 @@
 -- @migration-dependencies: 20260204193000_programs_goals_bank.sql
 -- @migration-rollback: Manually revert only if every goal_ids element is a UUID: cast column back to uuid[] with a vetted USING expression; ad-hoc string keys must be removed first.
 
+-- Postgres rejects subqueries directly inside ALTER COLUMN ... USING. Use a short-lived SQL helper, then drop it.
+
 begin;
+
+create or replace function public.__migration_client_session_notes_goal_ids_uuid_to_text(p_goal_ids uuid[])
+returns text[]
+language sql
+immutable
+as $function$
+  select case
+    when p_goal_ids is null then null::text[]
+    else coalesce(
+      (
+        select array_agg(u::text order by ord)
+        from unnest(p_goal_ids) with ordinality as t(u, ord)
+      ),
+      array[]::text[]
+    )
+  end;
+$function$;
 
 alter table public.client_session_notes
   alter column goal_ids drop default;
 
 alter table public.client_session_notes
   alter column goal_ids type text[]
-  using (
-    case
-      when goal_ids is null then null::text[]
-      else array(select unnest(goal_ids)::text)
-    end
-  );
+  using (public.__migration_client_session_notes_goal_ids_uuid_to_text(goal_ids));
 
 alter table public.client_session_notes
   alter column goal_ids set default '{}'::text[];
+
+drop function public.__migration_client_session_notes_goal_ids_uuid_to_text(uuid[]);
 
 comment on column public.client_session_notes.goal_ids is
   'Per-note goal keys: public.goals.id (UUID text) and/or ad-hoc session capture ids (adhoc-skill-|adhoc-bx- prefix).';

--- a/supabase/migrations/20260418100000_repair_client_session_notes_goal_ids_if_still_uuid.sql
+++ b/supabase/migrations/20260418100000_repair_client_session_notes_goal_ids_if_still_uuid.sql
@@ -1,0 +1,49 @@
+-- @migration-intent: Upgrade client_session_notes.goal_ids from uuid[] to text[] when a prior migration attempt left the column as uuid[] (invalid USING subquery on Postgres).
+-- @migration-dependencies: 20260415143000_client_session_notes_goal_ids_text_array.sql
+-- @migration-rollback: Not automated; after success the column is text[] and may already contain ad-hoc string keys.
+
+begin;
+
+do $repair$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'client_session_notes'
+      and column_name = 'goal_ids'
+      and udt_name = '_uuid'
+  ) then
+    create or replace function public.__migration_repair_csn_goal_ids_uuid_to_text(p_goal_ids uuid[])
+    returns text[]
+    language sql
+    immutable
+    as $fn$
+      select case
+        when p_goal_ids is null then null::text[]
+        else coalesce(
+          (
+            select array_agg(u::text order by ord)
+            from unnest(p_goal_ids) with ordinality as t(u, ord)
+          ),
+          array[]::text[]
+        )
+      end;
+    $fn$;
+
+    alter table public.client_session_notes
+      alter column goal_ids drop default;
+
+    alter table public.client_session_notes
+      alter column goal_ids type text[]
+      using (public.__migration_repair_csn_goal_ids_uuid_to_text(goal_ids));
+
+    alter table public.client_session_notes
+      alter column goal_ids set default '{}'::text[];
+
+    drop function public.__migration_repair_csn_goal_ids_uuid_to_text(uuid[]);
+  end if;
+end;
+$repair$;
+
+commit;


### PR DESCRIPTION
## Route-task (Workstream A)
- classification: high-risk human-reviewed
- lane: critical
- triggering paths: supabase/migrations/**

## Summary
- Replace invalid USING subquery in 20260415143000_client_session_notes_goal_ids_text_array.sql with a dropped SQL helper and ordered array_agg via unnest with ordinality.
- Add 20260418100000_repair_client_session_notes_goal_ids_if_still_uuid.sql for databases still on uuid[].

## Remote / MCP
- information_schema: goal_ids is _text on hosted project wnnjeqheqxxyrgsjmygy.
- Malformed ad-hoc goal_notes keys audit: 0 rows.
- MCP apply_migration repair_client_session_notes_goal_ids_if_still_uuid applied (no-op on current DB). Remote history may show timestamp 20260416141755 for that MCP apply; repo file 20260418100000 is the governed duplicate for supabase db push.

## Verification
- npm run ci:check-focused, npm run lint, npm run typecheck, npm run build
- npm run verify:local not run; validate:tenant not run locally

## Residual
- Hosted migration list may include 20260416060338_client_session_notes_goal_ids_text_array without a matching repo filename; align via Supabase repair if single-history parity is required.
