### PR TITLE
Replace target criteria with three goal fields

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
+++ b/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
@@ -115,3 +115,75 @@ export const parseObjectiveDataPointsInput = (
   }
   return parsed.filter((item): item is Record<string, unknown> => !!item && typeof item === "object");
 };
+
+export interface GoalTimelineFields {
+  shortTermGoal: string;
+  intermediateGoal: string;
+  longTermGoal: string;
+}
+
+export const EMPTY_GOAL_TIMELINE_FIELDS: GoalTimelineFields = {
+  shortTermGoal: "",
+  intermediateGoal: "",
+  longTermGoal: "",
+};
+
+const GOAL_TIMELINE_LABELS = [
+  { key: "shortTermGoal", label: "Short-term" },
+  { key: "intermediateGoal", label: "Intermediate" },
+  { key: "longTermGoal", label: "Long-term" },
+] as const satisfies ReadonlyArray<{ key: keyof GoalTimelineFields; label: string }>;
+
+export const formatGoalTimelineCriteria = (fields: GoalTimelineFields): string => {
+  const lines = GOAL_TIMELINE_LABELS.flatMap(({ key, label }) => {
+    const value = fields[key].trim();
+    return value ? [`${label}: ${value}`] : [];
+  });
+  return lines.join("\n");
+};
+
+export const parseGoalTimelineCriteria = (value?: string | null): GoalTimelineFields => {
+  const trimmedValue = value?.trim() ?? "";
+  if (!trimmedValue) {
+    return { ...EMPTY_GOAL_TIMELINE_FIELDS };
+  }
+
+  const lines = trimmedValue
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const parsed = { ...EMPTY_GOAL_TIMELINE_FIELDS };
+  const remainingLegacyLines: string[] = [];
+
+  for (const line of lines) {
+    const match = line.match(/^(Short-term|Intermediate|Long-term):\s*(.*)$/i);
+    if (!match) {
+      remainingLegacyLines.push(line);
+      continue;
+    }
+
+    const [, rawLabel, rawValue] = match;
+    const normalizedValue = rawValue.trim();
+    switch (rawLabel.toLowerCase()) {
+      case "short-term":
+        parsed.shortTermGoal = normalizedValue;
+        break;
+      case "intermediate":
+        parsed.intermediateGoal = normalizedValue;
+        break;
+      case "long-term":
+        parsed.longTermGoal = normalizedValue;
+        break;
+      default:
+        remainingLegacyLines.push(line);
+        break;
+    }
+  }
+
+  if (remainingLegacyLines.length > 0) {
+    parsed.shortTermGoal = trimmedValue;
+  }
+
+  return parsed;
+};

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -20,7 +20,9 @@ import {
   ENABLE_CHECKLIST_MAPPING_UI,
   MIN_CHILD_GOALS,
   MIN_PARENT_GOALS,
+  formatGoalTimelineCriteria,
   parseApiErrorMessage,
+  parseGoalTimelineCriteria,
   parseJson,
   parseObjectiveDataPointsInput,
   statusToneByAssessment,
@@ -30,6 +32,7 @@ import {
   type AssessmentDraftProgram,
   type AssessmentDraftResponse,
   type AssessmentPlanPdfResponse,
+  type GoalTimelineFields,
 } from "./ProgramsGoalsTab.helpers";
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -78,6 +81,15 @@ const buildProgramsQueryPath = (clientId: string): string =>
 
 const buildClientProgramsQueryKey = (clientId: string, organizationId?: string | null) =>
   ["client-programs", clientId, organizationId ?? "MISSING_ORG"] as const;
+
+const GOAL_TIMELINE_INPUTS: ReadonlyArray<{
+  key: keyof GoalTimelineFields;
+  placeholder: string;
+}> = [
+  { key: "shortTermGoal", placeholder: "Short-term goal" },
+  { key: "intermediateGoal", placeholder: "Intermediate goal" },
+  { key: "longTermGoal", placeholder: "Long-term goal" },
+];
 
 const buildProgramGoalsQueryKey = (programId: string | null, organizationId?: string | null) =>
   ["program-goals", programId, organizationId ?? "MISSING_ORG"] as const;
@@ -166,7 +178,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const [goalOriginalText, setGoalOriginalText] = useState("");
   const [goalMeasurementType, setGoalMeasurementType] = useState("");
   const [goalBaselineData, setGoalBaselineData] = useState("");
-  const [goalTargetCriteria, setGoalTargetCriteria] = useState("");
+  const [goalShortTermGoal, setGoalShortTermGoal] = useState("");
+  const [goalIntermediateGoal, setGoalIntermediateGoal] = useState("");
+  const [goalLongTermGoal, setGoalLongTermGoal] = useState("");
   const [goalMasteryCriteria, setGoalMasteryCriteria] = useState("");
   const [goalMaintenanceCriteria, setGoalMaintenanceCriteria] = useState("");
   const [goalGeneralizationCriteria, setGoalGeneralizationCriteria] = useState("");
@@ -191,7 +205,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         goalType: AssessmentDraftGoal["goal_type"];
         measurementType: string;
         baselineData: string;
-        targetCriteria: string;
+        shortTermGoal: string;
+        intermediateGoal: string;
+        longTermGoal: string;
         masteryCriteria: string;
         maintenanceCriteria: string;
         generalizationCriteria: string;
@@ -208,12 +224,15 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const [assessmentDocumentsNeedsRetry, setAssessmentDocumentsNeedsRetry] = useState(false);
 
   const applyDraftGoal = (goal: ProgramGoalDraftResponse["goals"][number]) => {
+    const parsedTargetCriteria = parseGoalTimelineCriteria(goal.target_criteria);
     setGoalTitle(goal.title);
     setGoalDescription(goal.description);
     setGoalOriginalText(goal.original_text);
     setGoalMeasurementType(goal.measurement_type ?? "");
     setGoalBaselineData(goal.baseline_data ?? "");
-    setGoalTargetCriteria(goal.target_criteria ?? "");
+    setGoalShortTermGoal(parsedTargetCriteria.shortTermGoal);
+    setGoalIntermediateGoal(parsedTargetCriteria.intermediateGoal);
+    setGoalLongTermGoal(parsedTargetCriteria.longTermGoal);
     setGoalMasteryCriteria(goal.mastery_criteria ?? "");
     setGoalMaintenanceCriteria(goal.maintenance_criteria ?? "");
     setGoalGeneralizationCriteria(goal.generalization_criteria ?? "");
@@ -551,7 +570,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         goalType: AssessmentDraftGoal["goal_type"];
         measurementType: string;
         baselineData: string;
-        targetCriteria: string;
+        shortTermGoal: string;
+        intermediateGoal: string;
+        longTermGoal: string;
         masteryCriteria: string;
         maintenanceCriteria: string;
         generalizationCriteria: string;
@@ -559,6 +580,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       }
     > = {};
     (assessmentDrafts?.goals ?? []).forEach((goal) => {
+      const parsedTargetCriteria = parseGoalTimelineCriteria(goal.target_criteria);
       nextGoals[goal.id] = {
         acceptState: goal.accept_state,
         reviewNotes: goal.review_notes ?? "",
@@ -568,7 +590,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         goalType: goal.goal_type,
         measurementType: goal.measurement_type ?? "",
         baselineData: goal.baseline_data ?? "",
-        targetCriteria: goal.target_criteria ?? "",
+        shortTermGoal: parsedTargetCriteria.shortTermGoal,
+        intermediateGoal: parsedTargetCriteria.intermediateGoal,
+        longTermGoal: parsedTargetCriteria.longTermGoal,
         masteryCriteria: goal.mastery_criteria ?? "",
         maintenanceCriteria: goal.maintenance_criteria ?? "",
         generalizationCriteria: goal.generalization_criteria ?? "",
@@ -803,6 +827,11 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         throw new Error("Goal edit state not found.");
       }
       const objectiveDataPoints = parseObjectiveDataPointsInput(edit.objectiveDataPoints);
+      const targetCriteria = formatGoalTimelineCriteria({
+        shortTermGoal: edit.shortTermGoal,
+        intermediateGoal: edit.intermediateGoal,
+        longTermGoal: edit.longTermGoal,
+      });
       const response = await callApi("/api/assessment-drafts", {
         method: "PATCH",
         body: JSON.stringify({
@@ -816,7 +845,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
           goal_type: edit.goalType,
           measurement_type: edit.measurementType || undefined,
           baseline_data: edit.baselineData || undefined,
-          target_criteria: edit.targetCriteria || undefined,
+          target_criteria: targetCriteria || undefined,
           mastery_criteria: edit.masteryCriteria || undefined,
           maintenance_criteria: edit.maintenanceCriteria || undefined,
           generalization_criteria: edit.generalizationCriteria || undefined,
@@ -968,6 +997,11 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         throw new Error("Select a program first");
       }
       const objectiveDataPoints = parseObjectiveDataPointsInput(goalObjectiveDataPoints);
+      const targetCriteria = formatGoalTimelineCriteria({
+        shortTermGoal: goalShortTermGoal,
+        intermediateGoal: goalIntermediateGoal,
+        longTermGoal: goalLongTermGoal,
+      });
       const payload = JSON.stringify({
         client_id: client.id,
         program_id: resolvedProgramId,
@@ -976,7 +1010,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         original_text: goalOriginalTextValue,
         measurement_type: goalMeasurementType || undefined,
         baseline_data: goalBaselineData || undefined,
-        target_criteria: goalTargetCriteria || undefined,
+        target_criteria: targetCriteria || undefined,
         mastery_criteria: goalMasteryCriteria || undefined,
         maintenance_criteria: goalMaintenanceCriteria || undefined,
         generalization_criteria: goalGeneralizationCriteria || undefined,
@@ -1000,7 +1034,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 original_text: goalOriginalTextValue,
                 measurement_type: goalMeasurementType || null,
                 baseline_data: goalBaselineData || null,
-                target_criteria: goalTargetCriteria || null,
+                target_criteria: targetCriteria || null,
                 mastery_criteria: goalMasteryCriteria || null,
                 maintenance_criteria: goalMaintenanceCriteria || null,
                 generalization_criteria: goalGeneralizationCriteria || null,
@@ -1035,7 +1069,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       setGoalOriginalText("");
       setGoalMeasurementType("");
       setGoalBaselineData("");
-      setGoalTargetCriteria("");
+      setGoalShortTermGoal("");
+      setGoalIntermediateGoal("");
+      setGoalLongTermGoal("");
       setGoalMasteryCriteria("");
       setGoalMaintenanceCriteria("");
       setGoalGeneralizationCriteria("");
@@ -1804,6 +1840,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 })}
 
                 {(assessmentDrafts?.goals ?? []).map((goal) => {
+                  const parsedTargetCriteria = parseGoalTimelineCriteria(goal.target_criteria);
                   const edit = draftGoalEdits[goal.id] ?? {
                     acceptState: goal.accept_state,
                     reviewNotes: goal.review_notes ?? "",
@@ -1813,7 +1850,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                     goalType: goal.goal_type,
                     measurementType: goal.measurement_type ?? "",
                     baselineData: goal.baseline_data ?? "",
-                    targetCriteria: goal.target_criteria ?? "",
+                    shortTermGoal: parsedTargetCriteria.shortTermGoal,
+                    intermediateGoal: parsedTargetCriteria.intermediateGoal,
+                    longTermGoal: parsedTargetCriteria.longTermGoal,
                     masteryCriteria: goal.mastery_criteria ?? "",
                     maintenanceCriteria: goal.maintenance_criteria ?? "",
                     generalizationCriteria: goal.generalization_criteria ?? "",
@@ -1909,21 +1948,24 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                           rows={2}
                           className="rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark text-sm"
                         />
-                        <textarea
-                          value={edit.targetCriteria}
-                          onChange={(event) =>
-                            setDraftGoalEdits((current) => ({
-                              ...current,
-                              [goal.id]: {
-                                ...edit,
-                                targetCriteria: event.target.value,
-                              },
-                            }))
-                          }
-                          placeholder="Target criteria"
-                          rows={2}
-                          className="rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark text-sm"
-                        />
+                        {GOAL_TIMELINE_INPUTS.map(({ key, placeholder }) => (
+                          <textarea
+                            key={`${goal.id}-${key}`}
+                            value={edit[key]}
+                            onChange={(event) =>
+                              setDraftGoalEdits((current) => ({
+                                ...current,
+                                [goal.id]: {
+                                  ...edit,
+                                  [key]: event.target.value,
+                                },
+                              }))
+                            }
+                            placeholder={placeholder}
+                            rows={2}
+                            className="rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark text-sm"
+                          />
+                        ))}
                         <textarea
                           value={edit.masteryCriteria}
                           onChange={(event) =>
@@ -2172,13 +2214,32 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 rows={2}
                 className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
               />
-              <textarea
-                value={goalTargetCriteria}
-                onChange={(event) => setGoalTargetCriteria(event.target.value)}
-                placeholder="Target criteria (optional)"
-                rows={2}
-                className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
-              />
+              {GOAL_TIMELINE_INPUTS.map(({ key, placeholder }) => (
+                <textarea
+                  key={key}
+                  value={
+                    key === "shortTermGoal"
+                      ? goalShortTermGoal
+                      : key === "intermediateGoal"
+                        ? goalIntermediateGoal
+                        : goalLongTermGoal
+                  }
+                  onChange={(event) => {
+                    if (key === "shortTermGoal") {
+                      setGoalShortTermGoal(event.target.value);
+                      return;
+                    }
+                    if (key === "intermediateGoal") {
+                      setGoalIntermediateGoal(event.target.value);
+                      return;
+                    }
+                    setGoalLongTermGoal(event.target.value);
+                  }}
+                  placeholder={`${placeholder} (optional)`}
+                  rows={2}
+                  className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
+                />
+              ))}
               <textarea
                 value={goalMasteryCriteria}
                 onChange={(event) => setGoalMasteryCriteria(event.target.value)}

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -613,6 +613,62 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     ).toHaveLength(noteFetchCountBeforeCreate);
   });
 
+  it("renders three goal fields and serializes them into target_criteria on create", async () => {
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    fireEvent.change(await screen.findByPlaceholderText("Program name"), {
+      target: { value: "Communication Program" },
+    });
+    await user.click(screen.getByRole("button", { name: "Create Program" }));
+
+    await waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith("Program created");
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("Goal title"), { target: { value: "Goal A" } });
+    fireEvent.change(screen.getByPlaceholderText("Goal description"), { target: { value: "Goal description" } });
+    fireEvent.change(screen.getByPlaceholderText("Original clinical wording"), { target: { value: "Original wording" } });
+    fireEvent.change(screen.getByPlaceholderText("Short-term goal (optional)"), {
+      target: { value: "Request preferred items with a prompt." },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Intermediate goal (optional)"), {
+      target: { value: "Request preferred items across two settings." },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Long-term goal (optional)"), {
+      target: { value: "Request preferred items independently." },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Create Goal" }));
+
+    await waitFor(() => {
+      expect(callEdgeFunctionHttp).toHaveBeenCalledWith(
+        "goals",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+
+    const createGoalCall = vi
+      .mocked(callEdgeFunctionHttp)
+      .mock.calls.find(([path, init]) => path === "goals" && init?.method === "POST");
+
+    expect(createGoalCall).toBeTruthy();
+    const [, init] = createGoalCall!;
+    const body = JSON.parse(String(init?.body)) as { target_criteria?: string };
+    expect(body.target_criteria).toBe(
+      "Short-term: Request preferred items with a prompt.\n" +
+        "Intermediate: Request preferred items across two settings.\n" +
+        "Long-term: Request preferred items independently.",
+    );
+  });
+
   it("adds a program note without refetching the notes list", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
@@ -1681,6 +1737,124 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
     expect(showSuccess).toHaveBeenCalledWith("Program draft saved. Not published yet.");
     expect(screen.getByText("Saves to draft only. Not visible in live records until published.")).toBeInTheDocument();
+  });
+
+  it("hydrates legacy target criteria into the short-term goal field and saves all three goals back into target_criteria", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/goals?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/program-notes?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/fba.pdf",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [],
+            goals: [
+              {
+                id: "draft-goal-1",
+                assessment_document_id: ASSESSMENT_ID,
+                organization_id: ORG_ID,
+                client_id: "client-1",
+                title: "Draft Goal",
+                description: "Draft goal description",
+                original_text: "Draft original wording",
+                goal_type: "child",
+                measurement_type: "percent opportunities",
+                baseline_data: "40%",
+                target_criteria: "Legacy target criteria text",
+                mastery_criteria: "80% across 3 sessions",
+                maintenance_criteria: "70% after 4 weeks",
+                generalization_criteria: "2 settings with 2 adults",
+                objective_data_points: [],
+                accept_state: "accepted",
+                review_notes: null,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "PATCH" && path === "/api/assessment-drafts") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    const shortTermField = await screen.findByDisplayValue("Legacy target criteria text");
+    expect(shortTermField).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Intermediate goal")).toHaveValue("");
+    expect(screen.getByPlaceholderText("Long-term goal")).toHaveValue("");
+
+    fireEvent.change(screen.getByPlaceholderText("Intermediate goal"), {
+      target: { value: "Intermediate draft goal" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Long-term goal"), {
+      target: { value: "Long-term draft goal" },
+    });
+
+    await user.click(screen.getByRole("button", { name: /Save Goal Draft/i }));
+
+    await waitFor(() => {
+      expect(callApi).toHaveBeenCalledWith(
+        "/api/assessment-drafts",
+        expect.objectContaining({
+          method: "PATCH",
+          body: expect.stringContaining("\"draft_type\":\"goal\""),
+        }),
+      );
+    });
+
+    const saveGoalDraftCall = vi
+      .mocked(callApi)
+      .mock.calls.find(
+        ([path, requestInit]) => path === "/api/assessment-drafts" && requestInit?.method === "PATCH",
+      );
+
+    expect(saveGoalDraftCall).toBeTruthy();
+    const [, requestInit] = saveGoalDraftCall!;
+    const body = JSON.parse(String(requestInit?.body)) as { target_criteria?: string };
+    expect(body.target_criteria).toBe(
+      "Short-term: Legacy target criteria text\n" +
+        "Intermediate: Intermediate draft goal\n" +
+        "Long-term: Long-term draft goal",
+    );
   });
 
   it("shows inline helper when promote is disabled", async () => {


### PR DESCRIPTION
## Summary
- replace the single target criteria input with separate short-term, intermediate, and long-term goal fields
- keep persistence on the existing target_criteria field by formatting and parsing a deterministic multi-line string
- add coverage for create serialization and legacy draft hydration

## Verification
- npm test -- ProgramsGoalsTab.test.tsx
- npm run lint
- npm run typecheck
- npm run build

## Notes
- npm run verify:local timed out locally and surfaced unrelated repo warnings outside this slice