### PR TITLE
Fix super_admin admin-management flows

### DIFF
--- a/docs/ai/super-admin-admin-management-handoff-2026-05-06.md
+++ b/docs/ai/super-admin-admin-management-handoff-2026-05-06.md
@@ -1,0 +1,87 @@
+# Super Admin Admin Management Handoff
+
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: the slice changes protected admin-management behavior across client actions, Supabase edge functions, and tenant-scoped RPC authorization.
+- triggering paths:
+  - `src/components/settings/AdminSettings.tsx`
+  - `supabase/functions/admin-reset-user-password/**`
+  - `supabase/migrations/20260506170000_super_admin_admin_management_authz.sql`
+
+## Scope
+
+- task intent: restore `super_admin` create, reset/edit, and delete admin flows in `/settings/admins` without broadening regular-admin authority or weakening org isolation.
+- files touched:
+  - `src/components/settings/AdminSettings.tsx`
+  - `src/components/settings/__tests__/AdminSettings.test.tsx`
+  - `supabase/functions/admin-reset-user-password/function.toml`
+  - `supabase/functions/admin-reset-user-password/index.ts`
+  - `supabase/migrations/20260506170000_super_admin_admin_management_authz.sql`
+  - `tests/admin-create-user.access.spec.ts`
+  - `tests/admin-reset-user-password.access.spec.ts`
+  - `tests/admins/manage_admin_users.log.spec.ts`
+- single-purpose diff: yes
+
+## Required Agents
+
+- required sequence:
+  - `specification-engineer`
+  - `software-architect`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+  - `security-engineer`
+- agents used:
+  - `tester`
+  - `reviewer`
+- reviewer: completed
+
+## Verification Card
+
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run verify:local`
+- executed checks:
+  - `npx vitest run src/components/settings/__tests__/AdminSettings.test.tsx tests/admin-create-user.access.spec.ts tests/admin-reset-user-password.access.spec.ts tests/admins/manage_admin_users.log.spec.ts src/server/rpc/__tests__/admin.test.ts`: pass
+  - `npx vitest run tests/admin-users-roles.access.spec.ts tests/admins/assign_role.spec.ts tests/admins/create-super-admin.security.spec.ts`: pass
+  - `npx vitest run tests/edge/auth-middleware.role-resolution.test.ts tests/edge/orgRoleRpc.parity.contract.test.ts`: pass
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+  - `npm run test:routes:tier0`: pass
+- blocked checks:
+  - `npm run test:ci`: fails outside this slice because `tests/edge/adminTherapistLinks.contract.test.ts` is already red and still expects SQL in `20260506153005_admin_therapist_links.sql` that is unrelated to this change.
+  - `npm run ci:playwright`: timed out locally before completing the full suite.
+  - `npm run verify:local`: fails because it includes the unrelated `npm run test:ci` failure above.
+- result: pass-with-blocked-checks
+- residual risk:
+  - `admin-reset-user-password` authorizes by scanning `get_admin_users_paged` up to 500 rows, so very large admin populations could produce false negative `403` or `404` responses without widening access.
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: no
+- protected-path drift: none
+- unrelated changes: none
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: no
+- required follow-up:
+  - create or link the Linear issue required for this critical slice
+  - resolve or explicitly waive the unrelated `tests/edge/adminTherapistLinks.contract.test.ts` failure before merge
+  - complete `npm run ci:playwright` in CI or a credentialed local environment
+
+## Handoff Summary
+
+This slice fixes the broken `super_admin` admin-management path by moving password reset behind a protected edge function and by updating the admin role RPC authorization so `super_admin` can manage admins without weakening same-org checks for regular admins. Focused UI, edge-function, RPC, policy, build, tenant-safety, and route-tier tests are green. The remaining blockers are process and environment related: no linked Linear issue yet, one unrelated red contract test still breaks `test:ci`, and the full Playwright suite timed out locally.

--- a/src/components/settings/AdminSettings.tsx
+++ b/src/components/settings/AdminSettings.tsx
@@ -454,11 +454,16 @@ export function AdminSettings() {
 
   const resetPasswordMutation = useMutation({
     mutationFn: async ({ email, password }: { email: string; password: string }) => {
-      const { error } = await supabase.rpc('reset_user_password', {
-        target_email: email,
-        new_password: password
+      const { error } = await supabase.functions.invoke('admin-reset-user-password', {
+        body: {
+          email,
+          new_password: password,
+        },
       });
-      if (error) throw error;
+
+      if (error) {
+        throw error;
+      }
     },
     onSuccess: () => {
       setIsPasswordModalOpen(false);

--- a/src/components/settings/__tests__/AdminSettings.test.tsx
+++ b/src/components/settings/__tests__/AdminSettings.test.tsx
@@ -719,6 +719,7 @@ describe('Admin therapist links', () => {
 
 describe('AdminSettings super admin access', () => {
   let fromSpy: ReturnType<typeof vi.spyOn> | null = null;
+  let invokeSpy: ReturnType<typeof vi.spyOn> | null = null;
 
   beforeEach(() => {
     const authStub = {
@@ -742,12 +743,18 @@ describe('AdminSettings super admin access', () => {
 
     vi.mocked(useAuth).mockReturnValue(authStub);
     rpcMock.mockClear();
+    vi.mocked(showError).mockClear();
+    vi.mocked(showSuccess).mockClear();
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     rpcMock.mockImplementation(async (functionName: string, params?: Record<string, unknown>) => {
       if (functionName === 'get_admin_users_paged') {
         return { data: [mockAdminUser], error: null };
       }
       if (functionName === 'get_admin_therapist_links') {
         return { data: [], error: null };
+      }
+      if (functionName === 'manage_admin_users') {
+        return { data: null, error: null };
       }
 
       if (functionName === 'guardian_link_queue_admin_view') {
@@ -781,12 +788,19 @@ describe('AdminSettings super admin access', () => {
 
       return originalFrom(table) as never;
     });
+    invokeSpy = vi
+      .spyOn(supabase.functions, 'invoke')
+      .mockResolvedValue({ data: null, error: null });
   });
 
   afterEach(() => {
     rpcMock.mockImplementation(defaultRpcImplementation ?? fallbackRpc);
     fromSpy?.mockRestore();
     fromSpy = null;
+    invokeSpy?.mockRestore();
+    invokeSpy = null;
+    confirmSpy?.mockRestore();
+    confirmSpy = null;
   });
 
   it('allows super admins to view and filter admins across organizations', async () => {
@@ -830,6 +844,74 @@ describe('AdminSettings super admin access', () => {
       });
     });
     expect(fromSpy).not.toHaveBeenCalledWith('therapists');
+  });
+
+  it('creates an admin in the selected organization', async () => {
+    renderWithProviders(<AdminSettings />);
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Add Admin' }));
+
+    const modal = await screen.findByRole('dialog', { name: 'Add New Admin' });
+    await userEvent.type(within(modal).getByLabelText('Email*'), 'super.created@example.com');
+    await userEvent.type(within(modal).getByLabelText('Password*'), 'StrongPass123!');
+    await userEvent.type(within(modal).getByLabelText('First Name*'), 'Super');
+    await userEvent.type(within(modal).getByLabelText('Last Name*'), 'Created');
+    await userEvent.selectOptions(within(modal).getByLabelText('Organization'), 'org-2');
+    await userEvent.type(within(modal).getByLabelText('Reason for admin access*'), 'Coverage for the Sunrise Therapy workspace.');
+
+    await userEvent.click(within(modal).getByRole('button', { name: 'Add Admin' }));
+
+    await waitFor(() => {
+      expect(invokeSpy).toHaveBeenCalledWith(
+        'admin-create-user',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            email: 'super.created@example.com',
+            organization_id: 'org-2',
+            reason: 'Coverage for the Sunrise Therapy workspace.',
+          }),
+        }),
+      );
+    });
+    expect(showSuccess).toHaveBeenCalledWith('Admin user created successfully');
+  });
+
+  it('resets an admin password through the canonical RPC without falling back when available', async () => {
+    invokeSpy?.mockResolvedValue({ data: null, error: null });
+    renderWithProviders(<AdminSettings />);
+
+    await userEvent.click(await screen.findByTitle('Reset password'));
+
+    const modal = await screen.findByRole('dialog', { name: `Reset Password for ${mockAdminUser.email}` });
+    await userEvent.type(within(modal).getByLabelText('New Password*'), 'UpdatedPass123!');
+    await userEvent.click(within(modal).getByRole('button', { name: 'Reset Password' }));
+
+    await waitFor(() => {
+      expect(invokeSpy).toHaveBeenCalledWith(
+        'admin-reset-user-password',
+        expect.objectContaining({
+          body: {
+            email: mockAdminUser.email,
+            new_password: 'UpdatedPass123!',
+          },
+        }),
+      );
+    });
+    expect(showSuccess).toHaveBeenCalledWith('Password reset successfully');
+  });
+
+  it('removes an admin through manage_admin_users for super admins', async () => {
+    renderWithProviders(<AdminSettings />);
+
+    await userEvent.click(await screen.findByTitle('Remove admin'));
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('manage_admin_users', {
+        operation: 'remove',
+        target_user_id: mockAdminUser.user_id,
+      });
+    });
+    expect(showSuccess).toHaveBeenCalledWith('Admin user removed successfully');
   });
 });
 

--- a/supabase/functions/admin-reset-user-password/function.toml
+++ b/supabase/functions/admin-reset-user-password/function.toml
@@ -1,0 +1,1 @@
+verify_jwt = true

--- a/supabase/functions/admin-reset-user-password/index.ts
+++ b/supabase/functions/admin-reset-user-password/index.ts
@@ -1,0 +1,155 @@
+import {
+  corsHeaders,
+  createProtectedRoute,
+  logApiAccess,
+  RouteOptions,
+  type Role,
+  type UserContext,
+} from "../_shared/auth-middleware.ts";
+import { createRequestClient, supabaseAdmin } from "../_shared/database.ts";
+
+interface ResetAdminPasswordPayload {
+  email: string;
+  new_password: string;
+}
+
+interface AdminUserRecord {
+  email?: string;
+  raw_user_meta_data?: Record<string, unknown> | null;
+}
+
+const ADMIN_USER_FETCH_LIMIT = 500;
+const MIN_PASSWORD_LENGTH = 8;
+
+const respond = (status: number, body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+const normalizeString = (value: unknown) =>
+  typeof value === "string" ? value.trim() : "";
+
+const parseOrganizationFromMetadata = (metadata: Record<string, unknown> | null | undefined) => {
+  if (!metadata || typeof metadata !== "object") return null;
+  const snake = metadata["organization_id"];
+  if (typeof snake === "string" && snake.trim().length > 0) return snake.trim();
+  const camel = metadata["organizationId"];
+  if (typeof camel === "string" && camel.trim().length > 0) return camel.trim();
+  return null;
+};
+
+const resolveCallerOrg = async (context: UserContext): Promise<string | null> => {
+  const { data, error } = await supabaseAdmin.auth.admin.getUserById(context.user.id);
+  if (error || !data?.user) {
+    console.error("Failed to resolve caller metadata", { error, callerId: context.user.id });
+    return null;
+  }
+
+  return parseOrganizationFromMetadata(
+    data.user.user_metadata as Record<string, unknown> | undefined,
+  );
+};
+
+const canManageAllOrganizations = (role: Role) => role === "super_admin";
+
+const invokeCanonicalReset = async (normalizedEmail: string, normalizedPassword: string) => {
+  const primaryResult = await supabaseAdmin.rpc("admin_reset_user_password", {
+    user_email: normalizedEmail,
+    new_password: normalizedPassword,
+  });
+
+  if (!primaryResult.error) {
+    return null;
+  }
+
+  if (primaryResult.error.code !== "PGRST202") {
+    return primaryResult.error;
+  }
+
+  const legacyResult = await supabaseAdmin.rpc("reset_user_password", {
+    target_email: normalizedEmail,
+    new_password: normalizedPassword,
+  });
+
+  return legacyResult.error ?? null;
+};
+
+const handler = createProtectedRoute(
+  async (req, userContext) => {
+    if (req.method !== "POST") {
+      return respond(405, { error: "Method not allowed" });
+    }
+
+    let payload: Partial<ResetAdminPasswordPayload>;
+    try {
+      payload = await req.json();
+    } catch {
+      return respond(400, { error: "Invalid JSON payload" });
+    }
+
+    const normalizedEmail = normalizeString(payload.email).toLowerCase();
+    if (!normalizedEmail || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(normalizedEmail)) {
+      return respond(400, { error: "A valid email address is required." });
+    }
+
+    const normalizedPassword = normalizeString(payload.new_password);
+    if (normalizedPassword.length < MIN_PASSWORD_LENGTH) {
+      return respond(400, { error: `Password must be at least ${MIN_PASSWORD_LENGTH} characters.` });
+    }
+
+    const requestClient = createRequestClient(req);
+    const callerCanManageAllOrgs = canManageAllOrganizations(userContext.profile.role);
+
+    let scopedOrganizationId: string | null = null;
+    if (!callerCanManageAllOrgs) {
+      scopedOrganizationId = await resolveCallerOrg(userContext);
+      if (!scopedOrganizationId) {
+        logApiAccess("POST", "/admin/reset-user-password", userContext, 400);
+        return respond(400, { error: "Caller is missing organization metadata." });
+      }
+    }
+
+    const { data: adminRows, error: adminRowsError } = await requestClient.rpc("get_admin_users_paged", {
+      organization_id: scopedOrganizationId,
+      p_limit: ADMIN_USER_FETCH_LIMIT,
+      p_offset: 0,
+    });
+
+    if (adminRowsError) {
+      const status = adminRowsError.code === "42501" ? 403 : 500;
+      logApiAccess("POST", "/admin/reset-user-password", userContext, status);
+      return respond(status, {
+        error: status === 403 ? "Access denied" : "Failed to validate admin scope.",
+      });
+    }
+
+    const adminList = Array.isArray(adminRows) ? adminRows as AdminUserRecord[] : [];
+    const targetAdmin = adminList.find((entry) => normalizeString(entry.email).toLowerCase() === normalizedEmail);
+
+    if (!targetAdmin) {
+      const status = callerCanManageAllOrgs ? 404 : 403;
+      logApiAccess("POST", "/admin/reset-user-password", userContext, status);
+      return respond(status, {
+        error: callerCanManageAllOrgs
+          ? "Admin user not found."
+          : "Target admin is outside the caller organization.",
+      });
+    }
+
+    const resetError = await invokeCanonicalReset(normalizedEmail, normalizedPassword);
+    if (resetError) {
+      console.error("admin_reset_user_password failed", { error: resetError, email: normalizedEmail });
+      logApiAccess("POST", "/admin/reset-user-password", userContext, 500);
+      return respond(500, { error: "Failed to reset admin password." });
+    }
+
+    logApiAccess("POST", "/admin/reset-user-password", userContext, 200);
+    return respond(200, { email: normalizedEmail });
+  },
+  RouteOptions.admin,
+);
+
+Deno.serve(handler);
+
+export default handler;

--- a/supabase/migrations/20260506170000_super_admin_admin_management_authz.sql
+++ b/supabase/migrations/20260506170000_super_admin_admin_management_authz.sql
@@ -1,0 +1,332 @@
+-- @migration-intent: Allow super_admin callers to use admin-management RPCs while preserving same-org enforcement for regular admins.
+-- @migration-dependencies: 20260318152000_admin_role_state_hardening.sql,20260202123000_fix_super_admin_governance.sql
+-- @migration-rollback: Re-run 20260318152000_admin_role_state_hardening.sql to restore the prior admin-only RPC authorization semantics.
+
+begin;
+
+set search_path = public;
+
+create or replace function public.assign_admin_role(
+  user_email text,
+  organization_id uuid,
+  reason text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_request_role text := current_setting('request.jwt.claim.role', true);
+  v_is_service_role boolean := v_request_role = 'service_role';
+  v_is_super_admin boolean := public.current_user_is_super_admin();
+  v_caller_id uuid := auth.uid();
+  v_caller_org uuid;
+  v_target_id uuid;
+  v_target_email text;
+  v_target_metadata jsonb;
+  v_target_org uuid;
+  v_admin_role_id uuid;
+  v_role_rows integer := 0;
+begin
+  if organization_id is null then
+    raise exception using errcode = '22023', message = 'Organization ID is required';
+  end if;
+
+  if not v_is_service_role then
+    if v_caller_id is null then
+      raise exception using errcode = '28000', message = 'Authentication required';
+    end if;
+
+    if not v_is_super_admin and not exists (
+      select 1
+      from user_roles ur
+      join roles r on r.id = ur.role_id
+      where ur.user_id = v_caller_id
+        and r.name = 'admin'
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+    ) then
+      raise exception using errcode = '42501', message = 'Only active administrators can assign admin role';
+    end if;
+
+    if not v_is_super_admin then
+      select get_organization_id_from_metadata(u.raw_user_meta_data)
+      into v_caller_org
+      from auth.users u
+      where u.id = v_caller_id;
+
+      if v_caller_org is null then
+        raise exception using errcode = '42501', message = 'Caller organization context is required';
+      end if;
+
+      if v_caller_org <> organization_id then
+        raise exception using errcode = '42501', message = 'Caller organization mismatch';
+      end if;
+    end if;
+  end if;
+
+  select id, email, raw_user_meta_data
+  into v_target_id, v_target_email, v_target_metadata
+  from auth.users
+  where email = user_email;
+
+  if v_target_id is null then
+    raise exception using errcode = 'P0002', message = format('User with email %s not found', user_email);
+  end if;
+
+  v_target_org := get_organization_id_from_metadata(v_target_metadata);
+
+  if v_target_org is not null and v_target_org <> organization_id then
+    raise exception using errcode = '42501', message = 'Target user belongs to a different organization';
+  end if;
+
+  v_target_metadata := coalesce(v_target_metadata, '{}'::jsonb);
+  v_target_metadata := jsonb_set(v_target_metadata, '{organization_id}', to_jsonb(organization_id::text), true);
+  v_target_metadata := jsonb_set(v_target_metadata, '{organizationId}', to_jsonb(organization_id::text), true);
+  v_target_metadata := jsonb_set(v_target_metadata, '{is_admin}', 'true'::jsonb, true);
+
+  update auth.users
+  set raw_user_meta_data = v_target_metadata
+  where id = v_target_id;
+
+  select id into v_admin_role_id
+  from roles
+  where name = 'admin';
+
+  if v_admin_role_id is null then
+    insert into roles (name, description)
+    values ('admin', 'Administrator role with full access')
+    returning id into v_admin_role_id;
+  end if;
+
+  insert into user_roles (user_id, role_id)
+  values (v_target_id, v_admin_role_id)
+  on conflict (user_id, role_id) do nothing;
+
+  get diagnostics v_role_rows = row_count;
+
+  begin
+    insert into admin_actions (
+      admin_user_id,
+      target_user_id,
+      organization_id,
+      action_type,
+      action_details
+    )
+    values (
+      v_caller_id,
+      v_target_id,
+      organization_id,
+      'admin_role_added',
+      jsonb_build_object(
+        'operation', 'add',
+        'target_email', v_target_email,
+        'service_role', v_is_service_role,
+        'role_inserted', v_role_rows > 0,
+        'reason', nullif(reason, '')
+      )
+    );
+  exception
+    when others then
+      raise warning 'Failed to log admin add action via assign_admin_role: %', sqlerrm;
+  end;
+end;
+$$;
+
+grant execute on function public.assign_admin_role(text, uuid, text) to authenticated;
+
+create or replace function public.manage_admin_users(
+  operation text,
+  target_user_id text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_request_role text := current_setting('request.jwt.claim.role', true);
+  v_is_service_role boolean := v_request_role = 'service_role';
+  v_is_super_admin boolean := public.current_user_is_super_admin();
+  v_admin_role_id uuid;
+  v_caller_id uuid := auth.uid();
+  v_caller_org uuid;
+  v_target_id uuid;
+  v_target_email text;
+  v_target_metadata jsonb;
+  v_target_org uuid;
+  v_admin_count integer;
+  v_effective_org uuid;
+begin
+  select id into v_admin_role_id
+  from roles
+  where name = 'admin';
+
+  if not v_is_service_role then
+    if v_caller_id is null then
+      raise exception using errcode = '28000', message = 'Authentication required';
+    end if;
+
+    if not v_is_super_admin and not exists (
+      select 1
+      from user_roles ur
+      join roles r on r.id = ur.role_id
+      where ur.user_id = v_caller_id
+        and r.name = 'admin'
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+    ) then
+      raise exception using errcode = '42501', message = 'Only active administrators can manage admin users';
+    end if;
+
+    if not v_is_super_admin then
+      select get_organization_id_from_metadata(u.raw_user_meta_data)
+      into v_caller_org
+      from auth.users u
+      where u.id = v_caller_id;
+
+      if v_caller_org is null then
+        raise exception using errcode = '42501', message = 'Caller organization context is required';
+      end if;
+    end if;
+  end if;
+
+  begin
+    v_target_id := target_user_id::uuid;
+  exception
+    when others then
+      select id
+      into v_target_id
+      from auth.users
+      where email = target_user_id;
+
+      if v_target_id is null then
+        raise exception using errcode = 'P0002', message = format('User with ID/email %s not found', target_user_id);
+      end if;
+  end;
+
+  select email, raw_user_meta_data
+  into v_target_email, v_target_metadata
+  from auth.users
+  where id = v_target_id;
+
+  if v_target_email is null then
+    raise exception using errcode = 'P0002', message = format('User with ID/email %s not found', target_user_id);
+  end if;
+
+  v_target_org := get_organization_id_from_metadata(v_target_metadata);
+
+  if not v_is_service_role and not v_is_super_admin then
+    if v_target_org is null then
+      raise exception using errcode = '42501', message = 'Target user organization metadata is required';
+    end if;
+
+    if v_caller_org <> v_target_org then
+      raise exception using errcode = '42501', message = 'Target user does not belong to the caller organization';
+    end if;
+  end if;
+
+  if v_admin_role_id is null then
+    insert into roles (name, description)
+    values ('admin', 'Administrator role with full access')
+    returning id into v_admin_role_id;
+  end if;
+
+  case operation
+    when 'add' then
+      if coalesce(v_target_org, v_caller_org) is null then
+        raise exception using errcode = '42501', message = 'Organization context is required to add an admin';
+      end if;
+
+      v_effective_org := coalesce(v_target_org, v_caller_org);
+
+      perform public.assign_admin_role(
+        v_target_email,
+        v_effective_org,
+        'manage_admin_users:add'
+      );
+
+      begin
+        insert into admin_actions (
+          admin_user_id,
+          target_user_id,
+          organization_id,
+          action_type,
+          action_details
+        )
+        values (
+          v_caller_id,
+          v_target_id,
+          v_effective_org,
+          'admin_role_added',
+          jsonb_build_object(
+            'operation', 'add',
+            'target_email', v_target_email,
+            'service_role', v_is_service_role
+          )
+        );
+      exception
+        when others then
+          raise warning 'Failed to log admin add action: %', sqlerrm;
+      end;
+
+    when 'remove' then
+      if not v_is_service_role and not v_is_super_admin then
+        select count(*)
+        into v_admin_count
+        from user_roles ur
+        join auth.users au on au.id = ur.user_id
+        where ur.role_id = v_admin_role_id
+          and get_organization_id_from_metadata(au.raw_user_meta_data) = v_caller_org
+          and coalesce(ur.is_active, true) = true
+          and (ur.expires_at is null or ur.expires_at > now());
+
+        if v_admin_count <= 1 and v_target_id = v_caller_id then
+          raise exception using errcode = '42501', message = 'Cannot remove the last active administrator for the organization';
+        end if;
+      end if;
+
+      delete from user_roles
+      where user_id = v_target_id
+        and role_id = v_admin_role_id;
+
+      update auth.users
+      set raw_user_meta_data = coalesce(raw_user_meta_data, '{}'::jsonb) - 'is_admin'
+      where id = v_target_id;
+
+      v_effective_org := coalesce(v_target_org, v_caller_org);
+
+      begin
+        insert into admin_actions (
+          admin_user_id,
+          target_user_id,
+          organization_id,
+          action_type,
+          action_details
+        )
+        values (
+          v_caller_id,
+          v_target_id,
+          v_effective_org,
+          'admin_role_removed',
+          jsonb_build_object(
+            'operation', 'remove',
+            'target_email', v_target_email,
+            'service_role', v_is_service_role
+          )
+        );
+      exception
+        when others then
+          raise warning 'Failed to log admin remove action: %', sqlerrm;
+      end;
+
+    else
+      raise exception using errcode = '22023', message = format('Invalid operation: %s', operation);
+  end case;
+end;
+$$;
+
+grant execute on function public.manage_admin_users(text, text) to authenticated;
+
+commit;

--- a/tests/admin-create-user.access.spec.ts
+++ b/tests/admin-create-user.access.spec.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { stubDenoEnv } from './utils/stubDeno';
+
+const envValues = new Map<string, string>([
+  ['SUPABASE_URL', 'http://localhost'],
+  ['SUPABASE_SERVICE_ROLE_KEY', 'service-role-key'],
+  ['SUPABASE_ANON_KEY', 'anon-key'],
+]);
+
+stubDenoEnv((key) => envValues.get(key) ?? '');
+
+type TestRole = 'client' | 'therapist' | 'admin' | 'super_admin';
+
+type TestUserContext = {
+  user: { id: string; email: string };
+  profile: { id: string; email: string; role: TestRole; is_active: boolean };
+};
+
+const logApiAccess = vi.fn();
+const userContexts = new Map<string, TestUserContext>();
+const createUserSpy = vi.fn();
+const assignAdminRoleSpy = vi.fn();
+const getUserByIdSpy = vi.fn();
+
+vi.mock('../supabase/functions/_shared/auth-middleware.ts', () => ({
+  corsHeaders: {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-Client-Info, apikey',
+    'Access-Control-Max-Age': '86400',
+  },
+  RouteOptions: {
+    admin: { requireAuth: true, allowedRoles: ['admin', 'super_admin'] },
+  },
+  logApiAccess,
+  createProtectedRoute: (
+    handler: (req: Request, userContext: TestUserContext) => Promise<Response>,
+    options: { allowedRoles?: TestRole[] } = {},
+  ) => {
+    return async (req: Request) => {
+      const contextKey = req.headers.get('x-test-user') ?? 'default';
+      const context = userContexts.get(contextKey);
+
+      if (!context) {
+        return new Response(JSON.stringify({ error: 'Authentication required' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (options.allowedRoles && !options.allowedRoles.includes(context.profile.role)) {
+        return new Response(JSON.stringify({ error: 'Insufficient permissions' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return handler(req, context);
+    };
+  },
+}));
+
+vi.mock('../supabase/functions/_shared/database.ts', () => ({
+  supabaseAdmin: {
+    auth: {
+      admin: {
+        createUser: createUserSpy,
+        getUserById: getUserByIdSpy,
+      },
+    },
+    rpc: assignAdminRoleSpy,
+  },
+}));
+
+describe('admin-create-user access control', () => {
+  beforeEach(() => {
+    userContexts.clear();
+    logApiAccess.mockClear();
+    createUserSpy.mockReset();
+    assignAdminRoleSpy.mockReset();
+    getUserByIdSpy.mockReset();
+
+    createUserSpy.mockResolvedValue({
+      data: { user: { id: 'new-admin-user-id' } },
+      error: null,
+    });
+    assignAdminRoleSpy.mockResolvedValue({ error: null });
+  });
+
+  it('allows a super_admin to create an admin in the requested organization', async () => {
+    userContexts.set('super', {
+      user: { id: 'super-user-id', email: 'super@example.com' },
+      profile: {
+        id: 'super-profile-id',
+        email: 'super@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-create-user/index.ts');
+
+    const response = await handler(new Request('http://localhost/functions/v1/admin-create-user', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+        'x-test-user': 'super',
+      },
+      body: JSON.stringify({
+        email: 'new.admin@example.com',
+        password: 'StrongPass123!',
+        first_name: 'New',
+        last_name: 'Admin',
+        organization_id: '22222222-2222-2222-2222-222222222222',
+        reason: 'Coverage for the selected organization.',
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(createUserSpy).toHaveBeenCalledWith(expect.objectContaining({
+      email: 'new.admin@example.com',
+      user_metadata: expect.objectContaining({
+        organization_id: '22222222-2222-2222-2222-222222222222',
+        organizationId: '22222222-2222-2222-2222-222222222222',
+      }),
+    }));
+    expect(assignAdminRoleSpy).toHaveBeenCalledWith('assign_admin_role', {
+      user_email: 'new.admin@example.com',
+      organization_id: '22222222-2222-2222-2222-222222222222',
+      reason: 'Coverage for the selected organization.',
+    });
+  });
+
+  it('denies a regular admin from creating an admin in a different organization', async () => {
+    userContexts.set('admin', {
+      user: { id: 'admin-user-id', email: 'admin@example.com' },
+      profile: {
+        id: 'admin-profile-id',
+        email: 'admin@example.com',
+        role: 'admin',
+        is_active: true,
+      },
+    });
+    getUserByIdSpy.mockResolvedValue({
+      data: {
+        user: {
+          id: 'admin-user-id',
+          user_metadata: { organization_id: '11111111-1111-1111-1111-111111111111' },
+        },
+      },
+      error: null,
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-create-user/index.ts');
+
+    const response = await handler(new Request('http://localhost/functions/v1/admin-create-user', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+        'x-test-user': 'admin',
+      },
+      body: JSON.stringify({
+        email: 'cross.org.admin@example.com',
+        password: 'StrongPass123!',
+        first_name: 'Cross',
+        last_name: 'Org',
+        organization_id: '22222222-2222-2222-2222-222222222222',
+        reason: 'Attempted cross organization admin grant.',
+      }),
+    }));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: 'Caller organization mismatch.' });
+    expect(createUserSpy).not.toHaveBeenCalled();
+    expect(assignAdminRoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('denies non-admin roles from creating admins', async () => {
+    userContexts.set('therapist', {
+      user: { id: 'therapist-user-id', email: 'therapist@example.com' },
+      profile: {
+        id: 'therapist-profile-id',
+        email: 'therapist@example.com',
+        role: 'therapist',
+        is_active: true,
+      },
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-create-user/index.ts');
+
+    const response = await handler(new Request('http://localhost/functions/v1/admin-create-user', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+        'x-test-user': 'therapist',
+      },
+      body: JSON.stringify({
+        email: 'unauthorized@example.com',
+        password: 'StrongPass123!',
+        first_name: 'Unauthorized',
+        last_name: 'User',
+        organization_id: '11111111-1111-1111-1111-111111111111',
+        reason: 'This should be denied by route protection.',
+      }),
+    }));
+
+    expect(response.status).toBe(403);
+    expect(createUserSpy).not.toHaveBeenCalled();
+    expect(assignAdminRoleSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/admin-reset-user-password.access.spec.ts
+++ b/tests/admin-reset-user-password.access.spec.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { stubDenoEnv } from './utils/stubDeno';
+
+const envValues = new Map<string, string>([
+  ['SUPABASE_URL', 'http://localhost'],
+  ['SUPABASE_SERVICE_ROLE_KEY', 'service-role-key'],
+  ['SUPABASE_ANON_KEY', 'anon-key'],
+]);
+
+stubDenoEnv((key) => envValues.get(key) ?? '');
+
+type TestRole = 'client' | 'therapist' | 'admin' | 'super_admin';
+
+type TestUserContext = {
+  user: { id: string; email: string };
+  profile: { id: string; email: string; role: TestRole; is_active: boolean };
+};
+
+const logApiAccess = vi.fn();
+const userContexts = new Map<string, TestUserContext>();
+const getUserByIdSpy = vi.fn();
+const supabaseAdminRpcSpy = vi.fn();
+const requestRpcSpy = vi.fn();
+
+vi.mock('../supabase/functions/_shared/auth-middleware.ts', () => ({
+  corsHeaders: {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-Client-Info, apikey',
+    'Access-Control-Max-Age': '86400',
+  },
+  RouteOptions: {
+    admin: { requireAuth: true, allowedRoles: ['admin', 'super_admin'] },
+  },
+  logApiAccess,
+  createProtectedRoute: (
+    handler: (req: Request, userContext: TestUserContext) => Promise<Response>,
+    options: { allowedRoles?: TestRole[] } = {},
+  ) => {
+    return async (req: Request) => {
+      const contextKey = req.headers.get('x-test-user') ?? 'default';
+      const context = userContexts.get(contextKey);
+
+      if (!context) {
+        return new Response(JSON.stringify({ error: 'Authentication required' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (options.allowedRoles && !options.allowedRoles.includes(context.profile.role)) {
+        return new Response(JSON.stringify({ error: 'Insufficient permissions' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return handler(req, context);
+    };
+  },
+}));
+
+vi.mock('../supabase/functions/_shared/database.ts', () => ({
+  supabaseAdmin: {
+    auth: {
+      admin: {
+        getUserById: getUserByIdSpy,
+      },
+    },
+    rpc: supabaseAdminRpcSpy,
+  },
+  createRequestClient: () => ({
+    rpc: requestRpcSpy,
+  }),
+}));
+
+describe('admin-reset-user-password access control', () => {
+  beforeEach(() => {
+    userContexts.clear();
+    logApiAccess.mockClear();
+    getUserByIdSpy.mockReset();
+    supabaseAdminRpcSpy.mockReset();
+    requestRpcSpy.mockReset();
+
+    supabaseAdminRpcSpy.mockResolvedValue({ error: null });
+  });
+
+  it('allows a super_admin to reset an admin password through the protected function', async () => {
+    userContexts.set('super', {
+      user: { id: 'super-user-id', email: 'super@example.com' },
+      profile: {
+        id: 'super-profile-id',
+        email: 'super@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    });
+    requestRpcSpy.mockResolvedValue({
+      data: [{ email: 'target.admin@example.com', raw_user_meta_data: { organization_id: 'org-2' } }],
+      error: null,
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-reset-user-password/index.ts');
+
+    const response = await handler(new Request('http://localhost/functions/v1/admin-reset-user-password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+        'x-test-user': 'super',
+      },
+      body: JSON.stringify({
+        email: 'target.admin@example.com',
+        new_password: 'UpdatedPass123!',
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(requestRpcSpy).toHaveBeenCalledWith('get_admin_users_paged', {
+      organization_id: null,
+      p_limit: 500,
+      p_offset: 0,
+    });
+    expect(supabaseAdminRpcSpy).toHaveBeenCalledWith('admin_reset_user_password', {
+      user_email: 'target.admin@example.com',
+      new_password: 'UpdatedPass123!',
+    });
+  });
+
+  it('denies a regular admin from resetting an admin outside the caller organization', async () => {
+    userContexts.set('admin', {
+      user: { id: 'admin-user-id', email: 'admin@example.com' },
+      profile: {
+        id: 'admin-profile-id',
+        email: 'admin@example.com',
+        role: 'admin',
+        is_active: true,
+      },
+    });
+    getUserByIdSpy.mockResolvedValue({
+      data: {
+        user: {
+          id: 'admin-user-id',
+          user_metadata: { organization_id: '11111111-1111-1111-1111-111111111111' },
+        },
+      },
+      error: null,
+    });
+    requestRpcSpy.mockResolvedValue({
+      data: [],
+      error: null,
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-reset-user-password/index.ts');
+
+    const response = await handler(new Request('http://localhost/functions/v1/admin-reset-user-password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+        'x-test-user': 'admin',
+      },
+      body: JSON.stringify({
+        email: 'cross.org.admin@example.com',
+        new_password: 'UpdatedPass123!',
+      }),
+    }));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'Target admin is outside the caller organization.',
+    });
+    expect(supabaseAdminRpcSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows a regular admin to reset a same-organization admin password', async () => {
+    userContexts.set('admin-success', {
+      user: { id: 'admin-user-id', email: 'admin@example.com' },
+      profile: {
+        id: 'admin-profile-id',
+        email: 'admin@example.com',
+        role: 'admin',
+        is_active: true,
+      },
+    });
+    getUserByIdSpy.mockResolvedValue({
+      data: {
+        user: {
+          id: 'admin-user-id',
+          user_metadata: { organization_id: '11111111-1111-1111-1111-111111111111' },
+        },
+      },
+      error: null,
+    });
+    requestRpcSpy.mockResolvedValue({
+      data: [{ email: 'same.org.admin@example.com', raw_user_meta_data: { organization_id: '11111111-1111-1111-1111-111111111111' } }],
+      error: null,
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-reset-user-password/index.ts');
+
+    const response = await handler(new Request('http://localhost/functions/v1/admin-reset-user-password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+        'x-test-user': 'admin-success',
+      },
+      body: JSON.stringify({
+        email: 'same.org.admin@example.com',
+        new_password: 'UpdatedPass123!',
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(requestRpcSpy).toHaveBeenCalledWith('get_admin_users_paged', {
+      organization_id: '11111111-1111-1111-1111-111111111111',
+      p_limit: 500,
+      p_offset: 0,
+    });
+    expect(supabaseAdminRpcSpy).toHaveBeenCalledWith('admin_reset_user_password', {
+      user_email: 'same.org.admin@example.com',
+      new_password: 'UpdatedPass123!',
+    });
+  });
+
+  it('falls back to the legacy RPC only when the canonical reset RPC is missing', async () => {
+    userContexts.set('super-fallback', {
+      user: { id: 'super-user-id', email: 'super@example.com' },
+      profile: {
+        id: 'super-profile-id',
+        email: 'super@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    });
+    requestRpcSpy.mockResolvedValue({
+      data: [{ email: 'target.admin@example.com', raw_user_meta_data: { organization_id: 'org-2' } }],
+      error: null,
+    });
+    supabaseAdminRpcSpy
+      .mockResolvedValueOnce({ error: { code: 'PGRST202' } })
+      .mockResolvedValueOnce({ error: null });
+
+    const { default: handler } = await import('../supabase/functions/admin-reset-user-password/index.ts');
+
+    const response = await handler(new Request('http://localhost/functions/v1/admin-reset-user-password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+        'x-test-user': 'super-fallback',
+      },
+      body: JSON.stringify({
+        email: 'target.admin@example.com',
+        new_password: 'UpdatedPass123!',
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(supabaseAdminRpcSpy).toHaveBeenNthCalledWith(1, 'admin_reset_user_password', {
+      user_email: 'target.admin@example.com',
+      new_password: 'UpdatedPass123!',
+    });
+    expect(supabaseAdminRpcSpy).toHaveBeenNthCalledWith(2, 'reset_user_password', {
+      target_email: 'target.admin@example.com',
+      new_password: 'UpdatedPass123!',
+    });
+  });
+});

--- a/tests/admins/manage_admin_users.log.spec.ts
+++ b/tests/admins/manage_admin_users.log.spec.ts
@@ -3,6 +3,36 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 describe('manage_admin_users logging', () => {
+  it('keeps super_admin access explicit while preserving same-org guards for regular admins', () => {
+    const migrationSql = readFileSync(
+      join(process.cwd(), 'supabase/migrations/20260506170000_super_admin_admin_management_authz.sql'),
+      'utf-8',
+    );
+
+    const assignFunctionMatch = migrationSql.match(
+      /create or replace function public\.assign_admin_role[\s\S]*?end;\s*\$\$/i,
+    );
+    expect(assignFunctionMatch, 'assign_admin_role should be redefined for super_admin support').toBeTruthy();
+
+    const manageFunctionMatch = migrationSql.match(
+      /create or replace function public\.manage_admin_users[\s\S]*?end;\s*\$\$/i,
+    );
+    expect(manageFunctionMatch, 'manage_admin_users should be redefined for super_admin support').toBeTruthy();
+
+    const assignFunctionSql = assignFunctionMatch?.[0] ?? '';
+    const manageFunctionSql = manageFunctionMatch?.[0] ?? '';
+
+    expect(assignFunctionSql).toMatch(/public\.current_user_is_super_admin\(\)/i);
+    expect(assignFunctionSql).not.toMatch(/app\.user_has_role\('super_admin'\)/i);
+    expect(assignFunctionSql).toMatch(/if not v_is_super_admin and not exists/i);
+    expect(assignFunctionSql).toMatch(/if not v_is_super_admin then[\s\S]*caller organization mismatch/i);
+
+    expect(manageFunctionSql).toMatch(/public\.current_user_is_super_admin\(\)/i);
+    expect(manageFunctionSql).not.toMatch(/app\.user_has_role\('super_admin'\)/i);
+    expect(manageFunctionSql).toMatch(/if not v_is_service_role and not v_is_super_admin then[\s\S]*target user does not belong to the caller organization/i);
+    expect(manageFunctionSql).toMatch(/cannot remove the last active administrator for the organization/i);
+  });
+
   it('defines admin action logging for add and remove operations', () => {
     const migrationSql = readFileSync(
       join(process.cwd(), 'supabase/migrations/20251025121500_admin_org_enforcement.sql'),


### PR DESCRIPTION
## Summary
- route admin password resets through a protected edge function instead of direct browser RPC
- allow super_admin callers to use admin-management RPCs while preserving same-org checks for regular admins
- add focused coverage and a critical-lane handoff artifact for create, reset, and delete flows

## Verification
- `npx vitest run src/components/settings/__tests__/AdminSettings.test.tsx tests/admin-create-user.access.spec.ts tests/admin-reset-user-password.access.spec.ts tests/admins/manage_admin_users.log.spec.ts src/server/rpc/__tests__/admin.test.ts`
- `npx vitest run tests/admin-users-roles.access.spec.ts tests/admins/assign_role.spec.ts tests/admins/create-super-admin.security.spec.ts`
- `npx vitest run tests/edge/auth-middleware.role-resolution.test.ts tests/edge/orgRoleRpc.parity.contract.test.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:routes:tier0`

## Blockers
- `npm run test:ci` is still red because of the unrelated existing failure in `tests/edge/adminTherapistLinks.contract.test.ts`
- `npm run ci:playwright` timed out locally and still needs a credentialed/CI run
- critical-lane Linear linkage is still missing for this slice
