### PR TITLE
fix(admin-users-roles): sync user_roles when super admins assign roles

### DIFF
--- a/supabase/functions/admin-users-roles/index.ts
+++ b/supabase/functions/admin-users-roles/index.ts
@@ -4,6 +4,104 @@ import { assertAdminOrSuperAdmin } from "../_shared/auth.ts";
 
 interface RoleUpdateRequest { role: 'client' | 'therapist' | 'admin' | 'super_admin'; is_active?: boolean; }
 
+type AppRole = RoleUpdateRequest["role"];
+
+const CANONICAL_ROLE_NAMES: AppRole[] = ["super_admin", "admin", "therapist", "client"];
+
+const ROLE_RANK: Record<AppRole, number> = {
+  super_admin: 4,
+  admin: 3,
+  therapist: 2,
+  client: 1,
+};
+
+/**
+ * `profiles.role` is not authoritative: middleware and RLS use `user_roles` + helpers
+ * (`current_user_is_super_admin`, `get_user_role_from_junction`). Authenticated clients
+ * cannot mutate another user's `user_roles` rows (RLS), so apply junction changes with the
+ * service role after this super-admin-only route has authorized the caller.
+ */
+async function syncCanonicalUserRoles(
+  targetUserId: string,
+  role: AppRole,
+  grantedBy: string,
+): Promise<string | null> {
+  const { data: roleRows, error: rolesError } = await supabaseAdmin
+    .from("roles")
+    .select("id,name")
+    .in("name", CANONICAL_ROLE_NAMES);
+
+  if (rolesError || !roleRows?.length) {
+    console.error("syncCanonicalUserRoles: failed to load roles", rolesError);
+    return "Failed to resolve canonical roles";
+  }
+
+  const roleIdByName = new Map<string, string>();
+  for (const row of roleRows) {
+    if (typeof row.name === "string" && typeof row.id === "string") {
+      roleIdByName.set(row.name, row.id);
+    }
+  }
+
+  const allStandardIds = CANONICAL_ROLE_NAMES
+    .map((name) => roleIdByName.get(name))
+    .filter((id): id is string => Boolean(id));
+
+  if (role === "client") {
+    const { error: clearError } = await supabaseAdmin
+      .from("user_roles")
+      .delete()
+      .eq("user_id", targetUserId)
+      .in("role_id", allStandardIds);
+    if (clearError) {
+      console.error("syncCanonicalUserRoles: clear standard roles failed", clearError);
+      return "Failed to update role assignments";
+    }
+    return null;
+  }
+
+  const targetRank = ROLE_RANK[role];
+  const elevatedIds = CANONICAL_ROLE_NAMES
+    .filter((name) => ROLE_RANK[name] > targetRank)
+    .map((name) => roleIdByName.get(name))
+    .filter((id): id is string => Boolean(id));
+
+  if (elevatedIds.length > 0) {
+    const { error: delError } = await supabaseAdmin
+      .from("user_roles")
+      .delete()
+      .eq("user_id", targetUserId)
+      .in("role_id", elevatedIds);
+    if (delError) {
+      console.error("syncCanonicalUserRoles: delete elevated roles failed", delError);
+      return "Failed to update role assignments";
+    }
+  }
+
+  const targetRoleId = roleIdByName.get(role);
+  if (!targetRoleId) {
+    return "Target role is not configured";
+  }
+
+  const nowIso = new Date().toISOString();
+  const { error: upsertError } = await supabaseAdmin.from("user_roles").upsert(
+    {
+      user_id: targetUserId,
+      role_id: targetRoleId,
+      granted_by: grantedBy,
+      granted_at: nowIso,
+      is_active: true,
+    },
+    { onConflict: "user_id,role_id" },
+  );
+
+  if (upsertError) {
+    console.error("syncCanonicalUserRoles: upsert failed", upsertError);
+    return "Failed to update role assignments";
+  }
+  return null;
+}
+
 export default createProtectedRoute(async (req: Request, userContext) => {
   if (req.method !== 'PATCH') return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   try {
@@ -31,6 +129,11 @@ export default createProtectedRoute(async (req: Request, userContext) => {
     if (userId === userContext.user.id && is_active === false) return new Response(JSON.stringify({ error: 'Cannot deactivate your own account' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
     const updateData: any = { role }; if (is_active !== undefined) updateData.is_active = is_active;
+
+    const junctionError = await syncCanonicalUserRoles(userId, role, userContext.user.id);
+    if (junctionError) {
+      return new Response(JSON.stringify({ error: junctionError }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
 
     const { data: updatedUser, error: updateError } = await adminClient
       .from('profiles').update(updateData).eq('id', userId)

--- a/tests/admin-users-roles.access.spec.ts
+++ b/tests/admin-users-roles.access.spec.ts
@@ -7,6 +7,13 @@ const envValues = new Map<string, string>([
   ['SUPABASE_ANON_KEY', 'anon-key'],
 ]);
 
+const CANONICAL_TEST_ROLES = [
+  { id: 'rid-super', name: 'super_admin' },
+  { id: 'rid-admin', name: 'admin' },
+  { id: 'rid-therapist', name: 'therapist' },
+  { id: 'rid-client', name: 'client' },
+] as const;
+
 type TestRole = 'client' | 'therapist' | 'admin' | 'super_admin';
 
 type TestUser = {
@@ -39,6 +46,7 @@ let existingProfile: TestProfile & {
   updated_at: string;
 };
 let adminActionInserts: Array<Record<string, unknown>> = [];
+let userRolesUpsertPayload: Record<string, unknown> | null = null;
 
 type AdminUserRecord = {
   id: string;
@@ -119,6 +127,32 @@ vi.mock('../supabase/functions/_shared/database.ts', () => {
           })),
         },
       },
+      from: vi.fn((table: string) => {
+        if (table === 'roles') {
+          return {
+            select: vi.fn(() => ({
+              in: vi.fn(async () => ({
+                data: CANONICAL_TEST_ROLES,
+                error: null,
+              })),
+            })),
+          };
+        }
+        if (table === 'user_roles') {
+          return {
+            delete: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                in: vi.fn(async () => ({ error: null })),
+              })),
+            })),
+            upsert: vi.fn((payload: Record<string, unknown>) => {
+              userRolesUpsertPayload = payload;
+              return Promise.resolve({ error: null });
+            }),
+          };
+        }
+        throw new Error(`Unexpected supabaseAdmin table: ${table}`);
+      }),
     },
     createRequestClient: () => ({
       rpc: vi.fn(async (functionName: string) => {
@@ -164,6 +198,7 @@ describe('admin-users-roles access control', () => {
     };
     adminActionInserts = [];
     adminUsers.clear();
+    userRolesUpsertPayload = null;
   });
 
   it('allows a super admin to demote another admin user', async () => {
@@ -208,6 +243,12 @@ describe('admin-users-roles access control', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.user.role).toBe('therapist');
+    expect(userRolesUpsertPayload).toMatchObject({
+      user_id: existingProfile.id,
+      role_id: 'rid-therapist',
+      granted_by: 'super-admin-1',
+      is_active: true,
+    });
     expect(latestUpdatePayload).toEqual({ role: 'therapist' });
     expect(logApiAccess).toHaveBeenCalledWith('PATCH', '/admin/users/11111111-1111-1111-1111-111111111111/roles', superAdminContext, 200);
     expect(adminActionInserts).toEqual([
@@ -222,5 +263,53 @@ describe('admin-users-roles access control', () => {
         },
       },
     ]);
+  });
+
+  it('syncs user_roles when promoting a user to super_admin', async () => {
+    rpcRoles = ['super_admin'];
+
+    const superAdminContext: TestUserContext = {
+      user: { id: 'super-admin-2', email: 'super2@example.com' },
+      profile: {
+        id: 'super-admin-profile-2',
+        email: 'super2@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    };
+
+    userContexts.set('super2', superAdminContext);
+    adminUsers.set('super-admin-2', {
+      id: 'super-admin-2',
+      email: 'super2@example.com',
+      user_metadata: { organization_id: 'org-123' },
+    });
+    adminUsers.set(existingProfile.id, {
+      id: existingProfile.id,
+      email: existingProfile.email,
+      user_metadata: { organization_id: 'org-999' },
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-users-roles/index.ts');
+
+    const response = await handler(
+      new Request('http://localhost/functions/v1/admin/users/11111111-1111-1111-1111-111111111111/roles', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+          'x-test-user': 'super2',
+        },
+        body: JSON.stringify({ role: 'super_admin' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(userRolesUpsertPayload).toMatchObject({
+      user_id: existingProfile.id,
+      role_id: 'rid-super',
+      granted_by: 'super-admin-2',
+      is_active: true,
+    });
   });
 });


### PR DESCRIPTION
The edge handler updated profiles.role only, while auth middleware and RLS helpers derive privileges from user_roles. Cross-user junction writes are blocked for authenticated clients, so apply updates with the service role after the super-admin-only route authorizes the actor.

Made-with: Cursor