### PR TITLE
WIN-111: Fix schedule day-view drag/drop and drop-target reliability

### DIFF
--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -2115,7 +2115,9 @@ export const Schedule = React.memo(() => {
               sessionSlotIndex={sessionSlotIndex}
               onCreateSession={handleCreateSession}
               onEditSession={handleEditSession}
+              onRescheduleSession={handleRescheduleSession}
               allowCreateInEmptySlot={!therapistScopedView}
+              allowDragAndDrop={!therapistScopedView}
             />
           ) : (
             <LazyScheduleWeekView

--- a/src/pages/ScheduleCalendarViewShared.tsx
+++ b/src/pages/ScheduleCalendarViewShared.tsx
@@ -9,6 +9,7 @@ import { getSessionStatusClasses } from './ScheduleSessionStatusStyles';
 export type ScheduleTimeSlotHandler = (timeSlot: { date: Date; time: string }) => void;
 export type ScheduleEditSessionHandler = (session: Session) => void;
 export type ScheduleSlotPosition = { date: Date; time: string };
+export type ScheduleDropPayload = { target: ScheduleSlotPosition; draggedSessionId?: string | null };
 
 export const TimeSlot = React.memo(
   ({
@@ -36,7 +37,7 @@ export const TimeSlot = React.memo(
     activeDragSessionId?: string | null;
     activeDropSlotKey?: string | null;
     onStartSessionDrag?: (session: Session, source: ScheduleSlotPosition) => void;
-    onSessionDrop?: (target: ScheduleSlotPosition) => void;
+    onSessionDrop?: (payload: ScheduleDropPayload) => void;
     onHoverSlotDuringDrag?: (targetSlotKey: string | null) => void;
     onEndSessionDrag?: () => void;
   }) => {
@@ -61,7 +62,7 @@ export const TimeSlot = React.memo(
         }
         event.preventDefault();
         if (allowDragAndDrop && activeDragSessionId !== null) {
-          onSessionDrop?.({ date: day, time });
+          onSessionDrop?.({ target: { date: day, time } });
           return;
         }
         if (enableSlotCreateChrome) {
@@ -69,7 +70,7 @@ export const TimeSlot = React.memo(
           return;
         }
         if (allowDragAndDrop) {
-          onSessionDrop?.({ date: day, time });
+          onSessionDrop?.({ target: { date: day, time } });
         }
       },
       [activeDragSessionId, allowDragAndDrop, day, enableSlotCreateChrome, handleTimeSlotClick, onSessionDrop, time],
@@ -118,7 +119,11 @@ export const TimeSlot = React.memo(
           allowDragAndDrop
             ? (event) => {
                 event.preventDefault();
-                onSessionDrop?.({ date: day, time });
+                const draggedSessionId = event.dataTransfer.getData("text/plain").trim();
+                onSessionDrop?.({
+                  target: { date: day, time },
+                  draggedSessionId: draggedSessionId.length > 0 ? draggedSessionId : null,
+                });
               }
             : undefined
         }
@@ -226,7 +231,7 @@ export const DayColumn = React.memo(
     activeDragSessionId?: string | null;
     activeDropSlotKey?: string | null;
     onStartSessionDrag?: (session: Session, source: ScheduleSlotPosition) => void;
-    onSessionDrop?: (target: ScheduleSlotPosition) => void;
+    onSessionDrop?: (payload: ScheduleDropPayload) => void;
     onHoverSlotDuringDrag?: (targetSlotKey: string | null) => void;
     onEndSessionDrag?: () => void;
   }) => {

--- a/src/pages/ScheduleDayView.tsx
+++ b/src/pages/ScheduleDayView.tsx
@@ -1,7 +1,13 @@
-import React from 'react';
-import { format } from 'date-fns';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { format, parseISO } from 'date-fns';
 import type { Session } from '../types';
-import { TimeSlot, type ScheduleEditSessionHandler, type ScheduleTimeSlotHandler } from './ScheduleCalendarViewShared';
+import {
+  TimeSlot,
+  type ScheduleDropPayload,
+  type ScheduleEditSessionHandler,
+  type ScheduleSlotPosition,
+  type ScheduleTimeSlotHandler,
+} from './ScheduleCalendarViewShared';
 import { createSessionSlotKey } from './schedule-utils';
 
 interface ScheduleDayViewProps {
@@ -10,7 +16,9 @@ interface ScheduleDayViewProps {
   sessionSlotIndex: Map<string, Session[]>;
   onCreateSession: ScheduleTimeSlotHandler;
   onEditSession: ScheduleEditSessionHandler;
+  onRescheduleSession?: (session: Session, target: ScheduleSlotPosition) => void;
   allowCreateInEmptySlot?: boolean;
+  allowDragAndDrop?: boolean;
 }
 
 const ScheduleDayViewComponent: React.FC<ScheduleDayViewProps> = ({
@@ -19,9 +27,70 @@ const ScheduleDayViewComponent: React.FC<ScheduleDayViewProps> = ({
   sessionSlotIndex,
   onCreateSession,
   onEditSession,
+  onRescheduleSession,
   allowCreateInEmptySlot = true,
+  allowDragAndDrop = false,
 }) => {
   const selectedDateKey = format(selectedDate, 'yyyy-MM-dd');
+  const [draggedSession, setDraggedSession] = useState<Session | null>(null);
+  const [dropSlotKey, setDropSlotKey] = useState<string | null>(null);
+  const draggedSessionRef = useRef<Session | null>(null);
+  const sourceSlotKeyRef = useRef<string | null>(null);
+  const sessionsById = useMemo(() => {
+    const next = new Map<string, Session>();
+    for (const slotSessions of sessionSlotIndex.values()) {
+      for (const session of slotSessions) {
+        next.set(session.id, session);
+      }
+    }
+    return next;
+  }, [sessionSlotIndex]);
+
+  const handleStartSessionDrag = useCallback((session: Session, source: ScheduleSlotPosition) => {
+    if (!allowDragAndDrop) {
+      return;
+    }
+    const nextSourceSlotKey = createSessionSlotKey(format(source.date, 'yyyy-MM-dd'), source.time);
+    draggedSessionRef.current = session;
+    sourceSlotKeyRef.current = nextSourceSlotKey;
+    setDraggedSession(session);
+    setDropSlotKey(null);
+  }, [allowDragAndDrop]);
+
+  const clearDragState = useCallback(() => {
+    draggedSessionRef.current = null;
+    sourceSlotKeyRef.current = null;
+    setDraggedSession(null);
+    setDropSlotKey(null);
+  }, []);
+
+  const handleHoverSlotDuringDrag = useCallback((targetSlotKey: string | null) => {
+    if (!allowDragAndDrop || !draggedSessionRef.current) {
+      return;
+    }
+    setDropSlotKey(targetSlotKey);
+  }, [allowDragAndDrop]);
+
+  const handleDropOnSlot = useCallback(({ target, draggedSessionId }: ScheduleDropPayload) => {
+    const sessionToMove =
+      draggedSessionRef.current ??
+      (draggedSessionId ? sessionsById.get(draggedSessionId) ?? null : null);
+    if (!allowDragAndDrop || !sessionToMove) {
+      clearDragState();
+      return;
+    }
+    const targetKey = createSessionSlotKey(format(target.date, 'yyyy-MM-dd'), target.time);
+    const fallbackSourceDate = parseISO(sessionToMove.start_time);
+    const fallbackSourceKey = Number.isNaN(fallbackSourceDate.getTime())
+      ? null
+      : createSessionSlotKey(format(fallbackSourceDate, 'yyyy-MM-dd'), format(fallbackSourceDate, 'HH:mm'));
+    const sourceKey = sourceSlotKeyRef.current ?? fallbackSourceKey;
+    const shouldReschedule = targetKey !== sourceKey;
+    clearDragState();
+    if (shouldReschedule) {
+      onRescheduleSession?.(sessionToMove, target);
+    }
+  }, [allowDragAndDrop, clearDragState, onRescheduleSession, sessionsById]);
 
   return (
     <div
@@ -59,6 +128,13 @@ const ScheduleDayViewComponent: React.FC<ScheduleDayViewProps> = ({
               onCreateSession={onCreateSession}
               onEditSession={onEditSession}
               allowCreateInEmptySlot={allowCreateInEmptySlot}
+              allowDragAndDrop={allowDragAndDrop}
+              activeDragSessionId={draggedSession?.id ?? null}
+              activeDropSlotKey={dropSlotKey}
+              onStartSessionDrag={handleStartSessionDrag}
+              onSessionDrop={handleDropOnSlot}
+              onHoverSlotDuringDrag={handleHoverSlotDuringDrag}
+              onEndSessionDrag={clearDragState}
             />
           ))}
         </div>

--- a/src/pages/ScheduleWeekView.tsx
+++ b/src/pages/ScheduleWeekView.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useRef, useState } from 'react';
-import { format } from 'date-fns';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { format, parseISO } from 'date-fns';
 import type { Session } from '../types';
 import {
   DayColumn,
+  type ScheduleDropPayload,
   type ScheduleEditSessionHandler,
   type ScheduleSlotPosition,
   type ScheduleTimeSlotHandler,
@@ -34,6 +35,15 @@ const ScheduleWeekViewComponent: React.FC<ScheduleWeekViewProps> = ({
   const [dropSlotKey, setDropSlotKey] = useState<string | null>(null);
   const draggedSessionRef = useRef<Session | null>(null);
   const sourceSlotKeyRef = useRef<string | null>(null);
+  const sessionsById = useMemo(() => {
+    const next = new Map<string, Session>();
+    for (const slotSessions of sessionSlotIndex.values()) {
+      for (const session of slotSessions) {
+        next.set(session.id, session);
+      }
+    }
+    return next;
+  }, [sessionSlotIndex]);
 
   const handleStartSessionDrag = useCallback((session: Session, source: ScheduleSlotPosition) => {
     if (!allowDragAndDrop) {
@@ -60,19 +70,26 @@ const ScheduleWeekViewComponent: React.FC<ScheduleWeekViewProps> = ({
     setDropSlotKey(targetSlotKey);
   }, [allowDragAndDrop]);
 
-  const handleDropOnSlot = useCallback((target: ScheduleSlotPosition) => {
-    const sessionToMove = draggedSessionRef.current;
+  const handleDropOnSlot = useCallback(({ target, draggedSessionId }: ScheduleDropPayload) => {
+    const sessionToMove =
+      draggedSessionRef.current ??
+      (draggedSessionId ? sessionsById.get(draggedSessionId) ?? null : null);
     if (!allowDragAndDrop || !sessionToMove) {
       clearDragState();
       return;
     }
     const targetKey = createSessionSlotKey(format(target.date, 'yyyy-MM-dd'), target.time);
-    const shouldReschedule = targetKey !== sourceSlotKeyRef.current;
+    const fallbackSourceDate = parseISO(sessionToMove.start_time);
+    const fallbackSourceKey = Number.isNaN(fallbackSourceDate.getTime())
+      ? null
+      : createSessionSlotKey(format(fallbackSourceDate, 'yyyy-MM-dd'), format(fallbackSourceDate, 'HH:mm'));
+    const sourceKey = sourceSlotKeyRef.current ?? fallbackSourceKey;
+    const shouldReschedule = targetKey !== sourceKey;
     clearDragState();
     if (shouldReschedule) {
       onRescheduleSession?.(sessionToMove, target);
     }
-  }, [allowDragAndDrop, clearDragState, onRescheduleSession]);
+  }, [allowDragAndDrop, clearDragState, onRescheduleSession, sessionsById]);
 
   return (
     <div className="bg-white dark:bg-dark-lighter rounded-lg shadow overflow-x-auto">

--- a/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { format } from "date-fns";
+import type { Session } from "../../types";
+import { createSessionSlotKey } from "../schedule-utils";
+import { ScheduleDayView } from "../ScheduleDayView";
+
+const buildSession = (startDate: Date): Session => ({
+  id: "session-1",
+  client_id: "client-1",
+  therapist_id: "therapist-1",
+  program_id: "program-1",
+  goal_id: "goal-1",
+  start_time: startDate.toISOString(),
+  end_time: new Date(startDate.getTime() + 60 * 60 * 1000).toISOString(),
+  status: "scheduled",
+  notes: "weekly session",
+  created_at: "2025-07-01T00:00:00.000Z",
+  created_by: "user-1",
+  updated_at: "2025-07-01T00:00:00.000Z",
+  updated_by: "user-1",
+  client: { id: "client-1", full_name: "Jamie Client" },
+  therapist: { id: "therapist-1", full_name: "Dr. Myles" },
+});
+
+const dragData = {
+  setData: vi.fn(),
+  getData: vi.fn(() => "session-1"),
+  effectAllowed: "move",
+  dropEffect: "move",
+};
+
+describe("ScheduleDayView drag and drop", () => {
+  it("invokes onRescheduleSession for a different target slot", () => {
+    const selectedDate = new Date("2025-07-07T00:00:00.000Z");
+    const sourceTime = "10:00";
+    const targetTime = "10:15";
+    const sessionStart = new Date(selectedDate);
+    sessionStart.setHours(10, 0, 0, 0);
+    const session = buildSession(sessionStart);
+    const onRescheduleSession = vi.fn();
+    const sourceStart = sessionStart;
+    const sourceKey = createSessionSlotKey(format(sourceStart, "yyyy-MM-dd"), format(sourceStart, "HH:mm"));
+    const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+    const { container } = render(
+      <ScheduleDayView
+        selectedDate={selectedDate}
+        timeSlots={[sourceTime, targetTime]}
+        sessionSlotIndex={sessionSlotIndex}
+        onCreateSession={vi.fn()}
+        onEditSession={vi.fn()}
+        onRescheduleSession={onRescheduleSession}
+        allowDragAndDrop
+      />,
+    );
+
+    const card = container.querySelector('[data-session-id="session-1"]');
+    const targetSlot = Array.from(container.querySelectorAll("[data-slot-key]")).find((slot) => {
+      const slotKey = slot.getAttribute("data-slot-key");
+      return typeof slotKey === "string" && slotKey.endsWith(`|${targetTime}`);
+    });
+    expect(card).toBeTruthy();
+    expect(targetSlot).toBeTruthy();
+
+    fireEvent.dragStart(card as HTMLElement, { dataTransfer: dragData });
+    fireEvent.dragEnter(targetSlot as HTMLElement, { dataTransfer: dragData });
+    fireEvent.dragOver(targetSlot as HTMLElement, { dataTransfer: dragData });
+    fireEvent.drop(targetSlot as HTMLElement, { dataTransfer: dragData });
+
+    expect(onRescheduleSession).toHaveBeenCalledTimes(1);
+    expect(onRescheduleSession).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "session-1" }),
+      expect.objectContaining({
+        time: targetTime,
+        date: expect.any(Date),
+      }),
+    );
+  });
+});

--- a/src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
@@ -1,17 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
+import { format } from "date-fns";
 import type { Session } from "../../types";
 import { createSessionSlotKey } from "../schedule-utils";
 import { ScheduleWeekView } from "../ScheduleWeekView";
 
-const buildSession = (): Session => ({
+const buildSession = (startDate: Date): Session => ({
   id: "session-1",
   client_id: "client-1",
   therapist_id: "therapist-1",
   program_id: "program-1",
   goal_id: "goal-1",
-  start_time: "2025-07-07T10:00:00.000Z",
-  end_time: "2025-07-07T11:00:00.000Z",
+  start_time: startDate.toISOString(),
+  end_time: new Date(startDate.getTime() + 60 * 60 * 1000).toISOString(),
   status: "scheduled",
   notes: "weekly session",
   created_at: "2025-07-01T00:00:00.000Z",
@@ -24,7 +25,7 @@ const buildSession = (): Session => ({
 
 const dragData = {
   setData: vi.fn(),
-  getData: vi.fn(),
+  getData: vi.fn(() => "session-1"),
   effectAllowed: "move",
 };
 
@@ -34,12 +35,12 @@ describe("ScheduleWeekView drag and drop", () => {
     const targetDay = new Date("2025-07-08T00:00:00.000Z");
     const sourceTime = "10:00";
     const targetTime = "10:15";
-    const session = buildSession();
+    const sessionStart = new Date(sourceDay);
+    sessionStart.setHours(10, 0, 0, 0);
+    const session = buildSession(sessionStart);
     const onRescheduleSession = vi.fn();
-    const sourceKey = createSessionSlotKey(
-      `${sourceDay.getFullYear()}-${String(sourceDay.getMonth() + 1).padStart(2, "0")}-${String(sourceDay.getDate()).padStart(2, "0")}`,
-      sourceTime,
-    );
+    const sourceStart = sessionStart;
+    const sourceKey = createSessionSlotKey(format(sourceStart, "yyyy-MM-dd"), format(sourceStart, "HH:mm"));
     const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
 
     const { container } = render(
@@ -80,9 +81,12 @@ describe("ScheduleWeekView drag and drop", () => {
   it("does not invoke onRescheduleSession when dropped on same slot", () => {
     const sourceDay = new Date("2025-07-07T00:00:00.000Z");
     const sourceTime = "10:00";
-    const session = buildSession();
+    const sessionStart = new Date(sourceDay);
+    sessionStart.setHours(10, 0, 0, 0);
+    const session = buildSession(sessionStart);
     const onRescheduleSession = vi.fn();
-    const sourceKey = createSessionSlotKey("2025-07-07", sourceTime);
+    const sourceStart = sessionStart;
+    const sourceKey = createSessionSlotKey(format(sourceStart, "yyyy-MM-dd"), format(sourceStart, "HH:mm"));
     const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
 
     const { container } = render(
@@ -114,9 +118,12 @@ describe("ScheduleWeekView drag and drop", () => {
     const targetDay = new Date("2025-07-08T00:00:00.000Z");
     const sourceTime = "10:00";
     const targetTime = "10:15";
-    const session = buildSession();
+    const sessionStart = new Date(sourceDay);
+    sessionStart.setHours(10, 0, 0, 0);
+    const session = buildSession(sessionStart);
     const onRescheduleSession = vi.fn();
-    const sourceKey = createSessionSlotKey("2025-07-07", sourceTime);
+    const sourceStart = sessionStart;
+    const sourceKey = createSessionSlotKey(format(sourceStart, "yyyy-MM-dd"), format(sourceStart, "HH:mm"));
     const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
 
     const { container } = render(


### PR DESCRIPTION
## Summary
- enable appointment drag-and-drop rescheduling in ScheduleDayView (desktop/mobile day mode) using the same schedule mutation path already used in week view
- harden drop resolution in week/day views by falling back to dataTransfer session id when drag state clears before drop, preventing no-op drops that appear unsaved
- add focused drag/drop regression tests for day view and stabilize week-view drag/drop tests for timezone-safe slot keys

## Test plan
- [x] npm test -- src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
- [x] npm run typecheck