### PR TITLE
WIN-111 Fix schedule reschedule reconciliation

### DIFF
--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -44,6 +44,7 @@ import { fetchLinkedClientIdsForTherapist } from "../lib/clients/therapistClient
 import { hasMeaningfulGoalMeasurementEntry, normalizeGoalMeasurementEntry } from "../lib/goal-measurements";
 import { upsertClientSessionNoteForSession } from "../lib/session-notes";
 import {
+  createSessionSlotKey,
   buildSessionSlotIndex,
   normalizeRecurrencePayload,
   reconcileOptimisticSessionMoves,

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -46,6 +46,7 @@ import { upsertClientSessionNoteForSession } from "../lib/session-notes";
 import {
   buildSessionSlotIndex,
   normalizeRecurrencePayload,
+  reconcileOptimisticSessionMoves,
   toPendingScheduleDetail,
   type PendingScheduleDetail,
   type RecurrenceFormState,
@@ -1031,19 +1032,23 @@ export const Schedule = React.memo(() => {
         overrides: undefined,
       });
     },
-    onSuccess: async (_result, variables) => {
-      await Promise.all([
-        queryClient.refetchQueries({ queryKey: ["sessions"], type: "active" }),
-        queryClient.refetchQueries({ queryKey: ["sessions-batch"], type: "active" }),
-      ]);
+    onSuccess: async (result, variables) => {
       setOptimisticSessionMoves((prev) => {
         if (!prev[variables.session.id]) {
           return prev;
         }
-        const next = { ...prev };
-        delete next[variables.session.id];
-        return next;
+        return {
+          ...prev,
+          [variables.session.id]: {
+            start_time: result.session.start_time,
+            end_time: result.session.end_time,
+          },
+        };
       });
+      await Promise.all([
+        queryClient.refetchQueries({ queryKey: ["sessions"], type: "active" }),
+        queryClient.refetchQueries({ queryKey: ["sessions-batch"], type: "active" }),
+      ]);
       showSuccess("Appointment moved");
     },
     onError: (error, variables) => {
@@ -1563,34 +1568,7 @@ export const Schedule = React.memo(() => {
     if (Object.keys(optimisticSessionMoves).length === 0) {
       return;
     }
-    const matchesPersistedInstant = (candidate: string, persisted: string): boolean => {
-      const candidateMs = parseISO(candidate).getTime();
-      const persistedMs = parseISO(persisted).getTime();
-      if (!Number.isNaN(candidateMs) && !Number.isNaN(persistedMs)) {
-        return candidateMs === persistedMs;
-      }
-      return candidate === persisted;
-    };
-    setOptimisticSessionMoves((prev) => {
-      let changed = false;
-      const next = { ...prev };
-      for (const [sessionId, optimisticMove] of Object.entries(prev)) {
-        const persisted = displayData.sessions.find((session) => session.id === sessionId);
-        if (!persisted) {
-          delete next[sessionId];
-          changed = true;
-          continue;
-        }
-        if (
-          matchesPersistedInstant(optimisticMove.start_time, persisted.start_time) &&
-          matchesPersistedInstant(optimisticMove.end_time, persisted.end_time)
-        ) {
-          delete next[sessionId];
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
+    setOptimisticSessionMoves((prev) => reconcileOptimisticSessionMoves(prev, displayData.sessions));
   }, [displayData.sessions, optimisticSessionMoves]);
 
   const sessionSlotIndex = useMemo(

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -14,6 +14,11 @@ currentSessionStart.setHours(10, 0, 0, 0);
 const currentSessionEnd = new Date(currentSessionStart);
 currentSessionEnd.setHours(11, 0, 0, 0);
 
+const originalSessionWindow = {
+  start_time: currentSessionStart.toISOString(),
+  end_time: currentSessionEnd.toISOString(),
+};
+
 const scheduleFixtures = {
   sessions: [
     {
@@ -22,8 +27,8 @@ const scheduleFixtures = {
       client_id: "client-1",
       program_id: "program-1",
       goal_id: "goal-1",
-      start_time: currentSessionStart.toISOString(),
-      end_time: currentSessionEnd.toISOString(),
+      start_time: originalSessionWindow.start_time,
+      end_time: originalSessionWindow.end_time,
       status: "scheduled",
       notes: "Initial session",
       therapist: { id: "therapist-1", full_name: "Dr. Myles" },
@@ -179,6 +184,11 @@ vi.mock("../../components/SessionModal", () => ({
 import { Schedule } from "../Schedule";
 
 describe("Schedule orchestration integration hardening", () => {
+  const resetScheduleFixtureWindow = () => {
+    scheduleFixtures.sessions[0].start_time = originalSessionWindow.start_time;
+    scheduleFixtures.sessions[0].end_time = originalSessionWindow.end_time;
+  };
+
   const openExistingSessionForEdit = async () => {
     await waitFor(() => {
       expect(document.querySelector("[data-session-status]")).toBeTruthy();
@@ -193,6 +203,7 @@ describe("Schedule orchestration integration hardening", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
+    resetScheduleFixtureWindow();
     upsertClientSessionNoteForSessionMock.mockResolvedValue({
       id: "linked-note-1",
     });
@@ -419,4 +430,5 @@ describe("Schedule orchestration integration hardening", () => {
     });
     expect(bookSessionViaApiMock).toHaveBeenCalledTimes(1);
   });
+
 });

--- a/src/pages/__tests__/Schedule.reschedule.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.reschedule.integration.test.tsx
@@ -1,0 +1,273 @@
+import { useSyncExternalStore } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "@testing-library/react";
+import { addDays, format, startOfWeek } from "date-fns";
+import { renderWithProviders, screen, waitFor } from "../../test/utils";
+import type { Client, Session, Therapist } from "../../types";
+import { createSessionSlotKey } from "../schedule-utils";
+
+const bookSessionViaApiMock = vi.fn();
+const showErrorMock = vi.fn();
+const showSuccessMock = vi.fn();
+let latestRescheduleHandler:
+  | ((session: Session, target: { date: Date; time: string }) => void)
+  | null = null;
+
+type ScheduleStore = {
+  sessions: Session[];
+  therapists: Therapist[];
+  clients: Client[];
+};
+
+const scheduleStoreListeners = new Set<() => void>();
+let scheduleStore: ScheduleStore;
+
+const subscribeToScheduleStore = (listener: () => void) => {
+  scheduleStoreListeners.add(listener);
+  return () => {
+    scheduleStoreListeners.delete(listener);
+  };
+};
+
+const getScheduleStoreSnapshot = () => scheduleStore;
+
+const useScheduleStore = () =>
+  useSyncExternalStore(subscribeToScheduleStore, getScheduleStoreSnapshot, getScheduleStoreSnapshot);
+
+const setScheduleStore = (next: ScheduleStore) => {
+  scheduleStore = next;
+  scheduleStoreListeners.forEach((listener) => listener());
+};
+
+vi.mock("../../lib/optimizedQueries", () => ({
+  useScheduleDataBatch: () => {
+    const data = useScheduleStore();
+    return { data, isLoading: false, isError: false, error: null };
+  },
+  useSessionsOptimized: () => {
+    const data = useScheduleStore();
+    return { data: data.sessions, isLoading: false, isError: false, error: null };
+  },
+  useDropdownData: () => {
+    const data = useScheduleStore();
+    return {
+      data: { therapists: data.therapists, clients: data.clients },
+      isLoading: false,
+      isError: false,
+      error: null,
+    };
+  },
+  useSmartPrefetch: () => ({
+    prefetchScheduleRange: vi.fn(),
+    prefetchNextWeek: vi.fn(),
+    prefetchReportData: vi.fn(),
+  }),
+}));
+
+vi.mock("../../features/scheduling/domain/booking", () => ({
+  buildBookSessionApiPayload: (session: unknown) => session,
+  bookSessionViaApi: (...args: unknown[]) => bookSessionViaApiMock(...args),
+}));
+
+vi.mock("../../lib/toast", () => ({
+  showError: (...args: unknown[]) => showErrorMock(...args),
+  showSuccess: (...args: unknown[]) => showSuccessMock(...args),
+}));
+
+vi.mock("../ScheduleWeekView", () => ({
+  ScheduleWeekView: ({
+    weekDays,
+    timeSlots,
+    sessionSlotIndex,
+    onRescheduleSession,
+  }: {
+    weekDays: Date[];
+    timeSlots: string[];
+    sessionSlotIndex: Map<string, Session[]>;
+    onRescheduleSession?: (session: Session, target: { date: Date; time: string }) => void;
+  }) => {
+    latestRescheduleHandler = onRescheduleSession ?? null;
+    const allSessions = Array.from(sessionSlotIndex.values()).flat();
+    const sessionToMove = allSessions[0] ?? null;
+    const targetDate = sessionToMove ? new Date(sessionToMove.start_time) : weekDays[0];
+
+    return (
+      <div data-testid="schedule-week-view-mock">
+        <div data-testid="reschedule-target-date">{targetDate?.toISOString() ?? ""}</div>
+        {weekDays.flatMap((day) =>
+          timeSlots.map((time) => {
+            const slotKey = createSessionSlotKey(format(day, "yyyy-MM-dd"), time);
+            const slotSessions = sessionSlotIndex.get(slotKey) ?? [];
+            return (
+              <div key={slotKey} data-slot-key={slotKey}>
+                {slotSessions.map((session) => (
+                  <div key={session.id} data-session-id={session.id}>
+                    {session.id}
+                  </div>
+                ))}
+              </div>
+            );
+          }),
+        )}
+      </div>
+    );
+  },
+}));
+
+import { Schedule } from "../Schedule";
+
+const buildOffsetTimestamp = (date: Date) => {
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absoluteOffsetMinutes = Math.abs(offsetMinutes);
+  const offsetHours = String(Math.floor(absoluteOffsetMinutes / 60)).padStart(2, "0");
+  const offsetRemainderMinutes = String(absoluteOffsetMinutes % 60).padStart(2, "0");
+  return `${format(date, "yyyy-MM-dd'T'HH:mm:ss")}${sign}${offsetHours}:${offsetRemainderMinutes}`;
+};
+
+const buildScheduleStore = () => {
+  const sourceDate = addDays(startOfWeek(new Date(), { weekStartsOn: 1 }), 1);
+  sourceDate.setHours(10, 0, 0, 0);
+  const session: Session = {
+    id: "session-1",
+    therapist_id: "therapist-1",
+    client_id: "client-1",
+    program_id: "program-1",
+    goal_id: "goal-1",
+    start_time: sourceDate.toISOString(),
+    end_time: new Date(sourceDate.getTime() + 60 * 60 * 1000).toISOString(),
+    status: "scheduled",
+    notes: "Initial session",
+    created_at: "2025-07-01T00:00:00.000Z",
+    created_by: "user-1",
+    updated_at: "2025-07-01T00:00:00.000Z",
+    updated_by: "user-1",
+    therapist: { id: "therapist-1", full_name: "Dr. Myles" },
+    client: { id: "client-1", full_name: "Jamie Client" },
+  };
+
+  return {
+    sessions: [session],
+    therapists: [
+      {
+        id: "therapist-1",
+        full_name: "Dr. Myles",
+        email: "myles@example.com",
+        availability_hours: {},
+      },
+    ],
+    clients: [
+      {
+        id: "client-1",
+        full_name: "Jamie Client",
+        email: "jamie@example.com",
+        availability_hours: {},
+      },
+    ],
+  } satisfies ScheduleStore;
+};
+
+const getSlotSessionIds = (container: HTMLElement, slotKey: string) => {
+  const slot = container.querySelector(`[data-slot-key="${slotKey}"]`);
+  if (!slot) {
+    throw new Error(`Expected slot ${slotKey} to exist.`);
+  }
+  return Array.from(slot.querySelectorAll("[data-session-id]")).map((node) => node.getAttribute("data-session-id"));
+};
+
+describe("Schedule reschedule integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scheduleStore = buildScheduleStore();
+    latestRescheduleHandler = null;
+  });
+
+  afterEach(() => {
+    scheduleStoreListeners.clear();
+  });
+
+  it("keeps the moved appointment in the optimistic slot until persisted canonical timestamps catch up", async () => {
+    let resolveBooking:
+      | ((value: { session: Session }) => void)
+      | undefined;
+
+    bookSessionViaApiMock.mockImplementation(
+      () =>
+        new Promise<{ session: Session }>((resolve) => {
+          resolveBooking = resolve;
+        }),
+    );
+
+    const { container } = renderWithProviders(<Schedule />);
+
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitFor(() => {
+      expect(container.querySelector('[data-session-id="session-1"]')).toBeTruthy();
+    });
+
+    const sourceSession = scheduleStore.sessions[0];
+    const sourceStart = new Date(sourceSession.start_time);
+    const sourceSlotKey = createSessionSlotKey(
+      format(sourceStart, "yyyy-MM-dd"),
+      format(sourceStart, "HH:mm"),
+    );
+    const targetTime = "10:15";
+    const targetSlotKey = createSessionSlotKey(format(sourceStart, "yyyy-MM-dd"), targetTime);
+    const movedStart = new Date(sourceStart);
+    movedStart.setHours(10, 15, 0, 0);
+    const movedEnd = new Date(movedStart.getTime() + 60 * 60 * 1000);
+
+    expect(latestRescheduleHandler).toBeTruthy();
+
+    act(() => {
+      latestRescheduleHandler?.(sourceSession, { date: sourceStart, time: targetTime });
+    });
+
+    await waitFor(() => {
+      expect(bookSessionViaApiMock).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(getSlotSessionIds(container, sourceSlotKey)).toEqual([]);
+      expect(getSlotSessionIds(container, targetSlotKey)).toEqual(["session-1"]);
+    });
+
+    resolveBooking?.({
+      session: {
+        ...sourceSession,
+        start_time: buildOffsetTimestamp(movedStart),
+        end_time: buildOffsetTimestamp(movedEnd),
+      },
+    });
+
+    await waitFor(() => {
+      expect(showSuccessMock).toHaveBeenCalledWith("Appointment moved");
+    });
+
+    await waitFor(() => {
+      expect(getSlotSessionIds(container, sourceSlotKey)).toEqual([]);
+      expect(getSlotSessionIds(container, targetSlotKey)).toEqual(["session-1"]);
+    });
+
+    act(() => {
+      setScheduleStore({
+        ...scheduleStore,
+        sessions: [
+          {
+            ...sourceSession,
+            start_time: buildOffsetTimestamp(movedStart),
+            end_time: buildOffsetTimestamp(movedEnd),
+          },
+        ],
+      });
+    });
+
+    await waitFor(() => {
+      expect(getSlotSessionIds(container, sourceSlotKey)).toEqual([]);
+      expect(getSlotSessionIds(container, targetSlotKey)).toEqual(["session-1"]);
+      expect(container.querySelectorAll('[data-session-id="session-1"]')).toHaveLength(1);
+    });
+
+    expect(showErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/__tests__/schedule-utils.reschedule.test.ts
+++ b/src/pages/__tests__/schedule-utils.reschedule.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { Session } from "../../types";
+import { reconcileOptimisticSessionMoves } from "../schedule-utils";
+
+const buildSession = (start_time: string, end_time: string): Session => ({
+  id: "session-1",
+  therapist_id: "therapist-1",
+  client_id: "client-1",
+  program_id: "program-1",
+  goal_id: "goal-1",
+  start_time,
+  end_time,
+  status: "scheduled",
+  notes: "Initial session",
+  created_at: "2025-07-01T00:00:00.000Z",
+  created_by: "user-1",
+  updated_at: "2025-07-01T00:00:00.000Z",
+  updated_by: "user-1",
+  therapist: { id: "therapist-1", full_name: "Dr. Myles" },
+  client: { id: "client-1", full_name: "Jamie Client" },
+});
+
+describe("reconcileOptimisticSessionMoves", () => {
+  it("keeps an optimistic move while persisted sessions still show the old slot", () => {
+    const optimisticMoves = {
+      "session-1": {
+        start_time: "2025-07-01T17:15:00.000Z",
+        end_time: "2025-07-01T18:15:00.000Z",
+      },
+    };
+
+    const persistedSessions = [
+      buildSession("2025-07-01T17:00:00.000Z", "2025-07-01T18:00:00.000Z"),
+    ];
+
+    expect(reconcileOptimisticSessionMoves(optimisticMoves, persistedSessions)).toEqual(optimisticMoves);
+  });
+
+  it("clears an optimistic move once persisted sessions catch up to the moved instant", () => {
+    const optimisticMoves = {
+      "session-1": {
+        start_time: "2025-07-01T17:15:00.000Z",
+        end_time: "2025-07-01T18:15:00.000Z",
+      },
+    };
+
+    const persistedSessions = [
+      buildSession("2025-07-01T10:15:00-07:00", "2025-07-01T11:15:00-07:00"),
+    ];
+
+    expect(reconcileOptimisticSessionMoves(optimisticMoves, persistedSessions)).toEqual({});
+  });
+});

--- a/src/pages/schedule-utils.ts
+++ b/src/pages/schedule-utils.ts
@@ -183,6 +183,41 @@ export function buildSessionSlotIndex(sessions: Session[]): Map<string, Session[
   return index;
 }
 
+export function reconcileOptimisticSessionMoves(
+  optimisticSessionMoves: Record<string, { start_time: string; end_time: string }>,
+  persistedSessions: Session[],
+): Record<string, { start_time: string; end_time: string }> {
+  const matchesPersistedInstant = (candidate: string, persisted: string): boolean => {
+    const candidateMs = new Date(candidate).getTime();
+    const persistedMs = new Date(persisted).getTime();
+    if (!Number.isNaN(candidateMs) && !Number.isNaN(persistedMs)) {
+      return candidateMs === persistedMs;
+    }
+    return candidate === persisted;
+  };
+
+  let changed = false;
+  const next = { ...optimisticSessionMoves };
+
+  for (const [sessionId, optimisticMove] of Object.entries(optimisticSessionMoves)) {
+    const persisted = persistedSessions.find((session) => session.id === sessionId);
+    if (!persisted) {
+      delete next[sessionId];
+      changed = true;
+      continue;
+    }
+    if (
+      matchesPersistedInstant(optimisticMove.start_time, persisted.start_time) &&
+      matchesPersistedInstant(optimisticMove.end_time, persisted.end_time)
+    ) {
+      delete next[sessionId];
+      changed = true;
+    }
+  }
+
+  return changed ? next : optimisticSessionMoves;
+}
+
 export async function mapWithConcurrency<T, R>(
   items: T[],
   worker: (item: T, index: number) => Promise<R>,


### PR DESCRIPTION
## Summary
- keep optimistic week-view reschedules in place until refetched session data matches the canonical moved timestamps
- update optimistic move state with the server-returned session window after a successful reschedule mutation
- add focused regression coverage for optimistic move reconciliation and reset the orchestration fixture window between tests

## Verification
- npm test -- src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
- npm test -- src/pages/__tests__/Schedule.orchestration.integration.test.tsx
- npm test -- src/pages/__tests__/schedule-utils.reschedule.test.ts
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run build
- npm run verify:local (fails in unrelated existing tests outside this slice)
