### PR TITLE
Add admin week-forward scheduling flow

### DIFF
--- a/src/features/scheduling/domain/weekForward.ts
+++ b/src/features/scheduling/domain/weekForward.ts
@@ -1,0 +1,86 @@
+import type {
+  WeekForwardCommitResult,
+  WeekForwardPreviewResult,
+  WeekForwardRequestBody,
+} from "../../../server/types";
+import { supabase } from "../../../lib/supabase";
+import { callApiRoute } from "../../../lib/sdk/client";
+import { parseJsonResponse } from "../../../lib/sdk/contracts";
+import { toNormalizedApiError, type NormalizedApiError } from "../../../lib/sdk/errors";
+import { weekForwardEnvelopeSchema } from "../../../lib/contracts/scheduling";
+import { getSupabaseAnonKey } from "../../../lib/runtimeConfig";
+
+const getSessionAccessToken = async (): Promise<string | null> => {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const token = session?.access_token?.trim();
+  return token && token.length > 0 ? token : null;
+};
+
+async function postWeekForward(
+  payload: WeekForwardRequestBody,
+): Promise<WeekForwardPreviewResult | WeekForwardCommitResult> {
+  const token = await getSessionAccessToken();
+  if (!token) {
+    throw new Error("Authentication is required to apply this week forward");
+  }
+
+  const headers: Record<string, string> = {};
+  try {
+    const anonKey = getSupabaseAnonKey().trim();
+    if (anonKey.length > 0) {
+      headers.apikey = anonKey;
+    }
+  } catch {
+    // Runtime config unavailable in tests or early startup; skip optional apikey.
+  }
+
+  const response = await callApiRoute(
+    "/api/sessions-week-forward",
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    },
+    {
+      accessToken: token,
+    },
+  );
+
+  const parsed = await parseJsonResponse(response.clone(), weekForwardEnvelopeSchema);
+  if (!response.ok || !parsed?.data) {
+    let fallbackPayload: Record<string, unknown> | null = null;
+    try {
+      fallbackPayload = await response.json() as Record<string, unknown>;
+    } catch {
+      fallbackPayload = null;
+    }
+    throw toNormalizedApiError(
+      fallbackPayload,
+      response.status,
+      "Failed to apply week-forward scheduling",
+    );
+  }
+
+  return parsed.data as WeekForwardPreviewResult | WeekForwardCommitResult;
+}
+
+export async function previewWeekForwardScheduling(
+  payload: Omit<WeekForwardRequestBody, "dryRun">,
+): Promise<WeekForwardPreviewResult> {
+  return postWeekForward({ ...payload, dryRun: true }) as Promise<WeekForwardPreviewResult>;
+}
+
+export async function applyWeekForwardScheduling(
+  payload: Omit<WeekForwardRequestBody, "dryRun">,
+): Promise<WeekForwardCommitResult> {
+  return postWeekForward({ ...payload, dryRun: false }) as Promise<WeekForwardCommitResult>;
+}
+
+export const asWeekForwardError = (error: unknown): NormalizedApiError => {
+  if (error instanceof Error) {
+    return error as NormalizedApiError;
+  }
+  return new Error(String(error)) as NormalizedApiError;
+};

--- a/src/lib/contracts/scheduling.ts
+++ b/src/lib/contracts/scheduling.ts
@@ -35,3 +35,30 @@ export const bookSessionEnvelopeSchema = baseApiEnvelopeSchema.extend({
   data: bookSessionResultSchema,
 });
 
+export const weekForwardConflictSchema = z.object({
+  sourceSessionId: z.string(),
+  conflictingSessionId: z.string().optional(),
+  startTime: z.string(),
+  endTime: z.string(),
+  therapistId: z.string(),
+  clientId: z.string(),
+  code: z.string(),
+  message: z.string(),
+});
+
+export const weekForwardPreviewResultSchema = z.object({
+  sourceSessionCount: z.number().int().nonnegative(),
+  generatedSessionCount: z.number().int().nonnegative(),
+  generatedWeekCount: z.number().int().nonnegative(),
+  endDate: z.string(),
+  conflicts: z.array(weekForwardConflictSchema),
+});
+
+export const weekForwardCommitResultSchema = weekForwardPreviewResultSchema.extend({
+  createdSessions: z.array(z.record(z.unknown())),
+});
+
+export const weekForwardEnvelopeSchema = baseApiEnvelopeSchema.extend({
+  data: z.union([weekForwardPreviewResultSchema, weekForwardCommitResultSchema]).optional(),
+});
+

--- a/src/lib/sdk/errors.ts
+++ b/src/lib/sdk/errors.ts
@@ -6,6 +6,7 @@ export type ApiErrorShape = {
   retryAfter?: string | null;
   retryAfterSeconds?: number | null;
   orchestration?: Record<string, unknown> | null;
+  data?: unknown;
 };
 
 export type NormalizedApiError = Error & {
@@ -15,6 +16,7 @@ export type NormalizedApiError = Error & {
   retryAfter?: string | null;
   retryAfterSeconds?: number | null;
   orchestration?: Record<string, unknown> | null;
+  data?: unknown;
 };
 
 export const toNormalizedApiError = (
@@ -30,6 +32,7 @@ export const toNormalizedApiError = (
   error.retryAfter = typeof payload?.retryAfter === "string" ? payload.retryAfter : null;
   error.retryAfterSeconds = typeof payload?.retryAfterSeconds === "number" ? payload.retryAfterSeconds : null;
   error.orchestration = payload?.orchestration ?? null;
+  error.data = payload?.data;
   return error;
 };
 

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -9,7 +9,7 @@ import React, {
   Suspense,
 } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { format, parseISO, startOfWeek, addDays, endOfWeek } from "date-fns";
+import { format, parseISO, startOfWeek, addDays, addMonths, endOfWeek } from "date-fns";
 import { getTimezoneOffset } from "date-fns-tz";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import {
@@ -25,6 +25,7 @@ import {
   type SessionModalSubmitData,
   type SessionModalClinicalNotesPayload,
 } from "../components/SessionModal";
+import type { WeekForwardPreviewResult } from "../server/types";
 import { SessionFilters } from "../components/SessionFilters";
 import { useDebounce } from "../lib/performance";
 import {
@@ -58,6 +59,11 @@ import {
   bookSessionViaApi,
   buildBookSessionApiPayload,
 } from "../features/scheduling/domain/booking";
+import {
+  applyWeekForwardScheduling,
+  asWeekForwardError,
+  previewWeekForwardScheduling,
+} from "../features/scheduling/domain/weekForward";
 import { buildScheduleDisplayData } from "../features/scheduling/domain/displayData";
 import {
   collectTherapistScopeCandidateIds,
@@ -88,6 +94,7 @@ import {
   SCHEDULE_MODAL_URL_TTL_MS,
 } from "./schedule-modal-url-state";
 import { getSessionStatusClasses } from "./ScheduleSessionStatusStyles";
+import { weekForwardPreviewResultSchema } from "../lib/contracts/scheduling";
 
 const MISSING_NOTES_RETRY_HINT =
   "Before closing this in-progress session, persist per-goal note text for each worked goal on a linked session note. Save session capture from Schedule (Session capture), or add notes in Client Details > Session Notes. Narrative and signatures are completed in Client Details.";
@@ -419,11 +426,14 @@ export const Schedule = React.memo(() => {
   }, []);
 
   const [recurrenceEnabled, setRecurrenceEnabled] = useState(false);
+  const [advancedRecurrenceEnabled, setAdvancedRecurrenceEnabled] = useState(false);
   const [recurrenceRule, setRecurrenceRule] = useState("FREQ=WEEKLY;INTERVAL=1");
   const [recurrenceCount, setRecurrenceCount] = useState<number | undefined>();
   const [recurrenceUntil, setRecurrenceUntil] = useState("");
   const [recurrenceExceptions, setRecurrenceExceptions] = useState<string[]>([]);
   const [recurrenceTimeZone, setRecurrenceTimeZone] = useState(userTimeZone);
+  const [weekForwardEndDate, setWeekForwardEndDate] = useState("");
+  const [weekForwardPreview, setWeekForwardPreview] = useState<WeekForwardPreviewResult | null>(null);
 
   useLayoutEffect(() => {
     setRecurrenceTimeZone(userTimeZone);
@@ -437,7 +447,7 @@ export const Schedule = React.memo(() => {
 
   const recurrenceFormState = useMemo<RecurrenceFormState>(
     () => ({
-      enabled: recurrenceEnabled,
+      enabled: advancedRecurrenceEnabled,
       rule: recurrenceRule,
       count: recurrenceCount,
       until: recurrenceUntil,
@@ -445,7 +455,7 @@ export const Schedule = React.memo(() => {
       timeZone: recurrenceTimeZone,
     }),
     [
-      recurrenceEnabled,
+      advancedRecurrenceEnabled,
       recurrenceRule,
       recurrenceCount,
       recurrenceUntil,
@@ -668,6 +678,13 @@ export const Schedule = React.memo(() => {
     therapistScopedView && !showOrgDirectoryEmpty && displayData.sessions.length === 0;
 
   useEffect(() => {
+    if (recurrenceEnabled) {
+      return;
+    }
+    setWeekForwardEndDate(format(addMonths(weekEnd, 2), "yyyy-MM-dd"));
+  }, [recurrenceEnabled, weekEnd]);
+
+  useEffect(() => {
     if (therapistScopedView) {
       setView("day");
     }
@@ -784,6 +801,27 @@ export const Schedule = React.memo(() => {
     scopedTherapistId,
     therapistLinkedClientIdsQuery.data,
   ]);
+  const weekForwardSourceSessions = displayData.sessions;
+  const weekForwardHasVisibleSessions = weekForwardSourceSessions.length > 0;
+  const weekForwardInvalidStatusSessions = useMemo(
+    () => weekForwardSourceSessions.filter((session) => session.status !== "scheduled"),
+    [weekForwardSourceSessions],
+  );
+  const weekForwardBlockedStatuses = useMemo(
+    () => Array.from(new Set(weekForwardInvalidStatusSessions.map((session) => session.status).filter(Boolean))),
+    [weekForwardInvalidStatusSessions],
+  );
+  const weekForwardRequiresOrgContext = effectiveRole === "super_admin" && !activeOrganizationId;
+  const weekForwardAvailableInCurrentView = view === "week";
+  const weekForwardSourceSummary = `${format(weekStart, "MMM d")} - ${format(weekEnd, "MMM d, yyyy")}`;
+  const weekForwardCanPreview =
+    !therapistScopedView &&
+    recurrenceEnabled &&
+    weekForwardAvailableInCurrentView &&
+    !weekForwardRequiresOrgContext &&
+    weekForwardHasVisibleSessions &&
+    weekForwardInvalidStatusSessions.length === 0 &&
+    weekForwardEndDate.trim().length > 0;
   const isScheduleShellNarrow = useSyncExternalStore(
     (onStoreChange) => {
       if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
@@ -809,7 +847,7 @@ export const Schedule = React.memo(() => {
     parts.push(view === "day" ? "Day view" : "Week view");
     parts.push(tzShort);
     if (!therapistScopedView && recurrenceEnabled) {
-      parts.push("Recurrence on");
+      parts.push("Week-forward on");
     }
     if (therapistScopedView) {
       parts.push("All therapists");
@@ -958,6 +996,72 @@ export const Schedule = React.memo(() => {
       handleScheduleMutationError(error);
     },
   });
+
+  const weekForwardPreviewMutation = useMutation({
+    mutationFn: async () =>
+      previewWeekForwardScheduling({
+        sourceSessionIds: weekForwardSourceSessions.map((session) => session.id),
+        displayedWeekStart: weekStart.toISOString(),
+        displayedWeekEnd: weekEnd.toISOString(),
+        endDate: weekForwardEndDate,
+        timeZone: recurrenceTimeZone,
+      }),
+    onSuccess: (result) => {
+      setWeekForwardPreview(result);
+      if (result.generatedSessionCount === 0) {
+        showSuccess("No future sessions will be created for the selected end date.");
+      }
+    },
+    onError: (error) => {
+      const normalized = asWeekForwardError(error);
+      const parsedPreview = weekForwardPreviewResultSchema.safeParse(normalized.data);
+      if (parsedPreview.success) {
+        setWeekForwardPreview(parsedPreview.data);
+      } else {
+        setWeekForwardPreview(null);
+      }
+      showError(normalized.message);
+    },
+  });
+
+  const weekForwardApplyMutation = useMutation({
+    mutationFn: async () =>
+      applyWeekForwardScheduling({
+        sourceSessionIds: weekForwardSourceSessions.map((session) => session.id),
+        displayedWeekStart: weekStart.toISOString(),
+        displayedWeekEnd: weekEnd.toISOString(),
+        endDate: weekForwardEndDate,
+        timeZone: recurrenceTimeZone,
+      }),
+    onSuccess: async (result) => {
+      setWeekForwardPreview(result);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["sessions"] }),
+        queryClient.invalidateQueries({ queryKey: ["sessions-batch"] }),
+      ]);
+      showSuccess(
+        `Applied ${result.sourceSessionCount} visible sessions through ${format(parseISO(`${result.endDate}T12:00:00Z`), "MMM d, yyyy")}.`,
+      );
+    },
+    onError: (error) => {
+      const normalized = asWeekForwardError(error);
+      const parsedPreview = weekForwardPreviewResultSchema.safeParse(normalized.data);
+      if (parsedPreview.success) {
+        setWeekForwardPreview(parsedPreview.data);
+      }
+      showError(normalized.message);
+    },
+  });
+
+  useEffect(() => {
+    setWeekForwardPreview(null);
+  }, [
+    recurrenceEnabled,
+    recurrenceTimeZone,
+    weekForwardEndDate,
+    weekForwardSourceSessions,
+    weekForwardAvailableInCurrentView,
+  ]);
 
   const cancelSessionMutation = useMutation({
     mutationFn: async ({
@@ -1889,7 +1993,7 @@ export const Schedule = React.memo(() => {
               checked={recurrenceEnabled}
               onChange={(event) => setRecurrenceEnabled(event.target.checked)}
             />
-            Enable recurrence (RRULE)
+            Apply this visible week forward
           </label>
 
           <div className="flex items-center gap-2 w-full md:w-auto">
@@ -1908,114 +2012,237 @@ export const Schedule = React.memo(() => {
         </div>
 
         {recurrenceEnabled && (
-          <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="md:col-span-2">
-              <label htmlFor="recurrence-rrule" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                RRULE
-              </label>
-              <input
-                id="recurrence-rrule"
-                type="text"
-                value={recurrenceRule}
-                onChange={(event) => setRecurrenceRule(event.target.value)}
-                className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:text-gray-200"
-                placeholder="FREQ=WEEKLY;BYDAY=MO,WE;INTERVAL=1"
-              />
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                Provide a valid RFC 5545 RRULE string. Weekly rules support automatic timezone-aware scheduling.
-              </p>
-            </div>
-
-            <div>
-              <label htmlFor="recurrence-count" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Count
-              </label>
-              <input
-                id="recurrence-count"
-                type="number"
-                min="1"
-                value={typeof recurrenceCount === "number" ? recurrenceCount : ""}
-                onChange={(event) => {
-                  const { value } = event.target;
-                  if (value.trim().length === 0) {
-                    setRecurrenceCount(undefined);
-                    return;
-                  }
-
-                  const parsed = Number(value);
-                  setRecurrenceCount(Number.isNaN(parsed) ? undefined : parsed);
-                }}
-                className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:text-gray-200"
-              />
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                Limit the number of occurrences. Leave blank to rely on the RRULE or end date.
-              </p>
-            </div>
-
-            <div>
-              <label htmlFor="recurrence-until" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Until
-              </label>
-              <input
-                id="recurrence-until"
-                type="datetime-local"
-                value={recurrenceUntil}
-                onChange={(event) => setRecurrenceUntil(event.target.value)}
-                className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:text-gray-200"
-              />
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                Optional end date in the selected time zone.
-              </p>
-            </div>
-
-            <div className="md:col-span-2">
-              <div className="flex items-center justify-between mb-2">
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Exceptions
-                </span>
-                <button
-                  type="button"
-                  onClick={handleAddRecurrenceException}
-                  className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-600 hover:text-blue-700 focus:outline-none"
-                >
-                  Add exception
-                </button>
+          <div className="mt-4 space-y-4">
+            {!weekForwardAvailableInCurrentView ? (
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+                Switch to Week view to apply the currently displayed week forward.
               </div>
-
-              {recurrenceExceptions.length === 0 ? (
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  No exception dates configured.
-                </p>
-              ) : (
-                <div className="space-y-2">
-                  {recurrenceExceptions.map((value, index) => (
-                    <div key={`recurrence-exception-${index}`} className="flex items-center gap-2">
-                      <label
-                        htmlFor={`recurrence-exception-input-${index}`}
-                        className="sr-only"
-                      >
-                        Exception date {index + 1}
-                      </label>
-                      <input
-                        id={`recurrence-exception-input-${index}`}
-                        type="datetime-local"
-                        value={value}
-                        onChange={(event) => handleRecurrenceExceptionChange(index, event.target.value)}
-                        className="flex-1 rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:text-gray-200"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => handleRemoveRecurrenceException(index)}
-                        aria-label={`Remove exception date ${index + 1}`}
-                        className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-red-600 hover:text-red-700 focus:outline-none"
-                      >
-                        Remove
-                      </button>
+            ) : (
+              <>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-dark">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Source week</div>
+                    <div className="mt-1 text-sm font-medium text-gray-900 dark:text-gray-100">{weekForwardSourceSummary}</div>
+                    <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      {weekForwardSourceSessions.length} visible {weekForwardSourceSessions.length === 1 ? "session" : "sessions"} will be used.
                     </div>
-                  ))}
+                  </div>
+
+                  <div>
+                    <label htmlFor="week-forward-end-date" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      End date
+                    </label>
+                    <input
+                      id="week-forward-end-date"
+                      type="date"
+                      value={weekForwardEndDate}
+                      min={format(addDays(weekEnd, 1), "yyyy-MM-dd")}
+                      onChange={(event) => setWeekForwardEndDate(event.target.value)}
+                      className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:text-gray-200"
+                    />
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      The displayed week will repeat weekly through this inclusive date in {recurrenceTimeZone}.
+                    </p>
+                  </div>
                 </div>
-              )}
-            </div>
+
+                <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-100">
+                  The operation stops on the first conflict and creates nothing unless the whole batch is valid.
+                </div>
+
+                {weekForwardRequiresOrgContext ? (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+                    Choose an organization context before applying a visible week forward as a super admin.
+                  </div>
+                ) : null}
+
+                {!weekForwardHasVisibleSessions ? (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+                    There are no visible sessions in this displayed week to reuse.
+                  </div>
+                ) : null}
+
+                {weekForwardInvalidStatusSessions.length > 0 ? (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+                    Every visible session must be scheduled before cloning this week forward.
+                    <div className="mt-1 text-xs">
+                      Blocking statuses: {weekForwardBlockedStatuses.join(", ")}.
+                    </div>
+                  </div>
+                ) : null}
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <button
+                    type="button"
+                    onClick={() => void weekForwardPreviewMutation.mutateAsync()}
+                    disabled={!weekForwardCanPreview || weekForwardPreviewMutation.isPending || weekForwardApplyMutation.isPending}
+                    className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {weekForwardPreviewMutation.isPending ? "Previewing..." : "Preview week-forward schedule"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void weekForwardApplyMutation.mutateAsync()}
+                    disabled={!weekForwardCanPreview || !weekForwardPreview || weekForwardPreview.generatedSessionCount === 0 || weekForwardPreviewMutation.isPending || weekForwardApplyMutation.isPending}
+                    className="inline-flex items-center justify-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {weekForwardApplyMutation.isPending ? "Applying..." : "Apply this week forward"}
+                  </button>
+                </div>
+
+                {weekForwardPreview ? (
+                  <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-dark">
+                    <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">Preview</div>
+                    <div className="mt-2 grid grid-cols-1 gap-3 md:grid-cols-3">
+                      <div>
+                        <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Source sessions</div>
+                        <div className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">{weekForwardPreview.sourceSessionCount}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Generated sessions</div>
+                        <div className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">{weekForwardPreview.generatedSessionCount}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Generated weeks</div>
+                        <div className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">{weekForwardPreview.generatedWeekCount}</div>
+                      </div>
+                    </div>
+
+                    {weekForwardPreview.conflicts.length > 0 ? (
+                      <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-800 dark:bg-red-950/40 dark:text-red-100">
+                        <div className="font-medium">Blocking conflict</div>
+                        {weekForwardPreview.conflicts.map((conflict) => (
+                          <div key={`${conflict.sourceSessionId}-${conflict.startTime}`} className="mt-2">
+                            {conflict.message} ({format(parseISO(conflict.startTime), "MMM d, yyyy h:mm a")} - {format(parseISO(conflict.endTime), "h:mm a")})
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </>
+            )}
+
+            <details className="rounded-lg border border-dashed border-gray-300 p-3 dark:border-gray-600">
+              <summary className="cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">
+                Advanced single-session RRULE
+              </summary>
+              <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div className="md:col-span-2">
+                  <label className="inline-flex items-center text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <input
+                      type="checkbox"
+                      className="mr-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                      checked={advancedRecurrenceEnabled}
+                      onChange={(event) => setAdvancedRecurrenceEnabled(event.target.checked)}
+                    />
+                    Apply raw RRULE when saving from the session modal
+                  </label>
+                </div>
+
+                <div className="md:col-span-2">
+                  <label htmlFor="recurrence-rrule" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    RRULE
+                  </label>
+                  <input
+                    id="recurrence-rrule"
+                    type="text"
+                    value={recurrenceRule}
+                    onChange={(event) => setRecurrenceRule(event.target.value)}
+                    className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:text-gray-200"
+                    placeholder="FREQ=WEEKLY;BYDAY=MO,WE;INTERVAL=1"
+                  />
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    Use this only when you need a manual RFC 5545 rule for a single modal save.
+                  </p>
+                </div>
+
+                <div>
+                  <label htmlFor="recurrence-count" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    Count
+                  </label>
+                  <input
+                    id="recurrence-count"
+                    type="number"
+                    min="1"
+                    value={typeof recurrenceCount === "number" ? recurrenceCount : ""}
+                    onChange={(event) => {
+                      const { value } = event.target;
+                      if (value.trim().length === 0) {
+                        setRecurrenceCount(undefined);
+                        return;
+                      }
+
+                      const parsed = Number(value);
+                      setRecurrenceCount(Number.isNaN(parsed) ? undefined : parsed);
+                    }}
+                    className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:text-gray-200"
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="recurrence-until" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    Until
+                  </label>
+                  <input
+                    id="recurrence-until"
+                    type="datetime-local"
+                    value={recurrenceUntil}
+                    onChange={(event) => setRecurrenceUntil(event.target.value)}
+                    className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:text-gray-200"
+                  />
+                </div>
+
+                <div className="md:col-span-2">
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Exceptions
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleAddRecurrenceException}
+                      className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-600 hover:text-blue-700 focus:outline-none"
+                    >
+                      Add exception
+                    </button>
+                  </div>
+
+                  {recurrenceExceptions.length === 0 ? (
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      No exception dates configured.
+                    </p>
+                  ) : (
+                    <div className="space-y-2">
+                      {recurrenceExceptions.map((value, index) => (
+                        <div key={`recurrence-exception-${index}`} className="flex items-center gap-2">
+                          <label
+                            htmlFor={`recurrence-exception-input-${index}`}
+                            className="sr-only"
+                          >
+                            Exception date {index + 1}
+                          </label>
+                          <input
+                            id={`recurrence-exception-input-${index}`}
+                            type="datetime-local"
+                            value={value}
+                            onChange={(event) => handleRecurrenceExceptionChange(index, event.target.value)}
+                            className="flex-1 rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:text-gray-200"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveRecurrenceException(index)}
+                            aria-label={`Remove exception date ${index + 1}`}
+                            className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-red-600 hover:text-red-700 focus:outline-none"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </details>
           </div>
         )}
       </fieldset>

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -361,56 +361,139 @@ describe("Schedule", () => {
     expect(screen.queryByRole("option", { name: /Riley Client/i })).not.toBeInTheDocument();
 
     expect(
-      screen.queryByRole("checkbox", { name: /Enable recurrence \(RRULE\)/i }),
+      screen.queryByRole("checkbox", { name: /Apply this visible week forward/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryAllByLabelText("Add session")).toHaveLength(0);
   });
 
-  it("exposes recurrence toggle and labeled recurrence controls when enabled", async () => {
+  it("exposes week-forward admin controls when enabled in week view", async () => {
     renderWithProviders(<Schedule />);
 
     const recurrenceToggle = await screen.findByRole("checkbox", {
-      name: /Enable recurrence \(RRULE\)/i,
+      name: /Apply this visible week forward/i,
     });
     expect(recurrenceToggle).not.toBeChecked();
     expect(screen.getByLabelText(/Time Zone/i)).toBeInTheDocument();
 
     await userEvent.click(recurrenceToggle);
-    expect(screen.getByLabelText(/^RRULE$/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Count/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Until/i)).toBeInTheDocument();
+    expect(screen.getByText(/Source week/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/End date/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Preview week-forward schedule/i })).toBeInTheDocument();
+    expect(screen.getByText(/Advanced single-session RRULE/i)).toBeInTheDocument();
   }, 15000);
 
-  it("shows accessible exception controls in recurrence panel", async () => {
+  it("previews and applies the visible week with the displayed week payload", async () => {
+    const capturedRequests: Array<Record<string, unknown>> = [];
+    server.use(
+      http.post("*/api/sessions-week-forward", async ({ request }) => {
+        const body = await request.json() as Record<string, unknown>;
+        capturedRequests.push(body);
+        return HttpResponse.json({
+          success: true,
+          data: body.dryRun === true
+            ? {
+                sourceSessionCount: 2,
+                generatedSessionCount: 8,
+                generatedWeekCount: 4,
+                endDate: "2025-08-31",
+                conflicts: [],
+              }
+            : {
+                sourceSessionCount: 2,
+                generatedSessionCount: 8,
+                generatedWeekCount: 4,
+                endDate: "2025-08-31",
+                conflicts: [],
+                createdSessions: [],
+              },
+        });
+      }),
+    );
+
     renderWithProviders(<Schedule />);
 
     const recurrenceToggle = await screen.findByRole("checkbox", {
-      name: /Enable recurrence \(RRULE\)/i,
+      name: /Apply this visible week forward/i,
     });
     await userEvent.click(recurrenceToggle);
+    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2025-08-31" } });
 
-    expect(screen.getByText(/Exceptions/i)).toBeInTheDocument();
-    expect(screen.getByText(/No exception dates configured/i)).toBeInTheDocument();
-
-    await userEvent.click(screen.getByRole("button", { name: /Add exception/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Preview week-forward schedule/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Remove/i })).toBeInTheDocument();
+      expect(screen.getByText(/^Preview$/i)).toBeInTheDocument();
+      expect(screen.getByText("8")).toBeInTheDocument();
     });
-    expect(screen.queryByText(/No exception dates configured/i)).not.toBeInTheDocument();
+
+    expect(capturedRequests).toHaveLength(1);
+    expect(capturedRequests[0]).toMatchObject({
+      sourceSessionIds: ["session-1", "session-2"],
+      endDate: "2025-08-31",
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      dryRun: true,
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Apply this week forward/i }));
+
+    await waitFor(() => {
+      expect(capturedRequests).toHaveLength(2);
+    });
+    expect(capturedRequests[1]).toMatchObject({
+      sourceSessionIds: ["session-1", "session-2"],
+      endDate: "2025-08-31",
+      dryRun: false,
+    });
   }, 15000);
 
-  it("assigns deterministic accessible names to recurrence exception row controls", async () => {
+  it("blocks week-forward when visible sessions are not all scheduled", async () => {
+    mockUseScheduleDataBatch.mockReturnValue({
+      data: {
+        ...scheduleFixtures,
+        sessions: [
+          scheduleFixtures.sessions[0],
+          {
+            ...scheduleFixtures.sessions[1],
+            status: "completed",
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
     renderWithProviders(<Schedule />);
 
     const recurrenceToggle = await screen.findByRole("checkbox", {
-      name: /Enable recurrence \(RRULE\)/i,
+      name: /Apply this visible week forward/i,
     });
     await userEvent.click(recurrenceToggle);
 
-    const addExceptionButton = await screen.findByRole("button", {
-      name: /Add exception/i,
+    expect(
+      screen.getByText(/Every visible session must be scheduled before cloning this week forward/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Preview week-forward schedule/i })).toBeDisabled();
+  }, 15000);
+
+  it("shows the missing-org state for super-admins without an active organization context", async () => {
+    mockUseActiveOrganizationId.mockReturnValue(null);
+
+    renderWithProviders(<Schedule />, {
+      auth: { role: "super_admin", organizationId: null },
     });
+
+    expect(await screen.findByTestId("schedule-missing-org")).toBeInTheDocument();
+    expect(screen.getByText(/Organization context unavailable/i)).toBeInTheDocument();
+  }, 15000);
+
+  it("keeps advanced RRULE exception controls accessible", async () => {
+    renderWithProviders(<Schedule />);
+
+    const recurrenceToggle = await screen.findByRole("checkbox", {
+      name: /Apply this visible week forward/i,
+    });
+    await userEvent.click(recurrenceToggle);
+
+    await userEvent.click(screen.getByText(/Advanced single-session RRULE/i));
+    const addExceptionButton = await screen.findByRole("button", { name: /Add exception/i });
     await userEvent.click(addExceptionButton);
     await userEvent.click(addExceptionButton);
 

--- a/src/server/__tests__/sessionsWeekForwardHandler.test.ts
+++ b/src/server/__tests__/sessionsWeekForwardHandler.test.ts
@@ -1,0 +1,243 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../test/setup";
+import { resetRateLimitsForTests } from "../api/shared";
+
+const importHandler = async () => {
+  const module = await import("../api/sessions-week-forward");
+  return module.sessionsWeekForwardHandler;
+};
+
+const TEST_SUPABASE_URL = "https://testing.supabase.co";
+const TEST_SUPABASE_ANON_KEY = "testing-anon-key";
+
+const ORIGINAL_ENV = {
+  SUPABASE_URL: process.env.SUPABASE_URL,
+  SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY,
+  DEFAULT_ORGANIZATION_ID: process.env.DEFAULT_ORGANIZATION_ID,
+};
+
+const validPayload = {
+  sourceSessionIds: [
+    "11111111-1111-4111-8111-111111111111",
+    "22222222-2222-4222-8222-222222222222",
+  ],
+  displayedWeekStart: "2025-06-30T07:00:00.000Z",
+  displayedWeekEnd: "2025-07-07T06:59:59.999Z",
+  endDate: "2025-08-31",
+  timeZone: "America/Los_Angeles",
+  dryRun: true,
+};
+
+const buildRequest = (body: unknown, init: RequestInit = {}) =>
+  new Request("http://localhost/api/sessions-week-forward", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer valid-token",
+      ...(init.headers ?? {}),
+    },
+    body: JSON.stringify(body),
+    ...init,
+  });
+
+beforeEach(async () => {
+  resetRateLimitsForTests();
+  vi.clearAllMocks();
+
+  const runtimeConfig = await import("../../lib/runtimeConfig");
+  runtimeConfig.resetRuntimeSupabaseConfigForTests();
+
+  process.env.SUPABASE_URL = TEST_SUPABASE_URL;
+  process.env.SUPABASE_ANON_KEY = TEST_SUPABASE_ANON_KEY;
+  process.env.DEFAULT_ORGANIZATION_ID = "5238e88b-6198-4862-80a2-dbe15bbeabdd";
+
+  server.use(
+    http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/current_user_is_super_admin`, () => HttpResponse.json(false)),
+    http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/current_user_organization_id`, () =>
+      HttpResponse.json("5238e88b-6198-4862-80a2-dbe15bbeabdd")),
+    http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/user_has_role_for_org`, async ({ request }) => {
+      const body = await request.json() as { role_name?: string };
+      return HttpResponse.json(body.role_name === "admin");
+    }),
+    http.get(`${TEST_SUPABASE_URL}/rest/v1/sessions`, () =>
+      HttpResponse.json([
+        {
+          id: validPayload.sourceSessionIds[0],
+          organization_id: "5238e88b-6198-4862-80a2-dbe15bbeabdd",
+          therapist_id: "therapist-1",
+          client_id: "client-1",
+          start_time: "2025-07-01T10:00:00Z",
+          end_time: "2025-07-01T11:00:00Z",
+          status: "scheduled",
+        },
+        {
+          id: validPayload.sourceSessionIds[1],
+          organization_id: "5238e88b-6198-4862-80a2-dbe15bbeabdd",
+          therapist_id: "therapist-2",
+          client_id: "client-2",
+          start_time: "2025-07-01T11:00:00Z",
+          end_time: "2025-07-01T12:00:00Z",
+          status: "scheduled",
+        },
+      ])),
+    http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/apply_schedule_week_forward`, async ({ request }) => {
+      const body = await request.json() as { p_dry_run?: boolean; p_end_date?: string };
+      return HttpResponse.json({
+        success: true,
+        source_session_count: 2,
+        generated_session_count: 8,
+        generated_week_count: 4,
+        end_date: body.p_end_date ?? validPayload.endDate,
+        conflicts: [],
+        ...(body.p_dry_run === true ? {} : { created_sessions: [] }),
+      });
+    }),
+  );
+});
+
+afterAll(() => {
+  if (typeof ORIGINAL_ENV.SUPABASE_URL === "string") {
+    process.env.SUPABASE_URL = ORIGINAL_ENV.SUPABASE_URL;
+  } else {
+    delete process.env.SUPABASE_URL;
+  }
+  if (typeof ORIGINAL_ENV.SUPABASE_ANON_KEY === "string") {
+    process.env.SUPABASE_ANON_KEY = ORIGINAL_ENV.SUPABASE_ANON_KEY;
+  } else {
+    delete process.env.SUPABASE_ANON_KEY;
+  }
+  if (typeof ORIGINAL_ENV.DEFAULT_ORGANIZATION_ID === "string") {
+    process.env.DEFAULT_ORGANIZATION_ID = ORIGINAL_ENV.DEFAULT_ORGANIZATION_ID;
+  } else {
+    delete process.env.DEFAULT_ORGANIZATION_ID;
+  }
+});
+
+describe("sessionsWeekForwardHandler", () => {
+  it("returns CORS headers for OPTIONS requests", async () => {
+    const handler = await importHandler();
+    const response = await handler(new Request("http://localhost/api/sessions-week-forward", {
+      method: "OPTIONS",
+      headers: { Origin: "http://localhost:3000" },
+    }));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
+  });
+
+  it("rejects non-admin actors", async () => {
+    server.use(
+      http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/user_has_role_for_org`, () => HttpResponse.json(false)),
+    );
+    const handler = await importHandler();
+    const response = await handler(buildRequest(validPayload));
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("Forbidden");
+  });
+
+  it("rejects source sessions that are outside the active organization scope", async () => {
+    server.use(
+      http.get(`${TEST_SUPABASE_URL}/rest/v1/sessions`, () =>
+        HttpResponse.json([
+          {
+            id: validPayload.sourceSessionIds[0],
+            organization_id: "5238e88b-6198-4862-80a2-dbe15bbeabdd",
+            therapist_id: "therapist-1",
+            client_id: "client-1",
+            start_time: "2025-07-01T10:00:00Z",
+            end_time: "2025-07-01T11:00:00Z",
+            status: "scheduled",
+          },
+        ])),
+    );
+    const handler = await importHandler();
+    const response = await handler(buildRequest(validPayload));
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.code).toBe("SOURCE_SCOPE_MISMATCH");
+  });
+
+  it("rejects visible source sessions that are not scheduled", async () => {
+    server.use(
+      http.get(`${TEST_SUPABASE_URL}/rest/v1/sessions`, () =>
+        HttpResponse.json([
+          {
+            id: validPayload.sourceSessionIds[0],
+            organization_id: "5238e88b-6198-4862-80a2-dbe15bbeabdd",
+            therapist_id: "therapist-1",
+            client_id: "client-1",
+            start_time: "2025-07-01T10:00:00Z",
+            end_time: "2025-07-01T11:00:00Z",
+            status: "scheduled",
+          },
+          {
+            id: validPayload.sourceSessionIds[1],
+            organization_id: "5238e88b-6198-4862-80a2-dbe15bbeabdd",
+            therapist_id: "therapist-2",
+            client_id: "client-2",
+            start_time: "2025-07-01T11:00:00Z",
+            end_time: "2025-07-01T12:00:00Z",
+            status: "completed",
+          },
+        ])),
+    );
+    const handler = await importHandler();
+    const response = await handler(buildRequest(validPayload));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/must be scheduled/i);
+  });
+
+  it("returns a preview for dry runs", async () => {
+    const handler = await importHandler();
+    const response = await handler(buildRequest(validPayload));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toMatchObject({
+      sourceSessionCount: 2,
+      generatedSessionCount: 8,
+      generatedWeekCount: 4,
+      endDate: "2025-08-31",
+      conflicts: [],
+    });
+  });
+
+  it("maps RPC conflicts to 409 responses with preview data", async () => {
+    server.use(
+      http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/apply_schedule_week_forward`, () =>
+        HttpResponse.json({
+          success: false,
+          error_code: "THERAPIST_CONFLICT",
+          error_message: "Therapist already has a session during this time.",
+          source_session_count: 2,
+          generated_session_count: 8,
+          generated_week_count: 4,
+          end_date: "2025-08-31",
+          conflicts: [
+            {
+              sourceSessionId: validPayload.sourceSessionIds[0],
+              conflictingSessionId: "33333333-3333-4333-8333-333333333333",
+              startTime: "2025-07-08T10:00:00Z",
+              endTime: "2025-07-08T11:00:00Z",
+              therapistId: "therapist-1",
+              clientId: "client-1",
+              code: "THERAPIST_CONFLICT",
+              message: "Therapist already has a session during this time.",
+            },
+          ],
+        })),
+    );
+    const handler = await importHandler();
+    const response = await handler(buildRequest(validPayload));
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.code).toBe("THERAPIST_CONFLICT");
+    expect(body.data).toMatchObject({
+      sourceSessionCount: 2,
+      generatedSessionCount: 8,
+      generatedWeekCount: 4,
+    });
+  });
+});

--- a/src/server/api/sessions-week-forward.ts
+++ b/src/server/api/sessions-week-forward.ts
@@ -1,0 +1,216 @@
+import "../bootstrapSupabase";
+import {
+  consumeRateLimit,
+  corsHeadersForRequest,
+  errorResponse,
+  fetchJson,
+  getSupabaseConfig,
+  getAccessToken,
+  isDisallowedOriginRequest,
+  jsonForRequest,
+  resolveOrgAndRoleWithStatus,
+} from "./shared";
+import {
+  type WeekForwardApiResponse,
+  type WeekForwardRequestBody,
+  weekForwardRequestBodySchema,
+} from "../types";
+
+const JSON_CONTENT_TYPE_HEADER: Record<string, string> = {
+  "Content-Type": "application/json",
+};
+
+type SourceSessionRow = {
+  id: string;
+  organization_id: string;
+  therapist_id: string;
+  client_id: string;
+  start_time: string;
+  end_time: string;
+  status: string;
+};
+
+const toInFilter = (ids: string[]) => ids.map((id) => `"${id}"`).join(",");
+
+const isIsoWithinRange = (iso: string, startIso: string, endIso: string): boolean => {
+  const value = Date.parse(iso);
+  const start = Date.parse(startIso);
+  const end = Date.parse(endIso);
+  return Number.isFinite(value) && Number.isFinite(start) && Number.isFinite(end) && value >= start && value <= end;
+};
+
+export async function sessionsWeekForwardHandler(request: Request): Promise<Response> {
+  if (isDisallowedOriginRequest(request)) {
+    return errorResponse(request, "forbidden", "Origin not allowed", { status: 403 });
+  }
+
+  if (request.method === "OPTIONS") {
+    return new Response("ok", {
+      status: 200,
+      headers: { ...JSON_CONTENT_TYPE_HEADER, ...corsHeadersForRequest(request) },
+    });
+  }
+
+  if (request.method !== "POST") {
+    return errorResponse(request, "validation_error", "Method not allowed", { status: 405 });
+  }
+
+  const rateLimit = await consumeRateLimit(request, {
+    keyPrefix: "api:sessions-week-forward",
+    maxRequests: 10,
+    windowMs: 60_000,
+  });
+  if (rateLimit.limited) {
+    return errorResponse(request, "rate_limited", "Too many week-forward scheduling requests", {
+      headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
+    });
+  }
+
+  const accessToken = getAccessToken(request);
+  if (!accessToken) {
+    return errorResponse(request, "unauthorized", "Missing authorization token", {
+      headers: { "WWW-Authenticate": "Bearer" },
+    });
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return errorResponse(request, "validation_error", "Invalid JSON body");
+  }
+
+  const parseResult = weekForwardRequestBodySchema.safeParse(rawBody);
+  if (!parseResult.success) {
+    return errorResponse(request, "validation_error", "Invalid request body", {
+      extra: { code: "invalid_request" },
+    });
+  }
+
+  const body: WeekForwardRequestBody = parseResult.data;
+  const roleResolution = await resolveOrgAndRoleWithStatus(accessToken);
+  if (roleResolution.upstreamError) {
+    return errorResponse(request, "upstream_error", "Unable to validate organization access", { status: 502 });
+  }
+  if (!roleResolution.organizationId) {
+    return errorResponse(request, "forbidden", "Organization context required", { status: 403 });
+  }
+  if (!roleResolution.isAdmin && !roleResolution.isSuperAdmin) {
+    return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
+  }
+
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const headers = {
+    ...JSON_CONTENT_TYPE_HEADER,
+    apikey: anonKey,
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  const encodedOrgId = encodeURIComponent(roleResolution.organizationId);
+  const encodedIdFilter = encodeURIComponent(`(${toInFilter(body.sourceSessionIds)})`);
+  const sourceSessionsUrl = `${supabaseUrl}/rest/v1/sessions?select=id,organization_id,therapist_id,client_id,start_time,end_time,status&organization_id=eq.${encodedOrgId}&id=in.${encodedIdFilter}&order=start_time.asc`;
+  const sourceSessionsResult = await fetchJson<SourceSessionRow[]>(sourceSessionsUrl, {
+    method: "GET",
+    headers,
+  });
+
+  if (!sourceSessionsResult.ok || !Array.isArray(sourceSessionsResult.data)) {
+    return errorResponse(request, "upstream_error", "Unable to load source sessions", { status: 502 });
+  }
+
+  const sourceSessions = sourceSessionsResult.data;
+  if (sourceSessions.length !== body.sourceSessionIds.length) {
+    return errorResponse(request, "forbidden", "One or more source sessions are not accessible in the active organization", {
+      status: 403,
+      extra: { code: "SOURCE_SCOPE_MISMATCH" },
+    });
+  }
+
+  const outOfWeekSource = sourceSessions.find(
+    (session) => !isIsoWithinRange(session.start_time, body.displayedWeekStart, body.displayedWeekEnd),
+  );
+  if (outOfWeekSource) {
+    return errorResponse(request, "validation_error", "One or more source sessions fall outside the displayed week", {
+      status: 400,
+      extra: { code: "SOURCE_WEEK_MISMATCH" },
+    });
+  }
+
+  const invalidStatusSource = sourceSessions.find((session) => session.status !== "scheduled");
+  if (invalidStatusSource) {
+    return errorResponse(request, "validation_error", "All visible source sessions must be scheduled before applying this week forward", {
+      status: 400,
+      extra: { code: "SOURCE_STATUS_INVALID" },
+    });
+  }
+
+  const rpcUrl = `${supabaseUrl}/rest/v1/rpc/apply_schedule_week_forward`;
+  const rpcResult = await fetchJson<{
+    success?: boolean;
+    error_code?: string;
+    error_message?: string;
+    source_session_count?: number;
+    generated_session_count?: number;
+    generated_week_count?: number;
+    end_date?: string;
+    conflicts?: unknown[];
+    created_sessions?: unknown[];
+  }>(rpcUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      p_source_session_ids: body.sourceSessionIds,
+      p_displayed_week_start: body.displayedWeekStart,
+      p_displayed_week_end: body.displayedWeekEnd,
+      p_end_date: body.endDate,
+      p_time_zone: body.timeZone,
+      p_dry_run: body.dryRun,
+    }),
+  });
+
+  if (!rpcResult.ok || !rpcResult.data) {
+    return errorResponse(request, "upstream_error", "Week-forward scheduling authority failed", { status: 502 });
+  }
+
+  const rpcData = rpcResult.data;
+  if (rpcData.success !== true) {
+    const status =
+      rpcData.error_code === "THERAPIST_CONFLICT" || rpcData.error_code === "CLIENT_CONFLICT"
+        ? 409
+        : rpcData.error_code === "FORBIDDEN"
+          ? 403
+          : 400;
+    return errorResponse(
+      request,
+      status === 409 ? "conflict" : status === 403 ? "forbidden" : "validation_error",
+      rpcData.error_message ?? "Unable to apply week-forward scheduling",
+      {
+        status,
+        extra: {
+          code: rpcData.error_code ?? "WEEK_FORWARD_FAILED",
+          data: {
+            sourceSessionCount: rpcData.source_session_count ?? 0,
+            generatedSessionCount: rpcData.generated_session_count ?? 0,
+            generatedWeekCount: rpcData.generated_week_count ?? 0,
+            endDate: rpcData.end_date ?? body.endDate,
+            conflicts: Array.isArray(rpcData.conflicts) ? rpcData.conflicts : [],
+          },
+        },
+      },
+    );
+  }
+
+  const responsePayload: WeekForwardApiResponse = {
+    success: true,
+    data: {
+      sourceSessionCount: rpcData.source_session_count ?? 0,
+      generatedSessionCount: rpcData.generated_session_count ?? 0,
+      generatedWeekCount: rpcData.generated_week_count ?? 0,
+      endDate: rpcData.end_date ?? body.endDate,
+      conflicts: Array.isArray(rpcData.conflicts) ? (rpcData.conflicts as never[]) : [],
+      ...(body.dryRun ? {} : { createdSessions: Array.isArray(rpcData.created_sessions) ? (rpcData.created_sessions as never[]) : [] }),
+    },
+  };
+
+  return jsonForRequest(request, responsePayload, 200);
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -152,3 +152,78 @@ export interface BookSessionApiResponse {
   retryAfterSeconds?: number | null;
   orchestration?: Record<string, unknown> | null;
 }
+
+export interface WeekForwardConflict {
+  sourceSessionId: string;
+  conflictingSessionId?: string;
+  startTime: string;
+  endTime: string;
+  therapistId: string;
+  clientId: string;
+  code: string;
+  message: string;
+}
+
+export interface WeekForwardPreviewResult {
+  sourceSessionCount: number;
+  generatedSessionCount: number;
+  generatedWeekCount: number;
+  endDate: string;
+  conflicts: WeekForwardConflict[];
+}
+
+export interface WeekForwardCommitResult extends WeekForwardPreviewResult {
+  createdSessions: Session[];
+}
+
+export const weekForwardConflictSchema = z.object({
+  sourceSessionId: nonEmptyString,
+  conflictingSessionId: nonEmptyString.optional(),
+  startTime: isoDateTime,
+  endTime: isoDateTime,
+  therapistId: nonEmptyString,
+  clientId: nonEmptyString,
+  code: nonEmptyString,
+  message: nonEmptyString,
+});
+
+const isoDateOnly = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
+export const weekForwardRequestBodySchema = z.object({
+  sourceSessionIds: z.array(nonEmptyString).min(1),
+  displayedWeekStart: isoDateTime,
+  displayedWeekEnd: isoDateTime,
+  endDate: isoDateOnly,
+  timeZone: nonEmptyString,
+  dryRun: z.boolean(),
+});
+
+export type WeekForwardRequestBody = z.infer<typeof weekForwardRequestBodySchema>;
+
+export const weekForwardPreviewResultSchema = z.object({
+  sourceSessionCount: z.number().int().nonnegative(),
+  generatedSessionCount: z.number().int().nonnegative(),
+  generatedWeekCount: z.number().int().nonnegative(),
+  endDate: isoDateOnly,
+  conflicts: z.array(weekForwardConflictSchema),
+});
+
+export const weekForwardCommitResultSchema = weekForwardPreviewResultSchema.extend({
+  createdSessions: z.array(z.record(z.unknown())),
+});
+
+export const weekForwardApiResponseSchema = z.object({
+  success: z.boolean(),
+  data: z.union([weekForwardPreviewResultSchema, weekForwardCommitResultSchema]).optional(),
+  error: z.string().optional(),
+  code: z.string().optional(),
+  hint: z.string().optional(),
+});
+
+export interface WeekForwardApiResponse {
+  success: boolean;
+  data?: WeekForwardPreviewResult | WeekForwardCommitResult;
+  error?: string;
+  code?: string;
+  hint?: string;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1321,6 +1321,36 @@ export const server = setupServer(
       },
     });
   }),
+  http.post('*/api/sessions-week-forward', async ({ request }) => {
+    let body: {
+      sourceSessionIds?: string[];
+      endDate?: string;
+      dryRun?: boolean;
+    } | null = null;
+    try {
+      body = await request.json();
+    } catch (error) {
+      console.error('Failed to parse week-forward API payload in tests', error);
+    }
+
+    const responseData = {
+      sourceSessionCount: body?.sourceSessionIds?.length ?? 0,
+      generatedSessionCount: Math.max((body?.sourceSessionIds?.length ?? 0) * 4, 0),
+      generatedWeekCount: 4,
+      endDate: body?.endDate ?? '2025-08-31',
+      conflicts: [],
+    };
+
+    return HttpResponse.json({
+      success: true,
+      data: body?.dryRun
+        ? responseData
+        : {
+            ...responseData,
+            createdSessions: [],
+          },
+    });
+  }),
   // Mock session hold + confirmation flow
   http.post('*/functions/v1/sessions-hold*', () => {
     return HttpResponse.json({

--- a/supabase/migrations/20260505190000_week_forward_admin_scheduling.sql
+++ b/supabase/migrations/20260505190000_week_forward_admin_scheduling.sql
@@ -1,0 +1,445 @@
+-- @migration-intent: Add transactional week-forward scheduling RPC for admin and super-admin schedule templating.
+-- @migration-dependencies: 20260318150000_batch_confirm_financial_hardening.sql,20260403133000_fix_super_admin_schedule_org_context_resolution.sql,20260422153000_user_has_role_for_org_storage_role_aliases.sql
+-- @migration-rollback: Drop public.apply_schedule_week_forward(uuid[], timestamptz, timestamptz, date, text, boolean).
+
+set search_path = public;
+
+create or replace function public.apply_schedule_week_forward(
+  p_source_session_ids uuid[],
+  p_displayed_week_start timestamptz,
+  p_displayed_week_end timestamptz,
+  p_end_date date,
+  p_time_zone text,
+  p_dry_run boolean default true
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_actor_id uuid := auth.uid();
+  v_source_count integer := 0;
+  v_generated_count integer := 0;
+  v_generated_week_count integer := 0;
+  v_conflict jsonb := '[]'::jsonb;
+  v_created_sessions jsonb := '[]'::jsonb;
+  v_source_org uuid;
+  v_first_source record;
+  v_source record;
+  v_candidate record;
+  v_created_session public.sessions;
+  v_goal_linked_count integer := 0;
+  v_local_start_date date;
+  v_local_start_time time;
+  v_duration interval;
+  v_future_local_date date;
+  v_existing_conflict record;
+  v_generated_conflict record;
+begin
+  if v_actor_id is null then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'UNAUTHORIZED',
+      'error_message', 'Authentication is required.'
+    );
+  end if;
+
+  if p_source_session_ids is null or coalesce(array_length(p_source_session_ids, 1), 0) = 0 then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'EMPTY_SOURCE',
+      'error_message', 'At least one visible source session is required.'
+    );
+  end if;
+
+  if p_displayed_week_start is null or p_displayed_week_end is null or p_displayed_week_end < p_displayed_week_start then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'INVALID_WEEK_RANGE',
+      'error_message', 'Displayed week range is invalid.'
+    );
+  end if;
+
+  if p_end_date is null then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'INVALID_END_DATE',
+      'error_message', 'End date is required.'
+    );
+  end if;
+
+  if coalesce(nullif(trim(p_time_zone), ''), '') = '' then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'INVALID_TIME_ZONE',
+      'error_message', 'Time zone is required.'
+    );
+  end if;
+
+  create temporary table if not exists week_forward_candidates (
+    source_session_id uuid not null,
+    organization_id uuid not null,
+    therapist_id uuid not null,
+    client_id uuid not null,
+    program_id uuid not null,
+    goal_id uuid not null,
+    notes text null,
+    location_type text null,
+    session_type text null,
+    duration_minutes integer null,
+    rate_per_hour numeric null,
+    total_cost numeric null,
+    candidate_start timestamptz not null,
+    candidate_end timestamptz not null
+  ) on commit drop;
+
+  truncate table week_forward_candidates;
+
+  select count(*)
+  into v_source_count
+  from public.sessions s
+  where s.id = any(p_source_session_ids);
+
+  if v_source_count <> array_length(p_source_session_ids, 1) then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'SOURCE_NOT_FOUND',
+      'error_message', 'One or more source sessions are missing.'
+    );
+  end if;
+
+  select s.*
+  into v_first_source
+  from public.sessions s
+  where s.id = p_source_session_ids[1]
+  limit 1;
+
+  if v_first_source.id is null then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'SOURCE_NOT_FOUND',
+      'error_message', 'Source sessions could not be loaded.'
+    );
+  end if;
+
+  v_source_org := v_first_source.organization_id;
+
+  if not (
+    app.user_has_role_for_org('admin', v_source_org, v_first_source.therapist_id, v_first_source.client_id, v_first_source.id)
+    or app.user_has_role_for_org('super_admin', v_source_org, v_first_source.therapist_id, v_first_source.client_id, v_first_source.id)
+  ) then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'FORBIDDEN',
+      'error_message', 'Admin or super-admin access is required for week-forward scheduling.'
+    );
+  end if;
+
+  for v_source in
+    select s.*
+    from public.sessions s
+    where s.id = any(p_source_session_ids)
+    order by s.start_time asc, s.id asc
+  loop
+    if v_source.organization_id <> v_source_org then
+      return jsonb_build_object(
+        'success', false,
+        'error_code', 'CROSS_ORG_SOURCE',
+        'error_message', 'All visible source sessions must belong to the same organization.'
+      );
+    end if;
+
+    if v_source.status <> 'scheduled' then
+      return jsonb_build_object(
+        'success', false,
+        'error_code', 'SOURCE_STATUS_INVALID',
+        'error_message', 'All visible source sessions must be scheduled before applying this week forward.'
+      );
+    end if;
+
+    if v_source.start_time < p_displayed_week_start or v_source.start_time > p_displayed_week_end then
+      return jsonb_build_object(
+        'success', false,
+        'error_code', 'SOURCE_WEEK_MISMATCH',
+        'error_message', 'All visible source sessions must belong to the displayed week.'
+      );
+    end if;
+
+    v_local_start_date := (v_source.start_time at time zone p_time_zone)::date;
+    v_local_start_time := (v_source.start_time at time zone p_time_zone)::time;
+    v_duration := v_source.end_time - v_source.start_time;
+    v_future_local_date := v_local_start_date + 7;
+
+    while v_future_local_date <= p_end_date loop
+      insert into week_forward_candidates (
+        source_session_id,
+        organization_id,
+        therapist_id,
+        client_id,
+        program_id,
+        goal_id,
+        notes,
+        location_type,
+        session_type,
+        duration_minutes,
+        rate_per_hour,
+        total_cost,
+        candidate_start,
+        candidate_end
+      )
+      values (
+        v_source.id,
+        v_source.organization_id,
+        v_source.therapist_id,
+        v_source.client_id,
+        v_source.program_id,
+        v_source.goal_id,
+        v_source.notes,
+        v_source.location_type,
+        v_source.session_type,
+        v_source.duration_minutes,
+        v_source.rate_per_hour,
+        v_source.total_cost,
+        ((v_future_local_date::text || ' ' || v_local_start_time::text)::timestamp at time zone p_time_zone),
+        (((v_future_local_date::text || ' ' || v_local_start_time::text)::timestamp at time zone p_time_zone) + v_duration)
+      );
+
+      v_future_local_date := v_future_local_date + 7;
+    end loop;
+  end loop;
+
+  select count(*), coalesce(count(distinct date_trunc('week', candidate_start at time zone p_time_zone)), 0)
+  into v_generated_count, v_generated_week_count
+  from week_forward_candidates;
+
+  select
+    c.source_session_id,
+    e.id as conflicting_session_id,
+    c.candidate_start,
+    c.candidate_end,
+    c.therapist_id,
+    c.client_id,
+    case
+      when e.therapist_id = c.therapist_id then 'THERAPIST_CONFLICT'
+      else 'CLIENT_CONFLICT'
+    end as conflict_code,
+    case
+      when e.therapist_id = c.therapist_id then 'Therapist already has a session during this time.'
+      else 'Client already has a session during this time.'
+    end as conflict_message
+  into v_existing_conflict
+  from week_forward_candidates c
+  join public.sessions e
+    on e.organization_id = c.organization_id
+   and e.status <> 'cancelled'
+   and tstzrange(e.start_time, e.end_time, '[)') && tstzrange(c.candidate_start, c.candidate_end, '[)')
+  order by c.candidate_start asc, c.source_session_id asc
+  limit 1;
+
+  if v_existing_conflict.source_session_id is not null then
+    v_conflict := jsonb_build_array(
+      jsonb_build_object(
+        'sourceSessionId', v_existing_conflict.source_session_id,
+        'conflictingSessionId', v_existing_conflict.conflicting_session_id,
+        'startTime', v_existing_conflict.candidate_start,
+        'endTime', v_existing_conflict.candidate_end,
+        'therapistId', v_existing_conflict.therapist_id,
+        'clientId', v_existing_conflict.client_id,
+        'code', v_existing_conflict.conflict_code,
+        'message', v_existing_conflict.conflict_message
+      )
+    );
+
+    return jsonb_build_object(
+      'success', false,
+      'error_code', v_existing_conflict.conflict_code,
+      'error_message', v_existing_conflict.conflict_message,
+      'source_session_count', v_source_count,
+      'generated_session_count', v_generated_count,
+      'generated_week_count', v_generated_week_count,
+      'end_date', p_end_date,
+      'conflicts', v_conflict
+    );
+  end if;
+
+  select
+    c1.source_session_id,
+    c1.candidate_start,
+    c1.candidate_end,
+    c1.therapist_id,
+    c1.client_id,
+    case
+      when c1.therapist_id = c2.therapist_id then 'THERAPIST_CONFLICT'
+      else 'CLIENT_CONFLICT'
+    end as conflict_code,
+    case
+      when c1.therapist_id = c2.therapist_id then 'Generated sessions would overlap for the same therapist.'
+      else 'Generated sessions would overlap for the same client.'
+    end as conflict_message
+  into v_generated_conflict
+  from week_forward_candidates c1
+  join week_forward_candidates c2
+    on c1.source_session_id <> c2.source_session_id
+   and c1.candidate_start < c2.candidate_end
+   and c2.candidate_start < c1.candidate_end
+   and (
+     c1.therapist_id = c2.therapist_id
+     or c1.client_id = c2.client_id
+   )
+  order by c1.candidate_start asc, c1.source_session_id asc
+  limit 1;
+
+  if v_generated_conflict.source_session_id is not null then
+    v_conflict := jsonb_build_array(
+      jsonb_build_object(
+        'sourceSessionId', v_generated_conflict.source_session_id,
+        'startTime', v_generated_conflict.candidate_start,
+        'endTime', v_generated_conflict.candidate_end,
+        'therapistId', v_generated_conflict.therapist_id,
+        'clientId', v_generated_conflict.client_id,
+        'code', v_generated_conflict.conflict_code,
+        'message', v_generated_conflict.conflict_message
+      )
+    );
+
+    return jsonb_build_object(
+      'success', false,
+      'error_code', v_generated_conflict.conflict_code,
+      'error_message', v_generated_conflict.conflict_message,
+      'source_session_count', v_source_count,
+      'generated_session_count', v_generated_count,
+      'generated_week_count', v_generated_week_count,
+      'end_date', p_end_date,
+      'conflicts', v_conflict
+    );
+  end if;
+
+  if p_dry_run then
+    return jsonb_build_object(
+      'success', true,
+      'source_session_count', v_source_count,
+      'generated_session_count', v_generated_count,
+      'generated_week_count', v_generated_week_count,
+      'end_date', p_end_date,
+      'conflicts', '[]'::jsonb
+    );
+  end if;
+
+  for v_candidate in
+    select *
+    from week_forward_candidates
+    order by candidate_start asc, source_session_id asc
+  loop
+    insert into public.sessions (
+      organization_id,
+      therapist_id,
+      client_id,
+      program_id,
+      goal_id,
+      start_time,
+      end_time,
+      status,
+      notes,
+      location_type,
+      session_type,
+      duration_minutes,
+      rate_per_hour,
+      total_cost
+    )
+    values (
+      v_candidate.organization_id,
+      v_candidate.therapist_id,
+      v_candidate.client_id,
+      v_candidate.program_id,
+      v_candidate.goal_id,
+      v_candidate.candidate_start,
+      v_candidate.candidate_end,
+      'scheduled',
+      v_candidate.notes,
+      v_candidate.location_type,
+      v_candidate.session_type,
+      v_candidate.duration_minutes,
+      v_candidate.rate_per_hour,
+      v_candidate.total_cost
+    )
+    returning *
+    into v_created_session;
+
+    v_goal_linked_count := 0;
+
+    insert into public.session_goals (
+      session_id,
+      goal_id,
+      organization_id,
+      client_id,
+      program_id
+    )
+    select
+      v_created_session.id,
+      sg.goal_id,
+      v_created_session.organization_id,
+      v_created_session.client_id,
+      v_created_session.program_id
+    from public.session_goals sg
+    where sg.session_id = v_candidate.source_session_id
+    on conflict (session_id, goal_id) do nothing;
+
+    get diagnostics v_goal_linked_count = row_count;
+
+    if coalesce(v_goal_linked_count, 0) = 0 then
+      insert into public.session_goals (
+        session_id,
+        goal_id,
+        organization_id,
+        client_id,
+        program_id
+      )
+      values (
+        v_created_session.id,
+        v_created_session.goal_id,
+        v_created_session.organization_id,
+        v_created_session.client_id,
+        v_created_session.program_id
+      )
+      on conflict (session_id, goal_id) do nothing;
+    end if;
+
+    v_created_sessions := v_created_sessions || jsonb_build_array(
+      jsonb_build_object(
+        'id', v_created_session.id,
+        'client_id', v_created_session.client_id,
+        'therapist_id', v_created_session.therapist_id,
+        'program_id', v_created_session.program_id,
+        'goal_id', v_created_session.goal_id,
+        'start_time', v_created_session.start_time,
+        'end_time', v_created_session.end_time,
+        'status', v_created_session.status,
+        'notes', v_created_session.notes,
+        'created_at', v_created_session.created_at,
+        'created_by', v_created_session.created_by,
+        'updated_at', v_created_session.updated_at,
+        'updated_by', v_created_session.updated_by,
+        'duration_minutes', v_created_session.duration_minutes,
+        'location_type', v_created_session.location_type,
+        'session_type', v_created_session.session_type,
+        'rate_per_hour', v_created_session.rate_per_hour,
+        'total_cost', v_created_session.total_cost
+      )
+    );
+  end loop;
+
+  return jsonb_build_object(
+    'success', true,
+    'source_session_count', v_source_count,
+    'generated_session_count', v_generated_count,
+    'generated_week_count', v_generated_week_count,
+    'end_date', p_end_date,
+    'conflicts', '[]'::jsonb,
+    'created_sessions', v_created_sessions
+  );
+end;
+$$;
+
+revoke execute on function public.apply_schedule_week_forward(uuid[], timestamptz, timestamptz, date, text, boolean) from public;
+revoke execute on function public.apply_schedule_week_forward(uuid[], timestamptz, timestamptz, date, text, boolean) from anon;
+grant execute on function public.apply_schedule_week_forward(uuid[], timestamptz, timestamptz, date, text, boolean) to authenticated;


### PR DESCRIPTION
## Summary
- replace the RRULE-first admin recurrence panel with a visible-week-forward scheduling flow
- add a protected /api/sessions-week-forward route plus a transactional Supabase RPC migration for all-or-nothing weekly cloning
- add Schedule UI coverage and direct handler tests for preview/apply, scope validation, and conflict handling

## Verification
- npm run verify:local
- npm run validate:tenant
- npm run playwright:schedule-conflict

## Notes
- Linear: WIN-128
- Full 
pm run ci:playwright exceeded the local timeout budget in this environment; targeted 
pm run playwright:schedule-conflict passed.
- Supabase MCP hosted inspection was unauthorized in this session, so remote migration state was not checked through MCP.