### PR TITLE
Fix admin profile organization assignment

### DIFF
--- a/supabase/functions/admin-create-user/index.ts
+++ b/supabase/functions/admin-create-user/index.ts
@@ -177,6 +177,20 @@ const handler = createProtectedRoute(
         return respond(500, { error: "User created, but assigning admin role failed." });
       }
 
+      const { data: profileOrgUpdate, error: profileOrgError } = await supabaseAdmin
+        .from("profiles")
+        .update({ organization_id: resolvedOrganization })
+        .eq("id", createResult.data.user.id)
+        .is("organization_id", null)
+        .select("id, organization_id")
+        .single();
+
+      if (profileOrgError || profileOrgUpdate?.organization_id !== resolvedOrganization) {
+        console.error("Admin profile organization assignment failed", { error: profileOrgError });
+        logApiAccess("POST", "/admin/create-user", userContext, 500);
+        return respond(500, { error: "User created, but assigning organization failed." });
+      }
+
       logApiAccess("POST", "/admin/create-user", userContext, 200);
 
       return respond(200, {

--- a/supabase/migrations/20260506200043_backfill_admin_profile_org_from_metadata.sql
+++ b/supabase/migrations/20260506200043_backfill_admin_profile_org_from_metadata.sql
@@ -1,0 +1,29 @@
+-- @migration-intent: Backfill admin profile organization_id from already-authoritative auth metadata so org-scoped admin access resolves correctly.
+-- @migration-dependencies: public.profiles, public.user_roles, public.roles, public.get_organization_id_from_metadata(jsonb)
+-- @migration-rollback: For affected users only, manually set public.profiles.organization_id back to null if the metadata-derived org was incorrect.
+
+begin;
+
+set local app.bypass_profile_role_guard = 'on';
+
+with admin_profiles_to_backfill as (
+  select
+    p.id,
+    public.get_organization_id_from_metadata(u.raw_user_meta_data) as metadata_org_id
+  from auth.users u
+  join public.profiles p on p.id = u.id
+  join public.user_roles ur on ur.user_id = u.id
+  join public.roles r on r.id = ur.role_id
+  where r.name = 'admin'
+    and coalesce(ur.is_active, true) = true
+    and (ur.expires_at is null or ur.expires_at > now())
+    and p.organization_id is null
+    and public.get_organization_id_from_metadata(u.raw_user_meta_data) is not null
+)
+update public.profiles p
+set organization_id = b.metadata_org_id,
+    updated_at = now()
+from admin_profiles_to_backfill b
+where p.id = b.id;
+
+commit;

--- a/tests/admin-create-user.access.spec.ts
+++ b/tests/admin-create-user.access.spec.ts
@@ -21,6 +21,11 @@ const userContexts = new Map<string, TestUserContext>();
 const createUserSpy = vi.fn();
 const assignAdminRoleSpy = vi.fn();
 const getUserByIdSpy = vi.fn();
+const profilesUpdateSpy = vi.fn();
+const profilesEqSpy = vi.fn();
+const profilesIsSpy = vi.fn();
+const profilesSelectSpy = vi.fn();
+const profilesSingleSpy = vi.fn();
 
 vi.mock('../supabase/functions/_shared/auth-middleware.ts', () => ({
   corsHeaders: {
@@ -69,6 +74,14 @@ vi.mock('../supabase/functions/_shared/database.ts', () => ({
       },
     },
     rpc: assignAdminRoleSpy,
+    from: (table: string) => {
+      if (table !== 'profiles') {
+        throw new Error(`Unexpected table ${table}`);
+      }
+      return {
+        update: profilesUpdateSpy,
+      };
+    },
   },
 }));
 
@@ -79,12 +92,28 @@ describe('admin-create-user access control', () => {
     createUserSpy.mockReset();
     assignAdminRoleSpy.mockReset();
     getUserByIdSpy.mockReset();
+    profilesUpdateSpy.mockReset();
+    profilesEqSpy.mockReset();
+    profilesIsSpy.mockReset();
+    profilesSelectSpy.mockReset();
+    profilesSingleSpy.mockReset();
 
     createUserSpy.mockResolvedValue({
       data: { user: { id: 'new-admin-user-id' } },
       error: null,
     });
     assignAdminRoleSpy.mockResolvedValue({ error: null });
+    profilesUpdateSpy.mockReturnValue({ eq: profilesEqSpy });
+    profilesEqSpy.mockReturnValue({ is: profilesIsSpy });
+    profilesIsSpy.mockReturnValue({ select: profilesSelectSpy });
+    profilesSelectSpy.mockReturnValue({ single: profilesSingleSpy });
+    profilesSingleSpy.mockResolvedValue({
+      data: {
+        id: 'new-admin-user-id',
+        organization_id: '22222222-2222-2222-2222-222222222222',
+      },
+      error: null,
+    });
   });
 
   it('allows a super_admin to create an admin in the requested organization', async () => {
@@ -130,6 +159,13 @@ describe('admin-create-user access control', () => {
       organization_id: '22222222-2222-2222-2222-222222222222',
       reason: 'Coverage for the selected organization.',
     });
+    expect(profilesUpdateSpy).toHaveBeenCalledWith({
+      organization_id: '22222222-2222-2222-2222-222222222222',
+    });
+    expect(profilesEqSpy).toHaveBeenCalledWith('id', 'new-admin-user-id');
+    expect(profilesIsSpy).toHaveBeenCalledWith('organization_id', null);
+    expect(profilesSelectSpy).toHaveBeenCalledWith('id, organization_id');
+    expect(profilesSingleSpy).toHaveBeenCalled();
   });
 
   it('denies a regular admin from creating an admin in a different organization', async () => {
@@ -175,6 +211,7 @@ describe('admin-create-user access control', () => {
     await expect(response.json()).resolves.toMatchObject({ error: 'Caller organization mismatch.' });
     expect(createUserSpy).not.toHaveBeenCalled();
     expect(assignAdminRoleSpy).not.toHaveBeenCalled();
+    expect(profilesUpdateSpy).not.toHaveBeenCalled();
   });
 
   it('denies non-admin roles from creating admins', async () => {
@@ -210,5 +247,83 @@ describe('admin-create-user access control', () => {
     expect(response.status).toBe(403);
     expect(createUserSpy).not.toHaveBeenCalled();
     expect(assignAdminRoleSpy).not.toHaveBeenCalled();
+    expect(profilesUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the created admin profile organization cannot be assigned', async () => {
+    userContexts.set('super-profile-org-failure', {
+      user: { id: 'super-user-id', email: 'super@example.com' },
+      profile: {
+        id: 'super-profile-id',
+        email: 'super@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    });
+    profilesSingleSpy.mockResolvedValue({
+      data: null,
+      error: { message: 'profile update failed' },
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-create-user/index.ts');
+
+    const response = await handler(new Request('http://localhost/functions/v1/admin-create-user', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+        'x-test-user': 'super-profile-org-failure',
+      },
+      body: JSON.stringify({
+        email: 'new.admin@example.com',
+        password: 'StrongPass123!',
+        first_name: 'New',
+        last_name: 'Admin',
+        organization_id: '22222222-2222-2222-2222-222222222222',
+        reason: 'Coverage for profile organization failure.',
+      }),
+    }));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'User created, but assigning organization failed.',
+    });
+  });
+
+  it('returns an error when assigning the profile organization updates no rows', async () => {
+    userContexts.set('super-profile-org-noop', {
+      user: { id: 'super-user-id', email: 'super@example.com' },
+      profile: {
+        id: 'super-profile-id',
+        email: 'super@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    });
+    profilesSingleSpy.mockResolvedValue({ data: null, error: null });
+
+    const { default: handler } = await import('../supabase/functions/admin-create-user/index.ts');
+
+    const response = await handler(new Request('http://localhost/functions/v1/admin-create-user', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+        'x-test-user': 'super-profile-org-noop',
+      },
+      body: JSON.stringify({
+        email: 'new.admin@example.com',
+        password: 'StrongPass123!',
+        first_name: 'New',
+        last_name: 'Admin',
+        organization_id: '22222222-2222-2222-2222-222222222222',
+        reason: 'Coverage for profile organization no-op.',
+      }),
+    }));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'User created, but assigning organization failed.',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- fix admin creation so the created admin profile gets the selected organization_id, not only auth metadata and user_roles
- fail admin creation response if the profile organization write errors or updates no row
- add a focused backfill migration for active admin profiles with missing profile org from existing auth metadata

## Hosted deployment
- migration `backfill_admin_profile_org_from_metadata` applied to Supabase project `wnnjeqheqxxyrgsjmygy`
- `admin-create-user` edge function deployed as active version 6 with `verify_jwt=true`
- post-deploy smoke: OPTIONS returns 204; unauthenticated POST returns 401
- `arich@westcoastaba.com` now has profile org `5238e88b-6198-4862-80a2-dbe15bbeabdd` / Default Organization
- remaining active admins with valid metadata but null profile org: 0

## Verification
- `npm test -- tests/admin-create-user.access.spec.ts` pass
- `npm run ci:check-focused` pass; DB-backed checks skipped locally because `SUPABASE_DB_URL` is not configured
- `npm run validate:tenant` pass
- `npm run lint` pass
- `npm run typecheck` pass
- `npm run build` pass
- `npm run test:routes:tier0` pass
- `git diff --check` pass
- `npm run test:ci` / `npm run verify:local` blocked by local missing `VITE_SUPABASE_URL` in `src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts`
- `npm run ci:playwright` blocked by missing `PW_ADMIN_EMAIL` / `PLAYWRIGHT_ADMIN_EMAIL`

## Tracking
- Linear: WIN-132