### PR TITLE
Clarify assessment retry guidance and coverage

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -533,10 +533,10 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     : hasExistingDrafts
       ? "Drafts already exist for this assessment. Review/edit current drafts instead of regenerating."
     : selectedAssessmentDocument?.status === "extraction_failed"
-      ? "Extraction failed for this assessment. Review the uploaded file and checklist manually, and replace the source document if it needs correction before generating AI proposals."
+      ? "Extraction failed. Manual review/manual notes fallback or re-upload is required before generating AI proposals."
     : !selectedAssessmentReadyForAiGeneration
       ? "Wait for extraction to complete before generating AI proposals."
-      : null;
+    : null;
 
   useEffect(() => {
     const firstAssessmentId = assessmentDocuments[0]?.id ?? null;

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1341,7 +1341,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     );
 
     await screen.findByText("fba.docx");
-    expect(await screen.findByText("Previous extraction warning should not block generation.")).toBeInTheDocument();
+    expect(await screen.findByText(/should not block generation/i)).toBeInTheDocument();
     const generateButton = await screen.findByRole("button", { name: /Generate with AI from Uploaded FBA/i });
     await waitFor(() => {
       expect(generateButton).not.toBeDisabled();
@@ -1482,6 +1482,76 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       expect(generateButton).toBeDisabled();
     });
     expect(await screen.findByText("Wait for extraction to complete before generating AI proposals.")).toBeInTheDocument();
+    expect(generateButton).toHaveAttribute("title", "Wait for extraction to complete before generating AI proposals.");
+
+    await user.click(generateButton);
+
+    expect(
+      vi.mocked(callApi).mock.calls.some(
+        ([path, init]) => path === "/api/assessment-drafts" && (init?.method ?? "").toUpperCase() === "POST",
+      ),
+    ).toBe(false);
+  });
+
+  it("shows extraction-failed guidance and disables uploaded FBA generation", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "synthetic-fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1234,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/synthetic-fba.pdf",
+              status: "extraction_failed",
+              extraction_error: "Extraction failed. Manual notes fallback or re-upload is required.",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <ProgramsGoalsTab client={buildClient()} />,
+      {
+        auth: {
+          role: "therapist",
+          organizationId: ORG_ID,
+          accessToken: "test-access-token",
+        },
+      },
+    );
+
+    const generateButton = await screen.findByRole("button", { name: /Generate with AI from Uploaded FBA/i });
+    await waitFor(() => {
+      expect(generateButton).toBeDisabled();
+    });
+    expect(
+      await screen.findByText("Extraction failed. Manual review/manual notes fallback or re-upload is required before generating AI proposals."),
+    ).toBeInTheDocument();
+    expect(generateButton).toHaveAttribute(
+      "title",
+      "Extraction failed. Manual review/manual notes fallback or re-upload is required before generating AI proposals.",
+    );
+    expect(screen.queryByText("Wait for extraction to complete before generating AI proposals.")).not.toBeInTheDocument();
 
     await user.click(generateButton);
 

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1415,7 +1415,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Extraction failed for this assessment. Review the uploaded file and checklist manually, and replace the source document if it needs correction before generating AI proposals.",
+        "Extraction failed. Manual review/manual notes fallback or re-upload is required before generating AI proposals.",
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Wait for extraction to complete before generating AI proposals.")).not.toBeInTheDocument();

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -1042,7 +1042,7 @@ describe("assessmentDocumentsHandler", () => {
     expect(draftWriteCalls).toHaveLength(0);
   });
 
-  it("marks extraction failure and cleans staged programs on missing_program_match", async () => {
+  it("keeps the document extracted and records draft_generation_failed on missing_program_match", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
@@ -1266,6 +1266,48 @@ describe("assessmentDocumentsHandler", () => {
       .mock.calls.find(([url]) => typeof url === "string" && url.includes("/rest/v1/goals"));
     expect(liveProgramWrite).toBeUndefined();
     expect(liveGoalWrite).toBeUndefined();
+
+    const extractedStatusPatchCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(([url, init]) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        const body = typeof init?.body === "string" ? init.body : "";
+        return (
+          typeof url === "string" &&
+          method === "PATCH" &&
+          url.includes("/rest/v1/assessment_documents?id=eq.doc-auto-2") &&
+          body.includes("\"status\":\"extracted\"") &&
+          body.includes("missing_program_match")
+        );
+      });
+    expect(extractedStatusPatchCall).toBeDefined();
+    const extractedStatusPatchPayload = JSON.parse(
+      ((extractedStatusPatchCall?.[1] as RequestInit).body ?? "{}") as string,
+    ) as Record<string, unknown>;
+    expect(extractedStatusPatchPayload).toMatchObject({
+      status: "extracted",
+    });
+    expect(typeof extractedStatusPatchPayload.extraction_error).toBe("string");
+    expect(String(extractedStatusPatchPayload.extraction_error)).toContain("missing_program_match");
+
+    const draftGenerationFailedEventCalls = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url, init]) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (typeof url !== "string" || method !== "POST") return false;
+        if (!url.includes("/rest/v1/assessment_review_events")) return false;
+        const body = typeof init?.body === "string" ? init.body : "";
+        return body.includes("\"action\":\"draft_generation_failed\"");
+      });
+    expect(draftGenerationFailedEventCalls).toHaveLength(1);
+    const draftGenerationFailedEventPayload = JSON.parse(
+      ((draftGenerationFailedEventCalls[0]?.[1] as RequestInit).body ?? "{}") as string,
+    ) as Record<string, unknown>;
+    expect(draftGenerationFailedEventPayload).toMatchObject({
+      action: "draft_generation_failed",
+      from_status: "extracted",
+      to_status: "extracted",
+    });
   });
 
   it.each(roleMatrix)("returns 403 for out-of-org assessment document delete as $label without side effects", async ({ role }) => {

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -199,7 +199,7 @@ describe("assessmentDraftsHandler", () => {
     expect(programPayload[0]?.confidence).toBe("medium");
   });
 
-  it("auto-generates staged drafts from extracted checklist values", async () => {
+  it("auto-generates staged drafts from extracted checklist values even when an extraction error is present", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -219,7 +219,15 @@ describe("assessmentDraftsHandler", () => {
         return {
           ok: true,
           status: 200,
-          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
+          data: [
+            {
+              id: "doc-1",
+              organization_id: "org-1",
+              client_id: "client-1",
+              status: "extracted",
+              extraction_error: "Automatic draft generation failed. You can retry with 'Generate with AI from Uploaded FBA'.",
+            },
+          ],
         };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?")) {


### PR DESCRIPTION
## Summary
- clarify uploaded-FBA disabled guidance for extraction_failed without changing the generation gate
- add focused UI coverage for extracted documents with extraction_error and no drafts
- document existing server invariants for extracted retryability in handler tests

## Verification
- npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx src/server/__tests__/assessmentDocumentsHandler.test.ts src/server/__tests__/assessmentDraftsHandler.test.ts --no-file-parallelism --maxWorkers=1 --reporter=verbose
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run build

## Blocked local checks
- npm run test:ci (timed out locally after 10 minutes)
- npm run verify:local (timed out locally because it depends on test:ci)