### PR TITLE
Add admin therapist linking

### DIFF
--- a/src/components/settings/AdminSettings.tsx
+++ b/src/components/settings/AdminSettings.tsx
@@ -55,6 +55,18 @@ interface ClientOption {
   displayName: string;
 }
 
+interface TherapistOption {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+}
+
+interface AdminTherapistLink {
+  user_id: string;
+  therapist_id: string;
+  therapist_name: string | null;
+}
+
 export function AdminSettings() {
   const ALL_ORGANIZATIONS_VALUE = 'ALL';
 
@@ -76,6 +88,7 @@ export function AdminSettings() {
   const [relationshipByRequest, setRelationshipByRequest] = useState<Record<string, string>>({});
   const [notesByRequest, setNotesByRequest] = useState<Record<string, string>>({});
   const [selectedOrganizationId, setSelectedOrganizationId] = useState<string>(ALL_ORGANIZATIONS_VALUE);
+  const [selectedTherapistByAdmin, setSelectedTherapistByAdmin] = useState<Record<string, string>>({});
 
   const addAdminEmailRef = useRef<HTMLInputElement>(null);
   const resetPasswordInputRef = useRef<HTMLInputElement>(null);
@@ -244,6 +257,77 @@ export function AdminSettings() {
     retry: false,
   });
 
+  const {
+    data: therapistOptions = [],
+    isLoading: isTherapistOptionsLoading,
+    error: therapistOptionsError,
+  } = useQuery<TherapistOption[], Error>({
+    queryKey: ['admin-link-therapists', activeOrganizationId ?? 'ALL'],
+    queryFn: async () => {
+      if (!activeOrganizationId) {
+        return [];
+      }
+
+      const { data, error } = await supabase.rpc('get_admin_linkable_therapists', {
+        p_organization_id: activeOrganizationId,
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      return ((data as TherapistOption[] | null) ?? []).map((therapist) => ({
+        id: therapist.id,
+        full_name: therapist.full_name ?? null,
+        email: therapist.email ?? null,
+      }));
+    },
+    enabled: Boolean(activeOrganizationId),
+    retry: false,
+  });
+
+  const {
+    data: adminTherapistLinks = [],
+    isLoading: isAdminTherapistLinksLoading,
+    error: adminTherapistLinksError,
+  } = useQuery<AdminTherapistLink[], Error>({
+    queryKey: ['admin-therapist-links', activeOrganizationId ?? 'ALL'],
+    queryFn: async () => {
+      if (!activeOrganizationId) {
+        return [];
+      }
+
+      const { data, error } = await supabase.rpc('get_admin_therapist_links', {
+        p_organization_id: activeOrganizationId,
+      });
+
+      if (error) {
+        const rpcError = error as PostgrestError & { status?: number };
+        const mapped = new Error(
+          rpcError.code === '42501'
+            ? 'You do not have permission to view admin therapist links for this organization.'
+            : error.message || 'Failed to load admin therapist links.'
+        );
+        (mapped as Error & { status?: number }).status = rpcError.code === '42501' ? 403 : 500;
+        throw mapped;
+      }
+
+      return (data as AdminTherapistLink[] | null) ?? [];
+    },
+    enabled: Boolean(activeOrganizationId),
+    retry: false,
+  });
+
+  const adminTherapistLinksByUser = useMemo(() => {
+    const grouped = new Map<string, AdminTherapistLink[]>();
+    adminTherapistLinks.forEach((link) => {
+      const existing = grouped.get(link.user_id) ?? [];
+      existing.push(link);
+      grouped.set(link.user_id, existing);
+    });
+    return grouped;
+  }, [adminTherapistLinks]);
+
   useEffect(() => {
     if (!adminsError) {
       if (!isSuperAdmin && organizationId) {
@@ -289,6 +373,22 @@ export function AdminSettings() {
 
     showError(organizationOptionsError);
   }, [organizationOptionsError]);
+
+  useEffect(() => {
+    if (!therapistOptionsError) {
+      return;
+    }
+
+    showError(therapistOptionsError);
+  }, [therapistOptionsError]);
+
+  useEffect(() => {
+    if (!adminTherapistLinksError) {
+      return;
+    }
+
+    showError(adminTherapistLinksError);
+  }, [adminTherapistLinksError]);
 
   const createAdminMutation = useMutation({
     mutationFn: async (data: AdminFormData) => {
@@ -467,6 +567,57 @@ export function AdminSettings() {
     },
   });
 
+  const linkAdminTherapistMutation = useMutation({
+    mutationFn: async ({ userId, therapistId }: { userId: string; therapistId: string }) => {
+      if (!activeOrganizationId) {
+        throw new Error('Select an organization before linking admins to therapists.');
+      }
+
+      const { error } = await supabase.rpc('set_admin_therapist_link', {
+        target_user_id: userId,
+        target_therapist_id: therapistId,
+        p_organization_id: activeOrganizationId,
+      });
+
+      if (error) {
+        throw error;
+      }
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['admin-therapist-links', activeOrganizationId ?? 'ALL'] });
+      setSelectedTherapistByAdmin((previous) => ({ ...previous, [variables.userId]: '' }));
+      showSuccess('Admin linked to therapist');
+    },
+    onError: (error) => {
+      showError(error);
+    },
+  });
+
+  const unlinkAdminTherapistMutation = useMutation({
+    mutationFn: async ({ userId, therapistId }: { userId: string; therapistId: string }) => {
+      if (!activeOrganizationId) {
+        throw new Error('Select an organization before unlinking admins from therapists.');
+      }
+
+      const { error } = await supabase.rpc('delete_admin_therapist_link', {
+        target_user_id: userId,
+        target_therapist_id: therapistId,
+        p_organization_id: activeOrganizationId,
+      });
+
+      if (error) {
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-therapist-links', activeOrganizationId ?? 'ALL'] });
+      showSuccess('Admin unlinked from therapist');
+    },
+    onError: (error) => {
+      showError(error);
+    },
+  });
+
   const resetForm = () => {
     setFormData({
       email: '',
@@ -498,6 +649,32 @@ export function AdminSettings() {
       ...previous,
       [requestId]: value,
     }));
+  };
+
+  const updateSelectedAdminTherapist = (userId: string, therapistId: string) => {
+    setSelectedTherapistByAdmin((previous) => ({
+      ...previous,
+      [userId]: therapistId,
+    }));
+  };
+
+  const handleLinkAdminTherapist = async (userId: string) => {
+    const therapistId = selectedTherapistByAdmin[userId];
+    if (!therapistId) {
+      showError(new Error('Select a therapist to link.'));
+      return;
+    }
+
+    linkAdminTherapistMutation.mutate({ userId, therapistId });
+  };
+
+  const handleUnlinkAdminTherapist = async (userId: string, therapistId: string, therapistName: string) => {
+    const shouldUnlink = window.confirm(`Unlink this admin from ${therapistName}?`);
+    if (!shouldUnlink) {
+      return;
+    }
+
+    unlinkAdminTherapistMutation.mutate({ userId, therapistId });
   };
 
   const getMetadataValue = (entry: GuardianQueueEntry, key: string) => {
@@ -711,6 +888,75 @@ export function AdminSettings() {
                       </span>
                     </div>
                   )}
+                  <div className="border-t border-gray-200 pt-3 dark:border-gray-700">
+                    <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Therapist Links
+                    </p>
+                    {!activeOrganizationId ? (
+                      <p className="text-xs text-amber-600 dark:text-amber-300">
+                        Select an organization to manage therapist links.
+                      </p>
+                    ) : isTherapistOptionsLoading || isAdminTherapistLinksLoading ? (
+                      <p className="text-xs text-gray-500 dark:text-gray-400">Loading therapist links…</p>
+                    ) : (
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap gap-2">
+                          {(adminTherapistLinksByUser.get(admin.user_id) ?? []).length === 0 ? (
+                            <span className="text-xs text-gray-500 dark:text-gray-400">No therapists linked</span>
+                          ) : (
+                            (adminTherapistLinksByUser.get(admin.user_id) ?? []).map((link) => {
+                              const therapistName = link.therapist_name ?? link.therapist_id;
+                              return (
+                                <span
+                                  key={`${admin.user_id}-${link.therapist_id}`}
+                                  className="inline-flex items-center gap-2 rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700 dark:bg-blue-900/20 dark:text-blue-200"
+                                >
+                                  {therapistName}
+                                  <button
+                                    type="button"
+                                    className="text-blue-500 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50"
+                                    disabled={unlinkAdminTherapistMutation.isPending}
+                                    onClick={() => handleUnlinkAdminTherapist(admin.user_id, link.therapist_id, therapistName)}
+                                    aria-label={`Unlink ${therapistName}`}
+                                  >
+                                    ×
+                                  </button>
+                                </span>
+                              );
+                            })
+                          )}
+                        </div>
+
+                        <div className="flex gap-2">
+                          <select
+                            className="min-w-0 flex-1 rounded-md border border-gray-300 px-2 py-1 text-xs dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                            value={selectedTherapistByAdmin[admin.user_id] ?? ''}
+                            onChange={(event) => updateSelectedAdminTherapist(admin.user_id, event.target.value)}
+                            aria-label={`Select therapist for ${admin.email}`}
+                          >
+                            <option value="">Select therapist</option>
+                            {therapistOptions.map((therapist) => (
+                              <option key={therapist.id} value={therapist.id}>
+                                {therapist.full_name ?? therapist.email ?? therapist.id}
+                              </option>
+                            ))}
+                          </select>
+                          <button
+                            type="button"
+                            className="rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                            disabled={
+                              linkAdminTherapistMutation.isPending ||
+                              !selectedTherapistByAdmin[admin.user_id] ||
+                              therapistOptions.length === 0
+                            }
+                            onClick={() => handleLinkAdminTherapist(admin.user_id)}
+                          >
+                            Link
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 </div>
               </div>
             );

--- a/src/components/settings/__tests__/AdminSettings.test.tsx
+++ b/src/components/settings/__tests__/AdminSettings.test.tsx
@@ -57,7 +57,34 @@ const mockAdminUser = {
   }
 };
 
+const mockTherapist = {
+  id: 'therapist-1',
+  full_name: 'Therapist One',
+  email: 'therapist@example.com',
+};
+
+const buildTherapistQuery = (data = [mockTherapist], error: Error | null = null) => {
+  const query: any = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue({ data, error }),
+  };
+  return query;
+};
+
+const buildEmptyClientsQuery = () => {
+  const query: any = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue({ data: [], error: null }),
+  };
+  return query;
+};
+
 describe('AdminSettings logging', () => {
+  let fromSpy: ReturnType<typeof vi.spyOn> | null = null;
+
   beforeEach(() => {
     const authStub = {
       user: {
@@ -88,6 +115,9 @@ describe('AdminSettings logging', () => {
         expect(params).toMatchObject({ organization_id: '11111111-1111-1111-1111-111111111111' });
         return { data: [mockAdminUser], error: null };
       }
+      if (functionName === 'get_admin_therapist_links') {
+        return { data: [], error: null };
+      }
       if (functionName === 'manage_admin_users') {
         expect(params).toMatchObject({
           operation: 'remove',
@@ -100,6 +130,12 @@ describe('AdminSettings logging', () => {
       }
       return fallbackRpc(functionName, params);
     });
+    fromSpy = vi.spyOn(supabase, 'from').mockImplementation((table: string) => {
+      if (table === 'therapists') {
+        return buildTherapistQuery() as never;
+      }
+      return originalFrom(table) as never;
+    });
     vi.mocked(logger.error).mockClear();
     vi.mocked(logger.info).mockClear();
     vi.mocked(showError).mockClear();
@@ -108,6 +144,8 @@ describe('AdminSettings logging', () => {
 
   afterEach(() => {
     rpcMock.mockImplementation(defaultRpcImplementation ?? fallbackRpc);
+    fromSpy?.mockRestore();
+    fromSpy = null;
     confirmSpy?.mockRestore();
     confirmSpy = null;
   });
@@ -145,6 +183,9 @@ describe('AdminSettings logging', () => {
     rpcMock.mockImplementation(async (functionName: string, params?: Record<string, unknown>) => {
       if (functionName === 'get_admin_users_paged') {
         return { data: [mockAdminUser], error: null };
+      }
+      if (functionName === 'get_admin_therapist_links') {
+        return { data: [], error: null };
       }
       if (functionName === 'manage_admin_users') {
         return { data: null, error: null };
@@ -203,6 +244,9 @@ describe('AdminSettings logging', () => {
     rpcMock.mockImplementation(async (functionName: string, params?: Record<string, unknown>) => {
       if (functionName === 'get_admin_users_paged') {
         return { data: [mockAdminUser], error: null };
+      }
+      if (functionName === 'get_admin_therapist_links') {
+        return { data: [], error: null };
       }
 
       if (defaultRpcImplementation) {
@@ -298,6 +342,9 @@ describe('Guardian approvals', () => {
       if (functionName === 'get_admin_users_paged') {
         return { data: [], error: null };
       }
+      if (functionName === 'get_admin_therapist_links') {
+        return { data: [], error: null };
+      }
 
       if (functionName === 'guardian_link_queue_admin_view') {
         expect(params).toMatchObject({
@@ -315,6 +362,10 @@ describe('Guardian approvals', () => {
     });
 
     fromSpy = vi.spyOn(supabase, 'from').mockImplementation((table: string) => {
+      if (table === 'therapists') {
+        return buildTherapistQuery() as never;
+      }
+
       if (table === 'clients') {
         const query: any = {
           select: vi.fn().mockReturnThis(),
@@ -363,6 +414,9 @@ describe('Guardian approvals', () => {
       if (functionName === 'get_admin_users_paged') {
         return { data: [], error: null };
       }
+      if (functionName === 'get_admin_therapist_links') {
+        return { data: [], error: null };
+      }
 
       if (functionName === 'guardian_link_queue_admin_view') {
         expect(params).toMatchObject({
@@ -392,6 +446,9 @@ describe('Guardian approvals', () => {
 
     rpcMock.mockImplementation(async (functionName: string, params?: Record<string, unknown>) => {
       if (functionName === 'get_admin_users_paged') {
+        return { data: [], error: null };
+      }
+      if (functionName === 'get_admin_therapist_links') {
         return { data: [], error: null };
       }
 
@@ -440,6 +497,226 @@ describe('Guardian approvals', () => {
   });
 });
 
+describe('Admin therapist links', () => {
+  let fromSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+  beforeEach(() => {
+    const authStub = {
+      user: {
+        user_metadata: {
+          organization_id: '11111111-1111-1111-1111-111111111111',
+        },
+      },
+      effectiveRole: 'admin',
+      profile: null,
+      session: null,
+      loading: false,
+      signIn: vi.fn(),
+      signUp: vi.fn(),
+      signOut: vi.fn(),
+      resetPassword: vi.fn(),
+      updateProfile: vi.fn(),
+      hasRole: vi.fn(() => true),
+      hasAnyRole: vi.fn(() => true),
+      isAdmin: vi.fn(() => true),
+      isSuperAdmin: vi.fn(() => false),
+    } as unknown as ReturnType<typeof useAuth>;
+
+    vi.mocked(useAuth).mockReturnValue(authStub);
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.mocked(showError).mockClear();
+    vi.mocked(showSuccess).mockClear();
+    rpcMock.mockClear();
+
+    fromSpy = vi.spyOn(supabase, 'from').mockImplementation((table: string) => {
+      if (table === 'clients') {
+        return buildEmptyClientsQuery() as never;
+      }
+
+      return originalFrom(table) as never;
+    });
+  });
+
+  afterEach(() => {
+    rpcMock.mockImplementation(defaultRpcImplementation ?? fallbackRpc);
+    fromSpy?.mockRestore();
+    fromSpy = null;
+    confirmSpy?.mockRestore();
+    confirmSpy = null;
+  });
+
+  it('links an admin to a same-organization therapist through the scoped RPC', async () => {
+    rpcMock.mockImplementation(async (functionName: string, params?: Record<string, unknown>) => {
+      if (functionName === 'get_admin_users_paged') {
+        return { data: [mockAdminUser], error: null };
+      }
+      if (functionName === 'guardian_link_queue_admin_view') {
+        return { data: [], error: null };
+      }
+      if (functionName === 'get_admin_linkable_therapists') {
+        return { data: [mockTherapist], error: null };
+      }
+      if (functionName === 'get_admin_therapist_links') {
+        expect(params).toMatchObject({
+          p_organization_id: '11111111-1111-1111-1111-111111111111',
+        });
+        return { data: [], error: null };
+      }
+      if (functionName === 'set_admin_therapist_link') {
+        return { data: [{ user_id: mockAdminUser.user_id, therapist_id: mockTherapist.id, therapist_name: mockTherapist.full_name }], error: null };
+      }
+
+      return fallbackRpc(functionName, params);
+    });
+
+    renderWithProviders(<AdminSettings />);
+
+    const therapistSelect = await screen.findByLabelText('Select therapist for admin@example.com');
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('get_admin_linkable_therapists', {
+        p_organization_id: '11111111-1111-1111-1111-111111111111',
+      });
+    });
+    expect(fromSpy).not.toHaveBeenCalledWith('therapists');
+
+    await userEvent.selectOptions(therapistSelect, mockTherapist.id);
+    await userEvent.click(screen.getByRole('button', { name: 'Link' }));
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith(
+        'set_admin_therapist_link',
+        {
+          target_user_id: mockAdminUser.user_id,
+          target_therapist_id: mockTherapist.id,
+          p_organization_id: '11111111-1111-1111-1111-111111111111',
+        }
+      );
+    });
+    expect(showSuccess).toHaveBeenCalledWith('Admin linked to therapist');
+  });
+
+  it('unlinks an existing admin therapist relationship through the scoped RPC', async () => {
+    rpcMock.mockImplementation(async (functionName: string, params?: Record<string, unknown>) => {
+      if (functionName === 'get_admin_users_paged') {
+        return { data: [mockAdminUser], error: null };
+      }
+      if (functionName === 'guardian_link_queue_admin_view') {
+        return { data: [], error: null };
+      }
+      if (functionName === 'get_admin_linkable_therapists') {
+        return { data: [mockTherapist], error: null };
+      }
+      if (functionName === 'get_admin_therapist_links') {
+        return {
+          data: [{
+            user_id: mockAdminUser.user_id,
+            therapist_id: mockTherapist.id,
+            therapist_name: mockTherapist.full_name,
+          }],
+          error: null,
+        };
+      }
+      if (functionName === 'delete_admin_therapist_link') {
+        return { data: true, error: null };
+      }
+
+      return fallbackRpc(functionName, params);
+    });
+
+    renderWithProviders(<AdminSettings />);
+
+    await userEvent.click(await screen.findByLabelText(`Unlink ${mockTherapist.full_name}`));
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith(
+        'delete_admin_therapist_link',
+        {
+          target_user_id: mockAdminUser.user_id,
+          target_therapist_id: mockTherapist.id,
+          p_organization_id: '11111111-1111-1111-1111-111111111111',
+        }
+      );
+    });
+    expect(confirmSpy).toHaveBeenCalledWith(`Unlink this admin from ${mockTherapist.full_name}?`);
+    expect(showSuccess).toHaveBeenCalledWith('Admin unlinked from therapist');
+  });
+
+  it('surfaces scoped RPC denial without falling back to direct table writes', async () => {
+    rpcMock.mockImplementation(async (functionName: string, params?: Record<string, unknown>) => {
+      if (functionName === 'get_admin_users_paged') {
+        return { data: [mockAdminUser], error: null };
+      }
+      if (functionName === 'guardian_link_queue_admin_view') {
+        return { data: [], error: null };
+      }
+      if (functionName === 'get_admin_linkable_therapists') {
+        return { data: [mockTherapist], error: null };
+      }
+      if (functionName === 'get_admin_therapist_links') {
+        return { data: [], error: null };
+      }
+      if (functionName === 'get_admin_linkable_therapists') {
+        return { data: [mockTherapist], error: null };
+      }
+      if (functionName === 'set_admin_therapist_link') {
+        return { data: null, error: new Error('Caller organization mismatch') };
+      }
+
+      return fallbackRpc(functionName, params);
+    });
+
+    renderWithProviders(<AdminSettings />);
+
+    await userEvent.selectOptions(
+      await screen.findByLabelText('Select therapist for admin@example.com'),
+      mockTherapist.id
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Link' }));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(expect.objectContaining({ message: 'Caller organization mismatch' }));
+    });
+    expect(fromSpy).not.toHaveBeenCalledWith('user_therapist_links');
+  });
+
+  it('surfaces read denial when therapist links are forbidden for the selected org', async () => {
+    rpcMock.mockImplementation(async (functionName: string, params?: Record<string, unknown>) => {
+      if (functionName === 'get_admin_users_paged') {
+        return { data: [mockAdminUser], error: null };
+      }
+      if (functionName === 'guardian_link_queue_admin_view') {
+        return { data: [], error: null };
+      }
+      if (functionName === 'get_admin_linkable_therapists') {
+        return { data: [mockTherapist], error: null };
+      }
+      if (functionName === 'get_admin_therapist_links') {
+        return {
+          data: null,
+          error: { code: '42501', message: 'Caller organization mismatch' },
+        };
+      }
+
+      return fallbackRpc(functionName, params);
+    });
+
+    renderWithProviders(<AdminSettings />);
+
+    await screen.findByText('Ada Admin');
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'You do not have permission to view admin therapist links for this organization.',
+        })
+      );
+    });
+    expect(rpcMock).toHaveBeenCalledWith('get_admin_therapist_links', {
+      p_organization_id: '11111111-1111-1111-1111-111111111111',
+    });
+  });
+});
+
 describe('AdminSettings super admin access', () => {
   let fromSpy: ReturnType<typeof vi.spyOn> | null = null;
 
@@ -469,6 +746,9 @@ describe('AdminSettings super admin access', () => {
       if (functionName === 'get_admin_users_paged') {
         return { data: [mockAdminUser], error: null };
       }
+      if (functionName === 'get_admin_therapist_links') {
+        return { data: [], error: null };
+      }
 
       if (functionName === 'guardian_link_queue_admin_view') {
         return { data: [], error: null };
@@ -496,12 +776,7 @@ describe('AdminSettings super admin access', () => {
       }
 
       if (table === 'clients') {
-        const query: any = {
-          select: vi.fn().mockReturnThis(),
-          eq: vi.fn().mockReturnThis(),
-          order: vi.fn().mockImplementation(() => Promise.resolve({ data: [], error: null })),
-        };
-        return query;
+        return buildEmptyClientsQuery() as never;
       }
 
       return originalFrom(table) as never;
@@ -533,9 +808,34 @@ describe('AdminSettings super admin access', () => {
       expect(adminCalls.some(([, params]) => params && (params as Record<string, unknown>).organization_id === 'org-1')).toBe(true);
     });
   });
+
+  it('keeps therapist link RPCs disabled for All organizations until a concrete org is selected', async () => {
+    renderWithProviders(<AdminSettings />);
+
+    const filterSelect = await screen.findByDisplayValue('All organizations');
+    await screen.findByText('Select an organization to manage therapist links.');
+
+    expect(rpcMock.mock.calls.some(([fnName]) => fnName === 'get_admin_linkable_therapists')).toBe(false);
+    expect(rpcMock.mock.calls.some(([fnName]) => fnName === 'get_admin_therapist_links')).toBe(false);
+    expect(fromSpy).not.toHaveBeenCalledWith('therapists');
+
+    await userEvent.selectOptions(filterSelect, 'org-1');
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('get_admin_linkable_therapists', {
+        p_organization_id: 'org-1',
+      });
+      expect(rpcMock).toHaveBeenCalledWith('get_admin_therapist_links', {
+        p_organization_id: 'org-1',
+      });
+    });
+    expect(fromSpy).not.toHaveBeenCalledWith('therapists');
+  });
 });
 
 describe('AdminSettings accessibility', () => {
+  let fromSpy: ReturnType<typeof vi.spyOn> | null = null;
+
   beforeEach(() => {
     const authStub = {
       user: {
@@ -563,6 +863,9 @@ describe('AdminSettings accessibility', () => {
       if (functionName === 'get_admin_users_paged') {
         return { data: [], error: null };
       }
+      if (functionName === 'get_admin_therapist_links') {
+        return { data: [], error: null };
+      }
 
       if (defaultRpcImplementation) {
         return defaultRpcImplementation(functionName, params as never);
@@ -570,10 +873,18 @@ describe('AdminSettings accessibility', () => {
 
       return fallbackRpc(functionName, params);
     });
+    fromSpy = vi.spyOn(supabase, 'from').mockImplementation((table: string) => {
+      if (table === 'therapists') {
+        return buildTherapistQuery() as never;
+      }
+      return originalFrom(table) as never;
+    });
   });
 
   afterEach(() => {
     rpcMock.mockImplementation(defaultRpcImplementation ?? fallbackRpc);
+    fromSpy?.mockRestore();
+    fromSpy = null;
   });
 
   it('traps focus within the add admin modal', async () => {

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -6213,6 +6213,42 @@ export type Database = {
           isSetofReturn: true
         }
       }
+      get_admin_linkable_therapists: {
+        Args: { p_organization_id: string }
+        Returns: {
+          id: string
+          full_name: string | null
+          email: string | null
+        }[]
+      }
+      get_admin_therapist_links: {
+        Args: { p_organization_id: string }
+        Returns: {
+          user_id: string
+          therapist_id: string
+          therapist_name: string | null
+        }[]
+      }
+      set_admin_therapist_link: {
+        Args: {
+          target_user_id: string
+          target_therapist_id: string
+          p_organization_id: string
+        }
+        Returns: {
+          user_id: string
+          therapist_id: string
+          therapist_name: string | null
+        }[]
+      }
+      delete_admin_therapist_link: {
+        Args: {
+          target_user_id: string
+          target_therapist_id: string
+          p_organization_id: string
+        }
+        Returns: boolean
+      }
       get_ai_cache_metrics: {
         Args: never
         Returns: {

--- a/supabase/migrations/20260506153005_admin_therapist_links.sql
+++ b/supabase/migrations/20260506153005_admin_therapist_links.sql
@@ -1,0 +1,321 @@
+-- @migration-intent: Add narrowly scoped admin/super-admin to therapist linking RPCs.
+-- @migration-dependencies: public.user_therapist_links, public.therapists, public.profiles, public.user_roles, public.roles, app.resolve_user_organization_id
+-- @migration-rollback: DROP FUNCTION IF EXISTS public.get_admin_linkable_therapists(uuid); DROP FUNCTION IF EXISTS public.get_admin_therapist_links(uuid); DROP FUNCTION IF EXISTS public.set_admin_therapist_link(uuid, uuid, uuid); DROP FUNCTION IF EXISTS public.delete_admin_therapist_link(uuid, uuid, uuid);
+
+begin;
+
+create or replace function public.get_admin_linkable_therapists(
+  p_organization_id uuid
+)
+returns table (
+  id uuid,
+  full_name text,
+  email text
+)
+language plpgsql
+security definer
+stable
+set search_path = public, auth, app
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_is_super_admin boolean;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  if p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Organization context required';
+  end if;
+
+  v_is_super_admin := app.current_user_is_super_admin();
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+
+  if not v_is_super_admin then
+    if v_actor_org is null or v_actor_org <> p_organization_id then
+      raise exception using errcode = '42501', message = 'Caller organization mismatch';
+    end if;
+
+    if not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_actor
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+        and r.name in ('admin', 'org_admin', 'super_admin', 'org_super_admin')
+    ) then
+      raise exception using errcode = '42501', message = 'Only administrators can view linkable therapists';
+    end if;
+  end if;
+
+  return query
+  select t.id, t.full_name, t.email
+  from public.therapists t
+  where t.organization_id = p_organization_id
+    and coalesce(t.is_active, true) = true
+    and t.deleted_at is null
+  order by t.full_name nulls last, t.email nulls last, t.id;
+end;
+$$;
+
+create or replace function public.get_admin_therapist_links(
+  p_organization_id uuid
+)
+returns table (
+  user_id uuid,
+  therapist_id uuid,
+  therapist_name text
+)
+language plpgsql
+security definer
+stable
+set search_path = public, auth, app
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_is_super_admin boolean;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  if p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Organization context required';
+  end if;
+
+  v_is_super_admin := app.current_user_is_super_admin();
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+
+  if not v_is_super_admin then
+    if v_actor_org is null or v_actor_org <> p_organization_id then
+      raise exception using errcode = '42501', message = 'Caller organization mismatch';
+    end if;
+
+    if not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_actor
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+        and r.name in ('admin', 'org_admin', 'super_admin', 'org_super_admin')
+    ) then
+      raise exception using errcode = '42501', message = 'Only administrators can view admin therapist links';
+    end if;
+  end if;
+
+  return query
+  select
+    utl.user_id,
+    utl.therapist_id,
+    t.full_name as therapist_name
+  from public.user_therapist_links utl
+  join public.therapists t
+    on t.id = utl.therapist_id
+   and t.organization_id = p_organization_id
+   and coalesce(t.is_active, true) = true
+   and t.deleted_at is null
+  join public.profiles p
+    on p.id = utl.user_id
+   and p.organization_id = p_organization_id
+  where exists (
+    select 1
+    from public.user_roles ur
+    join public.roles r on r.id = ur.role_id
+    where ur.user_id = utl.user_id
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+      and r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')
+  )
+  order by t.full_name nulls last, utl.created_at;
+end;
+$$;
+
+create or replace function public.set_admin_therapist_link(
+  target_user_id uuid,
+  target_therapist_id uuid,
+  p_organization_id uuid
+)
+returns table (
+  user_id uuid,
+  therapist_id uuid,
+  therapist_name text
+)
+language plpgsql
+security definer
+set search_path = public, auth, app
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_target_org uuid;
+  v_therapist_org uuid;
+  v_is_super_admin boolean;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  if target_user_id is null or target_therapist_id is null or p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Target user, therapist, and organization are required';
+  end if;
+
+  v_is_super_admin := app.current_user_is_super_admin();
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+
+  if not v_is_super_admin then
+    if v_actor_org is null or v_actor_org <> p_organization_id then
+      raise exception using errcode = '42501', message = 'Caller organization mismatch';
+    end if;
+
+    if not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_actor
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+        and r.name in ('admin', 'org_admin', 'super_admin', 'org_super_admin')
+    ) then
+      raise exception using errcode = '42501', message = 'Only administrators can manage admin therapist links';
+    end if;
+  end if;
+
+  v_target_org := app.resolve_user_organization_id(target_user_id);
+  if v_target_org is null or v_target_org <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Target user organization mismatch';
+  end if;
+
+  if not exists (
+    select 1
+    from public.user_roles ur
+    join public.roles r on r.id = ur.role_id
+    where ur.user_id = target_user_id
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+      and r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')
+  ) then
+    raise exception using errcode = '42501', message = 'Target user is not an administrator';
+  end if;
+
+  select t.organization_id
+  into v_therapist_org
+  from public.therapists t
+  where t.id = target_therapist_id
+    and coalesce(t.is_active, true) = true
+    and t.deleted_at is null;
+
+  if v_therapist_org is null then
+    raise exception using errcode = '22023', message = 'Therapist not found or inactive';
+  end if;
+
+  if v_therapist_org <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Therapist organization mismatch';
+  end if;
+
+  insert into public.user_therapist_links (user_id, therapist_id)
+  values (target_user_id, target_therapist_id)
+  on conflict (user_id, therapist_id) do nothing;
+
+  return query
+  select target_user_id, t.id, t.full_name
+  from public.therapists t
+  where t.id = target_therapist_id;
+end;
+$$;
+
+create or replace function public.delete_admin_therapist_link(
+  target_user_id uuid,
+  target_therapist_id uuid,
+  p_organization_id uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, auth, app
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_target_org uuid;
+  v_therapist_org uuid;
+  v_is_super_admin boolean;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  if target_user_id is null or target_therapist_id is null or p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Target user, therapist, and organization are required';
+  end if;
+
+  v_is_super_admin := app.current_user_is_super_admin();
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+
+  if not v_is_super_admin then
+    if v_actor_org is null or v_actor_org <> p_organization_id then
+      raise exception using errcode = '42501', message = 'Caller organization mismatch';
+    end if;
+
+    if not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_actor
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+        and r.name in ('admin', 'org_admin', 'super_admin', 'org_super_admin')
+    ) then
+      raise exception using errcode = '42501', message = 'Only administrators can manage admin therapist links';
+    end if;
+  end if;
+
+  v_target_org := app.resolve_user_organization_id(target_user_id);
+  if v_target_org is null or v_target_org <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Target user organization mismatch';
+  end if;
+
+  if not exists (
+    select 1
+    from public.user_roles ur
+    join public.roles r on r.id = ur.role_id
+    where ur.user_id = target_user_id
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+      and r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')
+  ) then
+    raise exception using errcode = '42501', message = 'Target user is not an administrator';
+  end if;
+
+  select t.organization_id
+  into v_therapist_org
+  from public.therapists t
+  where t.id = target_therapist_id;
+
+  if v_therapist_org is null or v_therapist_org <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Therapist organization mismatch';
+  end if;
+
+  delete from public.user_therapist_links
+  where user_id = target_user_id
+    and therapist_id = target_therapist_id;
+
+  return true;
+end;
+$$;
+
+revoke execute on function public.get_admin_linkable_therapists(uuid) from public, anon;
+revoke execute on function public.get_admin_therapist_links(uuid) from public, anon;
+revoke execute on function public.set_admin_therapist_link(uuid, uuid, uuid) from public, anon;
+revoke execute on function public.delete_admin_therapist_link(uuid, uuid, uuid) from public, anon;
+
+grant execute on function public.get_admin_linkable_therapists(uuid) to authenticated, service_role;
+grant execute on function public.get_admin_therapist_links(uuid) to authenticated, service_role;
+grant execute on function public.set_admin_therapist_link(uuid, uuid, uuid) to authenticated, service_role;
+grant execute on function public.delete_admin_therapist_link(uuid, uuid, uuid) to authenticated, service_role;
+
+commit;

--- a/tests/edge/adminTherapistLinks.contract.test.ts
+++ b/tests/edge/adminTherapistLinks.contract.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ADMIN_LINK_MIGRATION = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260506153005_admin_therapist_links.sql'
+);
+
+const CLIENT_LINK_MIGRATION = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260302120000_client_therapist_links.sql'
+);
+
+const readMigration = (migrationPath: string) => fs.readFileSync(migrationPath, 'utf8');
+
+const extractFunction = (sql: string, functionName: string) => {
+  const start = sql.indexOf(`create or replace function public.${functionName}(`);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const nextFunction = sql.indexOf('create or replace function public.', start + 1);
+  return sql.slice(start, nextFunction === -1 ? sql.length : nextFunction);
+};
+
+describe('admin therapist link migration contract', () => {
+  it('adds only RPC-bound admin/super-admin therapist link entrypoints', () => {
+    const sql = readMigration(ADMIN_LINK_MIGRATION);
+
+    expect(sql).toContain('create or replace function public.get_admin_linkable_therapists(');
+    expect(sql).toContain('create or replace function public.get_admin_therapist_links(');
+    expect(sql).toContain('create or replace function public.set_admin_therapist_link(');
+    expect(sql).toContain('create or replace function public.delete_admin_therapist_link(');
+    expect(sql).toContain('security definer');
+    expect(sql).toContain('set search_path = public, auth, app');
+    expect(sql).toContain('insert into public.user_therapist_links (user_id, therapist_id)');
+    expect(sql).toContain('delete from public.user_therapist_links');
+    expect(sql).not.toContain('public.get_organization_id_from_metadata');
+    expect(sql).not.toContain('alter table public.user_roles');
+    expect(sql).not.toContain('alter table public.roles');
+  });
+
+  it('requires authenticated admin authority and explicit organization scope', () => {
+    const sql = readMigration(ADMIN_LINK_MIGRATION);
+
+    expect(sql.match(/auth\.uid\(\)/g)?.length ?? 0).toBeGreaterThanOrEqual(4);
+    expect(sql.match(/p_organization_id is null/g)?.length ?? 0).toBeGreaterThanOrEqual(4);
+    expect(sql.match(/where ur\.user_id = v_actor/g)?.length ?? 0).toBe(4);
+    expect(sql.match(/r\.name in \('admin', 'org_admin', 'super_admin', 'org_super_admin'\)/g)?.length ?? 0).toBe(4);
+    expect(sql).toContain('app.current_user_is_super_admin()');
+    expect(sql).toContain("raise exception using errcode = '28000', message = 'Authentication required'");
+    expect(sql).toContain("raise exception using errcode = '42501', message = 'Caller organization mismatch'");
+  });
+
+  it('denies cross-org target users and therapists before writing links', () => {
+    const sql = readMigration(ADMIN_LINK_MIGRATION);
+
+    expect(sql).toContain('v_target_org := app.resolve_user_organization_id(target_user_id)');
+    expect(sql).toContain('join public.profiles p');
+    expect(sql).toContain('and p.organization_id = p_organization_id');
+    expect(sql).toContain('v_target_org is null or v_target_org <> p_organization_id');
+    expect(sql).toContain('t.organization_id = p_organization_id');
+    expect(sql).toContain('v_therapist_org <> p_organization_id');
+    expect(sql).toContain("raise exception using errcode = '42501', message = 'Target user organization mismatch'");
+    expect(sql).toContain("raise exception using errcode = '42501', message = 'Therapist organization mismatch'");
+  });
+
+  it('limits target users to administrator role names only', () => {
+    const sql = readMigration(ADMIN_LINK_MIGRATION);
+
+    expect(sql.match(/r\.name in \('admin', 'super_admin', 'org_admin', 'org_super_admin'\)/g)?.length ?? 0).toBe(3);
+    expect(sql.match(/where ur\.user_id = target_user_id/g)?.length ?? 0).toBe(2);
+    expect(sql).toContain('where ur.user_id = utl.user_id');
+    expect(sql.match(/raise exception using errcode = '42501', message = 'Target user is not an administrator'/g)?.length ?? 0).toBe(2);
+    expect(sql).not.toContain("r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin', 'therapist')");
+    expect(sql).not.toContain("r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin', 'client')");
+  });
+
+  it('keeps the delete RPC constrained to admin targets before unlinking', () => {
+    const sql = readMigration(ADMIN_LINK_MIGRATION);
+    const deleteRpc = extractFunction(sql, 'delete_admin_therapist_link');
+    const deleteStatementIndex = deleteRpc.indexOf('delete from public.user_therapist_links');
+
+    expect(deleteStatementIndex).toBeGreaterThanOrEqual(0);
+    expect(deleteRpc.indexOf('v_target_org := app.resolve_user_organization_id(target_user_id)')).toBeGreaterThanOrEqual(0);
+    expect(deleteRpc.indexOf('v_target_org is null or v_target_org <> p_organization_id')).toBeGreaterThanOrEqual(0);
+    expect(deleteRpc.indexOf("r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')")).toBeGreaterThanOrEqual(0);
+    expect(deleteRpc.indexOf("raise exception using errcode = '42501', message = 'Target user is not an administrator'")).toBeGreaterThanOrEqual(0);
+    expect(deleteRpc.indexOf('v_therapist_org is null or v_therapist_org <> p_organization_id')).toBeGreaterThanOrEqual(0);
+    expect(deleteRpc.indexOf("where user_id = target_user_id\n    and therapist_id = target_therapist_id")).toBeGreaterThanOrEqual(0);
+
+    expect(deleteRpc.indexOf('v_target_org is null or v_target_org <> p_organization_id')).toBeLessThan(deleteStatementIndex);
+    expect(deleteRpc.indexOf("r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')")).toBeLessThan(deleteStatementIndex);
+    expect(deleteRpc.indexOf('v_therapist_org is null or v_therapist_org <> p_organization_id')).toBeLessThan(deleteStatementIndex);
+  });
+
+  it('keeps direct execute access denied to public and anon callers', () => {
+    const sql = readMigration(ADMIN_LINK_MIGRATION);
+
+    expect(sql).toContain('revoke execute on function public.get_admin_linkable_therapists(uuid) from public, anon;');
+    expect(sql).toContain('revoke execute on function public.get_admin_therapist_links(uuid) from public, anon;');
+    expect(sql).toContain('revoke execute on function public.set_admin_therapist_link(uuid, uuid, uuid) from public, anon;');
+    expect(sql).toContain('revoke execute on function public.delete_admin_therapist_link(uuid, uuid, uuid) from public, anon;');
+    expect(sql).toContain('grant execute on function public.get_admin_linkable_therapists(uuid) to authenticated, service_role;');
+    expect(sql).toContain('grant execute on function public.get_admin_therapist_links(uuid) to authenticated, service_role;');
+    expect(sql).toContain('grant execute on function public.set_admin_therapist_link(uuid, uuid, uuid) to authenticated, service_role;');
+    expect(sql).toContain('grant execute on function public.delete_admin_therapist_link(uuid, uuid, uuid) to authenticated, service_role;');
+    expect(sql).not.toContain('grant execute on function public.set_admin_therapist_link(uuid, uuid, uuid) to anon;');
+  });
+});
+
+describe('client therapist link migration contract', () => {
+  it('keeps the existing client-therapist link authorization path intact', () => {
+    const sql = readMigration(CLIENT_LINK_MIGRATION);
+
+    expect(sql).toContain('create table if not exists public.client_therapist_links');
+    expect(sql).toContain('app.set_client_therapist_link_defaults()');
+    expect(sql).toContain('client_therapist_links_manage_scope');
+    expect(sql).toContain('app.can_access_client(client_id)');
+    expect(sql).toContain('therapist_id = app.current_therapist_id()');
+  });
+});


### PR DESCRIPTION
## Summary
- Add narrowly scoped admin/super-admin to therapist linking in Admin Settings.
- Add SECURITY DEFINER Supabase RPCs for listing linkable therapists, reading admin therapist links, linking, and unlinking.
- Enforce auth.uid(), explicit organization context, same-org caller/target/therapist checks, active admin/org-admin/super-admin/org-super-admin role checks, and public/anon execute revokes.
- Add focused component and migration contract coverage, including delete guard ordering and existing client-therapist link preservation.

Linear: WIN-130

## Route Task
- classification: high-risk human-reviewed
- lane: critical
- triggering paths / risk rationale: `supabase/migrations/**`, tenant-scoped admin/therapist role relationship logic, AdminSettings protected admin UI, generated Supabase types.
- allowed scope: AdminSettings admin therapist link UI, narrowly scoped Supabase RPC migration, generated types, focused tests.
- non-goals: no global auth refactor, no role hierarchy changes, no unrelated dashboard/client/therapist flows, no deploy/CI/runtime config changes.

## Verification Card
- classification: high-risk human-reviewed
- lane: critical
- change type: UI/component/page; database/RLS/migrations/tenant isolation; generated Supabase types
- required checks: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, targeted Vitest, `npm run validate:tenant`, `npm run build`, `npm run test:routes:tier0`, `npm run verify:local`
- executed checks: `npx vitest run --reporter=verbose tests/edge/adminTherapistLinks.contract.test.ts src/components/settings/__tests__/AdminSettings.test.tsx` passed; `npm run ci:check-focused` passed; `npm run lint` passed; `npm run typecheck` passed; `npm run validate:tenant` passed; `npm run build` passed; `npm run test:routes:tier0` passed on rerun after transient preview 404; `npm run verify:local` passed after final SQL fix; commit hook `npm run ci:check-focused` passed.
- blocked checks: live DB-backed RPC execution and DB grant/drift checks were not run locally because `SUPABASE_DB_URL` / `DATABASE_URL` are not configured; CI should confirm hosted DB grant/drift checks where secrets are available.
- result: pass-with-blocked-checks
- residual risk: SQL auth behavior is covered by static contract tests, not live authenticated DB execution in this local environment.

## PR Hygiene
- pr-ready: yes for human review
- lane: critical
- branch-ready: yes, dedicated `codex/admin-therapist-links`
- linear-ready: yes, WIN-130
- single-purpose: yes
- unrelated changes: none
- generated artifact drift: `database.types.ts` updated to match new RPCs
- protected-path drift: expected `supabase/migrations/**` only for this feature
- reviewer: completed; final code/security review approved