### PR TITLE
feat(session-notes): partial capture merge for live Skill/BX saves

### DIFF
--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -66,6 +66,8 @@ export interface SessionModalClinicalNotesPayload {
   session_note_goals_addressed?: string[];
   session_note_authorization_id?: string;
   session_note_service_code?: string;
+  /** When set, POST /api/session-notes/upsert merges only these goal keys from this payload (server-authoritative). */
+  session_note_capture_merge_goal_ids?: string[];
 }
 
 export type SessionModalSubmitData = Partial<Session> & SessionModalClinicalNotesPayload;
@@ -681,7 +683,10 @@ export function SessionModal({
     resolvedTimeZone,
   ]);
 
-  const handleFormSubmit = async (data: SessionModalFormValues) => {
+  const handleFormSubmit = async (
+    data: SessionModalFormValues,
+    options?: { captureMergeGoalIds?: string[] },
+  ) => {
     if (conflicts.length > 0) {
       if (!window.confirm('There are scheduling conflicts. Do you want to proceed anyway?')) {
         return;
@@ -756,16 +761,31 @@ export function SessionModal({
         working.session_note_authorization_id?.trim() || firstApprovedAuth?.id || '';
       const resolvedServiceCode =
         working.session_note_service_code?.trim() || firstDefaultServiceCode;
-      const hasCaptureInputFromSubmit =
-        Object.values(working.session_note_goal_notes ?? {}).some(
-          (value) => typeof value === 'string' && value.trim().length > 0,
-        ) ||
-        Object.entries(working.session_note_goal_measurements ?? {}).some(([goalKey, rawValue]) =>
-          hasMeaningfulGoalMeasurementEntry(
-            normalizeGoalMeasurementEntry(rawValue, goals.find((goal) => goal.id === goalKey)),
-          ),
-        );
-      if (hasCaptureInputFromSubmit) {
+      const mergeGoalIds = options?.captureMergeGoalIds?.filter((id) => id.trim().length > 0) ?? [];
+      const isPartialCaptureSave = mergeGoalIds.length > 0;
+      const hasCaptureInputFromSubmit = isPartialCaptureSave
+        ? mergeGoalIds.some((goalKey) => {
+            const noteText = (working.session_note_goal_notes?.[goalKey] ?? '').trim();
+            if (noteText.length > 0) {
+              return true;
+            }
+            const rawValue = working.session_note_goal_measurements?.[goalKey];
+            return hasMeaningfulGoalMeasurementEntry(
+              normalizeGoalMeasurementEntry(rawValue, goals.find((goal) => goal.id === goalKey)),
+            );
+          })
+        : Object.values(working.session_note_goal_notes ?? {}).some(
+            (value) => typeof value === 'string' && value.trim().length > 0,
+          ) ||
+          Object.entries(working.session_note_goal_measurements ?? {}).some(([goalKey, rawValue]) =>
+            hasMeaningfulGoalMeasurementEntry(
+              normalizeGoalMeasurementEntry(rawValue, goals.find((goal) => goal.id === goalKey)),
+            ),
+          );
+      const goalIdsRequiringNotes = isPartialCaptureSave
+        ? mergedGoalIds.filter((id) => mergeGoalIds.includes(id))
+        : mergedGoalIds;
+      if (hasCaptureInputFromSubmit || isPartialCaptureSave) {
         if (!session?.id) {
           showError('Session capture can only be saved for existing sessions.');
           return;
@@ -776,7 +796,7 @@ export function SessionModal({
           );
           return;
         }
-        for (const trackedGoalId of mergedGoalIds) {
+        for (const trackedGoalId of goalIdsRequiringNotes) {
           const goalNoteText = normalizedGoalNoteMap[trackedGoalId]?.trim() ?? '';
           if (!goalNoteText) {
             const goalLabel =
@@ -802,6 +822,7 @@ export function SessionModal({
           )),
         session_note_authorization_id: resolvedAuthorizationId,
         session_note_service_code: resolvedServiceCode,
+        ...(isPartialCaptureSave ? { session_note_capture_merge_goal_ids: mergeGoalIds } : {}),
         goal_ids: sessionGoalIds,
         // If a timezone prop is provided, normalize to UTC for consumers expecting Z times
         start_time: timeZone ? toUtcSessionIsoString(working.start_time, resolvedTimeZone) : working.start_time,
@@ -962,16 +983,21 @@ export function SessionModal({
   });
   const [mobileCaptureOpenGoalId, setMobileCaptureOpenGoalId] = useState<string | null>(null);
 
+  const sessionCaptureSkillGoalIds = useMemo(
+    () =>
+      sessionNoteGoalIds.filter((id) => showGoalOnSkillCaptureTab(goals.find((g) => g.id === id), id)),
+    [sessionNoteGoalIds, goals],
+  );
+  const sessionCaptureBxGoalIds = useMemo(
+    () => sessionNoteGoalIds.filter((id) => showGoalOnBxCaptureTab(goals.find((g) => g.id === id), id)),
+    [sessionNoteGoalIds, goals],
+  );
   const sessionCaptureGoalIdsForTab = useMemo(() => {
     if (sessionCaptureTab === 'skill') {
-      return sessionNoteGoalIds.filter((id) =>
-        showGoalOnSkillCaptureTab(goals.find((g) => g.id === id), id),
-      );
+      return sessionCaptureSkillGoalIds;
     }
-    return sessionNoteGoalIds.filter((id) =>
-      showGoalOnBxCaptureTab(goals.find((g) => g.id === id), id),
-    );
-  }, [sessionCaptureTab, sessionNoteGoalIds, goals]);
+    return sessionCaptureBxGoalIds;
+  }, [sessionCaptureBxGoalIds, sessionCaptureSkillGoalIds, sessionCaptureTab]);
 
   const bumpTrialCount = useCallback(
     (goalId: string, field: 'metric_value' | 'incorrect_trials', delta: number) => {
@@ -1949,6 +1975,55 @@ export function SessionModal({
                         BX
                       </button>
                     </div>
+                    {isInProgressSession ? (
+                      <div
+                        className="flex flex-col gap-2 rounded-lg border border-indigo-200/80 bg-white/95 p-3 shadow-sm dark:border-indigo-800/60 dark:bg-dark-lighter/90"
+                        data-testid="session-modal-capture-save-row"
+                      >
+                        <p className="text-[11px] leading-snug text-indigo-800 dark:text-indigo-200">
+                          Each button writes only that tab&apos;s goal rows to the session note; the other tab keeps its
+                          last saved values until you save it or use Save progress for everything.
+                        </p>
+                        <div className="flex flex-wrap gap-2" role="group" aria-label="Save session capture">
+                          <button
+                            type="button"
+                            data-testid="session-modal-save-capture-skills"
+                            disabled={
+                              isSubmitting ||
+                              isDependentDataLoading ||
+                              isLoadingAlternatives ||
+                              sessionCaptureSkillGoalIds.length === 0
+                            }
+                            onClick={() =>
+                              void handleSubmit((fd) =>
+                                handleFormSubmit(fd, { captureMergeGoalIds: sessionCaptureSkillGoalIds }),
+                              )()
+                            }
+                            className="inline-flex min-h-10 flex-1 items-center justify-center rounded-lg border border-indigo-300 bg-indigo-600 px-3 py-2 text-xs font-semibold text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-indigo-500 dark:focus:ring-offset-dark sm:text-sm"
+                          >
+                            Save skills
+                          </button>
+                          <button
+                            type="button"
+                            data-testid="session-modal-save-capture-behaviors"
+                            disabled={
+                              isSubmitting ||
+                              isDependentDataLoading ||
+                              isLoadingAlternatives ||
+                              sessionCaptureBxGoalIds.length === 0
+                            }
+                            onClick={() =>
+                              void handleSubmit((fd) =>
+                                handleFormSubmit(fd, { captureMergeGoalIds: sessionCaptureBxGoalIds }),
+                              )()
+                            }
+                            className="inline-flex min-h-10 flex-1 items-center justify-center rounded-lg border border-violet-300 bg-violet-600 px-3 py-2 text-xs font-semibold text-white shadow-sm hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-500 dark:focus:ring-offset-dark sm:text-sm"
+                          >
+                            Save behaviors
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
                     {sessionCaptureGoalIdsForTab.length === 0 ? (
                       <p className="text-sm text-indigo-900/90 dark:text-indigo-200/90">
                         No targets on this tab. Switch tabs, add an ad-hoc target above, or adjust goals under People

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -447,6 +447,9 @@ describe('SessionModal', () => {
     expect(screen.getByTestId('session-modal-notes-guidance')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Save progress/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^Close Session$/i })).toBeInTheDocument();
+    expect(screen.getByTestId('session-modal-capture-save-row')).toBeInTheDocument();
+    expect(screen.getByTestId('session-modal-save-capture-skills')).toBeInTheDocument();
+    expect(screen.getByTestId('session-modal-save-capture-behaviors')).toBeInTheDocument();
   });
 
   it('keeps update-session submit copy when edit session has not started', () => {
@@ -475,6 +478,7 @@ describe('SessionModal', () => {
     expect(screen.getByRole('button', { name: /Update Session/i })).toBeInTheDocument();
     expect(screen.queryByTestId('session-modal-in-progress-guidance')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Close Session$/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('session-modal-capture-save-row')).not.toBeInTheDocument();
   });
 
   it('does not show in-progress guidance for completed sessions with started_at', async () => {

--- a/src/lib/session-notes.ts
+++ b/src/lib/session-notes.ts
@@ -167,6 +167,7 @@ export interface UpsertClientSessionNoteForSessionInput {
   readonly goalMeasurements?: Record<string, SessionGoalMeasurementEntry> | null;
   readonly goalNotes: Record<string, string>;
   readonly narrative: string;
+  readonly captureMergeGoalIds?: string[];
 }
 
 export interface UpdateClientSessionNoteInput {
@@ -206,6 +207,8 @@ export interface SessionNoteUpsertApiPayload {
   readonly goalMeasurements?: Record<string, SessionGoalMeasurementEntry> | null;
   readonly narrative: string;
   readonly isLocked: boolean;
+  /** Server merges only these goal keys from the request into the existing session note. */
+  readonly captureMergeGoalIds?: string[];
 }
 
 /**
@@ -308,6 +311,7 @@ export const upsertClientSessionNoteForSession = async (
     goalMeasurements: payload.goalMeasurements ?? null,
     narrative: payload.narrative,
     isLocked: false,
+    ...(payload.captureMergeGoalIds?.length ? { captureMergeGoalIds: payload.captureMergeGoalIds } : {}),
   });
 };
 

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -41,6 +41,7 @@ import { useAuth } from "../lib/authContext";
 import { useActiveOrganizationId } from "../lib/organization";
 import { supabase } from "../lib/supabase";
 import { fetchLinkedClientIdsForTherapist } from "../lib/clients/therapistClientScope";
+import { hasMeaningfulGoalMeasurementEntry, normalizeGoalMeasurementEntry } from "../lib/goal-measurements";
 import { upsertClientSessionNoteForSession } from "../lib/session-notes";
 import {
   buildSessionSlotIndex,
@@ -110,6 +111,7 @@ const stripClinicalNoteFields = (data: ScheduleSubmitData): Partial<Session> => 
     session_note_goals_addressed: _sessionNoteGoalsAddressed,
     session_note_authorization_id: _sessionNoteAuthorizationId,
     session_note_service_code: _sessionNoteServiceCode,
+    session_note_capture_merge_goal_ids: _sessionNoteCaptureMergeGoalIds,
     ...sessionPayload
   } = data;
   return sessionPayload;
@@ -117,6 +119,7 @@ const stripClinicalNoteFields = (data: ScheduleSubmitData): Partial<Session> => 
 
 const buildClinicalNoteDraft = (
   data: SessionModalClinicalNotesPayload,
+  options?: { captureMergeGoalIds?: readonly string[] },
 ): {
   narrative: string;
   goalNotes: Record<string, string>;
@@ -149,7 +152,26 @@ const buildClinicalNoteDraft = (
   });
   const authorizationId = data.session_note_authorization_id?.trim() ?? "";
   const serviceCode = data.session_note_service_code?.trim() ?? "";
-  if (
+  const mergeIds = (options?.captureMergeGoalIds ?? []).filter(
+    (id): id is string => typeof id === "string" && id.trim().length > 0,
+  );
+  if (mergeIds.length > 0) {
+    const scopeHasContent =
+      narrative.length > 0 ||
+      mergeIds.some((id) => {
+        const note = (data.session_note_goal_notes?.[id] ?? "").trim();
+        if (note.length > 0) {
+          return true;
+        }
+        const raw = data.session_note_goal_measurements?.[id];
+        return hasMeaningfulGoalMeasurementEntry(
+          normalizeGoalMeasurementEntry(raw, undefined, { fallbackMetricUnit: null }),
+        );
+      });
+    if (!scopeHasContent) {
+      return null;
+    }
+  } else if (
     narrative.length === 0 &&
     Object.keys(goalNotes).length === 0 &&
     Object.keys(goalMeasurements).length === 0
@@ -1125,7 +1147,10 @@ export const Schedule = React.memo(() => {
   const handleSubmit = useCallback(
     async (data: ScheduleSubmitData) => {
       const sessionPayload = stripClinicalNoteFields(data);
-      const clinicalNoteDraft = buildClinicalNoteDraft(data);
+      const mergeCaptureIds = data.session_note_capture_merge_goal_ids?.filter(
+        (id): id is string => typeof id === "string" && id.trim().length > 0,
+      );
+      const clinicalNoteDraft = buildClinicalNoteDraft(data, { captureMergeGoalIds: mergeCaptureIds });
       const decision = decideScheduleSubmitBranch({
         selectedSession,
         data: sessionPayload,
@@ -1279,6 +1304,7 @@ export const Schedule = React.memo(() => {
               goalMeasurements: clinicalNoteDraft.goalMeasurements,
               goalNotes: clinicalNoteDraft.goalNotes,
               narrative: clinicalNoteDraft.narrative,
+              ...(mergeCaptureIds?.length ? { captureMergeGoalIds: mergeCaptureIds } : {}),
             });
           }
           await updateSessionMutation.mutateAsync(sessionPayload);

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -495,4 +495,111 @@ describe("sessionNotesUpsertHandler", () => {
     expect(response.status).toBe(400);
     expect(payload.error).toMatch(/client does not match/i);
   });
+
+  it("merges only captureMergeGoalIds into an existing note on update", async () => {
+    const gidA = "44444444-4444-4444-8444-444444444444";
+    const gidB = "55555555-5555-4555-8555-555555555555";
+    const sessionId = "66666666-6666-4666-8666-666666666666";
+    const noteId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+    const existingRow = buildSessionNoteRow(noteId);
+    existingRow.session_id = sessionId;
+    existingRow.goal_ids = [gidA, gidB];
+    existingRow.goals_addressed = ["Goal A", "Goal B"];
+    existingRow.goal_notes = { [gidA]: "server kept skill note", [gidB]: "server old bx note" };
+    existingRow.goal_measurements = {
+      [gidA]: {
+        version: 1,
+        data: {
+          metric_label: "Count",
+          metric_unit: null,
+          metric_value: 1,
+          incorrect_trials: null,
+          opportunities: null,
+          prompt_level: null,
+          note: null,
+          trial_prompt_note: null,
+        },
+      },
+    };
+
+    const savedAfterPatch = {
+      ...existingRow,
+      goal_notes: { [gidA]: "server kept skill note", [gidB]: "merged bx from client" },
+    };
+
+    let fullNoteSelectGets = 0;
+
+    const fetchJsonMock = vi.mocked(fetchJson);
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      const method = init?.method ?? "GET";
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (
+        requestUrl.includes("/rest/v1/client_session_notes?") &&
+        method === "GET" &&
+        requestUrl.includes(`session_id=eq.${encodeURIComponent(sessionId)}`)
+      ) {
+        return { ok: true, status: 200, data: [{ id: noteId, is_locked: false }] };
+      }
+      if (
+        requestUrl.includes("/rest/v1/client_session_notes?") &&
+        method === "GET" &&
+        requestUrl.includes(`id=eq.${encodeURIComponent(noteId)}`) &&
+        !requestUrl.includes("session_id=eq.")
+      ) {
+        fullNoteSelectGets += 1;
+        if (fullNoteSelectGets === 1) {
+          return { ok: true, status: 200, data: [existingRow] };
+        }
+        return { ok: true, status: 200, data: [savedAfterPatch] };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?id=eq.") && method === "PATCH") {
+        const parsedBody = JSON.parse(String(init.body)) as { goal_notes?: Record<string, string> };
+        expect(parsedBody.goal_notes?.[gidA]).toBe("server kept skill note");
+        expect(parsedBody.goal_notes?.[gidB]).toBe("merged bx from client");
+        return { ok: true, status: 200, data: [{ id: noteId }] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl} ${method}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          sessionId,
+          noteId: undefined,
+          goalIds: [gidA, gidB],
+          goalsAddressed: ["Goal A", "Goal B"],
+          goalNotes: {
+            [gidA]: "CLIENT STALE MUST NOT WIN",
+            [gidB]: "merged bx from client",
+          },
+          goalMeasurements: null,
+          captureMergeGoalIds: [gidB],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json() as { goal_notes?: Record<string, string> | null };
+    expect(json.goal_notes?.[gidA]).toBe("server kept skill note");
+    expect(json.goal_notes?.[gidB]).toBe("merged bx from client");
+  });
 });

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -81,6 +81,11 @@ const upsertSchema = z.object({
   goalMeasurements: z.record(z.unknown()).nullable().optional(),
   narrative: z.string().default(""),
   isLocked: z.boolean().default(false),
+  /** When updating an existing note, only these goal keys read `goalNotes` / `goalMeasurements` from the request; other goals keep server values. */
+  captureMergeGoalIds: z
+    .array(z.string().min(1).refine((id) => isValidSessionNoteGoalKey(id)))
+    .max(200)
+    .optional(),
 });
 
 const normalizeTime = (value: string): string => {
@@ -112,6 +117,57 @@ const trimGoalNotes = (goalNotes: Record<string, string>): Record<string, string
   );
 
   return Object.keys(cleaned).length > 0 ? cleaned : null;
+};
+
+const mergeScopedGoalCaptureFromExisting = (args: {
+  captureMergeGoalIds: readonly string[];
+  existingRow: SessionNoteRow;
+  incomingGoalNotes: Record<string, string>;
+  incomingGoalMeasurements: Record<string, unknown> | null | undefined;
+}): {
+  goalNotes: Record<string, string>;
+  goalMeasurements: Record<string, unknown> | null;
+} => {
+  const existingNotes = { ...((args.existingRow.goal_notes as Record<string, string> | null) ?? {}) };
+  const existingMeasNormalized = normalizeGoalMeasurements(args.existingRow.goal_measurements) ?? {};
+  const mergedMeasPlain: Record<string, unknown> = Object.fromEntries(
+    Object.entries(existingMeasNormalized).map(([id, entry]) => [id, entry as unknown]),
+  );
+  const mergedNotes = { ...existingNotes };
+
+  for (const id of args.captureMergeGoalIds) {
+    if (!isValidSessionNoteGoalKey(id)) {
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(args.incomingGoalNotes, id)) {
+      const raw = args.incomingGoalNotes[id];
+      const trimmed = typeof raw === "string" ? raw.trim() : "";
+      if (trimmed.length > 0) {
+        mergedNotes[id] = trimmed;
+      } else {
+        delete mergedNotes[id];
+      }
+    }
+
+    const incomingMap = args.incomingGoalMeasurements;
+    if (incomingMap && typeof incomingMap === "object" && Object.prototype.hasOwnProperty.call(incomingMap, id)) {
+      const normalized = normalizeGoalMeasurementEntry(
+        incomingMap[id as keyof typeof incomingMap],
+        undefined,
+        { fallbackMetricUnit: null },
+      );
+      if (normalized) {
+        mergedMeasPlain[id] = normalized;
+      } else {
+        delete mergedMeasPlain[id];
+      }
+    }
+  }
+
+  return {
+    goalNotes: mergedNotes,
+    goalMeasurements: Object.keys(mergedMeasPlain).length > 0 ? mergedMeasPlain : null,
+  };
 };
 
 const normalizeGoalMeasurements = (
@@ -329,9 +385,6 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
     return errorResponse(request, "validation_error", "End time must be later than start time.");
   }
 
-  const normalizedGoalNotes = trimGoalNotes(payload.goalNotes);
-  const normalizedGoalMeasurements = normalizeGoalMeasurements(payload.goalMeasurements ?? null);
-
   const { supabaseUrl, anonKey } = getSupabaseConfig();
   const headers = {
     "Content-Type": "application/json",
@@ -394,6 +447,32 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
   if (existingNote?.is_locked) {
     return errorResponse(request, "conflict", "Session note is locked and cannot be edited.", { status: 409 });
   }
+
+  const mergeGoalIds = payload.captureMergeGoalIds ?? [];
+  const shouldMergeScopedCapture = Boolean(existingNote) && mergeGoalIds.length > 0;
+
+  let goalNotesForNormalize = payload.goalNotes;
+  let goalMeasurementsForNormalize: Record<string, unknown> | null | undefined = payload.goalMeasurements ?? null;
+
+  if (shouldMergeScopedCapture && existingNote) {
+    const existingRowFull = await fetchSessionNoteById(supabaseUrl, headers, organizationId, existingNote.id);
+    if (!existingRowFull) {
+      return errorResponse(request, "upstream_error", "Unable to load existing session note for merge", {
+        status: 502,
+      });
+    }
+    const merged = mergeScopedGoalCaptureFromExisting({
+      captureMergeGoalIds: mergeGoalIds,
+      existingRow: existingRowFull,
+      incomingGoalNotes: payload.goalNotes,
+      incomingGoalMeasurements: payload.goalMeasurements ?? null,
+    });
+    goalNotesForNormalize = merged.goalNotes;
+    goalMeasurementsForNormalize = merged.goalMeasurements;
+  }
+
+  const normalizedGoalNotes = trimGoalNotes(goalNotesForNormalize);
+  const normalizedGoalMeasurements = normalizeGoalMeasurements(goalMeasurementsForNormalize ?? null);
 
   const alignedGoals = alignSessionNoteGoalPayload({
     goalIds: payload.goalIds,


### PR DESCRIPTION
## Summary
Adds **true partial persistence** for session capture: \captureMergeGoalIds\ on \POST /api/session-notes/upsert\ so an update only applies \goal_notes\ / \goal_measurements\ for listed goal keys; other goals keep server values.

## UI
- Live session **Save skills** / **Save behaviors** pass the tab’s goal ids as merge scope.
- **Save progress** omits merge ids (full capture write, prior behavior).

## Files
- \src/server/api/session-notes-upsert.ts\ — merge helper + handler branch
- \src/lib/session-notes.ts\, \src/pages/Schedule.tsx\ — payload wiring
- \src/components/SessionModal.tsx\ — buttons + validation scoped to merge set
- Tests: upsert handler + SessionModal

## Verification
- \
px vitest run src/server/__tests__/sessionNotesUpsertHandler.test.ts src/components/__tests__/SessionModal.test.tsx src/lib/__tests__/session-notes.test.ts\

Made with [Cursor](https://cursor.com)