### PR TITLE
Harden sessions-complete fallback parity

### DIFF
--- a/src/server/__tests__/sessionsCompleteHandler.test.ts
+++ b/src/server/__tests__/sessionsCompleteHandler.test.ts
@@ -203,6 +203,7 @@ describe("sessionsCompleteHandler", () => {
     expect(response.headers.get("Idempotency-Key")).toBe("edge-returned-key");
     expect(response.headers.get("Idempotent-Replay")).toBe("true");
     expect(response.headers.get("Retry-After")).toBe("3");
+    expect(response.headers.get("Content-Type")).toBe("application/json");
   });
 
   it("fails closed when edge returns 401 instead of degrading to runtime REST", async () => {

--- a/src/server/__tests__/sessionsCompleteHandler.test.ts
+++ b/src/server/__tests__/sessionsCompleteHandler.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { sessionsCompleteHandler } from "../api/sessions-complete";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __TESTING__, sessionsCompleteHandler } from "../api/sessions-complete";
 
 vi.mock("../api/shared", async () => {
   const actual = await vi.importActual<typeof import("../api/shared")>("../api/shared");
@@ -22,11 +22,91 @@ import { consumeRateLimit, getAccessToken } from "../api/shared";
 import { getRuntimeSupabaseConfig } from "../runtimeConfig";
 
 describe("sessionsCompleteHandler", () => {
+  const sessionId = "11111111-1111-1111-1111-111111111111";
+
   const jsonResponse = (body: unknown, status = 200) =>
     new Response(JSON.stringify(body), {
       status,
       headers: { "content-type": "application/json" },
     });
+
+  const makeFallbackFetchMock = ({
+    session = {
+      id: sessionId,
+      status: "scheduled",
+      therapist_id: "therapist-user",
+      start_time: "2026-03-31T09:00:00Z",
+      end_time: "2026-03-31T10:00:00Z",
+    },
+    updateRows = [{ id: sessionId, status: "completed", updated_at: "2026-03-31T10:05:00Z" }],
+    goalRows = [] as Array<Record<string, unknown>>,
+    noteRows = [] as Array<Record<string, unknown>>,
+    authStatus = 200,
+    sessionStatus = 200,
+    sessionRows,
+    goalsStatus = 200,
+    notesStatus = 200,
+    auditStatus = 200,
+    edgeNetworkFailure = false,
+  } = {}) => vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+
+    if (url.includes("/functions/v1/sessions-complete") && edgeNetworkFailure) {
+      throw new TypeError("fetch failed");
+    }
+    if (url.includes("/rest/v1/rpc/current_user_is_super_admin")) {
+      return jsonResponse(false);
+    }
+    if (url.includes("/rest/v1/rpc/current_user_organization_id")) {
+      return jsonResponse("org-1");
+    }
+    if (url.includes("/rest/v1/rpc/user_has_role_for_org")) {
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) as { role_name?: string } : {};
+      return jsonResponse(body.role_name === "admin");
+    }
+    if (url.includes("/auth/v1/user")) {
+      return jsonResponse(authStatus < 400 ? { id: "admin-user" } : { error: "Unauthorized" }, authStatus);
+    }
+    if (url.includes("/rest/v1/session_goals")) {
+      return jsonResponse(goalRows, goalsStatus);
+    }
+    if (url.includes("/rest/v1/client_session_notes")) {
+      return jsonResponse(noteRows, notesStatus);
+    }
+    if (url.includes("/rest/v1/sessions") && method === "GET") {
+      return jsonResponse(sessionRows ?? [session], sessionStatus);
+    }
+    if (url.includes("/rest/v1/sessions") && method === "PATCH") {
+      return jsonResponse(updateRows);
+    }
+    if (url.includes("/rest/v1/rpc/record_session_audit")) {
+      return jsonResponse({ ok: auditStatus < 400 }, auditStatus);
+    }
+
+    throw new Error(`Unexpected fetch call: ${method} ${url}`);
+  });
+
+  const getFetchBody = (fetchMock: ReturnType<typeof vi.spyOn>, path: string) => {
+    const call = fetchMock.mock.calls.find(([input]) => String(input).includes(path));
+    expect(call).toBeTruthy();
+    return JSON.parse(String(call?.[1]?.body));
+  };
+
+  const expectMetric = (
+    logSpy: ReturnType<typeof vi.spyOn>,
+    metric: string,
+    labels: Record<string, unknown>,
+  ) => {
+    const payloads = logSpy.mock.calls.map(([line]) => JSON.parse(String(line)) as Record<string, unknown>);
+    expect(payloads).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        level: "metric",
+        metric,
+        ...labels,
+      }),
+    ]));
+  };
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -40,6 +120,10 @@ describe("sessionsCompleteHandler", () => {
       retryAfterSeconds: null,
       mode: "memory",
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("returns 405 for non-POST methods", async () => {
@@ -73,7 +157,9 @@ describe("sessionsCompleteHandler", () => {
           status: 200,
           headers: {
             "content-type": "application/json",
+            "Idempotency-Key": "edge-returned-key",
             "Idempotent-Replay": "true",
+            "Retry-After": "3",
           },
         },
       ),
@@ -84,9 +170,12 @@ describe("sessionsCompleteHandler", () => {
       headers: {
         Authorization: "Bearer token-123",
         "Idempotency-Key": "complete-idempotency-key",
+        "x-request-id": "request-1",
+        "x-correlation-id": "correlation-1",
+        "x-agent-operation-id": "agent-op-1",
       },
       body: JSON.stringify({
-        session_id: "11111111-1111-1111-1111-111111111111",
+        session_id: sessionId,
         outcome: "completed",
         notes: "done",
       }),
@@ -100,7 +189,7 @@ describe("sessionsCompleteHandler", () => {
         method: "POST",
         headers: expect.any(Headers),
         body: JSON.stringify({
-          session_id: "11111111-1111-1111-1111-111111111111",
+          session_id: sessionId,
           outcome: "completed",
           notes: "done",
         }),
@@ -108,21 +197,32 @@ describe("sessionsCompleteHandler", () => {
     );
     const forwardedHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
     expect(forwardedHeaders.get("Idempotency-Key")).toBe("complete-idempotency-key");
-    expect(response.headers.get("Idempotency-Key")).toBe("complete-idempotency-key");
+    expect(forwardedHeaders.get("x-request-id")).toBe("request-1");
+    expect(forwardedHeaders.get("x-correlation-id")).toBe("correlation-1");
+    expect(forwardedHeaders.get("x-agent-operation-id")).toBe("agent-op-1");
+    expect(response.headers.get("Idempotency-Key")).toBe("edge-returned-key");
     expect(response.headers.get("Idempotent-Replay")).toBe("true");
-    fetchMock.mockRestore();
+    expect(response.headers.get("Retry-After")).toBe("3");
   });
 
   it("fails closed when edge returns 401 instead of degrading to runtime REST", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token-123");
     const fetchMock = vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(jsonResponse({ success: false, error: "Unauthorized" }, 401));
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: false, error: "Unauthorized" }), {
+          status: 401,
+          headers: {
+            "content-type": "application/json",
+            "WWW-Authenticate": "Bearer error=\"invalid_token\"",
+          },
+        }),
+      );
 
     const request = new Request("http://localhost/api/sessions-complete", {
       method: "POST",
       headers: { Authorization: "Bearer token-123" },
       body: JSON.stringify({
-        session_id: "11111111-1111-1111-1111-111111111111",
+        session_id: sessionId,
         outcome: "completed",
         notes: "done",
       }),
@@ -133,7 +233,280 @@ describe("sessionsCompleteHandler", () => {
     expect(response.status).toBe(401);
     expect(payload.success).toBe(false);
     expect(payload.error).toBe("Unauthorized");
+    expect(response.headers.get("WWW-Authenticate")).toBe("Bearer error=\"invalid_token\"");
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    fetchMock.mockRestore();
+  });
+
+  it("falls back to runtime REST when edge fetch has no HTTP response", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token-123");
+    const fetchMock = makeFallbackFetchMock({ edgeNetworkFailure: true });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const response = await sessionsCompleteHandler(
+      new Request("http://localhost/api/sessions-complete", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer token-123",
+          "x-request-id": "request-1",
+        },
+        body: JSON.stringify({
+          session_id: sessionId,
+          outcome: "completed",
+          notes: "done",
+        }),
+      }),
+    );
+    const body = await response.json() as { success: boolean; data: { outcome: string } };
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.outcome).toBe("completed");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://example.supabase.co/functions/v1/sessions-complete");
+    expect(getFetchBody(fetchMock, "/rest/v1/rpc/record_session_audit")).toEqual(expect.objectContaining({
+      p_event_type: "session_completed",
+      p_actor_id: "admin-user",
+    }));
+    expectMetric(logSpy, "session_complete_success_total", {
+      function: "sessions-complete",
+      orgId: "org-1",
+      outcome: "completed",
+    });
+  });
+
+  it("runtime REST fallback records completed-session audit and success metric", async () => {
+    const fetchMock = makeFallbackFetchMock();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: "done" },
+      accessToken: "token-123",
+      traceHeaders: {
+        "x-request-id": "request-1",
+        "x-correlation-id": "correlation-1",
+        "x-agent-operation-id": "agent-op-1",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const auditBody = getFetchBody(fetchMock, "/rest/v1/rpc/record_session_audit");
+    expect(auditBody).toEqual({
+      p_session_id: sessionId,
+      p_event_type: "session_completed",
+      p_actor_id: "admin-user",
+      p_event_payload: {
+        outcome: "completed",
+        startTime: "2026-03-31T09:00:00Z",
+        endTime: "2026-03-31T10:00:00Z",
+        notes: "done",
+        agentOperationId: "agent-op-1",
+        trace: {
+          requestId: "request-1",
+          correlationId: "correlation-1",
+          agentOperationId: "agent-op-1",
+        },
+      },
+    });
+    expectMetric(logSpy, "session_complete_success_total", {
+      function: "sessions-complete",
+      orgId: "org-1",
+      outcome: "completed",
+    });
+  });
+
+  it("runtime REST fallback records no-show audit event", async () => {
+    const fetchMock = makeFallbackFetchMock({
+      updateRows: [{ id: sessionId, status: "no-show", updated_at: "2026-03-31T10:05:00Z" }],
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "no-show", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+
+    expect(response.status).toBe(200);
+    expect(getFetchBody(fetchMock, "/rest/v1/rpc/record_session_audit")).toEqual(expect.objectContaining({
+      p_event_type: "session_no_show",
+      p_actor_id: "admin-user",
+    }));
+  });
+
+  it("runtime REST fallback emits notes-required metric", async () => {
+    makeFallbackFetchMock({
+      session: {
+        id: sessionId,
+        status: "in_progress",
+        therapist_id: "therapist-user",
+        start_time: "2026-03-31T09:00:00Z",
+        end_time: "2026-03-31T10:00:00Z",
+      },
+      goalRows: [{ goal_id: "goal-1" }],
+      noteRows: [],
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+    const body = await response.json() as { code: string };
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("SESSION_NOTES_REQUIRED");
+    expectMetric(logSpy, "session_notes_required_rejection_total", {
+      function: "sessions-complete",
+      orgId: "org-1",
+    });
+  });
+
+  it("runtime REST fallback emits concurrent-modification metric", async () => {
+    makeFallbackFetchMock({ updateRows: [] });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+    const body = await response.json() as { code: string; error: string };
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("CONCURRENT_MODIFICATION");
+    expect(body.error).toBe("Session was modified concurrently. Refresh and try again.");
+    expectMetric(logSpy, "session_complete_concurrent_total", {
+      function: "sessions-complete",
+      orgId: "org-1",
+    });
+  });
+
+  it("runtime REST fallback does not fail completion when audit RPC fails", async () => {
+    makeFallbackFetchMock({ auditStatus: 500 });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+
+    expect(response.status).toBe(200);
+    expectMetric(logSpy, "session_audit_failure_total", {
+      eventType: "session_completed",
+      required: false,
+      failureType: "rpc_error",
+    });
+  });
+
+  it("runtime REST fallback maps invalid authenticated user lookups to 401", async () => {
+    makeFallbackFetchMock({ authStatus: 401 });
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+    const body = await response.json() as { error: string };
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(response.headers.get("WWW-Authenticate")).toBe("Bearer");
+  });
+
+  it("runtime REST fallback maps session fetch failures to upstream errors", async () => {
+    makeFallbackFetchMock({ sessionStatus: 500 });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+
+    expect(response.status).toBe(502);
+    expectMetric(logSpy, "org_scoped_query_total", {
+      function: "sessions-complete",
+      orgId: "org-1",
+      operation: "fetch-session",
+    });
+  });
+
+  it("runtime REST fallback emits tenant denial metric when session is outside org scope", async () => {
+    makeFallbackFetchMock({ sessionRows: [] });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+    const body = await response.json() as { code: string };
+
+    expect(response.status).toBe(404);
+    expect(body.code).toBe("SESSION_NOT_FOUND");
+    expectMetric(logSpy, "tenant_denial_total", {
+      function: "sessions-complete",
+      orgId: "org-1",
+      reason: "session-not-found",
+    });
+  });
+
+  it("runtime REST fallback maps session_goals fetch failures to upstream errors", async () => {
+    makeFallbackFetchMock({
+      session: {
+        id: sessionId,
+        status: "in_progress",
+        therapist_id: "therapist-user",
+        start_time: "2026-03-31T09:00:00Z",
+        end_time: "2026-03-31T10:00:00Z",
+      },
+      goalsStatus: 500,
+    });
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+    const body = await response.json() as { error: string };
+
+    expect(response.status).toBe(502);
+    expect(body.error).toBe("Failed to load session goals for notes check");
+  });
+
+  it("runtime REST fallback maps client_session_notes fetch failures to upstream errors", async () => {
+    makeFallbackFetchMock({
+      session: {
+        id: sessionId,
+        status: "in_progress",
+        therapist_id: "therapist-user",
+        start_time: "2026-03-31T09:00:00Z",
+        end_time: "2026-03-31T10:00:00Z",
+      },
+      goalRows: [{ goal_id: "goal-1" }],
+      notesStatus: 500,
+    });
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+    const body = await response.json() as { error: string };
+
+    expect(response.status).toBe(502);
+    expect(body.error).toBe("Failed to load session notes for notes check");
   });
 });

--- a/src/server/api/sessions-complete.ts
+++ b/src/server/api/sessions-complete.ts
@@ -586,26 +586,24 @@ export async function sessionsCompleteHandler(request: Request): Promise<Respons
       });
     }
     const bodyText = await forwarded.text();
-    const responseHeaders: Record<string, string> = {
+    const responseHeaders = new Headers({
       ...corsHeadersForRequest(request),
       ...traceHeaders,
       "Content-Type": forwarded.headers.get("Content-Type") ?? "application/json",
-    };
+    });
     forwarded.headers.forEach((value, key) => {
       const normalized = key.toLowerCase();
       if (
-        normalized === "content-type" ||
         normalized === "retry-after" ||
         normalized === "idempotency-key" ||
         normalized === "idempotent-replay" ||
         normalized === "www-authenticate"
       ) {
-        responseHeaders[key] = value;
+        responseHeaders.set(key, value);
       }
     });
-    const hasReturnedIdempotency = Object.keys(responseHeaders).some((key) => key.toLowerCase() === "idempotency-key");
-    if (!hasReturnedIdempotency && idempotencyKeyHeader) {
-      responseHeaders["Idempotency-Key"] = idempotencyKeyHeader;
+    if (!responseHeaders.has("Idempotency-Key") && idempotencyKeyHeader) {
+      responseHeaders.set("Idempotency-Key", idempotencyKeyHeader);
     }
 
     return new Response(bodyText, {

--- a/src/server/api/sessions-complete.ts
+++ b/src/server/api/sessions-complete.ts
@@ -21,6 +21,38 @@ type CompleteSessionPayload = z.infer<typeof completeSessionSchema>;
 const COMPLETABLE_STATUSES = new Set(["scheduled", "in_progress"]);
 const TERMINAL_STATUSES = new Set(["completed", "cancelled", "no-show"]);
 
+type RuntimeMetricLabels = Record<string, string | number | boolean | null | undefined>;
+
+type RuntimeTraceMeta = {
+  requestId: string | null;
+  correlationId: string | null;
+  agentOperationId: string | null;
+};
+
+const sanitizeMetricLabels = (labels: RuntimeMetricLabels): RuntimeMetricLabels =>
+  Object.entries(labels).reduce<RuntimeMetricLabels>((acc, [key, value]) => {
+    if (value !== undefined && value !== null) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+
+const incrementRuntimeMetric = (name: string, labels: RuntimeMetricLabels = {}): void => {
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    level: "metric",
+    metric: name,
+    count: 1,
+    ...sanitizeMetricLabels(labels),
+  }));
+};
+
+const traceMetaFromHeaders = (traceHeaders: Record<string, string>): RuntimeTraceMeta => ({
+  requestId: traceHeaders["x-request-id"] ?? null,
+  correlationId: traceHeaders["x-correlation-id"] ?? null,
+  agentOperationId: traceHeaders["x-agent-operation-id"] ?? null,
+});
+
 const buildRuntimeHeaders = (accessToken: string, supabaseAnonKey: string): Record<string, string> => ({
   "Content-Type": "application/json",
   apikey: supabaseAnonKey,
@@ -109,16 +141,21 @@ const resolveRuntimeAuthenticatedUserWithStatus = async ({
   accessToken: string;
   supabaseUrl: string;
   supabaseAnonKey: string;
-}): Promise<{ userId: string | null; upstreamError: boolean }> => {
+}): Promise<{ userId: string | null; unauthorized: boolean; upstreamError: boolean }> => {
   const userResult = await fetchJson<{ id?: unknown }>(`${supabaseUrl}/auth/v1/user`, {
     method: "GET",
     headers: buildRuntimeHeaders(accessToken, supabaseAnonKey),
   });
   if (!userResult.ok || !userResult.data) {
-    return { userId: null, upstreamError: userResult.status >= 500 || userResult.status === 0 };
+    return {
+      userId: null,
+      unauthorized: userResult.status === 401 || userResult.status === 403,
+      upstreamError: userResult.status >= 500 || userResult.status === 0,
+    };
   }
   return {
     userId: typeof userResult.data.id === "string" && userResult.data.id.length > 0 ? userResult.data.id : null,
+    unauthorized: false,
     upstreamError: false,
   };
 };
@@ -133,12 +170,15 @@ const checkNotesCoverage = async ({
   organizationId: string;
   supabaseUrl: string;
   headers: Record<string, string>;
-}): Promise<{ ok: true } | { ok: false }> => {
+}): Promise<{ ok: true } | { ok: false } | { upstreamError: true; message: string }> => {
   const sessionGoalsResult = await fetchJson<Array<{ goal_id: string }>>(
     `${supabaseUrl}/rest/v1/session_goals?select=goal_id&organization_id=eq.${encodeURIComponent(organizationId)}&session_id=eq.${encodeURIComponent(sessionId)}`,
     { method: "GET", headers },
   );
-  if (!sessionGoalsResult.ok || !sessionGoalsResult.data || sessionGoalsResult.data.length === 0) {
+  if (!sessionGoalsResult.ok || !sessionGoalsResult.data) {
+    return { upstreamError: true, message: "Failed to load session goals for notes check" };
+  }
+  if (sessionGoalsResult.data.length === 0) {
     return { ok: true };
   }
 
@@ -150,7 +190,7 @@ const checkNotesCoverage = async ({
     { method: "GET", headers },
   );
   if (!notesRowsResult.ok || !notesRowsResult.data) {
-    return { ok: false };
+    return { upstreamError: true, message: "Failed to load session notes for notes check" };
   }
   const coveredGoalIds = new Set<string>();
   for (const row of notesRowsResult.data) {
@@ -170,7 +210,63 @@ const checkNotesCoverage = async ({
     : { ok: false };
 };
 
-const _completeSessionViaRuntimeRest = async ({
+const recordRuntimeSessionAuditEvent = async ({
+  sessionId,
+  eventType,
+  actorId,
+  payload,
+  supabaseUrl,
+  headers,
+}: {
+  sessionId: string;
+  eventType: string;
+  actorId: string;
+  payload: Record<string, unknown>;
+  supabaseUrl: string;
+  headers: Record<string, string>;
+}): Promise<void> => {
+  try {
+    const result = await fetchJson(`${supabaseUrl}/rest/v1/rpc/record_session_audit`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        p_session_id: sessionId,
+        p_event_type: eventType,
+        p_actor_id: actorId,
+        p_event_payload: payload,
+      }),
+    });
+
+    if (!result.ok) {
+      incrementRuntimeMetric("session_audit_failure_total", {
+        eventType,
+        required: false,
+        failureType: "rpc_error",
+      });
+      console.warn(JSON.stringify({
+        level: "warn",
+        message: "audit.event.persist_failed",
+        eventType,
+        sessionId,
+      }));
+    }
+  } catch (error) {
+    incrementRuntimeMetric("session_audit_failure_total", {
+      eventType,
+      required: false,
+      failureType: "exception",
+    });
+    console.error(JSON.stringify({
+      level: "error",
+      message: "audit.event.exception",
+      eventType,
+      sessionId,
+      error: error instanceof Error ? error.message : "unknown",
+    }));
+  }
+};
+
+const completeSessionViaRuntimeRest = async ({
   request,
   payload,
   accessToken,
@@ -190,6 +286,11 @@ const _completeSessionViaRuntimeRest = async ({
     });
   }
   if (!roleResolution.organizationId || (!roleResolution.isTherapist && !roleResolution.isAdmin && !roleResolution.isSuperAdmin)) {
+    incrementRuntimeMetric("tenant_denial_total", {
+      function: "sessions-complete",
+      orgId: roleResolution.organizationId ?? undefined,
+      reason: roleResolution.organizationId ? "role-denied" : "missing-org",
+    });
     return errorResponse(request, "forbidden", "Forbidden", { headers: traceHeaders });
   }
 
@@ -200,23 +301,65 @@ const _completeSessionViaRuntimeRest = async ({
       headers: traceHeaders,
     });
   }
+  if (currentUserResult.unauthorized) {
+    return errorResponse(request, "unauthorized", "Unauthorized", {
+      status: 401,
+      headers: { ...traceHeaders, "WWW-Authenticate": "Bearer" },
+    });
+  }
   if (!currentUserResult.userId) {
-    return errorResponse(request, "forbidden", "Forbidden", { headers: traceHeaders });
+    return errorResponse(request, "unauthorized", "Unauthorized", {
+      status: 401,
+      headers: { ...traceHeaders, "WWW-Authenticate": "Bearer" },
+    });
   }
 
   const organizationId = roleResolution.organizationId;
   const currentUserId = currentUserResult.userId;
   const headers = buildRuntimeHeaders(accessToken, supabaseAnonKey);
-  const sessionResult = await fetchJson<Array<{ id: string; status: string; therapist_id: string | null }>>(
-    `${supabaseUrl}/rest/v1/sessions?select=id,status,therapist_id&organization_id=eq.${encodeURIComponent(organizationId)}&id=eq.${encodeURIComponent(payload.session_id)}`,
+  const sessionResult = await fetchJson<Array<{
+    id: string;
+    status: string;
+    therapist_id: string | null;
+    start_time: string;
+    end_time: string;
+  }>>(
+    `${supabaseUrl}/rest/v1/sessions?select=id,status,therapist_id,start_time,end_time&organization_id=eq.${encodeURIComponent(organizationId)}&id=eq.${encodeURIComponent(payload.session_id)}`,
     { method: "GET", headers },
   );
-  if (!sessionResult.ok || !sessionResult.data || sessionResult.data.length === 0) {
-    return errorResponse(request, "not_found", "Session not found", { headers: traceHeaders });
+  incrementRuntimeMetric("org_scoped_query_total", {
+    function: "sessions-complete",
+    orgId: organizationId,
+    operation: "fetch-session",
+  });
+  if (!sessionResult.ok || !sessionResult.data) {
+    return errorResponse(request, "upstream_error", "Failed to load session", {
+      status: 502,
+      headers: traceHeaders,
+    });
+  }
+  if (sessionResult.data.length === 0) {
+    incrementRuntimeMetric("tenant_denial_total", {
+      function: "sessions-complete",
+      orgId: organizationId,
+      reason: "session-not-found",
+    });
+    return errorResponse(request, "not_found", "Session not found", {
+      headers: traceHeaders,
+      extra: { code: "SESSION_NOT_FOUND" },
+    });
   }
   const session = sessionResult.data[0];
   if (roleResolution.isTherapist && session.therapist_id !== currentUserId) {
-    return errorResponse(request, "forbidden", "Forbidden", { headers: traceHeaders });
+    incrementRuntimeMetric("tenant_denial_total", {
+      function: "sessions-complete",
+      orgId: organizationId,
+      reason: "therapist-mismatch",
+    });
+    return errorResponse(request, "forbidden", "Forbidden", {
+      headers: traceHeaders,
+      extra: { code: "FORBIDDEN" },
+    });
   }
   if (TERMINAL_STATUSES.has(session.status)) {
     return errorResponse(request, "conflict", `Session is already in a terminal state: ${session.status}`, {
@@ -240,7 +383,17 @@ const _completeSessionViaRuntimeRest = async ({
       supabaseUrl,
       headers,
     });
+    if ("upstreamError" in notesCoverage) {
+      return errorResponse(request, "upstream_error", notesCoverage.message, {
+        status: 502,
+        headers: traceHeaders,
+      });
+    }
     if (!notesCoverage.ok) {
+      incrementRuntimeMetric("session_notes_required_rejection_total", {
+        function: "sessions-complete",
+        orgId: organizationId,
+      });
       return errorResponse(
         request,
         "conflict",
@@ -272,13 +425,48 @@ const _completeSessionViaRuntimeRest = async ({
       body: JSON.stringify(updates),
     },
   );
-  if (!updateResult.ok || !updateResult.data || updateResult.data.length === 0) {
+  if (!updateResult.ok || !updateResult.data) {
     return errorResponse(request, "conflict", "Session could not be completed", {
       status: 409,
       headers: traceHeaders,
       extra: { code: "UPDATE_FAILED" },
     });
   }
+  if (updateResult.data.length === 0) {
+    incrementRuntimeMetric("session_complete_concurrent_total", {
+      function: "sessions-complete",
+      orgId: organizationId,
+    });
+    return errorResponse(request, "conflict", "Session was modified concurrently. Refresh and try again.", {
+      status: 409,
+      headers: traceHeaders,
+      extra: { code: "CONCURRENT_MODIFICATION" },
+    });
+  }
+
+  const traceMeta = traceMetaFromHeaders(traceHeaders);
+  const eventType = payload.outcome === "completed" ? "session_completed" : "session_no_show";
+  await recordRuntimeSessionAuditEvent({
+    sessionId: payload.session_id,
+    eventType,
+    actorId: currentUserId,
+    supabaseUrl,
+    headers,
+    payload: {
+      outcome: payload.outcome,
+      startTime: session.start_time,
+      endTime: session.end_time,
+      notes: payload.notes ?? null,
+      agentOperationId: traceMeta.agentOperationId,
+      trace: traceMeta,
+    },
+  });
+
+  incrementRuntimeMetric("session_complete_success_total", {
+    function: "sessions-complete",
+    orgId: organizationId,
+    outcome: payload.outcome,
+  });
 
   return jsonForRequest(
     request,
@@ -382,26 +570,47 @@ export async function sessionsCompleteHandler(request: Request): Promise<Respons
     if (idempotencyKeyHeader) {
       forwardHeaders.set("Idempotency-Key", idempotencyKeyHeader);
     }
-    const forwarded = await fetch(functionUrl, {
-      method: "POST",
-      headers: forwardHeaders,
-      body: JSON.stringify(parsed.data),
-    });
+    let forwarded: Response;
+    try {
+      forwarded = await fetch(functionUrl, {
+        method: "POST",
+        headers: forwardHeaders,
+        body: JSON.stringify(parsed.data),
+      });
+    } catch {
+      return completeSessionViaRuntimeRest({
+        request,
+        payload: parsed.data,
+        accessToken,
+        traceHeaders,
+      });
+    }
     const bodyText = await forwarded.text();
-    const retryAfter = forwarded.headers.get("Retry-After");
-    const returnedIdempotency = forwarded.headers.get("Idempotency-Key") ?? idempotencyKeyHeader ?? undefined;
-    const idempotentReplay = forwarded.headers.get("Idempotent-Replay");
+    const responseHeaders: Record<string, string> = {
+      ...corsHeadersForRequest(request),
+      ...traceHeaders,
+      "Content-Type": forwarded.headers.get("Content-Type") ?? "application/json",
+    };
+    forwarded.headers.forEach((value, key) => {
+      const normalized = key.toLowerCase();
+      if (
+        normalized === "content-type" ||
+        normalized === "retry-after" ||
+        normalized === "idempotency-key" ||
+        normalized === "idempotent-replay" ||
+        normalized === "www-authenticate"
+      ) {
+        responseHeaders[key] = value;
+      }
+    });
+    const hasReturnedIdempotency = Object.keys(responseHeaders).some((key) => key.toLowerCase() === "idempotency-key");
+    if (!hasReturnedIdempotency && idempotencyKeyHeader) {
+      responseHeaders["Idempotency-Key"] = idempotencyKeyHeader;
+    }
 
     return new Response(bodyText, {
       status: forwarded.status,
-      headers: {
-        ...corsHeadersForRequest(request),
-        ...traceHeaders,
-        "Content-Type": "application/json",
-        ...(retryAfter ? { "Retry-After": retryAfter } : {}),
-        ...(returnedIdempotency ? { "Idempotency-Key": returnedIdempotency } : {}),
-        ...(idempotentReplay ? { "Idempotent-Replay": idempotentReplay } : {}),
-      },
+      headers: responseHeaders,
     });
   } catch {
     return errorResponse(request, "upstream_error", "Failed to complete session", {
@@ -410,3 +619,7 @@ export async function sessionsCompleteHandler(request: Request): Promise<Respons
     });
   }
 }
+
+export const __TESTING__ = {
+  completeSessionViaRuntimeRest,
+};

--- a/tests/edge/sessions-complete.test.ts
+++ b/tests/edge/sessions-complete.test.ts
@@ -17,6 +17,8 @@ vi.mock("../../supabase/functions/_shared/metrics.ts", () => ({
 }));
 
 import * as database from "../../supabase/functions/_shared/database.ts";
+import { recordSessionAuditEvent } from "../../supabase/functions/_shared/audit.ts";
+import { increment } from "../../supabase/functions/_shared/metrics.ts";
 import { __TESTING__ } from "../../supabase/functions/sessions-complete/index.ts";
 
 const { handleSessionCompletion, parseCompletionPayload, checkSessionNotesPresent } = __TESTING__;
@@ -110,6 +112,23 @@ describe("sessions-complete handler", () => {
     expect(body.success).toBe(true);
     expect(body.data.outcome).toBe("completed");
     expect(body.data.session.id).toBe("session-1");
+    expect(recordSessionAuditEvent).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      sessionId: "session-1",
+      eventType: "session_completed",
+      actorId: "admin-user",
+      required: false,
+      payload: expect.objectContaining({
+        outcome: "completed",
+        startTime: "2026-03-31T09:00:00Z",
+        endTime: "2026-03-31T10:00:00Z",
+        notes: null,
+      }),
+    }));
+    expect(increment).toHaveBeenCalledWith("session_complete_success_total", {
+      function: "sessions-complete",
+      orgId: "org-1",
+      outcome: "completed",
+    });
   });
 
   it("marks an in_progress session as no-show (authorized admin)", async () => {
@@ -138,6 +157,21 @@ describe("sessions-complete handler", () => {
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
     expect(body.data.outcome).toBe("no-show");
+    expect(recordSessionAuditEvent).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      sessionId: "session-2",
+      eventType: "session_no_show",
+      actorId: "admin-user",
+      required: false,
+      payload: expect.objectContaining({
+        outcome: "no-show",
+        notes: "Client did not attend",
+      }),
+    }));
+    expect(increment).toHaveBeenCalledWith("session_complete_success_total", {
+      function: "sessions-complete",
+      orgId: "org-1",
+      outcome: "no-show",
+    });
   });
 
   it("allows a therapist to complete their own session", async () => {
@@ -275,6 +309,10 @@ describe("sessions-complete handler", () => {
     expect(response.status).toBe(409);
     expect(body.success).toBe(false);
     expect(body.code).toBe("CONCURRENT_MODIFICATION");
+    expect(increment).toHaveBeenCalledWith("session_complete_concurrent_total", {
+      function: "sessions-complete",
+      orgId: "org-1",
+    });
   });
 
   it("returns 404 when the session is not found in the org scope", async () => {
@@ -494,6 +532,10 @@ describe("sessions-complete handler — SESSION_NOTES_REQUIRED guard", () => {
     expect(response.status).toBe(409);
     expect(body.success).toBe(false);
     expect(body.code).toBe("SESSION_NOTES_REQUIRED");
+    expect(increment).toHaveBeenCalledWith("session_notes_required_rejection_total", {
+      function: "sessions-complete",
+      orgId: "org-1",
+    });
   });
 
   it("rejects an in_progress session when some goal_notes entries are missing (409 SESSION_NOTES_REQUIRED)", async () => {


### PR DESCRIPTION
## Summary
- Implement runtime REST fallback parity for `/api/sessions-complete` audit and metrics behavior.
- Route edge network failures without an HTTP response into the runtime fallback while preserving explicit edge HTTP responses.
- Add server and edge tests for proxy headers, fallback audit/metric parity, failure mapping, and edge oracle metrics.

Linear: WIN-126

## Verification
- `npx vitest run src/server/__tests__/sessionsCompleteHandler.test.ts tests/edge/sessions-complete.test.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:routes:tier0`
- `npm run verify:local`

## Notes
- Local policy checks skipped DB-backed grant/drift checks because `SUPABASE_DB_URL`/`DATABASE_URL` is not configured.
- Full `npm run ci:playwright` was not run locally; `verify:local` includes the tier-0 Cypress route/auth gate.