### PR TITLE
Fix schedule reschedule /api/book payload

### DIFF
--- a/src/features/scheduling/domain/__tests__/booking.test.ts
+++ b/src/features/scheduling/domain/__tests__/booking.test.ts
@@ -86,5 +86,29 @@ describe("booking domain payload builder", () => {
       expect(parsed.data.session.updated_at).toBeUndefined();
     }
   });
+
+  it("strips null notes from reschedule payloads so /api/book validation accepts the body", () => {
+    const payload = buildBookSessionApiPayload(
+      {
+        id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        therapist_id: "11111111-1111-1111-1111-111111111111",
+        client_id: "22222222-2222-2222-2222-222222222222",
+        program_id: "33333333-3333-3333-3333-333333333333",
+        goal_id: "44444444-4444-4444-4444-444444444444",
+        start_time: "2026-04-29T19:00:00.000Z",
+        end_time: "2026-04-29T20:00:00.000Z",
+        notes: null,
+      } as never,
+      {
+        startOffsetMinutes: -420,
+        endOffsetMinutes: -420,
+        timeZone: "America/Los_Angeles",
+      },
+    );
+
+    const parsed = bookSessionApiRequestBodySchema.safeParse(payload);
+    expect(parsed.success).toBe(true);
+    expect("notes" in payload.session).toBe(false);
+  });
 });
 

--- a/src/features/scheduling/domain/booking.ts
+++ b/src/features/scheduling/domain/booking.ts
@@ -60,7 +60,11 @@ export function buildBookSessionApiPayload(
   const normalizedSession = normalizeSessionPayloadSubtree({
     ...session,
     status: session.status ?? "scheduled",
-  }) as BookSessionApiRequestBody["session"];
+  }) as BookSessionApiRequestBody["session"] & { notes?: string | null };
+
+  if (normalizedSession.notes === null) {
+    delete normalizedSession.notes;
+  }
 
   return {
     session: normalizedSession,

--- a/src/pages/__tests__/Schedule.reschedule.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.reschedule.integration.test.tsx
@@ -65,8 +65,8 @@ vi.mock("../../lib/optimizedQueries", () => ({
   }),
 }));
 
-vi.mock("../../features/scheduling/domain/booking", () => ({
-  buildBookSessionApiPayload: (session: unknown) => session,
+vi.mock("../../features/scheduling/domain/booking", async () => ({
+  ...(await vi.importActual("../../features/scheduling/domain/booking")),
   bookSessionViaApi: (...args: unknown[]) => bookSessionViaApiMock(...args),
 }));
 
@@ -141,7 +141,7 @@ const buildScheduleStore = () => {
     start_time: sourceDate.toISOString(),
     end_time: new Date(sourceDate.getTime() + 60 * 60 * 1000).toISOString(),
     status: "scheduled",
-    notes: "Initial session",
+    notes: null,
     created_at: "2025-07-01T00:00:00.000Z",
     created_by: "user-1",
     updated_at: "2025-07-01T00:00:00.000Z",
@@ -233,12 +233,15 @@ describe("Schedule reschedule integration", () => {
     });
     expect(bookSessionViaApiMock.mock.calls[0][0]).toEqual(
       expect.objectContaining({
-        id: "session-1",
-        start_time: movedStart.toISOString(),
-        end_time: movedEnd.toISOString(),
+        session: expect.objectContaining({
+          id: "session-1",
+          start_time: movedStart.toISOString(),
+          end_time: movedEnd.toISOString(),
+        }),
         overrides: undefined,
       }),
     );
+    expect(bookSessionViaApiMock.mock.calls[0][0].session).not.toHaveProperty("notes");
 
     await waitFor(() => {
       expect(getSlotSessionIds(container, sourceSlotKey)).toEqual([]);


### PR DESCRIPTION
## Summary
- Reproduced the schedule drag/drop `POST /api/book` 400 for admin and super admin reschedules.
- Identified the invalid request as `session.notes: null`; the `/api/book` schema accepts an omitted optional string, but not null.
- Stripped null notes in the schedule booking payload builder and pinned the reschedule payload shape with focused tests.

## Root Cause
Drag/drop reschedule reused the selected session object, which can contain `notes: null`. `buildBookSessionApiPayload` passed that through to `/api/book`; Zod rejected the request at `session.notes` with `invalid_request` before booking relationship checks. Relationship checks for the reproduced therapist/client/program/goal IDs were valid, and role source was confirmed through the role RPC path.

## Verification
- `npx vitest run --reporter=verbose src/features/scheduling/domain/__tests__/booking.test.ts src/pages/__tests__/Schedule.reschedule.integration.test.tsx`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run ci:verify-coverage`
- `npm run build`
- `npm run test:routes:tier0`
- `npm run verify:local`

## Tracking
Linear: WIN-118

## Notes
No server/API/auth/runtime-config/Supabase/CI paths were changed. The deployed browser repro will continue to show the old 400 until this branch is deployed.