### PR TITLE
WIN-110 Fix mobile edit session forbidden update regression

### DIFF
--- a/docs/ai/WIN-110-mobile-edit-session-forbidden-debug-handoff.md
+++ b/docs/ai/WIN-110-mobile-edit-session-forbidden-debug-handoff.md
@@ -1,0 +1,81 @@
+# WIN-110 Mobile Edit Session Forbidden / Scheduling Issue Debug Handoff
+
+## Scope
+
+- Debugged the mobile Edit Session regression after the WIN-109 multi-program / multi-goal work.
+- Kept scope contained to:
+  - `src/components/SessionModal.tsx`
+  - `src/pages/Schedule.tsx`
+  - focused regression tests for those surfaces
+
+Non-goals:
+
+- no auth/session library changes
+- no server/API handler changes
+- no Supabase/RLS/migration changes
+- no unrelated schedule cleanup
+
+## Findings
+
+1. Scheduled-session `Update Session` could carry linked session-note context into the Schedule submit path even when the user had not explicitly requested a capture save in the current modal interaction. That made the page eligible to call `upsertClientSessionNoteForSession(...)` before the ordinary session update.
+2. The SessionModal local fallback conflict check did not exclude the session currently being edited, so mobile could show a false `1 scheduling issue` prompt for the session itself.
+
+## Fix Summary
+
+- Added an explicit client-side `session_note_persist_requested` signal to the SessionModal submit payload.
+- Set that signal only when:
+  - the user explicitly saves partial capture, or
+  - capture fields/targets were dirtied in the current modal interaction, or
+  - the session is already in progress (`Save progress` semantics preserved)
+- Updated `Schedule.tsx` to ignore session-note draft persistence unless `session_note_persist_requested === true`.
+- Excluded the currently edited session id from SessionModal's raw-time self-conflict fallback.
+
+## Verification Card
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- change type:
+  - `UI/component/page`
+- required checks:
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm test -- --run src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm test -- --run src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx` -> pass
+  - `npm run build` -> pass
+  - `npm run verify:local` -> fail (unrelated broader repo test failure in `src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx`)
+- blocked checks:
+  - `none`
+- result: `pass-with-known-external-failure`
+- residual risk:
+  - The bounded fix is covered locally, but full-repo `verify:local` still fails on an unrelated existing Schedule readiness test outside this slice.
+
+## PR Hygiene
+
+- pr-ready: `yes`
+- lane: `standard`
+- branch-ready: `yes`
+- linear-ready: `yes` (`WIN-110`)
+- single-purpose: `yes`
+- unrelated changes:
+  - existing dirty files outside this task were left untouched:
+    - `.cursor/mcp.json`
+    - `AGENTS.md`
+- generated artifact drift: `none`
+- protected-path drift: `none`
+- change summary: `present`
+- verification summary: `present`
+- pr handoff: `ready`
+- reviewer:
+  - completed; one real gap around capture-target dirty tracking was found and fixed before closeout
+
+## Notes For Review
+
+- The intended behavior is now:
+  - scheduled `Update Session` updates session details without opportunistically re-saving unchanged linked session-note content
+  - in-progress `Save progress` continues to persist capture state
+  - editing a session no longer shows a self-conflict scheduling warning for the current session row

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -67,6 +67,8 @@ export interface SessionModalClinicalNotesPayload {
   session_note_goals_addressed?: string[];
   session_note_authorization_id?: string;
   session_note_service_code?: string;
+  /** Explicitly signals that this submit should persist session-capture content. */
+  session_note_persist_requested?: boolean;
   /** When set, POST /api/session-notes/upsert merges only these goal keys from this payload (server-authoritative). */
   session_note_capture_merge_goal_ids?: string[];
 }
@@ -85,6 +87,14 @@ const toOptionalNumber = (value: unknown): number | null => {
 const toFormNumber = (value: unknown): number | undefined => {
   const normalized = toOptionalNumber(value);
   return normalized ?? undefined;
+};
+
+const hasNestedDirtyEntries = (value: unknown): boolean => {
+  if (!value || typeof value !== 'object') {
+    return Boolean(value);
+  }
+
+  return Object.values(value as Record<string, unknown>).some((entry) => hasNestedDirtyEntries(entry));
 };
 
 interface SessionModalProps {
@@ -171,7 +181,7 @@ export function SessionModal({
     setValue,
     reset,
     getValues,
-    formState: { errors, isSubmitting, isDirty },
+    formState: { errors, isSubmitting, isDirty, dirtyFields },
   } = useForm<SessionModalFormValues>({
     defaultValues: {
       therapist_id: session?.therapist_id || defaultTherapistId || '',
@@ -421,6 +431,21 @@ export function SessionModal({
   const hasGoalOptionForValue = typeof goalId === 'string' && goalId.length > 0
     ? selectedProgramGoals.some((goal) => goal.id === goalId)
     : false;
+  const hasDirtySessionCaptureFields = useMemo(
+    () =>
+      hasNestedDirtyEntries(dirtyFields.session_note_narrative) ||
+      hasNestedDirtyEntries(dirtyFields.session_note_goal_ids) ||
+      hasNestedDirtyEntries(dirtyFields.session_note_goals_addressed) ||
+      hasNestedDirtyEntries(dirtyFields.session_note_goal_notes) ||
+      hasNestedDirtyEntries(dirtyFields.session_note_goal_measurements),
+    [
+      dirtyFields.session_note_goal_ids,
+      dirtyFields.session_note_goals_addressed,
+      dirtyFields.session_note_goal_measurements,
+      dirtyFields.session_note_goal_notes,
+      dirtyFields.session_note_narrative,
+    ],
+  );
 
   useEffect(() => {
     if (session?.therapist_id) {
@@ -758,6 +783,9 @@ export function SessionModal({
           const localDate = localStart?.slice(0, 10);
           const localHHmm = localStart?.slice(11, 16);
           const overlapping = existingSessions.find((s) => {
+            if (session?.id && s.id === session.id) {
+              return false;
+            }
             if (s.therapist_id !== therapistId && s.client_id !== clientId) return false;
             const localIso = formatSessionLocalInput(s.start_time, resolvedTimeZone);
             const localSessionDate = localIso.slice(0, 10);
@@ -984,6 +1012,8 @@ export function SessionModal({
           )),
         session_note_authorization_id: resolvedAuthorizationId,
         session_note_service_code: resolvedServiceCode,
+        session_note_persist_requested:
+          isPartialCaptureSave || hasDirtySessionCaptureFields || isInProgressSession,
         ...(isPartialCaptureSave ? { session_note_capture_merge_goal_ids: mergeGoalIds } : {}),
         goal_ids: sessionGoalIds,
         // If a timezone prop is provided, normalize to UTC for consumers expecting Z times

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -3,11 +3,16 @@ import { renderWithProviders, screen, userEvent, waitFor } from '../../test/util
 import { fireEvent } from '@testing-library/react';
 import { SessionModal } from '../SessionModal';
 import { supabase } from '../../lib/supabase';
+import { fetchLinkedClientSessionNoteForSession } from '../../lib/session-note-linked-fetch';
 import type { Session } from '../../types';
 import { startSessionFromModal } from '../../features/scheduling/domain/sessionStart';
 
 vi.mock('../../features/scheduling/domain/sessionStart', () => ({
   startSessionFromModal: vi.fn(),
+}));
+
+vi.mock('../../lib/session-note-linked-fetch', () => ({
+  fetchLinkedClientSessionNoteForSession: vi.fn(),
 }));
 
 type SupabaseQueryChain = {
@@ -73,6 +78,7 @@ describe('SessionModal', () => {
 
   beforeEach(() => {
     vi.mocked(startSessionFromModal).mockReset();
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue(null);
     defaultProps.onClose.mockClear();
     defaultProps.onSubmit.mockClear();
 
@@ -952,6 +958,125 @@ describe('SessionModal', () => {
     );
   });
 
+  it('does not treat the edited session itself as a scheduling conflict fallback match', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const existingSession = {
+      id: 'session-self-overlap',
+      therapist_id: 'test-therapist-1',
+      client_id: 'test-client-1',
+      program_id: 'program-1',
+      goal_id: 'goal-1',
+      start_time: '2026-03-02T15:00:00.000Z',
+      end_time: '2026-03-02T16:00:00.000Z',
+      status: 'scheduled',
+      notes: '',
+      created_at: '2026-03-01T09:00:00.000Z',
+      created_by: null,
+      updated_at: '2026-03-01T09:00:00.000Z',
+      updated_by: null,
+      started_at: null,
+    } satisfies Session;
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={existingSession}
+        existingSessions={[existingSession]}
+      />
+    );
+
+    await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
+    await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
+    await screen.findByRole('option', { name: /Default Program/i });
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: /^Program$/i }), 'program-1');
+    await screen.findByRole('option', { name: /Default Goal/i });
+    await userEvent.selectOptions(screen.getByLabelText(/Primary Goal/i), 'goal-1');
+    fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2026-03-02T10:00' } });
+    fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2026-03-02T11:00' } });
+
+    await userEvent.click(screen.getByRole('button', { name: /Update Session/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+    expect(confirmSpy).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('marks unchanged linked session note content as non-persisting on scheduled updates', async () => {
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'linked-note-1',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: ['Default Goal'],
+      goal_ids: ['goal-1'],
+      goal_measurements: null,
+      goal_notes: { 'goal-1': 'Previously saved note' },
+      session_id: 'session-note-prefill',
+      narrative: '',
+      is_locked: false,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: null,
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T09:00:00.000Z',
+    });
+
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-note-prefill',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T15:00:00.000Z',
+          end_time: '2026-03-01T16:00:00.000Z',
+          status: 'scheduled',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
+    await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
+    await screen.findByRole('option', { name: /Default Program/i });
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: /^Program$/i }), 'program-1');
+    await screen.findByRole('option', { name: /Default Goal/i });
+    await userEvent.selectOptions(screen.getByLabelText(/Primary Goal/i), 'goal-1');
+    fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2026-03-01T10:00' } });
+    fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2026-03-01T11:00' } });
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    await userEvent.click(screen.getByRole('button', { name: /Update Session/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      session_note_goal_notes: { 'goal-1': 'Previously saved note' },
+      session_note_persist_requested: false,
+    }));
+    confirmSpy.mockRestore();
+  });
+
   it('renders session capture section for existing sessions', () => {
     renderWithProviders(
       <SessionModal
@@ -1199,6 +1324,30 @@ describe('SessionModal', () => {
       goals_addressed: ['Default Goal'],
     };
 
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'linked-note-legacy-measurements',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: linkedSessionNote.goals_addressed,
+      goal_ids: linkedSessionNote.goal_ids,
+      goal_measurements: linkedSessionNote.goal_measurements as Record<string, unknown>,
+      goal_notes: linkedSessionNote.goal_notes,
+      session_id: 'session-linked-legacy-measurements',
+      narrative: linkedSessionNote.narrative,
+      is_locked: false,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: null,
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T09:00:00.000Z',
+    });
+
     vi.mocked(supabase.from).mockImplementation((table: string) => {
       if (table === 'programs') {
         const chain: SupabaseQueryChain = {
@@ -1232,21 +1381,6 @@ describe('SessionModal', () => {
           limit: vi.fn(async () => ({ data: [], error: null })),
         };
         return chain;
-      }
-      if (table === 'client_session_notes') {
-        return {
-          select: () => ({
-            eq: () => ({
-              eq: () => ({
-                order: () => ({
-                  limit: () => ({
-                    maybeSingle: async () => ({ data: linkedSessionNote, error: null }),
-                  }),
-                }),
-              }),
-            }),
-          }),
-        };
       }
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
@@ -1289,6 +1423,7 @@ describe('SessionModal', () => {
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        session_note_persist_requested: true,
         session_note_goal_measurements: {
           'goal-1': {
             version: 1,
@@ -1335,6 +1470,30 @@ describe('SessionModal', () => {
       goals_addressed: ['Default Goal', 'Legacy Goal'],
     };
 
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'linked-note-drifted-goals',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: linkedSessionNote.goals_addressed,
+      goal_ids: linkedSessionNote.goal_ids,
+      goal_measurements: linkedSessionNote.goal_measurements as Record<string, unknown>,
+      goal_notes: linkedSessionNote.goal_notes,
+      session_id: 'session-linked-drifted-goals',
+      narrative: linkedSessionNote.narrative,
+      is_locked: false,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: null,
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T09:00:00.000Z',
+    });
+
     vi.mocked(supabase.from).mockImplementation((table: string) => {
       if (table === 'programs') {
         const chain: SupabaseQueryChain = {
@@ -1368,21 +1527,6 @@ describe('SessionModal', () => {
           limit: vi.fn(async () => ({ data: [], error: null })),
         };
         return chain;
-      }
-      if (table === 'client_session_notes') {
-        return {
-          select: () => ({
-            eq: () => ({
-              eq: () => ({
-                order: () => ({
-                  limit: () => ({
-                    maybeSingle: async () => ({ data: linkedSessionNote, error: null }),
-                  }),
-                }),
-              }),
-            }),
-          }),
-        };
       }
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -111,6 +111,7 @@ const stripClinicalNoteFields = (data: ScheduleSubmitData): Partial<Session> => 
     session_note_goals_addressed: _sessionNoteGoalsAddressed,
     session_note_authorization_id: _sessionNoteAuthorizationId,
     session_note_service_code: _sessionNoteServiceCode,
+    session_note_persist_requested: _sessionNotePersistRequested,
     session_note_capture_merge_goal_ids: _sessionNoteCaptureMergeGoalIds,
     ...sessionPayload
   } = data;
@@ -129,6 +130,10 @@ const buildClinicalNoteDraft = (
   authorizationId: string;
   serviceCode: string;
 } | null => {
+  if (data.session_note_persist_requested !== true) {
+    return null;
+  }
+
   const narrative = data.session_note_narrative?.trim() ?? "";
   const goalNotes = Object.fromEntries(
     Object.entries(data.session_note_goal_notes ?? {})

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -7,6 +7,7 @@ const cancelSessionsMock = vi.fn();
 const showErrorMock = vi.fn();
 const showSuccessMock = vi.fn();
 const buildBookSessionApiPayloadMock = vi.fn((session: unknown) => session);
+const upsertClientSessionNoteForSessionMock = vi.fn();
 
 const currentSessionStart = new Date();
 currentSessionStart.setHours(10, 0, 0, 0);
@@ -75,6 +76,11 @@ vi.mock("../../lib/toast", () => ({
   showSuccess: (...args: unknown[]) => showSuccessMock(...args),
 }));
 
+vi.mock("../../lib/session-notes", () => ({
+  upsertClientSessionNoteForSession: (...args: unknown[]) =>
+    upsertClientSessionNoteForSessionMock(...args),
+}));
+
 vi.mock("../../lib/conflictPolicy", () => ({
   buildSchedulingConflictHint: () => "conflict-hint",
 }));
@@ -130,6 +136,26 @@ vi.mock("../../components/SessionModal", () => ({
           submit-update
         </button>
         <button
+          aria-label="submit-update-with-note-context"
+          onClick={() => {
+            const result = onSubmit({
+              status: "scheduled",
+              session_note_goal_ids: ["goal-1"],
+              session_note_goals_addressed: ["Goal 1"],
+              session_note_goal_notes: { "goal-1": "Previously saved note" },
+              session_note_goal_measurements: {},
+              session_note_authorization_id: "auth-1",
+              session_note_service_code: "97153",
+              session_note_persist_requested: false,
+            });
+            if (result && typeof (result as Promise<unknown>).catch === "function") {
+              void (result as Promise<unknown>).catch(() => undefined);
+            }
+          }}
+        >
+          submit-update-with-note-context
+        </button>
+        <button
           aria-label="submit-cancel"
           onClick={() => {
             const result = onSubmit({
@@ -167,6 +193,9 @@ describe("Schedule orchestration integration hardening", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
+    upsertClientSessionNoteForSessionMock.mockResolvedValue({
+      id: "linked-note-1",
+    });
     bookSessionViaApiMock.mockResolvedValue({
       session: {
         id: "created-session",
@@ -348,6 +377,23 @@ describe("Schedule orchestration integration hardening", () => {
     expect(screen.getByTestId("retry-hint")).toHaveTextContent("");
     expect(showSuccessMock).not.toHaveBeenCalled();
     expect(cancelSessionsMock).not.toHaveBeenCalled();
+  });
+
+  it("manual scheduled update ignores unchanged linked note context unless capture persistence was requested", async () => {
+    renderWithProviders(<Schedule />);
+    await screen.findByRole("heading", { name: /Schedule/i });
+
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+    fireEvent.click(screen.getByLabelText("submit-update-with-note-context"));
+
+    await waitFor(() => {
+      expect(bookSessionViaApiMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(upsertClientSessionNoteForSessionMock).not.toHaveBeenCalled();
+    expect(bookSessionViaApiMock.mock.calls[0][1]).toBeUndefined();
+    expect(showErrorMock).not.toHaveBeenCalled();
   });
 
   it("manual close clears retry hint without success-style submission", async () => {


### PR DESCRIPTION
# WIN-110 Mobile Edit Session Forbidden / Scheduling Issue Debug Handoff

## Scope

- Debugged the mobile Edit Session regression after the WIN-109 multi-program / multi-goal work.
- Kept scope contained to:
  - `src/components/SessionModal.tsx`
  - `src/pages/Schedule.tsx`
  - focused regression tests for those surfaces

Non-goals:

- no auth/session library changes
- no server/API handler changes
- no Supabase/RLS/migration changes
- no unrelated schedule cleanup

## Findings

1. Scheduled-session `Update Session` could carry linked session-note context into the Schedule submit path even when the user had not explicitly requested a capture save in the current modal interaction. That made the page eligible to call `upsertClientSessionNoteForSession(...)` before the ordinary session update.
2. The SessionModal local fallback conflict check did not exclude the session currently being edited, so mobile could show a false `1 scheduling issue` prompt for the session itself.

## Fix Summary

- Added an explicit client-side `session_note_persist_requested` signal to the SessionModal submit payload.
- Set that signal only when:
  - the user explicitly saves partial capture, or
  - capture fields/targets were dirtied in the current modal interaction, or
  - the session is already in progress (`Save progress` semantics preserved)
- Updated `Schedule.tsx` to ignore session-note draft persistence unless `session_note_persist_requested === true`.
- Excluded the currently edited session id from SessionModal's raw-time self-conflict fallback.

## Verification Card

- classification: `low-risk autonomous`
- lane: `standard`
- change type:
  - `UI/component/page`
- required checks:
  - `npm run lint`
  - `npm run typecheck`
  - `npm test -- --run src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
  - `npm run build`
  - `npm run verify:local`
- executed checks:
  - `npm run lint` -> pass
  - `npm run typecheck` -> pass
  - `npm test -- --run src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx` -> pass
  - `npm run build` -> pass
  - `npm run verify:local` -> fail (unrelated broader repo test failure in `src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx`)
- blocked checks:
  - `none`
- result: `pass-with-known-external-failure`
- residual risk:
  - The bounded fix is covered locally, but full-repo `verify:local` still fails on an unrelated existing Schedule readiness test outside this slice.

## PR Hygiene

- pr-ready: `yes`
- lane: `standard`
- branch-ready: `yes`
- linear-ready: `yes` (`WIN-110`)
- single-purpose: `yes`
- unrelated changes:
  - existing dirty files outside this task were left untouched:
    - `.cursor/mcp.json`
    - `AGENTS.md`
- generated artifact drift: `none`
- protected-path drift: `none`
- change summary: `present`
- verification summary: `present`
- pr handoff: `ready`
- reviewer:
  - completed; one real gap around capture-target dirty tracking was found and fixed before closeout

## Notes For Review

- The intended behavior is now:
  - scheduled `Update Session` updates session details without opportunistically re-saving unchanged linked session-note content
  - in-progress `Save progress` continues to persist capture state
  - editing a session no longer shows a self-conflict scheduling warning for the current session row
