### PR TITLE
WIN-138 Restore Programs & Goals checklist review semantics

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
+++ b/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
@@ -51,7 +51,7 @@ export interface AssessmentPlanPdfResponse {
 export const EMPTY_ASSESSMENT_DOCUMENTS: AssessmentDocumentRecord[] = [];
 export const EMPTY_CHECKLIST_ITEMS: AssessmentChecklistItem[] = [];
 export const EMPTY_ASSESSMENT_DRAFTS: AssessmentDraftResponse = { programs: [], goals: [] };
-export const ENABLE_CHECKLIST_MAPPING_UI = false;
+export const ENABLE_CHECKLIST_MAPPING_UI = true;
 export const MIN_CHILD_GOALS = 20;
 export const MIN_PARENT_GOALS = 6;
 

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -429,7 +429,11 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     };
   }, [refetchAssessmentDocuments, shouldPollAssessmentDocuments]);
 
-  const { data: checklistItems = EMPTY_CHECKLIST_ITEMS } = useQuery({
+  const {
+    data: checklistItems = EMPTY_CHECKLIST_ITEMS,
+    isError: checklistItemsError,
+    isLoading: checklistItemsLoading,
+  } = useQuery({
     queryKey: ["assessment-checklist", selectedAssessmentId, organizationId ?? "MISSING_ORG"],
     queryFn: async () => {
       if (!selectedAssessmentId) return [];
@@ -474,8 +478,11 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const selectedAssessmentTemplateLabel = selectedAssessmentDocument
     ? TEMPLATE_LABELS[selectedAssessmentDocument.template_type]
     : TEMPLATE_LABELS[assessmentTemplateType];
+  const checklistReviewUnavailable =
+    ENABLE_CHECKLIST_MAPPING_UI && canQuerySelectedAssessment && (checklistItemsLoading || checklistItemsError);
   const hasPendingRequiredChecklistItems =
-    ENABLE_CHECKLIST_MAPPING_UI && checklistItems.some((item) => item.required && item.status !== "approved");
+    ENABLE_CHECKLIST_MAPPING_UI &&
+    (checklistReviewUnavailable || checklistItems.some((item) => item.required && item.status !== "approved"));
   const hasAcceptedDraftProgram = (assessmentDrafts?.programs ?? []).some(
     (program) => program.accept_state === "accepted" || program.accept_state === "edited",
   );
@@ -507,6 +514,10 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     : 0;
   const promoteDisabledReason = !canQuerySelectedAssessment
     ? "Select a valid assessment first."
+    : checklistReviewUnavailable
+      ? "Checklist review must load before publishing."
+    : hasPendingRequiredChecklistItems
+      ? `${unresolvedRequiredCount} required checklist row${unresolvedRequiredCount === 1 ? "" : "s"} must be approved before publishing.`
     : !hasAcceptedDraftProgram
         ? "Accept or edit at least one AI proposal program before publishing."
         : !hasAcceptedDraftGoal
@@ -677,7 +688,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         }),
       });
       if (!response.ok) {
-        throw new Error("Failed to update checklist row");
+        throw new Error(await parseApiErrorMessage(response, "Failed to update checklist row"));
       }
     },
     onSuccess: () => {
@@ -1656,6 +1667,12 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
               )}
               {!selectedAssessmentId ? (
                 <p className="text-sm text-gray-500">Upload and select an assessment to review checklist items.</p>
+              ) : checklistItemsLoading ? (
+                <p className="text-sm text-gray-500">Loading checklist review...</p>
+              ) : checklistItemsError ? (
+                <p className="text-sm text-rose-600 dark:text-rose-300">
+                  Checklist review failed to load. Publishing stays blocked until checklist rows can be reviewed.
+                </p>
               ) : checklistBySection.length === 0 ? (
                 <p className="text-sm text-gray-500">Checklist not available yet for this assessment.</p>
               ) : (
@@ -1672,6 +1689,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                             reviewNotes: row.review_notes ?? "",
                             valueText: row.value_text ?? "",
                           };
+                          const isApprovedStatusLocked = row.status === "approved";
                           return (
                             <div key={row.id} className="rounded border border-gray-200 dark:border-gray-700 p-2">
                               <div className="text-xs font-medium text-gray-800 dark:text-gray-200">{row.label}</div>
@@ -1682,6 +1700,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                               <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
                                 <select
                                   value={edit.status}
+                                  disabled={isApprovedStatusLocked}
                                   onChange={(event) =>
                                     setChecklistEdits((current) => ({
                                       ...current,
@@ -1735,6 +1754,11 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                               >
                                 Save Checklist Row
                               </button>
+                              {isApprovedStatusLocked && (
+                                <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-300">
+                                  Approved checklist rows stay approved; update notes or field value without lowering status.
+                                </p>
+                              )}
                             </div>
                           );
                         })}

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -2000,6 +2000,194 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(await screen.findByText("Select a valid assessment first.")).toBeInTheDocument();
   });
 
+  it("blocks publish with explicit checklist guidance when required rows are unresolved", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "checklist-item-1",
+              section_key: "assessment_summary",
+              label: "Assessment summary",
+              placeholder_key: "summary",
+              required: true,
+              mode: "ASSISTED",
+              status: "verified",
+              review_notes: null,
+              value_text: "Synthetic assessment summary",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/fba.pdf",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [{ id: "p1", name: "Program A", description: null, accept_state: "accepted", review_notes: null }],
+            goals: buildAcceptedDraftGoals(),
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findByText("1 required checklist row must be approved before publishing.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i })).toBeDisabled();
+  });
+
+  it("shows approved checklist rows as locked from status downgrades", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "checklist-item-1",
+              section_key: "assessment_summary",
+              label: "Assessment summary",
+              placeholder_key: "summary",
+              required: true,
+              mode: "ASSISTED",
+              status: "approved",
+              review_notes: null,
+              value_text: "Synthetic assessment summary",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/fba.pdf",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(
+      await screen.findByText("Approved checklist rows stay approved; update notes or field value without lowering status."),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("approved")).toBeDisabled();
+  });
+
+  it("blocks publish while checklist review fails to load", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify({ error: "Checklist unavailable" }), { status: 500 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/fba.pdf",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [{ id: "p1", name: "Program A", description: null, accept_state: "accepted", review_notes: null }],
+            goals: buildAcceptedDraftGoals(),
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(
+      await screen.findByText("Checklist review failed to load. Publishing stays blocked until checklist rows can be reviewed."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Checklist review must load before publishing.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i })).toBeDisabled();
+  });
+
   it("shows add-goal prerequisites when create goal is disabled", async () => {
     renderWithProviders(
       <ProgramsGoalsTab client={buildClient()} />,

--- a/src/server/__tests__/assessmentChecklistHandler.test.ts
+++ b/src/server/__tests__/assessmentChecklistHandler.test.ts
@@ -65,5 +65,122 @@ describe("assessmentChecklistHandler", () => {
     );
 
     expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid checklist status transition: verified -> drafted",
+    });
+  });
+
+  it("returns explicit guidance when approved checklist rows are downgraded", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [
+        {
+          id: "item-1",
+          assessment_document_id: "doc-1",
+          organization_id: "org-1",
+          client_id: "client-1",
+          status: "approved",
+        },
+      ],
+    });
+
+    const response = await assessmentChecklistHandler(
+      new Request("http://localhost/api/assessment-checklist", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          item_id: "11111111-1111-1111-1111-111111111111",
+          status: "verified",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Approved checklist rows cannot be downgraded. Edit notes or field value without lowering status.",
+    });
+  });
+
+  it("allows approved checklist rows to keep approved status while updating notes and value", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "item-1",
+            assessment_document_id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "approved",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "item-1",
+            status: "approved",
+            review_notes: "Reviewed again",
+            value_text: "Updated synthetic value",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 201, data: null });
+
+    const response = await assessmentChecklistHandler(
+      new Request("http://localhost/api/assessment-checklist", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          item_id: "11111111-1111-1111-1111-111111111111",
+          status: "approved",
+          review_notes: "Reviewed again",
+          value_text: "Updated synthetic value",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "item-1",
+      status: "approved",
+      review_notes: "Reviewed again",
+      value_text: "Updated synthetic value",
+    });
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_checklist_items?id=eq.item-1"),
+      expect.objectContaining({
+        method: "PATCH",
+        body: expect.stringContaining("\"status\":\"approved\""),
+      }),
+    );
   });
 });

--- a/src/server/api/assessment-checklist.ts
+++ b/src/server/api/assessment-checklist.ts
@@ -103,7 +103,15 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
 
     const nextStatus = parsed.data.status;
     if (nextStatus && !canTransitionStatus(existing.status, nextStatus)) {
-      return json({ error: `Invalid status transition: ${existing.status} -> ${nextStatus}` }, 400);
+      return json(
+        {
+          error:
+            existing.status === "approved"
+              ? "Approved checklist rows cannot be downgraded. Edit notes or field value without lowering status."
+              : `Invalid checklist status transition: ${existing.status} -> ${nextStatus}`,
+        },
+        400,
+      );
     }
 
     const actorId = getAccessTokenSubject(accessToken);


### PR DESCRIPTION
## Summary
- Enables the existing Programs & Goals checklist review UI for staged assessment drafts.
- Fails closed while checklist review is loading or errored, and shows explicit publish-blocking guidance.
- Keeps approved checklist rows from being downgraded while still allowing notes/value edits, with explicit server/UI messaging.

## Verification
- PASS: `npm test -- src/server/__tests__/assessmentChecklistHandler.test.ts`
- PASS: `npm test -- src/components/__tests__/ProgramsGoalsTab.test.tsx -- --runInBand`
- PASS: `npm test -- src/server/__tests__/assessmentDraftsHandler.test.ts`
- PASS: `npm run ci:check-focused`
- PASS: `npm run lint`
- PASS: `npm run typecheck`
- PASS: `npm run validate:tenant`
- PASS: `npm run build`
- FAIL local: `npm run test:ci` fails outside this diff because runtime-config tests load `.env.codex` Supabase publishable key over test fixture keys.
- FAIL local: `npm run verify:local` fails at the same `test:ci` runtime-config/env contamination point before coverage/routes.

## Risk Notes
- Critical lane because this touches `src/server/api/assessment-checklist.ts` and tenant-scoped checklist review data.
- No publish/live-promotion implementation included; `WIN-139` remains product-blocked for publish semantics.

Linear: WIN-138