### PR TITLE
chore(cursor): project hooks + ignore volatile hook state

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "node .cursor/hooks/before-submit-prompt.mjs",
+        "matcher": "UserPromptSubmit",
+        "timeout": 8
+      }
+    ],
+    "afterAgentResponse": [
+      {
+        "command": "node .cursor/hooks/after-agent-response.mjs",
+        "matcher": "AgentResponse",
+        "timeout": 8
+      }
+    ],
+    "stop": [
+      {
+        "command": "node .cursor/hooks/stop.mjs",
+        "matcher": "Stop",
+        "timeout": 8
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/after-agent-response.mjs
+++ b/.cursor/hooks/after-agent-response.mjs
@@ -1,0 +1,50 @@
+/**
+ * Lightweight lifecycle audit: one NDJSON line per response (text size only).
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const LOG_DIR = join(__dirname, "logs");
+
+function logDirEnsure() {
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function readStdinJson() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin.on("data", (c) => chunks.push(c));
+    process.stdin.on("end", () => {
+      try {
+        const raw = Buffer.concat(chunks).toString("utf8").trim();
+        if (!raw) resolve({});
+        else resolve(JSON.parse(raw));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    process.stdin.on("error", reject);
+  });
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    const text = typeof input.text === "string" ? input.text : "";
+    logDirEnsure();
+    const line = JSON.stringify({
+      hook: "afterAgentResponse",
+      ts: new Date().toISOString(),
+      textLength: text.length,
+    });
+    appendFileSync(join(LOG_DIR, "agent-response.ndjson"), `${line}\n`, "utf8");
+    process.stdout.write("{}");
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write("{}");
+  process.exit(0);
+});

--- a/.cursor/hooks/before-submit-prompt.mjs
+++ b/.cursor/hooks/before-submit-prompt.mjs
@@ -1,0 +1,66 @@
+/**
+ * Audit-only prompt gate: never blocks submission; logs high-signal secret-like
+ * shapes to .cursor/hooks/logs/ (gitignored). Hook crashes are fail-open.
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const LOG_DIR = join(__dirname, "logs");
+
+const PATTERNS = [
+  { id: "pem_private_key", re: /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/i },
+  { id: "stripe_secret_key", re: /\bsk_(live|test)_[0-9a-zA-Z]{8,}\b/i },
+  { id: "github_pat", re: /\bgh[psu]_[0-9a-zA-Z]{20,}\b/i },
+  { id: "aws_access_key", re: /\bAKIA[0-9A-Z]{16}\b/ },
+];
+
+function logDirEnsure() {
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function readStdinJson() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin.on("data", (c) => chunks.push(c));
+    process.stdin.on("end", () => {
+      try {
+        const raw = Buffer.concat(chunks).toString("utf8").trim();
+        if (!raw) resolve({});
+        else resolve(JSON.parse(raw));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    process.stdin.on("error", reject);
+  });
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    const prompt = typeof input.prompt === "string" ? input.prompt : "";
+    const hits = [];
+    for (const { id, re } of PATTERNS) {
+      if (re.test(prompt)) hits.push(id);
+    }
+    if (hits.length > 0) {
+      logDirEnsure();
+      const line = JSON.stringify({
+        hook: "beforeSubmitPrompt",
+        ts: new Date().toISOString(),
+        hits,
+        promptLength: prompt.length,
+        attachmentCount: Array.isArray(input.attachments) ? input.attachments.length : 0,
+      });
+      appendFileSync(join(LOG_DIR, "prompt-audit.ndjson"), `${line}\n`, "utf8");
+    }
+    process.stdout.write(JSON.stringify({ continue: true }));
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write(JSON.stringify({ continue: true }));
+  process.exit(0);
+});

--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "lastRunAtMs": 0,
-  "turnsSinceLastRun": 3,
-  "lastTranscriptMtimeMs": null,
-  "lastProcessedGenerationId": "83102417-d632-49b8-8a9d-767c0bc060a8",
-  "trialStartedAtMs": null
-}

--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "lastRunAtMs": 0,
+  "turnsSinceLastRun": 3,
+  "lastTranscriptMtimeMs": null,
+  "lastProcessedGenerationId": "83102417-d632-49b8-8a9d-767c0bc060a8",
+  "trialStartedAtMs": null
+}

--- a/.cursor/hooks/stop.mjs
+++ b/.cursor/hooks/stop.mjs
@@ -1,0 +1,50 @@
+/**
+ * Agent loop completion audit. Does not emit followup_message (no auto-chains).
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const LOG_DIR = join(__dirname, "logs");
+
+function logDirEnsure() {
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function readStdinJson() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin.on("data", (c) => chunks.push(c));
+    process.stdin.on("end", () => {
+      try {
+        const raw = Buffer.concat(chunks).toString("utf8").trim();
+        if (!raw) resolve({});
+        else resolve(JSON.parse(raw));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    process.stdin.on("error", reject);
+  });
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    logDirEnsure();
+    const line = JSON.stringify({
+      hook: "stop",
+      ts: new Date().toISOString(),
+      status: typeof input.status === "string" ? input.status : null,
+      loop_count: typeof input.loop_count === "number" ? input.loop_count : null,
+    });
+    appendFileSync(join(LOG_DIR, "stop.ndjson"), `${line}\n`, "utf8");
+    process.stdout.write("{}");
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write("{}");
+  process.exit(0);
+});

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ WHITE BIBLE.pdf
 .reports/*.json
 .reports/*.md
 
+# Cursor hook volatile state and local audit logs (never ship)
+.cursor/hooks/state/
+.cursor/hooks/logs/
+
 # Local agent / editor scratch (not shipped)
 .claude/
 


### PR DESCRIPTION
## Summary
Adds Cursor **project hooks** at `.cursor/hooks.json` and Node (`.mjs`) scripts under `.cursor/hooks/` so they run on **Windows, macOS, and Linux** (requires `node` on PATH, same as the app toolchain).

## Events (audit-only, fail-open)
| Event | Matcher | Behavior |
|-------|---------|----------|
| `beforeSubmitPrompt` | `UserPromptSubmit` | Always returns `{ "continue": true }`. If the prompt matches common secret-like shapes (PEM private key block, Stripe `sk_*`, GitHub PAT-style token, AWS `AKIA` access key id), appends a redacted line (hit ids and lengths only, no prompt body) to `.cursor/hooks/logs/prompt-audit.ndjson`. |
| `afterAgentResponse` | `AgentResponse` | Appends response text length and timestamp to `.cursor/hooks/logs/agent-response.ndjson`. Stdout `{}`. |
| `stop` | `Stop` | Appends `status`, `loop_count`, and timestamp to `.cursor/hooks/logs/stop.ndjson`. Stdout `{}` (no `followup_message`, so no auto follow-up chains). |

No `failClosed` flags: on parse/runtime errors the scripts exit 0 with safe JSON so Cursor keeps working (fail-open).

## Volatile / local-only
- `.gitignore` ignores `.cursor/hooks/state/` and `.cursor/hooks/logs/`.
- Stops tracking `.cursor/hooks/state/continual-learning.json` so machine-specific state is not committed (local file can be recreated by tooling).

## Disable locally
- Rename `.cursor/hooks.json` (for example to `hooks.json.off`), or remove the hook entries you do not want; Cursor reloads on save.
- Or use a workspace context where project hooks are not loaded (per Cursor trust settings).

## Verification
- `npm run lint`, `npm run typecheck`, `npm run test:ci` — all passed.
- Node stdin/stdout smoke for each hook script with sample payloads.
