### PR TITLE
chore(cursor): untrack continual-learning hook state

### DIFF
--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "lastRunAtMs": 0,
-  "turnsSinceLastRun": 3,
-  "lastTranscriptMtimeMs": null,
-  "lastProcessedGenerationId": "83102417-d632-49b8-8a9d-767c0bc060a8",
-  "trialStartedAtMs": null
-}


### PR DESCRIPTION
## Why
\.cursor/hooks/state/\ is gitignored (PR #452) for volatile Cursor hook data, but \continual-learning.json\ was still **tracked** after PR #451. Git then shows **M** whenever the hook rewrites the file — not a duplicate, just drift.

## What
- \git rm --cached\ — stop tracking the file; it stays on disk locally.
- After merge, the JSON updates will no longer appear under **Changes**.

Made with [Cursor](https://cursor.com)