### PR TITLE
fix(api): dashboard /api/dashboard 401 — align edge anon key and bearer headers

### DIFF
--- a/src/server/__tests__/dashboardHandler.test.ts
+++ b/src/server/__tests__/dashboardHandler.test.ts
@@ -54,6 +54,31 @@ describe("dashboardHandler", () => {
     expect(response.status).toBe(401);
   });
 
+  it("prefers X-Supabase-Authorization when Authorization bearer token is empty", async () => {
+    const fetchSpy = mockFetch();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, data: { ok: true } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const { dashboardHandler } = await import("../api/dashboard");
+    const response = await dashboardHandler(
+      new Request("http://localhost/api/dashboard", {
+        method: "GET",
+        headers: {
+          Authorization: "Bearer ",
+          "X-Supabase-Authorization": "Bearer real-token",
+          Origin: "http://localhost:3000",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("accepts X-Supabase-Authorization when Authorization is absent", async () => {
     const fetchSpy = mockFetch();
     fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: { ok: true } }), { status: 200, headers: { "content-type": "application/json" } }));

--- a/src/server/api/dashboard.ts
+++ b/src/server/api/dashboard.ts
@@ -34,10 +34,20 @@ export async function dashboardHandler(request: Request): Promise<Response> {
     });
   }
 
-  const authHeader =
-    request.headers.get("Authorization") ?? request.headers.get("X-Supabase-Authorization") ?? "";
-  const accessToken = typeof authHeader === "string" ? authHeader.replace(/^Bearer\s+/i, "").trim() : "";
-  if (!authHeader || accessToken.length === 0) {
+  const bearerPayload = (value: string | null): string => {
+    if (!value) {
+      return "";
+    }
+    const trimmed = value.trim();
+    if (!/^Bearer\s+/i.test(trimmed)) {
+      return "";
+    }
+    return trimmed.replace(/^Bearer\s+/i, "").trim();
+  };
+  const accessToken =
+    bearerPayload(request.headers.get("Authorization")) ||
+    bearerPayload(request.headers.get("X-Supabase-Authorization"));
+  if (!accessToken) {
     return errorResponse(request, "unauthorized", "Missing authorization token", {
       headers: { "WWW-Authenticate": "Bearer" },
     });

--- a/supabase/functions/_shared/auth-middleware.ts
+++ b/supabase/functions/_shared/auth-middleware.ts
@@ -11,7 +11,10 @@
 import { errorEnvelope, getRequestId } from "../lib/http/error.ts";
 import { resolveOrgId } from "./org.ts";
 import { corsHeadersForRequest as sharedCorsHeadersForRequest } from "./cors.ts";
-import { resolveSupabasePublishableKeyFromEnv, resolveSupabaseUrlFromEnv } from "./supabaseEnv.ts";
+import { resolveSupabaseUrlFromEnv } from "./supabaseEnv.ts";
+import { extractBearerToken, resolvePublishableApiKeyForRequest } from "./requestAuthHeaders.ts";
+
+export { extractBearerToken };
 
 type SupabaseModule = typeof import("npm:@supabase/supabase-js@2.50.0");
 
@@ -123,27 +126,6 @@ export function handleCors(req: Request): Response | null {
   return null;
 }
 
-/**
- * Extract Bearer token from Authorization header
- */
-export function extractBearerToken(req: Request): string | null {
-  const authHeader = req.headers.get('Authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return null;
-  }
-  return authHeader.substring(7);
-}
-
-const resolveAnonKeyForAuth = (req: Request): string => {
-  const fromEnv = resolveSupabasePublishableKeyFromEnv();
-  if (fromEnv.length > 0) {
-    return fromEnv;
-  }
-  // Same publishable key the browser sends on /api/dashboard proxies (public anon key).
-  const fromHeader = req.headers.get("apikey")?.trim();
-  return fromHeader && fromHeader.length > 0 ? fromHeader : "";
-};
-
 export async function createSupabaseClientForRequest(req: Request): Promise<{
   supabase: ReturnType<SupabaseModule["createClient"]>;
   token: string | null;
@@ -151,7 +133,7 @@ export async function createSupabaseClientForRequest(req: Request): Promise<{
   const token = extractBearerToken(req);
   const { createClient } = await loadSupabaseModule();
   const supabaseUrl = resolveSupabaseUrlFromEnv();
-  const anonKey = resolveAnonKeyForAuth(req);
+  const anonKey = resolvePublishableApiKeyForRequest(req);
   const supabase = createClient(
     supabaseUrl,
     anonKey,

--- a/supabase/functions/_shared/database.ts
+++ b/supabase/functions/_shared/database.ts
@@ -1,11 +1,12 @@
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2.50.0";
-import { resolveSupabasePublishableKeyFromEnv, resolveSupabaseUrlFromEnv } from "./supabaseEnv.ts";
+import { resolveSupabaseUrlFromEnv } from "./supabaseEnv.ts";
+import { resolveBearerAuthorizationHeader, resolvePublishableApiKeyForRequest } from "./requestAuthHeaders.ts";
 
 const SUPABASE_URL = resolveSupabaseUrlFromEnv();
-const ANON_KEY = resolveSupabasePublishableKeyFromEnv();
 const SERVICE_KEY  = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 export const supabaseAdmin: SupabaseClient = createClient(SUPABASE_URL, SERVICE_KEY);
 export function createRequestClient(req: Request): SupabaseClient {
-  const auth = req.headers.get("Authorization") || "";
-  return createClient(SUPABASE_URL, ANON_KEY, { global: { headers: { Authorization: auth } }});
+  const auth = resolveBearerAuthorizationHeader(req);
+  const anon = resolvePublishableApiKeyForRequest(req);
+  return createClient(SUPABASE_URL, anon, { global: { headers: { Authorization: auth } } });
 }

--- a/supabase/functions/_shared/requestAuthHeaders.ts
+++ b/supabase/functions/_shared/requestAuthHeaders.ts
@@ -1,0 +1,41 @@
+import { resolveSupabasePublishableKeyFromEnv } from "./supabaseEnv.ts";
+
+/**
+ * Bearer token from Authorization, else X-Supabase-Authorization (duplicate header path).
+ * Ignores empty payloads after the Bearer prefix so a bad primary header cannot mask a valid fallback.
+ */
+export function extractBearerToken(req: Request): string | null {
+  const fromBearerHeader = (value: string | null): string | null => {
+    if (!value) {
+      return null;
+    }
+    const trimmed = value.trim();
+    if (!/^Bearer\s+/i.test(trimmed)) {
+      return null;
+    }
+    const token = trimmed.replace(/^Bearer\s+/i, "").trim();
+    return token.length > 0 ? token : null;
+  };
+
+  return (
+    fromBearerHeader(req.headers.get("Authorization")) ??
+    fromBearerHeader(req.headers.get("X-Supabase-Authorization"))
+  );
+}
+
+/**
+ * Prefer request apikey (browser /api/dashboard forwards runtime anon) over edge env so JWT + anon
+ * stay on the same Supabase project when operator env drifts from the live SPA config.
+ */
+export function resolvePublishableApiKeyForRequest(req: Request): string {
+  const fromHeader = req.headers.get("apikey")?.trim();
+  if (fromHeader && fromHeader.length > 0) {
+    return fromHeader;
+  }
+  return resolveSupabasePublishableKeyFromEnv();
+}
+
+export function resolveBearerAuthorizationHeader(req: Request): string {
+  const token = extractBearerToken(req);
+  return token ? `Bearer ${token}` : "";
+}


### PR DESCRIPTION
## Summary
Fixes admin dashboard load failures where \GET /api/dashboard\ returned **401** despite a logged-in session.

## Root cause
1. Edge auth preferred **Deno env** publishable key over the incoming **\pikey\** header, so JWT validation could use a different Supabase project than the SPA when Netlify/edge env drifted from runtime config.
2. Netlify \dashboardHandler\ preferred \Authorization\ even when it was \Bearer \ with an **empty** token, ignoring a valid \X-Supabase-Authorization\.

## Changes
- New \supabase/functions/_shared/requestAuthHeaders.ts\: dual-header bearer extraction; **prefer request \pikey\ then env** for publishable key.
- Wire through \uth-middleware\ and \database.createRequestClient\.
- Server \dashboard.ts\: first **non-empty** bearer from either header.
- Regression test in \dashboardHandler.test.ts\.

## Verification (local)
\
pm run ci:check-focused\, \lint\, \	ypecheck\, \	est:ci\, \ci:verify-coverage\, \uild\, \	est:routes:tier0\, \alidate:tenant\, targeted Vitest (dashboard handler / parity / envelope / profiles-me contract).

## Residual risk
\SUPABASE_URL\ on edge must still match the project implied by forwarded \pikey\; this fixes anon/JWT skew, not URL-only misconfiguration.

## Blocked / CI
\ci:playwright\ not run locally; please confirm on PR checks.

Made with [Cursor](https://cursor.com)