### PR TITLE
Stabilize session retry-after regressions and timeout-sensitive tests

### DIFF
--- a/src/components/settings/__tests__/AdminSettings.test.tsx
+++ b/src/components/settings/__tests__/AdminSettings.test.tsx
@@ -874,7 +874,7 @@ describe('AdminSettings super admin access', () => {
       );
     });
     expect(showSuccess).toHaveBeenCalledWith('Admin user created successfully');
-  });
+  }, 20_000);
 
   it('resets an admin password through the canonical RPC without falling back when available', async () => {
     invokeSpy?.mockResolvedValue({ data: null, error: null });
@@ -883,7 +883,10 @@ describe('AdminSettings super admin access', () => {
     await userEvent.click(await screen.findByTitle('Reset password'));
 
     const modal = await screen.findByRole('dialog', { name: `Reset Password for ${mockAdminUser.email}` });
-    await userEvent.type(within(modal).getByLabelText('New Password*'), 'UpdatedPass123!');
+    const passwordInput = within(modal).getByLabelText('New Password*');
+    await userEvent.clear(passwordInput);
+    await userEvent.type(passwordInput, 'UpdatedPass123!');
+    expect(passwordInput).toHaveValue('UpdatedPass123!');
     await userEvent.click(within(modal).getByRole('button', { name: 'Reset Password' }));
 
     await waitFor(() => {
@@ -898,7 +901,7 @@ describe('AdminSettings super admin access', () => {
       );
     });
     expect(showSuccess).toHaveBeenCalledWith('Password reset successfully');
-  });
+  }, 20_000);
 
   it('removes an admin through manage_admin_users for super admins', async () => {
     renderWithProviders(<AdminSettings />);

--- a/src/lib/__tests__/idempotencyService.test.ts
+++ b/src/lib/__tests__/idempotencyService.test.ts
@@ -12,7 +12,7 @@ describe("hashResponse", () => {
     const first = await hashResponse({ success: true }, 200);
     const second = await hashResponse({ success: true }, 200);
     expect(first).toEqual(second);
-  });
+  }, 20_000);
 
   it("changes hash when payload or status differ", async () => {
     const hashA = await hashResponse({ success: true }, 200);
@@ -21,7 +21,7 @@ describe("hashResponse", () => {
 
     expect(hashA).not.toEqual(hashB);
     expect(hashA).not.toEqual(hashC);
-  });
+  }, 20_000);
 });
 
 describe("IdempotencyService", () => {

--- a/src/server/__tests__/bookHandler.integration.test.ts
+++ b/src/server/__tests__/bookHandler.integration.test.ts
@@ -166,7 +166,7 @@ describe("bookHandler integration", () => {
       expect.any(Object),
       expect.objectContaining({ accessToken }),
     );
-  });
+  }, 20_000);
 
   it("sends recurring booking batches through the active edge booking authority and preserves confirm batching payloads", async () => {
     process.env.API_AUTHORITY_MODE = "edge";

--- a/src/server/__tests__/sessionsCompleteHandler.test.ts
+++ b/src/server/__tests__/sessionsCompleteHandler.test.ts
@@ -238,6 +238,55 @@ describe("sessionsCompleteHandler", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves downstream Retry-After when edge returns a retryable completion conflict", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token-123");
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: false,
+          error: "Session could not be completed yet",
+          code: "UPDATE_FAILED",
+          retryAfter: "2026-03-31T10:05:03.000Z",
+        }),
+        {
+          status: 409,
+          headers: {
+            "content-type": "application/json",
+            "Retry-After": "3",
+            "Idempotency-Key": "edge-complete-conflict",
+          },
+        },
+      ),
+    );
+
+    const response = await sessionsCompleteHandler(
+      new Request("http://localhost/api/sessions-complete", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer token-123",
+          "Idempotency-Key": "complete-idempotency-key",
+          "x-request-id": "request-complete-conflict",
+        },
+        body: JSON.stringify({
+          session_id: sessionId,
+          outcome: "completed",
+          notes: null,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(response.headers.get("Retry-After")).toBe("3");
+    expect(response.headers.get("Idempotency-Key")).toBe("edge-complete-conflict");
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Session could not be completed yet",
+      code: "UPDATE_FAILED",
+      retryAfter: "2026-03-31T10:05:03.000Z",
+    });
+  });
+
   it("falls back to runtime REST when edge fetch has no HTTP response", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token-123");
     const fetchMock = makeFallbackFetchMock({ edgeNetworkFailure: true });

--- a/tests/admin-create-user.access.spec.ts
+++ b/tests/admin-create-user.access.spec.ts
@@ -166,7 +166,7 @@ describe('admin-create-user access control', () => {
     expect(profilesIsSpy).toHaveBeenCalledWith('organization_id', null);
     expect(profilesSelectSpy).toHaveBeenCalledWith('id, organization_id');
     expect(profilesSingleSpy).toHaveBeenCalled();
-  });
+  }, 20_000);
 
   it('denies a regular admin from creating an admin in a different organization', async () => {
     userContexts.set('admin', {

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -223,12 +223,13 @@ describe('admin invite edge function', () => {
     });
 
     expect(assertAdminOrSuperAdmin).toHaveBeenCalledTimes(1);
-  });
+  }, 20_000);
 
   it('replaces an expired invite token with a new one', async () => {
+    const expiredEmail = 'expiredadmin@example.com';
     const expiredToken: StoredInviteToken = {
       id: 'invite-old',
-      email: 'newadmin@example.com',
+      email: expiredEmail,
       organization_id: 'org-123',
       token_hash: 'deadbeef',
       expires_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
@@ -244,7 +245,7 @@ describe('admin invite edge function', () => {
       new Request('https://edge.example.com/admin/invite', {
         method: 'POST',
         headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
-        body: JSON.stringify({ email: 'newadmin@example.com', expiresInHours: 4 }),
+        body: JSON.stringify({ email: expiredEmail, expiresInHours: 4 }),
       }),
     );
 
@@ -259,8 +260,8 @@ describe('admin invite edge function', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(adminActionRows).toHaveLength(1);
     expect(adminActionRows[0]?.action_details).toMatchObject({
-      email: 'newadmin@example.com',
+      email: expiredEmail,
       email_delivery_status: 'sent',
     });
-  });
+  }, 20_000);
 });

--- a/tests/edge/initiate-client-onboarding.utils.test.ts
+++ b/tests/edge/initiate-client-onboarding.utils.test.ts
@@ -19,7 +19,7 @@ describe("initiate-client-onboarding helpers", () => {
     const second = await __TESTING__.hashPrefillToken(token);
     expect(first).toHaveLength(64);
     expect(first).toEqual(second);
-  });
+  }, 20_000);
 
   it("allows consume only for therapist and above", () => {
     expect(__TESTING__.resolveConsumeRole("super_admin")).toBe("super_admin");

--- a/tests/edge/sessions-cancel.retry-after.contract.test.ts
+++ b/tests/edge/sessions-cancel.retry-after.contract.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stubDenoEnv } from "../utils/stubDeno";
+
+const envValues = new Map<string, string>([
+  ["CORS_ALLOWED_ORIGINS", "https://app.example.com,https://preview.example.com"],
+]);
+
+const createRequestClientMock = vi.fn();
+const createSupabaseIdempotencyServiceMock = vi.fn();
+
+stubDenoEnv((key) => envValues.get(key) ?? "");
+
+async function loadHandler() {
+  let serveHandler: ((req: Request) => Promise<Response>) | undefined;
+  const denoObject = (globalThis as typeof globalThis & { Deno?: Record<string, unknown> }).Deno ?? {};
+
+  vi.stubGlobal("Deno", {
+    ...denoObject,
+    env: {
+      get: (key: string) => envValues.get(key) ?? "",
+    },
+    serve: vi.fn((handler: (req: Request) => Promise<Response>) => {
+      serveHandler = handler;
+      return {};
+    }),
+  });
+
+  vi.doMock("../../supabase/functions/_shared/database.ts", () => ({
+    createRequestClient: createRequestClientMock,
+    supabaseAdmin: {
+      from: vi.fn(),
+      rpc: vi.fn(),
+    },
+  }));
+  vi.doMock("../../supabase/functions/_shared/idempotency.ts", async () => {
+    const actual = await vi.importActual<typeof import("../../supabase/functions/_shared/idempotency.ts")>(
+      "../../supabase/functions/_shared/idempotency.ts",
+    );
+    return {
+      ...actual,
+      createSupabaseIdempotencyService: createSupabaseIdempotencyServiceMock,
+    };
+  });
+
+  await import("../../supabase/functions/sessions-cancel/index.ts");
+
+  if (!serveHandler) {
+    throw new Error("Expected sessions-cancel to register a Deno.serve handler");
+  }
+
+  return serveHandler;
+}
+
+describe("sessions-cancel retry-after contract", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+
+    createRequestClientMock.mockReturnValue({
+      auth: {
+        getUser: vi.fn(async () => ({
+          data: { user: { id: "user-1" } },
+          error: null,
+        })),
+      },
+    });
+    createSupabaseIdempotencyServiceMock.mockReturnValue({
+      find: vi.fn(async () => null),
+      persist: vi.fn(async () => undefined),
+    });
+  });
+
+  it("does not emit Retry-After for non-retryable cancellation validation failures", async () => {
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request("https://edge.example.com/functions/v1/sessions-cancel", {
+        method: "POST",
+        headers: {
+          Origin: "https://preview.example.com",
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Retry-After")).toBeNull();
+    expect(response.headers.get("Content-Type")).toContain("application/json");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://preview.example.com");
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Must provide hold_key, session_ids, or date",
+    });
+  });
+});

--- a/tests/runtime-migration-parity.test.ts
+++ b/tests/runtime-migration-parity.test.ts
@@ -60,7 +60,7 @@ describe("runtime migration parity helpers", () => {
     } finally {
       rmSync(repoDir, { recursive: true, force: true });
     }
-  }, 20_000);
+  }, 60_000);
 
   it("returns an empty list when all required versions are present", () => {
     const missing = resolveMissingVersions(

--- a/tests/supabase-preview-drift.test.ts
+++ b/tests/supabase-preview-drift.test.ts
@@ -34,7 +34,7 @@ describe("supabase preview drift helpers", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
-  });
+  }, 20_000);
 
   it("computes bidirectional drift correctly", () => {
     const drift = resolveMigrationDrift({

--- a/tests/utils/check-secrets.spec.ts
+++ b/tests/utils/check-secrets.spec.ts
@@ -42,7 +42,7 @@ describe('check-secrets script', () => {
     expect(formatMissingMessage(missing)).toMatch(/Missing required secrets/);
 
     consoleError.mockRestore();
-  });
+  }, 20_000);
 
   it('allows missing service role when access token can hydrate', () => {
     const env: NodeJS.ProcessEnv = { ...Object.fromEntries(allKeys.map((key) => [key, 'value'])) };


### PR DESCRIPTION
## Summary
- add retry-after regression coverage for session complete and cancel failure branches
- stabilize the timeout-sensitive full-suite tests with bounded per-test timeout budgets
- harden the flaky admin/invite test assertions without changing production behavior

## Verification
- npx vitest run src/server/__tests__/sessionsCompleteHandler.test.ts tests/edge/sessions-cancel.retry-after.contract.test.ts
- npx vitest run tests/admin-create-user.access.spec.ts tests/admins/invite_flow.spec.ts src/components/settings/__tests__/AdminSettings.test.tsx --reporter=verbose
- npx vitest run src/server/__tests__/bookHandler.integration.test.ts tests/runtime-migration-parity.test.ts tests/utils/check-secrets.spec.ts tests/edge/initiate-client-onboarding.utils.test.ts --reporter=verbose
- npx vitest run tests/supabase-preview-drift.test.ts src/lib/__tests__/idempotencyService.test.ts --reporter=verbose
- npm run test:ci
- npm run verify:local

## Notes
- no production logic changes in the stabilization slice
- no Linear issue linked for this branch