### PR TITLE
chore: commit client routes E2E audit artifacts (2026-04-15)

### DIFF
--- a/docs/audits/client-routes-e2e-audit-2026-04-15T03-30-10-716Z.json
+++ b/docs/audits/client-routes-e2e-audit-2026-04-15T03-30-10-716Z.json
@@ -1,0 +1,52 @@
+{
+  "target": "https://app.allincompassing.ai",
+  "timestamp": "2026-04-15T03:30:10.716Z",
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "skipped": 0,
+    "blocked": 0
+  },
+  "auth": {
+    "attempted": true,
+    "success": true
+  },
+  "routes": [
+    {
+      "route": "/schedule",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/schedule",
+      "checks": [
+        "Schedule heading is visible",
+        "Day view control is visible",
+        "Week view control is visible"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/clients",
+      "checks": [
+        "Clients heading is visible",
+        "Search clients input is visible",
+        "Found at least one client details link"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients/:clientId",
+      "status": "failed",
+      "url": "https://app.allincompassing.ai/clients/0082a5fb-faa9-4811-b122-5e55bb46938b",
+      "checks": [],
+      "errors": [
+        "locator.waitFor: Timeout 10000ms exceeded.\nCall log:\n  - waiting for getByRole('heading', { name: /client records:/i }).first() to be visible\n"
+      ],
+      "screenshotPath": "C:\\Users\\test\\Desktop\\AllIincompassing\\artifacts\\latest\\playwright-client-routes-client-details-1776223829208.png"
+    }
+  ],
+  "consoleErrors": [
+    "[ERROR] Failed to fetch profile record {scope: authContext.fetchProfile, userId: bcfba991-4c9b-48bd-8ede-086ac4c3954d}"
+  ],
+  "networkErrors": []
+}

--- a/docs/audits/client-routes-e2e-audit-2026-04-15T03-31-35-622Z.json
+++ b/docs/audits/client-routes-e2e-audit-2026-04-15T03-31-35-622Z.json
@@ -1,0 +1,52 @@
+{
+  "target": "https://app.allincompassing.ai",
+  "timestamp": "2026-04-15T03:31:35.622Z",
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "skipped": 0,
+    "blocked": 0
+  },
+  "auth": {
+    "attempted": true,
+    "success": true
+  },
+  "routes": [
+    {
+      "route": "/schedule",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/schedule",
+      "checks": [
+        "Schedule heading is visible",
+        "Day view control is visible",
+        "Week view control is visible"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/clients",
+      "checks": [
+        "Clients heading is visible",
+        "Search clients input is visible",
+        "Found at least one client details link"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients/:clientId",
+      "status": "failed",
+      "url": "https://app.allincompassing.ai/clients/0082a5fb-faa9-4811-b122-5e55bb46938b",
+      "checks": [],
+      "errors": [
+        "locator.waitFor: Timeout 10000ms exceeded.\nCall log:\n  - waiting for getByText('Client record', { exact: true }).first() to be visible\n"
+      ],
+      "screenshotPath": "C:\\Users\\test\\Desktop\\AllIincompassing\\artifacts\\latest\\playwright-client-routes-client-details-1776223914431.png"
+    }
+  ],
+  "consoleErrors": [
+    "[ERROR] Failed to fetch profile record {scope: authContext.fetchProfile, userId: bcfba991-4c9b-48bd-8ede-086ac4c3954d}"
+  ],
+  "networkErrors": []
+}

--- a/docs/audits/client-routes-e2e-audit-2026-04-15T03-32-23-535Z.json
+++ b/docs/audits/client-routes-e2e-audit-2026-04-15T03-32-23-535Z.json
@@ -1,0 +1,52 @@
+{
+  "target": "https://app.allincompassing.ai",
+  "timestamp": "2026-04-15T03:32:23.535Z",
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "skipped": 0,
+    "blocked": 0
+  },
+  "auth": {
+    "attempted": true,
+    "success": true
+  },
+  "routes": [
+    {
+      "route": "/schedule",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/schedule",
+      "checks": [
+        "Schedule heading is visible",
+        "Day view control is visible",
+        "Week view control is visible"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/clients",
+      "checks": [
+        "Clients heading is visible",
+        "Search clients input is visible",
+        "Using PW_FOREIGN_CLIENT_ID as client details target"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients/:clientId",
+      "status": "failed",
+      "url": "https://app.allincompassing.ai/clients/0a11114b-a209-4619-8299-cdfe1f929df3",
+      "checks": [],
+      "errors": [
+        "locator.waitFor: Timeout 10000ms exceeded.\nCall log:\n  - waiting for getByText('Client record', { exact: true }).first() to be visible\n"
+      ],
+      "screenshotPath": "C:\\Users\\test\\Desktop\\AllIincompassing\\artifacts\\latest\\playwright-client-routes-client-details-1776223961716.png"
+    }
+  ],
+  "consoleErrors": [
+    "[ERROR] Failed to fetch profile record {scope: authContext.fetchProfile, userId: bcfba991-4c9b-48bd-8ede-086ac4c3954d}"
+  ],
+  "networkErrors": []
+}

--- a/docs/audits/client-routes-e2e-audit-2026-04-15T03-33-33-054Z.json
+++ b/docs/audits/client-routes-e2e-audit-2026-04-15T03-33-33-054Z.json
@@ -1,0 +1,52 @@
+{
+  "target": "https://app.allincompassing.ai",
+  "timestamp": "2026-04-15T03:33:33.054Z",
+  "summary": {
+    "passed": 3,
+    "failed": 0,
+    "skipped": 0,
+    "blocked": 0
+  },
+  "auth": {
+    "attempted": true,
+    "success": true
+  },
+  "routes": [
+    {
+      "route": "/schedule",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/schedule",
+      "checks": [
+        "Schedule heading is visible",
+        "Day view control is visible",
+        "Week view control is visible"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/clients",
+      "checks": [
+        "Clients heading is visible",
+        "Search clients input is visible",
+        "Found 2 client detail link(s) on /clients"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients/:clientId",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/clients/d33c28d7-6edd-4c0c-bff1-a73c4275c031",
+      "checks": [
+        "Skipped non-owned client: /clients/0082a5fb-faa9-4811-b122-5e55bb46938b",
+        "Client record label is visible",
+        "Profile tab is visible",
+        "Session Notes tab is visible"
+      ],
+      "errors": []
+    }
+  ],
+  "consoleErrors": [],
+  "networkErrors": []
+}

--- a/reports/evidence/client-routes-e2e-audit-2026-04-15T03-30-10-716Z.json
+++ b/reports/evidence/client-routes-e2e-audit-2026-04-15T03-30-10-716Z.json
@@ -1,0 +1,52 @@
+{
+  "target": "https://app.allincompassing.ai",
+  "timestamp": "2026-04-15T03:30:10.716Z",
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "skipped": 0,
+    "blocked": 0
+  },
+  "auth": {
+    "attempted": true,
+    "success": true
+  },
+  "routes": [
+    {
+      "route": "/schedule",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/schedule",
+      "checks": [
+        "Schedule heading is visible",
+        "Day view control is visible",
+        "Week view control is visible"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/clients",
+      "checks": [
+        "Clients heading is visible",
+        "Search clients input is visible",
+        "Found at least one client details link"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients/:clientId",
+      "status": "failed",
+      "url": "https://app.allincompassing.ai/clients/0082a5fb-faa9-4811-b122-5e55bb46938b",
+      "checks": [],
+      "errors": [
+        "locator.waitFor: Timeout 10000ms exceeded.\nCall log:\n  - waiting for getByRole('heading', { name: /client records:/i }).first() to be visible\n"
+      ],
+      "screenshotPath": "C:\\Users\\test\\Desktop\\AllIincompassing\\artifacts\\latest\\playwright-client-routes-client-details-1776223829208.png"
+    }
+  ],
+  "consoleErrors": [
+    "[ERROR] Failed to fetch profile record {scope: authContext.fetchProfile, userId: bcfba991-4c9b-48bd-8ede-086ac4c3954d}"
+  ],
+  "networkErrors": []
+}

--- a/reports/evidence/client-routes-e2e-audit-2026-04-15T03-31-35-622Z.json
+++ b/reports/evidence/client-routes-e2e-audit-2026-04-15T03-31-35-622Z.json
@@ -1,0 +1,52 @@
+{
+  "target": "https://app.allincompassing.ai",
+  "timestamp": "2026-04-15T03:31:35.622Z",
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "skipped": 0,
+    "blocked": 0
+  },
+  "auth": {
+    "attempted": true,
+    "success": true
+  },
+  "routes": [
+    {
+      "route": "/schedule",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/schedule",
+      "checks": [
+        "Schedule heading is visible",
+        "Day view control is visible",
+        "Week view control is visible"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/clients",
+      "checks": [
+        "Clients heading is visible",
+        "Search clients input is visible",
+        "Found at least one client details link"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients/:clientId",
+      "status": "failed",
+      "url": "https://app.allincompassing.ai/clients/0082a5fb-faa9-4811-b122-5e55bb46938b",
+      "checks": [],
+      "errors": [
+        "locator.waitFor: Timeout 10000ms exceeded.\nCall log:\n  - waiting for getByText('Client record', { exact: true }).first() to be visible\n"
+      ],
+      "screenshotPath": "C:\\Users\\test\\Desktop\\AllIincompassing\\artifacts\\latest\\playwright-client-routes-client-details-1776223914431.png"
+    }
+  ],
+  "consoleErrors": [
+    "[ERROR] Failed to fetch profile record {scope: authContext.fetchProfile, userId: bcfba991-4c9b-48bd-8ede-086ac4c3954d}"
+  ],
+  "networkErrors": []
+}

--- a/reports/evidence/client-routes-e2e-audit-2026-04-15T03-32-23-535Z.json
+++ b/reports/evidence/client-routes-e2e-audit-2026-04-15T03-32-23-535Z.json
@@ -1,0 +1,52 @@
+{
+  "target": "https://app.allincompassing.ai",
+  "timestamp": "2026-04-15T03:32:23.535Z",
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "skipped": 0,
+    "blocked": 0
+  },
+  "auth": {
+    "attempted": true,
+    "success": true
+  },
+  "routes": [
+    {
+      "route": "/schedule",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/schedule",
+      "checks": [
+        "Schedule heading is visible",
+        "Day view control is visible",
+        "Week view control is visible"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/clients",
+      "checks": [
+        "Clients heading is visible",
+        "Search clients input is visible",
+        "Using PW_FOREIGN_CLIENT_ID as client details target"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients/:clientId",
+      "status": "failed",
+      "url": "https://app.allincompassing.ai/clients/0a11114b-a209-4619-8299-cdfe1f929df3",
+      "checks": [],
+      "errors": [
+        "locator.waitFor: Timeout 10000ms exceeded.\nCall log:\n  - waiting for getByText('Client record', { exact: true }).first() to be visible\n"
+      ],
+      "screenshotPath": "C:\\Users\\test\\Desktop\\AllIincompassing\\artifacts\\latest\\playwright-client-routes-client-details-1776223961716.png"
+    }
+  ],
+  "consoleErrors": [
+    "[ERROR] Failed to fetch profile record {scope: authContext.fetchProfile, userId: bcfba991-4c9b-48bd-8ede-086ac4c3954d}"
+  ],
+  "networkErrors": []
+}

--- a/reports/evidence/client-routes-e2e-audit-2026-04-15T03-33-33-054Z.json
+++ b/reports/evidence/client-routes-e2e-audit-2026-04-15T03-33-33-054Z.json
@@ -1,0 +1,52 @@
+{
+  "target": "https://app.allincompassing.ai",
+  "timestamp": "2026-04-15T03:33:33.054Z",
+  "summary": {
+    "passed": 3,
+    "failed": 0,
+    "skipped": 0,
+    "blocked": 0
+  },
+  "auth": {
+    "attempted": true,
+    "success": true
+  },
+  "routes": [
+    {
+      "route": "/schedule",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/schedule",
+      "checks": [
+        "Schedule heading is visible",
+        "Day view control is visible",
+        "Week view control is visible"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/clients",
+      "checks": [
+        "Clients heading is visible",
+        "Search clients input is visible",
+        "Found 2 client detail link(s) on /clients"
+      ],
+      "errors": []
+    },
+    {
+      "route": "/clients/:clientId",
+      "status": "passed",
+      "url": "https://app.allincompassing.ai/clients/d33c28d7-6edd-4c0c-bff1-a73c4275c031",
+      "checks": [
+        "Skipped non-owned client: /clients/0082a5fb-faa9-4811-b122-5e55bb46938b",
+        "Client record label is visible",
+        "Profile tab is visible",
+        "Session Notes tab is visible"
+      ],
+      "errors": []
+    }
+  ],
+  "consoleErrors": [],
+  "networkErrors": []
+}


### PR DESCRIPTION
## Summary

Adds **four** client-routes E2E audit runs from **2026-04-15** (paired copies under `docs/audits/` and `reports/evidence/`).

No application code or config changes — artifact-only for traceability and report cross-reference.

## Verification

- `npm run ci:check-focused` (pre-commit hook)
