### PR TITLE
fix: SW bypass for /api + JSON; no-store dashboard fetch

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const APP_VERSION = '20260304';
+const APP_VERSION = '20260420';
 const PRECACHE_CACHE = `allincompassing-precache-${APP_VERSION}`;
 const RUNTIME_CACHE = `allincompassing-runtime-${APP_VERSION}`;
 const IMMUTABLE_CACHE = `allincompassing-immutable-${APP_VERSION}`;
@@ -34,11 +34,6 @@ const isHashedAsset = (url) => {
   return /\/assets\/.+\.[a-f0-9]{8,}\.(js|css|mjs|woff2|png|jpe?g|svg|webp)$/.test(url.pathname);
 };
 
-const isJsonRequest = (request) => {
-  const acceptHeader = request.headers.get('accept') || '';
-  return request.destination === '' && acceptHeader.includes('application/json');
-};
-
 const cacheFirst = async (request, cacheName) => {
   const cache = await caches.open(cacheName);
   const cachedResponse = await cache.match(request);
@@ -68,14 +63,11 @@ const staleWhileRevalidate = async (request, cacheName) => {
   return cachedResponse || networkResponsePromise;
 };
 
-const networkOnly = async (request) => {
-  try {
-    return await fetch(request);
-  } catch (error) {
-    throw error;
-  }
-};
-
+/**
+ * Do not call respondWith for same-origin `/api/*` or JSON Accept fetches.
+ * Let the browser handle them so Authorization and Supabase RPC traffic are
+ * not routed through the SW fetch path (avoids 401 / odd status in production).
+ */
 self.addEventListener('fetch', (event) => {
   const { request } = event;
   if (request.method !== 'GET') {
@@ -100,16 +92,6 @@ self.addEventListener('fetch', (event) => {
           }
           return caches.match(OFFLINE_URL);
         }),
-    );
-    return;
-  }
-
-  if (isJsonRequest(request) || url.pathname.startsWith('/api/')) {
-    event.respondWith(
-      networkOnly(request).catch(async () => {
-        const fallback = await caches.match(OFFLINE_URL);
-        return fallback || Response.error();
-      }),
     );
     return;
   }

--- a/src/lib/__tests__/optimizedQueries.dashboard.test.ts
+++ b/src/lib/__tests__/optimizedQueries.dashboard.test.ts
@@ -44,6 +44,7 @@ describe("useDashboardData /api/dashboard fetch", () => {
     const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
     const headers = init?.headers as Headers | undefined;
     expect(init?.method).toBe("GET");
+    expect(init?.cache).toBe("no-store");
     expect(headers?.get("Authorization")).toBe("Bearer token");
     expect(headers?.get("X-Supabase-Authorization")).toBe("Bearer token");
     expect(headers?.get("apikey")).toBe("test-anon-key");

--- a/src/lib/optimizedQueries.ts
+++ b/src/lib/optimizedQueries.ts
@@ -217,6 +217,7 @@ export const fetchDashboardData = async () => {
         '/api/dashboard',
         {
           method: 'GET',
+          cache: 'no-store',
           headers: {
             apikey: anonKey,
           },


### PR DESCRIPTION
## Problem
Production Network tab showed repeated **401** on \/api/dashboard\ with initiators including \sw.js\ and the reports bundle. SW was calling \espondWith\ for all same-origin \/api/*\ and JSON \Accept\ GETs, which can interact poorly with authenticated fetches.

## Fix
- **public/sw.js**: Stop intercepting \/api/*\ and JSON-mode GETs — let the browser handle them (no \espondWith\). Keep caching for navigate shell, fonts, images, hashed assets, scripts/styles.
- **APP_VERSION** bump (\20260420\) so clients pick up the new SW after deploy.
- **fetchDashboardData**: \cache: 'no-store'\ on the \callApi\ GET to avoid reusing a cached 401.
- Unit test asserts \cache: 'no-store'\ on the dashboard request.

## Notes
- \get_session_metrics\ uses **POST** and was not covered by this SW GET handler; if 300 persists, capture full URL/headers in a separate ticket.