### PR TITLE
Fix schedule drag eligibility and test readiness

### DIFF
--- a/src/components/__tests__/SchedulingBasic.test.tsx
+++ b/src/components/__tests__/SchedulingBasic.test.tsx
@@ -4,6 +4,13 @@ import { http, HttpResponse } from 'msw';
 import { server } from '../../test/setup';
 import { Schedule } from '../../pages/Schedule';
 
+const waitForScheduleGridReady = () =>
+  waitFor(() => {
+    const activeView = screen.queryByTestId('week-view') ?? screen.queryByTestId('day-view');
+    expect(activeView).toBeTruthy();
+    return activeView!;
+  }, { timeout: 10000 });
+
 // Test data that matches the expected API response format
 const mockScheduleData = {
   sessions: [
@@ -133,6 +140,7 @@ describe('Scheduling Basic Functionality', () => {
       },
       { timeout: 3000 }
     );
+    await waitForScheduleGridReady();
 
     // Note: Session display might depend on the current date/week view
     // This test verifies the component loads successfully with mock data
@@ -157,6 +165,7 @@ describe('Scheduling Basic Functionality', () => {
     await waitFor(() => {
       expect(screen.getByText('Schedule')).toBeInTheDocument();
     });
+    await waitForScheduleGridReady();
 
     // The Week button should be active by default (based on the component code)
     const weekButton = screen.getByText('Week');
@@ -188,13 +197,9 @@ describe('Scheduling Basic Functionality', () => {
 
     renderWithProviders(<Schedule />);
 
-    // Page should still render successfully
-    await waitFor(() => {
-      expect(screen.getByText('Schedule')).toBeInTheDocument();
-    });
-
+    expect(await screen.findByRole('heading', { name: 'Schedule' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Day view/i })).toBeInTheDocument();
-  });
+  }, 15000);
 
   it('should handle API errors gracefully', async () => {
     // Mock API errors

--- a/src/pages/ScheduleCalendarViewShared.tsx
+++ b/src/pages/ScheduleCalendarViewShared.tsx
@@ -4,7 +4,7 @@ import { format, parseISO } from 'date-fns';
 import { Clock, Edit2, Plus } from 'lucide-react';
 import type { Session } from '../types';
 import { createSessionSlotKey } from './schedule-utils';
-import { getSessionStatusClasses } from './ScheduleSessionStatusStyles';
+import { getSessionStatusClasses, isScheduleSessionDragEligible } from './ScheduleSessionStatusStyles';
 
 export type ScheduleTimeSlotHandler = (timeSlot: { date: Date; time: string }) => void;
 export type ScheduleEditSessionHandler = (session: Session) => void;
@@ -195,16 +195,19 @@ export const TimeSlot = React.memo(
         {enableSlotCreateChrome ? (
           <span
             aria-hidden="true"
-            className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 p-1 rounded-full text-gray-500 transition-opacity dark:text-gray-400"
+            className="pointer-events-none absolute top-1 right-1 opacity-0 group-hover:opacity-100 p-1 rounded-full text-gray-500 transition-opacity dark:text-gray-400"
           >
             <Plus className="w-4 h-4 text-gray-500 dark:text-gray-400" />
           </span>
         ) : null}
 
         {slotSessions.map((session) => {
+          const dragEligibleSession = isScheduleSessionDragEligible(session.status);
           const statusStyles = getSessionStatusClasses(session.status);
           const touchMovePickup =
-            !hasFinePointer && allowDragAndDrop && session.status === "scheduled";
+            !hasFinePointer && allowDragAndDrop && dragEligibleSession;
+          const canDragWithFinePointer =
+            allowDragAndDrop && hasFinePointer && dragEligibleSession;
 
           const onSessionPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
             if (!touchMovePickup) {
@@ -250,7 +253,7 @@ export const TimeSlot = React.memo(
               key={session.id}
               data-session-status={session.status}
               data-session-id={session.id}
-              draggable={allowDragAndDrop && session.status === "scheduled" && hasFinePointer}
+              draggable={canDragWithFinePointer}
               aria-grabbed={allowDragAndDrop && activeDragSessionId === session.id}
               title={
                 touchMovePickup
@@ -258,7 +261,7 @@ export const TimeSlot = React.memo(
                   : undefined
               }
               onDragStart={
-                allowDragAndDrop && session.status === "scheduled" && hasFinePointer
+                canDragWithFinePointer
                   ? (event) => {
                       event.stopPropagation();
                       event.dataTransfer.effectAllowed = "move";
@@ -268,14 +271,14 @@ export const TimeSlot = React.memo(
                   : undefined
               }
               onDragEnd={
-                allowDragAndDrop && hasFinePointer
+                canDragWithFinePointer
                   ? () => {
                       onEndSessionDrag?.();
                     }
                   : undefined
               }
               className={`${statusStyles.card} touch-manipulation rounded p-1 text-xs mb-1 group/session relative transition-colors ${
-                allowDragAndDrop && session.status === "scheduled"
+                allowDragAndDrop && dragEligibleSession
                   ? hasFinePointer
                     ? "cursor-grab active:cursor-grabbing"
                     : "cursor-pointer"
@@ -313,7 +316,7 @@ export const TimeSlot = React.memo(
 
               <span
                 aria-hidden="true"
-                className="absolute top-1 right-1 opacity-0 group-hover/session:opacity-100"
+                className="pointer-events-none absolute top-1 right-1 opacity-0 group-hover/session:opacity-100"
               >
                 <Edit2 className="w-3 h-3" />
               </span>

--- a/src/pages/ScheduleSessionStatusStyles.ts
+++ b/src/pages/ScheduleSessionStatusStyles.ts
@@ -1,5 +1,13 @@
 import type { Session } from '../types';
 
+const CANONICAL_SESSION_STATUSES = new Set<Session['status']>([
+  'scheduled',
+  'in_progress',
+  'completed',
+  'cancelled',
+  'no-show',
+]);
+
 const SESSION_STATUS_STYLES: Record<
   Session['status'],
   { card: string; secondary: string; time: string }
@@ -31,8 +39,23 @@ const SESSION_STATUS_STYLES: Record<
   },
 };
 
+export function normalizeScheduleSessionStatus(
+  status: Session['status'] | string | null | undefined,
+): Session['status'] {
+  const normalized = typeof status === 'string' ? status.trim().toLowerCase() : '';
+  return CANONICAL_SESSION_STATUSES.has(normalized as Session['status'])
+    ? (normalized as Session['status'])
+    : 'scheduled';
+}
+
+export function isScheduleSessionDragEligible(
+  status: Session['status'] | string | null | undefined,
+): boolean {
+  return typeof status === 'string' && status.trim().toLowerCase() === 'scheduled';
+}
+
 export function getSessionStatusClasses(
-  status: Session['status'],
+  status: Session['status'] | string | null | undefined,
 ): { card: string; secondary: string; time: string } {
-  return SESSION_STATUS_STYLES[status] ?? SESSION_STATUS_STYLES.scheduled;
+  return SESSION_STATUS_STYLES[normalizeScheduleSessionStatus(status)];
 }

--- a/src/pages/ScheduleWeekView.tsx
+++ b/src/pages/ScheduleWeekView.tsx
@@ -96,7 +96,10 @@ const ScheduleWeekViewComponent: React.FC<ScheduleWeekViewProps> = ({
   }, [allowDragAndDrop, clearDragState, onRescheduleSession, sessionsById]);
 
   return (
-    <div className="bg-white dark:bg-dark-lighter rounded-lg shadow overflow-x-auto">
+    <div
+      className="bg-white dark:bg-dark-lighter rounded-lg shadow overflow-x-auto"
+      data-testid="week-view"
+    >
       <div className="grid grid-cols-[72px_repeat(6,minmax(90px,1fr))] sm:grid-cols-7 border-b dark:border-gray-700 min-w-[620px] sm:min-w-[800px]">
         <div className="py-2 px-1.5 text-center text-sm font-medium text-gray-500 border-r dark:border-gray-700 dark:text-gray-400 sm:px-2">
           Time

--- a/src/pages/__tests__/Schedule.dataLoadUx.test.tsx
+++ b/src/pages/__tests__/Schedule.dataLoadUx.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderWithProviders, screen, userEvent } from "../../test/utils";
+import { renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
 
 const mockUseScheduleDataBatch = vi.fn(() => ({
   data: {
@@ -65,6 +65,13 @@ vi.mock("../../components/SessionModal", () => ({
 }));
 
 import { Schedule } from "../Schedule";
+
+const waitForScheduleGridReady = () =>
+  waitFor(() => {
+    const activeView = screen.queryByTestId("week-view") ?? screen.queryByTestId("day-view");
+    expect(activeView).toBeTruthy();
+    return activeView!;
+  }, { timeout: 10_000 });
 
 describe("Schedule data-load UX", () => {
   beforeEach(() => {
@@ -191,10 +198,11 @@ describe("Schedule data-load UX", () => {
 
     renderWithProviders(<Schedule />);
 
-    expect(await screen.findByText(/^Time$/)).toBeInTheDocument();
+    await waitForScheduleGridReady();
+    expect(screen.getByText(/^Time$/)).toBeInTheDocument();
     expect(screen.queryByTestId("schedule-empty-sessions")).not.toBeInTheDocument();
     expect(screen.queryByTestId("schedule-data-load-error")).not.toBeInTheDocument();
-  });
+  }, 15_000);
 
   it("shows an explicit empty state when there are no sessions and no therapists or clients (no schedule data)", async () => {
     mockUseScheduleDataBatch.mockReturnValue({
@@ -269,9 +277,10 @@ describe("Schedule data-load UX", () => {
 
     renderWithProviders(<Schedule />);
 
-    expect(await screen.findByText(/^Time$/)).toBeInTheDocument();
+    await waitForScheduleGridReady();
+    expect(screen.getByText(/^Time$/)).toBeInTheDocument();
     expect(screen.queryByTestId("schedule-empty-sessions")).not.toBeInTheDocument();
-  });
+  }, 15_000);
 
   it("uses generic copy when sessions query is in error but no error object is present", async () => {
     mockUseScheduleDataBatch.mockReturnValue({

--- a/src/pages/__tests__/Schedule.lazyModal.test.tsx
+++ b/src/pages/__tests__/Schedule.lazyModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
-import { renderWithProviders, screen } from "../../test/utils";
+import { renderWithProviders, screen, waitFor } from "../../test/utils";
 import userEvent from "@testing-library/user-event";
 
 const mockUseScheduleDataBatch = vi.fn();
@@ -37,6 +37,13 @@ vi.mock("../../components/SessionModal", () => {
 });
 
 import { Schedule } from "../Schedule";
+
+const waitForScheduleGridReady = () =>
+  waitFor(() => {
+    const activeView = screen.queryByTestId("week-view") ?? screen.queryByTestId("day-view");
+    expect(activeView).toBeTruthy();
+    return activeView!;
+  }, { timeout: 10_000 });
 
 const scheduleFixtures = {
   sessions: [
@@ -104,6 +111,7 @@ describe("Schedule lazy session modal", () => {
     renderWithProviders(<Schedule />);
 
     await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
     expect(sessionModalLoadCount).toBe(0);
 
     const addButtons = await screen.findAllByLabelText("Add session");
@@ -111,5 +119,5 @@ describe("Schedule lazy session modal", () => {
 
     expect(await screen.findByTestId("session-modal")).toHaveTextContent("Session modal for 08:00");
     expect(sessionModalLoadCount).toBe(1);
-  });
+  }, 15_000);
 });

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -183,6 +183,13 @@ vi.mock("../../components/SessionModal", () => ({
 
 import { Schedule } from "../Schedule";
 
+const waitForScheduleGridReady = () =>
+  waitFor(() => {
+    const activeView = screen.queryByTestId("week-view") ?? screen.queryByTestId("day-view");
+    expect(activeView).toBeTruthy();
+    return activeView!;
+  }, { timeout: 10_000 });
+
 describe("Schedule orchestration integration hardening", () => {
   const resetScheduleFixtureWindow = () => {
     scheduleFixtures.sessions[0].start_time = originalSessionWindow.start_time;
@@ -235,6 +242,7 @@ describe("Schedule orchestration integration hardening", () => {
 
     renderWithProviders(<Schedule />);
     await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
     await screen.findByTestId("session-modal");
     expect(localStorage.getItem("pendingSchedule")).toBeNull();
 
@@ -267,7 +275,7 @@ describe("Schedule orchestration integration hardening", () => {
       requestId: undefined,
       correlationId: undefined,
     });
-  });
+  }, 15_000);
 
   it("create 409 keeps modal open and sets retry hint distinct from non-409", async () => {
     bookSessionViaApiMock.mockRejectedValueOnce({
@@ -281,6 +289,7 @@ describe("Schedule orchestration integration hardening", () => {
 
     renderWithProviders(<Schedule />);
     await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
 
     fireEvent.click(screen.getAllByLabelText("Add session")[0]);
     await screen.findByTestId("session-modal");
@@ -288,8 +297,8 @@ describe("Schedule orchestration integration hardening", () => {
 
     await waitFor(() => {
       expect(showErrorMock).toHaveBeenCalled();
+      expect(screen.getByTestId("retry-hint")).toHaveTextContent("conflict-hint");
     });
-    expect(screen.getByTestId("retry-hint")).toHaveTextContent("conflict-hint");
     expect(screen.getByTestId("session-modal")).toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText("submit-create"));
@@ -299,11 +308,12 @@ describe("Schedule orchestration integration hardening", () => {
     });
     expect(screen.getByTestId("retry-hint")).toHaveTextContent("");
     expect(screen.getByTestId("session-modal")).toBeInTheDocument();
-  });
+  }, 15_000);
 
   it("manual edit cancel path stays distinct and closes modal", async () => {
     renderWithProviders(<Schedule />);
     await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
 
     await openExistingSessionForEdit();
     await screen.findByTestId("session-modal");

--- a/src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx
+++ b/src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx
@@ -165,7 +165,14 @@ vi.mock("../../lib/toast", async () => {
   };
 });
 
-describe("Schedule session-close readiness precheck", { timeout: 15_000 }, () => {
+const waitForScheduleGridReady = () =>
+  waitFor(() => {
+    const activeView = screen.queryByTestId("week-view") ?? screen.queryByTestId("day-view");
+    expect(activeView).toBeTruthy();
+    return activeView!;
+  }, { timeout: 10_000 });
+
+describe("Schedule session-close readiness precheck", { timeout: 30_000 }, () => {
   beforeEach(() => {
     sessionStatus = "in_progress";
     completeSessionFromModalMock.mockReset();
@@ -189,6 +196,7 @@ describe("Schedule session-close readiness precheck", { timeout: 15_000 }, () =>
 
     renderWithProviders(<Schedule />);
 
+    await waitForScheduleGridReady();
     fireEvent.click(await screen.findByText("Jamie Client"));
     fireEvent.click(await screen.findByRole("button", { name: "Submit terminal" }));
 
@@ -218,6 +226,7 @@ describe("Schedule session-close readiness precheck", { timeout: 15_000 }, () =>
 
     renderWithProviders(<Schedule />);
 
+    await waitForScheduleGridReady();
     fireEvent.click(await screen.findByText("Jamie Client"));
     fireEvent.click(await screen.findByRole("button", { name: "Submit terminal" }));
 
@@ -233,6 +242,7 @@ describe("Schedule session-close readiness precheck", { timeout: 15_000 }, () =>
   it("proceeds with completion when readiness passes", async () => {
     renderWithProviders(<Schedule />);
 
+    await waitForScheduleGridReady();
     fireEvent.click(await screen.findByText("Jamie Client"));
     fireEvent.click(await screen.findByRole("button", { name: "Submit terminal" }));
 
@@ -251,6 +261,7 @@ describe("Schedule session-close readiness precheck", { timeout: 15_000 }, () =>
 
     renderWithProviders(<Schedule />);
 
+    await waitForScheduleGridReady();
     fireEvent.click(await screen.findByText("Jamie Client"));
     fireEvent.click(await screen.findByRole("button", { name: "Submit terminal" }));
 

--- a/src/pages/__tests__/Schedule.statusStyles.test.ts
+++ b/src/pages/__tests__/Schedule.statusStyles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getSessionStatusClasses } from "../ScheduleSessionStatusStyles";
+import { getSessionStatusClasses, normalizeScheduleSessionStatus } from "../ScheduleSessionStatusStyles";
 
 describe("getSessionStatusClasses", () => {
   it("returns distinct card classes for all five statuses", () => {
@@ -30,5 +30,10 @@ describe("getSessionStatusClasses", () => {
     // @ts-expect-error intentional unknown status for fallback coverage
     const result = getSessionStatusClasses("unknown_status");
     expect(result).toEqual(getSessionStatusClasses("scheduled"));
+  });
+
+  it("normalizes casing and whitespace before applying schedule behavior", () => {
+    expect(normalizeScheduleSessionStatus(" Scheduled ")).toBe("scheduled");
+    expect(normalizeScheduleSessionStatus("IN_PROGRESS")).toBe("in_progress");
   });
 });

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -145,6 +145,13 @@ import { Schedule } from "../Schedule";
 
 const defaultRpcImplementation = vi.mocked(supabase.rpc as any).getMockImplementation();
 
+const waitForScheduleGridReady = () =>
+  waitFor(() => {
+    const activeView = screen.queryByTestId("week-view") ?? screen.queryByTestId("day-view");
+    expect(activeView).toBeTruthy();
+    return activeView!;
+  }, { timeout: 10_000 });
+
 describe("Schedule", () => {
   beforeEach(() => {
     sessionModalModuleLoads = 0;
@@ -260,6 +267,7 @@ describe("Schedule", () => {
     renderWithProviders(<Schedule />);
 
     await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
     expect(sessionModalModuleLoads).toBe(0);
 
     const addButtons = await screen.findAllByLabelText("Add session");
@@ -269,12 +277,13 @@ describe("Schedule", () => {
       expect(sessionModalModuleLoads).toBe(1);
     });
     expect(await screen.findByTestId("session-modal-sessions")).toHaveTextContent("session-1");
-  });
+  }, 15_000);
 
   it("prefetches the next schedule batch when the next-period control is hovered", async () => {
     renderWithProviders(<Schedule />);
 
     await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
 
     fireEvent.mouseEnter(screen.getByRole("button", { name: /Next period/i }));
 
@@ -292,14 +301,15 @@ describe("Schedule", () => {
     expect((targetStart as Date).toISOString()).toBe(expectedStart.toISOString());
     expect((targetEnd as Date).toISOString()).toBe(expectedEnd.toISOString());
     expect(options).toEqual({ organizationId: "org-1" });
-  });
+  }, 15_000);
 
   it("applies therapist filters to batched sessions", async () => {
     renderWithProviders(<Schedule />);
 
+    await waitForScheduleGridReady();
     const addButtons = await screen.findAllByLabelText("Add session");
     fireEvent.click(addButtons[0]);
-    expect(screen.getByTestId("session-modal-sessions")).toHaveTextContent("session-1");
+    expect(await screen.findByTestId("session-modal-sessions")).toHaveTextContent("session-1");
     expect(screen.getByTestId("session-modal-sessions")).toHaveTextContent("session-2");
 
     await userEvent.selectOptions(screen.getByLabelText("Therapist"), "therapist-2");
@@ -308,7 +318,7 @@ describe("Schedule", () => {
       expect(screen.getByTestId("session-modal-sessions")).not.toHaveTextContent("session-1");
       expect(screen.getByTestId("session-modal-sessions")).toHaveTextContent("session-2");
     });
-  });
+  }, 15_000);
 
   it("locks therapist scope and limits clients for therapist users", async () => {
     mockUseDropdownData.mockReturnValue({

--- a/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
@@ -5,7 +5,7 @@ import type { Session } from "../../types";
 import { createSessionSlotKey } from "../schedule-utils";
 import { ScheduleDayView } from "../ScheduleDayView";
 
-const buildSession = (startDate: Date): Session => ({
+const buildSession = (startDate: Date, overrides: Partial<Session> = {}): Session => ({
   id: "session-1",
   client_id: "client-1",
   therapist_id: "therapist-1",
@@ -21,6 +21,7 @@ const buildSession = (startDate: Date): Session => ({
   updated_by: "user-1",
   client: { id: "client-1", full_name: "Jamie Client" },
   therapist: { id: "therapist-1", full_name: "Dr. Myles" },
+  ...overrides,
 });
 
 const dragData = {
@@ -89,6 +90,57 @@ describe("ScheduleDayView drag and drop", () => {
     expect(onRescheduleSession).toHaveBeenCalledTimes(1);
     expect(onRescheduleSession).toHaveBeenCalledWith(
       expect.objectContaining({ id: "session-1" }),
+      expect.objectContaining({
+        time: targetTime,
+        date: expect.any(Date),
+      }),
+    );
+  });
+
+  it("allows dragging a visible session when scheduled status casing drifts", () => {
+    const selectedDate = new Date("2025-07-07T00:00:00.000Z");
+    const sourceTime = "10:00";
+    const targetTime = "10:15";
+    const sessionStart = new Date(selectedDate);
+    sessionStart.setHours(10, 0, 0, 0);
+    const session = buildSession(sessionStart, {
+      id: "session-2",
+      // @ts-expect-error regression coverage for non-canonical runtime values
+      status: " Scheduled ",
+      client: { id: "client-2", full_name: "Jorge Eduardo" },
+    });
+    const onRescheduleSession = vi.fn();
+    const sourceKey = createSessionSlotKey(format(sessionStart, "yyyy-MM-dd"), format(sessionStart, "HH:mm"));
+    const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+    const { container } = render(
+      <ScheduleDayView
+        selectedDate={selectedDate}
+        timeSlots={[sourceTime, targetTime]}
+        sessionSlotIndex={sessionSlotIndex}
+        onCreateSession={vi.fn()}
+        onEditSession={vi.fn()}
+        onRescheduleSession={onRescheduleSession}
+        allowDragAndDrop
+      />,
+    );
+
+    const card = container.querySelector('[data-session-id="session-2"]') as HTMLElement;
+    const targetSlot = Array.from(container.querySelectorAll("[data-slot-key]")).find((slot) => {
+      const slotKey = slot.getAttribute("data-slot-key");
+      return typeof slotKey === "string" && slotKey.endsWith(`|${targetTime}`);
+    });
+    expect(card.getAttribute("draggable")).toBe("true");
+    expect(targetSlot).toBeTruthy();
+
+    fireEvent.dragStart(card, { dataTransfer: dragData });
+    fireEvent.dragEnter(targetSlot as HTMLElement, { dataTransfer: dragData });
+    fireEvent.dragOver(targetSlot as HTMLElement, { dataTransfer: dragData });
+    fireEvent.drop(targetSlot as HTMLElement, { dataTransfer: dragData });
+
+    expect(onRescheduleSession).toHaveBeenCalledTimes(1);
+    expect(onRescheduleSession).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "session-2", status: " Scheduled " }),
       expect.objectContaining({
         time: targetTime,
         date: expect.any(Date),

--- a/src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
@@ -5,7 +5,7 @@ import type { Session } from "../../types";
 import { createSessionSlotKey } from "../schedule-utils";
 import { ScheduleWeekView } from "../ScheduleWeekView";
 
-const buildSession = (startDate: Date): Session => ({
+const buildSession = (startDate: Date, overrides: Partial<Session> = {}): Session => ({
   id: "session-1",
   client_id: "client-1",
   therapist_id: "therapist-1",
@@ -21,6 +21,7 @@ const buildSession = (startDate: Date): Session => ({
   updated_by: "user-1",
   client: { id: "client-1", full_name: "Jamie Client" },
   therapist: { id: "therapist-1", full_name: "Dr. Myles" },
+  ...overrides,
 });
 
 const dragData = {
@@ -170,6 +171,59 @@ describe("ScheduleWeekView drag and drop", () => {
     expect(onRescheduleSession).toHaveBeenCalledTimes(1);
     expect(onRescheduleSession).toHaveBeenCalledWith(
       expect.objectContaining({ id: "session-1" }),
+      expect.objectContaining({
+        time: targetTime,
+        date: expect.any(Date),
+      }),
+    );
+  });
+
+  it("allows dragging a visible session when scheduled status casing drifts", () => {
+    const sourceDay = new Date("2025-07-07T00:00:00.000Z");
+    const targetDay = new Date("2025-07-08T00:00:00.000Z");
+    const sourceTime = "10:00";
+    const targetTime = "10:15";
+    const sourceStart = new Date(sourceDay);
+    sourceStart.setHours(10, 0, 0, 0);
+    const session = buildSession(sourceStart, {
+      id: "session-2",
+      // @ts-expect-error regression coverage for non-canonical runtime values
+      status: "SCHEDULED",
+      client: { id: "client-2", full_name: "Calvin Tran" },
+    });
+    const onRescheduleSession = vi.fn();
+    const sourceKey = createSessionSlotKey(format(sourceStart, "yyyy-MM-dd"), format(sourceStart, "HH:mm"));
+    const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+    const { container } = render(
+      <ScheduleWeekView
+        weekDays={[sourceDay, targetDay]}
+        timeSlots={[sourceTime, targetTime]}
+        sessionSlotIndex={sessionSlotIndex}
+        onCreateSession={vi.fn()}
+        onEditSession={vi.fn()}
+        onRescheduleSession={onRescheduleSession}
+        allowDragAndDrop
+      />,
+    );
+
+    const card = container.querySelector('[data-session-id="session-2"]') as HTMLElement;
+    const targetSlot = Array.from(container.querySelectorAll("[data-slot-key]")).find((slot) => {
+      const slotKey = slot.getAttribute("data-slot-key");
+      return typeof slotKey === "string" && slotKey !== sourceKey && slotKey.endsWith(`|${targetTime}`);
+    });
+
+    expect(card.getAttribute("draggable")).toBe("true");
+    expect(targetSlot).toBeTruthy();
+
+    fireEvent.dragStart(card, { dataTransfer: dragData });
+    fireEvent.dragEnter(targetSlot as HTMLElement, { dataTransfer: dragData });
+    fireEvent.dragOver(targetSlot as HTMLElement, { dataTransfer: dragData });
+    fireEvent.drop(targetSlot as HTMLElement, { dataTransfer: dragData });
+
+    expect(onRescheduleSession).toHaveBeenCalledTimes(1);
+    expect(onRescheduleSession).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "session-2", status: "SCHEDULED" }),
       expect.objectContaining({
         time: targetTime,
         date: expect.any(Date),


### PR DESCRIPTION
## Summary
- normalize schedule drag eligibility so admin/super-admin drag/drop treats scheduled status casing/whitespace consistently
- add a stable schedule view readiness hook for lazy-loaded calendar tests and harden affected schedule specs under coverage
- keep the fix inside schedule UI and schedule-related tests only

## Root cause
Some appointment cards rendered with scheduled styling but failed the drag gate because drag eligibility compared `session.status` to the exact string `"scheduled"`. Separately, multiple schedule tests used brittle readiness signals that raced the lazy-loaded calendar view under `test:ci`/coverage.

## Verification
- `npx vitest run src/pages/__tests__/Schedule.test.tsx src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx src/pages/__tests__/Schedule.dataLoadUx.test.tsx src/pages/__tests__/Schedule.lazyModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx src/components/__tests__/SchedulingBasic.test.tsx`
- `npx vitest run src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx src/pages/__tests__/Schedule.statusStyles.test.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run ci:verify-coverage`
- `npm run build`
- `npm run test:routes:tier0`

## Remaining blocker
- `npm run verify:local` is still blocked by an unrelated timeout in `tests/runtime-migration-parity.test.ts > collects added migration versions from a git merge range` during the repo-wide run. This PR does not widen into that non-schedule test.
