### PR TITLE
Harden schedule drag and drop

### DIFF
--- a/src/pages/ScheduleCalendarViewShared.tsx
+++ b/src/pages/ScheduleCalendarViewShared.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import React, { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import { format, parseISO } from 'date-fns';
 import { Clock, Edit2, Plus } from 'lucide-react';
 import type { Session } from '../types';
@@ -134,6 +134,12 @@ export const TimeSlot = React.memo(
 
     const slotHasDropTarget = allowDragAndDrop && activeDropSlotKey === slotKey && activeDragSessionId !== null;
 
+    useEffect(() => {
+      if (activeDragSessionId === null) {
+        suppressSessionClickRef.current = false;
+      }
+    }, [activeDragSessionId]);
+
     return (
       <div
         className={`h-10 border-b border-r p-2 relative group dark:border-gray-700 transition-colors ${
@@ -244,8 +250,12 @@ export const TimeSlot = React.memo(
             }
           };
 
-          const endLongPressTracking = () => {
+          const endLongPressTracking = (cancelActiveDrag = false) => {
             clearLongPressTimer();
+            if (cancelActiveDrag && activeDragSessionId === session.id) {
+              suppressSessionClickRef.current = false;
+              onEndSessionDrag?.();
+            }
           };
 
           return (
@@ -288,14 +298,20 @@ export const TimeSlot = React.memo(
               tabIndex={0}
               onPointerDown={touchMovePickup ? onSessionPointerDown : undefined}
               onPointerMove={touchMovePickup ? onSessionPointerMove : undefined}
-              onPointerUp={touchMovePickup ? endLongPressTracking : undefined}
-              onPointerCancel={touchMovePickup ? endLongPressTracking : undefined}
-              onPointerLeave={touchMovePickup ? endLongPressTracking : undefined}
+              onPointerUp={touchMovePickup ? () => endLongPressTracking() : undefined}
+              onPointerCancel={touchMovePickup ? () => endLongPressTracking(true) : undefined}
+              onPointerLeave={touchMovePickup ? () => endLongPressTracking() : undefined}
               onClick={(event) => {
                 if (suppressSessionClickRef.current) {
                   event.preventDefault();
                   event.stopPropagation();
                   suppressSessionClickRef.current = false;
+                  return;
+                }
+                if (allowDragAndDrop && activeDragSessionId === session.id) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onEndSessionDrag?.();
                   return;
                 }
                 handleSessionClick(event, session);

--- a/src/pages/__tests__/Schedule.reschedule.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.reschedule.integration.test.tsx
@@ -12,6 +12,7 @@ const showSuccessMock = vi.fn();
 let latestRescheduleHandler:
   | ((session: Session, target: { date: Date; time: string }) => void)
   | null = null;
+let latestAllowDragAndDrop: boolean | undefined;
 
 type ScheduleStore = {
   sessions: Session[];
@@ -80,13 +81,16 @@ vi.mock("../ScheduleWeekView", () => ({
     timeSlots,
     sessionSlotIndex,
     onRescheduleSession,
+    allowDragAndDrop,
   }: {
     weekDays: Date[];
     timeSlots: string[];
     sessionSlotIndex: Map<string, Session[]>;
     onRescheduleSession?: (session: Session, target: { date: Date; time: string }) => void;
+    allowDragAndDrop?: boolean;
   }) => {
     latestRescheduleHandler = onRescheduleSession ?? null;
+    latestAllowDragAndDrop = allowDragAndDrop;
     const allSessions = Array.from(sessionSlotIndex.values()).flat();
     const sessionToMove = allSessions[0] ?? null;
     const targetDate = sessionToMove ? new Date(sessionToMove.start_time) : weekDays[0];
@@ -180,6 +184,7 @@ describe("Schedule reschedule integration", () => {
     vi.clearAllMocks();
     scheduleStore = buildScheduleStore();
     latestRescheduleHandler = null;
+    latestAllowDragAndDrop = undefined;
   });
 
   afterEach(() => {
@@ -226,6 +231,14 @@ describe("Schedule reschedule integration", () => {
     await waitFor(() => {
       expect(bookSessionViaApiMock).toHaveBeenCalledTimes(1);
     });
+    expect(bookSessionViaApiMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        id: "session-1",
+        start_time: movedStart.toISOString(),
+        end_time: movedEnd.toISOString(),
+        overrides: undefined,
+      }),
+    );
 
     await waitFor(() => {
       expect(getSlotSessionIds(container, sourceSlotKey)).toEqual([]);
@@ -269,5 +282,21 @@ describe("Schedule reschedule integration", () => {
     });
 
     expect(showErrorMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["admin", "admin", true],
+    ["super admin", "super_admin", true],
+    ["therapist", "therapist", false],
+  ] as const)("wires schedule drag/drop availability for %s users", async (_label, role, expectedAllowDragAndDrop) => {
+    renderWithProviders(<Schedule />, {
+      auth: { role },
+    });
+
+    await screen.findByRole("heading", { name: /Schedule/i });
+
+    await waitFor(() => {
+      expect(latestAllowDragAndDrop).toBe(expectedAllowDragAndDrop);
+    });
   });
 });

--- a/src/pages/__tests__/Schedule.statusStyles.test.ts
+++ b/src/pages/__tests__/Schedule.statusStyles.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { getSessionStatusClasses, normalizeScheduleSessionStatus } from "../ScheduleSessionStatusStyles";
+import {
+  getSessionStatusClasses,
+  isScheduleSessionDragEligible,
+  normalizeScheduleSessionStatus,
+} from "../ScheduleSessionStatusStyles";
 
 describe("getSessionStatusClasses", () => {
   it("returns distinct card classes for all five statuses", () => {
@@ -35,5 +39,16 @@ describe("getSessionStatusClasses", () => {
   it("normalizes casing and whitespace before applying schedule behavior", () => {
     expect(normalizeScheduleSessionStatus(" Scheduled ")).toBe("scheduled");
     expect(normalizeScheduleSessionStatus("IN_PROGRESS")).toBe("in_progress");
+  });
+
+  it("keeps drag eligibility narrower than fallback styling", () => {
+    expect(isScheduleSessionDragEligible(" Scheduled ")).toBe(true);
+    expect(isScheduleSessionDragEligible("SCHEDULED")).toBe(true);
+    expect(isScheduleSessionDragEligible("in_progress")).toBe(false);
+    expect(isScheduleSessionDragEligible("completed")).toBe(false);
+    expect(isScheduleSessionDragEligible("cancelled")).toBe(false);
+    expect(isScheduleSessionDragEligible("no-show")).toBe(false);
+    expect(isScheduleSessionDragEligible("unknown_status")).toBe(false);
+    expect(isScheduleSessionDragEligible(null)).toBe(false);
   });
 });

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -155,6 +155,17 @@ const waitForScheduleGridReady = () =>
 describe("Schedule", () => {
   beforeEach(() => {
     sessionModalModuleLoads = 0;
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(any-pointer: fine)",
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
     mockUseActiveOrganizationId.mockReturnValue("org-1");
     mockPrefetchScheduleRange.mockReset();
     mockUseScheduleDataBatch.mockReset();

--- a/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
@@ -148,6 +148,82 @@ describe("ScheduleDayView drag and drop", () => {
     );
   });
 
+  it("keeps canonical non-scheduled statuses non-draggable", () => {
+    const selectedDate = new Date("2025-07-07T00:00:00.000Z");
+    const sourceTime = "10:00";
+    const targetTime = "10:15";
+    const sessionStart = new Date(selectedDate);
+    sessionStart.setHours(10, 0, 0, 0);
+    const session = buildSession(sessionStart, {
+      id: "session-completed",
+      status: "completed",
+      client: { id: "client-3", full_name: "Completed Client" },
+    });
+    const onRescheduleSession = vi.fn();
+    const sourceKey = createSessionSlotKey(format(sessionStart, "yyyy-MM-dd"), format(sessionStart, "HH:mm"));
+    const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+    const { container } = render(
+      <ScheduleDayView
+        selectedDate={selectedDate}
+        timeSlots={[sourceTime, targetTime]}
+        sessionSlotIndex={sessionSlotIndex}
+        onCreateSession={vi.fn()}
+        onEditSession={vi.fn()}
+        onRescheduleSession={onRescheduleSession}
+        allowDragAndDrop
+      />,
+    );
+
+    const card = container.querySelector('[data-session-id="session-completed"]') as HTMLElement;
+    const targetSlot = Array.from(container.querySelectorAll("[data-slot-key]")).find((slot) => {
+      const slotKey = slot.getAttribute("data-slot-key");
+      return typeof slotKey === "string" && slotKey.endsWith(`|${targetTime}`);
+    });
+    expect(card.getAttribute("draggable")).toBe("false");
+    expect(targetSlot).toBeTruthy();
+
+    fireEvent.dragStart(card, { dataTransfer: dragData });
+    fireEvent.dragOver(targetSlot as HTMLElement, { dataTransfer: dragData });
+    fireEvent.drop(targetSlot as HTMLElement, { dataTransfer: dragData });
+
+    expect(onRescheduleSession).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke onRescheduleSession when dropped on the same day slot", () => {
+    const selectedDate = new Date("2025-07-07T00:00:00.000Z");
+    const sourceTime = "10:00";
+    const sessionStart = new Date(selectedDate);
+    sessionStart.setHours(10, 0, 0, 0);
+    const session = buildSession(sessionStart);
+    const onRescheduleSession = vi.fn();
+    const sourceKey = createSessionSlotKey(format(sessionStart, "yyyy-MM-dd"), format(sessionStart, "HH:mm"));
+    const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+    const { container } = render(
+      <ScheduleDayView
+        selectedDate={selectedDate}
+        timeSlots={[sourceTime]}
+        sessionSlotIndex={sessionSlotIndex}
+        onCreateSession={vi.fn()}
+        onEditSession={vi.fn()}
+        onRescheduleSession={onRescheduleSession}
+        allowDragAndDrop
+      />,
+    );
+
+    const card = container.querySelector('[data-session-id="session-1"]');
+    const sourceSlot = container.querySelector(`[data-slot-key="${sourceKey}"]`);
+    expect(card).toBeTruthy();
+    expect(sourceSlot).toBeTruthy();
+
+    fireEvent.dragStart(card as HTMLElement, { dataTransfer: dragData });
+    fireEvent.dragOver(sourceSlot as HTMLElement, { dataTransfer: dragData });
+    fireEvent.drop(sourceSlot as HTMLElement, { dataTransfer: dragData });
+
+    expect(onRescheduleSession).not.toHaveBeenCalled();
+  });
+
   describe("coarse pointer (touch) move path", () => {
     beforeEach(() => {
       vi.useFakeTimers();
@@ -199,6 +275,237 @@ describe("ScheduleDayView drag and drop", () => {
 
       expect(onEditSession).toHaveBeenCalledTimes(1);
       expect(onEditSession).toHaveBeenCalledWith(expect.objectContaining({ id: "session-1" }));
+    });
+
+    it("long-press moves a scheduled status variant to a tapped slot", () => {
+      const selectedDate = new Date("2025-07-07T00:00:00.000Z");
+      const sourceTime = "10:00";
+      const targetTime = "10:15";
+      const sessionStart = new Date(selectedDate);
+      sessionStart.setHours(10, 0, 0, 0);
+      const session = buildSession(sessionStart, {
+        id: "session-touch",
+        // @ts-expect-error regression coverage for non-canonical runtime values
+        status: " Scheduled ",
+      });
+      const onEditSession = vi.fn();
+      const onRescheduleSession = vi.fn();
+      const sourceKey = createSessionSlotKey(format(sessionStart, "yyyy-MM-dd"), format(sessionStart, "HH:mm"));
+      const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+      const { container } = render(
+        <ScheduleDayView
+          selectedDate={selectedDate}
+          timeSlots={[sourceTime, targetTime]}
+          sessionSlotIndex={sessionSlotIndex}
+          onCreateSession={vi.fn()}
+          onEditSession={onEditSession}
+          onRescheduleSession={onRescheduleSession}
+          allowDragAndDrop
+          allowCreateInEmptySlot={false}
+        />,
+      );
+
+      const card = container.querySelector('[data-session-id="session-touch"]') as HTMLElement;
+      const targetSlot = Array.from(container.querySelectorAll("[data-slot-key]")).find((slot) => {
+        const slotKey = slot.getAttribute("data-slot-key");
+        return typeof slotKey === "string" && slotKey.endsWith(`|${targetTime}`);
+      }) as HTMLElement | undefined;
+      expect(targetSlot).toBeTruthy();
+      expect(card.getAttribute("draggable")).toBe("false");
+
+      fireEvent.pointerDown(card, { button: 0, clientX: 10, clientY: 10, pointerId: 1 });
+      act(() => {
+        vi.advanceTimersByTime(480);
+      });
+      fireEvent.click(targetSlot!);
+
+      expect(onRescheduleSession).toHaveBeenCalledTimes(1);
+      expect(onRescheduleSession).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "session-touch", status: " Scheduled " }),
+        expect.objectContaining({
+          time: targetTime,
+          date: expect.any(Date),
+        }),
+      );
+
+      fireEvent.click(card);
+
+      expect(onEditSession).toHaveBeenCalledWith(expect.objectContaining({ id: "session-touch" }));
+    });
+
+    it("lets a second tap on the picked-up card cancel coarse-pointer move mode", () => {
+      const selectedDate = new Date("2025-07-07T00:00:00.000Z");
+      const sourceTime = "10:00";
+      const targetTime = "10:15";
+      const sessionStart = new Date(selectedDate);
+      sessionStart.setHours(10, 0, 0, 0);
+      const session = buildSession(sessionStart);
+      const onEditSession = vi.fn();
+      const onRescheduleSession = vi.fn();
+      const sourceKey = createSessionSlotKey(format(sessionStart, "yyyy-MM-dd"), format(sessionStart, "HH:mm"));
+      const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+      const { container } = render(
+        <ScheduleDayView
+          selectedDate={selectedDate}
+          timeSlots={[sourceTime, targetTime]}
+          sessionSlotIndex={sessionSlotIndex}
+          onCreateSession={vi.fn()}
+          onEditSession={onEditSession}
+          onRescheduleSession={onRescheduleSession}
+          allowDragAndDrop
+          allowCreateInEmptySlot={false}
+        />,
+      );
+
+      const card = container.querySelector('[data-session-id="session-1"]') as HTMLElement;
+      const targetSlot = Array.from(container.querySelectorAll("[data-slot-key]")).find((slot) => {
+        const slotKey = slot.getAttribute("data-slot-key");
+        return typeof slotKey === "string" && slotKey.endsWith(`|${targetTime}`);
+      }) as HTMLElement | undefined;
+      expect(targetSlot).toBeTruthy();
+
+      fireEvent.pointerDown(card, { button: 0, clientX: 10, clientY: 10, pointerId: 1 });
+      act(() => {
+        vi.advanceTimersByTime(480);
+      });
+      fireEvent.pointerUp(card, { button: 0, pointerId: 1 });
+      fireEvent.click(card);
+      fireEvent.click(card);
+      fireEvent.click(targetSlot!);
+
+      expect(onEditSession).not.toHaveBeenCalled();
+      expect(onRescheduleSession).not.toHaveBeenCalled();
+    });
+
+    it("clears coarse-pointer move mode on pointer cancel after pickup", () => {
+      const selectedDate = new Date("2025-07-07T00:00:00.000Z");
+      const sourceTime = "10:00";
+      const targetTime = "10:15";
+      const sessionStart = new Date(selectedDate);
+      sessionStart.setHours(10, 0, 0, 0);
+      const session = buildSession(sessionStart);
+      const onRescheduleSession = vi.fn();
+      const sourceKey = createSessionSlotKey(format(sessionStart, "yyyy-MM-dd"), format(sessionStart, "HH:mm"));
+      const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+      const { container } = render(
+        <ScheduleDayView
+          selectedDate={selectedDate}
+          timeSlots={[sourceTime, targetTime]}
+          sessionSlotIndex={sessionSlotIndex}
+          onCreateSession={vi.fn()}
+          onEditSession={vi.fn()}
+          onRescheduleSession={onRescheduleSession}
+          allowDragAndDrop
+          allowCreateInEmptySlot={false}
+        />,
+      );
+
+      const card = container.querySelector('[data-session-id="session-1"]') as HTMLElement;
+      const targetSlot = Array.from(container.querySelectorAll("[data-slot-key]")).find((slot) => {
+        const slotKey = slot.getAttribute("data-slot-key");
+        return typeof slotKey === "string" && slotKey.endsWith(`|${targetTime}`);
+      }) as HTMLElement | undefined;
+      expect(targetSlot).toBeTruthy();
+
+      fireEvent.pointerDown(card, { button: 0, clientX: 10, clientY: 10, pointerId: 1 });
+      act(() => {
+        vi.advanceTimersByTime(480);
+      });
+      fireEvent.pointerCancel(card, { pointerId: 1 });
+      fireEvent.click(targetSlot!);
+
+      expect(onRescheduleSession).not.toHaveBeenCalled();
+    });
+
+    it("does not pick up non-scheduled sessions on long-press", () => {
+      const selectedDate = new Date("2025-07-07T00:00:00.000Z");
+      const sourceTime = "10:00";
+      const targetTime = "10:15";
+      const sessionStart = new Date(selectedDate);
+      sessionStart.setHours(10, 0, 0, 0);
+      const session = buildSession(sessionStart, {
+        id: "session-cancelled",
+        status: "cancelled",
+      });
+      const onCreateSession = vi.fn();
+      const onRescheduleSession = vi.fn();
+      const sourceKey = createSessionSlotKey(format(sessionStart, "yyyy-MM-dd"), format(sessionStart, "HH:mm"));
+      const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+      const { container } = render(
+        <ScheduleDayView
+          selectedDate={selectedDate}
+          timeSlots={[sourceTime, targetTime]}
+          sessionSlotIndex={sessionSlotIndex}
+          onCreateSession={onCreateSession}
+          onEditSession={vi.fn()}
+          onRescheduleSession={onRescheduleSession}
+          allowDragAndDrop
+          allowCreateInEmptySlot={false}
+        />,
+      );
+
+      const card = container.querySelector('[data-session-id="session-cancelled"]') as HTMLElement;
+      const targetSlot = Array.from(container.querySelectorAll("[data-slot-key]")).find((slot) => {
+        const slotKey = slot.getAttribute("data-slot-key");
+        return typeof slotKey === "string" && slotKey.endsWith(`|${targetTime}`);
+      }) as HTMLElement | undefined;
+      expect(targetSlot).toBeTruthy();
+
+      fireEvent.pointerDown(card, { button: 0, clientX: 10, clientY: 10, pointerId: 1 });
+      act(() => {
+        vi.advanceTimersByTime(480);
+      });
+      fireEvent.click(targetSlot!);
+
+      expect(onRescheduleSession).not.toHaveBeenCalled();
+      expect(onCreateSession).not.toHaveBeenCalled();
+    });
+
+    it("cancels long-press pickup when the pointer moves before the threshold", () => {
+      const selectedDate = new Date("2025-07-07T00:00:00.000Z");
+      const sourceTime = "10:00";
+      const targetTime = "10:15";
+      const sessionStart = new Date(selectedDate);
+      sessionStart.setHours(10, 0, 0, 0);
+      const session = buildSession(sessionStart);
+      const onCreateSession = vi.fn();
+      const onRescheduleSession = vi.fn();
+      const sourceKey = createSessionSlotKey(format(sessionStart, "yyyy-MM-dd"), format(sessionStart, "HH:mm"));
+      const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [session]]]);
+
+      const { container } = render(
+        <ScheduleDayView
+          selectedDate={selectedDate}
+          timeSlots={[sourceTime, targetTime]}
+          sessionSlotIndex={sessionSlotIndex}
+          onCreateSession={onCreateSession}
+          onEditSession={vi.fn()}
+          onRescheduleSession={onRescheduleSession}
+          allowDragAndDrop
+          allowCreateInEmptySlot={false}
+        />,
+      );
+
+      const card = container.querySelector('[data-session-id="session-1"]') as HTMLElement;
+      const targetSlot = Array.from(container.querySelectorAll("[data-slot-key]")).find((slot) => {
+        const slotKey = slot.getAttribute("data-slot-key");
+        return typeof slotKey === "string" && slotKey.endsWith(`|${targetTime}`);
+      }) as HTMLElement | undefined;
+      expect(targetSlot).toBeTruthy();
+
+      fireEvent.pointerDown(card, { button: 0, clientX: 10, clientY: 10, pointerId: 1 });
+      fireEvent.pointerMove(card, { clientX: 25, clientY: 10, pointerId: 1 });
+      act(() => {
+        vi.advanceTimersByTime(480);
+      });
+      fireEvent.click(targetSlot!);
+
+      expect(onRescheduleSession).not.toHaveBeenCalled();
+      expect(onCreateSession).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
@@ -230,4 +230,64 @@ describe("ScheduleWeekView drag and drop", () => {
       }),
     );
   });
+
+  it("keeps overlapping non-scheduled sessions non-draggable without blocking scheduled siblings", () => {
+    const sourceDay = new Date("2025-07-07T00:00:00.000Z");
+    const targetDay = new Date("2025-07-08T00:00:00.000Z");
+    const sourceTime = "10:00";
+    const targetTime = "10:15";
+    const sourceStart = new Date(sourceDay);
+    sourceStart.setHours(10, 0, 0, 0);
+    const scheduledSession = buildSession(sourceStart, {
+      id: "session-scheduled",
+      client: { id: "client-1", full_name: "Jorge Thorpe" },
+    });
+    const completedSession = buildSession(sourceStart, {
+      id: "session-completed",
+      status: "completed",
+      client: { id: "client-2", full_name: "Calvin Tran" },
+    });
+    const onRescheduleSession = vi.fn();
+    const sourceKey = createSessionSlotKey(format(sourceStart, "yyyy-MM-dd"), format(sourceStart, "HH:mm"));
+    const sessionSlotIndex = new Map<string, Session[]>([[sourceKey, [scheduledSession, completedSession]]]);
+
+    const { container } = render(
+      <ScheduleWeekView
+        weekDays={[sourceDay, targetDay]}
+        timeSlots={[sourceTime, targetTime]}
+        sessionSlotIndex={sessionSlotIndex}
+        onCreateSession={vi.fn()}
+        onEditSession={vi.fn()}
+        onRescheduleSession={onRescheduleSession}
+        allowDragAndDrop
+      />,
+    );
+
+    const scheduledCard = container.querySelector('[data-session-id="session-scheduled"]') as HTMLElement;
+    const completedCard = container.querySelector('[data-session-id="session-completed"]') as HTMLElement;
+    const targetSlot = Array.from(container.querySelectorAll("[data-slot-key]")).find((slot) => {
+      const slotKey = slot.getAttribute("data-slot-key");
+      return typeof slotKey === "string" && slotKey !== sourceKey && slotKey.endsWith(`|${targetTime}`);
+    });
+
+    expect(scheduledCard.getAttribute("draggable")).toBe("true");
+    expect(completedCard.getAttribute("draggable")).toBe("false");
+    expect(targetSlot).toBeTruthy();
+
+    fireEvent.dragStart(completedCard, { dataTransfer: dragData });
+    fireEvent.dragOver(targetSlot as HTMLElement, { dataTransfer: dragData });
+    fireEvent.drop(targetSlot as HTMLElement, { dataTransfer: dragData });
+    expect(onRescheduleSession).not.toHaveBeenCalled();
+
+    dragData.getData.mockReturnValueOnce("session-scheduled");
+    fireEvent.dragStart(scheduledCard, { dataTransfer: dragData });
+    fireEvent.dragOver(targetSlot as HTMLElement, { dataTransfer: dragData });
+    fireEvent.drop(targetSlot as HTMLElement, { dataTransfer: dragData });
+
+    expect(onRescheduleSession).toHaveBeenCalledTimes(1);
+    expect(onRescheduleSession).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "session-scheduled" }),
+      expect.objectContaining({ time: targetTime, date: expect.any(Date) }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Harden coarse-pointer schedule move mode so a picked-up appointment can be cancelled from the card, pointer-cancel clears active move state, and click suppression is cleared after a successful slot drop.
- Expand schedule drag/drop regression coverage for status eligibility, admin/super admin vs therapist drag wiring, overlapping cards, coarse long-press/tap behavior, same-slot no-ops, and reschedule `/api/book` payload shape.
- Keep drag eligibility narrow: normalized `scheduled` variants are draggable; canonical non-scheduled and unknown statuses remain non-draggable.

## Verification
- `npx vitest run --reporter=verbose src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx src/pages/__tests__/Schedule.statusStyles.test.ts src/pages/__tests__/Schedule.reschedule.integration.test.tsx src/pages/__tests__/Schedule.test.tsx`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci` with non-secret local placeholders: `VITE_SUPABASE_URL=http://127.0.0.1:54321`, `VITE_SUPABASE_ANON_KEY=test-anon-key`
- `npm run ci:verify-coverage`
- `npm run build`
- `npm run test:routes:tier0`
- `npm run verify:local` with the same non-secret local placeholders

## Notes
- First unqualified `test:ci` failed locally because server contract tests require `VITE_SUPABASE_URL`; rerun with non-secret placeholders passed.
- First `verify:local` attempt hit one unrelated `SessionModal.test.tsx` timeout; the timed-out case passed standalone and the bounded full retry passed.
- No auth, server/API, Supabase, runtime config, CI policy, migration, or tenant-sensitive files were changed.

Linear: WIN-117
