### PR TITLE
chore(cursor): expand project hooks (session, shell, MCP, env, edits)

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,11 +1,48 @@
 {
   "version": 1,
   "hooks": {
+    "sessionStart": [
+      {
+        "command": "node .cursor/hooks/session-start.mjs",
+        "timeout": 5
+      }
+    ],
     "beforeSubmitPrompt": [
       {
         "command": "node .cursor/hooks/before-submit-prompt.mjs",
         "matcher": "UserPromptSubmit",
         "timeout": 8
+      }
+    ],
+    "beforeReadFile": [
+      {
+        "command": "node .cursor/hooks/before-read-file.mjs",
+        "matcher": "Read",
+        "timeout": 8
+      }
+    ],
+    "preToolUse": [
+      {
+        "command": "node .cursor/hooks/pre-tool-use.mjs",
+        "timeout": 8
+      }
+    ],
+    "postToolUse": [
+      {
+        "command": "node .cursor/hooks/post-tool-use.mjs",
+        "timeout": 8
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "node .cursor/hooks/before-shell-execution.mjs",
+        "timeout": 12
+      }
+    ],
+    "beforeMCPExecution": [
+      {
+        "command": "node .cursor/hooks/before-mcp-execution.mjs",
+        "timeout": 12
       }
     ],
     "afterAgentResponse": [

--- a/.cursor/hooks/after-agent-response.mjs
+++ b/.cursor/hooks/after-agent-response.mjs
@@ -4,29 +4,13 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const LOG_DIR = join(__dirname, "logs");
 
 function logDirEnsure() {
   mkdirSync(LOG_DIR, { recursive: true });
-}
-
-function readStdinJson() {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    process.stdin.on("data", (c) => chunks.push(c));
-    process.stdin.on("end", () => {
-      try {
-        const raw = Buffer.concat(chunks).toString("utf8").trim();
-        if (!raw) resolve({});
-        else resolve(JSON.parse(raw));
-      } catch (e) {
-        reject(e);
-      }
-    });
-    process.stdin.on("error", reject);
-  });
 }
 
 function main() {

--- a/.cursor/hooks/before-mcp-execution.mjs
+++ b/.cursor/hooks/before-mcp-execution.mjs
@@ -1,0 +1,40 @@
+/**
+ * Asks for confirmation on MCP calls that look like SQL/migration execution (fail-open).
+ */
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+
+const ASK_TOOL_SUBSTRINGS = ["apply_migration", "execute_sql", "executesql", "exec_sql"];
+
+function normalizeToolName(input) {
+  const n = input.tool_name;
+  return typeof n === "string" ? n.toLowerCase() : "";
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    const tool = normalizeToolName(input);
+    const hits = [];
+    for (const s of ASK_TOOL_SUBSTRINGS) {
+      if (tool.includes(s)) hits.push(s);
+    }
+
+    if (hits.length > 0) {
+      process.stdout.write(
+        JSON.stringify({
+          permission: "ask",
+          user_message:
+            "This MCP call may run SQL or apply migrations. Confirm only if you trust the arguments and target project.",
+          agent_message: `MCP hook tags: ${[...new Set(hits)].join(", ")}.`,
+        }),
+      );
+    } else {
+      process.stdout.write(JSON.stringify({ permission: "allow" }));
+    }
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write(JSON.stringify({ permission: "allow" }));
+  process.exit(0);
+});

--- a/.cursor/hooks/before-read-file.mjs
+++ b/.cursor/hooks/before-read-file.mjs
@@ -1,0 +1,28 @@
+/**
+ * Blocks Agent reads of .env* (except .env.example / .env.sample). Fail-open on errors.
+ */
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+import { isProtectedEnvPath } from "./lib/repo-paths.mjs";
+
+function main() {
+  return readStdinJson().then((input) => {
+    const filePath = typeof input.file_path === "string" ? input.file_path : "";
+    if (filePath && isProtectedEnvPath(filePath)) {
+      process.stdout.write(
+        JSON.stringify({
+          permission: "deny",
+          user_message:
+            "Project hook: reading this .env file into the agent is blocked. Use .env.example or ask explicitly with a redacted snippet if you must discuss shape.",
+        }),
+      );
+    } else {
+      process.stdout.write(JSON.stringify({ permission: "allow" }));
+    }
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write(JSON.stringify({ permission: "allow" }));
+  process.exit(0);
+});

--- a/.cursor/hooks/before-shell-execution.mjs
+++ b/.cursor/hooks/before-shell-execution.mjs
@@ -1,0 +1,44 @@
+/**
+ * Prompts user to confirm potentially risky shell commands (fail-open on errors).
+ */
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+
+const ASK_PATTERNS = [
+  { id: "network_fetch", re: /\b(curl|wget|Invoke-WebRequest|Invoke-RestMethod)\b/i },
+  { id: "powershell_iwr", re: /\biwr\s+/i },
+  { id: "rm_rf", re: /\brm\b[^\n]*-\s*rf\b/i },
+  { id: "rmdir_windows", re: /\brmdir\s+\/s\b/i },
+  { id: "remove_item_recurse", re: /Remove-Item\s+[^\n]*-Recurse/i },
+  { id: "supabase_db_push_reset", re: /\bsupabase\s+db\s+(push|reset)\b/i },
+  { id: "git_force_push", re: /\bgit\s+push\b[^\n]*(\s--force|\s-f)(\s|$)/i },
+  { id: "curl_pipe_shell", re: /\|\s*(ba)?sh\b/i },
+  { id: "npm_publish", re: /\bnpm\s+publish\b/i },
+];
+
+function main() {
+  return readStdinJson().then((input) => {
+    const command = typeof input.command === "string" ? input.command : "";
+    const hits = [];
+    for (const { id, re } of ASK_PATTERNS) {
+      if (re.test(command)) hits.push(id);
+    }
+    if (hits.length > 0) {
+      process.stdout.write(
+        JSON.stringify({
+          permission: "ask",
+          user_message:
+            "A project hook flagged this shell command (network, destructive delete, Supabase DB push/reset, force-push, or similar). Confirm only if you intend to run it.",
+          agent_message: `Hook review tags: ${hits.join(", ")}.`,
+        }),
+      );
+    } else {
+      process.stdout.write(JSON.stringify({ permission: "allow" }));
+    }
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write(JSON.stringify({ permission: "allow" }));
+  process.exit(0);
+});

--- a/.cursor/hooks/before-submit-prompt.mjs
+++ b/.cursor/hooks/before-submit-prompt.mjs
@@ -5,6 +5,7 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const LOG_DIR = join(__dirname, "logs");
@@ -18,23 +19,6 @@ const PATTERNS = [
 
 function logDirEnsure() {
   mkdirSync(LOG_DIR, { recursive: true });
-}
-
-function readStdinJson() {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    process.stdin.on("data", (c) => chunks.push(c));
-    process.stdin.on("end", () => {
-      try {
-        const raw = Buffer.concat(chunks).toString("utf8").trim();
-        if (!raw) resolve({});
-        else resolve(JSON.parse(raw));
-      } catch (e) {
-        reject(e);
-      }
-    });
-    process.stdin.on("error", reject);
-  });
 }
 
 function main() {

--- a/.cursor/hooks/lib/read-stdin-json.mjs
+++ b/.cursor/hooks/lib/read-stdin-json.mjs
@@ -1,0 +1,18 @@
+/**
+ * @returns {Promise<Record<string, unknown>>}
+ */
+export function readStdinJson() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin.on("data", (c) => chunks.push(c));
+    process.stdin.on("end", () => {
+      try {
+        const raw = Buffer.concat(chunks).toString("utf8").trim();
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+    process.stdin.on("error", reject);
+  });
+}

--- a/.cursor/hooks/lib/repo-paths.mjs
+++ b/.cursor/hooks/lib/repo-paths.mjs
@@ -1,0 +1,51 @@
+/**
+ * @param {string} p
+ */
+export function normalizeRepoSlashes(p) {
+  return p.replace(/\\/g, "/").toLowerCase();
+}
+
+/**
+ * Block reads/writes of local env files except documented examples.
+ * @param {string} filePath
+ */
+export function isProtectedEnvPath(filePath) {
+  const norm = normalizeRepoSlashes(filePath);
+  const base = norm.split("/").pop() ?? "";
+  if (base === ".env.example" || base === ".env.sample") return false;
+  if (base === ".env" || base.startsWith(".env.")) return true;
+  return false;
+}
+
+/**
+ * AGENTS.md high-risk path hints (substring match on normalized path).
+ * @param {string} filePath
+ */
+export function isHighRiskRepoPath(filePath) {
+  const n = normalizeRepoSlashes(filePath);
+  if (n.endsWith("/netlify.toml") || n.endsWith("netlify.toml")) return true;
+  const needles = [
+    "supabase/migrations/",
+    "supabase/functions/",
+    "src/server/",
+    "src/lib/auth",
+    "src/lib/runtimeconfig",
+    "scripts/ci/",
+    ".github/workflows/",
+  ];
+  return needles.some((s) => n.includes(s));
+}
+
+/**
+ * @param {unknown} toolInput
+ */
+export function extractTargetPath(toolInput) {
+  if (!toolInput || typeof toolInput !== "object") return null;
+  const o = /** @type {Record<string, unknown>} */ (toolInput);
+  const keys = ["file_path", "path", "target_file", "filePath", "absolute_path"];
+  for (const k of keys) {
+    const v = o[k];
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  return null;
+}

--- a/.cursor/hooks/lib/repo-paths.mjs
+++ b/.cursor/hooks/lib/repo-paths.mjs
@@ -6,14 +6,18 @@ export function normalizeRepoSlashes(p) {
 }
 
 /**
- * Block reads/writes of local env files except documented examples.
+ * Block reads/writes of committed-style env files. Allows dev-local files:
+ * `.env.local`, `.env.example`, `.env.sample`.
  * @param {string} filePath
  */
 export function isProtectedEnvPath(filePath) {
   const norm = normalizeRepoSlashes(filePath);
   const base = norm.split("/").pop() ?? "";
-  if (base === ".env.example" || base === ".env.sample") return false;
-  if (base === ".env" || base.startsWith(".env.")) return true;
+  if (base === ".env.example" || base === ".env.sample" || base === ".env.local") {
+    return false;
+  }
+  if (base === ".env") return true;
+  if (base.startsWith(".env.")) return true;
   return false;
 }
 

--- a/.cursor/hooks/post-tool-use.mjs
+++ b/.cursor/hooks/post-tool-use.mjs
@@ -31,7 +31,7 @@ function main() {
       "[Project hook] This edit touched a high-risk path per AGENTS.md.",
       "Before claiming done: npm run ci:check-focused (when policy-relevant), npm run lint, npm run typecheck, npm run test:ci, and npm run build as appropriate.",
       "If migrations / RLS / tenant boundaries changed, also run npm run validate:tenant.",
-    ].join(" ");
+    ].join("\n");
 
     process.stdout.write(JSON.stringify({ additional_context: msg }));
     process.exit(0);

--- a/.cursor/hooks/post-tool-use.mjs
+++ b/.cursor/hooks/post-tool-use.mjs
@@ -1,0 +1,44 @@
+/**
+ * After successful edits, remind verification when AGENTS.md high-risk paths change.
+ */
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+import { extractTargetPath, isHighRiskRepoPath } from "./lib/repo-paths.mjs";
+
+/** @param {string} name */
+function normTool(name) {
+  return name.toLowerCase().replace(/[_-]/g, "");
+}
+
+const EDIT_TOOLS = new Set(["write", "delete", "strreplace", "searchreplace", "edit", "applypatch"]);
+
+function main() {
+  return readStdinJson().then((input) => {
+    const toolName = typeof input.tool_name === "string" ? input.tool_name : "";
+    if (!EDIT_TOOLS.has(normTool(toolName))) {
+      process.stdout.write("{}");
+      process.exit(0);
+      return;
+    }
+
+    const path = extractTargetPath(input.tool_input);
+    if (!path || !isHighRiskRepoPath(path)) {
+      process.stdout.write("{}");
+      process.exit(0);
+      return;
+    }
+
+    const msg = [
+      "[Project hook] This edit touched a high-risk path per AGENTS.md.",
+      "Before claiming done: npm run ci:check-focused (when policy-relevant), npm run lint, npm run typecheck, npm run test:ci, and npm run build as appropriate.",
+      "If migrations / RLS / tenant boundaries changed, also run npm run validate:tenant.",
+    ].join(" ");
+
+    process.stdout.write(JSON.stringify({ additional_context: msg }));
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write("{}");
+  process.exit(0);
+});

--- a/.cursor/hooks/pre-tool-use.mjs
+++ b/.cursor/hooks/pre-tool-use.mjs
@@ -1,0 +1,43 @@
+/**
+ * Blocks Write/Delete (and common patch tools) into .env* (except examples). Fail-open on errors.
+ */
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+import { extractTargetPath, isProtectedEnvPath } from "./lib/repo-paths.mjs";
+
+/** @param {string} name */
+function normTool(name) {
+  return name.toLowerCase().replace(/[_-]/g, "");
+}
+
+const EDIT_TOOLS = new Set(["write", "delete", "strreplace", "searchreplace", "edit", "applypatch"]);
+
+function main() {
+  return readStdinJson().then((input) => {
+    const toolName = typeof input.tool_name === "string" ? input.tool_name : "";
+    if (!EDIT_TOOLS.has(normTool(toolName))) {
+      process.stdout.write(JSON.stringify({ permission: "allow" }));
+      process.exit(0);
+      return;
+    }
+
+    const path = extractTargetPath(input.tool_input);
+    if (path && isProtectedEnvPath(path)) {
+      process.stdout.write(
+        JSON.stringify({
+          permission: "deny",
+          user_message: "Project hook: writing or deleting protected .env files is blocked.",
+          agent_message:
+            "Do not modify .env secrets files; use .env.example and runtime config patterns from the repo.",
+        }),
+      );
+    } else {
+      process.stdout.write(JSON.stringify({ permission: "allow" }));
+    }
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write(JSON.stringify({ permission: "allow" }));
+  process.exit(0);
+});

--- a/.cursor/hooks/session-start.mjs
+++ b/.cursor/hooks/session-start.mjs
@@ -6,7 +6,7 @@ import { readStdinJson } from "./lib/read-stdin-json.mjs";
 const CONTEXT = [
   "[Project hooks] AllIincompassing guardrails:",
   "- High-risk areas (human review before merge): supabase/migrations, supabase/functions, src/server, src/lib/auth*, src/lib/runtimeConfig*, scripts/ci, .github/workflows, netlify.toml.",
-  "- Do not read or commit real .env* secrets; use .env.example / synthetic fixtures.",
+  "- Agents may use `.env.local` for dev. Do not read/commit root `.env` or other `.env.*` secrets (use .env.example / synthetic fixtures for docs and CI).",
   "- After substantive edits: npm run lint, npm run typecheck, npm run test:ci (and policy checks when touching protected surfaces).",
   "- Tenant/auth surfaces: npm run validate:tenant when DB/RLS paths change.",
 ].join("\n");

--- a/.cursor/hooks/session-start.mjs
+++ b/.cursor/hooks/session-start.mjs
@@ -1,0 +1,22 @@
+/**
+ * Injects short repo guardrails into new Agent sessions (fire-and-forget hook).
+ */
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+
+const CONTEXT = [
+  "[Project hooks] AllIincompassing guardrails:",
+  "- High-risk areas (human review before merge): supabase/migrations, supabase/functions, src/server, src/lib/auth*, src/lib/runtimeConfig*, scripts/ci, .github/workflows, netlify.toml.",
+  "- Do not read or commit real .env* secrets; use .env.example / synthetic fixtures.",
+  "- After substantive edits: npm run lint, npm run typecheck, npm run test:ci (and policy checks when touching protected surfaces).",
+  "- Tenant/auth surfaces: npm run validate:tenant when DB/RLS paths change.",
+].join("\n");
+
+readStdinJson()
+  .then(() => {
+    process.stdout.write(JSON.stringify({ additional_context: CONTEXT }));
+    process.exit(0);
+  })
+  .catch(() => {
+    process.stdout.write("{}");
+    process.exit(0);
+  });

--- a/.cursor/hooks/stop.mjs
+++ b/.cursor/hooks/stop.mjs
@@ -4,29 +4,13 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const LOG_DIR = join(__dirname, "logs");
 
 function logDirEnsure() {
   mkdirSync(LOG_DIR, { recursive: true });
-}
-
-function readStdinJson() {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    process.stdin.on("data", (c) => chunks.push(c));
-    process.stdin.on("end", () => {
-      try {
-        const raw = Buffer.concat(chunks).toString("utf8").trim();
-        if (!raw) resolve({});
-        else resolve(JSON.parse(raw));
-      } catch (e) {
-        reject(e);
-      }
-    });
-    process.stdin.on("error", reject);
-  });
 }
 
 function main() {


### PR DESCRIPTION
## Summary
Expands [`.cursor/hooks.json`](.cursor/hooks.json) with additional **Node (`.mjs`)** hooks so the team can see policy-style automation in Cursor: session context, shell/MCP confirmation, env-file blocks, and post-edit verification nudges.

## New / updated behavior
| Event | Role | Fail mode |
|-------|------|-----------|
| `sessionStart` | Injects short **AGENTS.md-aligned** guardrails into the session context. | Fail-open |
| `beforeReadFile` (matcher `Read`) | **Denies** loading `.env` / `.env.*` into the agent (allows `.env.example`, `.env.sample`). | Fail-open |
| `preToolUse` | **Denies** Write/Delete/patch-style tools targeting protected `.env` paths. | Fail-open |
| `postToolUse` | After edits to **high-risk paths** (migrations, functions, `src/server`, `src/lib/auth*`, `src/lib/runtimeConfig*`, `scripts/ci`, `.github/workflows`, `netlify.toml`), injects **`additional_context`** with suggested `npm` checks. | Fail-open |
| `beforeShellExecution` | **`permission: ask`** for network fetchers, `rm -rf`-style deletes, `supabase db push|reset`, force `git push`, `npm publish`, shell pipes to `sh`/`bash`. | Fail-open |
| `beforeMCPExecution` | **`permission: ask`** when the MCP tool name suggests `apply_migration` / `execute_sql` style operations. | Fail-open |

Existing audit hooks (`beforeSubmitPrompt`, `afterAgentResponse`, `stop`) unchanged in intent; they now share [`read-stdin-json.mjs`](.cursor/hooks/lib/read-stdin-json.mjs).

## Disable / tune
- Rename or trim entries in [`.cursor/hooks.json`](.cursor/hooks.json); Cursor reloads on save.
- Adjust patterns in the `.mjs` scripts under [`.cursor/hooks/`](.cursor/hooks/) as the team learns false-positive rates.

## Verification
- `npm run lint` and `npm run typecheck` passed.
- Local stdin/stdout smoke for each new script with representative JSON payloads.
