### PR TITLE
feat(schedule): polish live session modal UX

### DIFF
--- a/scripts/lib/playwright-inprogress-session-setup.ts
+++ b/scripts/lib/playwright-inprogress-session-setup.ts
@@ -356,7 +356,9 @@ async function openSessionModal(page: Page) {
     browserGlobal.dispatchEvent(new browserGlobal.CustomEvent("openScheduleModal", { detail: { start_time: now.toISOString() } }));
   });
   await page
-    .locator('[role="dialog"]:has-text("New Session"), [role="dialog"]:has-text("Edit Session")')
+    .locator(
+      '[role="dialog"]:has-text("New Session"), [role="dialog"]:has-text("Edit Session"), [role="dialog"]:has-text("Live session")',
+    )
     .first()
     .waitFor({ state: "visible", timeout: 10_000 });
 }

--- a/scripts/playwright-schedule-blocked-close.ts
+++ b/scripts/playwright-schedule-blocked-close.ts
@@ -325,7 +325,9 @@ async function run(): Promise<void> {
     await withStepTimeout("open-edit-modal-via-url", async () => {
       await activePage.goto(editUrl, { waitUntil: "domcontentloaded", timeout: 90_000 });
       await activePage.waitForLoadState("networkidle").catch(() => undefined);
-      await activePage.getByRole("dialog", { name: /edit session/i }).waitFor({ state: "visible", timeout: 60_000 });
+      await activePage
+        .getByRole("dialog", { name: /edit session|live session/i })
+        .waitFor({ state: "visible", timeout: 60_000 });
       await activePage
         .locator('[role="dialog"][data-session-status="in_progress"]')
         .waitFor({ state: "visible", timeout: 90_000 });
@@ -376,7 +378,7 @@ async function run(): Promise<void> {
     });
 
     await withStepTimeout("attempt-terminal-close-and-assert-guidance", async () => {
-      const editDialog = activePage.getByRole("dialog", { name: /edit session/i });
+      const editDialog = activePage.getByRole("dialog", { name: /edit session|live session/i });
       await editDialog.waitFor({ state: "visible", timeout: 15_000 });
 
       const statusBefore = await activePage.locator("#status-select").inputValue();
@@ -448,7 +450,7 @@ async function run(): Promise<void> {
       if (outcome.kind === "none") {
         const dialogVisible = await editDialog.isVisible().catch(() => false);
         throw new Error(
-          `No blocked-close UI after Update Session. editDialogVisible=${dialogVisible} url=${activePage.url()}`,
+          `No blocked-close UI after session submit. editDialogVisible=${dialogVisible} url=${activePage.url()}`,
         );
       }
 

--- a/scripts/playwright-schedule-conflict.ts
+++ b/scripts/playwright-schedule-conflict.ts
@@ -103,7 +103,9 @@ async function openSessionModal(page: Page) {
     const detail = { start_time: now.toISOString() };
     window.dispatchEvent(new CustomEvent('openScheduleModal', { detail }));
   });
-  const modal = page.locator('[role="dialog"]:has-text("New Session"), [role="dialog"]:has-text("Edit Session")');
+  const modal = page.locator(
+    '[role="dialog"]:has-text("New Session"), [role="dialog"]:has-text("Edit Session"), [role="dialog"]:has-text("Live session")',
+  );
   await modal.waitFor({ state: 'visible', timeout: 5000 });
 }
 

--- a/scripts/playwright-session-capture-adhoc-upsert.ts
+++ b/scripts/playwright-session-capture-adhoc-upsert.ts
@@ -1,5 +1,5 @@
 /**
- * Proves Schedule > Edit Session (in progress) can save ad-hoc session capture rows:
+ * Proves Schedule > Live session (in progress) can save ad-hoc session capture rows:
  * POST /api/session-notes/upsert succeeds and returns goal_notes keys matching adhoc-skill-*.
  *
  * Requires the same Playwright env contract as other non-AI session scripts (see playwright-preflight).
@@ -79,7 +79,7 @@ const openEditSessionModalFromUrl = async (page: Page, scheduleUrl: string, sess
       waitUntil: "networkidle",
       timeout: 60000,
     });
-    const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session/i });
+    const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
     try {
       await dialog.waitFor({ state: "visible", timeout: 12_000 });
       return;
@@ -87,7 +87,7 @@ const openEditSessionModalFromUrl = async (page: Page, scheduleUrl: string, sess
       await page.waitForTimeout(500 + attempt * 250);
     }
   }
-  throw new Error("Edit Session modal did not open from schedule deep link.");
+  throw new Error("Session modal (Edit Session / Live session) did not open from schedule deep link.");
 }
 
 async function waitForSessionStatus(sessionId: string, status: string, timeoutMs = 120_000): Promise<void> {
@@ -214,7 +214,7 @@ async function run(): Promise<void> {
 
     await withStepTimeout("open-modal-and-save-adhoc-capture", async () => {
       await openEditSessionModalFromUrl(activePage, scheduleUrl, booked.sessionId);
-      const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session/i });
+      const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
       const capture = editDialog.getByTestId("session-modal-capture-section");
       await capture.waitFor({ state: "visible", timeout: 30_000 });
 
@@ -230,7 +230,7 @@ async function run(): Promise<void> {
         (res) => res.url().includes("/api/session-notes/upsert") && res.request().method() === "POST",
         { timeout: 120_000 },
       );
-      await activePage.getByRole("button", { name: /Save Session Details/i }).click();
+      await activePage.getByRole("button", { name: /Save progress/i }).click();
       const res = await upsertPromise;
       assert.equal(res.ok(), true, `session-notes upsert failed: HTTP ${res.status()}`);
       const body = (await res.json()) as {

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -345,7 +345,7 @@ const openEditSessionModalFromUrl = async (page: Page, scheduleUrl: string, sess
       waitUntil: "networkidle",
       timeout: 60000,
     });
-    const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session/i });
+    const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
     try {
       await dialog.waitFor({ state: "visible", timeout: 12_000 });
       return;
@@ -354,7 +354,7 @@ const openEditSessionModalFromUrl = async (page: Page, scheduleUrl: string, sess
     }
   }
   throw new Error(
-    "Edit Session modal did not open from schedule deep link; session may not be loaded in schedule data yet.",
+    "Session modal (Edit Session / Live session) did not open from schedule deep link; session may not be loaded in schedule data yet.",
   );
 };
 
@@ -369,7 +369,9 @@ async function openSessionModal(page: Page) {
     browserGlobal.dispatchEvent(new browserGlobal.CustomEvent("openScheduleModal", { detail: { start_time: now.toISOString() } }));
   });
   await page
-    .locator('[role="dialog"]:has-text("New Session"), [role="dialog"]:has-text("Edit Session")')
+    .locator(
+      '[role="dialog"]:has-text("New Session"), [role="dialog"]:has-text("Edit Session"), [role="dialog"]:has-text("Live session")',
+    )
     .first()
     .waitFor({ state: "visible", timeout: 10_000 });
 }
@@ -688,7 +690,7 @@ async function startSessionViaScheduleModal(
   const startButton = page.getByRole("button", { name: /^Start Session$/i });
   await startButton.waitFor({ state: "visible", timeout: 20_000 });
   await expectStartButtonEnabled(page, startButton);
-  const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session/i });
+  const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
 
   let uiEmittedStart = false;
   try {
@@ -729,7 +731,7 @@ async function markTerminalViaScheduleModal(
   strictMode: boolean,
 ): Promise<void> {
   await openEditSessionModalFromUrl(page, scheduleUrl, sessionId);
-  const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session/i });
+  const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
   await page.locator("#status-select").selectOption(terminalStatus);
   page.once("dialog", (dialog) => {
     void dialog.accept();

--- a/scripts/playwright-session-note-measurement-roundtrip.ts
+++ b/scripts/playwright-session-note-measurement-roundtrip.ts
@@ -99,7 +99,7 @@ const openEditSessionModalFromUrl = async (page: Page, scheduleUrl: string, sess
       waitUntil: "networkidle",
       timeout: 60000,
     });
-    const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session/i });
+    const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
     try {
       await dialog.waitFor({ state: "visible", timeout: 12_000 });
       return;
@@ -107,7 +107,7 @@ const openEditSessionModalFromUrl = async (page: Page, scheduleUrl: string, sess
       await page.waitForTimeout(500 + attempt * 250);
     }
   }
-  throw new Error("Edit Session modal did not open from schedule deep link.");
+  throw new Error("Session modal (Edit Session / Live session) did not open from schedule deep link.");
 };
 
 async function waitForSessionStatus(sessionId: string, status: string, timeoutMs = 120_000): Promise<void> {
@@ -237,7 +237,7 @@ async function run(): Promise<void> {
 
     await withStepTimeout("open-session-modal-clinical", async () => {
       await openEditSessionModalFromUrl(activePage, scheduleUrl, booked.sessionId);
-      const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session/i });
+      const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
       await editDialog.getByRole("button", { name: /Show details/i }).click();
       await activePage.locator("#session-note-auth-select").waitFor({ state: "visible", timeout: 20_000 });
       const authSelect = activePage.locator("#session-note-auth-select");
@@ -274,7 +274,7 @@ async function run(): Promise<void> {
         (res) => res.url().includes("/api/session-notes/upsert") && res.request().method() === "POST",
         { timeout: 120_000 },
       );
-      await activePage.getByRole("button", { name: /Save Session Details/i }).click();
+      await activePage.getByRole("button", { name: /Save progress/i }).click();
       const res = await upsertPromise;
       assert.equal(res.ok(), true, `session-notes upsert failed: HTTP ${res.status()}`);
       const body = (await res.json()) as unknown;

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -129,6 +129,7 @@ export function SessionModal({
   const [isLoadingAlternatives, setIsLoadingAlternatives] = useState(false);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
+  const sessionCaptureSectionRef = useRef<HTMLElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const previousActiveElementRef = useRef<HTMLElement | null>(null);
   const previousClientIdRef = useRef<string | null>(null);
@@ -915,7 +916,34 @@ export function SessionModal({
     !hasTerminalSessionStatus &&
     (session?.status === 'in_progress' || hasStartedSession);
   const isDependentDataLoading = (Boolean(clientId) && isProgramsFetching) || (Boolean(programId) && isGoalsFetching);
-  const canStartSession = Boolean(session?.id && !hasStartedSession && programId && goalId);
+  const canStartSession = Boolean(
+    session?.id &&
+      !hasStartedSession &&
+      session?.status !== 'in_progress' &&
+      programId &&
+      goalId,
+  );
+  const sessionModalMode = useMemo(() => {
+    if (!session) {
+      return 'create';
+    }
+    return isInProgressSession ? 'live' : 'edit';
+  }, [session, isInProgressSession]);
+  const modalTitle = useMemo(() => {
+    if (!session) {
+      return 'New Session';
+    }
+    return isInProgressSession ? 'Live session' : 'Edit Session';
+  }, [session, isInProgressSession]);
+  const modalSubtitle = useMemo(() => {
+    if (!session) {
+      return 'Choose therapist, client, time, and plan details before creating this appointment.';
+    }
+    if (isInProgressSession) {
+      return 'Log trials and per-goal notes, then save to sync. Use Close session when the visit ends.';
+    }
+    return 'Review core details first, then add notes before saving.';
+  }, [session, isInProgressSession]);
   const sessionNoteGoalIds = useMemo(
     () => mergeUniqueGoalIds(
       Array.isArray(goalIds) ? goalIds : [],
@@ -1158,6 +1186,23 @@ export function SessionModal({
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen || !isInProgressSession) {
+      return;
+    }
+    setIsPlanSummaryExpanded(false);
+  }, [isOpen, isInProgressSession, session?.id]);
+
+  useEffect(() => {
+    if (!isOpen || !isInProgressSession) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      sessionCaptureSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [isOpen, isInProgressSession, session?.id]);
+
   if (!isOpen) return null;
 
   return (
@@ -1179,6 +1224,7 @@ export function SessionModal({
         aria-labelledby={dialogTitleId}
         aria-describedby={dialogDescriptionIds}
         data-session-status={session?.status ?? ""}
+        data-session-modal-mode={sessionModalMode}
         tabIndex={-1}
       >
         {/* Header */}
@@ -1193,10 +1239,10 @@ export function SessionModal({
                 className="mt-1 flex items-center text-lg font-semibold text-gray-900 dark:text-white sm:text-xl"
               >
                 <Calendar className="mr-2 h-5 w-5 text-blue-600 sm:h-6 sm:w-6" />
-                {session ? 'Edit Session' : 'New Session'}
+                {modalTitle}
               </h2>
               <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                Review core details first, then add notes before saving.
+                {modalSubtitle}
               </p>
             </div>
           <button
@@ -1312,8 +1358,7 @@ export function SessionModal({
               >
                 <p className="font-medium">Session in progress</p>
                 <p className="mt-1">
-                  You can update program, primary goal, and additional goals while this session is active.
-                  Save session details to keep this plan in sync.
+                  You can adjust program and goals while active; save to keep the plan in sync with the schedule.
                 </p>
               </div>
             )}
@@ -1791,6 +1836,7 @@ export function SessionModal({
 
             {session?.id && (
               <section
+                ref={sessionCaptureSectionRef}
                 className="rounded-xl border border-indigo-200 bg-indigo-50/70 p-4 space-y-4 dark:border-indigo-900/40 dark:bg-indigo-900/10"
                 data-testid="session-modal-capture-section"
               >
@@ -1798,10 +1844,18 @@ export function SessionModal({
                   <div className="min-w-0">
                     <p className="text-sm font-semibold text-indigo-900 dark:text-indigo-200">Session capture</p>
                     <p className="mt-1 text-xs text-indigo-700 dark:text-indigo-300">
-                      Per-goal notes and trial data save with the session. Billing uses the first approved authorization
-                      on file when defaults exist. Full narrative and signatures are completed in Client Details.
-                      Ad-hoc skill and behavior rows are stored on the session note.
+                      Per-goal notes and trial counts save with this session. Ad-hoc skill and behavior rows live on the
+                      session note.
                     </p>
+                    <details className="mt-2 text-xs text-indigo-700 dark:text-indigo-300">
+                      <summary className="cursor-pointer font-semibold text-indigo-800 hover:underline dark:text-indigo-200">
+                        Billing, authorization, and full narratives
+                      </summary>
+                      <p className="mt-2 leading-snug">
+                        Billing uses the first approved authorization on file when defaults exist. Full narrative,
+                        signatures, and additional measurement fields are completed in Client Details.
+                      </p>
+                    </details>
                   </div>
                   <div className="flex flex-shrink-0 flex-wrap justify-end gap-2">
                     <button
@@ -2095,21 +2149,21 @@ export function SessionModal({
 
         {/* Footer */}
         <div className="sticky bottom-0 z-10 border-t border-gray-200/80 bg-white/90 px-4 py-2 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] backdrop-blur-md dark:border-gray-700 dark:bg-dark-lighter/90 sm:px-5 sm:py-4 sm:pb-4">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
-            <div className="flex flex-wrap items-center justify-center gap-x-1 gap-y-1 sm:flex sm:flex-wrap sm:justify-end sm:gap-2">
-            <button
-              type="button"
-              onClick={handleAttemptClose}
-              disabled={isSubmitting}
-              className="min-h-11 shrink-0 rounded-full px-4 text-sm font-medium text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800 sm:min-h-11 sm:w-auto sm:rounded-md sm:border sm:border-gray-300 sm:bg-white sm:px-4 sm:text-gray-700 sm:shadow-sm sm:hover:bg-gray-50"
+          <div className="flex flex-col gap-3">
+            <div
+              role="group"
+              aria-label="Session actions"
+              className="flex flex-wrap items-center justify-center gap-2 border-b border-gray-200/70 pb-2 dark:border-gray-700/80 sm:justify-end sm:border-0 sm:pb-0"
             >
-              Cancel
-            </button>
-            {session?.id && (
-              <>
-                <span className="hidden text-gray-300 dark:text-gray-600 max-sm:inline" aria-hidden>
-                  ·
-                </span>
+              <button
+                type="button"
+                onClick={handleAttemptClose}
+                disabled={isSubmitting}
+                className="min-h-11 shrink-0 rounded-full px-4 text-sm font-medium text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800 sm:min-h-11 sm:w-auto sm:rounded-md sm:border sm:border-gray-300 sm:bg-white sm:px-4 sm:text-gray-700 sm:shadow-sm sm:hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              {session?.id && session.status === 'scheduled' && !hasStartedSession ? (
                 <button
                   type="button"
                   onClick={handleStartSession}
@@ -2118,13 +2172,8 @@ export function SessionModal({
                 >
                   Start Session
                 </button>
-              </>
-            )}
-            {session?.id && isInProgressSession && (
-              <>
-                <span className="hidden text-gray-300 dark:text-gray-600 max-sm:inline" aria-hidden>
-                  ·
-                </span>
+              ) : null}
+              {session?.id && isInProgressSession ? (
                 <button
                   type="button"
                   onClick={handleCloseSession}
@@ -2133,29 +2182,30 @@ export function SessionModal({
                 >
                   Close Session
                 </button>
-              </>
-            )}
+              ) : null}
             </div>
-            <button
-              type="submit"
-              form="session-form"
-              disabled={isSubmitting || isDependentDataLoading || isLoadingAlternatives}
-              className="flex min-h-12 w-full items-center justify-center rounded-xl border border-transparent bg-blue-600 px-4 py-2.5 text-base font-semibold text-white shadow-lg shadow-blue-600/25 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-11 sm:w-auto sm:min-w-[12rem] sm:rounded-md sm:py-2 sm:text-sm sm:font-medium sm:shadow-sm sm:shadow-none max-sm:mt-0.5"
-            >
-              {isSubmitting ? (
-                <>
-                  <div className="animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent mr-2" />
-                  Saving...
-                </>
-              ) : (
-                <>
-                  <CheckCircle2 className="w-4 h-4 mr-2" />
-                  {session
-                    ? (isInProgressSession ? 'Save Session Details' : 'Update Session')
-                    : 'Create Session'}
-                </>
-              )}
-            </button>
+            <div className="flex justify-center sm:justify-end">
+              <button
+                type="submit"
+                form="session-form"
+                disabled={isSubmitting || isDependentDataLoading || isLoadingAlternatives}
+                className="flex min-h-12 w-full items-center justify-center rounded-xl border border-transparent bg-blue-600 px-4 py-2.5 text-base font-semibold text-white shadow-lg shadow-blue-600/25 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-11 sm:w-auto sm:min-w-[12rem] sm:rounded-md sm:py-2 sm:text-sm sm:font-medium sm:shadow-sm sm:shadow-none"
+              >
+                {isSubmitting ? (
+                  <>
+                    <div className="animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent mr-2" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <CheckCircle2 className="w-4 h-4 mr-2" />
+                    {session
+                      ? (isInProgressSession ? 'Save progress' : 'Update Session')
+                      : 'Create Session'}
+                  </>
+                )}
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1076,7 +1076,7 @@ describe('SessionModal', () => {
     await userEvent.click(screen.getByRole('button', { name: /Add 5 correct trials/i }));
     await userEvent.click(screen.getByRole('button', { name: /Increase correct trials/i }));
 
-    await userEvent.click(screen.getByRole('button', { name: /Save Session Details/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -122,6 +122,7 @@ describe('SessionModal', () => {
     renderWithProviders(<SessionModal {...defaultProps} />);
     expect(screen.getByText(/New Session/)).toBeInTheDocument();
     const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('data-session-modal-mode', 'create');
     expect(dialog).toHaveAttribute('aria-labelledby', 'session-modal-title');
     expect(dialog).toHaveAttribute('aria-describedby', 'session-modal-description');
     expect(screen.queryByRole('region', { name: /Session not saved/i })).not.toBeInTheDocument();
@@ -383,7 +384,7 @@ describe('SessionModal', () => {
     outsideButton.remove();
   });
 
-  it('disables start session when authoritative details already show started_at', async () => {
+  it('hides start session when authoritative details already show started_at', async () => {
     const buildChain = (rows: unknown[], singleRow: unknown = null) => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
@@ -437,13 +438,14 @@ describe('SessionModal', () => {
       />
     );
 
-    const startButton = await screen.findByRole('button', { name: /Start Session/i });
     await waitFor(() => {
-      expect(startButton).toBeDisabled();
+      expect(screen.queryByRole('button', { name: /Start Session/i })).not.toBeInTheDocument();
     });
+    expect(screen.getByText('Live session')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-session-modal-mode', 'live');
     expect(screen.getByTestId('session-modal-in-progress-guidance')).toBeInTheDocument();
     expect(screen.getByTestId('session-modal-notes-guidance')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Save Session Details/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Save progress/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^Close Session$/i })).toBeInTheDocument();
   });
 
@@ -917,6 +919,9 @@ describe('SessionModal', () => {
     );
 
     expect(screen.getByTestId('session-modal-capture-section')).toBeInTheDocument();
+    expect(screen.getByText('Live session')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-session-modal-mode', 'live');
+    expect(screen.queryByRole('button', { name: /Start Session/i })).not.toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /^Skill$/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /^BX$/i })).toBeInTheDocument();
   });
@@ -987,7 +992,7 @@ describe('SessionModal', () => {
       target: { value: 'Needed one reminder at the start' },
     });
 
-    await userEvent.click(screen.getByRole('button', { name: /Save Session Details/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
@@ -1116,7 +1121,7 @@ describe('SessionModal', () => {
       expect(screen.getByDisplayValue('Observed steady progress')).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByRole('button', { name: /Save Session Details/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
@@ -1252,7 +1257,7 @@ describe('SessionModal', () => {
       expect(screen.getByDisplayValue('Maintained prior skill with faded prompts')).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByRole('button', { name: /Save Session Details/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
@@ -1344,7 +1349,7 @@ describe('SessionModal', () => {
     fireEvent.change(await screen.findByLabelText(/^Per-goal note$/i), {
       target: { value: 'Progress details' },
     });
-    await userEvent.click(screen.getByRole('button', { name: /Save Session Details/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
 
     expect(onSubmit).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
- Mode-first titles: Live session vs Edit/New; subtitles and data-session-modal-mode.
- Hide Start Session unless status is scheduled and not started; tighten canStartSession.
- Footer: group Cancel/Start/Close vs full-width Save progress; remove disabled Start clutter.
- Collapse plan summary and smooth-scroll to session capture when opening a live session.
- Shorten in-progress banner; move billing/narrative copy into a details disclosure.
- Align Playwright locators and in-progress save button label with the new UI.

Made-with: Cursor