### PR TITLE
[codex] Fix extraction failure guidance

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -532,6 +532,8 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     ? "Select a valid uploaded assessment before generating AI proposals."
     : hasExistingDrafts
       ? "Drafts already exist for this assessment. Review/edit current drafts instead of regenerating."
+    : selectedAssessmentDocument?.status === "extraction_failed"
+      ? "Extraction failed for this assessment. Review the uploaded file and checklist manually, and replace the source document if it needs correction before generating AI proposals."
     : !selectedAssessmentReadyForAiGeneration
       ? "Wait for extraction to complete before generating AI proposals."
       : null;

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1310,6 +1310,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
               bucket_id: "client-documents",
               object_path: "clients/client-1/assessments/fba.docx",
               status: "extracted",
+              extraction_error: "Previous extraction warning should not block generation.",
               created_at: "2026-02-11T00:00:00.000Z",
             },
           ]),
@@ -1340,6 +1341,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     );
 
     await screen.findByText("fba.docx");
+    expect(await screen.findByText("Previous extraction warning should not block generation.")).toBeInTheDocument();
     const generateButton = await screen.findByRole("button", { name: /Generate with AI from Uploaded FBA/i });
     await waitFor(() => {
       expect(generateButton).not.toBeDisabled();
@@ -1358,6 +1360,75 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       ).toBe(true);
     });
     expect(showSuccess).toHaveBeenCalledWith("AI proposal program and goals generated from uploaded FBA.");
+  });
+
+  it("shows extraction-failed guidance instead of generic waiting copy for uploaded assessments", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "failed-fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1234,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/failed-fba.pdf",
+              status: "extraction_failed",
+              extraction_error: "Extraction failed. Review the checklist manually or upload a cleaner FBA.",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <ProgramsGoalsTab client={buildClient()} />,
+      {
+        auth: {
+          role: "therapist",
+          organizationId: ORG_ID,
+          accessToken: "test-access-token",
+        },
+      },
+    );
+
+    await screen.findByText("failed-fba.pdf");
+    expect(
+      await screen.findByText("Extraction failed. Review the checklist manually or upload a cleaner FBA."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Extraction failed for this assessment. Review the uploaded file and checklist manually, and replace the source document if it needs correction before generating AI proposals.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Wait for extraction to complete before generating AI proposals.")).not.toBeInTheDocument();
+
+    const generateButton = await screen.findByRole("button", { name: /Generate with AI from Uploaded FBA/i });
+    await waitFor(() => {
+      expect(generateButton).toBeDisabled();
+    });
+    expect(
+      vi.mocked(callApi).mock.calls.some(
+        ([path, init]) => path === "/api/assessment-drafts" && (init?.method ?? "").toUpperCase() === "POST",
+      ),
+    ).toBe(false);
   });
 
   it("waits for extraction before generating staged drafts from an uploaded assessment", async () => {


### PR DESCRIPTION
## Summary
- Show failure-specific guidance when an uploaded assessment is in `extraction_failed` status.
- Preserve the existing uploaded-FBA generation gate: only `extracted` assessments without drafts can generate.
- Add focused component coverage for `extraction_failed` guidance and `extracted` documents with `extraction_error` remaining retryable.

## Verification
- PASS: `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx --no-file-parallelism --maxWorkers=1 --reporter=verbose` (36 tests)
- PASS: `npm run ci:check-focused` (commit hook and `verify:local` partial run)
- PASS: `npm run lint` (`verify:local` partial run)
- PASS: `npm run typecheck` (`verify:local` partial run)
- PASS: `npm run build`
- BLOCKED: `npm test -- src/components/__tests__/ProgramsGoalsTab.test.tsx` via repo wrapper hit the wrapper hang guard before output; direct Vitest command above passed.
- BLOCKED: `npm run verify:local` failed during `npm run test:ci` on unrelated runtime-config/env and timeout failures, including Supabase anon key/env expectations and test timeouts outside this UI slice.

## Risk
Low. Final diff is limited to the allowed component and component test files. No server/API, migration, auth, runtime config, tenant-sensitive, or shared workflow contracts changed.
