### PR TITLE
fix(db): repair client_session_notes goal_measurements drift

### DIFF
--- a/supabase/migrations/20260424024908_repair_client_session_notes_goal_measurements.sql
+++ b/supabase/migrations/20260424024908_repair_client_session_notes_goal_measurements.sql
@@ -1,0 +1,19 @@
+-- @migration-intent: Repair hosted schema drift by ensuring client_session_notes.goal_measurements exists for Session Data Collection 2.0.
+-- @migration-dependencies: 20260416141755_repair_client_session_notes_goal_ids_if_still_uuid.sql
+-- @migration-rollback: alter table public.client_session_notes drop constraint if exists client_session_notes_goal_measurements_object_chk; alter table public.client_session_notes drop column if exists goal_measurements;
+
+alter table public.client_session_notes
+  add column if not exists goal_measurements jsonb;
+
+comment on column public.client_session_notes.goal_measurements is
+  'Session Data Collection 2.0: versioned per-goal measurement payload keyed by goal UUID.';
+
+alter table public.client_session_notes
+  drop constraint if exists client_session_notes_goal_measurements_object_chk;
+
+alter table public.client_session_notes
+  add constraint client_session_notes_goal_measurements_object_chk
+  check (
+    goal_measurements is null
+    or jsonb_typeof(goal_measurements) = 'object'
+  );


### PR DESCRIPTION
## Summary
- add an idempotent repair migration to ensure `public.client_session_notes.goal_measurements` exists and remains constrained to JSON object payloads
- apply the migration to hosted Supabase project `wnnjeqheqxxyrgsjmygy` to remove runtime schema drift and restore strict Session Data Collection 2.0 parity
- verify the original failing path now runs in strict mode (`goalMeasurementsSupported=true`) via `playwright:session-note-measurement-roundtrip`
- Linear: [WIN-110](https://linear.app/winningedgeai/issue/WIN-110/debug-mobile-edit-session-forbidden-update-and-scheduling-issue-prompt)

## Test plan
- [x] `npm run ci:check-focused`
- [x] `npm run test:ci`
- [x] `npm run validate:tenant`
- [x] `npm run build`
- [x] `npm run verify:local`
- [x] `npm run playwright:session-note-measurement-roundtrip`