### PR TITLE
fix(schedule): relax session capture billing gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@ VITE_SUPABASE_URL=****
 VITE_SUPABASE_ANON_KEY=****
 VITE_SUPABASE_EDGE_URL=****
 
+# Session capture / billing: unset or any value except the literal `false` keeps the billing gate relaxed
+# (authorizations need not be approved; see docs/session-capture-billing-gate.md). Set to false on client
+# and set SESSION_CAPTURE_RELAX_BILLING_GATE=false on the server to enforce strict billing again.
+# VITE_SESSION_CAPTURE_RELAX_BILLING_GATE=false
+# SESSION_CAPTURE_RELAX_BILLING_GATE=false
+
 # ---------------------------------------------------------------------------
 # Server-only Supabase secrets
 # These must remain on the server: do not embed them in front-end bundles or

--- a/docs/session-capture-billing-gate.md
+++ b/docs/session-capture-billing-gate.md
@@ -1,0 +1,33 @@
+# Session capture and the billing / authorization gate
+
+## What was wrong
+
+Saving **Save progress** / session capture from Schedule calls `POST /api/session-notes/upsert`, which requires an **approved** authorization, a **service code** on that authorization, and the session date to fall in the authorization window. The modal also blocked submit when no approved authorization + service could be resolved.
+
+If a client had no approved authorization (or services were not linked yet), therapists saw: *No approved authorization or service is available for this client* and capture did not persist.
+
+## Current behavior (relaxed by default)
+
+The billing gate is **relaxed unless explicitly turned off**:
+
+- **Client:** `VITE_SESSION_CAPTURE_RELAX_BILLING_GATE` — if unset or any value other than the string `false`, capture may use authorizations in **any** status (pending, etc.), preferring `approved` when present.
+- **Server:** `SESSION_CAPTURE_RELAX_BILLING_GATE` — same rule. When relaxed, the upsert handler skips “must be approved”, session-date window vs authorization, and “service code must be listed on the authorization” checks. If the request omits a service code but the gate is relaxed, the server may use the first service on the authorization or the placeholder `UNSPECIFIED`.
+
+There must still be **at least one authorization row** for the client so `authorization_id` remains a valid FK.
+
+## Re-enabling strict billing
+
+Set **both** to the literal string `false`:
+
+- `VITE_SESSION_CAPTURE_RELAX_BILLING_GATE=false` (rebuild the app)
+- `SESSION_CAPTURE_RELAX_BILLING_GATE=false` (API / Netlify / server env)
+
+If they disagree (e.g. client relaxed, server strict), the client may allow submit while the API returns validation errors—keep them aligned.
+
+## Files
+
+- Client gate + helpers: `src/lib/sessionCaptureBillingGate.ts`
+- Server gate: `src/server/sessionCaptureBillingGate.ts`
+- Modal: `src/components/SessionModal.tsx`
+- Schedule submit: `src/pages/Schedule.tsx`
+- API: `src/server/api/session-notes-upsert.ts`

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -56,6 +56,12 @@ import {
   showGoalOnBxCaptureTab,
   showGoalOnSkillCaptureTab,
 } from '../lib/session-adhoc-targets';
+import {
+  firstServiceCodeOnAuthorization,
+  isSessionCaptureBillingGateRelaxed,
+  pickPrimaryBillingAuthorization,
+  SESSION_CAPTURE_RELAXED_FALLBACK_SERVICE_CODE,
+} from '../lib/sessionCaptureBillingGate';
 
 const ENABLE_ALTERNATIVE_TIME_SUGGESTIONS = false;
 
@@ -314,25 +320,38 @@ export function SessionModal({
     enabled: Boolean(clientId && activeOrganizationId),
   });
 
-  const { data: approvedAuthorizations = [] } = useQuery({
-    queryKey: ['session-note-authorizations', clientId, activeOrganizationId ?? 'MISSING_ORG'],
+  const captureBillingRelaxed = isSessionCaptureBillingGateRelaxed();
+
+  const { data: billingAuthorizations = [] } = useQuery({
+    queryKey: [
+      'session-note-billing-authorizations',
+      clientId,
+      activeOrganizationId ?? 'MISSING_ORG',
+      captureBillingRelaxed ? 'relaxed' : 'strict',
+    ],
     queryFn: async () => {
       if (!clientId || !activeOrganizationId) {
         return [];
       }
-      const { data, error } = await supabase
+      let query = supabase
         .from('authorizations')
-        .select('id, authorization_number, services:authorization_services(service_code)')
+        .select(
+          'id, status, authorization_number, services:authorization_services(service_code)',
+        )
         .eq('client_id', clientId)
         .eq('organization_id', activeOrganizationId)
-        .eq('status', 'approved')
         .order('start_date', { ascending: false });
+      if (!captureBillingRelaxed) {
+        query = query.eq('status', 'approved');
+      }
+      const { data, error } = await query;
       if (error) {
         throw error;
       }
       return (
         data as Array<{
           id: string;
+          status: string;
           authorization_number: string;
           services?: Array<{ service_code: string | null }> | null;
         }>
@@ -340,6 +359,11 @@ export function SessionModal({
     },
     enabled: Boolean(clientId && activeOrganizationId),
   });
+
+  const primaryBillingAuthorization = useMemo(
+    () => pickPrimaryBillingAuthorization(billingAuthorizations),
+    [billingAuthorizations],
+  );
 
   const { data: linkedSessionNote } = useQuery({
     queryKey: ['session-note-linked', session?.id, activeOrganizationId ?? 'MISSING_ORG'],
@@ -942,15 +966,20 @@ export function SessionModal({
           })
           .filter((entry): entry is [string, SessionGoalMeasurementEntry] => Boolean(entry)),
       );
-      const firstApprovedAuth = approvedAuthorizations[0];
-      const firstDefaultServiceCode =
-        (firstApprovedAuth?.services ?? [])
-          .map((s) => s.service_code?.trim())
-          .find((c): c is string => Boolean(c)) ?? '';
+      const firstDefaultServiceCode = firstServiceCodeOnAuthorization(primaryBillingAuthorization);
       const resolvedAuthorizationId =
-        working.session_note_authorization_id?.trim() || firstApprovedAuth?.id || '';
-      const resolvedServiceCode =
+        working.session_note_authorization_id?.trim() ||
+        primaryBillingAuthorization?.id ||
+        '';
+      let resolvedServiceCode =
         working.session_note_service_code?.trim() || firstDefaultServiceCode;
+      if (
+        captureBillingRelaxed &&
+        resolvedAuthorizationId &&
+        !resolvedServiceCode
+      ) {
+        resolvedServiceCode = SESSION_CAPTURE_RELAXED_FALLBACK_SERVICE_CODE;
+      }
       const mergeGoalIds = options?.captureMergeGoalIds?.filter((id) => id.trim().length > 0) ?? [];
       const isPartialCaptureSave = mergeGoalIds.length > 0;
       const hasCaptureInputFromSubmit = isPartialCaptureSave
@@ -980,9 +1009,16 @@ export function SessionModal({
           showError('Session capture can only be saved for existing sessions.');
           return;
         }
-        if (!resolvedAuthorizationId || !resolvedServiceCode) {
+        if (!captureBillingRelaxed) {
+          if (!resolvedAuthorizationId || !resolvedServiceCode) {
+            showError(
+              'No approved authorization or service is available for this client. Ask an admin to configure billing defaults.',
+            );
+            return;
+          }
+        } else if (!resolvedAuthorizationId) {
           showError(
-            'No approved authorization or service is available for this client. Ask an admin to configure billing defaults.',
+            'No authorization on file for this client. Add an authorization (any status) before saving session capture, or ask an admin.',
           );
           return;
         }
@@ -2248,8 +2284,9 @@ export function SessionModal({
                         Billing, authorization, and full narratives
                       </summary>
                       <p className="mt-2 leading-snug">
-                        Billing uses the first approved authorization on file when defaults exist. Full narrative,
-                        signatures, and additional measurement fields are completed in Client Details.
+                        {captureBillingRelaxed
+                          ? 'Billing defaults prefer an approved authorization when one exists; otherwise the most recent authorization for this client may be used so capture can save. See docs/session-capture-billing-gate.md to re-enable strict checks.'
+                          : 'Billing uses the first approved authorization on file when defaults exist. Full narrative, signatures, and additional measurement fields are completed in Client Details.'}
                       </p>
                     </details>
                   </div>

--- a/src/lib/sessionCaptureBillingGate.ts
+++ b/src/lib/sessionCaptureBillingGate.ts
@@ -1,0 +1,35 @@
+/**
+ * Live session capture (per-goal notes / trials) is normally tied to an approved authorization and
+ * a service code for billing. When this gate is relaxed, any authorization status may be used and
+ * the server skips strict billing alignment checks so capture can persist while billing is still
+ * being configured.
+ *
+ * Default is relaxed (`!== 'false'`) so capture saves without blocking; set to the literal `false`
+ * string on both client and server before enforcing billing again.
+ *
+ * @see docs/session-capture-billing-gate.md
+ */
+export const isSessionCaptureBillingGateRelaxed = (): boolean =>
+  import.meta.env.VITE_SESSION_CAPTURE_RELAX_BILLING_GATE !== 'false';
+
+export function pickPrimaryBillingAuthorization<
+  T extends { id: string; status: string; services?: Array<{ service_code: string | null }> | null },
+>(rows: readonly T[]): T | undefined {
+  if (rows.length === 0) {
+    return undefined;
+  }
+  const approved = rows.find((row) => row.status === 'approved');
+  return approved ?? rows[0];
+}
+
+export function firstServiceCodeOnAuthorization<
+  T extends { services?: Array<{ service_code: string | null }> | null },
+>(auth: T | undefined): string {
+  const codes = (auth?.services ?? [])
+    .map((service) => service.service_code?.trim())
+    .filter((code): code is string => Boolean(code));
+  return codes[0] ?? '';
+}
+
+/** Placeholder service code when relaxed mode has an authorization but no linked services row. */
+export const SESSION_CAPTURE_RELAXED_FALLBACK_SERVICE_CODE = 'UNSPECIFIED' as const;

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -43,6 +43,7 @@ import { supabase } from "../lib/supabase";
 import { fetchLinkedClientIdsForTherapist } from "../lib/clients/therapistClientScope";
 import { hasMeaningfulGoalMeasurementEntry, normalizeGoalMeasurementEntry } from "../lib/goal-measurements";
 import { upsertClientSessionNoteForSession } from "../lib/session-notes";
+import { isSessionCaptureBillingGateRelaxed } from "../lib/sessionCaptureBillingGate";
 import {
   createSessionSlotKey,
   buildSessionSlotIndex,
@@ -1415,9 +1416,15 @@ export const Schedule = React.memo(() => {
             if (!user?.id) {
               throw new Error("Sign in again before saving session capture.");
             }
-            if (!clinicalNoteDraft.authorizationId || !clinicalNoteDraft.serviceCode) {
+            if (!isSessionCaptureBillingGateRelaxed()) {
+              if (!clinicalNoteDraft.authorizationId || !clinicalNoteDraft.serviceCode) {
+                throw new Error(
+                  "Authorization and service code are required to save session capture from Schedule (configure billing defaults for the client).",
+                );
+              }
+            } else if (!clinicalNoteDraft.authorizationId) {
               throw new Error(
-                "Authorization and service code are required to save session capture from Schedule (configure billing defaults for the client).",
+                "An authorization id is required to save session capture (add any authorization for this client).",
               );
             }
             await upsertClientSessionNoteForSession({

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -89,6 +89,7 @@ const buildSessionNoteRow = (id: string) => ({
 describe("sessionNotesUpsertHandler", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    process.env.SESSION_CAPTURE_RELAX_BILLING_GATE = "false";
     vi.mocked(getAccessToken).mockReturnValue(ACCESS_TOKEN);
     vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
       organizationId: "org-1",
@@ -460,6 +461,62 @@ describe("sessionNotesUpsertHandler", () => {
 
     expect(response.status).toBe(400);
     expect(payload.error).toMatch(/service code/i);
+  });
+
+  it("when billing gate relaxed, skips date/service strict checks and uses first listed service code", async () => {
+    delete process.env.SESSION_CAPTURE_RELAX_BILLING_GATE;
+    const fetchJsonMock = vi.mocked(fetchJson);
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "pending",
+            start_date: "2026-01-01",
+            end_date: "2026-01-31",
+            services: [{ service_code: "97151", approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        const parsedBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+        expect(parsedBody.service_code).toBe("97151");
+        return { ok: true, status: 201, data: [{ id: "note-relaxed" }] };
+      }
+      if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes("id=eq.note-relaxed")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            ...buildSessionNoteRow("note-relaxed"),
+            service_code: "97151",
+          }],
+        };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          sessionDate: "2026-03-10",
+          serviceCode: "97153",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
   });
 
   it("rejects when client does not match authorization", async () => {

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -13,6 +13,7 @@ import {
   jsonForRequest,
   resolveOrgAndRoleWithStatus,
 } from "./shared";
+import { isSessionCaptureBillingGateRelaxed } from "../sessionCaptureBillingGate";
 
 type SessionNoteRow = {
   id: string;
@@ -534,21 +535,38 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
   if (authorization.client_id !== payload.clientId) {
     return errorResponse(request, "validation_error", "Client does not match the selected authorization.");
   }
-  if (authorization.status !== "approved") {
-    return errorResponse(request, "validation_error", "Authorization must be approved before saving session notes.");
+
+  const captureBillingRelaxed = isSessionCaptureBillingGateRelaxed();
+
+  if (!captureBillingRelaxed) {
+    if (authorization.status !== "approved") {
+      return errorResponse(request, "validation_error", "Authorization must be approved before saving session notes.");
+    }
+
+    const sessionDateStrict = toDate(payload.sessionDate);
+    if (
+      sessionDateStrict < toDate(authorization.start_date) ||
+      sessionDateStrict > toDate(authorization.end_date)
+    ) {
+      return errorResponse(request, "validation_error", "Session date must be within the authorization date range.");
+    }
+
+    const hasAuthorizedServiceStrict = (authorization.services ?? []).some(
+      (service) => service.service_code === payload.serviceCode,
+    );
+    if (!hasAuthorizedServiceStrict) {
+      return errorResponse(request, "validation_error", "Selected service code is not part of this authorization.");
+    }
   }
 
-  const sessionDate = toDate(payload.sessionDate);
-  if (sessionDate < toDate(authorization.start_date) || sessionDate > toDate(authorization.end_date)) {
-    return errorResponse(request, "validation_error", "Session date must be within the authorization date range.");
-  }
-
-  const hasAuthorizedService = (authorization.services ?? []).some(
-    (service) => service.service_code === payload.serviceCode,
-  );
-  if (!hasAuthorizedService) {
-    return errorResponse(request, "validation_error", "Selected service code is not part of this authorization.");
-  }
+  const services = authorization.services ?? [];
+  const hasAuthorizedService = services.some((service) => service.service_code === payload.serviceCode);
+  const firstListedServiceCode =
+    services.map((service) => service.service_code?.trim()).find((code): code is string => Boolean(code)) ?? "";
+  const effectiveServiceCode =
+    captureBillingRelaxed && !hasAuthorizedService
+      ? firstListedServiceCode || "UNSPECIFIED"
+      : payload.serviceCode;
 
   const existingNote = await fetchExistingNote(supabaseUrl, headers, organizationId, {
     noteId: payload.noteId,
@@ -601,7 +619,7 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
     client_id: payload.clientId,
     therapist_id: payload.therapistId,
     organization_id: organizationId,
-    service_code: payload.serviceCode,
+    service_code: effectiveServiceCode,
     session_date: payload.sessionDate,
     start_time: payload.startTime,
     end_time: payload.endTime,

--- a/src/server/sessionCaptureBillingGate.ts
+++ b/src/server/sessionCaptureBillingGate.ts
@@ -1,0 +1,8 @@
+/**
+ * Mirrors client `sessionCaptureBillingGate` for `/api/session-notes/upsert`.
+ * Set `SESSION_CAPTURE_RELAX_BILLING_GATE=false` on the server to restore strict billing checks.
+ *
+ * @see docs/session-capture-billing-gate.md
+ */
+export const isSessionCaptureBillingGateRelaxed = (): boolean =>
+  process.env.SESSION_CAPTURE_RELAX_BILLING_GATE !== 'false';


### PR DESCRIPTION
## Summary
Live session **Save progress** was blocked by the toast: no approved authorization/service. Session capture is now tied to a **relaxed** billing gate by default so capture can persist using the best available authorization (preferring approved) and relaxed server validation.

## Changes
- Client: \SessionModal\ loads authorizations without the approved-only filter when relaxed; resolves service code with \UNSPECIFIED\ fallback when needed.
- \Schedule\ no longer throws when service/approval metadata is missing under the same gate.
- API \session-notes-upsert\: when relaxed, skips approved status, session-date window, and strict service-code membership; writes first listed service or \UNSPECIFIED\.
- Docs: \docs/session-capture-billing-gate.md\; \.env.example\ comments.

## Re-enable strict billing
Set \VITE_SESSION_CAPTURE_RELAX_BILLING_GATE=false\ and \SESSION_CAPTURE_RELAX_BILLING_GATE=false\ (see doc).

## Verification
- \
pm run typecheck\, \
pm run lint\
- \
pm test -- --run src/components/__tests__/SessionModal.test.tsx\
- \
pm test -- --run src/pages/__tests__/Schedule.orchestration.integration.test.tsx\
- \
pm test -- --run src/server/__tests__/sessionNotesUpsertHandler.test.ts\

## Risk
Touches \src/server/api\ (human review per AGENTS). Clients with **no** authorization row still cannot save (FK/RLS unchanged).

Made with [Cursor](https://cursor.com)