### PR TITLE
WIN-133 Allow super_admin session cancellation

### DIFF
--- a/docs/ai/WIN-133-super-admin-session-cancel-handoff.md
+++ b/docs/ai/WIN-133-super-admin-session-cancel-handoff.md
@@ -1,0 +1,44 @@
+# WIN-133 Super Admin Session Cancel Handoff
+
+## Scope
+
+- Allow `super_admin` users to cancel sessions from the schedule UI using the existing cancellation flow.
+- Keep cancellation org-scoped and preserve current audit, status, invalidation, and therapist ownership semantics.
+
+## Route Task
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+
+## Files In Scope
+
+- `src/pages/Schedule.tsx`
+- `src/lib/sessionCancellation.ts`
+- `supabase/functions/sessions-cancel/index.ts`
+- focused cancellation tests
+
+## Implementation Summary
+
+- Kept the existing schedule UI cancel entry points and `cancelSessions` client contract unchanged for users.
+- Extended `sessions-cancel` so that when direct org context is missing, only `super_admin` callers can derive scheduling scope server-side from the targeted session ids, hold key, or therapist scheduling context.
+- Preserved existing org-scoped session lookup, therapist self-ownership restrictions, audit writes, mutation summaries, and schedule query invalidation.
+
+## Verification
+
+- Focused tests:
+  - `npm test -- --run src/lib/__tests__/sessionCancellation.test.ts`
+  - `npm test -- --run src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
+  - `npm test -- --run tests/edge/sessions-cancel.org-scope.test.ts`
+- Additional checks run:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run verify:local` (failed due unrelated existing test failures; record exact failures in final verification card)
+
+## Residual Risk
+
+- Full `verify:local` is still red on unrelated pre-existing failures outside this slice.
+- I did not add new browser automation specifically for clicking cancel in a live seeded schedule because local verification here relied on existing schedule integration coverage plus the route/browser gates.

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -310,8 +310,13 @@ describe("Schedule orchestration integration hardening", () => {
     expect(screen.getByTestId("session-modal")).toBeInTheDocument();
   }, 15_000);
 
-  it("manual edit cancel path stays distinct and closes modal", async () => {
-    renderWithProviders(<Schedule />);
+  it.each([
+    ["admin", "admin"],
+    ["super admin", "super_admin"],
+  ] as const)("manual edit cancel path stays distinct and closes modal for %s", async (_label, role) => {
+    renderWithProviders(<Schedule />, {
+      auth: { role, organizationId: "org-1" },
+    });
     await screen.findByRole("heading", { name: /Schedule/i });
     await waitForScheduleGridReady();
 
@@ -322,10 +327,10 @@ describe("Schedule orchestration integration hardening", () => {
     fireEvent.click(screen.getByLabelText("submit-cancel"));
 
     await waitFor(() => {
-      expect(cancelSessionsMock).toHaveBeenCalledWith({
+      expect(cancelSessionsMock).toHaveBeenCalledWith(expect.objectContaining({
         sessionIds: ["session-1"],
         reason: "cancel reason",
-      });
+      }));
     });
     expect(showSuccessMock).toHaveBeenCalled();
   });

--- a/supabase/functions/sessions-cancel/index.ts
+++ b/supabase/functions/sessions-cancel/index.ts
@@ -7,11 +7,12 @@ import {
 } from "../_shared/idempotency.ts";
 import { evaluateTherapistAuthorization } from "../_shared/authorization.ts";
 import {
-  requireOrg,
+  requireOrgForScheduling,
   assertUserHasOrgRole,
   orgScopedQuery,
   MissingOrgContextError,
   ForbiddenError,
+  resolveOrgId,
 } from "../_shared/org.ts";
 import { getLogger, type Logger } from "../_shared/logging.ts";
 import { increment } from "../_shared/metrics.ts";
@@ -215,6 +216,104 @@ async function resolveCancellationRole(
     return "therapist";
   }
   return null;
+}
+
+async function currentUserIsSuperAdmin(db: SupabaseClient): Promise<boolean> {
+  const { data, error } = await db.rpc("current_user_is_super_admin");
+  if (error) {
+    console.error("currentUserIsSuperAdmin error", error);
+    throw new MissingOrgContextError();
+  }
+  return data === true;
+}
+
+async function resolveOrgFromHoldKey(holdKey: string): Promise<string> {
+  const { data, error } = await supabaseAdmin
+    .from("session_holds")
+    .select("organization_id")
+    .eq("hold_key", holdKey)
+    .maybeSingle();
+
+  if (error) {
+    console.error("resolveOrgFromHoldKey error", error);
+    throw new MissingOrgContextError();
+  }
+
+  const organizationId =
+    data && typeof (data as { organization_id?: unknown }).organization_id === "string"
+      ? (data as { organization_id: string }).organization_id.trim()
+      : "";
+
+  if (organizationId.length === 0) {
+    throw new ForbiddenError("Forbidden");
+  }
+
+  return organizationId;
+}
+
+async function resolveOrgFromSessionIds(sessionIds: string[]): Promise<string> {
+  const { data, error } = await supabaseAdmin
+    .from("sessions")
+    .select("id, organization_id")
+    .in("id", sessionIds);
+
+  if (error) {
+    console.error("resolveOrgFromSessionIds error", error);
+    throw new MissingOrgContextError();
+  }
+
+  const rows = Array.isArray(data) ? data : [];
+  if (rows.length !== sessionIds.length) {
+    throw new ForbiddenError("Forbidden");
+  }
+
+  const uniqueOrganizationIds = new Set(
+    rows
+      .map((row) =>
+        row && typeof (row as { organization_id?: unknown }).organization_id === "string"
+          ? (row as { organization_id: string }).organization_id.trim()
+          : ""
+      )
+      .filter((organizationId) => organizationId.length > 0),
+  );
+
+  if (uniqueOrganizationIds.size !== 1) {
+    throw new ForbiddenError("Forbidden");
+  }
+
+  return Array.from(uniqueOrganizationIds)[0];
+}
+
+async function resolveOrgForCancellationRequest(
+  db: SupabaseClient,
+  payload: {
+    holdKey: string | null;
+    sessionIds: string[];
+    therapistId: string | null;
+  },
+): Promise<string> {
+  const directOrgId = await resolveOrgId(db);
+  if (directOrgId) {
+    return directOrgId;
+  }
+
+  if (!await currentUserIsSuperAdmin(db)) {
+    throw new MissingOrgContextError();
+  }
+
+  if (payload.holdKey) {
+    return resolveOrgFromHoldKey(payload.holdKey);
+  }
+
+  if (payload.sessionIds.length > 0) {
+    return resolveOrgFromSessionIds(payload.sessionIds);
+  }
+
+  if (payload.therapistId) {
+    return requireOrgForScheduling(db, payload.therapistId);
+  }
+
+  throw new MissingOrgContextError();
 }
 
 async function handleHoldRelease(
@@ -563,7 +662,13 @@ Deno.serve(async (req) => {
     };
     const idempotencyService = createSupabaseIdempotencyService(supabaseAdmin);
 
-    const orgId = await requireOrg(db);
+    const payload = parseCancelPayload(await req.json());
+
+    const orgId = await resolveOrgForCancellationRequest(db, {
+      holdKey: payload.holdKey,
+      sessionIds: payload.sessionIds,
+      therapistId: payload.therapistId,
+    });
     currentOrgId = orgId;
     scopedLogger = userLogger.with({ orgId });
     scopedLogger.info("request.org-scoped");
@@ -594,8 +699,6 @@ Deno.serve(async (req) => {
         );
       }
     }
-
-    const payload = parseCancelPayload(await req.json());
 
     if (payload.therapistId) {
       const authorization = await evaluateTherapistAuthorization(db, payload.therapistId);
@@ -699,4 +802,8 @@ export const __TESTING__ = {
   handleHoldRelease,
   parseCancelPayload,
   buildDateRange,
+  resolveCancellationRole,
+  resolveOrgForCancellationRequest,
+  resolveOrgFromSessionIds,
+  resolveOrgFromHoldKey,
 };

--- a/tests/edge/sessions-cancel.org-scope.test.ts
+++ b/tests/edge/sessions-cancel.org-scope.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as orgHelpers from "../../supabase/functions/_shared/org.ts";
 import { __TESTING__ } from "../../supabase/functions/sessions-cancel/index.ts";
 import { ForbiddenError } from "../../supabase/functions/_shared/org.ts";
+import { supabaseAdmin } from "../../supabase/functions/_shared/database.ts";
 
 type QueryResult = { data: unknown[]; error: null };
 
@@ -166,6 +167,81 @@ describe("sessions-cancel org scoping", () => {
     expect(payload.data.summary.cancelledCount).toBe(0);
   });
 
+  it("allows super_admin cancellation for an in-scope scheduled session", async () => {
+    const selectBuilder = makeSelectBuilder({
+      data: [
+        { id: "session-super", status: "scheduled", therapist_id: "therapist-9" },
+      ],
+      error: null,
+    });
+    vi.spyOn(orgHelpers, "orgScopedQuery").mockImplementation(
+      () => selectBuilder as unknown as ReturnType<typeof orgHelpers.orgScopedQuery>,
+    );
+
+    const updateBuilder = makeUpdateBuilder();
+    vi.spyOn(supabaseAdmin, "from").mockReturnValue(updateBuilder as never);
+    const mockDb: any = {
+      from: vi.fn(() => updateBuilder),
+      rpc: vi.fn(async () => ({ error: null })),
+    };
+
+    const logger = createStubLogger();
+
+    const response = await __TESTING__.handleSessionCancellation(
+      mockDb,
+      "org-9",
+      {
+        sessionIds: ["session-super"],
+        dateRange: null,
+        therapistId: null,
+        reason: "Scoped super admin cancellation",
+      },
+      "super-admin-user",
+      "super_admin",
+      logger,
+    );
+
+    const payload = await response.json() as {
+      success: boolean;
+      data: { summary: { cancelledCount: number; cancelledSessionIds: string[] } };
+    };
+    expect(payload.success).toBe(true);
+    expect(payload.data.summary.cancelledCount).toBe(1);
+    expect(payload.data.summary.cancelledSessionIds).toEqual(["session-super"]);
+  });
+
+  it("denies super_admin cancellation when the target session is outside the chosen org scope", async () => {
+    const selectBuilder = makeSelectBuilder({
+      data: [],
+      error: null,
+    });
+    vi.spyOn(orgHelpers, "orgScopedQuery").mockImplementation(
+      () => selectBuilder as unknown as ReturnType<typeof orgHelpers.orgScopedQuery>,
+    );
+
+    const mockDb: any = {
+      from: vi.fn(() => makeUpdateBuilder()),
+    };
+
+    const logger = createStubLogger();
+
+    await expect(
+      __TESTING__.handleSessionCancellation(
+        mockDb,
+        "org-a",
+        {
+          sessionIds: ["session-org-b"],
+          dateRange: null,
+          therapistId: null,
+          reason: null,
+        },
+        "super-admin-user",
+        "super_admin",
+        logger,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
   it("treats in_progress sessions as cancellable for lifecycle parity", async () => {
     const selectBuilder = makeSelectBuilder({
       data: [
@@ -231,6 +307,109 @@ describe("sessions-cancel org scoping", () => {
         time_zone: "Mars/Phobos",
       }),
     ).toThrowError("Invalid date or time_zone for cancellation window");
+  });
+
+  it("derives super_admin scheduling org from targeted sessions when direct org context is absent", async () => {
+    const mockDb: any = {
+      rpc: vi.fn(async (fn: string) => {
+        if (fn === "current_user_organization_id") {
+          return { data: null, error: null };
+        }
+        if (fn === "current_user_is_super_admin") {
+          return { data: true, error: null };
+        }
+        return { data: null, error: null };
+      }),
+    };
+    const selectBuilder = {
+      select: vi.fn(() => selectBuilder),
+      in: vi.fn(() => Promise.resolve({
+        data: [{ id: "session-a", organization_id: "org-42" }],
+        error: null,
+      })),
+    } as any;
+    vi.spyOn(supabaseAdmin, "from").mockReturnValue(selectBuilder);
+
+    await expect(
+      __TESTING__.resolveOrgForCancellationRequest(
+        mockDb,
+        { holdKey: null, sessionIds: ["session-a"], therapistId: null },
+      ),
+    ).resolves.toBe("org-42");
+  });
+
+  it("denies super_admin fallback when targeted sessions span multiple organizations", async () => {
+    const mockDb: any = {
+      rpc: vi.fn(async (fn: string) => {
+        if (fn === "current_user_organization_id") {
+          return { data: null, error: null };
+        }
+        if (fn === "current_user_is_super_admin") {
+          return { data: true, error: null };
+        }
+        return { data: null, error: null };
+      }),
+    };
+    const selectBuilder = {
+      select: vi.fn(() => selectBuilder),
+      in: vi.fn(() => Promise.resolve({
+        data: [
+          { id: "session-a", organization_id: "org-42" },
+          { id: "session-b", organization_id: "org-43" },
+        ],
+        error: null,
+      })),
+    } as any;
+    vi.spyOn(supabaseAdmin, "from").mockReturnValue(selectBuilder);
+
+    await expect(
+      __TESTING__.resolveOrgForCancellationRequest(
+        mockDb,
+        { holdKey: null, sessionIds: ["session-a", "session-b"], therapistId: null },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it("derives super_admin scheduling org from targeted hold when direct org context is absent", async () => {
+    const mockDb: any = {
+      rpc: vi.fn(async (fn: string) => {
+        if (fn === "current_user_organization_id") {
+          return { data: null, error: null };
+        }
+        if (fn === "current_user_is_super_admin") {
+          return { data: true, error: null };
+        }
+        return { data: null, error: null };
+      }),
+    };
+    const selectBuilder = {
+      select: vi.fn(() => selectBuilder),
+      eq: vi.fn(() => selectBuilder),
+      maybeSingle: vi.fn(() => Promise.resolve({
+        data: { organization_id: "org-hold" },
+        error: null,
+      })),
+    } as any;
+    vi.spyOn(supabaseAdmin, "from").mockReturnValue(selectBuilder);
+
+    await expect(
+      __TESTING__.resolveOrgForCancellationRequest(
+        mockDb,
+        { holdKey: "hold-1", sessionIds: [], therapistId: null },
+      ),
+    ).resolves.toBe("org-hold");
+  });
+
+  it("returns no cancellation role for unauthorized users", async () => {
+    vi.spyOn(orgHelpers, "assertUserHasOrgRole").mockResolvedValue(false);
+
+    const mockDb: any = {
+      rpc: vi.fn(),
+    };
+
+    await expect(
+      __TESTING__.resolveCancellationRole(mockDb, "org-1", "viewer-user"),
+    ).resolves.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- allow super_admin cancellation to reuse the existing schedule/session cancel flow
- derive scheduling org server-side in sessions-cancel when super_admin lacks direct org context
- add focused schedule and edge tests for super_admin cancel scope and cross-org denial

## Verification
- npm test -- --run src/lib/__tests__/sessionCancellation.test.ts
- npm test -- --run src/pages/__tests__/Schedule.orchestration.integration.test.tsx
- npm test -- --run tests/edge/sessions-cancel.org-scope.test.ts
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run validate:tenant
- npm run build
- npm run test:routes:tier0
- npm run verify:local (fails on unrelated pre-existing tests: tests/edge/adminTherapistLinks.contract.test.ts and src/components/settings/__tests__/AdminSettings.test.tsx)
- npm run ci:playwright (timed out locally after ~15 minutes)

## Risk
- protected path: session cancellation authorization remains org-scoped and now uses only server-derived fallback scope for super_admin callers
