### PR TITLE
WIN-114 Guard dashboard upstream timeout

### DIFF
--- a/src/server/__tests__/dashboardHandler.test.ts
+++ b/src/server/__tests__/dashboardHandler.test.ts
@@ -1,15 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetRateLimitsForTests } from "../api/shared";
 
+const serverLoggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock("../../lib/logger/server", () => ({
+  serverLogger: serverLoggerMock,
+}));
+
 describe("dashboardHandler", () => {
   const ORIGINAL_ENV = { ...process.env } as NodeJS.ProcessEnv;
   const mockFetch = () => vi.spyOn(globalThis, "fetch");
 
   beforeEach(async () => {
     resetRateLimitsForTests();
+    vi.useRealTimers();
+    serverLoggerMock.info.mockReset();
+    serverLoggerMock.warn.mockReset();
+    serverLoggerMock.error.mockReset();
+    serverLoggerMock.debug.mockReset();
     process.env.SUPABASE_URL = "https://example.supabase.co";
     process.env.SUPABASE_ANON_KEY = "anon";
     process.env.API_AUTHORITY_MODE = "edge";
+    delete process.env.SUPABASE_EDGE_URL;
     vi.resetModules();
   });
 
@@ -128,6 +145,28 @@ describe("dashboardHandler", () => {
     expect(json).toMatchObject(body);
   });
 
+  it("propagates x-request-id to the edge authority and response", async () => {
+    const fetchSpy = mockFetch();
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: { ok: true } }), { status: 200 }));
+
+    const { dashboardHandler } = await import("../api/dashboard");
+    const response = await dashboardHandler(
+      new Request("http://localhost/api/dashboard", {
+        method: "GET",
+        headers: {
+          Authorization: "Bearer token",
+          Origin: "http://localhost:3000",
+          "x-request-id": "dash-req-1",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-request-id")).toBe("dash-req-1");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(init.headers).get("x-request-id")).toBe("dash-req-1");
+  });
+
   it("returns upstream_error when edge authority request throws", async () => {
     const fetchSpy = mockFetch();
     fetchSpy.mockRejectedValueOnce(new TypeError("fetch failed"));
@@ -146,6 +185,164 @@ describe("dashboardHandler", () => {
       }),
       message: "Failed to load dashboard data",
       success: false,
+    });
+  });
+
+  it("aborts slow edge authority requests before the platform timeout and returns a typed upstream error", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = mockFetch();
+    fetchSpy.mockImplementationOnce((_, init) => new Promise<Response>((_, reject) => {
+      const signal = (init as RequestInit)?.signal;
+      if (!(signal instanceof AbortSignal)) {
+        reject(new Error("missing abort signal"));
+        return;
+      }
+      signal.addEventListener("abort", () => reject(new DOMException("The operation was aborted", "AbortError")));
+    }));
+
+    const { dashboardHandler } = await import("../api/dashboard");
+    const promise = dashboardHandler(
+      new Request("http://localhost/api/dashboard", {
+        method: "GET",
+        headers: {
+          Authorization: "Bearer secret-dashboard-token",
+          Origin: "http://localhost:3000",
+          "x-request-id": "dash-timeout-req",
+        },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(8_000);
+    const response = await promise;
+    const text = await response.text();
+
+    expect(response.status).toBe(502);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
+    expect(response.headers.get("x-request-id")).toBe("dash-timeout-req");
+    expect(text).not.toContain("secret-dashboard-token");
+    expect(text).not.toContain("anon");
+    expect(JSON.parse(text)).toMatchObject({
+      requestId: "dash-timeout-req",
+      code: "upstream_error",
+      message: "Failed to load dashboard data",
+      success: false,
+      upstream: "get-dashboard-data",
+      timedOut: true,
+      classification: expect.objectContaining({
+        retryable: true,
+        httpStatus: 502,
+      }),
+    });
+    expect(serverLoggerMock.warn).toHaveBeenCalledWith(
+      "dashboard proxy upstream failed",
+      expect.not.objectContaining({
+        accessToken: expect.anything(),
+        apikey: expect.anything(),
+      }),
+    );
+    expect(JSON.stringify(serverLoggerMock.warn.mock.calls)).not.toContain("secret-dashboard-token");
+    expect(JSON.stringify(serverLoggerMock.warn.mock.calls)).not.toContain("anon");
+  });
+
+  it("aborts when edge authority headers arrive but the response body stalls", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = mockFetch();
+    const stalledResponse = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"success":'));
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+    fetchSpy.mockResolvedValueOnce(stalledResponse);
+
+    const { dashboardHandler } = await import("../api/dashboard");
+    const promise = dashboardHandler(createRequest("GET", "token"));
+    await vi.advanceTimersByTimeAsync(8_000);
+    const response = await promise;
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(body).toMatchObject({
+      code: "upstream_error",
+      success: false,
+      upstream: "get-dashboard-data",
+      timedOut: true,
+    });
+  });
+
+  it("generates a request ID and uses the same ID upstream and in the response", async () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("generated-dashboard-request-id");
+    const fetchSpy = mockFetch();
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: { ok: true } }), { status: 200 }));
+
+    const { dashboardHandler } = await import("../api/dashboard");
+    const response = await dashboardHandler(createRequest("GET", "token"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-request-id")).toBe("generated-dashboard-request-id");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(init.headers).get("x-request-id")).toBe("generated-dashboard-request-id");
+  });
+
+  it("logs only long correlation suffixes for caller-provided correlation identifiers", async () => {
+    const fetchSpy = mockFetch();
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: { ok: true } }), { status: 200 }));
+
+    const { dashboardHandler } = await import("../api/dashboard");
+    await dashboardHandler(
+      new Request("http://localhost/api/dashboard", {
+        method: "GET",
+        headers: {
+          Authorization: "Bearer token",
+          Origin: "http://localhost:3000",
+          "x-correlation-id": "sensitive-correlation-value",
+        },
+      }),
+    );
+
+    const logs = JSON.stringify(serverLoggerMock.info.mock.calls);
+    expect(logs).toContain("on-value");
+    expect(logs).not.toContain("sensitive-correlation-value");
+  });
+
+  it("does not log short caller-provided correlation identifiers verbatim", async () => {
+    const fetchSpy = mockFetch();
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: { ok: true } }), { status: 200 }));
+
+    const { dashboardHandler } = await import("../api/dashboard");
+    await dashboardHandler(
+      new Request("http://localhost/api/dashboard", {
+        method: "GET",
+        headers: {
+          Authorization: "Bearer token",
+          Origin: "http://localhost:3000",
+          "x-correlation-id": "shortid",
+        },
+      }),
+    );
+
+    expect(JSON.stringify(serverLoggerMock.info.mock.calls)).not.toContain("shortid");
+  });
+
+  it("returns a typed upstream error when the edge authority URL is not HTTP(S)", async () => {
+    process.env.SUPABASE_EDGE_URL = "postgres://user:password@example.supabase.co:5432/postgres";
+    const fetchSpy = mockFetch();
+
+    const { dashboardHandler } = await import("../api/dashboard");
+    const response = await dashboardHandler(createRequest("GET", "token"));
+    const text = await response.text();
+
+    expect(response.status).toBe(502);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(text).not.toContain("password");
+    expect(JSON.parse(text)).toMatchObject({
+      code: "upstream_error",
+      success: false,
+      upstream: "get-dashboard-data",
     });
   });
 

--- a/src/server/__tests__/dashboardHandler.test.ts
+++ b/src/server/__tests__/dashboardHandler.test.ts
@@ -329,7 +329,7 @@ describe("dashboardHandler", () => {
   });
 
   it("returns a typed upstream error when the edge authority URL is not HTTP(S)", async () => {
-    process.env.SUPABASE_EDGE_URL = "postgres://user:password@example.supabase.co:5432/postgres";
+    process.env.SUPABASE_EDGE_URL = "ftp://example.supabase.co/functions/v1";
     const fetchSpy = mockFetch();
 
     const { dashboardHandler } = await import("../api/dashboard");

--- a/src/server/api/dashboard.ts
+++ b/src/server/api/dashboard.ts
@@ -2,13 +2,24 @@ import {
   consumeRateLimit,
   corsHeadersForRequest,
   errorResponse,
+  getRequestId,
   isDisallowedOriginRequest,
 } from "./shared";
-import { proxyToEdgeAuthority } from "./edgeAuthority";
+import { getEdgeAuthorityBaseUrl, proxyToEdgeAuthority } from "./edgeAuthority";
+import { serverLogger } from "../../lib/logger/server";
 
 const JSON_HEADERS: Record<string, string> = {
   "Content-Type": "application/json",
 };
+
+const DASHBOARD_UPSTREAM_TIMEOUT_MS = 8_000;
+
+class DashboardUpstreamConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DashboardUpstreamConfigError";
+  }
+}
 
 const isProxyTransportFailure = (error: unknown): boolean => {
   if (!(error instanceof Error)) {
@@ -22,6 +33,62 @@ const isProxyTransportFailure = (error: unknown): boolean => {
     message.includes("load failed") ||
     message.includes("aborted")
   );
+};
+
+const withRequestId = (request: Request, requestId: string): Request => {
+  if (request.headers.get("x-request-id")?.trim()) {
+    return request;
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set("x-request-id", requestId);
+  return new Request(request, { headers });
+};
+
+const describeEdgeTarget = (baseUrl: string): { protocol: string; host: string; projectRef?: string } => {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new DashboardUpstreamConfigError("Dashboard Edge authority URL is invalid");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new DashboardUpstreamConfigError("Dashboard Edge authority URL must use http or https");
+  }
+
+  const hostname = parsed.hostname;
+  const projectRef = hostname.endsWith(".supabase.co") ? hostname.split(".")[0] : undefined;
+  return {
+    protocol: parsed.protocol.replace(":", ""),
+    host: hostname,
+    ...(projectRef ? { projectRef } : {}),
+  };
+};
+
+const getHeaderSuffix = (value: string | null): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 8 ? trimmed.slice(-8) : undefined;
+};
+
+const readUpstreamBody = (response: Response, signal: AbortSignal): Promise<string> => {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("The operation was aborted", "AbortError"));
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    const onAbort = () => reject(new DOMException("The operation was aborted", "AbortError"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    response.text().then(
+      (body) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(body);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 };
 
 export async function dashboardHandler(request: Request): Promise<Response> {
@@ -67,29 +134,74 @@ export async function dashboardHandler(request: Request): Promise<Response> {
     });
   }
 
+  const requestId = getRequestId(request);
+  const requestWithId = withRequestId(request, requestId);
+  const startedAt = Date.now();
+  let target: ReturnType<typeof describeEdgeTarget> | undefined;
+  let timedOut = false;
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    abortController.abort();
+  }, DASHBOARD_UPSTREAM_TIMEOUT_MS);
+
   try {
-    const forwarded = await proxyToEdgeAuthority(request, {
+    target = describeEdgeTarget(getEdgeAuthorityBaseUrl());
+    serverLogger.info("dashboard proxy request started", {
+      requestId,
+      correlationIdSuffix: getHeaderSuffix(requestWithId.headers.get("x-correlation-id")),
+      netlifyRequestIdSuffix: getHeaderSuffix(requestWithId.headers.get("x-nf-request-id")),
+      target,
+      timeoutMs: DASHBOARD_UPSTREAM_TIMEOUT_MS,
+    });
+
+    const forwarded = await proxyToEdgeAuthority(requestWithId, {
       functionName: "get-dashboard-data",
       accessToken,
       method: "GET",
+      signal: abortController.signal,
     });
-    const body = await forwarded.text();
+    const body = await readUpstreamBody(forwarded, abortController.signal);
     const retryAfter = forwarded.headers.get("Retry-After");
+    serverLogger.info("dashboard proxy upstream completed", {
+      requestId,
+      status: forwarded.status,
+      elapsedMs: Date.now() - startedAt,
+      target,
+    });
     return new Response(body, {
       status: forwarded.status,
       headers: {
         ...JSON_HEADERS,
-        ...corsHeadersForRequest(request),
+        ...corsHeadersForRequest(requestWithId),
+        "x-request-id": requestId,
         ...(retryAfter ? { "Retry-After": retryAfter } : {}),
       },
     });
   } catch (error) {
-    if (isProxyTransportFailure(error)) {
-      return errorResponse(request, "upstream_error", "Failed to load dashboard data", {
+    const elapsedMs = Date.now() - startedAt;
+    if (error instanceof DashboardUpstreamConfigError || timedOut || isProxyTransportFailure(error)) {
+      serverLogger.warn("dashboard proxy upstream failed", {
+        requestId,
+        elapsedMs,
+        timedOut,
+        timeoutMs: DASHBOARD_UPSTREAM_TIMEOUT_MS,
+        target,
+        errorName: error instanceof Error ? error.name : typeof error,
+      });
+      return errorResponse(requestWithId, "upstream_error", "Failed to load dashboard data", {
         status: 502,
+        headers: { "x-request-id": requestId },
+        extra: {
+          upstream: "get-dashboard-data",
+          timedOut,
+          elapsedMs,
+        },
       });
     }
     throw error;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/src/server/api/edgeAuthority.ts
+++ b/src/server/api/edgeAuthority.ts
@@ -99,6 +99,7 @@ export async function proxyToEdgeAuthority(request: Request, options: {
   accessToken?: string | null;
   method?: "GET" | "POST";
   body?: string;
+  signal?: AbortSignal;
 }): Promise<Response> {
   const method = options.method ?? (request.method === "GET" ? "GET" : "POST");
   const baseUrl = getEdgeAuthorityBaseUrl();
@@ -115,6 +116,7 @@ export async function proxyToEdgeAuthority(request: Request, options: {
     method,
     headers,
     body,
+    signal: options.signal,
   });
 }
 


### PR DESCRIPTION
## Summary
- Adds an 8s abortable upstream deadline around `/api/dashboard` proxying to `get-dashboard-data`, below the existing 10s client dashboard fallback timer and far below the observed ~40s Netlify raw 502 cutoff.
- Keeps the timeout active through both fetch and response body read, returning the existing typed `upstream_error` dashboard response with `x-request-id` instead of hanging into a platform 502.
- Adds redacted request-correlated diagnostics for dashboard proxy start/completion/failure without logging bearer tokens, apikeys, cookies, JWTs, service-role keys, raw user IDs, or full caller correlation IDs.
- Adds focused regression coverage for hanging fetches, stalled upstream bodies, request ID propagation/generation, invalid Edge URL handling, and secret non-leakage.

## Route / Risk
- Linear: WIN-114
- route-task: `high-risk human-reviewed`, lane `critical`
- Protected paths: `src/server/**`
- Out of scope: dashboard UI redesign, auth/session architecture, Supabase migrations/RLS/schema, tenant policy, CI/workflow changes, production secret/env mutation.

## Verification
- PASS `npx vitest run src/server/__tests__/dashboardHandler.test.ts --config vitest.config.ts`
- PASS `npx vitest run src/server/__tests__/dashboardHandler.test.ts src/server/__tests__/dashboardParity.contract.test.ts tests/edge/dashboard.parity.contract.test.ts tests/edge/get-dashboard-data.rate-limit.contract.test.ts tests/edge/get-dashboard-data.todaysSessions.test.ts --config vitest.config.ts`
- PASS `npm run ci:check-focused`
- PASS `npm run lint`
- PASS `npm run typecheck`
- PASS `npm run build`
- PASS `npm run test:routes:tier0`
- PASS `git diff --check`
- BLOCKED `npm run verify:local`: broad `test:ci` failed in unrelated `src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx` assertions for `Jamie Client`, outside this dashboard slice.
- BLOCKED `npm run ci:playwright`: local run timed out after 5 minutes; rely on CI/human follow-up for browser auth gate.

## Env Note
Netlify production env key presence was inspected with values redacted. `SUPABASE_URL`, `SUPABASE_EDGE_URL`, and `DEFAULT_ORGANIZATION_ID` were not listed. Per AGENTS.md, no production env/provider values were modified. Recommended operator action: set `SUPABASE_URL=https://wnnjeqheqxxyrgsjmygy.supabase.co`, set `DEFAULT_ORGANIZATION_ID=<active clinic uuid>`, and leave `SUPABASE_EDGE_URL` unset unless intentionally overriding to `https://wnnjeqheqxxyrgsjmygy.supabase.co/functions/v1`.

## Residual Risk
This prevents `/api/dashboard` from waiting long enough to produce a raw Netlify 502 in the server handler path, but it does not fix the underlying Supabase Edge/RPC hang. Post-deploy authenticated validation is still needed to confirm production now returns typed JSON before the platform cutoff.