### PR TITLE
fix(scheduling): resolve Forbidden for org_admin / org_member on book and session APIs

### DIFF
--- a/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
+++ b/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
@@ -35,27 +35,39 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
     fetchSpy.mockRestore();
   });
 
-  it("calls current_user_is_super_admin, current_user_organization_id, then user_has_role_for_org twice with untargeted payloads", async () => {
+  it("calls current_user_is_super_admin, current_user_organization_id, then user_has_role_for_org for therapist/admin/org_admin/org_member", async () => {
     fetchSpy
       .mockResolvedValueOnce(jsonResponse(false))
       .mockResolvedValueOnce(jsonResponse("org-1"))
       .mockResolvedValueOnce(jsonResponse(true))
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(false))
       .mockResolvedValueOnce(jsonResponse(false));
 
     await resolveOrgAndRoleWithStatus(accessToken);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    expect(fetchSpy).toHaveBeenCalledTimes(6);
     expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/rest/v1/rpc/current_user_is_super_admin");
     expect(String(fetchSpy.mock.calls[1]?.[0])).toContain("/rest/v1/rpc/current_user_organization_id");
 
     const therapistInit = fetchSpy.mock.calls[2]?.[1] as RequestInit;
     const adminInit = fetchSpy.mock.calls[3]?.[1] as RequestInit;
+    const orgAdminInit = fetchSpy.mock.calls[4]?.[1] as RequestInit;
+    const orgMemberInit = fetchSpy.mock.calls[5]?.[1] as RequestInit;
     expect(JSON.parse(String(therapistInit.body))).toEqual({
       role_name: "therapist",
       target_organization_id: "org-1",
     });
     expect(JSON.parse(String(adminInit.body))).toEqual({
       role_name: "admin",
+      target_organization_id: "org-1",
+    });
+    expect(JSON.parse(String(orgAdminInit.body))).toEqual({
+      role_name: "org_admin",
+      target_organization_id: "org-1",
+    });
+    expect(JSON.parse(String(orgMemberInit.body))).toEqual({
+      role_name: "org_member",
       target_organization_id: "org-1",
     });
   });
@@ -65,12 +77,15 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       .mockResolvedValueOnce(jsonResponse(false))
       .mockResolvedValueOnce(jsonResponse("org-1"))
       .mockResolvedValueOnce(jsonResponse(true))
-      .mockResolvedValueOnce(jsonResponse(true));
+      .mockResolvedValueOnce(jsonResponse(true))
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(false));
 
     await expect(resolveOrgAndRoleWithStatus(accessToken)).resolves.toEqual({
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: true,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -81,12 +96,15 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       .mockResolvedValueOnce(jsonResponse(true))
       .mockResolvedValueOnce(jsonResponse("org-1"))
       .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(false))
       .mockResolvedValueOnce(jsonResponse(false));
 
     await expect(resolveOrgAndRoleWithStatus(accessToken)).resolves.toEqual({
       organizationId: "org-1",
       isTherapist: false,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: true,
       upstreamError: false,
     });
@@ -101,6 +119,7 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       organizationId: null,
       isTherapist: false,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -112,12 +131,15 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       .mockResolvedValueOnce(jsonResponse(false))
       .mockResolvedValueOnce(jsonResponse("org-1"))
       .mockResolvedValueOnce(new Response("", { status: 503 }))
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(false))
       .mockResolvedValueOnce(jsonResponse(false));
 
     await expect(resolveOrgAndRoleWithStatus(accessToken)).resolves.toEqual({
       organizationId: "org-1",
       isTherapist: false,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: true,
     });

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -94,6 +94,7 @@ describe("sessionNotesUpsertHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });

--- a/src/server/__tests__/sessionsStartHandler.test.ts
+++ b/src/server/__tests__/sessionsStartHandler.test.ts
@@ -73,6 +73,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -128,6 +129,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -171,6 +173,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -224,6 +227,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -281,6 +285,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -338,6 +343,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -391,6 +397,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -452,6 +459,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -486,6 +494,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -544,6 +553,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: false,
       isAdmin: true,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -599,6 +609,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });
@@ -631,6 +642,7 @@ describe("sessionsStartHandler", () => {
       organizationId: null,
       isTherapist: false,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: true,
     });
@@ -658,6 +670,7 @@ describe("sessionsStartHandler", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });

--- a/src/server/__tests__/sessionsStartParity.contract.test.ts
+++ b/src/server/__tests__/sessionsStartParity.contract.test.ts
@@ -36,6 +36,7 @@ describe("sessionsStartHandler edge proxy parity (WIN-38E / A08)", () => {
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin: false,
       upstreamError: false,
     });

--- a/src/server/api/book.ts
+++ b/src/server/api/book.ts
@@ -72,6 +72,7 @@ async function assertBookRequestScope(
   const {
     isTherapist,
     isAdmin,
+    isOrgMember,
     isSuperAdmin,
     upstreamError: roleUpstreamError,
   } = roleResolution;
@@ -127,7 +128,7 @@ async function assertBookRequestScope(
     }
   }
 
-  if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin)) {
+  if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember)) {
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 
@@ -139,7 +140,7 @@ async function assertBookRequestScope(
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 
-  if (isTherapist && body.session.therapist_id !== currentUserId) {
+  if (isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember && body.session.therapist_id !== currentUserId) {
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -351,12 +351,12 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
     });
   }
 
-  const { organizationId, isTherapist, isAdmin, isSuperAdmin, upstreamError: roleUpstreamError } =
+  const { organizationId, isTherapist, isAdmin, isOrgMember, isSuperAdmin, upstreamError: roleUpstreamError } =
     await resolveOrgAndRoleWithStatus(accessToken);
   if (roleUpstreamError) {
     return errorResponse(request, "upstream_error", "Unable to validate organization access", { status: 502 });
   }
-  if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin)) {
+  if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember)) {
     return errorResponse(request, "forbidden", "Forbidden");
   }
 

--- a/src/server/api/sessions-start.ts
+++ b/src/server/api/sessions-start.ts
@@ -71,7 +71,7 @@ export async function sessionsStartHandler(request: Request): Promise<Response> 
       });
     }
 
-    const { organizationId, isTherapist, isAdmin, isSuperAdmin, upstreamError: roleUpstreamError } =
+    const { organizationId, isTherapist, isAdmin, isOrgMember, isSuperAdmin, upstreamError: roleUpstreamError } =
       await resolveOrgAndRoleWithStatus(accessToken);
     if (roleUpstreamError) {
       return errorResponse(request, "upstream_error", "Unable to validate organization access", {
@@ -79,7 +79,7 @@ export async function sessionsStartHandler(request: Request): Promise<Response> 
         headers: traceHeaders,
       });
     }
-    if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin)) {
+    if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember)) {
       return errorResponse(request, "forbidden", "Forbidden", { headers: traceHeaders });
     }
 

--- a/src/server/api/shared.ts
+++ b/src/server/api/shared.ts
@@ -231,6 +231,7 @@ export async function resolveOrgAndRole(accessToken: string): Promise<{
   organizationId: string | null;
   isTherapist: boolean;
   isAdmin: boolean;
+  isOrgMember: boolean;
   isSuperAdmin: boolean;
 }> {
   const result = await resolveOrgAndRoleWithStatus(accessToken);
@@ -238,6 +239,7 @@ export async function resolveOrgAndRole(accessToken: string): Promise<{
     organizationId: result.organizationId,
     isTherapist: result.isTherapist,
     isAdmin: result.isAdmin,
+    isOrgMember: result.isOrgMember,
     isSuperAdmin: result.isSuperAdmin,
   };
 }
@@ -246,6 +248,8 @@ export async function resolveOrgAndRoleWithStatus(accessToken: string): Promise<
   organizationId: string | null;
   isTherapist: boolean;
   isAdmin: boolean;
+  /** Scheduling-staff role (RLS storage name); may reschedule sessions without being a therapist row. */
+  isOrgMember: boolean;
   isSuperAdmin: boolean;
   upstreamError: boolean;
 }> {
@@ -283,6 +287,7 @@ export async function resolveOrgAndRoleWithStatus(accessToken: string): Promise<
       organizationId: null,
       isTherapist: false,
       isAdmin: false,
+      isOrgMember: false,
       isSuperAdmin,
       upstreamError: superAdminUpstreamError || orgUpstreamError,
     };
@@ -299,18 +304,35 @@ export async function resolveOrgAndRoleWithStatus(accessToken: string): Promise<
     headers,
     body: JSON.stringify({ role_name: "admin", target_organization_id: organizationId }),
   });
+  const orgAdminResult = await fetchJson<boolean>(roleUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ role_name: "org_admin", target_organization_id: organizationId }),
+  });
+  const orgMemberResult = await fetchJson<boolean>(roleUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ role_name: "org_member", target_organization_id: organizationId }),
+  });
   const therapistUpstreamError = !therapistResult.ok && therapistResult.status >= 500;
   const adminUpstreamError = !adminResult.ok && adminResult.status >= 500;
+  const orgAdminUpstreamError = !orgAdminResult.ok && orgAdminResult.status >= 500;
+  const orgMemberUpstreamError = !orgMemberResult.ok && orgMemberResult.status >= 500;
+  const isOrgMember = orgMemberResult.ok && orgMemberResult.data === true;
   return {
     organizationId,
     isTherapist: therapistResult.ok && therapistResult.data === true,
-    isAdmin: adminResult.ok && adminResult.data === true,
+    isAdmin:
+      (adminResult.ok && adminResult.data === true) || (orgAdminResult.ok && orgAdminResult.data === true),
+    isOrgMember,
     isSuperAdmin,
     upstreamError:
       superAdminUpstreamError ||
       orgUpstreamError ||
       therapistUpstreamError ||
-      adminUpstreamError,
+      adminUpstreamError ||
+      orgAdminUpstreamError ||
+      orgMemberUpstreamError,
   };
 }
 

--- a/supabase/migrations/20260422153000_user_has_role_for_org_storage_role_aliases.sql
+++ b/supabase/migrations/20260422153000_user_has_role_for_org_storage_role_aliases.sql
@@ -1,0 +1,122 @@
+-- @migration-intent: Align app.user_has_role_for_org(role_name text, ...) with storage-backed role names
+--   (org_admin, org_member, org_super_admin) so scheduling RPCs and edge functions match RLS conventions.
+-- @migration-dependencies: 20260313120000_onboarding_authz_and_prefill_retention_hardening.sql
+-- @migration-rollback: Re-apply the prior app.user_has_role_for_org(text, uuid, uuid, uuid, uuid) body from migration 20260313120000_onboarding_authz_and_prefill_retention_hardening.sql (exact role_name match on public.roles.name).
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION app.user_has_role_for_org(
+  role_name text,
+  target_organization_id uuid DEFAULT NULL,
+  target_therapist_id uuid DEFAULT NULL,
+  target_client_id uuid DEFAULT NULL,
+  target_session_id uuid DEFAULT NULL
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  caller_id uuid;
+  caller_org uuid;
+  resolved_org uuid;
+  resolved_client_id uuid := target_client_id;
+  normalized_role text;
+BEGIN
+  caller_id := auth.uid();
+  IF caller_id IS NULL OR role_name IS NULL OR btrim(role_name) = '' THEN
+    RETURN false;
+  END IF;
+
+  IF app.current_user_is_super_admin() THEN
+    RETURN true;
+  END IF;
+
+  caller_org := app.resolve_user_organization_id(caller_id);
+  IF caller_org IS NULL THEN
+    RETURN false;
+  END IF;
+
+  resolved_org := target_organization_id;
+
+  IF resolved_org IS NULL AND target_therapist_id IS NOT NULL THEN
+    SELECT t.organization_id
+    INTO resolved_org
+    FROM public.therapists t
+    WHERE t.id = target_therapist_id;
+  END IF;
+
+  IF resolved_org IS NULL AND target_session_id IS NOT NULL THEN
+    SELECT COALESCE(s.organization_id, t.organization_id), s.client_id
+    INTO resolved_org, resolved_client_id
+    FROM public.sessions s
+    LEFT JOIN public.therapists t ON t.id = s.therapist_id
+    WHERE s.id = target_session_id;
+  END IF;
+
+  IF resolved_org IS NULL AND target_client_id IS NOT NULL THEN
+    SELECT COALESCE(
+      c.organization_id,
+      (
+        SELECT COALESCE(s.organization_id, t.organization_id)
+        FROM public.sessions s
+        LEFT JOIN public.therapists t ON t.id = s.therapist_id
+        WHERE s.client_id = c.id
+        ORDER BY s.created_at DESC NULLS LAST
+        LIMIT 1
+      )
+    ), c.id
+    INTO resolved_org, resolved_client_id
+    FROM public.clients c
+    WHERE c.id = target_client_id;
+  END IF;
+
+  IF resolved_org IS NULL OR resolved_org <> caller_org THEN
+    RETURN false;
+  END IF;
+
+  IF role_name = 'client' THEN
+    IF resolved_client_id IS NOT NULL THEN
+      IF caller_id = resolved_client_id THEN
+        RETURN true;
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM public.client_guardians cg
+        WHERE cg.guardian_id = caller_id
+          AND cg.client_id = resolved_client_id
+          AND cg.organization_id = resolved_org
+          AND cg.deleted_at IS NULL
+      ) THEN
+        RETURN true;
+      END IF;
+    END IF;
+
+    RETURN false;
+  END IF;
+
+  normalized_role := lower(btrim(role_name));
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    WHERE ur.user_id = caller_id
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+      AND (
+        (normalized_role = 'admin' AND r.name IN ('admin', 'org_admin'))
+        OR (normalized_role = 'therapist' AND r.name IN ('therapist', 'org_member'))
+        OR (normalized_role = 'super_admin' AND r.name IN ('super_admin', 'org_super_admin'))
+        OR r.name = role_name
+      )
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION app.user_has_role_for_org(text, uuid, uuid, uuid, uuid) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Session reschedule could return **403 Forbidden** before the session was updated when the signed-in user had storage-aligned roles (`org_admin`, `org_member`) in `user_roles`, because Netlify handlers only queried `user_has_role_for_org` for `admin` and `therapist`.

## Changes

- `resolveOrgAndRoleWithStatus`: treat `org_admin` as admin; expose `isOrgMember`.
- `/api/book`: allow `isOrgMember` through the scheduler gate; therapist self-booking only when caller is therapist-only.
- Session notes upsert and sessions-start: same gate as booking.
- Migration: `app.user_has_role_for_org` (5-arg) maps canonical role names so edge `sessions-hold` auth matches RLS.

## Verification (local)

- `npm run typecheck`
- `npm run lint`
- Targeted Vitest: orgRoleRpcEquivalence, sessionNotesUpsertHandler, sessionsStartHandler, sessionsStartParity, bookHandler (+ integration)

## Deploy notes

Apply the new Supabase migration in the same release as the API so edge and Node stay aligned.
