### PR TITLE
WIN-115 Fix dashboard Edge function hang

### DIFF
--- a/supabase/functions/get-dashboard-data/index.ts
+++ b/supabase/functions/get-dashboard-data/index.ts
@@ -12,6 +12,10 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, X-Client-Info, apikey, content-type, x-request-id',
 }
 
+const DASHBOARD_ROUTE_TIMEOUT_MS = 6_500;
+const DASHBOARD_ORG_TIMEOUT_MS = 2_500;
+const DASHBOARD_RPC_TIMEOUT_MS = 4_500;
+
 type TodaySession = {
   id: string
   status: string
@@ -47,6 +51,48 @@ const parseDefaultOrganizationId = (): string | null => {
   const trimmed = raw.trim();
   return trimmed.length > 0 ? trimmed : null;
 }
+
+class DashboardStepTimeoutError extends Error {
+  constructor(
+    public readonly step: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(`Dashboard step timed out: ${step}`);
+    this.name = "DashboardStepTimeoutError";
+  }
+}
+
+const elapsedMsSince = (startedAt: number): number => Date.now() - startedAt;
+
+const logDashboardStep = (
+  level: "info" | "warn" | "error",
+  message: string,
+  fields: Record<string, unknown>,
+) => {
+  console[level](message, fields);
+};
+
+const withDashboardStepTimeout = async <T>(
+  operation: Promise<T>,
+  step: string,
+  timeoutMs: number,
+): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new DashboardStepTimeoutError(step, timeoutMs));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+};
 
 const asRecord = (value: unknown): Record<string, unknown> | null =>
   value && typeof value === "object" && !Array.isArray(value)
@@ -130,11 +176,27 @@ export async function handleGetDashboardData({ req, db: providedDb }: HandlerOpt
     })
   }
 
+  const requestId = getRequestId(req)
+  const startedAt = Date.now()
+
   try {
-    const requestId = getRequestId(req)
+    logDashboardStep("info", "get-dashboard-data request started", {
+      requestId,
+      method: req.method,
+    });
 
     const db = providedDb ?? createRequestClient(req);
-    await resolveDashboardOrganizationId(db);
+    const orgStartedAt = Date.now();
+    await withDashboardStepTimeout(
+      resolveDashboardOrganizationId(db),
+      "org_resolution",
+      DASHBOARD_ORG_TIMEOUT_MS,
+    );
+    logDashboardStep("info", "get-dashboard-data step completed", {
+      requestId,
+      step: "org_resolution",
+      elapsedMs: elapsedMsSince(orgStartedAt),
+    });
 
     const ip = req.headers.get('x-forwarded-for') || 'unknown'
     const rl = rateLimit(`dashboard:${ip}`, 60, 60_000)
@@ -148,10 +210,28 @@ export async function handleGetDashboardData({ req, db: providedDb }: HandlerOpt
       })
     }
 
-    const { data: rpcData, error: rpcError } = await db.rpc('get_dashboard_data');
+    const rpcStartedAt = Date.now();
+    const { data: rpcData, error: rpcError } = await withDashboardStepTimeout(
+      db.rpc('get_dashboard_data'),
+      "dashboard_rpc",
+      DASHBOARD_RPC_TIMEOUT_MS,
+    );
+    logDashboardStep("info", "get-dashboard-data step completed", {
+      requestId,
+      step: "dashboard_rpc",
+      elapsedMs: elapsedMsSince(rpcStartedAt),
+      hasError: Boolean(rpcError),
+    });
     if (rpcError) {
       const code = typeof rpcError.code === 'string' ? rpcError.code : '';
       const status = code === '42501' ? 403 : 500;
+      logDashboardStep("warn", "get-dashboard-data rpc failed", {
+        requestId,
+        step: "dashboard_rpc",
+        status,
+        elapsedMs: elapsedMsSince(rpcStartedAt),
+        rpcCode: code || "unknown",
+      });
       return errorEnvelope({
         requestId,
         code: status === 403 ? 'forbidden' : 'upstream_error',
@@ -180,12 +260,31 @@ export async function handleGetDashboardData({ req, db: providedDb }: HandlerOpt
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
     )
   } catch (error) {
+    if (error instanceof DashboardStepTimeoutError) {
+      // The timed operation may eventually reject with an authz error, but after this deadline
+      // the only safe observable state is "no dashboard data returned in time".
+      logDashboardStep("warn", "get-dashboard-data step timed out", {
+        requestId,
+        step: error.step,
+        timeoutMs: error.timeoutMs,
+        elapsedMs: elapsedMsSince(startedAt),
+      });
+      return errorEnvelope({
+        requestId,
+        code: 'upstream_timeout',
+        message: 'Dashboard data request timed out',
+        status: 504,
+        headers: corsHeaders,
+      })
+    }
     if (error instanceof MissingOrgContextError) {
-      const requestId = getRequestId(new Request('http://local'))
       return errorEnvelope({ requestId, code: 'missing_org', message: error.message, status: 403, headers: corsHeaders })
     }
-    const requestId = getRequestId(new Request('http://local'))
-    console.error('Dashboard data error:', error)
+    logDashboardStep("error", "Dashboard data error", {
+      requestId,
+      elapsedMs: elapsedMsSince(startedAt),
+      errorName: error instanceof Error ? error.name : typeof error,
+    })
     return errorEnvelope({ requestId, code: 'internal_error', message: 'Unexpected error', status: 500, headers: corsHeaders })
   }
 }
@@ -193,6 +292,55 @@ export async function handleGetDashboardData({ req, db: providedDb }: HandlerOpt
 export const __TESTING__ = {
   aggregateTodaysSessions,
   resolveDashboardOrganizationId,
+  withDashboardStepTimeout,
 }
 
-export default createProtectedRoute((req: Request) => handleGetDashboardData({ req }), RouteOptions.admin)
+const dashboardRoute = createProtectedRoute((req: Request) => handleGetDashboardData({ req }), RouteOptions.admin)
+
+const servedDashboardRoute = async (req: Request): Promise<Response> => {
+  const requestId = getRequestId(req)
+  const startedAt = Date.now()
+  try {
+    logDashboardStep("info", "get-dashboard-data edge route received", {
+      requestId,
+      method: req.method,
+      timeoutMs: DASHBOARD_ROUTE_TIMEOUT_MS,
+    })
+    const response = await withDashboardStepTimeout(
+      dashboardRoute(req),
+      "edge_route",
+      DASHBOARD_ROUTE_TIMEOUT_MS,
+    )
+    logDashboardStep("info", "get-dashboard-data edge route completed", {
+      requestId,
+      status: response.status,
+      elapsedMs: elapsedMsSince(startedAt),
+    })
+    return response
+  } catch (error) {
+    if (error instanceof DashboardStepTimeoutError) {
+      // Fail closed before the /api/dashboard proxy timeout; never infer success or tenant scope
+      // from a route that did not complete.
+      logDashboardStep("warn", "get-dashboard-data edge route timed out", {
+        requestId,
+        step: error.step,
+        timeoutMs: error.timeoutMs,
+        elapsedMs: elapsedMsSince(startedAt),
+      })
+      return errorEnvelope({
+        requestId,
+        code: 'upstream_timeout',
+        message: 'Dashboard data request timed out',
+        status: 504,
+        headers: corsHeaders,
+      })
+    }
+    throw error
+  }
+}
+
+if (typeof Deno !== "undefined" && typeof Deno.serve === "function") {
+  Deno.serve(servedDashboardRoute)
+}
+
+export default servedDashboardRoute

--- a/tests/edge/dashboard.parity.contract.test.ts
+++ b/tests/edge/dashboard.parity.contract.test.ts
@@ -25,10 +25,12 @@ async function loadDashboardModule() {
 describe("get-dashboard-data organization context parity", () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.useRealTimers();
     envValues.delete("DEFAULT_ORGANIZATION_ID");
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     envValues.delete("DEFAULT_ORGANIZATION_ID");
   });
 
@@ -102,6 +104,141 @@ describe("get-dashboard-data organization context parity", () => {
     expect(response.status).toBe(403);
     const body = (await response.json()) as { code?: string };
     expect(body.code).toBe("forbidden");
+  });
+
+  it("returns a typed timeout when organization resolution does not complete", async () => {
+    vi.useFakeTimers();
+    const mod = await loadDashboardModule();
+    const db = {
+      rpc: (fn: string) => {
+        if (fn === "current_user_organization_id") return new Promise(() => undefined);
+        return Promise.resolve({ data: null, error: null });
+      },
+    };
+    const responsePromise = mod.handleGetDashboardData({
+      req: createDashboardRequest("GET", "org-timeout"),
+      db: db as never,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    const response = await responsePromise;
+    expect(response.status).toBe(504);
+    const body = (await response.json()) as { code?: string; requestId?: string; classification?: { category?: string } };
+    expect(body).toMatchObject({
+      requestId: "req-dash-org-timeout",
+      code: "upstream_timeout",
+      classification: { category: "upstream" },
+    });
+  });
+
+  it("returns a typed timeout when the dashboard RPC does not complete", async () => {
+    vi.useFakeTimers();
+    const mod = await loadDashboardModule();
+    const db = {
+      rpc: (fn: string) => {
+        if (fn === "current_user_organization_id") return Promise.resolve({ data: "org-resolved", error: null });
+        if (fn === "get_dashboard_data") return new Promise(() => undefined);
+        return Promise.resolve({ data: null, error: null });
+      },
+    };
+    const responsePromise = mod.handleGetDashboardData({
+      req: createDashboardRequest("GET", "rpc-timeout"),
+      db: db as never,
+    });
+
+    await vi.advanceTimersByTimeAsync(4_500);
+
+    const response = await responsePromise;
+    expect(response.status).toBe(504);
+    const body = (await response.json()) as { code?: string; requestId?: string; classification?: { category?: string } };
+    expect(body).toMatchObject({
+      requestId: "req-dash-rpc-timeout",
+      code: "upstream_timeout",
+      classification: { category: "upstream" },
+    });
+  });
+
+  it("fails closed as timeout when the dashboard RPC permission failure is slower than the deadline", async () => {
+    vi.useFakeTimers();
+    const mod = await loadDashboardModule();
+    const db = {
+      rpc: (fn: string) => {
+        if (fn === "current_user_organization_id") return Promise.resolve({ data: "org-resolved", error: null });
+        if (fn === "get_dashboard_data") {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              resolve({ data: null, error: { code: "42501", message: "permission denied for function" } });
+            }, 5_000);
+          });
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
+    };
+    const responsePromise = mod.handleGetDashboardData({
+      req: createDashboardRequest("GET", "slow-forbidden"),
+      db: db as never,
+    });
+
+    await vi.advanceTimersByTimeAsync(4_500);
+
+    const response = await responsePromise;
+    expect(response.status).toBe(504);
+    const body = (await response.json()) as { code?: string; requestId?: string; classification?: { category?: string } };
+    expect(body).toMatchObject({
+      requestId: "req-dash-slow-forbidden",
+      code: "upstream_timeout",
+      classification: { category: "upstream" },
+    });
+  });
+});
+
+describe("get-dashboard-data Supabase Edge entrypoint", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    stubDenoEnv((key) => envValues.get(key) ?? "");
+    vi.resetModules();
+  });
+
+  it("registers a Deno.serve handler when the Edge runtime provides serve", async () => {
+    const serve = vi.fn();
+    vi.stubGlobal("Deno", {
+      env: {
+        get: (key: string) => envValues.get(key) ?? "",
+      },
+      serve,
+    });
+
+    await loadDashboardModule();
+
+    expect(serve).toHaveBeenCalledTimes(1);
+    expect(serve.mock.calls[0]?.[0]).toEqual(expect.any(Function));
+  });
+
+  it("returns a typed timeout when the protected Edge route does not complete", async () => {
+    vi.useFakeTimers();
+    vi.doMock("../../supabase/functions/_shared/auth-middleware.ts", () => ({
+      createProtectedRoute: () => () => new Promise(() => undefined),
+      RouteOptions: { admin: { requireAuth: true, allowedRoles: ["admin", "super_admin"] } },
+    }));
+    const module = await loadDashboardModule();
+    const responsePromise = module.default(createDashboardRequest("GET", "route-timeout"));
+
+    await vi.advanceTimersByTimeAsync(6_500);
+
+    const response = await responsePromise;
+    expect(response.status).toBe(504);
+    const body = (await response.json()) as { code?: string; requestId?: string; classification?: { category?: string } };
+    expect(body).toMatchObject({
+      requestId: "req-dash-route-timeout",
+      code: "upstream_timeout",
+      classification: { category: "upstream" },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Register `get-dashboard-data` with `Deno.serve` so Supabase Edge actually serves the protected route instead of only booting the module.
- Add fail-closed Edge-side deadlines around the protected route, org resolution, and `get_dashboard_data` RPC, all below the `/api/dashboard` 8s proxy timeout.
- Add request-ID-preserving, redacted timing logs and focused tests for entrypoint registration, org/RPC timeout handling, route timeout handling, and late security-failure timeout semantics.

## Route / Risk
- Linear: WIN-115
- route-task: `high-risk human-reviewed`, lane `critical`
- Protected path: `supabase/functions/get-dashboard-data/index.ts`

## Verification
- PASS `npx vitest run src/server/__tests__/dashboardHandler.test.ts src/server/__tests__/dashboardParity.contract.test.ts tests/edge/dashboard.parity.contract.test.ts tests/edge/get-dashboard-data.rate-limit.contract.test.ts tests/edge/get-dashboard-data.todaysSessions.test.ts --config vitest.config.ts`
- PASS `npm run ci:check-focused`
- PASS `npm run validate:tenant`
- PASS `npm run lint`
- PASS `npm run build`
- FAIL/BLOCKED `npm run test:ci`: unrelated existing failures/timeouts in Schedule lazy/modal tests, CalOptima PDF render map, and bookHandler integration; no failures in changed dashboard/Edge files.
- FAIL/BLOCKED `npm run verify:local`: passes policy/lint/typecheck, then fails at the same unrelated `test:ci` failures above.

## Notes
- No schema, RLS, migration, auth/session architecture, deploy config, or tenant policy changes.
- Auth/tenant checks are not bypassed. If a protected dashboard operation does not return before the deadline, the function returns typed `504 upstream_timeout` rather than inferring access or data.