### PR TITLE
Test sessions-book top-level datetime validation

### DIFF
--- a/supabase/functions/sessions-book/index.ts
+++ b/supabase/functions/sessions-book/index.ts
@@ -1,11 +1,13 @@
 import { z } from "npm:zod@3.23.8";
 import { resolveAllowedOriginForRequest, corsHeadersForRequest } from "../_shared/cors.ts";
 
+const isoDateTime = z.string().datetime({ offset: true });
+
 const sessionSchema = z.object({
   therapist_id: z.string().uuid(),
   client_id: z.string().uuid(),
-  start_time: z.string(),
-  end_time: z.string(),
+  start_time: isoDateTime,
+  end_time: isoDateTime,
   id: z.string().uuid().optional(),
   program_id: z.string().uuid(),
   goal_id: z.string().uuid(),

--- a/tests/edge/sessions-book.success-envelope.contract.test.ts
+++ b/tests/edge/sessions-book.success-envelope.contract.test.ts
@@ -39,6 +39,31 @@ async function loadHandler() {
   return serveHandler;
 }
 
+const buildValidBookingPayload = () => ({
+  session: {
+    therapist_id: '11111111-1111-1111-1111-111111111111',
+    client_id: '22222222-2222-2222-2222-222222222222',
+    program_id: '33333333-3333-3333-3333-333333333333',
+    goal_id: '44444444-4444-4444-4444-444444444444',
+    start_time: '2026-03-30T05:00:00.000Z',
+    end_time: '2026-03-30T05:30:00.000Z',
+  },
+  startTimeOffsetMinutes: -420,
+  endTimeOffsetMinutes: -420,
+  timeZone: 'America/Los_Angeles',
+});
+
+const buildBookRequest = (body: unknown) =>
+  new Request('https://edge.example.com/functions/v1/sessions-book', {
+    method: 'POST',
+    headers: {
+      Origin: 'https://preview.example.com',
+      Authorization: 'Bearer token',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
 describe('sessions-book success envelope vs bookSessionEnvelopeSchema', () => {
   beforeEach(() => {
     vi.resetModules();
@@ -344,5 +369,45 @@ describe('sessions-book success envelope vs bookSessionEnvelopeSchema', () => {
     expect(confirmBody.occurrences[0].session.start_time).toBe(sessionRowTwo.start_time);
     expect(confirmBody.occurrences[1].hold_key).toBe('hold-1');
     expect(confirmBody.occurrences[1].session.start_time).toBe(sessionRowOne.start_time);
+  });
+
+  it('returns 400 before hold when top-level session.start_time is malformed', async () => {
+    const handler = await loadHandler();
+    const response = await handler(
+      buildBookRequest({
+        ...buildValidBookingPayload(),
+        session: {
+          ...buildValidBookingPayload().session,
+          start_time: 'not-a-date',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'Invalid request body',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 before hold when top-level session.end_time is malformed', async () => {
+    const handler = await loadHandler();
+    const response = await handler(
+      buildBookRequest({
+        ...buildValidBookingPayload(),
+        session: {
+          ...buildValidBookingPayload().session,
+          end_time: 'not-a-date',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'Invalid request body',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- require ISO offset datetime validation for top-level session.start_time and session.end_time in sessions-book
- add direct edge regressions for malformed top-level start_time and end_time
- assert invalid requests return 400 with success:false and do not call downstream hold/confirm fetch

## Verification
- npm test -- tests/edge/sessions-book.success-envelope.contract.test.ts
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run build
- npm run validate:tenant

## Blocked / partial checks
- npm run test:ci timed out locally after 240s with unrelated existing dashboard/MSW and AI documentation fetch warnings

## Risk
- protected path: supabase/functions/sessions-book/index.ts
- no auth, client, routing, runtime config, migration, RLS, policy, RPC, seed, or remote-state changes
- reviewer completed with no findings