### PR TITLE
WIN-137 Fix uploaded assessment draft generation gating

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -493,6 +493,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     acceptedDraftChildGoalCount >= MIN_CHILD_GOALS && acceptedDraftParentGoalCount >= MIN_PARENT_GOALS;
   const hasStagedDraftChanges = hasExistingDrafts;
   const hasDraftsButNoLivePrograms = hasExistingDrafts && livePrograms.length === 0;
+  const selectedAssessmentReadyForAiGeneration = selectedAssessmentDocument?.status === "extracted";
+  const canGenerateUploadedAssessmentDraft =
+    canQuerySelectedAssessment && selectedAssessmentReadyForAiGeneration && !hasExistingDrafts;
   const canPromoteAssessment =
     canQuerySelectedAssessment &&
     !hasPendingRequiredChecklistItems &&
@@ -511,6 +514,13 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
           : !hasRequiredAcceptedGoalMix
             ? `Accepted draft goals must include at least ${MIN_CHILD_GOALS} child and ${MIN_PARENT_GOALS} parent goals before publishing.`
           : null;
+  const uploadedAssessmentGenerateDisabledReason = !canQuerySelectedAssessment
+    ? "Select a valid uploaded assessment before generating AI proposals."
+    : hasExistingDrafts
+      ? "Drafts already exist for this assessment. Review/edit current drafts instead of regenerating."
+    : !selectedAssessmentReadyForAiGeneration
+      ? "Wait for extraction to complete before generating AI proposals."
+      : null;
 
   useEffect(() => {
     const firstAssessmentId = assessmentDocuments[0]?.id ?? null;
@@ -1442,16 +1452,17 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
               <button
                 type="button"
                 onClick={() => generateDraftsFromUploadedAssessment.mutate()}
-                disabled={!canQuerySelectedAssessment || hasExistingDrafts || generateDraftsFromUploadedAssessment.isLoading}
+                disabled={!canGenerateUploadedAssessmentDraft || generateDraftsFromUploadedAssessment.isLoading}
+                title={uploadedAssessmentGenerateDisabledReason ?? undefined}
                 className="w-full px-3 py-2 text-sm font-medium text-white bg-cyan-600 rounded-md hover:bg-cyan-700 disabled:opacity-50"
               >
                 {generateDraftsFromUploadedAssessment.isLoading
                   ? "Generating AI Proposal..."
                   : "Generate with AI from Uploaded FBA"}
               </button>
-              {hasExistingDrafts && !generateDraftsFromUploadedAssessment.isLoading && (
+              {uploadedAssessmentGenerateDisabledReason && !generateDraftsFromUploadedAssessment.isLoading && (
                 <p className="text-xs text-gray-500 dark:text-gray-300">
-                  Drafts already exist for this assessment. Review/edit current drafts instead of regenerating.
+                  {uploadedAssessmentGenerateDisabledReason}
                 </p>
               )}
               <button

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1352,11 +1352,135 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
           ([path, init]) =>
             path === "/api/assessment-drafts" &&
             init?.method === "POST" &&
-            String(init.body).includes("\"auto_generate\":true"),
+            JSON.parse(String(init.body)).assessment_document_id === ASSESSMENT_ID &&
+            JSON.parse(String(init.body)).auto_generate === true,
         ),
       ).toBe(true);
     });
     expect(showSuccess).toHaveBeenCalledWith("AI proposal program and goals generated from uploaded FBA.");
+  });
+
+  it("waits for extraction before generating staged drafts from an uploaded assessment", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "synthetic-fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1234,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/synthetic-fba.pdf",
+              status: "extracting",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <ProgramsGoalsTab client={buildClient()} />,
+      {
+        auth: {
+          role: "therapist",
+          organizationId: ORG_ID,
+          accessToken: "test-access-token",
+        },
+      },
+    );
+
+    const generateButton = await screen.findByRole("button", { name: /Generate with AI from Uploaded FBA/i });
+    await waitFor(() => {
+      expect(generateButton).toBeDisabled();
+    });
+    expect(await screen.findByText("Wait for extraction to complete before generating AI proposals.")).toBeInTheDocument();
+
+    await user.click(generateButton);
+
+    expect(
+      vi.mocked(callApi).mock.calls.some(
+        ([path, init]) => path === "/api/assessment-drafts" && (init?.method ?? "").toUpperCase() === "POST",
+      ),
+    ).toBe(false);
+  });
+
+  it("shows existing-draft guidance for drafted uploaded assessments", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "synthetic-fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1234,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/synthetic-fba.pdf",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [{ id: "draft-program-1", accept_state: "pending", name: "Draft Program" }],
+            goals: [],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <ProgramsGoalsTab client={buildClient()} />,
+      {
+        auth: {
+          role: "therapist",
+          organizationId: ORG_ID,
+          accessToken: "test-access-token",
+        },
+      },
+    );
+
+    const generateButton = await screen.findByRole("button", { name: /Generate with AI from Uploaded FBA/i });
+    await waitFor(() => {
+      expect(generateButton).toBeDisabled();
+    });
+    expect(
+      await screen.findByText("Drafts already exist for this assessment. Review/edit current drafts instead of regenerating."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Wait for extraction to complete before generating AI proposals.")).not.toBeInTheDocument();
   });
 
   it("generates completed CalOptima PDF for selected assessment", async () => {

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -82,7 +82,7 @@ describe("assessmentDraftsHandler", () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1" }],
+        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
       })
       .mockResolvedValueOnce({ ok: true, status: 201, data: [{ id: "draft-program-1", name: "Communication Program" }] })
       .mockResolvedValueOnce({ ok: true, status: 201, data: null })
@@ -219,7 +219,7 @@ describe("assessmentDraftsHandler", () => {
         return {
           ok: true,
           status: 200,
-          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1" }],
+          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
         };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?")) {
@@ -387,7 +387,7 @@ describe("assessmentDraftsHandler", () => {
         return {
           ok: true,
           status: 200,
-          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1" }],
+          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
         };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
@@ -506,7 +506,7 @@ describe("assessmentDraftsHandler", () => {
         return {
           ok: true,
           status: 200,
-          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1" }],
+          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
         };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?")) {
@@ -584,6 +584,156 @@ describe("assessmentDraftsHandler", () => {
     expect(fetchJson).toHaveBeenCalledWith(
       expect.stringContaining("/rest/v1/assessment_draft_programs?id=in.(draft-program-mismatch-1)"),
       expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("rejects malformed auto-generation request bodies before draft generation", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "not-a-uuid", auto_generate: true }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid request body" });
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid JSON bodies before draft generation", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: "{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("rejects auto-generation until extraction is complete", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracting" }],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-1111-1111-111111111111",
+          auto_generate: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Assessment extraction must complete before AI proposals can be generated.",
+    });
+    expect(fetchJson).toHaveBeenCalledTimes(3);
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_checklist_items"),
+      expect.anything(),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/generate-program-goals"),
+      expect.anything(),
+    );
+  });
+
+  it("keeps existing-draft conflict messaging for drafted assessments", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
+        return { ok: true, status: 200, data: [{ id: "draft-program-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-1111-1111-111111111111",
+          auto_generate: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Drafts already exist for this assessment. Review existing drafts instead of regenerating.",
+    });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/generate-program-goals"),
+      expect.anything(),
     );
   });
 

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -108,6 +108,7 @@ interface AssessmentDocumentScopeRow {
   id: string;
   organization_id: string;
   client_id: string;
+  status: string;
 }
 
 interface AssessmentDraftProgramRow {
@@ -198,7 +199,7 @@ const getAssessmentDocument = async (
   organizationId: string,
   assessmentDocumentId: string,
 ): Promise<AssessmentDocumentScopeRow | null> => {
-  const lookupUrl = `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id&id=eq.${encodeURIComponent(
+  const lookupUrl = `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status&id=eq.${encodeURIComponent(
     assessmentDocumentId,
   )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`;
   const lookup = await fetchJson<AssessmentDocumentScopeRow[]>(lookupUrl, { method: "GET", headers });
@@ -491,6 +492,20 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
       return json({ draft_program_id: result.draftProgramId }, 201);
     }
 
+    const hasExistingDrafts = await draftsAlreadyExistForDocument({
+      supabaseUrl,
+      headers,
+      organizationId,
+      assessmentDocumentId,
+    });
+    if (hasExistingDrafts) {
+      return json({ error: "Drafts already exist for this assessment. Review existing drafts instead of regenerating." }, 409);
+    }
+
+    if (document.status !== "extracted") {
+      return json({ error: "Assessment extraction must complete before AI proposals can be generated." }, 409);
+    }
+
     const checklistResult = await fetchJson<AssessmentChecklistWithStatusValueRow[]>(
       `${supabaseUrl}/rest/v1/assessment_checklist_items?select=section_key,label,placeholder_key,value_text,value_json,required,status&organization_id=eq.${encodeURIComponent(
         organizationId,
@@ -514,16 +529,6 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
     );
     if (!extractionResult.ok) {
       return json({ error: "Failed to load extraction evidence for AI proposal generation." }, extractionResult.status || 500);
-    }
-
-    const hasExistingDrafts = await draftsAlreadyExistForDocument({
-      supabaseUrl,
-      headers,
-      organizationId,
-      assessmentDocumentId,
-    });
-    if (hasExistingDrafts) {
-      return json({ error: "Drafts already exist for this assessment. Review existing drafts instead of regenerating." }, 409);
     }
 
     const clientResult = await fetchJson<Array<{ full_name: string | null }>>(


### PR DESCRIPTION
## Summary
- Gate uploaded-assessment AI generation until the selected assessment has completed extraction.
- Add the same server-side status guard for `/api/assessment-drafts` auto-generation while preserving existing-draft conflict precedence.
- Add focused UI and handler regression coverage for valid auto-generate payloads, invalid bodies, extracting assessments, and drafted assessments with existing staged drafts.

## Verification
- `npx vitest run --reporter=verbose src/server/__tests__/assessmentDraftsHandler.test.ts src/components/__tests__/ProgramsGoalsTab.test.tsx` passed.
- `npm run ci:check-focused` passed.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run build` passed.
- `npm run validate:tenant` passed.
- `npm run test:routes:tier0` passed, 91/91 Cypress checks.
- Netlify-dev smoke passed: upload registration returned 201, generation stayed disabled while extraction was pending, helper was visible, and no `/api/assessment-drafts` POST fired.

## Blocked / partial checks
- `npm run test:ci` failed in unrelated runtime-config tests because local env files inject a real Supabase publishable key into Vitest; focused WIN-137 tests pass.
- `npm run verify:local` fails at the same `test:ci` stage for the same local env issue.
- `npm run ci:playwright` timed out after 10 minutes while running the broader Playwright suite; timed-out local processes were cleaned up.

Linear: WIN-137