### PR TITLE
fix: prevent /api/dashboard 401 when JWT not ready

### DIFF
--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -27,6 +27,7 @@ import { checkSchedulingConflicts, suggestAlternativeTimes, type Conflict, type 
 import { logger } from '../lib/logger/logger';
 import { AlternativeTimes } from './AlternativeTimes';
 import { supabase } from '../lib/supabase';
+import { fetchLinkedClientSessionNoteForSession } from '../lib/session-note-linked-fetch';
 import { useActiveOrganizationId } from '../lib/organization';
 import { showError, showSuccess } from '../lib/toast';
 import {
@@ -332,18 +333,10 @@ export function SessionModal({
       if (!session?.id || !activeOrganizationId) {
         return null;
       }
-      const { data, error } = await supabase
-        .from('client_session_notes')
-        .select('id, authorization_id, service_code, narrative, goal_notes, goal_measurements, goal_ids, goals_addressed')
-        .eq('session_id', session.id)
-        .eq('organization_id', activeOrganizationId)
-        .order('updated_at', { ascending: false })
-        .limit(1)
-        .maybeSingle();
-      if (error) {
-        throw error;
-      }
-      return data ?? null;
+      return fetchLinkedClientSessionNoteForSession({
+        sessionId: session.id,
+        organizationId: activeOrganizationId,
+      });
     },
     enabled: Boolean(session?.id && activeOrganizationId),
   });

--- a/src/lib/__tests__/optimizedQueries.dashboard.test.ts
+++ b/src/lib/__tests__/optimizedQueries.dashboard.test.ts
@@ -75,7 +75,7 @@ describe("useDashboardData /api/dashboard fetch", () => {
     expect(headers?.get("apikey")).toBe("test-anon-key");
   });
 
-  it("surfaces 401 when no access token can be resolved", async () => {
+  it("does not call /api/dashboard when no access token can be resolved", async () => {
     getSessionMock.mockResolvedValue({
       data: { session: null },
       error: null,
@@ -96,7 +96,6 @@ describe("useDashboardData /api/dashboard fetch", () => {
     vi.stubGlobal("fetch", fetchMock);
     const { fetchDashboardData } = await import("../optimizedQueries");
     await expect(fetchDashboardData()).rejects.toMatchObject({ status: 401 });
-    expect(fetchMock).toHaveBeenCalled();
-    expect(String(fetchMock.mock.calls[0]?.[0] ?? "")).toContain("/api/dashboard");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/__tests__/session-note-linked-fetch.test.ts
+++ b/src/lib/__tests__/session-note-linked-fetch.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isMissingColumnSelectError } from "../session-note-linked-fetch";
+
+const { maybeSingleMock, fromMock } = vi.hoisted(() => {
+  const maybeSingle = vi.fn();
+  const from = vi.fn(() => {
+    const chain = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      order: vi.fn(),
+      limit: vi.fn(),
+      maybeSingle: maybeSingle,
+    };
+    chain.select.mockReturnValue(chain);
+    chain.eq.mockReturnValue(chain);
+    chain.order.mockReturnValue(chain);
+    chain.limit.mockReturnValue(chain);
+    return chain;
+  });
+  return { maybeSingleMock: maybeSingle, fromMock: from };
+});
+
+vi.mock("../supabase", () => ({
+  supabase: {
+    from: fromMock,
+  },
+}));
+
+describe("isMissingColumnSelectError", () => {
+  it("returns true for Postgres undefined_column code", () => {
+    expect(isMissingColumnSelectError({ code: "42703", message: "whatever" })).toBe(true);
+  });
+
+  it("returns true when message names goal_measurements and missing column", () => {
+    expect(
+      isMissingColumnSelectError({
+        code: "PGRST204",
+        message: "Could not find the 'goal_measurements' column of 'client_session_notes' in the schema cache",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isMissingColumnSelectError({ code: "42501", message: "permission denied" })).toBe(false);
+    expect(isMissingColumnSelectError(null)).toBe(false);
+  });
+});
+
+describe("fetchLinkedClientSessionNoteForSession", () => {
+  afterEach(() => {
+    maybeSingleMock.mockReset();
+    fromMock.mockClear();
+    vi.resetModules();
+  });
+
+  it("returns row when full select succeeds", async () => {
+    const row = {
+      id: "n1",
+      authorization_id: "a1",
+      service_code: "97151",
+      narrative: null,
+      goal_notes: {},
+      goal_measurements: { g: {} },
+      goal_ids: [],
+      goals_addressed: [],
+    };
+    maybeSingleMock.mockResolvedValueOnce({ data: row, error: null });
+    const { fetchLinkedClientSessionNoteForSession } = await import("../session-note-linked-fetch");
+    const result = await fetchLinkedClientSessionNoteForSession({
+      sessionId: "sess-1",
+      organizationId: "org-1",
+    });
+    expect(result).toEqual(row);
+    expect(fromMock).toHaveBeenCalledWith("client_session_notes");
+    expect(maybeSingleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries without goal_measurements when first select fails on missing column", async () => {
+    const baseRow = {
+      id: "n1",
+      authorization_id: "a1",
+      service_code: "97151",
+      narrative: null,
+      goal_notes: {},
+      goal_ids: [] as string[] | null,
+      goals_addressed: [] as string[] | null,
+    };
+    maybeSingleMock
+      .mockResolvedValueOnce({
+        data: null,
+        error: {
+          code: "42703",
+          message: 'column "goal_measurements" does not exist',
+        },
+      })
+      .mockResolvedValueOnce({ data: baseRow, error: null });
+
+    const { fetchLinkedClientSessionNoteForSession } = await import("../session-note-linked-fetch");
+    const result = await fetchLinkedClientSessionNoteForSession({
+      sessionId: "sess-1",
+      organizationId: "org-1",
+    });
+
+    expect(maybeSingleMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ...baseRow, goal_measurements: null });
+  });
+
+  it("throws when full select fails with a non-schema error", async () => {
+    maybeSingleMock.mockResolvedValueOnce({
+      data: null,
+      error: { code: "42501", message: "permission denied" },
+    });
+    const { fetchLinkedClientSessionNoteForSession } = await import("../session-note-linked-fetch");
+    await expect(
+      fetchLinkedClientSessionNoteForSession({ sessionId: "sess-1", organizationId: "org-1" }),
+    ).rejects.toMatchObject({ code: "42501" });
+    expect(maybeSingleMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,7 +43,8 @@ const shouldRefreshAccessToken = (token: string): boolean => {
   return expiry * 1000 <= Date.now() + 60_000;
 };
 
-const getCurrentAccessToken = async (): Promise<string | null> => {
+/** Shared with dashboard batching so we never hit `/api/dashboard` without resolving a JWT first. */
+export const getCurrentAccessToken = async (): Promise<string | null> => {
   try {
     const { data } = await supabase.auth.getSession();
     const currentToken = data?.session?.access_token ?? null;

--- a/src/lib/optimizedQueries.ts
+++ b/src/lib/optimizedQueries.ts
@@ -6,7 +6,7 @@ import type { Session } from '../types';
 import { logger } from './logger/logger';
 import { toError } from './logger/normalizeError';
 import { useDashboardLiveRefresh } from './dashboardLiveRefresh';
-import { callApi } from './api';
+import { callApi, getCurrentAccessToken } from './api';
 import { ensureRuntimeSupabaseConfig, getSupabaseAnonKey } from './runtimeConfig';
 
 const buildOrgScopedScheduleBatchKey = (
@@ -186,6 +186,13 @@ export const useSessionMetrics = (
  */
 export const fetchDashboardData = async () => {
   const DASHBOARD_REQUEST_TIMEOUT_MS = 10000;
+
+  const token = await getCurrentAccessToken();
+  if (!token || token.trim().length === 0) {
+    const err = new Error('Not authenticated') as Error & { status: number };
+    err.status = 401;
+    throw err;
+  }
 
   const dashboardRouteFallback = async () => {
     // Same-origin GET /api/dashboard (no browser CORS). Wait for runtime config so URL/key

--- a/src/lib/session-note-linked-fetch.ts
+++ b/src/lib/session-note-linked-fetch.ts
@@ -1,0 +1,74 @@
+import { supabase } from './supabase';
+
+/** Columns always expected on `client_session_notes` for SessionModal hydration. */
+const LINKED_NOTE_BASE_SELECT =
+  'id, authorization_id, service_code, narrative, goal_notes, goal_ids, goals_addressed';
+
+const LINKED_NOTE_FULL_SELECT = `${LINKED_NOTE_BASE_SELECT}, goal_measurements`;
+
+export type LinkedClientSessionNoteRow = {
+  id: string;
+  authorization_id: string;
+  service_code: string;
+  narrative: string | null;
+  goal_notes: unknown;
+  goal_measurements: unknown;
+  goal_ids: string[] | null;
+  goals_addressed: string[] | null;
+};
+
+/**
+ * PostgREST / Postgres signals when `select` references a column missing from the schema cache
+ * (e.g. production DB behind app migrations).
+ */
+export const isMissingColumnSelectError = (error: { code?: string; message?: string } | null): boolean => {
+  if (!error) {
+    return false;
+  }
+  const message = typeof error.message === 'string' ? error.message : '';
+  if (error.code === '42703') {
+    return true;
+  }
+  if (/goal_measurements/i.test(message) && /column|does not exist|schema cache/i.test(message)) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Latest `client_session_notes` row for a session. Retries without `goal_measurements` when the
+ * column is absent so older databases do not return HTTP 400 for the whole modal.
+ */
+export async function fetchLinkedClientSessionNoteForSession(params: {
+  sessionId: string;
+  organizationId: string;
+}): Promise<LinkedClientSessionNoteRow | null> {
+  const run = (select: string) =>
+    supabase
+      .from('client_session_notes')
+      .select(select)
+      .eq('session_id', params.sessionId)
+      .eq('organization_id', params.organizationId)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+  const full = await run(LINKED_NOTE_FULL_SELECT);
+  if (!full.error) {
+    return (full.data ?? null) as LinkedClientSessionNoteRow | null;
+  }
+
+  if (isMissingColumnSelectError(full.error)) {
+    const base = await run(LINKED_NOTE_BASE_SELECT);
+    if (base.error) {
+      throw base.error;
+    }
+    const row = base.data as Omit<LinkedClientSessionNoteRow, 'goal_measurements'> | null;
+    if (!row) {
+      return null;
+    }
+    return { ...row, goal_measurements: null };
+  }
+
+  throw full.error;
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -362,8 +362,9 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
 };
 
 const Dashboard = () => {
-  const { effectiveRole } = useAuth();
+  const { effectiveRole, session, loading: authLoading } = useAuth();
   const canViewStaffDashboard = canAccessStaffDashboard(effectiveRole);
+  const hasAccessToken = Boolean(session?.access_token && session.access_token.trim().length > 0);
   const {
     data: dashboardData,
     isLoading: isLoadingDashboard,
@@ -371,7 +372,7 @@ const Dashboard = () => {
     refetch,
     refreshConfig,
   } = useDashboardData({
-    enabled: canViewStaffDashboard,
+    enabled: canViewStaffDashboard && hasAccessToken && !authLoading,
   }) as unknown as {
     data: DashboardDataShape | null;
     isLoading: boolean;

--- a/src/pages/__tests__/Dashboard.dashboardQueryGate.test.tsx
+++ b/src/pages/__tests__/Dashboard.dashboardQueryGate.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+let capturedDashboardEnabled: boolean | undefined;
+
+vi.mock("../../lib/optimizedQueries", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/optimizedQueries")>();
+  return {
+    ...actual,
+    useDashboardData: (options?: { enabled?: boolean }) => {
+      capturedDashboardEnabled = options?.enabled;
+      return actual.useDashboardData(options);
+    },
+  };
+});
+
+const mockUseAuth = vi.fn();
+vi.mock("../../lib/authContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+import { Dashboard } from "../Dashboard";
+
+const authStub = (partial: Record<string, unknown>) =>
+  ({
+    user: null,
+    profile: null,
+    metadataRole: null,
+    effectiveRole: "client",
+    roleMismatch: false,
+    isGuardian: false,
+    authFlow: "normal" as const,
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn(),
+    resetPassword: vi.fn(),
+    updateProfile: vi.fn(),
+    hasRole: vi.fn(() => false),
+    hasAnyRole: vi.fn(() => false),
+    isAdmin: vi.fn(() => false),
+    isSuperAdmin: vi.fn(() => false),
+    ...partial,
+  }) as ReturnType<typeof import("../../lib/authContext").useAuth>;
+
+const renderDashboard = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <Dashboard />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe("Dashboard staff dashboard query gate", () => {
+  beforeEach(() => {
+    capturedDashboardEnabled = undefined;
+    mockUseAuth.mockReset();
+  });
+
+  it("disables useDashboardData until auth loading completes and a bearer exists", () => {
+    mockUseAuth.mockReturnValue(
+      authStub({
+        effectiveRole: "admin",
+        session: { access_token: "t" } as import("@supabase/supabase-js").Session,
+        loading: true,
+        isAdmin: () => true,
+        isSuperAdmin: () => false,
+      }),
+    );
+
+    renderDashboard();
+    expect(capturedDashboardEnabled).toBe(false);
+  });
+
+  it("disables useDashboardData for therapist even with a bearer (staff dashboard only)", () => {
+    mockUseAuth.mockReturnValue(
+      authStub({
+        effectiveRole: "therapist",
+        session: { access_token: "valid-token" } as import("@supabase/supabase-js").Session,
+        loading: false,
+        isAdmin: () => false,
+        isSuperAdmin: () => false,
+      }),
+    );
+
+    renderDashboard();
+    expect(capturedDashboardEnabled).toBe(false);
+  });
+
+  it("disables useDashboardData for admin without access token", () => {
+    mockUseAuth.mockReturnValue(
+      authStub({
+        effectiveRole: "admin",
+        session: null,
+        loading: false,
+        isAdmin: () => true,
+        isSuperAdmin: () => false,
+      }),
+    );
+
+    renderDashboard();
+    expect(capturedDashboardEnabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Production logged 401 on GET /api/dashboard when the dashboard query ran before a Supabase access token was available.

## Changes

- fetchDashboardData: getCurrentAccessToken first; throw 401 without fetch if missing.
- Dashboard: useDashboardData enabled only when staff role, session.access_token present, and auth not loading.
- Export getCurrentAccessToken from api.ts for shared resolution with callApi.

## Verification

- vitest: optimizedQueries.dashboard, Dashboard.dashboardQueryGate
- npm run typecheck
