### PR TITLE
Fix ad-hoc session capture Playwright harness

### DIFF
--- a/scripts/playwright-session-capture-adhoc-upsert.ts
+++ b/scripts/playwright-session-capture-adhoc-upsert.ts
@@ -90,6 +90,39 @@ const openEditSessionModalFromUrl = async (page: Page, scheduleUrl: string, sess
   throw new Error("Session modal (Edit Session / Live session) did not open from schedule deep link.");
 }
 
+const selectFirstOptionIfEmpty = async (
+  selectLocator: ReturnType<Page["locator"]>,
+  label: string,
+): Promise<string | null> => {
+  const select = selectLocator.first();
+  const count = await select.count();
+  if (count === 0) {
+    return null;
+  }
+  const currentValue = await select.inputValue().catch(() => "");
+  if (currentValue.trim().length > 0) {
+    return currentValue.trim();
+  }
+  const started = Date.now();
+  let selectedValue = "";
+  while (Date.now() - started < 30_000 && !selectedValue) {
+    const values = await select.locator("option").evaluateAll((nodes) =>
+      nodes
+        .map((node) => (node as HTMLOptionElement).value)
+        .filter((value) => typeof value === "string" && value.trim().length > 0),
+    );
+    selectedValue = values[0] ?? "";
+    if (!selectedValue) {
+      await select.page().waitForTimeout(250);
+    }
+  }
+  if (!selectedValue) {
+    throw new Error(`No selectable ${label} option was available for session capture.`);
+  }
+  await select.selectOption(selectedValue);
+  return selectedValue;
+};
+
 async function waitForSessionStatus(sessionId: string, status: string, timeoutMs = 120_000): Promise<void> {
   const supabaseUrl = getEnv("VITE_SUPABASE_URL");
   const serviceRole = getEnv("SUPABASE_SERVICE_ROLE_KEY");
@@ -217,21 +250,63 @@ async function run(): Promise<void> {
       const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
       const capture = editDialog.getByTestId("session-modal-capture-section");
       await capture.waitFor({ state: "visible", timeout: 30_000 });
+      await selectFirstOptionIfEmpty(
+        editDialog.first().locator('#session-note-auth-select, select[name="session_note_authorization_id"]'),
+        "authorization",
+      );
+      await selectFirstOptionIfEmpty(
+        editDialog.first().locator('#session-note-service-code-select, select[name="session_note_service_code"]'),
+        "service code",
+      );
 
       await editDialog.locator(`#goal-note-${booked.goalId}`).fill(`Plan note ${marker}`);
 
       await capture.getByRole("button", { name: /Add skill/i }).click();
-      const adhocCard = capture.locator(".rounded-lg.border").last();
-      await adhocCard.getByPlaceholder("Name this target").fill(`Adhoc title ${marker}`);
+      const adhocCard = capture.locator('[data-testid^="session-modal-goal-capture-adhoc-skill-"]').last();
+      await adhocCard.waitFor({ state: "visible", timeout: 30_000 });
+      await adhocCard.scrollIntoViewIfNeeded();
+      await adhocCard.locator('input[placeholder="Name this target"]:visible').first().fill(`Adhoc title ${marker}`);
       await adhocCard.getByLabel(/^Per-goal note$/i).fill(`Adhoc note ${marker}`);
-      await adhocCard.getByRole("button", { name: /Increase correct trials/i }).click();
+      await adhocCard.getByRole("button", { name: /Increase correct trials/i }).first().click();
 
       const upsertPromise = activePage.waitForResponse(
         (res) => res.url().includes("/api/session-notes/upsert") && res.request().method() === "POST",
         { timeout: 120_000 },
       );
-      await activePage.getByRole("button", { name: /Save progress/i }).click();
-      const res = await upsertPromise;
+      await capture.getByRole("button", { name: /Save skills/i }).click();
+      const res = await upsertPromise.catch(async (error) => {
+        const diagnostics = await activePage.evaluate(() => {
+          const form = document.querySelector("#session-form") as HTMLFormElement | null;
+          const invalidFields = form
+            ? Array.from(form.elements)
+                .filter((element): element is HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement =>
+                  "validity" in element && !element.validity.valid)
+                .map((element) => ({
+                  id: element.id,
+                  name: element.name,
+                  value: element.value,
+                  validationMessage: element.validationMessage,
+                }))
+            : [];
+          const saveSkillsButton = Array.from(document.querySelectorAll("button")).find((button) =>
+            /Save skills/i.test(button.textContent ?? ""));
+          return {
+            formValid: form?.checkValidity() ?? null,
+            invalidFields,
+            saveSkillsDisabled: saveSkillsButton instanceof HTMLButtonElement ? saveSkillsButton.disabled : null,
+            visibleAdhocTitleCount: document.querySelectorAll('input[placeholder="Name this target"]').length,
+            sessionNoteAuthSelectCount: document.querySelectorAll(
+              '#session-note-auth-select, select[name="session_note_authorization_id"]',
+            ).length,
+            sessionNoteServiceCodeSelectCount: document.querySelectorAll(
+              '#session-note-service-code-select, select[name="session_note_service_code"]',
+            ).length,
+          };
+        });
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)} diagnostics=${JSON.stringify(diagnostics)}`,
+        );
+      });
       assert.equal(res.ok(), true, `session-notes upsert failed: HTTP ${res.status()}`);
       const body = (await res.json()) as {
         goal_notes?: Record<string, string> | null;


### PR DESCRIPTION
## Summary
- Fixes the ad-hoc session capture Playwright harness that was failing before `/api/session-notes/upsert` was emitted.
- Waits for dialog-scoped billing metadata options before saving capture, avoiding the async hydration race.
- Targets the actual ad-hoc skill capture card by stable `data-testid`, fills the visible responsive title input, and uses the `Save skills` partial-save control that directly exercises the upsert path.
- Adds failure-only diagnostics for blocked upsert submissions.

## /api/book finding
- The reported `/api/book` 400 was not reproduced with local `.env.local` credentials.
- Real schedule conflict browser flow returned the expected 409 conflict response; focused booking/server tests and hosted relationship sanity checks did not identify a frontend-only `/api/book` payload defect.

## Verification
- `npm run playwright:preflight` passed with `.env.local` via `PLAYWRIGHT_ENV_FILE`.
- `npm run playwright:auth` passed.
- `PW_CONFLICT_MODE=mock npm run playwright:schedule-conflict` passed.
- `PW_CONFLICT_MODE=real npm run playwright:schedule-conflict` passed with expected 409.
- Focused booking tests passed.
- `npm run playwright:session-capture-adhoc-upsert` passed.
- `npm run ci:playwright` passed.
- `npm run ci:check-focused` passed.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run test:ci` passed on retry; one unrelated `SessionModal` timeout passed standalone.
- `npm run ci:verify-coverage` passed.
- `npm run build` passed.
- `npm run test:routes:tier0` passed.
- `npm run verify:local` reached internal `test:ci` and failed on an unrelated `SessionModal` timeout; that exact test passed standalone.

Linear: WIN-118