### PR TITLE
fix(schedule): touch move for mobile / coarse pointers

### DIFF
--- a/src/pages/ScheduleCalendarViewShared.tsx
+++ b/src/pages/ScheduleCalendarViewShared.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
 import { format, parseISO } from 'date-fns';
 import { Clock, Edit2, Plus } from 'lucide-react';
 import type { Session } from '../types';
@@ -10,6 +10,25 @@ export type ScheduleTimeSlotHandler = (timeSlot: { date: Date; time: string }) =
 export type ScheduleEditSessionHandler = (session: Session) => void;
 export type ScheduleSlotPosition = { date: Date; time: string };
 export type ScheduleDropPayload = { target: ScheduleSlotPosition; draggedSessionId?: string | null };
+
+/** True when the primary input is touch (phones, most tablets). HTML5 drag/drop is unreliable here. */
+function useCoarsePointer(): boolean {
+  const getSnapshot = () =>
+    typeof window !== 'undefined' ? window.matchMedia('(pointer: coarse)').matches : false;
+
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      if (typeof window === 'undefined') {
+        return () => {};
+      }
+      const mq = window.matchMedia('(pointer: coarse)');
+      mq.addEventListener('change', onStoreChange);
+      return () => mq.removeEventListener('change', onStoreChange);
+    },
+    getSnapshot,
+    getSnapshot,
+  );
+}
 
 export const TimeSlot = React.memo(
   ({
@@ -41,6 +60,11 @@ export const TimeSlot = React.memo(
     onHoverSlotDuringDrag?: (targetSlotKey: string | null) => void;
     onEndSessionDrag?: () => void;
   }) => {
+    const coarsePointer = useCoarsePointer();
+    const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const longPressOriginRef = useRef<{ x: number; y: number } | null>(null);
+    const suppressSessionClickRef = useRef(false);
+
     const dayKey = useMemo(() => format(day, 'yyyy-MM-dd'), [day]);
     const slotKey = useMemo(() => createSessionSlotKey(dayKey, time), [dayKey, time]);
     const handleTimeSlotClick = useCallback(() => {
@@ -54,7 +78,35 @@ export const TimeSlot = React.memo(
       },
       [onEditSession],
     );
+
+    const clearLongPressTimer = useCallback(() => {
+      if (longPressTimerRef.current !== null) {
+        clearTimeout(longPressTimerRef.current);
+        longPressTimerRef.current = null;
+      }
+      longPressOriginRef.current = null;
+    }, []);
+
     const enableSlotCreateChrome = allowCreateInEmptySlot;
+
+    const handleSlotClick = useCallback(() => {
+      if (coarsePointer && allowDragAndDrop && activeDragSessionId !== null) {
+        onSessionDrop?.({ target: { date: day, time }, draggedSessionId: activeDragSessionId });
+        return;
+      }
+      if (enableSlotCreateChrome) {
+        handleTimeSlotClick();
+      }
+    }, [
+      coarsePointer,
+      allowDragAndDrop,
+      activeDragSessionId,
+      onSessionDrop,
+      day,
+      time,
+      enableSlotCreateChrome,
+      handleTimeSlotClick,
+    ]);
     const handleSlotKeyDown = useCallback(
       (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (event.key !== 'Enter' && event.key !== ' ') {
@@ -129,7 +181,9 @@ export const TimeSlot = React.memo(
         }
         {...(enableSlotCreateChrome || allowDragAndDrop
           ? {
-              ...(enableSlotCreateChrome ? { onClick: handleTimeSlotClick } : {}),
+              ...(enableSlotCreateChrome || (coarsePointer && allowDragAndDrop)
+                ? { onClick: handleSlotClick }
+                : {}),
               onKeyDown: handleSlotKeyDown,
             }
           : {})}
@@ -145,15 +199,62 @@ export const TimeSlot = React.memo(
 
         {slotSessions.map((session) => {
           const statusStyles = getSessionStatusClasses(session.status);
+          const touchMovePickup =
+            coarsePointer && allowDragAndDrop && session.status === "scheduled";
+
+          const onSessionPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+            if (!touchMovePickup) {
+              return;
+            }
+            if (event.pointerType === "mouse" && typeof event.button === "number" && event.button !== 0) {
+              return;
+            }
+            clearLongPressTimer();
+            longPressOriginRef.current = { x: event.clientX, y: event.clientY };
+            longPressTimerRef.current = setTimeout(() => {
+              longPressTimerRef.current = null;
+              longPressOriginRef.current = null;
+              suppressSessionClickRef.current = true;
+              onStartSessionDrag?.(session, { date: day, time });
+              if (typeof navigator !== "undefined" && typeof navigator.vibrate === "function") {
+                try {
+                  navigator.vibrate(12);
+                } catch {
+                  /* ignore */
+                }
+              }
+            }, 480);
+          };
+
+          const onSessionPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+            if (longPressTimerRef.current === null || !longPressOriginRef.current) {
+              return;
+            }
+            const dx = event.clientX - longPressOriginRef.current.x;
+            const dy = event.clientY - longPressOriginRef.current.y;
+            if (dx * dx + dy * dy > 100) {
+              clearLongPressTimer();
+            }
+          };
+
+          const endLongPressTracking = () => {
+            clearLongPressTimer();
+          };
+
           return (
             <div
               key={session.id}
               data-session-status={session.status}
               data-session-id={session.id}
-              draggable={allowDragAndDrop && session.status === "scheduled"}
+              draggable={allowDragAndDrop && session.status === "scheduled" && !coarsePointer}
               aria-grabbed={allowDragAndDrop && activeDragSessionId === session.id}
+              title={
+                touchMovePickup
+                  ? "Press and hold to move, then tap a time slot. Tap again to cancel."
+                  : undefined
+              }
               onDragStart={
-                allowDragAndDrop && session.status === "scheduled"
+                allowDragAndDrop && session.status === "scheduled" && !coarsePointer
                   ? (event) => {
                       event.stopPropagation();
                       event.dataTransfer.effectAllowed = "move";
@@ -163,18 +264,35 @@ export const TimeSlot = React.memo(
                   : undefined
               }
               onDragEnd={
-                allowDragAndDrop
+                allowDragAndDrop && !coarsePointer
                   ? () => {
                       onEndSessionDrag?.();
                     }
                   : undefined
               }
-              className={`${statusStyles.card} rounded p-1 text-xs mb-1 group/session relative transition-colors ${
-                allowDragAndDrop && session.status === "scheduled" ? "cursor-grab active:cursor-grabbing" : "cursor-pointer"
-              } ${activeDragSessionId === session.id ? "opacity-50" : ""}`}
+              className={`${statusStyles.card} touch-manipulation rounded p-1 text-xs mb-1 group/session relative transition-colors ${
+                allowDragAndDrop && session.status === "scheduled"
+                  ? coarsePointer
+                    ? "cursor-pointer"
+                    : "cursor-grab active:cursor-grabbing"
+                  : "cursor-pointer"
+              } ${activeDragSessionId === session.id ? "opacity-50 ring-2 ring-blue-400 ring-offset-1 dark:ring-offset-gray-900" : ""}`}
               role="button"
               tabIndex={0}
-              onClick={(event) => handleSessionClick(event, session)}
+              onPointerDown={touchMovePickup ? onSessionPointerDown : undefined}
+              onPointerMove={touchMovePickup ? onSessionPointerMove : undefined}
+              onPointerUp={touchMovePickup ? endLongPressTracking : undefined}
+              onPointerCancel={touchMovePickup ? endLongPressTracking : undefined}
+              onPointerLeave={touchMovePickup ? endLongPressTracking : undefined}
+              onClick={(event) => {
+                if (suppressSessionClickRef.current) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  suppressSessionClickRef.current = false;
+                  return;
+                }
+                handleSessionClick(event, session);
+              }}
               onKeyDown={(event) => {
                 if (event.key === 'Enter' || event.key === ' ') {
                   event.preventDefault();

--- a/src/pages/ScheduleDayView.tsx
+++ b/src/pages/ScheduleDayView.tsx
@@ -46,23 +46,27 @@ const ScheduleDayViewComponent: React.FC<ScheduleDayViewProps> = ({
     return next;
   }, [sessionSlotIndex]);
 
-  const handleStartSessionDrag = useCallback((session: Session, source: ScheduleSlotPosition) => {
-    if (!allowDragAndDrop) {
-      return;
-    }
-    const nextSourceSlotKey = createSessionSlotKey(format(source.date, 'yyyy-MM-dd'), source.time);
-    draggedSessionRef.current = session;
-    sourceSlotKeyRef.current = nextSourceSlotKey;
-    setDraggedSession(session);
-    setDropSlotKey(null);
-  }, [allowDragAndDrop]);
-
   const clearDragState = useCallback(() => {
     draggedSessionRef.current = null;
     sourceSlotKeyRef.current = null;
     setDraggedSession(null);
     setDropSlotKey(null);
   }, []);
+
+  const handleStartSessionDrag = useCallback((session: Session, source: ScheduleSlotPosition) => {
+    if (!allowDragAndDrop) {
+      return;
+    }
+    const nextSourceSlotKey = createSessionSlotKey(format(source.date, 'yyyy-MM-dd'), source.time);
+    if (draggedSessionRef.current?.id === session.id) {
+      clearDragState();
+      return;
+    }
+    draggedSessionRef.current = session;
+    sourceSlotKeyRef.current = nextSourceSlotKey;
+    setDraggedSession(session);
+    setDropSlotKey(null);
+  }, [allowDragAndDrop, clearDragState]);
 
   const handleHoverSlotDuringDrag = useCallback((targetSlotKey: string | null) => {
     if (!allowDragAndDrop || !draggedSessionRef.current) {

--- a/src/pages/ScheduleWeekView.tsx
+++ b/src/pages/ScheduleWeekView.tsx
@@ -45,23 +45,27 @@ const ScheduleWeekViewComponent: React.FC<ScheduleWeekViewProps> = ({
     return next;
   }, [sessionSlotIndex]);
 
-  const handleStartSessionDrag = useCallback((session: Session, source: ScheduleSlotPosition) => {
-    if (!allowDragAndDrop) {
-      return;
-    }
-    const nextSourceSlotKey = createSessionSlotKey(format(source.date, 'yyyy-MM-dd'), source.time);
-    draggedSessionRef.current = session;
-    sourceSlotKeyRef.current = nextSourceSlotKey;
-    setDraggedSession(session);
-    setDropSlotKey(null);
-  }, [allowDragAndDrop]);
-
   const clearDragState = useCallback(() => {
     draggedSessionRef.current = null;
     sourceSlotKeyRef.current = null;
     setDraggedSession(null);
     setDropSlotKey(null);
   }, []);
+
+  const handleStartSessionDrag = useCallback((session: Session, source: ScheduleSlotPosition) => {
+    if (!allowDragAndDrop) {
+      return;
+    }
+    const nextSourceSlotKey = createSessionSlotKey(format(source.date, 'yyyy-MM-dd'), source.time);
+    if (draggedSessionRef.current?.id === session.id) {
+      clearDragState();
+      return;
+    }
+    draggedSessionRef.current = session;
+    sourceSlotKeyRef.current = nextSourceSlotKey;
+    setDraggedSession(session);
+    setDropSlotKey(null);
+  }, [allowDragAndDrop, clearDragState]);
 
   const handleHoverSlotDuringDrag = useCallback((targetSlotKey: string | null) => {
     if (!allowDragAndDrop || !draggedSessionRef.current) {

--- a/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import { fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render } from "@testing-library/react";
 import { format } from "date-fns";
 import type { Session } from "../../types";
 import { createSessionSlotKey } from "../schedule-utils";
@@ -76,5 +76,59 @@ describe("ScheduleDayView drag and drop", () => {
         date: expect.any(Date),
       }),
     );
+  });
+
+  describe("coarse pointer (touch) move path", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        configurable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: query === "(pointer: coarse)",
+          media: query,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    it("short tap still opens edit via onEditSession", () => {
+      const selectedDate = new Date("2025-07-07T00:00:00.000Z");
+      const sourceTime = "10:00";
+      const sessionStart = new Date(selectedDate);
+      sessionStart.setHours(10, 0, 0, 0);
+      const session = buildSession(sessionStart);
+      const onEditSession = vi.fn();
+      const sourceKey = createSessionSlotKey(format(sessionStart, "yyyy-MM-dd"), format(sessionStart, "HH:mm"));
+      const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+      const { container } = render(
+        <ScheduleDayView
+          selectedDate={selectedDate}
+          timeSlots={[sourceTime, "10:15"]}
+          sessionSlotIndex={sessionSlotIndex}
+          onCreateSession={vi.fn()}
+          onEditSession={onEditSession}
+          onRescheduleSession={vi.fn()}
+          allowDragAndDrop
+        />,
+      );
+
+      const card = container.querySelector('[data-session-id="session-1"]') as HTMLElement;
+      fireEvent.pointerDown(card, { button: 0, clientX: 10, clientY: 10, pointerId: 1 });
+      vi.advanceTimersByTime(100);
+      fireEvent.pointerUp(card, { button: 0, pointerId: 1 });
+      fireEvent.click(card);
+
+      expect(onEditSession).toHaveBeenCalledTimes(1);
+      expect(onEditSession).toHaveBeenCalledWith(expect.objectContaining({ id: "session-1" }));
+    });
   });
 });


### PR DESCRIPTION
## Summary

HTML5 drag-and-drop is unreliable on touch devices. This adds a **coarse-pointer** path: long-press a session to pick it up, then tap a target time slot to reschedule. Mouse drag-and-drop is unchanged.

## Changes

- `ScheduleCalendarViewShared.tsx`: `useCoarsePointer()`, long-press timer, slot tap drop, `touch-manipulation`, optional haptics, accessibility hints
- `ScheduleDayView` / `ScheduleWeekView`: clear drag state before pickup; second long-press on same session cancels move mode
- Tests: keep desktop DnD coverage; coarse-pointer short tap still opens edit (no flaky long-press timer assertion)

## Verification (local)

- `npm run lint`
- `npm run typecheck`
- `npx vitest run src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx`

## Risk

Low: UI interaction only; no API or auth changes.
