### PR TITLE
WIN-113 Guard /api/dashboard transport failures

### DIFF
--- a/docs/ai/WIN-113-dashboard-api-502-handoff.md
+++ b/docs/ai/WIN-113-dashboard-api-502-handoff.md
@@ -67,9 +67,12 @@
 - verification summary: present
 - pr-ready: no
 - required follow-up:
-  - push branch and open PR
-  - report live PR checks and merge blockers
+  - wait for live PR checks on `#478`
+  - obtain human review before merge
+  - resolve any required check failures if CI disagrees with the local scoped result
 
 ## Handoff Summary
 
 This slice keeps the outage fix constrained to the dashboard API proxy. The change adds a `try/catch` around the edge-authority call in `src/server/api/dashboard.ts` so a thrown upstream fetch no longer escapes the handler and instead returns a typed `upstream_error` response with status `502`. A focused regression test now covers that path, while broader repo verification remains limited by unrelated pre-existing test failures and local browser-runner instability outside this dashboard slice.
+
+Draft PR: `#478` (`WIN-113 Guard /api/dashboard transport failures`)

--- a/docs/ai/WIN-113-dashboard-api-502-handoff.md
+++ b/docs/ai/WIN-113-dashboard-api-502-handoff.md
@@ -1,0 +1,75 @@
+# WIN-113 Dashboard API 502 Handoff
+
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: the bounded fix changes the `/api/dashboard` server/API proxy path under `src/server/**`, which is a protected path and runtime boundary
+- triggering paths:
+  - `src/server/api/dashboard.ts`
+  - `src/server/__tests__/dashboardHandler.test.ts`
+
+## Scope
+
+- task intent: keep the dashboard outage fix tightly scoped to `/api/dashboard` so thrown upstream proxy failures do not escape the handler
+- files touched:
+  - `src/server/api/dashboard.ts`
+  - `src/server/__tests__/dashboardHandler.test.ts`
+- single-purpose diff: yes
+
+## Required Agents
+
+- required sequence:
+  - `specification-engineer`
+  - `software-architect`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+  - `security-engineer`
+- agents used:
+  - `explorer` for debugging-specialist-equivalent code-path analysis
+  - `tester` for verification planning
+  - `reviewer` for final diff review
+- reviewer: completed
+
+## Verification Card
+
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run verify:local`
+- executed checks:
+  - `npm test -- --run src/server/__tests__/dashboardHandler.test.ts src/server/__tests__/dashboardParity.contract.test.ts src/lib/__tests__/optimizedQueries.dashboard.test.ts`: pass
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+  - `npm run test:ci`: fail
+  - `npm run test:routes:tier0`: fail
+  - `npm run verify:local`: fail
+- blocked checks:
+  - `npm run ci:playwright`: not run locally; browser/auth gate not attempted after `test:routes:tier0` failed on local Cypress runtime and the repo already has unrelated suite instability outside this slice
+- result: fail
+- residual risk: the endpoint now converts thrown edge-authority failures into a typed JSON `502`, but I could not verify a deployed non-502 dashboard path because production/preview environment access and live auth/browser execution are not available here
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes (`WIN-113`)
+- protected-path drift: `src/server/api/dashboard.ts`
+- unrelated changes: none
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: no
+- required follow-up:
+  - push branch and open PR
+  - report live PR checks and merge blockers
+
+## Handoff Summary
+
+This slice keeps the outage fix constrained to the dashboard API proxy. The change adds a `try/catch` around the edge-authority call in `src/server/api/dashboard.ts` so a thrown upstream fetch no longer escapes the handler and instead returns a typed `upstream_error` response with status `502`. A focused regression test now covers that path, while broader repo verification remains limited by unrelated pre-existing test failures and local browser-runner instability outside this dashboard slice.

--- a/src/server/__tests__/dashboardHandler.test.ts
+++ b/src/server/__tests__/dashboardHandler.test.ts
@@ -127,6 +127,51 @@ describe("dashboardHandler", () => {
     const json = await response.json();
     expect(json).toMatchObject(body);
   });
+
+  it("returns upstream_error when edge authority request throws", async () => {
+    const fetchSpy = mockFetch();
+    fetchSpy.mockRejectedValueOnce(new TypeError("fetch failed"));
+
+    const { dashboardHandler } = await import("../api/dashboard");
+    const response = await dashboardHandler(createRequest("GET", "token"));
+
+    expect(response.status).toBe(502);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
+    await expect(response.json()).resolves.toMatchObject({
+      code: "upstream_error",
+      classification: expect.objectContaining({
+        retryable: true,
+        httpStatus: 502,
+      }),
+      message: "Failed to load dashboard data",
+      success: false,
+    });
+  });
+
+  it("rethrows non-transport failures instead of relabeling them as upstream errors", async () => {
+    const fetchSpy = mockFetch();
+    fetchSpy.mockRejectedValueOnce(new Error("unexpected parse failure"));
+
+    const { dashboardHandler } = await import("../api/dashboard");
+
+    await expect(dashboardHandler(createRequest("GET", "token"))).rejects.toThrow(
+      /unexpected parse failure/i,
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows non-network TypeErrors instead of relabeling them as upstream errors", async () => {
+    const fetchSpy = mockFetch();
+    fetchSpy.mockRejectedValueOnce(new TypeError("invalid url format"));
+
+    const { dashboardHandler } = await import("../api/dashboard");
+
+    await expect(dashboardHandler(createRequest("GET", "token"))).rejects.toThrow(
+      /invalid url format/i,
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 

--- a/src/server/api/dashboard.ts
+++ b/src/server/api/dashboard.ts
@@ -10,6 +10,20 @@ const JSON_HEADERS: Record<string, string> = {
   "Content-Type": "application/json",
 };
 
+const isProxyTransportFailure = (error: unknown): boolean => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.trim().toLowerCase();
+  return (
+    message.includes("fetch failed") ||
+    message.includes("network") ||
+    message.includes("load failed") ||
+    message.includes("aborted")
+  );
+};
+
 export async function dashboardHandler(request: Request): Promise<Response> {
   if (isDisallowedOriginRequest(request)) {
     return errorResponse(request, "forbidden", "Origin not allowed", { status: 403 });
@@ -53,21 +67,30 @@ export async function dashboardHandler(request: Request): Promise<Response> {
     });
   }
 
-  const forwarded = await proxyToEdgeAuthority(request, {
-    functionName: "get-dashboard-data",
-    accessToken,
-    method: "GET",
-  });
-  const body = await forwarded.text();
-  const retryAfter = forwarded.headers.get("Retry-After");
-  return new Response(body, {
-    status: forwarded.status,
-    headers: {
-      ...JSON_HEADERS,
-      ...corsHeadersForRequest(request),
-      ...(retryAfter ? { "Retry-After": retryAfter } : {}),
-    },
-  });
+  try {
+    const forwarded = await proxyToEdgeAuthority(request, {
+      functionName: "get-dashboard-data",
+      accessToken,
+      method: "GET",
+    });
+    const body = await forwarded.text();
+    const retryAfter = forwarded.headers.get("Retry-After");
+    return new Response(body, {
+      status: forwarded.status,
+      headers: {
+        ...JSON_HEADERS,
+        ...corsHeadersForRequest(request),
+        ...(retryAfter ? { "Retry-After": retryAfter } : {}),
+      },
+    });
+  } catch (error) {
+    if (isProxyTransportFailure(error)) {
+      return errorResponse(request, "upstream_error", "Failed to load dashboard data", {
+        status: 502,
+      });
+    }
+    throw error;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- guard `/api/dashboard` against thrown transport/proxy failures so the handler returns the standard JSON envelope instead of escaping the API boundary
- keep non-transport failures bubbling so local config/logic faults are not mislabeled as upstream `502` errors
- add focused dashboard handler regression coverage and the required `WIN-113` handoff artifact

## Verification
- `npm test -- --run src/server/__tests__/dashboardHandler.test.ts src/server/__tests__/dashboardParity.contract.test.ts src/lib/__tests__/optimizedQueries.dashboard.test.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Known blockers
- `npm run test:ci` failed outside this slice in `src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx` and `tests/runtime-migration-parity.test.ts`
- `npm run test:routes:tier0` failed locally due a Cypress cachedDataRejected runtime issue
- `npm run verify:local` timed out after surfacing the same existing browser/test instability
- `npm run ci:playwright` not run locally

Linear: WIN-113
