### PR TITLE
WIN-119 Harden sessions booking authority and lifecycle parity

### DIFF
--- a/docs/api/ENDPOINT_OWNERSHIP_MATRIX.md
+++ b/docs/api/ENDPOINT_OWNERSHIP_MATRIX.md
@@ -9,11 +9,11 @@ Machine-readable source: `docs/api/endpoint-convergence-status.json`
 | `/api/dashboard` | Netlify `dashboard` transport adapter | Supabase edge `get-dashboard-data` | A | converged_adapter | Backend Platform | 2026-05-15 |
 | `/api/book` | Netlify `book` transport adapter | Supabase edge `sessions-book` (delegates to hold/confirm authority paths) | B | migrating_adapter | Backend Platform | 2026-05-15 |
 | `/api/sessions-start` | Netlify `sessions-start` transport adapter | Supabase edge `sessions-start` | B | migrating_adapter | Backend Platform | 2026-05-15 |
-| `/api/assessment-documents` | Netlify `assessment-documents` | Supabase edge `extract-assessment-fields` + assessment storage domain | A | migrating | Backend Platform | 2026-04-30 |
-| `/api/assessment-checklist` | Netlify `assessment-checklist` | Supabase edge `extract-assessment-fields` checklist domain | A | migrating | Backend Platform | 2026-04-30 |
-| `/api/assessment-drafts` | Netlify `assessment-drafts` | Supabase edge `generate-program-goals` drafts domain | A | migrating | Backend Platform | 2026-04-30 |
-| `/api/assessment-promote` | Netlify `assessment-promote` | Supabase edge `generate-assessment-plan-pdf` promote domain | B | legacy_shim | Backend Platform | 2026-04-30 |
-| `/api/assessment-plan-pdf` | Netlify `assessment-plan-pdf` | Supabase edge `generate-assessment-plan-pdf` | A | migrating | Backend Platform | 2026-04-30 |
+| `/api/assessment-documents` | Netlify `assessment-documents` | Supabase edge `extract-assessment-fields` + assessment storage domain | A | migrating | Backend Platform | 2026-06-30 |
+| `/api/assessment-checklist` | Netlify `assessment-checklist` | Supabase edge `extract-assessment-fields` checklist domain | A | migrating | Backend Platform | 2026-06-30 |
+| `/api/assessment-drafts` | Netlify `assessment-drafts` | Supabase edge `generate-program-goals` drafts domain | A | migrating | Backend Platform | 2026-06-30 |
+| `/api/assessment-promote` | Netlify `assessment-promote` | Supabase edge `generate-assessment-plan-pdf` promote domain | B | legacy_shim | Backend Platform | 2026-06-30 |
+| `/api/assessment-plan-pdf` | Netlify `assessment-plan-pdf` | Supabase edge `generate-assessment-plan-pdf` | A | migrating | Backend Platform | 2026-06-30 |
 | `/api/programs` | Retired Netlify shim | Supabase edge `programs` | B | retired | Backend Platform | N/A |
 | `/api/goals` | Retired Netlify shim | Supabase edge `goals` | B | retired | Backend Platform | N/A |
 | `/api/program-notes` | Retired Netlify shim | Supabase edge `program-notes` | B | retired | Backend Platform | N/A |

--- a/docs/api/runtime-exceptions.json
+++ b/docs/api/runtime-exceptions.json
@@ -5,35 +5,35 @@
       "publicApiPath": "/api/assessment-checklist",
       "reason": "Server-side checklist workflow logic has not yet been ported to a dedicated edge endpoint.",
       "owner": "Backend Platform",
-      "expiresAt": "2026-04-30"
+      "expiresAt": "2026-06-30"
     },
     {
       "functionFile": "assessment-documents.ts",
       "publicApiPath": "/api/assessment-documents",
       "reason": "Document registration/extraction orchestration still runs through server API handler.",
       "owner": "Backend Platform",
-      "expiresAt": "2026-04-30"
+      "expiresAt": "2026-06-30"
     },
     {
       "functionFile": "assessment-drafts.ts",
       "publicApiPath": "/api/assessment-drafts",
       "reason": "Draft CRUD and promotion-prep logic requires edge parity implementation.",
       "owner": "Backend Platform",
-      "expiresAt": "2026-04-30"
+      "expiresAt": "2026-06-30"
     },
     {
       "functionFile": "assessment-promote.ts",
       "publicApiPath": "/api/assessment-promote",
       "reason": "Promotion transaction semantics are not yet migrated to an authoritative edge endpoint.",
       "owner": "Backend Platform",
-      "expiresAt": "2026-04-30"
+      "expiresAt": "2026-06-30"
     },
     {
       "functionFile": "assessment-plan-pdf.ts",
       "publicApiPath": "/api/assessment-plan-pdf",
       "reason": "PDF generation flow depends on template/runtime behavior pending edge-native migration.",
       "owner": "Backend Platform",
-      "expiresAt": "2026-04-30"
+      "expiresAt": "2026-06-30"
     },
     {
       "functionFile": "book.ts",

--- a/src/features/scheduling/domain/booking.ts
+++ b/src/features/scheduling/domain/booking.ts
@@ -56,6 +56,7 @@ export function buildBookSessionApiPayload(
   },
   recurrence?: BookSessionApiRequestBody["recurrence"],
   holdSeconds = DEFAULT_SESSION_HOLD_SECONDS,
+  occurrences?: BookSessionApiRequestBody["occurrences"],
 ): BookSessionApiRequestBody {
   const normalizedSession = normalizeSessionPayloadSubtree({
     ...session,
@@ -72,6 +73,7 @@ export function buildBookSessionApiPayload(
     endTimeOffsetMinutes: metadata.endOffsetMinutes,
     timeZone: metadata.timeZone,
     holdSeconds,
+    ...(occurrences && occurrences.length > 0 ? { occurrences } : {}),
     ...(recurrence ? { recurrence } : {}),
   };
 }

--- a/src/lib/__tests__/cacheStrategy.test.ts
+++ b/src/lib/__tests__/cacheStrategy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { generateCacheKey } from "../cacheStrategy";
+
+describe("generateCacheKey.sessions", () => {
+  it("scopes session query keys by organization", () => {
+    expect(
+      generateCacheKey.sessions(
+        "2026-03-30T00:00:00.000Z",
+        "2026-04-06T00:00:00.000Z",
+        "therapist-1",
+        "client-1",
+        "org-a",
+      ),
+    ).toEqual([
+      "sessions",
+      "org-a",
+      "2026-03-30T00:00:00.000Z",
+      "2026-04-06T00:00:00.000Z",
+      "therapist-1",
+      "client-1",
+    ]);
+  });
+});

--- a/src/lib/__tests__/sessionCancellation.test.ts
+++ b/src/lib/__tests__/sessionCancellation.test.ts
@@ -72,7 +72,7 @@ describe("cancelSessions", () => {
     expect(body.session_ids).toEqual(["s1", "s2"]);
   });
 
-  it("generates an idempotency key when not provided", async () => {
+  it("generates an idempotency key and forwards time_zone for date-based cancellation", async () => {
     mockedCallEdge.mockResolvedValueOnce(
       jsonResponse(
         {
@@ -92,13 +92,14 @@ describe("cancelSessions", () => {
       ),
     );
 
-    await cancelSessions({ date: "2025-03-18" });
+    await cancelSessions({ date: "2025-03-18", timeZone: "America/Los_Angeles" });
 
     const requestInit = mockedCallEdge.mock.calls[0][1];
     const headers = requestInit?.headers as Headers;
     expect(headers.get("Idempotency-Key")).toBeTruthy();
     const body = JSON.parse(requestInit?.body as string);
     expect(body.date).toBe("2025-03-18");
+    expect(body.time_zone).toBe("America/Los_Angeles");
   });
 
   it("throws when the API responds with an error", async () => {

--- a/src/lib/cacheStrategy.ts
+++ b/src/lib/cacheStrategy.ts
@@ -52,8 +52,9 @@ export const CACHE_STRATEGIES = {
 // ============================================================================
 
 export const generateCacheKey = {
-  sessions: (startDate: string, endDate: string, therapistId?: string, clientId?: string) => [
+  sessions: (startDate: string, endDate: string, therapistId?: string, clientId?: string, organizationId?: string | null) => [
     'sessions',
+    organizationId || 'org:none',
     startDate,
     endDate,
     therapistId || 'all',

--- a/src/lib/optimizedQueries.ts
+++ b/src/lib/optimizedQueries.ts
@@ -81,6 +81,7 @@ export const useSessionsOptimized = (
   therapistId?: string,
   clientId?: string,
   enabled = true,
+  organizationId?: string | null,
 ) => {
   // Debounce filter changes to prevent excessive API calls
   const debouncedTherapistId = useDebounce(therapistId, 300);
@@ -91,7 +92,8 @@ export const useSessionsOptimized = (
       startDate.toISOString(),
       endDate.toISOString(),
       debouncedTherapistId,
-      debouncedClientId
+      debouncedClientId,
+      organizationId,
     ),
     queryFn: async () => {
       const { data, error } = await supabase.rpc('get_sessions_optimized', {
@@ -107,7 +109,7 @@ export const useSessionsOptimized = (
       return data?.map((item: { session_data: Session }) => item.session_data) || [];
     },
     staleTime: CACHE_STRATEGIES.SESSIONS.current_week,
-    enabled: !!startDate && !!endDate && enabled,
+    enabled: !!startDate && !!endDate && enabled && Boolean(organizationId),
   });
 };
 

--- a/src/lib/sessionCancellation.ts
+++ b/src/lib/sessionCancellation.ts
@@ -3,6 +3,7 @@ import { callEdge } from "./supabase";
 export interface CancelSessionsPayload {
   sessionIds?: string[];
   date?: string;
+  timeZone?: string;
   therapistId?: string;
   reason?: string | null;
   idempotencyKey?: string;
@@ -70,6 +71,9 @@ export async function cancelSessions(payload: CancelSessionsPayload): Promise<Ca
   }
   if (payload.date) {
     body.date = payload.date;
+    if (payload.timeZone && payload.timeZone.trim().length > 0) {
+      body.time_zone = payload.timeZone.trim();
+    }
   }
   if (payload.therapistId) {
     body.therapist_id = payload.therapistId;

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -583,6 +583,7 @@ export const Schedule = React.memo(() => {
     debouncedTherapist,
     debouncedClient,
     enableFallbackSessionsQuery,
+    activeOrganizationId,
   );
 
   // Use dropdown data hook for therapists and clients

--- a/src/pages/__tests__/Schedule.orgGuard.test.tsx
+++ b/src/pages/__tests__/Schedule.orgGuard.test.tsx
@@ -108,6 +108,13 @@ describe("Schedule org-context guard", () => {
       );
     });
 
+    it("passes the active organization id to useSessionsOptimized", () => {
+      renderWithProviders(<Schedule />);
+      const calls = sessionsMock.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls[0][5]).toBe("org-abc-123");
+    });
+
     it("passes enabled: true to useDropdownData", () => {
       renderWithProviders(<Schedule />);
       expect(dropdownMock).toHaveBeenCalledWith({ enabled: true });

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -270,6 +270,7 @@ describe("Schedule", () => {
       null,
       null,
       false,
+      null,
     );
     expect(mockUseDropdownData).toHaveBeenCalledWith({ enabled: false });
   });

--- a/src/server/__tests__/bookHandler.test.ts
+++ b/src/server/__tests__/bookHandler.test.ts
@@ -13,6 +13,70 @@ const loggerMock = vi.hoisted(() => ({
 
 vi.mock("../bookSession", () => ({
   bookSession: bookSessionMock,
+  deriveBookSessionOccurrences: (payload: {
+    session: { start_time: string; end_time: string };
+    startTimeOffsetMinutes: number;
+    endTimeOffsetMinutes: number;
+    occurrences?: Array<{
+      startTime: string;
+      endTime: string;
+      startOffsetMinutes: number;
+      endOffsetMinutes: number;
+    }>;
+    recurrence?: { count?: number; timeZone?: string } | null;
+    timeZone: string;
+  }) => {
+    if (payload.recurrence?.count === 2 && payload.session.start_time === "2026-03-30T05:00:00.000Z") {
+      const derivedOccurrences = [
+        {
+          startTime: "2026-03-30T05:00:00.000Z",
+          endTime: "2026-03-30T05:30:00.000Z",
+          startOffsetMinutes: payload.startTimeOffsetMinutes,
+          endOffsetMinutes: payload.endTimeOffsetMinutes,
+        },
+        {
+          startTime: "2026-04-06T05:00:00.000Z",
+          endTime: "2026-04-06T05:30:00.000Z",
+          startOffsetMinutes: payload.startTimeOffsetMinutes,
+          endOffsetMinutes: payload.endTimeOffsetMinutes,
+        },
+      ];
+
+      if (!Array.isArray(payload.occurrences) || payload.occurrences.length === 0) {
+        return derivedOccurrences;
+      }
+
+      const matches = payload.occurrences.length === derivedOccurrences.length
+        && payload.occurrences.every((occurrence, index) =>
+          occurrence.startTime === derivedOccurrences[index]?.startTime
+          && occurrence.endTime === derivedOccurrences[index]?.endTime
+          && occurrence.startOffsetMinutes === derivedOccurrences[index]?.startOffsetMinutes
+          && occurrence.endOffsetMinutes === derivedOccurrences[index]?.endOffsetMinutes
+        );
+      if (!matches) {
+        const error = new Error("Provided booking occurrences do not match the server-derived recurrence windows.") as Error & {
+          status?: number;
+          code?: string;
+        };
+        error.status = 400;
+        error.code = "INVALID_OCCURRENCES";
+        throw error;
+      }
+
+      return derivedOccurrences;
+    }
+
+    if (Array.isArray(payload.occurrences) && payload.occurrences.length > 0) {
+      return payload.occurrences;
+    }
+
+    return [{
+      startTime: payload.session.start_time,
+      endTime: payload.session.end_time,
+      startOffsetMinutes: payload.startTimeOffsetMinutes,
+      endOffsetMinutes: payload.endTimeOffsetMinutes,
+    }];
+  },
 }));
 
 vi.mock("../../lib/logger/logger", () => ({
@@ -223,6 +287,51 @@ describe("bookHandler", () => {
     expect(body.success).toBe(false);
     expect(body.error).toMatch(/authorization/i);
     expect(bookSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects caller-supplied occurrences that do not match the server-derived recurrence windows", async () => {
+    process.env.API_AUTHORITY_MODE = "edge";
+    const bookHandler = await importBookHandler();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const response = await bookHandler(
+      createRequest({
+        ...validPayload,
+        recurrence: {
+          rule: "FREQ=WEEKLY;COUNT=2;BYDAY=MO",
+          count: 2,
+          timeZone: "America/Los_Angeles",
+        },
+        session: {
+          ...validPayload.session,
+          start_time: "2026-03-30T05:00:00.000Z",
+          end_time: "2026-03-30T05:30:00.000Z",
+        },
+        occurrences: [
+          {
+            startTime: "2026-03-30T05:00:00.000Z",
+            endTime: "2026-03-30T05:30:00.000Z",
+            startOffsetMinutes: 0,
+            endOffsetMinutes: 0,
+          },
+          {
+            startTime: "2026-04-13T05:00:00.000Z",
+            endTime: "2026-04-13T05:30:00.000Z",
+            startOffsetMinutes: 0,
+            endOffsetMinutes: 0,
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.code).toBe("INVALID_OCCURRENCES");
+    expect(bookSessionMock).not.toHaveBeenCalled();
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url).includes("/functions/v1/sessions-book")),
+    ).toBe(false);
+    fetchSpy.mockRestore();
   });
 
   it("accepts session payloads when audit timestamps omit timezone offsets (RPC-shaped rows)", async () => {
@@ -682,6 +791,48 @@ describe("bookHandler", () => {
     expect(body.orchestration).toBeUndefined();
   });
 
+  it("forwards derived recurrence occurrences to edge booking authority", async () => {
+    process.env.API_AUTHORITY_MODE = "edge";
+    let forwardedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post(`${TEST_SUPABASE_EDGE_URL.replace(/\/$/, "")}/sessions-book`, async ({ request }) => {
+        forwardedBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({
+          success: true,
+          data: {
+            session: { id: "session-recurring" },
+            sessions: [{ id: "session-recurring-1" }, { id: "session-recurring-2" }],
+            hold: { holdKey: "hold-recurring", holdId: "hold-recurring", expiresAt: "2026-03-30T05:05:00.000Z", holds: [] },
+            cpt: {},
+          },
+        });
+      }),
+    );
+
+    const recurringPayload = {
+      ...validPayload,
+      session: {
+        ...validPayload.session,
+        start_time: "2026-03-30T05:00:00.000Z",
+        end_time: "2026-03-30T05:30:00.000Z",
+      },
+      recurrence: {
+        rule: "FREQ=WEEKLY;INTERVAL=1",
+        count: 2,
+        timeZone: "America/Los_Angeles",
+      },
+    };
+
+    const bookHandler = await importBookHandler();
+    const response = await bookHandler(createRequest(recurringPayload));
+
+    expect(response.status).toBe(200);
+    expect(bookSessionMock).not.toHaveBeenCalled();
+    expect(Array.isArray(forwardedBody?.occurrences)).toBe(true);
+    expect((forwardedBody?.occurrences as unknown[])?.length).toBe(2);
+    expect((forwardedBody?.occurrences as Array<Record<string, unknown>>)?.[1]?.startTime).toBe("2026-04-06T05:00:00.000Z");
+  });
+
   it("falls back to legacy booking when edge authority is unavailable", async () => {
     process.env.API_AUTHORITY_MODE = "edge";
     server.use(
@@ -755,53 +906,21 @@ describe("bookHandler", () => {
     expect(body.code).toBe("THERAPIST_CONFLICT");
   });
 
-  it("falls back to legacy booking when edge authority returns 401", async () => {
+  it("does not fallback to legacy booking when edge authority returns 401", async () => {
     process.env.API_AUTHORITY_MODE = "edge";
     server.use(
       http.post(`${TEST_SUPABASE_EDGE_URL.replace(/\/$/, "")}/sessions-book`, () =>
         HttpResponse.json({ success: false, error: "Missing authorization token" }, { status: 401 })),
     );
-    bookSessionMock.mockResolvedValueOnce({
-      session: {
-        id: "session-edge-401-fallback",
-        client_id: "client-1",
-        therapist_id: "therapist-1",
-        start_time: "2025-01-01T10:00:00Z",
-        end_time: "2025-01-01T11:00:00Z",
-        status: "scheduled",
-        notes: "",
-        created_at: "2025-01-01T09:00:00Z",
-        created_by: "user-1",
-        updated_at: "2025-01-01T09:00:00Z",
-        updated_by: "user-1",
-        duration_minutes: 60,
-      },
-      sessions: [],
-      hold: {
-        holdKey: "hold",
-        holdId: "1",
-        startTime: "2025-01-01T10:00:00Z",
-        endTime: "2025-01-01T11:00:00Z",
-        expiresAt: "2025-01-01T10:05:00Z",
-        holds: [],
-      },
-      cpt: {
-        code: "97153",
-        description: "Adaptive behavior treatment by protocol",
-        modifiers: [],
-        source: "fallback",
-        durationMinutes: 60,
-      },
-    });
 
     const bookHandler = await importBookHandler();
     const response = await bookHandler(createRequest(validPayload));
 
-    expect(response.status).toBe(200);
-    expect(bookSessionMock).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(401);
+    expect(bookSessionMock).not.toHaveBeenCalled();
     const body = await response.json();
-    expect(body.success).toBe(true);
-    expect(body.data.session.id).toBe("session-edge-401-fallback");
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Missing authorization token");
   });
 
   it("falls back to legacy booking when edge authority request throws", async () => {

--- a/src/server/__tests__/bookSession.test.ts
+++ b/src/server/__tests__/bookSession.test.ts
@@ -603,6 +603,21 @@ describe("bookSession", () => {
     });
     expect(mockedConfirmSessionBooking).not.toHaveBeenCalled();
   });
+
+  it("fails closed when hold authority rejects the request", async () => {
+    const bookSession = await importBookSession();
+    mockedRequestSessionHold.mockRejectedValueOnce({
+      status: 401,
+      code: "SESSIONS_HOLD_UNAUTHORIZED",
+      message: "Unauthorized",
+    });
+
+    await expect(bookSession(basePayload)).rejects.toMatchObject({
+      status: 502,
+      code: "BOOKING_AUTHORITY_UNAVAILABLE",
+    });
+    expect(mockedConfirmSessionBooking).not.toHaveBeenCalled();
+  });
 });
 
 afterAll(() => {

--- a/src/server/__tests__/sessionsCompleteHandler.test.ts
+++ b/src/server/__tests__/sessionsCompleteHandler.test.ts
@@ -69,13 +69,22 @@ describe("sessionsCompleteHandler", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response(
         JSON.stringify({ success: true, data: { outcome: "completed" } }),
-        { status: 200, headers: { "content-type": "application/json" } },
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "Idempotent-Replay": "true",
+          },
+        },
       ),
     );
 
     const request = new Request("http://localhost/api/sessions-complete", {
       method: "POST",
-      headers: { Authorization: "Bearer token-123" },
+      headers: {
+        Authorization: "Bearer token-123",
+        "Idempotency-Key": "complete-idempotency-key",
+      },
       body: JSON.stringify({
         session_id: "11111111-1111-1111-1111-111111111111",
         outcome: "completed",
@@ -89,6 +98,7 @@ describe("sessionsCompleteHandler", () => {
       "https://example.supabase.co/functions/v1/sessions-complete",
       expect.objectContaining({
         method: "POST",
+        headers: expect.any(Headers),
         body: JSON.stringify({
           session_id: "11111111-1111-1111-1111-111111111111",
           outcome: "completed",
@@ -96,23 +106,17 @@ describe("sessionsCompleteHandler", () => {
         }),
       }),
     );
+    const forwardedHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(forwardedHeaders.get("Idempotency-Key")).toBe("complete-idempotency-key");
+    expect(response.headers.get("Idempotency-Key")).toBe("complete-idempotency-key");
+    expect(response.headers.get("Idempotent-Replay")).toBe("true");
     fetchMock.mockRestore();
   });
 
-  it("falls back to runtime REST completion when edge returns 401", async () => {
+  it("fails closed when edge returns 401 instead of degrading to runtime REST", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token-123");
     const fetchMock = vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(jsonResponse({ success: false, error: "Unauthorized" }, 401))
-      .mockResolvedValueOnce(jsonResponse(false, 200))
-      .mockResolvedValueOnce(jsonResponse("org-1", 200))
-      .mockResolvedValueOnce(jsonResponse(true, 200))
-      .mockResolvedValueOnce(jsonResponse(false, 200))
-      .mockResolvedValueOnce(jsonResponse(false, 200))
-      .mockResolvedValueOnce(jsonResponse({ id: "therapist-1" }, 200))
-      .mockResolvedValueOnce(jsonResponse([{ id: "session-1", status: "in_progress", therapist_id: "therapist-1" }], 200))
-      .mockResolvedValueOnce(jsonResponse([{ goal_id: "goal-1" }], 200))
-      .mockResolvedValueOnce(jsonResponse([{ goal_notes: { "goal-1": "Covered" } }], 200))
-      .mockResolvedValueOnce(jsonResponse([{ id: "session-1", status: "completed", updated_at: "2026-01-01T00:00:00.000Z" }], 200));
+      .mockResolvedValueOnce(jsonResponse({ success: false, error: "Unauthorized" }, 401));
 
     const request = new Request("http://localhost/api/sessions-complete", {
       method: "POST",
@@ -124,11 +128,12 @@ describe("sessionsCompleteHandler", () => {
       }),
     });
     const response = await sessionsCompleteHandler(request);
-    const payload = await response.json() as { success: boolean };
+    const payload = await response.json() as { success: boolean; error: string };
 
-    expect(response.status).toBe(200);
-    expect(payload.success).toBe(true);
-    expect(fetchMock).toHaveBeenCalledTimes(11);
+    expect(response.status).toBe(401);
+    expect(payload.success).toBe(false);
+    expect(payload.error).toBe("Unauthorized");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     fetchMock.mockRestore();
   });
 });

--- a/src/server/api/book.ts
+++ b/src/server/api/book.ts
@@ -1,5 +1,5 @@
 import "../bootstrapSupabase";
-import { bookSession } from "../bookSession";
+import { bookSession, deriveBookSessionOccurrences } from "../bookSession";
 import {
   consumeRateLimit,
   corsHeadersForRequest,
@@ -28,7 +28,7 @@ const JSON_CONTENT_TYPE_HEADER: Record<string, string> = {
 };
 
 function shouldFallbackToLegacyBooking(status: number): boolean {
-  return status === 401 || status === 403 || status === 404 || status === 408 || status >= 500;
+  return status === 404 || status === 408 || status >= 500;
 }
 
 function normalizePayload(
@@ -42,8 +42,18 @@ function normalizePayload(
     agentOperationId?: string;
   },
 ): BookSessionRequest {
+  const occurrences = deriveBookSessionOccurrences({
+    session: body.session,
+    recurrence: body.recurrence,
+    occurrences: body.occurrences,
+    startTimeOffsetMinutes: body.startTimeOffsetMinutes,
+    endTimeOffsetMinutes: body.endTimeOffsetMinutes,
+    timeZone: body.timeZone,
+  });
+
   return {
     ...body,
+    occurrences,
     idempotencyKey,
     accessToken,
     anonKey,
@@ -267,14 +277,53 @@ export async function bookHandler(request: Request): Promise<Response> {
   }
 
   const body: BookSessionApiRequestBody = parseResult.data;
+  let derivedOccurrences;
+  try {
+    derivedOccurrences = deriveBookSessionOccurrences({
+      session: body.session,
+      recurrence: body.recurrence,
+      occurrences: body.occurrences,
+      startTimeOffsetMinutes: body.startTimeOffsetMinutes,
+      endTimeOffsetMinutes: body.endTimeOffsetMinutes,
+      timeZone: body.timeZone,
+    });
+  } catch (error) {
+    const status = typeof (error as { status?: unknown })?.status === "number"
+      ? (error as { status: number }).status
+      : 500;
+    if (status === 400) {
+      const code = typeof (error as { code?: unknown })?.code === "string"
+        ? (error as { code: string }).code
+        : undefined;
+      logger.warn("Rejected invalid booking occurrence payload", {
+        metadata: {
+          status,
+          code: code ?? null,
+        },
+        context: { handler: "bookHandler" },
+      });
+      return errorResponse(request, "validation_error", "Booking failed", {
+        status,
+        extra: {
+          ...(code ? { code } : {}),
+          conflictCode: code ?? null,
+        },
+      });
+    }
+    throw error;
+  }
 
   if (getApiAuthorityMode() === "edge") {
     try {
+      const edgePayload: BookSessionApiRequestBody = {
+        ...body,
+        occurrences: derivedOccurrences,
+      };
       const forwarded = await proxyToEdgeAuthority(request, {
         functionName: "sessions-book",
         accessToken,
         method: "POST",
-        body: JSON.stringify(body),
+        body: JSON.stringify(edgePayload),
       });
       const forwardedBody = await forwarded.text();
       if (!shouldFallbackToLegacyBooking(forwarded.status)) {
@@ -325,7 +374,10 @@ export async function bookHandler(request: Request): Promise<Response> {
       correlationId: request.headers.get("x-correlation-id") ?? undefined,
       agentOperationId: request.headers.get("x-agent-operation-id") ?? undefined,
     };
-    const result = await bookSession(normalizePayload(body, idempotencyKey, accessToken, anonKey, trace));
+    const result = await bookSession({
+      ...normalizePayload(body, idempotencyKey, accessToken, anonKey, trace),
+      occurrences: derivedOccurrences,
+    });
     const headers = idempotencyKey
       ? { ...JSON_CONTENT_TYPE_HEADER, "Idempotency-Key": idempotencyKey }
       : { ...JSON_CONTENT_TYPE_HEADER };
@@ -408,6 +460,7 @@ export async function bookHandler(request: Request): Promise<Response> {
       {
         status,
         extra: {
+          ...(conflictCode ? { code: conflictCode } : {}),
           conflictCode: conflictCode ?? null,
           ...(isUnauthorized
             ? {

--- a/src/server/api/sessions-complete.ts
+++ b/src/server/api/sessions-complete.ts
@@ -170,7 +170,7 @@ const checkNotesCoverage = async ({
     : { ok: false };
 };
 
-const completeSessionViaRuntimeRest = async ({
+const _completeSessionViaRuntimeRest = async ({
   request,
   payload,
   accessToken,
@@ -369,6 +369,7 @@ export async function sessionsCompleteHandler(request: Request): Promise<Respons
     const requestIdHeader = request.headers.get("x-request-id");
     const correlationIdHeader = request.headers.get("x-correlation-id");
     const agentOperationIdHeader = request.headers.get("x-agent-operation-id");
+    const idempotencyKeyHeader = request.headers.get("Idempotency-Key")?.trim();
     if (requestIdHeader) {
       forwardHeaders.set("x-request-id", requestIdHeader);
     }
@@ -378,21 +379,18 @@ export async function sessionsCompleteHandler(request: Request): Promise<Respons
     if (agentOperationIdHeader) {
       forwardHeaders.set("x-agent-operation-id", agentOperationIdHeader);
     }
+    if (idempotencyKeyHeader) {
+      forwardHeaders.set("Idempotency-Key", idempotencyKeyHeader);
+    }
     const forwarded = await fetch(functionUrl, {
       method: "POST",
       headers: forwardHeaders,
       body: JSON.stringify(parsed.data),
     });
-    if (forwarded.status === 401) {
-      return completeSessionViaRuntimeRest({
-        request,
-        payload: parsed.data,
-        accessToken,
-        traceHeaders,
-      });
-    }
     const bodyText = await forwarded.text();
     const retryAfter = forwarded.headers.get("Retry-After");
+    const returnedIdempotency = forwarded.headers.get("Idempotency-Key") ?? idempotencyKeyHeader ?? undefined;
+    const idempotentReplay = forwarded.headers.get("Idempotent-Replay");
 
     return new Response(bodyText, {
       status: forwarded.status,
@@ -401,6 +399,8 @@ export async function sessionsCompleteHandler(request: Request): Promise<Respons
         ...traceHeaders,
         "Content-Type": "application/json",
         ...(retryAfter ? { "Retry-After": retryAfter } : {}),
+        ...(returnedIdempotency ? { "Idempotency-Key": returnedIdempotency } : {}),
+        ...(idempotentReplay ? { "Idempotent-Replay": idempotentReplay } : {}),
       },
     });
   } catch {

--- a/src/server/bookSession.ts
+++ b/src/server/bookSession.ts
@@ -108,7 +108,7 @@ const createUserScopedFallbackClient = (payload: BookSessionRequest) => {
   });
 };
 
-async function bookSessionViaServiceRoleFallback(payload: BookSessionRequest, occurrences: RecurrenceOccurrence[], cpt: ReturnType<typeof deriveCptMetadata>): Promise<BookSessionResult> {
+async function _bookSessionViaServiceRoleFallback(payload: BookSessionRequest, occurrences: RecurrenceOccurrence[], cpt: ReturnType<typeof deriveCptMetadata>): Promise<BookSessionResult> {
   const buildFallbackResponse = (insertedRows: Array<Record<string, unknown>>): BookSessionResult => {
     const holds = occurrences.map((occurrence, index) => {
       const sessionId = typeof insertedRows[index]?.id === "string" ? insertedRows[index].id : `fallback-${index + 1}`;
@@ -530,6 +530,58 @@ function generateOccurrences(
   return occurrences;
 }
 
+export function deriveBookSessionOccurrences(payload: Pick<
+  BookSessionRequest,
+  "session" | "recurrence" | "startTimeOffsetMinutes" | "endTimeOffsetMinutes" | "timeZone" | "occurrences"
+>): RecurrenceOccurrence[] {
+  const recurrence = payload.recurrence ?? payload.session.recurrence ?? null;
+  const generatedOccurrences = generateOccurrences(payload.session, recurrence, {
+    startOffsetMinutes: payload.startTimeOffsetMinutes,
+    endOffsetMinutes: payload.endTimeOffsetMinutes,
+    timeZone: payload.timeZone,
+  });
+
+  if (!Array.isArray(payload.occurrences) || payload.occurrences.length === 0) {
+    return generatedOccurrences;
+  }
+
+  if (payload.occurrences.length !== generatedOccurrences.length) {
+    const mismatchError = new Error("Provided booking occurrences do not match the server-derived recurrence windows.") as Error & {
+      status?: number;
+      code?: string;
+    };
+    mismatchError.status = 400;
+    mismatchError.code = "INVALID_OCCURRENCES";
+    throw mismatchError;
+  }
+
+  const providedByWindow = new Map<string, RecurrenceOccurrence>();
+  for (const occurrence of payload.occurrences) {
+    const key = occurrenceKey(occurrence.startTime, occurrence.endTime);
+    providedByWindow.set(key, occurrence);
+  }
+
+  for (const occurrence of generatedOccurrences) {
+    const key = occurrenceKey(occurrence.startTime, occurrence.endTime);
+    const providedOccurrence = providedByWindow.get(key);
+    if (
+      !providedOccurrence ||
+      providedOccurrence.startOffsetMinutes !== occurrence.startOffsetMinutes ||
+      providedOccurrence.endOffsetMinutes !== occurrence.endOffsetMinutes
+    ) {
+      const mismatchError = new Error("Provided booking occurrences do not match the server-derived recurrence windows.") as Error & {
+        status?: number;
+        code?: string;
+      };
+      mismatchError.status = 400;
+      mismatchError.code = "INVALID_OCCURRENCES";
+      throw mismatchError;
+    }
+  }
+
+  return generatedOccurrences;
+}
+
 export async function bookSession(payload: BookSessionRequest): Promise<BookSessionResult> {
   if (!payload?.session) {
     throw new Error("Session payload is required");
@@ -546,11 +598,7 @@ export async function bookSession(payload: BookSessionRequest): Promise<BookSess
 
   const sessionId = typeof payload.session.id === "string" ? payload.session.id : undefined;
 
-  const occurrences = generateOccurrences(payload.session, recurrence, {
-    startOffsetMinutes: payload.startTimeOffsetMinutes,
-    endOffsetMinutes: payload.endTimeOffsetMinutes,
-    timeZone: payload.timeZone,
-  });
+  const occurrences = deriveBookSessionOccurrences(payload);
 
   const [primaryOccurrence] = occurrences;
   if (!primaryOccurrence) {
@@ -585,7 +633,12 @@ export async function bookSession(payload: BookSessionRequest): Promise<BookSess
       ? (error as { status: number }).status
       : 0;
     if (status === 401 || status === 403) {
-      return bookSessionViaServiceRoleFallback(payload, occurrences, cpt);
+      const authorizationError = new Error(
+        "Booking authority rejected the request before hold acquisition; refusing unsafe fallback.",
+      ) as Error & { status?: number; code?: string };
+      authorizationError.status = 502;
+      authorizationError.code = "BOOKING_AUTHORITY_UNAVAILABLE";
+      throw authorizationError;
     }
     throw error;
   }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -37,6 +37,7 @@ export interface BookSessionRequest {
   startTimeOffsetMinutes: number;
   endTimeOffsetMinutes: number;
   timeZone: string;
+  occurrences?: RecurrenceOccurrence[];
   holdSeconds?: number;
   idempotencyKey?: string;
   overrides?: BookingOverrides;
@@ -75,6 +76,13 @@ const recurrenceSchema = z.object({
   until: isoDateTime.optional(),
   exceptions: z.array(isoDateTime).optional(),
   timeZone: nonEmptyString.optional(),
+});
+
+const occurrenceSchema = z.object({
+  startTime: isoDateTime,
+  endTime: isoDateTime,
+  startOffsetMinutes: z.number().int(),
+  endOffsetMinutes: z.number().int(),
 });
 
 const bookingOverridesSchema = z.object({
@@ -126,6 +134,7 @@ export const bookSessionApiRequestBodySchema = z.object({
   startTimeOffsetMinutes: z.number().int(),
   endTimeOffsetMinutes: z.number().int(),
   timeZone: nonEmptyString,
+  occurrences: z.array(occurrenceSchema).min(1).optional(),
   holdSeconds: z.number().int().min(0).optional(),
   overrides: bookingOverridesSchema.optional(),
   recurrence: recurrenceSchema.nullable().optional(),

--- a/supabase/functions/sessions-book/index.ts
+++ b/supabase/functions/sessions-book/index.ts
@@ -19,6 +19,12 @@ const requestSchema = z.object({
   startTimeOffsetMinutes: z.number(),
   endTimeOffsetMinutes: z.number(),
   timeZone: z.string().min(1),
+  occurrences: z.array(z.object({
+    startTime: z.string(),
+    endTime: z.string(),
+    startOffsetMinutes: z.number(),
+    endOffsetMinutes: z.number(),
+  })).optional(),
   holdSeconds: z.number().int().positive().optional(),
   overrides: z.record(z.unknown()).optional(),
   recurrence: z.unknown().optional(),
@@ -78,6 +84,9 @@ const parseEdgeJson = async (response: Response): Promise<Record<string, unknown
   }
 };
 
+const occurrenceKey = (startTime: string, endTime: string): string =>
+  `${new Date(startTime).toISOString()}::${new Date(endTime).toISOString()}`;
+
 /** Plain objects for bookSessionEnvelopeSchema (z.record); never null — matches legacy bookSession shape. */
 const asBookingRecord = (value: unknown): Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value)
@@ -118,6 +127,14 @@ Deno.serve(async (req) => {
   const baseUrl = normalizeEdgeBase();
   const idempotencyKey = req.headers.get("Idempotency-Key")?.trim() || null;
   const headers = forwardHeaders(req, idempotencyKey);
+  const occurrencePayloads = Array.isArray(payload.occurrences) && payload.occurrences.length > 0
+    ? payload.occurrences
+    : [{
+        startTime: payload.session.start_time,
+        endTime: payload.session.end_time,
+        startOffsetMinutes: payload.startTimeOffsetMinutes,
+        endOffsetMinutes: payload.endTimeOffsetMinutes,
+      }];
 
   const holdResponse = await fetch(`${baseUrl}/sessions-hold`, {
     method: "POST",
@@ -132,6 +149,12 @@ Deno.serve(async (req) => {
       start_time_offset_minutes: payload.startTimeOffsetMinutes,
       end_time_offset_minutes: payload.endTimeOffsetMinutes,
       time_zone: payload.timeZone,
+      occurrences: occurrencePayloads.map((occurrence) => ({
+        start_time: occurrence.startTime,
+        end_time: occurrence.endTime,
+        start_time_offset_minutes: occurrence.startOffsetMinutes,
+        end_time_offset_minutes: occurrence.endOffsetMinutes,
+      })),
     }),
   });
 
@@ -153,6 +176,47 @@ Deno.serve(async (req) => {
     return json(req, 500, { success: false, error: "Hold response missing hold key" });
   }
 
+  const holdOccurrences = Array.isArray((holdBody.data as { holds?: unknown[] } | undefined)?.holds)
+    ? ((holdBody.data as { holds: Array<Record<string, unknown>> }).holds)
+    : [];
+  const confirmOccurrences = holdOccurrences.length > 0
+    ? (() => {
+        const occurrenceByWindow = new Map(
+          occurrencePayloads.map((occurrence) => [occurrenceKey(occurrence.startTime, occurrence.endTime), occurrence] as const),
+        );
+
+        return holdOccurrences.map((heldOccurrence) => {
+          const holdStartTime = typeof heldOccurrence.startTime === "string" ? heldOccurrence.startTime : null;
+          const holdEndTime = typeof heldOccurrence.endTime === "string" ? heldOccurrence.endTime : null;
+          const holdKey = typeof heldOccurrence.holdKey === "string" ? heldOccurrence.holdKey : null;
+          if (!holdStartTime || !holdEndTime || !holdKey) {
+            throw new Error("Hold response missing occurrence window metadata");
+          }
+
+          const occurrence = occurrenceByWindow.get(occurrenceKey(holdStartTime, holdEndTime));
+          if (!occurrence) {
+            throw new Error("Hold occurrences did not align with requested booking windows");
+          }
+
+          return {
+            hold_key: holdKey,
+            session: {
+              ...payload.session,
+              start_time: occurrence.startTime,
+              end_time: occurrence.endTime,
+            },
+            cpt: payload.overrides ?? null,
+            goal_ids: Array.isArray(payload.session.goal_ids)
+              ? payload.session.goal_ids
+              : [payload.session.goal_id].filter(Boolean),
+            start_time_offset_minutes: occurrence.startOffsetMinutes,
+            end_time_offset_minutes: occurrence.endOffsetMinutes,
+            time_zone: payload.timeZone,
+          };
+        });
+      })()
+    : undefined;
+
   const confirmResponse = await fetch(`${baseUrl}/sessions-confirm`, {
     method: "POST",
     headers,
@@ -166,6 +230,7 @@ Deno.serve(async (req) => {
       start_time_offset_minutes: payload.startTimeOffsetMinutes,
       end_time_offset_minutes: payload.endTimeOffsetMinutes,
       time_zone: payload.timeZone,
+      ...(confirmOccurrences ? { occurrences: confirmOccurrences } : {}),
     }),
   });
 

--- a/supabase/functions/sessions-cancel/index.ts
+++ b/supabase/functions/sessions-cancel/index.ts
@@ -18,11 +18,13 @@ import { increment } from "../_shared/metrics.ts";
 import { recordSessionAuditEvent } from "../_shared/audit.ts";
 import { orchestrateScheduling } from "../_shared/scheduling-orchestrator.ts";
 import type { SupabaseClient } from "npm:@supabase/supabase-js@2.50.0";
+import { deriveOffsetFromTimeZone } from "../_shared/timezone.ts";
 
 interface CancelPayload {
   hold_key?: unknown;
   session_ids?: unknown;
   date?: unknown;
+  time_zone?: unknown;
   therapist_id?: unknown;
   reason?: unknown;
 }
@@ -107,7 +109,7 @@ function normalizeSessionIds(value: unknown): string[] {
   return Array.from(seen);
 }
 
-function buildDateRange(value: unknown): { start: string; end: string } | null {
+function buildDateRange(value: unknown, timeZone: unknown): { start: string; end: string; timeZone: string } | null {
   if (typeof value !== "string") {
     return null;
   }
@@ -117,9 +119,41 @@ function buildDateRange(value: unknown): { start: string; end: string } | null {
     return null;
   }
 
-  const start = `${trimmed}T00:00:00`;
-  const end = `${trimmed}T23:59:59.999`;
-  return { start, end };
+  const resolvedTimeZone =
+    typeof timeZone === "string" && timeZone.trim().length > 0
+      ? timeZone.trim()
+      : "UTC";
+
+  const toUtcIso = (localClockTime: string) => {
+    const utcGuess = new Date(`${trimmed}T${localClockTime}Z`);
+    if (Number.isNaN(utcGuess.getTime())) {
+      return null;
+    }
+
+    const firstOffset = deriveOffsetFromTimeZone(resolvedTimeZone, utcGuess.toISOString());
+    if (firstOffset === null) {
+      return null;
+    }
+
+    const firstCandidate = new Date(utcGuess.getTime() - firstOffset * 60_000);
+    const secondOffset = deriveOffsetFromTimeZone(resolvedTimeZone, firstCandidate.toISOString());
+    if (secondOffset === null) {
+      return null;
+    }
+
+    const finalCandidate = secondOffset === firstOffset
+      ? firstCandidate
+      : new Date(utcGuess.getTime() - secondOffset * 60_000);
+    return finalCandidate.toISOString();
+  };
+
+  const start = toUtcIso("00:00:00.000");
+  const end = toUtcIso("23:59:59.999");
+  if (!start || !end) {
+    return null;
+  }
+
+  return { start, end, timeZone: resolvedTimeZone };
 }
 
 function parseCancelPayload(input: unknown): {
@@ -141,7 +175,9 @@ function parseCancelPayload(input: unknown): {
       : null;
 
   const sessionIds = normalizeSessionIds(payload.session_ids);
-  const dateRange = buildDateRange(payload.date);
+  const dateRange = buildDateRange(payload.date, payload.time_zone);
+  const hasDateInput = typeof payload.date === "string" && payload.date.trim().length > 0;
+  const hasTimeZoneInput = typeof payload.time_zone === "string" && payload.time_zone.trim().length > 0;
   const therapistId =
     typeof payload.therapist_id === "string" && payload.therapist_id.trim().length > 0
       ? payload.therapist_id.trim()
@@ -150,6 +186,10 @@ function parseCancelPayload(input: unknown): {
     typeof payload.reason === "string" && payload.reason.trim().length > 0
       ? payload.reason.trim()
       : null;
+
+  if (hasDateInput && hasTimeZoneInput && !dateRange) {
+    throw new BadRequestError("Invalid date or time_zone for cancellation window");
+  }
 
   if (!holdKey && sessionIds.length === 0 && !dateRange) {
     throw new BadRequestError("Must provide hold_key, session_ids, or date");
@@ -658,4 +698,5 @@ export const __TESTING__ = {
   handleSessionCancellation,
   handleHoldRelease,
   parseCancelPayload,
+  buildDateRange,
 };

--- a/tests/edge/sessions-book.success-envelope.contract.test.ts
+++ b/tests/edge/sessions-book.success-envelope.contract.test.ts
@@ -120,4 +120,229 @@ describe('sessions-book success envelope vs bookSessionEnvelopeSchema', () => {
     const parsed = bookSessionEnvelopeSchema.safeParse(payload);
     expect(parsed.success, parsed.success ? '' : JSON.stringify(parsed.error.format())).toBe(true);
   });
+
+  it('forwards batched occurrences to hold and confirm and preserves multi-session responses', async () => {
+    const sessionRowOne = {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      therapist_id: '11111111-1111-1111-1111-111111111111',
+      client_id: '22222222-2222-2222-2222-222222222222',
+      program_id: '33333333-3333-3333-3333-333333333333',
+      goal_id: '44444444-4444-4444-4444-444444444444',
+      start_time: '2026-03-30T05:00:00.000Z',
+      end_time: '2026-03-30T05:30:00.000Z',
+      status: 'scheduled',
+    };
+    const sessionRowTwo = {
+      ...sessionRowOne,
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      start_time: '2026-04-06T05:00:00.000Z',
+      end_time: '2026-04-06T05:30:00.000Z',
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              holdKey: 'hold-1',
+              holdId: 'hold-id-1',
+              expiresAt: '2026-03-30T05:05:00.000Z',
+              holds: [
+                {
+                  holdKey: 'hold-1',
+                  holdId: 'hold-id-1',
+                  startTime: sessionRowOne.start_time,
+                  endTime: sessionRowOne.end_time,
+                  expiresAt: '2026-03-30T05:05:00.000Z',
+                },
+                {
+                  holdKey: 'hold-2',
+                  holdId: 'hold-id-2',
+                  startTime: sessionRowTwo.start_time,
+                  endTime: sessionRowTwo.end_time,
+                  expiresAt: '2026-03-30T05:05:00.000Z',
+                },
+              ],
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              session: sessionRowOne,
+              sessions: [sessionRowOne, sessionRowTwo],
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/functions/v1/sessions-book', {
+        method: 'POST',
+        headers: {
+          Origin: 'https://preview.example.com',
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          session: {
+            therapist_id: '11111111-1111-1111-1111-111111111111',
+            client_id: '22222222-2222-2222-2222-222222222222',
+            program_id: '33333333-3333-3333-3333-333333333333',
+            goal_id: '44444444-4444-4444-4444-444444444444',
+            goal_ids: ['44444444-4444-4444-4444-444444444444', '55555555-5555-5555-5555-555555555555'],
+            start_time: sessionRowOne.start_time,
+            end_time: sessionRowOne.end_time,
+          },
+          startTimeOffsetMinutes: -420,
+          endTimeOffsetMinutes: -420,
+          timeZone: 'America/Los_Angeles',
+          occurrences: [
+            {
+              startTime: sessionRowOne.start_time,
+              endTime: sessionRowOne.end_time,
+              startOffsetMinutes: -420,
+              endOffsetMinutes: -420,
+            },
+            {
+              startTime: sessionRowTwo.start_time,
+              endTime: sessionRowTwo.end_time,
+              startOffsetMinutes: -420,
+              endOffsetMinutes: -420,
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const holdBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(holdBody.occurrences).toHaveLength(2);
+    expect(holdBody.occurrences[1].start_time).toBe(sessionRowTwo.start_time);
+
+    const confirmBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(confirmBody.occurrences).toHaveLength(2);
+    expect(confirmBody.occurrences[1].hold_key).toBe('hold-2');
+    expect(confirmBody.occurrences[1].session.start_time).toBe(sessionRowTwo.start_time);
+
+    const payload = await response.json();
+    expect(payload.data.sessions).toHaveLength(2);
+  });
+
+  it('matches hold occurrences by time window instead of relying on returned order', async () => {
+    const sessionRowOne = {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      therapist_id: '11111111-1111-1111-1111-111111111111',
+      client_id: '22222222-2222-2222-2222-222222222222',
+      program_id: '33333333-3333-3333-3333-333333333333',
+      goal_id: '44444444-4444-4444-4444-444444444444',
+      start_time: '2026-03-30T05:00:00.000Z',
+      end_time: '2026-03-30T05:30:00.000Z',
+      status: 'scheduled',
+    };
+    const sessionRowTwo = {
+      ...sessionRowOne,
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      start_time: '2026-04-06T05:00:00.000Z',
+      end_time: '2026-04-06T05:30:00.000Z',
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              holdKey: 'hold-1',
+              holdId: 'hold-id-1',
+              expiresAt: '2026-03-30T05:05:00.000Z',
+              holds: [
+                {
+                  holdKey: 'hold-2',
+                  holdId: 'hold-id-2',
+                  startTime: sessionRowTwo.start_time,
+                  endTime: sessionRowTwo.end_time,
+                  expiresAt: '2026-03-30T05:05:00.000Z',
+                },
+                {
+                  holdKey: 'hold-1',
+                  holdId: 'hold-id-1',
+                  startTime: sessionRowOne.start_time,
+                  endTime: sessionRowOne.end_time,
+                  expiresAt: '2026-03-30T05:05:00.000Z',
+                },
+              ],
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              session: sessionRowOne,
+              sessions: [sessionRowOne, sessionRowTwo],
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/functions/v1/sessions-book', {
+        method: 'POST',
+        headers: {
+          Origin: 'https://preview.example.com',
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          session: {
+            therapist_id: '11111111-1111-1111-1111-111111111111',
+            client_id: '22222222-2222-2222-2222-222222222222',
+            program_id: '33333333-3333-3333-3333-333333333333',
+            goal_id: '44444444-4444-4444-4444-444444444444',
+            start_time: sessionRowOne.start_time,
+            end_time: sessionRowOne.end_time,
+          },
+          startTimeOffsetMinutes: -420,
+          endTimeOffsetMinutes: -420,
+          timeZone: 'America/Los_Angeles',
+          occurrences: [
+            {
+              startTime: sessionRowOne.start_time,
+              endTime: sessionRowOne.end_time,
+              startOffsetMinutes: -420,
+              endOffsetMinutes: -420,
+            },
+            {
+              startTime: sessionRowTwo.start_time,
+              endTime: sessionRowTwo.end_time,
+              startOffsetMinutes: -420,
+              endOffsetMinutes: -420,
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const confirmBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(confirmBody.occurrences[0].hold_key).toBe('hold-2');
+    expect(confirmBody.occurrences[0].session.start_time).toBe(sessionRowTwo.start_time);
+    expect(confirmBody.occurrences[1].hold_key).toBe('hold-1');
+    expect(confirmBody.occurrences[1].session.start_time).toBe(sessionRowOne.start_time);
+  });
 });

--- a/tests/edge/sessions-cancel.org-scope.test.ts
+++ b/tests/edge/sessions-cancel.org-scope.test.ts
@@ -207,5 +207,30 @@ describe("sessions-cancel org scoping", () => {
     expect(payload.data.summary.cancelledCount).toBe(0);
     expect(payload.data.summary.nonCancellableCount).toBe(0);
   });
+
+  it("builds explicit timezone-aware UTC ranges for date cancellation across DST", () => {
+    const springForward = __TESTING__.buildDateRange("2025-03-09", "America/Los_Angeles");
+    const fallBack = __TESTING__.buildDateRange("2025-11-02", "America/Los_Angeles");
+
+    expect(springForward).toEqual({
+      start: "2025-03-09T08:00:00.000Z",
+      end: "2025-03-10T06:59:59.999Z",
+      timeZone: "America/Los_Angeles",
+    });
+    expect(fallBack).toEqual({
+      start: "2025-11-02T07:00:00.000Z",
+      end: "2025-11-03T07:59:59.999Z",
+      timeZone: "America/Los_Angeles",
+    });
+  });
+
+  it("reports invalid time zones as a bad date-window request instead of missing date input", () => {
+    expect(() =>
+      __TESTING__.parseCancelPayload({
+        date: "2025-03-09",
+        time_zone: "Mars/Phobos",
+      }),
+    ).toThrowError("Invalid date or time_zone for cancellation window");
+  });
 });
 


### PR DESCRIPTION
## Summary
- preserve recurrence and occurrence batching through the active edge booking path
- fail closed on unsafe booking authority fallback paths and tighten occurrence validation
- scope optimized sessions cache keys by organization and make date cancellation timezone-aware
- preserve `/api/sessions-complete` idempotency parity and quarantine the unrelated runtime exception TTL update for separate retirement

## Linked Linear
- WIN-119
- Follow-up parent for retiring temporary assessment exceptions: WIN-120

## What changed
- recurrence now survives `/api/book` -> `sessions-book` -> `sessions-hold` -> `sessions-confirm`
- caller-supplied occurrences are validated against server-derived recurrence windows
- the direct-write booking fallback no longer bypasses hold/confirm authority on 401/403
- `useSessionsOptimized` cache keys now include organization scope
- date-based session cancellation builds explicit timezone-aware UTC bounds
- `/api/sessions-complete` forwards `Idempotency-Key` and preserves `Idempotent-Replay`
- the temporary API convergence exception TTL extension is isolated and will be retired in a separate follow-up

## Verification
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`
- `npm run validate:tenant`
- `npm run test:routes:tier0`
- `npm run verify:local`
- `npm run ci:playwright`

## Risk
- protected-path changes in `src/server/**` and `supabase/functions/**`
- no schema or migration rewrites in this branch
- temporary runtime exception entries still need retirement in WIN-120
