### PR TITLE
fix(db): dashboard active counts + Cursor hooks wiring

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -7,6 +7,12 @@
         "timeout": 5
       }
     ],
+    "sessionEnd": [
+      {
+        "command": "node .cursor/hooks/session-end.mjs",
+        "timeout": 5
+      }
+    ],
     "beforeSubmitPrompt": [
       {
         "command": "node .cursor/hooks/before-submit-prompt.mjs",
@@ -24,12 +30,39 @@
     "preToolUse": [
       {
         "command": "node .cursor/hooks/pre-tool-use.mjs",
+        "matcher": "Write|write|Delete|delete|StrReplace|strReplace|strreplace|SearchReplace|searchReplace|searchreplace|search_replace|Search_Replace|Edit|edit|ApplyPatch|applyPatch|applypatch|apply_patch",
         "timeout": 8
       }
     ],
     "postToolUse": [
       {
         "command": "node .cursor/hooks/post-tool-use.mjs",
+        "matcher": "Write|write|Delete|delete|StrReplace|strReplace|strreplace|SearchReplace|searchReplace|searchreplace|search_replace|Search_Replace|Edit|edit|ApplyPatch|applyPatch|applypatch|apply_patch",
+        "timeout": 8
+      }
+    ],
+    "postToolUseFailure": [
+      {
+        "command": "node .cursor/hooks/post-tool-use-failure.mjs",
+        "matcher": "Write|write|Delete|delete|StrReplace|strReplace|strreplace|SearchReplace|searchReplace|searchreplace|search_replace|Search_Replace|Edit|edit|ApplyPatch|applyPatch|applypatch|apply_patch",
+        "timeout": 8
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "node .cursor/hooks/pre-compact.mjs",
+        "timeout": 5
+      }
+    ],
+    "subagentStart": [
+      {
+        "command": "node .cursor/hooks/subagent-start.mjs",
+        "timeout": 8
+      }
+    ],
+    "subagentStop": [
+      {
+        "command": "node .cursor/hooks/subagent-stop.mjs",
         "timeout": 8
       }
     ],
@@ -39,9 +72,21 @@
         "timeout": 12
       }
     ],
+    "afterShellExecution": [
+      {
+        "command": "node .cursor/hooks/after-shell-execution.mjs",
+        "timeout": 12
+      }
+    ],
     "beforeMCPExecution": [
       {
         "command": "node .cursor/hooks/before-mcp-execution.mjs",
+        "timeout": 12
+      }
+    ],
+    "afterMCPExecution": [
+      {
+        "command": "node .cursor/hooks/after-mcp-execution.mjs",
         "timeout": 12
       }
     ],

--- a/.cursor/hooks/after-mcp-execution.mjs
+++ b/.cursor/hooks/after-mcp-execution.mjs
@@ -1,0 +1,57 @@
+/**
+ * Audit: MCP call completed — metadata only (fail-open).
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const LOG_DIR = join(__dirname, "logs");
+
+function logDirEnsure() {
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    const server =
+      typeof input.server === "string"
+        ? input.server
+        : typeof input.mcp_server === "string"
+          ? input.mcp_server
+          : typeof input.server_name === "string"
+            ? input.server_name
+            : "";
+    const toolName =
+      typeof input.tool_name === "string"
+        ? input.tool_name
+        : typeof input.toolName === "string"
+          ? input.toolName
+          : "";
+    const durationMs =
+      typeof input.duration_ms === "number"
+        ? input.duration_ms
+        : typeof input.durationMs === "number"
+          ? input.durationMs
+          : typeof input.elapsed_ms === "number"
+            ? input.elapsed_ms
+            : null;
+    const line = JSON.stringify({
+      hook: "afterMCPExecution",
+      ts: new Date().toISOString(),
+      server: server || null,
+      tool_name: toolName || null,
+      duration_ms: durationMs,
+    });
+    logDirEnsure();
+    appendFileSync(join(LOG_DIR, "mcp-after.ndjson"), `${line}\n`, "utf8");
+    process.stdout.write("{}");
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write("{}");
+  process.exit(0);
+});

--- a/.cursor/hooks/after-shell-execution.mjs
+++ b/.cursor/hooks/after-shell-execution.mjs
@@ -1,0 +1,55 @@
+/**
+ * Audit: shell completion with redacted command (fail-open).
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+import { redactCommandLine } from "./lib/redact-secrets.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const LOG_DIR = join(__dirname, "logs");
+
+function logDirEnsure() {
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function pickScalar(input, keys) {
+  for (const k of keys) {
+    const v = input[k];
+    if (typeof v === "string" && v.length > 0) return v;
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    const command = typeof input.command === "string" ? input.command : "";
+    const cwd =
+      typeof input.cwd === "string"
+        ? input.cwd
+        : typeof input.working_directory === "string"
+          ? input.working_directory
+          : typeof input.workingDirectory === "string"
+            ? input.workingDirectory
+            : "";
+    const exitCode = pickScalar(input, ["exit_code", "exitCode", "code"]);
+    const line = JSON.stringify({
+      hook: "afterShellExecution",
+      ts: new Date().toISOString(),
+      command_redacted: redactCommandLine(command),
+      exit_code: exitCode,
+      cwd: cwd ? redactCommandLine(cwd, 300) : null,
+    });
+    logDirEnsure();
+    appendFileSync(join(LOG_DIR, "shell-after.ndjson"), `${line}\n`, "utf8");
+    process.stdout.write("{}");
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write("{}");
+  process.exit(0);
+});

--- a/.cursor/hooks/lib/redact-secrets.mjs
+++ b/.cursor/hooks/lib/redact-secrets.mjs
@@ -1,0 +1,42 @@
+/**
+ * Best-effort redaction for hook audit logs (commands and error snippets).
+ * @param {string} s
+ */
+export function redactSensitiveStrings(s) {
+  if (typeof s !== "string" || s.length === 0) return "";
+  let out = s;
+  out = out.replace(/\b-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/gi, "[REDACTED_PEM]");
+  out = out.replace(/\bsk_(live|test)_[0-9a-zA-Z]+\b/gi, "[REDACTED_STRIPE]");
+  out = out.replace(/\bgh[psu]_[0-9a-zA-Z]+\b/gi, "[REDACTED_GITHUB_TOKEN]");
+  out = out.replace(/\bAKIA[0-9A-Z]{16}\b/g, "[REDACTED_AWS_KEY]");
+  out = out.replace(/\bAIza[0-9A-Za-z_-]{20,}\b/g, "[REDACTED_GOOGLE_KEY]");
+  out = out.replace(/\bxox[baprs]-[0-9A-Za-z-]+\b/gi, "[REDACTED_SLACK]");
+  out = out.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED_JWT]");
+  return out;
+}
+
+/**
+ * @param {string} cmd
+ * @param {number} [maxLen]
+ */
+export function redactCommandLine(cmd, maxLen = 600) {
+  const redacted = redactSensitiveStrings(typeof cmd === "string" ? cmd : "");
+  return redacted.length > maxLen ? `${redacted.slice(0, maxLen)}…` : redacted;
+}
+
+/**
+ * @param {unknown} err
+ * @param {number} [maxLen]
+ */
+export function redactErrorSnippet(err, maxLen = 400) {
+  const raw =
+    typeof err === "string"
+      ? err
+      : err && typeof err === "object" && "message" in err && typeof err.message === "string"
+        ? err.message
+        : err != null
+          ? String(err)
+          : "";
+  const redacted = redactSensitiveStrings(raw);
+  return redacted.length > maxLen ? `${redacted.slice(0, maxLen)}…` : redacted;
+}

--- a/.cursor/hooks/post-tool-use-failure.mjs
+++ b/.cursor/hooks/post-tool-use-failure.mjs
@@ -1,0 +1,37 @@
+/**
+ * Audit: one NDJSON line per failed edit-style tool use (fail-open).
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+import { redactErrorSnippet } from "./lib/redact-secrets.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const LOG_DIR = join(__dirname, "logs");
+
+function logDirEnsure() {
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    const toolName = typeof input.tool_name === "string" ? input.tool_name : "";
+    const errRaw = input.error ?? input.tool_error ?? input.failure_message ?? input.message;
+    const line = JSON.stringify({
+      hook: "postToolUseFailure",
+      ts: new Date().toISOString(),
+      tool_name: toolName || null,
+      error: redactErrorSnippet(errRaw),
+    });
+    logDirEnsure();
+    appendFileSync(join(LOG_DIR, "tool-use-failure.ndjson"), `${line}\n`, "utf8");
+    process.stdout.write("{}");
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write("{}");
+  process.exit(0);
+});

--- a/.cursor/hooks/pre-compact.mjs
+++ b/.cursor/hooks/pre-compact.mjs
@@ -1,0 +1,35 @@
+/**
+ * Audit: context compaction observed — keys only, no payload (fail-open).
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const LOG_DIR = join(__dirname, "logs");
+
+function logDirEnsure() {
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    const keys = input && typeof input === "object" ? Object.keys(input).sort() : [];
+    const line = JSON.stringify({
+      hook: "preCompact",
+      ts: new Date().toISOString(),
+      input_key_count: keys.length,
+      input_keys: keys.slice(0, 40),
+    });
+    logDirEnsure();
+    appendFileSync(join(LOG_DIR, "pre-compact.ndjson"), `${line}\n`, "utf8");
+    process.stdout.write("{}");
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write("{}");
+  process.exit(0);
+});

--- a/.cursor/hooks/session-end.mjs
+++ b/.cursor/hooks/session-end.mjs
@@ -1,0 +1,42 @@
+/**
+ * Audit: agent session ended — scalar metadata only (fail-open).
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const LOG_DIR = join(__dirname, "logs");
+
+function logDirEnsure() {
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    const reason =
+      typeof input.reason === "string"
+        ? input.reason
+        : typeof input.status === "string"
+          ? input.status
+          : typeof input.end_reason === "string"
+            ? input.end_reason
+            : null;
+    const line = JSON.stringify({
+      hook: "sessionEnd",
+      ts: new Date().toISOString(),
+      reason,
+      status: typeof input.status === "string" ? input.status : null,
+    });
+    logDirEnsure();
+    appendFileSync(join(LOG_DIR, "session-end.ndjson"), `${line}\n`, "utf8");
+    process.stdout.write("{}");
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write("{}");
+  process.exit(0);
+});

--- a/.cursor/hooks/subagent-start.mjs
+++ b/.cursor/hooks/subagent-start.mjs
@@ -1,0 +1,50 @@
+/**
+ * Audit: subagent / task started — metadata only, never blocks (fail-open).
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const LOG_DIR = join(__dirname, "logs");
+
+function logDirEnsure() {
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    const subagentType =
+      typeof input.subagent_type === "string"
+        ? input.subagent_type
+        : typeof input.subagentType === "string"
+          ? input.subagentType
+          : typeof input.type === "string"
+            ? input.type
+            : null;
+    const subagentId =
+      typeof input.subagent_id === "string"
+        ? input.subagent_id
+        : typeof input.subagentId === "string"
+          ? input.subagentId
+          : typeof input.id === "string"
+            ? input.id
+            : null;
+    const line = JSON.stringify({
+      hook: "subagentStart",
+      ts: new Date().toISOString(),
+      subagent_type: subagentType,
+      subagent_id: subagentId,
+    });
+    logDirEnsure();
+    appendFileSync(join(LOG_DIR, "subagent-start.ndjson"), `${line}\n`, "utf8");
+    process.stdout.write("{}");
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write("{}");
+  process.exit(0);
+});

--- a/.cursor/hooks/subagent-stop.mjs
+++ b/.cursor/hooks/subagent-stop.mjs
@@ -1,0 +1,45 @@
+/**
+ * Audit: subagent / task stopped — metadata only, no followup_message (fail-open).
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readStdinJson } from "./lib/read-stdin-json.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const LOG_DIR = join(__dirname, "logs");
+
+function logDirEnsure() {
+  mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function main() {
+  return readStdinJson().then((input) => {
+    const subagentType =
+      typeof input.subagent_type === "string"
+        ? input.subagent_type
+        : typeof input.subagentType === "string"
+          ? input.subagentType
+          : typeof input.type === "string"
+            ? input.type
+            : null;
+    const status = typeof input.status === "string" ? input.status : null;
+    const loopCount = typeof input.loop_count === "number" ? input.loop_count : typeof input.loopCount === "number" ? input.loopCount : null;
+    const line = JSON.stringify({
+      hook: "subagentStop",
+      ts: new Date().toISOString(),
+      subagent_type: subagentType,
+      status,
+      loop_count: loopCount,
+    });
+    logDirEnsure();
+    appendFileSync(join(LOG_DIR, "subagent-stop.ndjson"), `${line}\n`, "utf8");
+    process.stdout.write("{}");
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write("{}");
+  process.exit(0);
+});

--- a/supabase/migrations/20260421223930_fix_dashboard_active_counts.sql
+++ b/supabase/migrations/20260421223930_fix_dashboard_active_counts.sql
@@ -1,0 +1,149 @@
+/*
+  @migration-intent: Align dashboard client/therapist "active" counts with row status, not client created_at window.
+  @migration-dependencies: 20260320120000_dashboard_authz_hardening.sql
+  @migration-rollback: Re-apply prior get_dashboard_data body from 20260320120000_dashboard_authz_hardening.sql if emergency rollback is required.
+  Remote project wnnjeqheqxxyrgsjmygy: applied via Supabase MCP apply_migration (version matches hosted history).
+*/
+
+set search_path = public;
+
+begin;
+
+create or replace function get_dashboard_data()
+returns jsonb
+language plpgsql
+security invoker
+as $$
+declare
+  v_org uuid;
+  v_is_org_admin boolean;
+  v_is_super_admin boolean;
+  result jsonb;
+  today_sessions jsonb;
+  incomplete_sessions jsonb;
+  billing_alerts jsonb;
+  client_metrics jsonb;
+  therapist_metrics jsonb;
+begin
+  set local row_security = on;
+
+  v_org := app.current_user_organization_id();
+  if v_org is null then
+    raise exception using errcode = '42501', message = 'Organization context required';
+  end if;
+
+  v_is_org_admin := app.user_has_role_for_org(
+    app.current_user_id(),
+    v_org,
+    array['org_admin'::text, 'admin'::text]
+  );
+  v_is_super_admin := app.current_user_is_super_admin();
+
+  if coalesce(v_is_org_admin, false) is not true and coalesce(v_is_super_admin, false) is not true then
+    raise exception using errcode = '42501', message = 'Admin dashboard access required';
+  end if;
+
+  select jsonb_agg(
+    jsonb_build_object(
+      'id', s.id,
+      'client_id', s.client_id,
+      'therapist_id', s.therapist_id,
+      'start_time', s.start_time,
+      'end_time', s.end_time,
+      'status', s.status,
+      'therapist', jsonb_build_object(
+        'id', t.id,
+        'full_name', t.full_name
+      ),
+      'client', jsonb_build_object(
+        'id', c.id,
+        'full_name', c.full_name
+      )
+    )
+  ) into today_sessions
+  from sessions s
+  join therapists t on t.id = s.therapist_id
+  join clients c on c.id = s.client_id
+  where s.organization_id = v_org
+    and t.organization_id = v_org
+    and c.organization_id = v_org
+    and date(s.start_time at time zone 'UTC') = current_date;
+
+  select jsonb_agg(
+    jsonb_build_object(
+      'id', s.id,
+      'client_id', s.client_id,
+      'therapist_id', s.therapist_id,
+      'start_time', s.start_time,
+      'end_time', s.end_time,
+      'status', s.status,
+      'therapist', jsonb_build_object(
+        'id', t.id,
+        'full_name', t.full_name
+      ),
+      'client', jsonb_build_object(
+        'id', c.id,
+        'full_name', c.full_name
+      )
+    )
+  ) into incomplete_sessions
+  from sessions s
+  join therapists t on t.id = s.therapist_id
+  join clients c on c.id = s.client_id
+  where s.organization_id = v_org
+    and t.organization_id = v_org
+    and c.organization_id = v_org
+    and s.status = 'completed'
+    and (s.notes is null or s.notes = '');
+
+  select jsonb_agg(
+    jsonb_build_object(
+      'id', br.id,
+      'session_id', br.session_id,
+      'amount', br.amount,
+      'status', br.status,
+      'created_at', br.created_at
+    )
+  ) into billing_alerts
+  from billing_records br
+  where br.organization_id = v_org
+    and br.status in ('pending', 'rejected');
+
+  select jsonb_build_object(
+    'total', count(*),
+    'active', count(*) filter (where coalesce(nullif(trim(lower(c.status)), ''), 'active') = 'active'),
+    'totalUnits', coalesce(sum(
+      coalesce(c.one_to_one_units, 0) +
+      coalesce(c.supervision_units, 0) +
+      coalesce(c.parent_consult_units, 0)
+    ), 0)
+  ) into client_metrics
+  from clients c
+  where c.organization_id = v_org;
+
+  select jsonb_build_object(
+    'total', count(*),
+    'active', count(*) filter (where coalesce(nullif(trim(lower(t.status)), ''), 'active') = 'active'),
+    'totalHours', coalesce(sum(coalesce(t.weekly_hours_max, 0)), 0)
+  ) into therapist_metrics
+  from therapists t
+  where t.organization_id = v_org;
+
+  result := jsonb_build_object(
+    'todaySessions', coalesce(today_sessions, '[]'::jsonb),
+    'incompleteSessions', coalesce(incomplete_sessions, '[]'::jsonb),
+    'billingAlerts', coalesce(billing_alerts, '[]'::jsonb),
+    'clientMetrics', coalesce(client_metrics, '{}'::jsonb),
+    'therapistMetrics', coalesce(therapist_metrics, '{}'::jsonb)
+  );
+
+  return result;
+end;
+$$;
+
+-- Preserve grants from prior migration
+revoke execute on function get_dashboard_data() from authenticated;
+grant execute on function get_dashboard_data() to dashboard_consumer;
+grant execute on function get_dashboard_data() to service_role;
+
+commit;


### PR DESCRIPTION
## Summary
- **Dashboard RPC:** \get_dashboard_data()\ now counts **active** clients and therapists using **normalized \status\** (treat empty/null status as \ctive\ for therapists/clients). Previously client \ctive\ incorrectly used **created in last 30 days**, which showed **0** for stable caseloads.
- **Production DB:** Migration already applied to project **\wnnjeqheqxxyrgsjmygy\** via **Supabase Cursor MCP** \pply_migration\ (hosted version **\20260421223930_fix_dashboard_active_counts\**). Repo file matches that version string so local/CI history stays aligned with remote.
- **Cursor hooks:** Extends \.cursor/hooks.json\ and adds scripts for session end, pre-compact, subagent start/stop, post-tool-use failure, after shell/MCP execution, and shared \edact-secrets\ helper.

## Files
- \supabase/migrations/20260421223930_fix_dashboard_active_counts.sql\
- \.cursor/hooks.json\
- \.cursor/hooks/*.mjs\ (new hook scripts + \lib/redact-secrets.mjs\)

## Notes
- \.cursor/hooks/logs/\ and \.cursor/hooks/state/\ remain gitignored.
- Other environments: run migrations as usual; SQL is idempotent (\CREATE OR REPLACE\).

## Verification
- \
pm run validate:tenant\ (pass)
- Pre-commit \ci:check-focused\ / migration governance (pass)

Made with [Cursor](https://cursor.com)