### PR TITLE
WIN-116: Fix dashboard authority RPC path

### DIFF
--- a/supabase/functions/get-dashboard-data/index.ts
+++ b/supabase/functions/get-dashboard-data/index.ts
@@ -1,7 +1,7 @@
 import { errorEnvelope, getRequestId, rateLimit } from '../lib/http/error.ts'
 import type { SupabaseClient } from "npm:@supabase/supabase-js@2.50.0";
-import { createRequestClient } from "../_shared/database.ts";
-import { createProtectedRoute, RouteOptions } from "../_shared/auth-middleware.ts";
+import { createRequestClient, supabaseAdmin } from "../_shared/database.ts";
+import { createProtectedRoute, RouteOptions, type UserContext } from "../_shared/auth-middleware.ts";
 import { MissingOrgContextError, resolveOrgId } from "../_shared/org.ts";
 import { resolveAllowedOrigin } from "../_shared/cors.ts";
 
@@ -41,6 +41,8 @@ const aggregateTodaysSessions = (
 interface HandlerOptions {
   req: Request;
   db?: SupabaseClient;
+  adminDb?: SupabaseClient;
+  userContext?: UserContext;
 }
 
 const parseDefaultOrganizationId = (): string | null => {
@@ -165,7 +167,29 @@ const resolveDashboardOrganizationId = async (db: SupabaseClient): Promise<strin
   throw new MissingOrgContextError();
 }
 
-export async function handleGetDashboardData({ req, db: providedDb }: HandlerOptions) {
+const resolveDashboardActorId = async (
+  db: SupabaseClient,
+  userContext?: UserContext,
+): Promise<string> => {
+  const contextUserId = typeof userContext?.user?.id === "string" ? userContext.user.id.trim() : "";
+  if (contextUserId.length > 0) {
+    return contextUserId;
+  }
+
+  const { data: authData, error: authError } = await db.auth.getUser();
+  const userId = typeof authData?.user?.id === "string" ? authData.user.id.trim() : "";
+  if (authError || userId.length === 0) {
+    throw new MissingOrgContextError("Authenticated dashboard actor required");
+  }
+  return userId;
+};
+
+export async function handleGetDashboardData({
+  req,
+  db: providedDb,
+  adminDb: providedAdminDb,
+  userContext,
+}: HandlerOptions) {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
   }
@@ -187,7 +211,7 @@ export async function handleGetDashboardData({ req, db: providedDb }: HandlerOpt
 
     const db = providedDb ?? createRequestClient(req);
     const orgStartedAt = Date.now();
-    await withDashboardStepTimeout(
+    const orgId = await withDashboardStepTimeout(
       resolveDashboardOrganizationId(db),
       "org_resolution",
       DASHBOARD_ORG_TIMEOUT_MS,
@@ -210,9 +234,25 @@ export async function handleGetDashboardData({ req, db: providedDb }: HandlerOpt
       })
     }
 
+    const actorStartedAt = Date.now();
+    const actorUserId = await withDashboardStepTimeout(
+      resolveDashboardActorId(db, userContext),
+      "actor_resolution",
+      DASHBOARD_ORG_TIMEOUT_MS,
+    );
+    logDashboardStep("info", "get-dashboard-data step completed", {
+      requestId,
+      step: "actor_resolution",
+      elapsedMs: elapsedMsSince(actorStartedAt),
+    });
+
+    const dashboardDb = providedAdminDb ?? supabaseAdmin;
     const rpcStartedAt = Date.now();
     const { data: rpcData, error: rpcError } = await withDashboardStepTimeout(
-      db.rpc('get_dashboard_data'),
+      dashboardDb.rpc('get_dashboard_data_for_org', {
+        actor_user_id: actorUserId,
+        target_organization_id: orgId,
+      }),
       "dashboard_rpc",
       DASHBOARD_RPC_TIMEOUT_MS,
     );
@@ -235,7 +275,7 @@ export async function handleGetDashboardData({ req, db: providedDb }: HandlerOpt
       return errorEnvelope({
         requestId,
         code: status === 403 ? 'forbidden' : 'upstream_error',
-        message: rpcError.message || 'Dashboard RPC failed',
+        message: status === 403 ? 'Dashboard access denied' : 'Dashboard RPC failed',
         status,
         headers: corsHeaders,
       });
@@ -293,9 +333,13 @@ export const __TESTING__ = {
   aggregateTodaysSessions,
   resolveDashboardOrganizationId,
   withDashboardStepTimeout,
+  resolveDashboardActorId,
 }
 
-const dashboardRoute = createProtectedRoute((req: Request) => handleGetDashboardData({ req }), RouteOptions.admin)
+const dashboardRoute = createProtectedRoute(
+  (req: Request, userContext: UserContext) => handleGetDashboardData({ req, userContext }),
+  RouteOptions.admin,
+)
 
 const servedDashboardRoute = async (req: Request): Promise<Response> => {
   const requestId = getRequestId(req)

--- a/supabase/migrations/20260429142000_dashboard_service_authority_rpc.sql
+++ b/supabase/migrations/20260429142000_dashboard_service_authority_rpc.sql
@@ -1,0 +1,190 @@
+/*
+  @migration-intent: Add a service-role-only dashboard authority RPC for Edge-mediated dashboard aggregation.
+  @migration-dependencies: 20260421223930_fix_dashboard_active_counts.sql
+  @migration-rollback: DROP FUNCTION IF EXISTS public.get_dashboard_data_for_org(uuid, uuid); keep direct get_dashboard_data() authenticated execute revoked.
+*/
+
+set search_path = public;
+
+begin;
+
+create or replace function public.get_dashboard_data_for_org(
+  actor_user_id uuid,
+  target_organization_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, app, auth
+as $$
+declare
+  v_actor_org uuid;
+  v_actor_active boolean := false;
+  v_is_org_admin boolean := false;
+  v_is_super_admin boolean := false;
+  result jsonb;
+  today_sessions jsonb;
+  incomplete_sessions jsonb;
+  billing_alerts jsonb;
+  client_metrics jsonb;
+  therapist_metrics jsonb;
+begin
+  if actor_user_id is null then
+    raise exception using errcode = '42501', message = 'Dashboard actor required';
+  end if;
+
+  if target_organization_id is null then
+    raise exception using errcode = '42501', message = 'Organization context required';
+  end if;
+
+  select exists (
+    select 1
+    from public.profiles p
+    where p.id = actor_user_id
+      and coalesce(p.is_active, true) = true
+  ) into v_actor_active;
+
+  if coalesce(v_actor_active, false) is not true then
+    raise exception using errcode = '42501', message = 'Active dashboard actor required';
+  end if;
+
+  select app.resolve_user_organization_id(actor_user_id)
+  into v_actor_org;
+
+  select exists (
+    select 1
+    from public.user_roles ur
+    join public.roles r on r.id = ur.role_id
+    where ur.user_id = actor_user_id
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+      and r.name = 'super_admin'
+  ) into v_is_super_admin;
+
+  select exists (
+    select 1
+    from public.user_roles ur
+    join public.roles r on r.id = ur.role_id
+    where ur.user_id = actor_user_id
+      and v_actor_org = target_organization_id
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+      and r.name in ('admin', 'org_admin', 'org_super_admin')
+  ) into v_is_org_admin;
+
+  if coalesce(v_is_org_admin, false) is not true and coalesce(v_is_super_admin, false) is not true then
+    raise exception using errcode = '42501', message = 'Admin dashboard access required';
+  end if;
+
+  select jsonb_agg(
+    jsonb_build_object(
+      'id', s.id,
+      'client_id', s.client_id,
+      'therapist_id', s.therapist_id,
+      'start_time', s.start_time,
+      'end_time', s.end_time,
+      'status', s.status,
+      'therapist', jsonb_build_object(
+        'id', t.id,
+        'full_name', t.full_name
+      ),
+      'client', jsonb_build_object(
+        'id', c.id,
+        'full_name', c.full_name
+      )
+    )
+  ) into today_sessions
+  from public.sessions s
+  join public.therapists t on t.id = s.therapist_id
+  join public.clients c on c.id = s.client_id
+  where s.organization_id = target_organization_id
+    and t.organization_id = target_organization_id
+    and c.organization_id = target_organization_id
+    and date(s.start_time at time zone 'UTC') = current_date;
+
+  select jsonb_agg(
+    jsonb_build_object(
+      'id', s.id,
+      'client_id', s.client_id,
+      'therapist_id', s.therapist_id,
+      'start_time', s.start_time,
+      'end_time', s.end_time,
+      'status', s.status,
+      'therapist', jsonb_build_object(
+        'id', t.id,
+        'full_name', t.full_name
+      ),
+      'client', jsonb_build_object(
+        'id', c.id,
+        'full_name', c.full_name
+      )
+    )
+  ) into incomplete_sessions
+  from public.sessions s
+  join public.therapists t on t.id = s.therapist_id
+  join public.clients c on c.id = s.client_id
+  where s.organization_id = target_organization_id
+    and t.organization_id = target_organization_id
+    and c.organization_id = target_organization_id
+    and s.status = 'completed'
+    and (s.notes is null or s.notes = '');
+
+  select jsonb_agg(
+    jsonb_build_object(
+      'id', br.id,
+      'session_id', br.session_id,
+      'amount', br.amount,
+      'status', br.status,
+      'created_at', br.created_at
+    )
+  ) into billing_alerts
+  from public.billing_records br
+  where br.organization_id = target_organization_id
+    and br.status in ('pending', 'rejected');
+
+  select jsonb_build_object(
+    'total', count(*),
+    'active', count(*) filter (where coalesce(nullif(trim(lower(c.status)), ''), 'active') = 'active'),
+    'totalUnits', coalesce(sum(
+      coalesce(c.one_to_one_units, 0) +
+      coalesce(c.supervision_units, 0) +
+      coalesce(c.parent_consult_units, 0)
+    ), 0)
+  ) into client_metrics
+  from public.clients c
+  where c.organization_id = target_organization_id;
+
+  select jsonb_build_object(
+    'total', count(*),
+    'active', count(*) filter (where coalesce(nullif(trim(lower(t.status)), ''), 'active') = 'active'),
+    'totalHours', coalesce(sum(coalesce(t.weekly_hours_max, 0)), 0)
+  ) into therapist_metrics
+  from public.therapists t
+  where t.organization_id = target_organization_id;
+
+  result := jsonb_build_object(
+    'todaySessions', coalesce(today_sessions, '[]'::jsonb),
+    'incompleteSessions', coalesce(incomplete_sessions, '[]'::jsonb),
+    'billingAlerts', coalesce(billing_alerts, '[]'::jsonb),
+    'clientMetrics', coalesce(client_metrics, '{}'::jsonb),
+    'therapistMetrics', coalesce(therapist_metrics, '{}'::jsonb)
+  );
+
+  return result;
+end;
+$$;
+
+revoke all on function public.get_dashboard_data_for_org(uuid, uuid) from public;
+revoke execute on function public.get_dashboard_data_for_org(uuid, uuid) from anon;
+revoke execute on function public.get_dashboard_data_for_org(uuid, uuid) from authenticated;
+revoke execute on function public.get_dashboard_data_for_org(uuid, uuid) from dashboard_consumer;
+grant execute on function public.get_dashboard_data_for_org(uuid, uuid) to service_role;
+
+-- Preserve the dashboard contract: browser-authenticated users cannot call the legacy aggregate RPC directly.
+revoke execute on function public.get_dashboard_data() from public;
+revoke execute on function public.get_dashboard_data() from anon;
+revoke execute on function public.get_dashboard_data() from authenticated;
+grant execute on function public.get_dashboard_data() to dashboard_consumer;
+grant execute on function public.get_dashboard_data() to service_role;
+
+commit;

--- a/tests/edge/dashboard.parity.contract.test.ts
+++ b/tests/edge/dashboard.parity.contract.test.ts
@@ -54,11 +54,18 @@ describe("get-dashboard-data organization context parity", () => {
 
   it("super_admin resolves organization_id from user_metadata then returns dashboard payload", async () => {
     const mod = await loadDashboardModule();
+    const adminRpc = vi.fn(async (fn: string, payload?: Record<string, unknown>) => {
+      expect(fn).toBe("get_dashboard_data_for_org");
+      expect(payload).toMatchObject({
+        actor_user_id: "user-1",
+        target_organization_id: "org-from-metadata",
+      });
+      return { data: { todaySessions: [] }, error: null };
+    });
     const db = {
       rpc: async (fn: string) => {
         if (fn === "current_user_organization_id") return { data: null, error: null };
         if (fn === "current_user_is_super_admin") return { data: true, error: null };
-        if (fn === "get_dashboard_data") return { data: { todaySessions: [] }, error: null };
         return { data: null, error: null };
       },
       auth: {
@@ -79,8 +86,10 @@ describe("get-dashboard-data organization context parity", () => {
     const response = await mod.handleGetDashboardData({
       req: createDashboardRequest("GET", "b"),
       db: db as never,
+      adminDb: { rpc: adminRpc } as never,
     });
     expect(response.status).toBe(200);
+    expect(adminRpc).toHaveBeenCalledTimes(1);
     const body = (await response.json()) as { success?: boolean; data?: { todaySessions?: unknown[] } };
     expect(body.success).toBe(true);
     expect(Array.isArray(body.data?.todaySessions)).toBe(true);
@@ -88,22 +97,29 @@ describe("get-dashboard-data organization context parity", () => {
 
   it("maps RPC error code 42501 to 403 forbidden", async () => {
     const mod = await loadDashboardModule();
+    const adminRpc = vi.fn(async (fn: string) => {
+      if (fn === "get_dashboard_data_for_org") {
+        return { data: null, error: { code: "42501", message: "permission denied for function" } };
+      }
+      return { data: null, error: null };
+    });
     const db = {
       rpc: async (fn: string) => {
         if (fn === "current_user_organization_id") return { data: "org-resolved", error: null };
-        if (fn === "get_dashboard_data") {
-          return { data: null, error: { code: "42501", message: "permission denied for relation" } };
-        }
         return { data: null, error: null };
       },
     };
     const response = await mod.handleGetDashboardData({
       req: createDashboardRequest("GET", "c"),
       db: db as never,
+      adminDb: { rpc: adminRpc } as never,
+      userContext: { user: { id: "user-1", email: null }, profile: { id: "user-1", email: null, role: "admin", is_active: true } },
     });
     expect(response.status).toBe(403);
-    const body = (await response.json()) as { code?: string };
+    const body = (await response.json()) as { code?: string; message?: string };
     expect(body.code).toBe("forbidden");
+    expect(body.message).toBe("Dashboard access denied");
+    expect(JSON.stringify(body)).not.toContain("permission denied");
   });
 
   it("returns a typed timeout when organization resolution does not complete", async () => {
@@ -135,16 +151,21 @@ describe("get-dashboard-data organization context parity", () => {
   it("returns a typed timeout when the dashboard RPC does not complete", async () => {
     vi.useFakeTimers();
     const mod = await loadDashboardModule();
+    const adminRpc = vi.fn((fn: string) => {
+      if (fn === "get_dashboard_data_for_org") return new Promise(() => undefined);
+      return Promise.resolve({ data: null, error: null });
+    });
     const db = {
       rpc: (fn: string) => {
         if (fn === "current_user_organization_id") return Promise.resolve({ data: "org-resolved", error: null });
-        if (fn === "get_dashboard_data") return new Promise(() => undefined);
         return Promise.resolve({ data: null, error: null });
       },
     };
     const responsePromise = mod.handleGetDashboardData({
       req: createDashboardRequest("GET", "rpc-timeout"),
       db: db as never,
+      adminDb: { rpc: adminRpc } as never,
+      userContext: { user: { id: "user-1", email: null }, profile: { id: "user-1", email: null, role: "admin", is_active: true } },
     });
 
     await vi.advanceTimersByTimeAsync(4_500);
@@ -162,22 +183,27 @@ describe("get-dashboard-data organization context parity", () => {
   it("fails closed as timeout when the dashboard RPC permission failure is slower than the deadline", async () => {
     vi.useFakeTimers();
     const mod = await loadDashboardModule();
+    const adminRpc = vi.fn((fn: string) => {
+      if (fn === "get_dashboard_data_for_org") {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({ data: null, error: { code: "42501", message: "permission denied for function" } });
+          }, 5_000);
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    });
     const db = {
       rpc: (fn: string) => {
         if (fn === "current_user_organization_id") return Promise.resolve({ data: "org-resolved", error: null });
-        if (fn === "get_dashboard_data") {
-          return new Promise((resolve) => {
-            setTimeout(() => {
-              resolve({ data: null, error: { code: "42501", message: "permission denied for function" } });
-            }, 5_000);
-          });
-        }
         return Promise.resolve({ data: null, error: null });
       },
     };
     const responsePromise = mod.handleGetDashboardData({
       req: createDashboardRequest("GET", "slow-forbidden"),
       db: db as never,
+      adminDb: { rpc: adminRpc } as never,
+      userContext: { user: { id: "user-1", email: null }, profile: { id: "user-1", email: null, role: "admin", is_active: true } },
     });
 
     await vi.advanceTimersByTimeAsync(4_500);

--- a/tests/edge/dashboardAuthorityMigration.contract.test.ts
+++ b/tests/edge/dashboardAuthorityMigration.contract.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  "supabase",
+  "migrations",
+  "20260429142000_dashboard_service_authority_rpc.sql",
+);
+
+function readMigration(): string {
+  return fs.readFileSync(MIGRATION_PATH, "utf8");
+}
+
+describe("dashboard authority migration", () => {
+  it("adds a service-role-only trusted dashboard RPC", () => {
+    const sql = readMigration();
+
+    expect(sql).toContain("create or replace function public.get_dashboard_data_for_org(");
+    expect(sql).toContain("actor_user_id uuid");
+    expect(sql).toContain("target_organization_id uuid");
+    expect(sql).toContain("security definer");
+    expect(sql).toContain("grant execute on function public.get_dashboard_data_for_org(uuid, uuid) to service_role;");
+    expect(sql).toContain("revoke execute on function public.get_dashboard_data_for_org(uuid, uuid) from authenticated;");
+    expect(sql).toContain("revoke execute on function public.get_dashboard_data_for_org(uuid, uuid) from dashboard_consumer;");
+  });
+
+  it("keeps direct authenticated dashboard RPC denied", () => {
+    const sql = readMigration();
+
+    expect(sql).toContain("revoke execute on function public.get_dashboard_data() from authenticated;");
+    expect(sql).toContain("grant execute on function public.get_dashboard_data() to dashboard_consumer;");
+    expect(sql).toContain("grant execute on function public.get_dashboard_data() to service_role;");
+    expect(sql).not.toContain("grant execute on function public.get_dashboard_data() to authenticated;");
+  });
+
+  it("re-checks actor authority and explicitly filters dashboard reads by requested organization", () => {
+    const sql = readMigration();
+
+    expect(sql).toContain("where p.id = actor_user_id");
+    expect(sql).toContain("ur.user_id = actor_user_id");
+    expect(sql).toContain("r.name in ('admin', 'org_admin', 'org_super_admin')");
+    expect(sql).toContain("r.name = 'super_admin'");
+    expect(sql).not.toContain("r.name in ('super_admin', 'org_super_admin')");
+    expect(sql).toContain("v_actor_org = target_organization_id");
+    expect(sql).toContain("s.organization_id = target_organization_id");
+    expect(sql).toContain("t.organization_id = target_organization_id");
+    expect(sql).toContain("c.organization_id = target_organization_id");
+    expect(sql).toContain("br.organization_id = target_organization_id");
+  });
+});

--- a/tests/edge/get-dashboard-data.rate-limit.contract.test.ts
+++ b/tests/edge/get-dashboard-data.rate-limit.contract.test.ts
@@ -9,6 +9,7 @@ const envValues = new Map<string, string>([
 ]);
 
 const createRequestClientMock = vi.fn();
+const supabaseAdminRpcMock = vi.fn();
 const resolveOrgIdMock = vi.fn();
 const rateLimitMock = vi.fn();
 
@@ -17,6 +18,9 @@ stubDenoEnv((key) => envValues.get(key) ?? '');
 async function loadHandler() {
   vi.doMock('../../supabase/functions/_shared/database.ts', () => ({
     createRequestClient: createRequestClientMock,
+    supabaseAdmin: {
+      rpc: supabaseAdminRpcMock,
+    },
   }));
   vi.doMock('../../supabase/functions/_shared/auth-middleware.ts', async () => {
     const actual = await vi.importActual<typeof import('../../supabase/functions/_shared/auth-middleware.ts')>(
@@ -79,6 +83,7 @@ describe('get-dashboard-data rate-limit contract', () => {
     expect(createRequestClientMock).toHaveBeenCalledTimes(1);
     expect(resolveOrgIdMock).toHaveBeenCalledTimes(1);
     expect(rateLimitMock).toHaveBeenCalledWith('dashboard:203.0.113.27', 60, 60_000);
+    expect(supabaseAdminRpcMock).not.toHaveBeenCalled();
 
     expect(response.status).toBe(429);
     expect(response.headers.get('Retry-After')).toBe('41');

--- a/tests/integration/_helpers/liveRlsHarness.ts
+++ b/tests/integration/_helpers/liveRlsHarness.ts
@@ -34,6 +34,12 @@ export type LiveRlsHarness =
       orgBId: string;
       orgA: OrgDataFixture;
       orgB: OrgDataFixture;
+      orgAAdminUserId: string;
+      orgBAdminUserId: string;
+      callTrustedDashboardRpc: (
+        actorUserId: string,
+        organizationId: string,
+      ) => Promise<Awaited<ReturnType<SupabaseClient["rpc"]>>>;
       signInAdminA: () => Promise<TypedClient>;
       signInAdminB: () => Promise<TypedClient>;
       cleanup: () => Promise<void>;
@@ -248,6 +254,13 @@ export async function setupLiveRlsHarness(): Promise<LiveRlsHarness> {
     orgBId,
     orgA,
     orgB,
+    orgAAdminUserId: orgAAdmin.userId,
+    orgBAdminUserId: orgBAdmin.userId,
+    callTrustedDashboardRpc: (actorUserId: string, organizationId: string) =>
+      serviceClient.rpc("get_dashboard_data_for_org", {
+        actor_user_id: actorUserId,
+        target_organization_id: organizationId,
+      }),
     signInAdminA: () => signInAdmin(orgAAdmin),
     signInAdminB: () => signInAdmin(orgBAdmin),
     cleanup,

--- a/tests/integration/rpc.dashboard.org-scope.test.ts
+++ b/tests/integration/rpc.dashboard.org-scope.test.ts
@@ -18,7 +18,7 @@ afterAll(async () => {
 });
 
 describe("get_dashboard_data org scoping (live RPC)", () => {
-  it("returns only data for requested org", async () => {
+  it("keeps direct authenticated get_dashboard_data denied", async () => {
     if (!harness.enabled) {
       if (harness.required) {
         throw new Error(harness.skipReason);
@@ -27,9 +27,22 @@ describe("get_dashboard_data org scoping (live RPC)", () => {
     }
 
     const orgAClient = await harness.signInAdminA();
-    const orgBClient = await harness.signInAdminB();
-    const orgAResult = await orgAClient.rpc("get_dashboard_data");
-    const orgBResult = await orgBClient.rpc("get_dashboard_data");
+    const result = await orgAClient.rpc("get_dashboard_data");
+
+    expect(result.data).toBeNull();
+    expect(result.error?.code).toBe("42501");
+  });
+
+  it("trusted service RPC returns only data for the requested actor org", async () => {
+    if (!harness.enabled) {
+      if (harness.required) {
+        throw new Error(harness.skipReason);
+      }
+      return;
+    }
+
+    const orgAResult = await harness.callTrustedDashboardRpc(harness.orgAAdminUserId, harness.orgAId);
+    const orgBResult = await harness.callTrustedDashboardRpc(harness.orgBAdminUserId, harness.orgBId);
 
     expect(orgAResult.error).toBeNull();
     expect(orgBResult.error).toBeNull();
@@ -50,7 +63,7 @@ describe("get_dashboard_data org scoping (live RPC)", () => {
     expect(orgBBillingAlerts.map(alert => alert.id)).not.toContain(harness.orgA.billingRecordId);
   });
 
-  it("does not leak org-b data when querying org-a", async () => {
+  it("trusted service RPC denies an org-a admin querying org-b", async () => {
     if (!harness.enabled) {
       if (harness.required) {
         throw new Error(harness.skipReason);
@@ -58,12 +71,9 @@ describe("get_dashboard_data org scoping (live RPC)", () => {
       return;
     }
 
-    const orgAClient = await harness.signInAdminA();
-    const result = await orgAClient.rpc("get_dashboard_data");
+    const result = await harness.callTrustedDashboardRpc(harness.orgAAdminUserId, harness.orgBId);
 
-    expect(result.error).toBeNull();
-    const orgAIncompleteSessions = ((result.data as { incompleteSessions?: Array<{ id: string }> })?.incompleteSessions ?? []);
-    expect(orgAIncompleteSessions.map(session => session.id)).toContain(harness.orgA.sessionId);
-    expect(orgAIncompleteSessions.map(session => session.id)).not.toContain(harness.orgB.sessionId);
+    expect(result.data).toBeNull();
+    expect(result.error?.code).toBe("42501");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `public.get_dashboard_data_for_org(actor_user_id uuid, target_organization_id uuid)` as a service-role-only trusted dashboard RPC.
- Keeps direct browser/client `get_dashboard_data()` denied to `authenticated`.
- Updates `get-dashboard-data` Edge function to authenticate and resolve org with the request client, apply rate limiting, then call the trusted RPC via service role with explicit actor/org parameters.
- Adds focused contract/live-harness tests for grant isolation, generic `42501` mapping, rate-limit short-circuiting, and tenant scoping.

## Route-task
- Classification: `high-risk human-reviewed`
- Lane: `critical`
- Triggering paths: `supabase/migrations/**`, `supabase/functions/**`, RPC grants, tenant-scoped dashboard reads, runtime/env alignment recommendations.

## Verification
Passed:
- `npx vitest run src/server/__tests__/dashboardHandler.test.ts src/server/__tests__/dashboardParity.contract.test.ts tests/edge/dashboard.parity.contract.test.ts tests/edge/get-dashboard-data.rate-limit.contract.test.ts tests/edge/get-dashboard-data.todaysSessions.test.ts tests/integration/rpc.dashboard.org-scope.test.ts tests/edge/dashboardAuthorityMigration.contract.test.ts --config vitest.config.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:routes:tier0`

Blocked/failed locally:
- `npm run test:ci` failed in unrelated Schedule UI tests (`Schedule.dataLoadUx.test.tsx`, `Schedule.test.tsx`, `Schedule.sessionCloseReadiness.test.tsx`) while dashboard-focused tests pass. The failed Schedule tests passed when run in isolation.
- `npm run verify:local` failed at the same `test:ci` step.
- Live `RUN_DB_IT=1` service-role RPC validation was not run locally because it requires configured Supabase integration secrets.

## Deployment / Operator Notes
- Production env changes were not applied because repo policy forbids modifying secrets/deployment provider keys in this workflow.
- Proposed operator alignment remains:
  - Netlify Production `SUPABASE_URL=https://wnnjeqheqxxyrgsjmygy.supabase.co`
  - Netlify Production `DEFAULT_ORGANIZATION_ID=<active clinic uuid>`
  - Leave `SUPABASE_EDGE_URL` unset unless intentionally overriding to `https://wnnjeqheqxxyrgsjmygy.supabase.co/functions/v1`
  - Confirm Supabase Edge secret `DEFAULT_ORGANIZATION_ID` if super-admin fallback depends on it.

## Risk
Critical protected-path change. Requires human tenant/security review before merge and live migration/function validation after deployment.