### PR TITLE
WIN-108 Optimize Programs & Goals tab responsiveness

### DIFF
--- a/docs/ai/WIN-108-programs-goals-responsiveness-handoff.md
+++ b/docs/ai/WIN-108-programs-goals-responsiveness-handoff.md
@@ -1,0 +1,48 @@
+# WIN-108 Programs & Goals Responsiveness Handoff
+
+## Scope
+
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Allowed surfaces used:
+  - `src/components/ClientDetails/ProgramsGoalsTab.tsx`
+  - `src/components/__tests__/ProgramsGoalsTab.test.tsx`
+
+## What Changed
+
+- Replaced several post-mutation refetches in `ProgramsGoalsTab` with cache-aware updates for:
+  - program create
+  - goal create
+  - note create
+  - program archive
+  - goal archive
+- Added bounded query `staleTime` to reduce needless remount churn for programs, goals, notes, and assessment documents.
+- Replaced unconditional 3-second assessment queue polling with conditional polling that runs only while:
+  - an upload is actively processing
+  - the queue contains `uploaded` or `extracting` assessment rows
+  - a transient assessment queue fetch failure still needs retry recovery
+- Kept existing workflow semantics intact after reviewer follow-up:
+  - removed the temporary empty-cache seeding for new-program goal/note queries
+  - added retry recovery for transient empty-state assessment queue failures
+
+## Verification
+
+- Passed:
+  - `npm test -- --run src/components/__tests__/ProgramsGoalsTab.test.tsx`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run build`
+- Attempted but not authoritative:
+  - `npm run verify:local`
+    - timed out locally after broader repo checks
+    - emitted unrelated warnings and external/network-related failures outside this slice
+
+## Reviewer Notes
+
+- Initial reviewer findings on empty seeded caches and assessment retry recovery were addressed in the final diff.
+- Final reviewer re-check requested before PR handoff.
+
+## Residual Risk
+
+- This slice improves perceived responsiveness and avoids avoidable tab-local refetch churn, but it does not change edge/API latency itself.
+- Broader repo-level `verify:local` remains noisy and is not a reliable signal for this bounded UI slice without separate repo follow-up.

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -40,6 +40,12 @@ const PROGRAM_NOTES_REQUEST_TIMEOUT_MS = 12_000;
 const PROGRAM_CREATE_REQUEST_TIMEOUT_MS = 12_000;
 const GOAL_CREATE_REQUEST_TIMEOUT_MS = 12_000;
 const PROGRAM_NOTE_CREATE_REQUEST_TIMEOUT_MS = 12_000;
+const TAB_QUERY_STALE_TIME_MS = 30_000;
+const ASSESSMENT_DOCUMENT_POLL_INTERVAL_MS = 3_000;
+const ACTIVE_ASSESSMENT_POLL_STATUSES: ReadonlySet<AssessmentDocumentRecord["status"]> = new Set([
+  "uploaded",
+  "extracting",
+]);
 
 const withTimeout = async <T,>(
   promise: Promise<T>,
@@ -69,6 +75,35 @@ const PROGRAM_NOTES_EDGE_PATH = "program-notes";
 
 const buildProgramsQueryPath = (clientId: string): string =>
   `${PROGRAMS_EDGE_PATH}?client_id=${encodeURIComponent(clientId)}`;
+
+const buildClientProgramsQueryKey = (clientId: string, organizationId?: string | null) =>
+  ["client-programs", clientId, organizationId ?? "MISSING_ORG"] as const;
+
+const buildProgramGoalsQueryKey = (programId: string | null, organizationId?: string | null) =>
+  ["program-goals", programId, organizationId ?? "MISSING_ORG"] as const;
+
+const buildProgramNotesQueryKey = (programId: string | null, organizationId?: string | null) =>
+  ["program-notes", programId, organizationId ?? "MISSING_ORG"] as const;
+
+const upsertById = <T extends { id: string }>(current: T[] | undefined, nextItem: T): T[] => {
+  const existingItems = Array.isArray(current) ? current : [];
+  const existingIndex = existingItems.findIndex((item) => item.id === nextItem.id);
+  if (existingIndex >= 0) {
+    const nextItems = [...existingItems];
+    nextItems[existingIndex] = nextItem;
+    return nextItems;
+  }
+  return [nextItem, ...existingItems];
+};
+
+const mapById = <T extends { id: string }>(
+  current: T[] | undefined,
+  id: string,
+  mapItem: (item: T) => T,
+): T[] => {
+  const existingItems = Array.isArray(current) ? current : [];
+  return existingItems.map((item) => (item.id === id ? mapItem(item) : item));
+};
 
 const shouldFallbackToApi = (error: unknown): boolean => {
   if (!(error instanceof Error)) {
@@ -119,6 +154,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const { session } = useAuth();
   const publishSectionRef = useRef<HTMLDivElement | null>(null);
   const assessmentDocumentsQueryKey = ["assessment-documents", client.id, organizationId ?? "MISSING_ORG"] as const;
+  const clientProgramsQueryKey = buildClientProgramsQueryKey(client.id, organizationId);
   const [selectedProgramId, setSelectedProgramId] = useState<string | null>(null);
   const [selectedAssessmentId, setSelectedAssessmentId] = useState<string | null>(null);
   const [assessmentFile, setAssessmentFile] = useState<File | null>(null);
@@ -169,6 +205,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const [archivingProgramId, setArchivingProgramId] = useState<string | null>(null);
   const [archivingGoalId, setArchivingGoalId] = useState<string | null>(null);
   const [isUploadProcessing, setIsUploadProcessing] = useState(false);
+  const [assessmentDocumentsNeedsRetry, setAssessmentDocumentsNeedsRetry] = useState(false);
 
   const applyDraftGoal = (goal: ProgramGoalDraftResponse["goals"][number]) => {
     setGoalTitle(goal.title);
@@ -188,7 +225,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     isLoading: programsLoading,
     error: programsQueryError,
   } = useQuery({
-    queryKey: ["client-programs", client.id, organizationId ?? "MISSING_ORG"],
+    queryKey: clientProgramsQueryKey,
     queryFn: async () => {
       if (!organizationId) {
         throw new Error("Organization context is required to load programs.");
@@ -217,6 +254,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     },
     enabled: Boolean(client.id && organizationId),
     retry: false,
+    staleTime: TAB_QUERY_STALE_TIME_MS,
   });
 
   const livePrograms = useMemo(
@@ -253,13 +291,15 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     : !noteContentValue
       ? "Program note is required."
       : null;
+  const programGoalsQueryKey = buildProgramGoalsQueryKey(resolvedProgramId, organizationId);
+  const programNotesQueryKey = buildProgramNotesQueryKey(resolvedProgramId, organizationId);
 
   const {
     data: goals = [],
     isLoading: goalsLoading,
     error: goalsQueryError,
   } = useQuery({
-    queryKey: ["program-goals", resolvedProgramId, organizationId ?? "MISSING_ORG"],
+    queryKey: programGoalsQueryKey,
     queryFn: async () => {
       if (!resolvedProgramId) return [];
       const response = await callEdgeWithSupabaseFallback({
@@ -288,6 +328,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     },
     enabled: Boolean(resolvedProgramId),
     retry: false,
+    staleTime: TAB_QUERY_STALE_TIME_MS,
   });
 
   const liveGoals = useMemo(
@@ -296,7 +337,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   );
 
   const { data: programNotes = [] } = useQuery({
-    queryKey: ["program-notes", resolvedProgramId, organizationId ?? "MISSING_ORG"],
+    queryKey: programNotesQueryKey,
     queryFn: async () => {
       if (!resolvedProgramId) return [];
       const response = await callEdgeWithSupabaseFallback({
@@ -323,27 +364,51 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     },
     enabled: Boolean(resolvedProgramId),
     retry: false,
+    staleTime: TAB_QUERY_STALE_TIME_MS,
   });
 
-  const { data: assessmentDocuments = EMPTY_ASSESSMENT_DOCUMENTS, isLoading: assessmentLoading } = useQuery({
+  const {
+    data: assessmentDocuments = EMPTY_ASSESSMENT_DOCUMENTS,
+    isLoading: assessmentLoading,
+    refetch: refetchAssessmentDocuments,
+  } = useQuery({
     queryKey: assessmentDocumentsQueryKey,
     queryFn: async () => {
       const response = await callApi(`/api/assessment-documents?client_id=${encodeURIComponent(client.id)}`);
       if (!response.ok) {
+        setAssessmentDocumentsNeedsRetry(true);
         const cachedDocuments = queryClient.getQueryData<AssessmentDocumentRecord[]>(assessmentDocumentsQueryKey);
         return cachedDocuments ?? EMPTY_ASSESSMENT_DOCUMENTS;
       }
+      setAssessmentDocumentsNeedsRetry(false);
       return parseJson<AssessmentDocumentRecord[]>(response);
     },
     enabled: Boolean(client.id && organizationId),
-    // Keep queue status fresh while avoiding version-specific callback signatures.
-    refetchInterval: 3000,
+    staleTime: TAB_QUERY_STALE_TIME_MS,
   });
+  const shouldPollAssessmentDocuments =
+    isUploadProcessing ||
+    assessmentDocumentsNeedsRetry ||
+    assessmentDocuments.some((document) => ACTIVE_ASSESSMENT_POLL_STATUSES.has(document.status));
   const selectedAssessmentIdIsValid = Boolean(selectedAssessmentId && UUID_PATTERN.test(selectedAssessmentId));
   const selectedAssessmentInQueue = Boolean(
     selectedAssessmentId && assessmentDocuments.some((document) => document.id === selectedAssessmentId),
   );
   const canQuerySelectedAssessment = selectedAssessmentIdIsValid && selectedAssessmentInQueue;
+
+  useEffect(() => {
+    if (!shouldPollAssessmentDocuments) {
+      return undefined;
+    }
+
+    const pollHandle = window.setInterval(() => {
+      void refetchAssessmentDocuments();
+    }, ASSESSMENT_DOCUMENT_POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(pollHandle);
+    };
+  }, [refetchAssessmentDocuments, shouldPollAssessmentDocuments]);
 
   const { data: checklistItems = EMPTY_CHECKLIST_ITEMS } = useQuery({
     queryKey: ["assessment-checklist", selectedAssessmentId, organizationId ?? "MISSING_ORG"],
@@ -545,7 +610,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         const withoutCreated = currentRecords.filter((record) => record.id !== created.id);
         return [{ ...created }, ...withoutCreated];
       });
-      queryClient.invalidateQueries({ queryKey: assessmentDocumentsQueryKey });
       showSuccess(`${createdTemplateLabel} uploaded and checklist initialized.`);
     },
     onError: showError,
@@ -625,9 +689,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       });
       queryClient.removeQueries({
         queryKey: ["assessment-drafts", document.id, organizationId ?? "MISSING_ORG"],
-      });
-      queryClient.invalidateQueries({
-        queryKey: assessmentDocumentsQueryKey,
       });
       queryClient.invalidateQueries({
         queryKey: ["assessment-checklist", document.id, organizationId ?? "MISSING_ORG"],
@@ -896,21 +957,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       setProgramName("");
       setProgramDescription("");
       setSelectedProgramId(created.id);
-      queryClient.setQueryData<Program[]>(
-        ["client-programs", client.id, organizationId ?? "MISSING_ORG"],
-        (current = []) => {
-          const existingIndex = current.findIndex((program) => program.id === created.id);
-          if (existingIndex >= 0) {
-            const next = [...current];
-            next[existingIndex] = created;
-            return next;
-          }
-          return [created, ...current];
-        },
-      );
-      queryClient.invalidateQueries({
-        queryKey: ["client-programs", client.id, organizationId ?? "MISSING_ORG"],
-      });
+      queryClient.setQueryData<Program[]>(clientProgramsQueryKey, (current) => upsertById(current, created));
     },
     onError: showError,
   });
@@ -981,7 +1028,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       }
       return parseJson<Goal>(response);
     },
-    onSuccess: () => {
+    onSuccess: (created) => {
       showSuccess("Goal created");
       setGoalTitle("");
       setGoalDescription("");
@@ -993,9 +1040,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       setGoalMaintenanceCriteria("");
       setGoalGeneralizationCriteria("");
       setGoalObjectiveDataPoints("[]");
-      queryClient.invalidateQueries({
-        queryKey: ["program-goals", resolvedProgramId, organizationId ?? "MISSING_ORG"],
-      });
+      queryClient.setQueryData<Goal[]>(buildProgramGoalsQueryKey(created.program_id, organizationId), (current) =>
+        upsertById(current, created),
+      );
     },
     onError: showError,
   });
@@ -1037,9 +1084,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       if (selectedProgramId === program.id) {
         setSelectedProgramId(null);
       }
-      queryClient.invalidateQueries({
-        queryKey: ["client-programs", client.id, organizationId ?? "MISSING_ORG"],
-      });
+      queryClient.setQueryData<Program[]>(clientProgramsQueryKey, (current) =>
+        mapById(current, program.id, (currentProgram) => ({ ...currentProgram, status: "archived" })),
+      );
     },
     onError: showError,
     onSettled: () => {
@@ -1081,9 +1128,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     },
     onSuccess: (_, goal) => {
       showSuccess(`Goal "${goal.title}" removed from active care plan.`);
-      queryClient.invalidateQueries({
-        queryKey: ["program-goals", goal.program_id, organizationId ?? "MISSING_ORG"],
-      });
+      queryClient.setQueryData<Goal[]>(buildProgramGoalsQueryKey(goal.program_id, organizationId), (current) =>
+        mapById(current, goal.id, (currentGoal) => ({ ...currentGoal, status: "archived" })),
+      );
     },
     onError: showError,
     onSettled: () => {
@@ -1137,12 +1184,12 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       }
       return parseJson<ProgramNote>(response);
     },
-    onSuccess: () => {
+    onSuccess: (created) => {
       showSuccess("Program note added");
       setNoteContent("");
-      queryClient.invalidateQueries({
-        queryKey: ["program-notes", resolvedProgramId, organizationId ?? "MISSING_ORG"],
-      });
+      queryClient.setQueryData<ProgramNote[]>(buildProgramNotesQueryKey(created.program_id, organizationId), (current) =>
+        upsertById(current, created),
+      );
     },
     onError: showError,
   });

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -287,6 +287,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -560,6 +561,24 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Create Goal" })).toBeEnabled();
     });
+
+    const goalFetchCountBeforeCreate = vi
+      .mocked(callApi)
+      .mock.calls.filter(
+        ([path, init]) =>
+          typeof path === "string" &&
+          path.startsWith("/api/goals?") &&
+          (init?.method ?? "GET").toUpperCase() === "GET",
+      ).length;
+    const noteFetchCountBeforeCreate = vi
+      .mocked(callApi)
+      .mock.calls.filter(
+        ([path, init]) =>
+          typeof path === "string" &&
+          path.startsWith("/api/program-notes?") &&
+          (init?.method ?? "GET").toUpperCase() === "GET",
+      ).length;
+
     await user.click(screen.getByRole("button", { name: "Create Goal" }));
 
     await waitFor(() => {
@@ -572,6 +591,232 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       );
     });
     expect(showSuccess).toHaveBeenCalledWith("Goal created");
+    expect(
+      vi
+        .mocked(callApi)
+        .mock.calls.filter(
+          ([path, init]) =>
+            typeof path === "string" &&
+            path.startsWith("/api/goals?") &&
+            (init?.method ?? "GET").toUpperCase() === "GET",
+        ),
+    ).toHaveLength(goalFetchCountBeforeCreate);
+    expect(
+      vi
+        .mocked(callApi)
+        .mock.calls.filter(
+          ([path, init]) =>
+            typeof path === "string" &&
+            path.startsWith("/api/program-notes?") &&
+            (init?.method ?? "GET").toUpperCase() === "GET",
+        ),
+    ).toHaveLength(noteFetchCountBeforeCreate);
+  });
+
+  it("adds a program note without refetching the notes list", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "program-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              name: "Communication Program",
+              description: "Live program",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goals?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/program-notes?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "POST" && path === "/api/program-notes") {
+        return new Response(
+          JSON.stringify({
+            id: "note-2",
+            organization_id: ORG_ID,
+            program_id: "program-1",
+            author_id: "therapist-user-id",
+            note_type: "plan_update",
+            content: { text: "Progress note" },
+            created_at: "2026-02-11T00:00:00.000Z",
+            updated_at: "2026-02-11T00:00:00.000Z",
+          }),
+          { status: 201 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("Communication Program");
+
+    const noteFetchCountBeforeCreate = vi
+      .mocked(callApi)
+      .mock.calls.filter(
+        ([path, init]) =>
+          typeof path === "string" &&
+          path.startsWith("/api/program-notes?") &&
+          (init?.method ?? "GET").toUpperCase() === "GET",
+      ).length;
+
+    fireEvent.change(await screen.findByPlaceholderText("Add a program note"), {
+      target: { value: "Progress note" },
+    });
+    await user.click(screen.getByRole("button", { name: "Add Note" }));
+
+    await waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith("Program note added");
+    });
+
+    expect(
+      vi
+        .mocked(callApi)
+        .mock.calls.filter(
+          ([path, init]) =>
+            typeof path === "string" &&
+            path.startsWith("/api/program-notes?") &&
+            (init?.method ?? "GET").toUpperCase() === "GET",
+        ),
+    ).toHaveLength(noteFetchCountBeforeCreate);
+    expect(await screen.findByText("Progress note")).toBeInTheDocument();
+  });
+
+  it("polls assessment documents only while extraction work is active", async () => {
+    let assessmentFetchCount = 0;
+
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        assessmentFetchCount += 1;
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "iehp_fba",
+              file_name: "iehp-fba.docx",
+              mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/iehp-fba.docx",
+              status: assessmentFetchCount === 1 ? "extracting" : "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText(/Extracting fields from uploaded file/i);
+    await new Promise((resolve) => setTimeout(resolve, 3_300));
+
+    await waitFor(() => {
+      expect(assessmentFetchCount).toBeGreaterThanOrEqual(2);
+    });
+
+    const completedPollCount = assessmentFetchCount;
+    await new Promise((resolve) => setTimeout(resolve, 3_300));
+    expect(assessmentFetchCount).toBe(completedPollCount);
+  });
+
+  it("retries the assessment queue after a transient load failure", async () => {
+    let assessmentFetchCount = 0;
+
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        assessmentFetchCount += 1;
+        if (assessmentFetchCount === 1) {
+          return new Response(JSON.stringify({ error: "Temporary upstream failure" }), { status: 503 });
+        }
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "iehp_fba",
+              file_name: "iehp-fba.docx",
+              mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/iehp-fba.docx",
+              status: "extracting",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findByText("No uploaded assessments yet.")).toBeInTheDocument();
+    await new Promise((resolve) => setTimeout(resolve, 3_300));
+
+    await waitFor(() => {
+      expect(assessmentFetchCount).toBeGreaterThanOrEqual(2);
+    });
+    expect(await screen.findByText(/Extracting fields from uploaded file/i)).toBeInTheDocument();
   });
 
   it("falls back to same-origin API when program edge calls time out", async () => {


### PR DESCRIPTION
## Summary
- reduce Programs & Goals tab refetch churn with cache-aware updates for program, goal, note, and archive actions
- replace unconditional assessment queue polling with bounded polling that only runs during active extraction/upload work or retry recovery
- add focused regression coverage for post-mutation cache behavior and transient assessment queue recovery

## Verification
- npm run lint
- npm run typecheck
- npm test -- --run src/components/__tests__/ProgramsGoalsTab.test.tsx
- npm run build
- npm run verify:local (timed out on broader repo checks; non-authoritative for this bounded slice)

## Linear
- WIN-108
