### PR TITLE
WIN-136 Tighten Programs & Goals route shell

### DIFF
--- a/src/pages/ClientDetails.tsx
+++ b/src/pages/ClientDetails.tsx
@@ -50,6 +50,16 @@ export function ClientDetails() {
     enabled: Boolean(clientId && activeOrganizationId),
   });
 
+  const isTherapistViewer = effectiveRole === 'therapist';
+  const isClientViewer = effectiveRole === 'client';
+  const viewingOwnClientRecord = Boolean(isClientViewer && client?.id === profile?.id);
+  const therapistOwnsClient = Boolean(isTherapistViewer && client?.therapist_id === profile?.id);
+  const canViewClientRecord = Boolean(
+    client &&
+      (!isTherapistViewer || therapistOwnsClient) &&
+      (!isClientViewer || viewingOwnClientRecord),
+  );
+
   const { data: nextSession } = useQuery({
     queryKey: ['client-next-session', clientId, activeOrganizationId ?? 'MISSING_ORG'],
     queryFn: async () => {
@@ -74,7 +84,7 @@ export function ClientDetails() {
 
       return data ?? null;
     },
-    enabled: Boolean(clientId && activeOrganizationId),
+    enabled: Boolean(clientId && activeOrganizationId && canViewClientRecord),
   });
 
   const { data: openIssuesCount = 0 } = useQuery({
@@ -97,7 +107,7 @@ export function ClientDetails() {
 
       return count ?? 0;
     },
-    enabled: Boolean(clientId && activeOrganizationId),
+    enabled: Boolean(clientId && activeOrganizationId && canViewClientRecord),
   });
 
   const tabs = [
@@ -193,13 +203,6 @@ export function ClientDetails() {
       </div>
     );
   }
-
-  const isTherapistViewer = effectiveRole === 'therapist';
-  const isClientViewer = effectiveRole === 'client';
-  const viewingOwnClientRecord = isClientViewer && client.id === profile?.id;
-  const therapistOwnsClient = isTherapistViewer
-    ? client.therapist_id === profile?.id
-    : false;
 
   if (isTherapistViewer && !therapistOwnsClient) {
     return (

--- a/src/pages/__tests__/ClientDetails.test.tsx
+++ b/src/pages/__tests__/ClientDetails.test.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor } from '@testing-library/react';
 import { renderWithProviders, userEvent } from '../../test/utils';
 import { ClientDetails } from '../ClientDetails';
 import { supabase } from '../../lib/supabase';
+import { fetchClientById } from '../../lib/clients/fetchers';
 
 let mockLocationSearch = '';
 
@@ -74,7 +75,14 @@ const createIssuesBuilder = () => {
 
 describe('ClientDetails page', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockLocationSearch = '';
+    vi.mocked(fetchClientById).mockResolvedValue({
+      id: 'client-1',
+      full_name: 'Alyana Perez',
+      therapist_id: 'admin-user-id',
+      authorized_hours_per_month: 12,
+    });
     vi.spyOn(supabase, 'from').mockImplementation((table: string) => {
       if (table === 'sessions') {
         return createSessionsBuilder();
@@ -119,7 +127,41 @@ describe('ClientDetails page', () => {
     renderWithProviders(<ClientDetails />);
 
     await waitFor(() => expect(screen.getByText('ProgramsGoalsTabContent')).toBeInTheDocument());
+    await waitFor(() => expect(supabase.from).toHaveBeenCalledWith('sessions'));
+    expect(supabase.from).toHaveBeenCalledWith('client_issues');
     expect(screen.queryByText('ProfileTabContent')).not.toBeInTheDocument();
+  });
+
+  it('does not render Programs & Goals or summary queries for an unassigned therapist deeplink', async () => {
+    mockLocationSearch = '?tab=programs-goals';
+    vi.mocked(fetchClientById).mockResolvedValue({
+      id: 'client-1',
+      full_name: 'Alyana Perez',
+      therapist_id: 'different-therapist-id',
+      authorized_hours_per_month: 12,
+    });
+
+    renderWithProviders(<ClientDetails />, {
+      auth: { role: 'therapist', userId: 'therapist-user-id' },
+    });
+
+    await waitFor(() => expect(screen.getByText('You are not assigned to this client')).toBeInTheDocument());
+
+    expect(screen.queryByText('ProgramsGoalsTabContent')).not.toBeInTheDocument();
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('does not render Programs & Goals or summary queries for a client viewing another record', async () => {
+    mockLocationSearch = '?tab=programs-goals';
+
+    renderWithProviders(<ClientDetails />, {
+      auth: { role: 'client', userId: 'different-client-id' },
+    });
+
+    await waitFor(() => expect(screen.getByText('You can only view your own record')).toBeInTheDocument());
+
+    expect(screen.queryByText('ProgramsGoalsTabContent')).not.toBeInTheDocument();
+    expect(supabase.from).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Link: WIN-136
- Tightens ClientDetails route-shell gating so summary-side client queries only run after the loaded client passes the same role/client ownership checks required before protected tab rendering.
- Adds focused regression coverage for Programs & Goals deeplinks under allowed and denied viewer states.

## Scope
- Allowed implementation surface only: src/pages/ClientDetails.tsx
- Allowed test surface only: src/pages/__tests__/ClientDetails.test.tsx
- No server/API, Supabase, runtime config, upload/extraction, AI proposal, review, or publish behavior changes.

## Verification
- npm test -- src/pages/__tests__/ClientDetails.test.tsx
- npm run verify:local

## Notes
- Browser repro/evidence for WIN-140 remains blocked by missing approved test credentials, non-PHI test client, and synthetic upload artifact.