### PR TITLE
fix(schedule): booking 400 from naive RPC timestamps on drag reschedule

### DIFF
--- a/src/features/scheduling/domain/__tests__/booking.test.ts
+++ b/src/features/scheduling/domain/__tests__/booking.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { bookSessionApiRequestBodySchema } from "../../../../server/types";
 import {
   buildBookSessionApiPayload,
   buildBookingTimeMetadata,
@@ -56,6 +57,34 @@ describe("booking domain payload builder", () => {
         end_time: "still-not-a-date",
       }),
     ).toThrow("Invalid session time provided");
+  });
+
+  it("strips naive-offset session audit timestamps so payloads match /api/book Zod rules", () => {
+    const payload = buildBookSessionApiPayload(
+      {
+        id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        therapist_id: "11111111-1111-1111-1111-111111111111",
+        client_id: "22222222-2222-2222-2222-222222222222",
+        program_id: "33333333-3333-3333-3333-333333333333",
+        goal_id: "44444444-4444-4444-4444-444444444444",
+        start_time: "2026-04-28T19:00:00.000Z",
+        end_time: "2026-04-28T20:00:00.000Z",
+        created_at: "2026-04-01T10:00:00",
+        updated_at: "2026-04-01T11:00:00",
+      } as never,
+      {
+        startOffsetMinutes: 420,
+        endOffsetMinutes: 420,
+        timeZone: "America/Los_Angeles",
+      },
+    );
+
+    const parsed = bookSessionApiRequestBodySchema.safeParse(payload);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.session.created_at).toBeUndefined();
+      expect(parsed.data.session.updated_at).toBeUndefined();
+    }
   });
 });
 

--- a/src/features/scheduling/domain/booking.ts
+++ b/src/features/scheduling/domain/booking.ts
@@ -13,6 +13,7 @@ import { callApiRoute } from "../../../lib/sdk/client";
 import { parseJsonResponse } from "../../../lib/sdk/contracts";
 import { toNormalizedApiError, type NormalizedApiError } from "../../../lib/sdk/errors";
 import { bookSessionEnvelopeSchema } from "../../../lib/contracts/scheduling";
+import { normalizeSessionPayloadSubtree } from "../../../lib/scheduling/bookingRequestBodyNormalize";
 
 const DEFAULT_SESSION_HOLD_SECONDS = 5 * 60;
 
@@ -56,10 +57,10 @@ export function buildBookSessionApiPayload(
   recurrence?: BookSessionApiRequestBody["recurrence"],
   holdSeconds = DEFAULT_SESSION_HOLD_SECONDS,
 ): BookSessionApiRequestBody {
-  const normalizedSession = {
+  const normalizedSession = normalizeSessionPayloadSubtree({
     ...session,
     status: session.status ?? "scheduled",
-  } as BookSessionApiRequestBody["session"];
+  }) as BookSessionApiRequestBody["session"];
 
   return {
     session: normalizedSession,

--- a/src/lib/scheduling/__tests__/bookingRequestBodyNormalize.test.ts
+++ b/src/lib/scheduling/__tests__/bookingRequestBodyNormalize.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { bookSessionApiRequestBodySchema } from "../../../server/types";
+import { normalizeBookRequestBodyForZod, normalizeSessionPayloadSubtree } from "../bookingRequestBodyNormalize";
+
+describe("bookingRequestBodyNormalize", () => {
+  it("removes session created_at/updated_at when they lack a timezone offset", () => {
+    const raw = {
+      session: {
+        therapist_id: "t1",
+        client_id: "c1",
+        program_id: "p1",
+        goal_id: "g1",
+        start_time: "2025-01-01T10:00:00Z",
+        end_time: "2025-01-01T11:00:00Z",
+        created_at: "2025-01-01T09:00:00",
+        updated_at: "2025-01-01T09:30:00",
+      },
+      startTimeOffsetMinutes: 0,
+      endTimeOffsetMinutes: 0,
+      timeZone: "UTC",
+    };
+
+    const normalized = normalizeBookRequestBodyForZod(raw) as typeof raw;
+    expect(normalized.session.created_at).toBeUndefined();
+    expect(normalized.session.updated_at).toBeUndefined();
+    expect(bookSessionApiRequestBodySchema.safeParse(normalized).success).toBe(true);
+  });
+
+  it("filters recurrence exceptions that lack offset datetimes", () => {
+    const session = normalizeSessionPayloadSubtree({
+      therapist_id: "t1",
+      client_id: "c1",
+      program_id: "p1",
+      goal_id: "g1",
+      start_time: "2025-01-01T10:00:00Z",
+      end_time: "2025-01-01T11:00:00Z",
+      recurrence: {
+        rule: "FREQ=WEEKLY;INTERVAL=1",
+        exceptions: ["2025-01-08T10:00:00Z", "2025-01-15T10:00:00"],
+      },
+    }) as Record<string, unknown>;
+
+    const rec = session.recurrence as { exceptions?: string[] };
+    expect(rec.exceptions).toEqual(["2025-01-08T10:00:00Z"]);
+  });
+});

--- a/src/lib/scheduling/bookingRequestBodyNormalize.ts
+++ b/src/lib/scheduling/bookingRequestBodyNormalize.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+/** Matches `sessionSchema` / `recurrenceSchema` datetime rules in `src/server/types.ts`. */
+const isoDateTimeWithOffset = z.string().datetime({ offset: true });
+
+function isValidOffsetDateTime(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 && isoDateTimeWithOffset.safeParse(trimmed).success;
+}
+
+function normalizeRecurrenceRecord(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  const rec = { ...(value as Record<string, unknown>) };
+
+  if ("until" in rec) {
+    const until = rec.until;
+    if (until !== undefined && until !== null && !isValidOffsetDateTime(until)) {
+      delete rec.until;
+    }
+  }
+
+  if (Array.isArray(rec.exceptions)) {
+    const filtered = rec.exceptions.filter((entry) => isValidOffsetDateTime(entry));
+    if (filtered.length > 0) {
+      rec.exceptions = filtered;
+    } else {
+      delete rec.exceptions;
+    }
+  }
+
+  return rec;
+}
+
+export function normalizeSessionPayloadSubtree(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  const session = { ...(value as Record<string, unknown>) };
+
+  for (const key of ["created_at", "updated_at"] as const) {
+    if (key in session) {
+      const v = session[key];
+      if (v !== undefined && v !== null && !isValidOffsetDateTime(v)) {
+        delete session[key];
+      }
+    }
+  }
+
+  if (session.recurrence !== undefined && session.recurrence !== null) {
+    session.recurrence = normalizeRecurrenceRecord(session.recurrence);
+  }
+
+  return session;
+}
+
+/**
+ * Strips or relaxes booking JSON fields that commonly fail Zod `datetime({ offset: true })`
+ * when upstream RPCs return Postgres timestamps without explicit offsets.
+ */
+export function normalizeBookRequestBodyForZod(rawBody: unknown): unknown {
+  if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+    return rawBody;
+  }
+
+  const body = { ...(rawBody as Record<string, unknown>) };
+
+  if ("session" in body) {
+    body.session = normalizeSessionPayloadSubtree(body.session);
+  }
+
+  if ("recurrence" in body && body.recurrence !== undefined && body.recurrence !== null) {
+    body.recurrence = normalizeRecurrenceRecord(body.recurrence);
+  }
+
+  return body;
+}

--- a/src/server/__tests__/bookHandler.test.ts
+++ b/src/server/__tests__/bookHandler.test.ts
@@ -225,6 +225,56 @@ describe("bookHandler", () => {
     expect(bookSessionMock).not.toHaveBeenCalled();
   });
 
+  it("accepts session payloads when audit timestamps omit timezone offsets (RPC-shaped rows)", async () => {
+    bookSessionMock.mockResolvedValueOnce({
+      session: {
+        id: "session-naive-audit",
+        client_id: "client-1",
+        therapist_id: "therapist-1",
+        start_time: "2025-01-01T10:00:00Z",
+        end_time: "2025-01-01T11:00:00Z",
+        status: "scheduled",
+        notes: "",
+        created_at: "2025-01-01T09:00:00Z",
+        created_by: "user-1",
+        updated_at: "2025-01-01T09:00:00Z",
+        updated_by: "user-1",
+        duration_minutes: 60,
+      },
+      sessions: [],
+      hold: {
+        holdKey: "hold",
+        holdId: "1",
+        startTime: "2025-01-01T10:00:00Z",
+        endTime: "2025-01-01T11:00:00Z",
+        expiresAt: "2025-01-01T10:05:00Z",
+        holds: [],
+      },
+      cpt: {
+        code: "97153",
+        description: "Adaptive behavior treatment by protocol",
+        modifiers: [],
+        source: "fallback",
+        durationMinutes: 60,
+      },
+    });
+
+    const bookHandler = await importBookHandler();
+    const response = await bookHandler(
+      createRequest({
+        ...validPayload,
+        session: {
+          ...validPayload.session,
+          created_at: "2025-01-01T09:00:00",
+          updated_at: "2025-01-01T09:30:00",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(bookSessionMock).toHaveBeenCalledTimes(1);
+  });
+
   it("returns 400 when booking entity relationships are invalid", async () => {
     server.use(
       http.get(`${TEST_SUPABASE_URL}/rest/v1/programs`, () =>

--- a/src/server/api/book.ts
+++ b/src/server/api/book.ts
@@ -21,6 +21,7 @@ import {
 } from "../types";
 import { logger } from "../../lib/logger/logger";
 import { toError } from "../../lib/logger/normalizeError";
+import { normalizeBookRequestBodyForZod } from "../../lib/scheduling/bookingRequestBodyNormalize";
 
 const JSON_CONTENT_TYPE_HEADER: Record<string, string> = {
   "Content-Type": "application/json",
@@ -249,7 +250,7 @@ export async function bookHandler(request: Request): Promise<Response> {
     return errorResponse(request, "validation_error", "Invalid JSON body");
   }
 
-  const parseResult = bookSessionApiRequestBodySchema.safeParse(rawBody);
+  const parseResult = bookSessionApiRequestBodySchema.safeParse(normalizeBookRequestBodyForZod(rawBody));
 
   if (!parseResult.success) {
     logger.warn("Rejected invalid booking payload", {


### PR DESCRIPTION
## Summary

Drag-and-drop reschedule on `/schedule` POSTs the full session row from `get_schedule_data_batch` to `/api/book`. Zod `bookSessionApiRequestBodySchema` requires `datetime({ offset: true })` on optional `created_at` / `updated_at` (and recurrence datetimes). RPC-shaped rows can omit timezone offsets on those audit fields, causing `safeParse` to fail with HTTP 400 before scope checks or `bookSession` run.

## Changes

- Add `normalizeBookRequestBodyForZod` / `normalizeSessionPayloadSubtree` to strip invalid optional datetimes and filter recurrence `until` / `exceptions`.
- Apply normalization in `bookHandler` before Zod (fixes all clients).
- Apply session subtree normalization in `buildBookSessionApiPayload` (schedule booking path).

## Verification

- `npm run verify:local` (pass)
- Targeted vitest: booking normalize, booking domain, bookHandler

## Risk

Low: only removes or filters fields that already fail validation; does not bypass auth, org scope, or entity relationship checks.
