### PR TITLE
feat(schedule): mobile session capture accordions and trial +5

### DIFF
--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -926,6 +926,13 @@ export function SessionModal({
     [goalIds, sessionNoteGoalMeasurements, sessionNoteGoalNotes, sessionNoteStoredGoalIds],
   );
   const [sessionCaptureTab, setSessionCaptureTab] = useState<'skill' | 'bx'>('skill');
+  const [isSessionCaptureNarrow, setIsSessionCaptureNarrow] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    return window.matchMedia?.('(max-width: 639px)')?.matches ?? false;
+  });
+  const [mobileCaptureOpenGoalId, setMobileCaptureOpenGoalId] = useState<string | null>(null);
 
   const sessionCaptureGoalIdsForTab = useMemo(() => {
     if (sessionCaptureTab === 'skill') {
@@ -1009,6 +1016,33 @@ export function SessionModal({
     },
     [getValues, setValue],
   );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+    const media = window.matchMedia('(max-width: 639px)');
+    const syncNarrow = () => {
+      setIsSessionCaptureNarrow(media.matches);
+    };
+    syncNarrow();
+    media.addEventListener('change', syncNarrow);
+    return () => media.removeEventListener('change', syncNarrow);
+  }, []);
+
+  useEffect(() => {
+    if (!isSessionCaptureNarrow) {
+      return;
+    }
+    const ids = sessionCaptureGoalIdsForTab;
+    if (ids.length === 0) {
+      setMobileCaptureOpenGoalId(null);
+      return;
+    }
+    setMobileCaptureOpenGoalId((current) =>
+      current != null && ids.includes(current) ? current : ids[0] ?? null,
+    );
+  }, [isSessionCaptureNarrow, sessionCaptureGoalIdsForTab]);
 
   const saveStateMessage = useMemo(() => {
     if (isSubmitting) {
@@ -1908,12 +1942,55 @@ export function SessionModal({
                             typeof incorrectWatch === 'number' && Number.isFinite(incorrectWatch)
                               ? incorrectWatch
                               : Number(incorrectWatch) || 0;
+                          const mobileGoalSummaryLabel = isAdhocSessionTargetId(selectedGoalId)
+                            ? (storedTitle.trim() ? storedTitle : 'Ad-hoc target')
+                            : (selectedGoal?.title ?? selectedGoalId);
+                          const captureDetailsOpen =
+                            !isSessionCaptureNarrow || mobileCaptureOpenGoalId === selectedGoalId;
                           return (
-                            <div
+                            <details
                               key={selectedGoalId}
-                              className="rounded-lg border border-indigo-100 bg-white/80 p-3 dark:border-indigo-900/40 dark:bg-dark-lighter/40"
+                              open={captureDetailsOpen}
+                              onToggle={(event) => {
+                                if (!isSessionCaptureNarrow) {
+                                  return;
+                                }
+                                setMobileCaptureOpenGoalId(
+                                  event.currentTarget.open ? selectedGoalId : null,
+                                );
+                              }}
+                              className="group rounded-lg border border-indigo-100 bg-white/80 p-3 dark:border-indigo-900/40 dark:bg-dark-lighter/40"
+                              data-testid={`session-modal-goal-capture-${selectedGoalId}`}
                             >
-                              <div className="flex items-start justify-between gap-2">
+                              <summary className="mb-0 flex cursor-pointer list-none items-center gap-2 rounded-md px-0.5 py-1 sm:hidden [&::-webkit-details-marker]:hidden">
+                                <div className="min-w-0 flex-1">
+                                  <p className="truncate text-left text-xs font-semibold uppercase tracking-wide text-indigo-800 dark:text-indigo-200">
+                                    {mobileGoalSummaryLabel}
+                                  </p>
+                                  <p className="mt-0.5 text-left text-[11px] tabular-nums text-gray-600 dark:text-gray-400">
+                                    Trials +{correctDisplay} · −{incorrectDisplay}
+                                  </p>
+                                </div>
+                                {isAdhocSessionTargetId(selectedGoalId) ? (
+                                  <button
+                                    type="button"
+                                    onClick={(event) => {
+                                      event.preventDefault();
+                                      event.stopPropagation();
+                                      removeAdhocSessionTarget(selectedGoalId);
+                                    }}
+                                    className="shrink-0 rounded-full p-2 text-indigo-700 hover:bg-indigo-100 dark:text-indigo-200 dark:hover:bg-indigo-900/40"
+                                    aria-label="Remove ad-hoc target"
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </button>
+                                ) : null}
+                                <ChevronDown
+                                  className="h-4 w-4 shrink-0 text-indigo-700 transition-transform group-open:rotate-180 dark:text-indigo-200"
+                                  aria-hidden
+                                />
+                              </summary>
+                              <div className="hidden sm:flex sm:items-start sm:justify-between sm:gap-2">
                                 {isAdhocSessionTargetId(selectedGoalId) ? (
                                   <div className="min-w-0 flex-1">
                                     <label
@@ -1949,9 +2026,29 @@ export function SessionModal({
                                   </button>
                                 )}
                               </div>
+                              {isAdhocSessionTargetId(selectedGoalId) ? (
+                                <div className="mt-3 sm:hidden">
+                                  <label
+                                    htmlFor={`adhoc-title-mobile-${selectedGoalId}`}
+                                    className="block text-[11px] font-medium uppercase tracking-wide text-indigo-800 dark:text-indigo-200"
+                                  >
+                                    Target title
+                                  </label>
+                                  <input
+                                    id={`adhoc-title-mobile-${selectedGoalId}`}
+                                    value={storedTitle}
+                                    onChange={(event) =>
+                                      updateStoredGoalLabelAtId(selectedGoalId, event.target.value)
+                                    }
+                                    className="mt-1 w-full rounded-md border border-indigo-200 bg-white px-2 py-1.5 text-sm font-semibold text-indigo-900 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-indigo-800 dark:bg-dark dark:text-indigo-100"
+                                    placeholder="Name this target"
+                                    autoComplete="off"
+                                  />
+                                </div>
+                              ) : null}
                               <label
                                 htmlFor={`goal-note-${selectedGoalId}`}
-                                className="mt-2 block text-xs font-medium text-gray-600 dark:text-gray-300"
+                                className="mt-3 block text-xs font-medium text-gray-600 dark:text-gray-300 sm:mt-2"
                               >
                                 Per-goal note
                               </label>
@@ -2006,7 +2103,7 @@ export function SessionModal({
                                   </p>
                                 )}
                                 <div className="mt-3 flex flex-wrap items-center gap-3">
-                                  <div className="flex items-center gap-2">
+                                  <div className="flex flex-wrap items-center gap-2">
                                     <span className="text-xs font-medium text-gray-700 dark:text-gray-300">+</span>
                                     <button
                                       type="button"
@@ -2027,8 +2124,25 @@ export function SessionModal({
                                     >
                                       −
                                     </button>
+                                    <button
+                                      type="button"
+                                      aria-label="Add 5 correct trials"
+                                      className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
+                                      onClick={() => bumpTrialCount(selectedGoalId, 'metric_value', 5)}
+                                    >
+                                      +5
+                                    </button>
+                                    <button
+                                      type="button"
+                                      aria-label="Subtract 5 correct trials"
+                                      disabled={correctDisplay < 5}
+                                      className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
+                                      onClick={() => bumpTrialCount(selectedGoalId, 'metric_value', -5)}
+                                    >
+                                      −5
+                                    </button>
                                   </div>
-                                  <div className="flex items-center gap-2">
+                                  <div className="flex flex-wrap items-center gap-2">
                                     <span className="text-xs font-medium text-gray-700 dark:text-gray-300">−</span>
                                     <button
                                       type="button"
@@ -2048,6 +2162,23 @@ export function SessionModal({
                                       onClick={() => bumpTrialCount(selectedGoalId, 'incorrect_trials', -1)}
                                     >
                                       −
+                                    </button>
+                                    <button
+                                      type="button"
+                                      aria-label="Add 5 incorrect or no-response trials"
+                                      className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
+                                      onClick={() => bumpTrialCount(selectedGoalId, 'incorrect_trials', 5)}
+                                    >
+                                      +5
+                                    </button>
+                                    <button
+                                      type="button"
+                                      aria-label="Subtract 5 incorrect trials"
+                                      disabled={incorrectDisplay < 5}
+                                      className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
+                                      onClick={() => bumpTrialCount(selectedGoalId, 'incorrect_trials', -5)}
+                                    >
+                                      −5
                                     </button>
                                   </div>
                                 </div>
@@ -2081,7 +2212,7 @@ export function SessionModal({
                                   placeholder="Record prompts used and client reactions for these trials..."
                                 />
                               </div>
-                            </div>
+                            </details>
                           );
                         })}
                       </div>

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1009,6 +1009,113 @@ describe('SessionModal', () => {
     });
   }, 10000);
 
+  it('includes +5 trial shortcut in saved correct counts', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const buildChain = (rows: unknown[]) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals);
+      }
+      if (table === 'authorizations') {
+        return buildChain([
+          {
+            id: 'auth-1',
+            authorization_number: 'AUTH-001',
+            services: [{ service_code: '97153' }],
+          },
+        ]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-trial-plus-five',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    await screen.findByRole('button', { name: /Add 5 correct trials/i });
+    fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
+      target: { value: 'Bundled trials' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /Add 5 correct trials/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Increase correct trials/i }));
+
+    await userEvent.click(screen.getByRole('button', { name: /Save Session Details/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          session_note_goal_measurements: {
+            'goal-1': {
+              version: 1,
+              data: expect.objectContaining({
+                metric_value: 6,
+              }),
+            },
+          },
+        }),
+      );
+    });
+  }, 10000);
+
+  it('disables subtract-5 correct trials when count is under five', async () => {
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        session={{
+          id: 'session-trial-minus-five-disabled',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    await screen.findByRole('button', { name: /Subtract 5 correct trials/i });
+    expect(screen.getByRole('button', { name: /Subtract 5 correct trials/i })).toBeDisabled();
+  });
+
   it('normalizes linked legacy goal_measurements payloads on save', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const linkedSessionNote = {


### PR DESCRIPTION
Follow-up UX for in-progress session capture.

- On viewports under 640px, each goal uses a native details/summary row (title, trial totals, chevron) so long multi-goal sessions stay scannable. sm and up keeps the prior always-expanded card layout.
- Ad-hoc targets show remove in the mobile summary with stopPropagation; title field appears inside the expanded panel on small screens only (separate id from desktop).
- Trial rows gain +5 and subtract-5 controls for both correct and incorrect counts; subtract-5 disables when the count is under five.

Verification: npm test (SessionModal.test.tsx), npm run typecheck, npm run lint, npm run build.

Made with [Cursor](https://cursor.com)