### PR TITLE
Isolate runtime config tests from local env

### DIFF
--- a/src/server/__tests__/bookHandler.integration.test.ts
+++ b/src/server/__tests__/bookHandler.integration.test.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 
@@ -6,6 +8,7 @@ import { server } from "../../test/setup";
 
 const originalCallEdge = supabaseModule.callEdge;
 const callEdgeMock = vi.spyOn(supabaseModule, "callEdge");
+const ORIGINAL_PROCESS_ENV = { ...process.env };
 
 const importBookHandler = async () => {
   const module = await import("../api/book");
@@ -16,12 +19,22 @@ const TEST_SUPABASE_URL = "https://testing.supabase.co";
 const TEST_SUPABASE_ANON_KEY = "testing-anon-key-12345678901234567890";
 const TEST_SUPABASE_EDGE_URL = "https://testing.supabase.co/functions/v1/";
 
-const ORIGINAL_ENV = {
-  SUPABASE_URL: process.env.SUPABASE_URL,
-  SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY,
-  SUPABASE_EDGE_URL: process.env.SUPABASE_EDGE_URL,
-  DEFAULT_ORGANIZATION_ID: process.env.DEFAULT_ORGANIZATION_ID,
-  API_AUTHORITY_MODE: process.env.API_AUTHORITY_MODE,
+const ISOLATED_MISSING_ENV_PATH = join(
+  tmpdir(),
+  `book-handler-integration-tests-missing-${process.pid}-${Date.now()}.env`,
+);
+
+const clearPublishableSupabaseEnv = (): void => {
+  for (const key of Object.keys(process.env)) {
+    if (key.includes("PUBLISHABLE") && key.endsWith("_SUPABASE_ANON_KEY")) {
+      delete process.env[key];
+    }
+  }
+
+  delete process.env.SUPABASE_PUBLISHABLE_KEY;
+  delete process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
+  delete process.env.SUPABASE_PUBLISHABLE_KEY_SUPABASE_ANON_KEY;
+  delete process.env.VITE_SUPABASE_PUBLISHABLE_KEY_SUPABASE_ANON_KEY;
 };
 
 function jsonResponse(body: unknown, status = 200) {
@@ -51,6 +64,8 @@ describe("bookHandler integration", () => {
     callEdgeMock.mockReset().mockRejectedValue(new Error("callEdgeMock not configured"));
     const runtimeConfig = await import("../../lib/runtimeConfig");
     runtimeConfig.resetRuntimeSupabaseConfigForTests();
+    clearPublishableSupabaseEnv();
+    process.env.CODEX_ENV_PATH = ISOLATED_MISSING_ENV_PATH;
     process.env.SUPABASE_URL = TEST_SUPABASE_URL;
     process.env.SUPABASE_ANON_KEY = TEST_SUPABASE_ANON_KEY;
     process.env.SUPABASE_EDGE_URL = TEST_SUPABASE_EDGE_URL;
@@ -463,29 +478,5 @@ describe("bookHandler integration", () => {
 
 afterAll(() => {
   callEdgeMock.mockRestore();
-  if (typeof ORIGINAL_ENV.SUPABASE_URL === "string") {
-    process.env.SUPABASE_URL = ORIGINAL_ENV.SUPABASE_URL;
-  } else {
-    delete process.env.SUPABASE_URL;
-  }
-  if (typeof ORIGINAL_ENV.SUPABASE_ANON_KEY === "string") {
-    process.env.SUPABASE_ANON_KEY = ORIGINAL_ENV.SUPABASE_ANON_KEY;
-  } else {
-    delete process.env.SUPABASE_ANON_KEY;
-  }
-  if (typeof ORIGINAL_ENV.SUPABASE_EDGE_URL === "string") {
-    process.env.SUPABASE_EDGE_URL = ORIGINAL_ENV.SUPABASE_EDGE_URL;
-  } else {
-    delete process.env.SUPABASE_EDGE_URL;
-  }
-  if (typeof ORIGINAL_ENV.DEFAULT_ORGANIZATION_ID === "string") {
-    process.env.DEFAULT_ORGANIZATION_ID = ORIGINAL_ENV.DEFAULT_ORGANIZATION_ID;
-  } else {
-    delete process.env.DEFAULT_ORGANIZATION_ID;
-  }
-  if (typeof ORIGINAL_ENV.API_AUTHORITY_MODE === "string") {
-    process.env.API_AUTHORITY_MODE = ORIGINAL_ENV.API_AUTHORITY_MODE;
-  } else {
-    delete process.env.API_AUTHORITY_MODE;
-  }
+  process.env = { ...ORIGINAL_PROCESS_ENV } as NodeJS.ProcessEnv;
 });

--- a/src/server/__tests__/healthHandler.test.ts
+++ b/src/server/__tests__/healthHandler.test.ts
@@ -1,12 +1,30 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { healthHandler } from "../api/health";
 import { resetEnvCacheForTests } from "../env";
 
 const originalEnv = { ...process.env };
+const isolatedMissingEnvPath = join(tmpdir(), `health-handler-tests-missing-${process.pid}-${Date.now()}.env`);
+
+const clearRuntimeConfigEnv = (): void => {
+  for (const key of Object.keys(process.env)) {
+    if (key.includes("PUBLISHABLE") && key.endsWith("_SUPABASE_ANON_KEY")) {
+      delete process.env[key];
+    }
+  }
+
+  delete process.env.SUPABASE_PUBLISHABLE_KEY;
+  delete process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
+  delete process.env.SUPABASE_PUBLISHABLE_KEY_SUPABASE_ANON_KEY;
+  delete process.env.VITE_SUPABASE_PUBLISHABLE_KEY_SUPABASE_ANON_KEY;
+};
 
 describe("healthHandler", () => {
   beforeEach(() => {
     process.env = { ...originalEnv } as NodeJS.ProcessEnv;
+    clearRuntimeConfigEnv();
+    process.env.CODEX_ENV_PATH = isolatedMissingEnvPath;
     process.env.SUPABASE_URL = "https://example.supabase.co";
     process.env.SUPABASE_ANON_KEY = "anon-key-12345678901234567890";
     process.env.DEFAULT_ORGANIZATION_ID = "5238e88b-6198-4862-80a2-dbe15bbeabdd";
@@ -38,4 +56,8 @@ describe("healthHandler", () => {
     const payload = (await response.json()) as { readiness: string };
     expect(payload.readiness).toBe("not_ready");
   });
+});
+
+afterAll(() => {
+  process.env = { ...originalEnv } as NodeJS.ProcessEnv;
 });

--- a/src/server/__tests__/runtimeConfigHandler.test.ts
+++ b/src/server/__tests__/runtimeConfigHandler.test.ts
@@ -18,23 +18,38 @@ vi.mock('../../lib/logger/server', () => ({
 }));
 
 const originalEnv = { ...process.env };
+const isolatedMissingEnvPath = join(
+  tmpdir(),
+  `runtime-config-handler-tests-missing-${process.pid}-${Date.now()}.env`,
+);
+
+const clearRuntimeConfigEnv = (): void => {
+  for (const key of Object.keys(process.env)) {
+    if (key.includes('PUBLISHABLE') && key.endsWith('_SUPABASE_ANON_KEY')) {
+      delete process.env[key];
+    }
+  }
+
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_ANON_KEY;
+  delete process.env.SUPABASE_PUBLISHABLE_KEY;
+  delete process.env.VITE_SUPABASE_URL;
+  delete process.env.VITE_SUPABASE_ANON_KEY;
+  delete process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
+  delete process.env.SUPABASE_PUBLISHABLE_KEY_SUPABASE_ANON_KEY;
+  delete process.env.VITE_SUPABASE_PUBLISHABLE_KEY_SUPABASE_ANON_KEY;
+  delete process.env.SUPABASE_EDGE_URL;
+  delete process.env.VITE_SUPABASE_EDGE_URL;
+  delete process.env.DEFAULT_ORGANIZATION_ID;
+};
 
 describe('runtimeConfigHandler', () => {
   const VALID_ANON_KEY = 'anon-key-12345678901234567890';
 
   beforeEach(() => {
     process.env = { ...originalEnv } as NodeJS.ProcessEnv;
-    delete process.env.CODEX_ENV_PATH;
-    delete process.env.SUPABASE_URL;
-    delete process.env.SUPABASE_ANON_KEY;
-    delete process.env.SUPABASE_PUBLISHABLE_KEY;
-    delete process.env.VITE_SUPABASE_URL;
-    delete process.env.VITE_SUPABASE_ANON_KEY;
-    delete process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
-    delete process.env.SUPABASE_PUBLISHABLE_KEY_SUPABASE_ANON_KEY;
-    delete process.env.VITE_SUPABASE_PUBLISHABLE_KEY_SUPABASE_ANON_KEY;
-    delete process.env.VITE_SUPABASE_EDGE_URL;
-    delete process.env.DEFAULT_ORGANIZATION_ID;
+    clearRuntimeConfigEnv();
+    process.env.CODEX_ENV_PATH = isolatedMissingEnvPath;
     resetEnvCacheForTests();
     loggerMock.info.mockReset();
     loggerMock.warn.mockReset();
@@ -57,6 +72,25 @@ describe('runtimeConfigHandler', () => {
     expect(payload.supabaseUrl).toBe('https://example.supabase.co');
     expect(payload.supabaseAnonKey).toBe(VALID_ANON_KEY);
     expect(payload.defaultOrganizationId).toBe('5238e88b-6198-4862-80a2-dbe15bbeabdd');
+  });
+
+  it('isolates tests from generated publishable anon-key environment values', async () => {
+    process.env.MY_TEAM_PUBLISHABLE_SUPABASE_ANON_KEY = 'sb_publishable_contaminant_1234567890';
+    clearRuntimeConfigEnv();
+    expect(process.env.MY_TEAM_PUBLISHABLE_SUPABASE_ANON_KEY).toBeUndefined();
+
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_ANON_KEY = VALID_ANON_KEY;
+    process.env.DEFAULT_ORGANIZATION_ID = '5238e88b-6198-4862-80a2-dbe15bbeabdd';
+
+    const response = await runtimeConfigHandler(new Request('http://localhost/api/runtime-config'));
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.supabaseAnonKey).toBe(VALID_ANON_KEY);
+    expect(loggerMock.warn).not.toHaveBeenCalledWith(
+      'Using generated publishable anon-key override for runtime Supabase config',
+      expect.anything(),
+    );
   });
 
   it('falls back to baked-in org id when DEFAULT_ORGANIZATION_ID is missing', async () => {


### PR DESCRIPTION
## Summary
- Isolate runtime-config-related server tests from host `.env.codex` and generated publishable Supabase anon-key environment values.
- Add focused regression coverage for arbitrary `*PUBLISHABLE*_SUPABASE_ANON_KEY` contamination.
- Restore full `process.env` in the book handler integration suite to avoid downstream order-sensitive leaks.

## Verification
- `npx vitest run src/server/__tests__/runtimeConfigHandler.test.ts src/server/__tests__/healthHandler.test.ts src/server/__tests__/bookHandler.integration.test.ts --reporter=verbose --no-file-parallelism --maxWorkers=1`
- `npx vitest run src/server/__tests__/runtimeConfigHandler.test.ts src/server/__tests__/healthHandler.test.ts src/server/__tests__/bookHandler.integration.test.ts --reporter=verbose`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci` passed once after env-isolation fixes; a later rerun failed on unrelated `assessmentPlanPdfTemplate.test.ts` timeout, which passed in isolation.
- `npm run ci:verify-coverage`
- `npm run build`
- `npm run test:routes:tier0`

## Notes
- No production runtime-config or server handler behavior changed.
- `npm run verify:local` is blocked by unrelated local full-suite timeout instability in `tests/runtime-migration-parity.test.ts`; that spec passed in isolation.