### PR TITLE
Fix admin reset password edge handler

### DIFF
--- a/supabase/functions/admin-reset-user-password/index.ts
+++ b/supabase/functions/admin-reset-user-password/index.ts
@@ -14,6 +14,7 @@ interface ResetAdminPasswordPayload {
 }
 
 interface AdminUserRecord {
+  user_id?: string;
   email?: string;
   raw_user_meta_data?: Record<string, unknown> | null;
 }
@@ -52,28 +53,6 @@ const resolveCallerOrg = async (context: UserContext): Promise<string | null> =>
 };
 
 const canManageAllOrganizations = (role: Role) => role === "super_admin";
-
-const invokeCanonicalReset = async (normalizedEmail: string, normalizedPassword: string) => {
-  const primaryResult = await supabaseAdmin.rpc("admin_reset_user_password", {
-    user_email: normalizedEmail,
-    new_password: normalizedPassword,
-  });
-
-  if (!primaryResult.error) {
-    return null;
-  }
-
-  if (primaryResult.error.code !== "PGRST202") {
-    return primaryResult.error;
-  }
-
-  const legacyResult = await supabaseAdmin.rpc("reset_user_password", {
-    target_email: normalizedEmail,
-    new_password: normalizedPassword,
-  });
-
-  return legacyResult.error ?? null;
-};
 
 const handler = createProtectedRoute(
   async (req, userContext) => {
@@ -137,9 +116,19 @@ const handler = createProtectedRoute(
       });
     }
 
-    const resetError = await invokeCanonicalReset(normalizedEmail, normalizedPassword);
-    if (resetError) {
-      console.error("admin_reset_user_password failed", { error: resetError, email: normalizedEmail });
+    const targetUserId = normalizeString(targetAdmin.user_id);
+    if (!targetUserId) {
+      console.error("Admin password reset target is missing user_id");
+      logApiAccess("POST", "/admin/reset-user-password", userContext, 500);
+      return respond(500, { error: "Failed to reset admin password." });
+    }
+
+    const resetResult = await supabaseAdmin.auth.admin.updateUserById(targetUserId, {
+      password: normalizedPassword,
+    });
+
+    if (resetResult.error) {
+      console.error("Admin password reset failed", { error: resetResult.error });
       logApiAccess("POST", "/admin/reset-user-password", userContext, 500);
       return respond(500, { error: "Failed to reset admin password." });
     }

--- a/tests/admin-reset-user-password.access.spec.ts
+++ b/tests/admin-reset-user-password.access.spec.ts
@@ -19,7 +19,7 @@ type TestUserContext = {
 const logApiAccess = vi.fn();
 const userContexts = new Map<string, TestUserContext>();
 const getUserByIdSpy = vi.fn();
-const supabaseAdminRpcSpy = vi.fn();
+const updateUserByIdSpy = vi.fn();
 const requestRpcSpy = vi.fn();
 
 vi.mock('../supabase/functions/_shared/auth-middleware.ts', () => ({
@@ -65,9 +65,9 @@ vi.mock('../supabase/functions/_shared/database.ts', () => ({
     auth: {
       admin: {
         getUserById: getUserByIdSpy,
+        updateUserById: updateUserByIdSpy,
       },
     },
-    rpc: supabaseAdminRpcSpy,
   },
   createRequestClient: () => ({
     rpc: requestRpcSpy,
@@ -79,10 +79,10 @@ describe('admin-reset-user-password access control', () => {
     userContexts.clear();
     logApiAccess.mockClear();
     getUserByIdSpy.mockReset();
-    supabaseAdminRpcSpy.mockReset();
+    updateUserByIdSpy.mockReset();
     requestRpcSpy.mockReset();
 
-    supabaseAdminRpcSpy.mockResolvedValue({ error: null });
+    updateUserByIdSpy.mockResolvedValue({ error: null });
   });
 
   it('allows a super_admin to reset an admin password through the protected function', async () => {
@@ -96,7 +96,11 @@ describe('admin-reset-user-password access control', () => {
       },
     });
     requestRpcSpy.mockResolvedValue({
-      data: [{ email: 'target.admin@example.com', raw_user_meta_data: { organization_id: 'org-2' } }],
+      data: [{
+        user_id: '22222222-2222-2222-2222-222222222222',
+        email: 'target.admin@example.com',
+        raw_user_meta_data: { organization_id: 'org-2' },
+      }],
       error: null,
     });
 
@@ -121,9 +125,8 @@ describe('admin-reset-user-password access control', () => {
       p_limit: 500,
       p_offset: 0,
     });
-    expect(supabaseAdminRpcSpy).toHaveBeenCalledWith('admin_reset_user_password', {
-      user_email: 'target.admin@example.com',
-      new_password: 'UpdatedPass123!',
+    expect(updateUserByIdSpy).toHaveBeenCalledWith('22222222-2222-2222-2222-222222222222', {
+      password: 'UpdatedPass123!',
     });
   });
 
@@ -170,7 +173,7 @@ describe('admin-reset-user-password access control', () => {
     await expect(response.json()).resolves.toMatchObject({
       error: 'Target admin is outside the caller organization.',
     });
-    expect(supabaseAdminRpcSpy).not.toHaveBeenCalled();
+    expect(updateUserByIdSpy).not.toHaveBeenCalled();
   });
 
   it('allows a regular admin to reset a same-organization admin password', async () => {
@@ -193,7 +196,11 @@ describe('admin-reset-user-password access control', () => {
       error: null,
     });
     requestRpcSpy.mockResolvedValue({
-      data: [{ email: 'same.org.admin@example.com', raw_user_meta_data: { organization_id: '11111111-1111-1111-1111-111111111111' } }],
+      data: [{
+        user_id: '33333333-3333-3333-3333-333333333333',
+        email: 'same.org.admin@example.com',
+        raw_user_meta_data: { organization_id: '11111111-1111-1111-1111-111111111111' },
+      }],
       error: null,
     });
 
@@ -218,14 +225,13 @@ describe('admin-reset-user-password access control', () => {
       p_limit: 500,
       p_offset: 0,
     });
-    expect(supabaseAdminRpcSpy).toHaveBeenCalledWith('admin_reset_user_password', {
-      user_email: 'same.org.admin@example.com',
-      new_password: 'UpdatedPass123!',
+    expect(updateUserByIdSpy).toHaveBeenCalledWith('33333333-3333-3333-3333-333333333333', {
+      password: 'UpdatedPass123!',
     });
   });
 
-  it('falls back to the legacy RPC only when the canonical reset RPC is missing', async () => {
-    userContexts.set('super-fallback', {
+  it('returns a server error without resetting when the scoped target row is missing user_id', async () => {
+    userContexts.set('super-missing-id', {
       user: { id: 'super-user-id', email: 'super@example.com' },
       profile: {
         id: 'super-profile-id',
@@ -238,9 +244,6 @@ describe('admin-reset-user-password access control', () => {
       data: [{ email: 'target.admin@example.com', raw_user_meta_data: { organization_id: 'org-2' } }],
       error: null,
     });
-    supabaseAdminRpcSpy
-      .mockResolvedValueOnce({ error: { code: 'PGRST202' } })
-      .mockResolvedValueOnce({ error: null });
 
     const { default: handler } = await import('../supabase/functions/admin-reset-user-password/index.ts');
 
@@ -249,7 +252,7 @@ describe('admin-reset-user-password access control', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer test-token',
-        'x-test-user': 'super-fallback',
+        'x-test-user': 'super-missing-id',
       },
       body: JSON.stringify({
         email: 'target.admin@example.com',
@@ -257,14 +260,7 @@ describe('admin-reset-user-password access control', () => {
       }),
     }));
 
-    expect(response.status).toBe(200);
-    expect(supabaseAdminRpcSpy).toHaveBeenNthCalledWith(1, 'admin_reset_user_password', {
-      user_email: 'target.admin@example.com',
-      new_password: 'UpdatedPass123!',
-    });
-    expect(supabaseAdminRpcSpy).toHaveBeenNthCalledWith(2, 'reset_user_password', {
-      target_email: 'target.admin@example.com',
-      new_password: 'UpdatedPass123!',
-    });
+    expect(response.status).toBe(500);
+    expect(updateUserByIdSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- replace the admin reset password RPC call with Supabase Auth Admin updateUserById after existing scoped admin validation
- keep cross-org denial behavior and add coverage that no password update occurs when the target is outside scope
- deploy admin-reset-user-password edge function version 2 to Supabase project wnnjeqheqxxyrgsjmygy

## Verification
- npm test -- tests/admin-reset-user-password.access.spec.ts
- npm run ci:check-focused
- npm run validate:tenant
- npm run build
- hosted OPTIONS /functions/v1/admin-reset-user-password -> 204
- hosted unauthenticated POST /functions/v1/admin-reset-user-password -> 401 UNAUTHORIZED_NO_AUTH_HEADER

## Notes
- npm run test:ci was attempted locally but timed out after 3 minutes while emitting unrelated AI documentation/MSW output; CI should complete the full suite.