### PR TITLE
chore(cursor): add continual-learning hook state for shared Cursor hooks

### DIFF
--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "lastRunAtMs": 0,
+  "turnsSinceLastRun": 3,
+  "lastTranscriptMtimeMs": null,
+  "lastProcessedGenerationId": "83102417-d632-49b8-8a9d-767c0bc060a8",
+  "trialStartedAtMs": null
+}


### PR DESCRIPTION
Tracks .cursor/hooks/state so the continual-learning hook payload is versioned with the repo (see Cursor project hooks under .cursor/hooks).

Made-with: Cursor