### PR TITLE
[codex] WIN-139 harden Programs & Goals publish path

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -156,6 +156,9 @@ const isSupportedAssessmentFile = (file: File): boolean => {
   return SUPPORTED_ASSESSMENT_FILE_EXTENSIONS.some((extension) => lowerFileName.endsWith(extension));
 };
 
+const formatCountLabel = (count: number, singular: string, plural: string): string =>
+  `${count} ${count === 1 ? singular : plural}`;
+
 interface ProgramsGoalsTabProps {
   client: Client;
 }
@@ -898,7 +901,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       if (!response.ok) {
         throw new Error(await parseApiErrorMessage(response, "Assessment cannot be promoted yet."));
       }
-      return parseJson<{ created_goal_count: number }>(response);
+      return parseJson<{ created_program_count: number; created_goal_count: number }>(response);
     },
     onSuccess: (result) => {
       queryClient.invalidateQueries({
@@ -910,7 +913,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       queryClient.invalidateQueries({
         queryKey: ["program-goals", resolvedProgramId, organizationId ?? "MISSING_ORG"],
       });
-      showSuccess(`Published to live records. Created production program and ${result.created_goal_count} goals.`);
+      showSuccess(
+        `Published to live records. Created ${formatCountLabel(result.created_program_count, "production program", "production programs")} and ${formatCountLabel(result.created_goal_count, "goal", "goals")}.`,
+      );
     },
     onError: showError,
   });

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1771,6 +1771,143 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     confirmSpy.mockRestore();
   });
 
+  it("shows plural publish success counts from the live-promotion response", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [
+              { id: "p1", name: "Program A", description: null, accept_state: "accepted", review_notes: null },
+              { id: "p2", name: "Program B", description: null, accept_state: "edited", review_notes: null },
+            ],
+            goals: buildAcceptedDraftGoals(),
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/fba.pdf",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "POST" && path === "/api/assessment-promote") {
+        return new Response(JSON.stringify({ created_program_count: 2, created_goal_count: 26 }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("fba.pdf");
+    const publishButton = screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i });
+    await waitFor(() => {
+      expect(publishButton).not.toBeDisabled();
+    });
+    await user.click(publishButton);
+
+    await waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith(
+        "Published to live records. Created 2 production programs and 26 goals.",
+      );
+    });
+    confirmSpy.mockRestore();
+  });
+
+  it("shows singular publish success counts for the program label", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [{ id: "p1", name: "Program A", description: null, accept_state: "accepted", review_notes: null }],
+            goals: buildAcceptedDraftGoals(),
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/fba.pdf",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "POST" && path === "/api/assessment-promote") {
+        return new Response(JSON.stringify({ created_program_count: 1, created_goal_count: 26 }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("fba.pdf");
+    const publishButton = screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i });
+    await waitFor(() => {
+      expect(publishButton).not.toBeDisabled();
+    });
+    await user.click(publishButton);
+
+    await waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith(
+        "Published to live records. Created 1 production program and 26 goals.",
+      );
+    });
+    confirmSpy.mockRestore();
+  });
+
   it("shows draft-vs-live status messaging in review panel", async () => {
     renderWithProviders(
       <ProgramsGoalsTab client={buildClient()} />,

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -13,7 +13,7 @@ vi.mock("../api/shared", async () => {
   };
 });
 
-import { fetchJson, getAccessToken, getSupabaseConfig, resolveOrgAndRole } from "../api/shared";
+import { fetchJson, getAccessToken, getAccessTokenSubject, getSupabaseConfig, resolveOrgAndRole } from "../api/shared";
 
 const buildAcceptedGoals = (): Array<Record<string, unknown>> => [
   ...Array.from({ length: 20 }, (_, index) => ({
@@ -39,8 +39,9 @@ describe("assessmentPromoteHandler", () => {
     vi.resetAllMocks();
   });
 
-  it("promotes accepted drafts without checklist mapping approvals", async () => {
+  it("promotes all accepted draft programs and preserves goal-to-program links", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
       isTherapist: true,
@@ -57,20 +58,42 @@ describe("assessmentPromoteHandler", () => {
         return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }] };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
-        return { ok: true, status: 200, data: [{ id: "program-1", name: "Draft Program", description: "x", accept_state: "accepted" }] };
-      }
-      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
         return {
           ok: true,
           status: 200,
-          data: buildAcceptedGoals(),
+          data: [
+            { id: "draft-program-1", name: "Draft Program 1", description: "x", accept_state: "accepted" },
+            { id: "draft-program-2", name: "Draft Program 2", description: "y", accept_state: "edited" },
+          ],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        const goals = buildAcceptedGoals();
+        return {
+          ok: true,
+          status: 200,
+          data: goals.map((goal, index) => ({
+            ...goal,
+            draft_program_id: index < 13 ? "draft-program-1" : "draft-program-2",
+          })),
         };
       }
       if (method === "POST" && url.includes("/rest/v1/programs")) {
-        return { ok: true, status: 201, data: [{ id: "prod-program-1" }] };
+        const body = JSON.parse(String(init?.body)) as { name: string };
+        if (body.name === "Draft Program 1") {
+          return { ok: true, status: 201, data: [{ id: "prod-program-1" }] };
+        }
+        if (body.name === "Draft Program 2") {
+          return { ok: true, status: 201, data: [{ id: "prod-program-2" }] };
+        }
+        return { ok: false, status: 500, data: null };
       }
       if (method === "POST" && url.includes("/rest/v1/goals")) {
-        return { ok: true, status: 201, data: [{ id: "prod-goal-1" }] };
+        return {
+          ok: true,
+          status: 201,
+          data: buildAcceptedGoals().map((_, index) => ({ id: `prod-goal-${index + 1}` })),
+        };
       }
       if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
         return { ok: true, status: 200, data: null };
@@ -90,6 +113,11 @@ describe("assessmentPromoteHandler", () => {
     );
 
     expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      created_program_count: 2,
+      created_goal_count: 26,
+      created_program_ids: ["prod-program-1", "prod-program-2"],
+    });
     const createGoalsCall = vi
       .mocked(fetchJson)
       .mock.calls.find(([url, init]) => typeof url === "string" && url.includes("/rest/v1/goals") && init?.method === "POST");
@@ -98,6 +126,8 @@ describe("assessmentPromoteHandler", () => {
     expect(createGoalsPayload[0]?.goal_type).toBe("child");
     expect(createGoalsPayload.filter((goal) => goal.goal_type === "child")).toHaveLength(20);
     expect(createGoalsPayload.filter((goal) => goal.goal_type === "parent")).toHaveLength(6);
+    expect(createGoalsPayload.slice(0, 13).every((goal) => goal.program_id === "prod-program-1")).toBe(true);
+    expect(createGoalsPayload.slice(13).every((goal) => goal.program_id === "prod-program-2")).toBe(true);
   });
 
   it("blocks promotion when accepted goals contain duplicate titles", async () => {
@@ -248,5 +278,299 @@ describe("assessmentPromoteHandler", () => {
     const body = await response.json();
     expect(response.status).toBe(409);
     expect(body.error).toContain("Promotion requires at least");
+  });
+
+  it("rolls back created programs when production goal creation fails", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
+        return { ok: true, status: 200, data: [{ id: "draft-program-1", name: "Draft Program", description: "x", accept_state: "accepted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: buildAcceptedGoals().map((goal) => ({ ...goal, draft_program_id: "draft-program-1" })),
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/programs")) {
+        return { ok: true, status: 201, data: [{ id: "prod-program-rollback-1" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/goals")) {
+        return { ok: false, status: 500, data: null };
+      }
+      if (
+        method === "DELETE" &&
+        url.includes("/rest/v1/programs?id=in.(prod-program-rollback-1)&organization_id=eq.org-1&client_id=eq.client-1")
+      ) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (
+        method === "DELETE" &&
+        url.includes("/rest/v1/goals?program_id=in.(prod-program-rollback-1)&organization_id=eq.org-1&client_id=eq.client-1")
+      ) {
+        return { ok: true, status: 200, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error).toContain("rolled back safely");
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/programs?id=in.(prod-program-rollback-1)&organization_id=eq.org-1&client_id=eq.client-1"),
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("rolls back already-created programs when a later program create fails", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            { id: "draft-program-1", name: "Draft Program 1", description: "x", accept_state: "accepted" },
+            { id: "draft-program-2", name: "Draft Program 2", description: "y", accept_state: "accepted" },
+          ],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: buildAcceptedGoals().map((goal) => ({ ...goal, draft_program_id: "draft-program-1" })),
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/programs")) {
+        const body = JSON.parse(String(init?.body)) as { name: string };
+        if (body.name === "Draft Program 1") {
+          return { ok: true, status: 201, data: [{ id: "prod-program-1" }] };
+        }
+        if (body.name === "Draft Program 2") {
+          return { ok: false, status: 500, data: null };
+        }
+      }
+      if (method === "DELETE" && url.includes("/rest/v1/goals?program_id=in.(prod-program-1)&organization_id=eq.org-1&client_id=eq.client-1")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "DELETE" && url.includes("/rest/v1/programs?id=in.(prod-program-1)&organization_id=eq.org-1&client_id=eq.client-1")) {
+        return { ok: true, status: 200, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error).toContain("rolled back safely");
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/programs?id=in.(prod-program-1)&organization_id=eq.org-1&client_id=eq.client-1"),
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("blocks promotion when accepted goals point to a non-accepted draft program", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "draft-program-1", name: "Draft Program", description: "x", accept_state: "accepted" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: buildAcceptedGoals().map((goal) => ({ ...goal, draft_program_id: "draft-program-rejected" })),
+      });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(409);
+    expect(body.error).toContain("must belong to an accepted draft program");
+  });
+
+  it("blocks promotion when multiple accepted programs include unlinked accepted goals", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          { id: "draft-program-1", name: "Draft Program 1", description: "x", accept_state: "accepted" },
+          { id: "draft-program-2", name: "Draft Program 2", description: "y", accept_state: "accepted" },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: buildAcceptedGoals().map((goal) => ({ ...goal, draft_program_id: null })),
+      });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(409);
+    expect(body.error).toContain("must keep their draft program link");
+  });
+
+  it("rolls back live writes and restores assessment status when review-event persistence fails", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
+        return { ok: true, status: 200, data: [{ id: "draft-program-1", name: "Draft Program", description: "x", accept_state: "accepted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: buildAcceptedGoals().map((goal) => ({ ...goal, draft_program_id: "draft-program-1" })),
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/programs")) {
+        return { ok: true, status: 201, data: [{ id: "prod-program-1" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/goals")) {
+        return {
+          ok: true,
+          status: 201,
+          data: buildAcceptedGoals().map((_, index) => ({ id: `prod-goal-${index + 1}` })),
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: false, status: 500, data: null };
+      }
+      if (method === "DELETE" && url.includes("/rest/v1/goals?program_id=in.(prod-program-1)&organization_id=eq.org-1&client_id=eq.client-1")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "DELETE" && url.includes("/rest/v1/programs?id=in.(prod-program-1)&organization_id=eq.org-1&client_id=eq.client-1")) {
+        return { ok: true, status: 200, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error).toContain("rolled back safely");
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_documents?id=eq.doc-1"),
+      expect.objectContaining({
+        method: "PATCH",
+        body: expect.stringContaining('"status":"drafted"'),
+      }),
+    );
   });
 });

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -32,6 +32,7 @@ interface DraftProgramRow {
 
 interface DraftGoalRow {
   id: string;
+  draft_program_id: string | null;
   title: string;
   description: string;
   original_text: string;
@@ -51,6 +52,8 @@ const normalizeTitle = (value: string): string => value.trim().replace(/\s+/g, "
 
 const isMinGoalQuality = (goal: DraftGoalRow): boolean =>
   goal.title.trim().length >= 3 && goal.description.trim().length >= 10 && goal.original_text.trim().length >= 10;
+
+const buildInFilter = (ids: string[]): string => `in.(${ids.map((id) => encodeURIComponent(id)).join(",")})`;
 
 export async function assessmentPromoteHandler(request: Request): Promise<Response> {
   if (request.method === "OPTIONS") {
@@ -109,7 +112,7 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
       { method: "GET", headers },
     ),
     fetchJson<DraftGoalRow[]>(
-      `${supabaseUrl}/rest/v1/assessment_draft_goals?select=id,title,description,original_text,goal_type,target_behavior,measurement_type,baseline_data,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,objective_data_points,accept_state&organization_id=eq.${encodeURIComponent(
+      `${supabaseUrl}/rest/v1/assessment_draft_goals?select=id,draft_program_id,title,description,original_text,goal_type,target_behavior,measurement_type,baseline_data,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,objective_data_points,accept_state&organization_id=eq.${encodeURIComponent(
         organizationId,
       )}&assessment_document_id=eq.${encodeURIComponent(parsed.data.assessment_document_id)}&order=created_at.asc`,
       { method: "GET", headers },
@@ -180,28 +183,105 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     );
   }
 
-  const selectedProgram = acceptedPrograms[0];
-  const createProgramResult = await fetchJson<Array<{ id: string }>>(`${supabaseUrl}/rest/v1/programs`, {
-    method: "POST",
-    headers: { ...headers, Prefer: "return=representation" },
-    body: JSON.stringify({
-      organization_id: organizationId,
-      client_id: document.client_id,
-      name: selectedProgram.name,
-      description: selectedProgram.description ?? null,
-      status: "active",
-    }),
-  });
-
-  if (!createProgramResult.ok || !Array.isArray(createProgramResult.data) || !createProgramResult.data[0]) {
-    return json({ error: "Failed to create production program" }, createProgramResult.status || 500);
+  const acceptedProgramByDraftId = new Map(acceptedPrograms.map((program) => [program.id, program]));
+  const acceptedGoalsMappedToRejectedPrograms = acceptedGoals.filter(
+    (goal) => goal.draft_program_id && !acceptedProgramByDraftId.has(goal.draft_program_id),
+  );
+  if (acceptedGoalsMappedToRejectedPrograms.length > 0) {
+    return json({ error: "Accepted goals must belong to an accepted draft program before promotion." }, 409);
   }
 
-  const createdProgramId = createProgramResult.data[0].id;
+  const acceptedGoalsWithoutProgramLink = acceptedGoals.filter((goal) => !goal.draft_program_id);
+  if (acceptedPrograms.length > 1 && acceptedGoalsWithoutProgramLink.length > 0) {
+    return json({ error: "Accepted goals must keep their draft program link when promoting multiple programs." }, 409);
+  }
+
+  const rollbackLivePromotion = async (args: { createdProgramIds: string[]; restoreDocumentStatus: boolean }) => {
+    const { createdProgramIds, restoreDocumentStatus } = args;
+    const failedSteps: string[] = [];
+
+    if (createdProgramIds.length > 0) {
+      const programIdFilter = buildInFilter(createdProgramIds);
+      const deleteGoalsResult = await fetchJson(
+        `${supabaseUrl}/rest/v1/goals?program_id=${programIdFilter}&organization_id=eq.${encodeURIComponent(
+          organizationId,
+        )}&client_id=eq.${encodeURIComponent(document.client_id)}`,
+        { method: "DELETE", headers },
+      );
+      if (!deleteGoalsResult.ok) {
+        failedSteps.push("delete_goals");
+      }
+
+      const deleteProgramsResult = await fetchJson(
+        `${supabaseUrl}/rest/v1/programs?id=${programIdFilter}&organization_id=eq.${encodeURIComponent(
+          organizationId,
+        )}&client_id=eq.${encodeURIComponent(document.client_id)}`,
+        { method: "DELETE", headers },
+      );
+      if (!deleteProgramsResult.ok) {
+        failedSteps.push("delete_programs");
+      }
+    }
+
+    if (restoreDocumentStatus) {
+      const restoreDocumentResult = await fetchJson(
+        `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}`,
+        {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({
+            status: document.status,
+            approved_at: null,
+            updated_at: new Date().toISOString(),
+          }),
+        },
+      );
+      if (!restoreDocumentResult.ok) {
+        failedSteps.push("restore_document_status");
+      }
+    }
+
+    return { ok: failedSteps.length === 0, failedSteps };
+  };
+
+  const createdProgramIds: string[] = [];
+  const createdProgramIdByDraftProgramId = new Map<string, string>();
+  for (const program of acceptedPrograms) {
+    const createProgramResult = await fetchJson<Array<{ id: string }>>(`${supabaseUrl}/rest/v1/programs`, {
+      method: "POST",
+      headers: { ...headers, Prefer: "return=representation" },
+      body: JSON.stringify({
+        organization_id: organizationId,
+        client_id: document.client_id,
+        name: program.name,
+        description: program.description ?? null,
+        status: "active",
+      }),
+    });
+    if (!createProgramResult.ok || !Array.isArray(createProgramResult.data) || !createProgramResult.data[0]?.id) {
+      const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+      return json(
+        {
+          error: rollback.ok
+            ? "Failed to create production programs. Promotion rolled back safely."
+            : "Failed to create production programs, and rollback did not complete cleanly.",
+          rollback_failed_steps: rollback.ok ? undefined : rollback.failedSteps,
+        },
+        createProgramResult.status || 500,
+      );
+    }
+    const createdProgramId = createProgramResult.data[0].id;
+    createdProgramIds.push(createdProgramId);
+    createdProgramIdByDraftProgramId.set(program.id, createdProgramId);
+  }
+
+  const fallbackProgramId = acceptedPrograms.length === 1 ? createdProgramIds[0] ?? null : null;
   const createGoalsPayload = acceptedGoals.map((goal) => ({
     organization_id: organizationId,
     client_id: document.client_id,
-    program_id: createdProgramId,
+    program_id: goal.draft_program_id
+      ? createdProgramIdByDraftProgramId.get(goal.draft_program_id) ?? null
+      : fallbackProgramId,
     title: goal.title,
     description: goal.description,
     original_text: goal.original_text,
@@ -217,6 +297,11 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     status: "active",
   }));
 
+  if (createGoalsPayload.some((goal) => !goal.program_id)) {
+    await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+    return json({ error: "Accepted goals could not be matched to the promoted programs." }, 409);
+  }
+
   const createGoalsResult = await fetchJson<Array<{ id: string }>>(`${supabaseUrl}/rest/v1/goals`, {
     method: "POST",
     headers: { ...headers, Prefer: "return=representation" },
@@ -224,45 +309,79 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   });
 
   if (!createGoalsResult.ok) {
-    return json({ error: "Failed to create production goals" }, createGoalsResult.status || 500);
+    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+    return json(
+      {
+        error: rollback.ok
+          ? "Failed to create production goals. Promotion rolled back safely."
+          : "Failed to create production goals, and rollback did not complete cleanly.",
+        rollback_failed_steps: rollback.ok ? undefined : rollback.failedSteps,
+      },
+      createGoalsResult.status || 500,
+    );
   }
 
   const actorId = getAccessTokenSubject(accessToken);
   const now = new Date().toISOString();
-  await Promise.all([
-    fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}`, {
-      method: "PATCH",
-      headers,
-      body: JSON.stringify({
-        status: "approved",
-        approved_at: now,
-        updated_at: now,
-      }),
+  const updateDocumentResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify({
+      status: "approved",
+      approved_at: now,
+      updated_at: now,
     }),
-    fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        assessment_document_id: document.id,
-        organization_id: organizationId,
-        client_id: document.client_id,
-        item_type: "document",
-        item_id: document.id,
-        action: "promoted_to_production",
-        from_status: document.status,
-        to_status: "approved",
-        actor_id: actorId,
-        event_payload: {
-          created_program_id: createdProgramId,
-          created_goal_count: Array.isArray(createGoalsResult.data) ? createGoalsResult.data.length : 0,
-        },
-      }),
+  });
+  if (!updateDocumentResult.ok) {
+    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+    return json(
+      {
+        error: rollback.ok
+          ? "Failed to finalize assessment status. Promotion rolled back safely."
+          : "Failed to finalize assessment status, and rollback did not complete cleanly.",
+        rollback_failed_steps: rollback.ok ? undefined : rollback.failedSteps,
+      },
+      updateDocumentResult.status || 500,
+    );
+  }
+
+  const createEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      assessment_document_id: document.id,
+      organization_id: organizationId,
+      client_id: document.client_id,
+      item_type: "document",
+      item_id: document.id,
+      action: "promoted_to_production",
+      from_status: document.status,
+      to_status: "approved",
+      actor_id: actorId,
+      event_payload: {
+        created_program_count: createdProgramIds.length,
+        created_program_ids: createdProgramIds,
+        created_goal_count: Array.isArray(createGoalsResult.data) ? createGoalsResult.data.length : acceptedGoals.length,
+      },
     }),
-  ]);
+  });
+  if (!createEventResult.ok) {
+    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: true });
+    return json(
+      {
+        error: rollback.ok
+          ? "Failed to record promotion event. Promotion rolled back safely."
+          : "Failed to record promotion event, and rollback did not complete cleanly.",
+        rollback_failed_steps: rollback.ok ? undefined : rollback.failedSteps,
+      },
+      createEventResult.status || 500,
+    );
+  }
 
   return json({
     assessment_document_id: document.id,
-    created_program_id: createdProgramId,
-    created_goal_count: Array.isArray(createGoalsResult.data) ? createGoalsResult.data.length : 0,
+    created_program_count: createdProgramIds.length,
+    created_program_ids: createdProgramIds,
+    created_goal_count: Array.isArray(createGoalsResult.data) ? createGoalsResult.data.length : acceptedGoals.length,
   });
 }


### PR DESCRIPTION
## Summary
- align assessment promotion with the plural Programs & Goals publish contract by creating one live program per accepted draft program
- preserve accepted goal-to-program mapping during promotion and reject ambiguous draft goal links before writing live data
- add compensating rollback so failed live promotion does not leave partially published programs, goals, or assessment status updates behind

## Why
WIN-139 is the next bounded Programs & Goals publish-path slice. The existing handler only promoted the first accepted draft program, attached all accepted goals to it, and could leave unsafe half-published live records behind on partial failure.

## Validation
- npx vitest run src/server/__tests__/assessmentPromoteHandler.test.ts
- npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run build

## Blocked checks
- npm run test:ci (timed out locally)
- npm run verify:local (timed out locally)

## Risk
- full-suite integration evidence is still pending because the long aggregate checks timed out locally
- merge should wait for CI and human review because this is a protected-path `src/server/**` change