### PR TITLE
[codex] WIN-144 retry assessment draft generation after extraction failure

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -49,6 +49,11 @@ const ACTIVE_ASSESSMENT_POLL_STATUSES: ReadonlySet<AssessmentDocumentRecord["sta
   "uploaded",
   "extracting",
 ]);
+const AI_GENERATION_READY_STATUSES: ReadonlySet<AssessmentDocumentRecord["status"]> = new Set([
+  "extracted",
+  "extraction_failed",
+]);
+const MIN_ASSESSMENT_TEXT_CHARS_FOR_AI_GENERATION = 20;
 
 const withTimeout = async <T,>(
   promise: Promise<T>,
@@ -150,6 +155,12 @@ const callEdgeWithSupabaseFallback = async (params: {
     return fallback();
   }
 };
+
+const hasSufficientChecklistTextForAiGeneration = (items: AssessmentChecklistItem[]): boolean =>
+  items
+    .map((item) => item.value_text?.trim() ?? "")
+    .filter(Boolean)
+    .join("\n").length >= MIN_ASSESSMENT_TEXT_CHARS_FOR_AI_GENERATION;
 
 const isSupportedAssessmentFile = (file: File): boolean => {
   const lowerFileName = file.name.trim().toLowerCase();
@@ -503,9 +514,16 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     acceptedDraftChildGoalCount >= MIN_CHILD_GOALS && acceptedDraftParentGoalCount >= MIN_PARENT_GOALS;
   const hasStagedDraftChanges = hasExistingDrafts;
   const hasDraftsButNoLivePrograms = hasExistingDrafts && livePrograms.length === 0;
-  const selectedAssessmentReadyForAiGeneration = selectedAssessmentDocument?.status === "extracted";
+  const selectedAssessmentReadyForAiGeneration = selectedAssessmentDocument
+    ? AI_GENERATION_READY_STATUSES.has(selectedAssessmentDocument.status)
+    : false;
+  const selectedFailedExtractionHasChecklistEvidence =
+    selectedAssessmentDocument?.status !== "extraction_failed" || hasSufficientChecklistTextForAiGeneration(checklistItems);
   const canGenerateUploadedAssessmentDraft =
-    canQuerySelectedAssessment && selectedAssessmentReadyForAiGeneration && !hasExistingDrafts;
+    canQuerySelectedAssessment &&
+    selectedAssessmentReadyForAiGeneration &&
+    selectedFailedExtractionHasChecklistEvidence &&
+    !hasExistingDrafts;
   const canPromoteAssessment =
     canQuerySelectedAssessment &&
     !hasPendingRequiredChecklistItems &&
@@ -532,11 +550,13 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     ? "Select a valid uploaded assessment before generating AI proposals."
     : hasExistingDrafts
       ? "Drafts already exist for this assessment. Review/edit current drafts instead of regenerating."
+    : selectedAssessmentDocument?.status === "extraction_failed" && !selectedFailedExtractionHasChecklistEvidence
+      ? "Extraction failed for this assessment, but no extracted checklist evidence is available for AI proposal generation. Replace the source document or add checklist evidence before retrying."
     : selectedAssessmentDocument?.status === "extraction_failed"
-      ? "Extraction failed. Manual review/manual notes fallback or re-upload is required before generating AI proposals."
+      ? "Extraction failed for this assessment. Retry AI proposal generation using the extracted checklist evidence, or replace the source document if it needs correction."
     : !selectedAssessmentReadyForAiGeneration
       ? "Wait for extraction to complete before generating AI proposals."
-    : null;
+      : null;
 
   useEffect(() => {
     const firstAssessmentId = assessmentDocuments[0]?.id ?? null;

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1341,7 +1341,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     );
 
     await screen.findByText("fba.docx");
-    expect(await screen.findByText(/should not block generation/i)).toBeInTheDocument();
+    expect(await screen.findByText("Previous extraction warning should not block generation.")).toBeInTheDocument();
     const generateButton = await screen.findByRole("button", { name: /Generate with AI from Uploaded FBA/i });
     await waitFor(() => {
       expect(generateButton).not.toBeDisabled();
@@ -1362,7 +1362,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(showSuccess).toHaveBeenCalledWith("AI proposal program and goals generated from uploaded FBA.");
   });
 
-  it("shows extraction-failed guidance instead of generic waiting copy for uploaded assessments", async () => {
+  it("allows retry generation after extraction failure and shows retry guidance", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -1390,10 +1390,28 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
         );
       }
       if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
-        return new Response(JSON.stringify([]), { status: 200 });
+        return new Response(
+          JSON.stringify([
+            {
+              id: "checklist-item-1",
+              section_key: "behavior_summary",
+              label: "Behavior Summary",
+              placeholder_key: "behavior_summary",
+              required: true,
+              mode: "AUTO",
+              status: "verified",
+              review_notes: null,
+              value_text: "Aggression occurs during transitions and denied access.",
+            },
+          ]),
+          { status: 200 },
+        );
       }
       if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
         return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      if (method === "POST" && path === "/api/assessment-drafts") {
+        return new Response(JSON.stringify({ draft_program_id: "draft-program-1", auto_generated: true }), { status: 201 });
       }
       return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
     });
@@ -1414,20 +1432,104 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       await screen.findByText("Extraction failed. Review the checklist manually or upload a cleaner FBA."),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Extraction failed. Manual review/manual notes fallback or re-upload is required before generating AI proposals.",
+      await screen.findByText(
+        "Extraction failed for this assessment. Retry AI proposal generation using the extracted checklist evidence, or replace the source document if it needs correction.",
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Wait for extraction to complete before generating AI proposals.")).not.toBeInTheDocument();
 
     const generateButton = await screen.findByRole("button", { name: /Generate with AI from Uploaded FBA/i });
     await waitFor(() => {
-      expect(generateButton).toBeDisabled();
+      expect(generateButton).not.toBeDisabled();
     });
+    await user.click(generateButton);
+    await waitFor(() => {
+      expect(
+        vi.mocked(callApi).mock.calls.some(
+          ([path, init]) =>
+            path === "/api/assessment-drafts" &&
+            (init?.method ?? "").toUpperCase() === "POST" &&
+            JSON.parse(String(init?.body)).assessment_document_id === ASSESSMENT_ID &&
+            JSON.parse(String(init?.body)).auto_generate === true,
+        ),
+      ).toBe(true);
+    });
+    expect(showSuccess).toHaveBeenCalledWith("AI proposal program and goals generated from uploaded FBA.");
+  });
+
+  it("keeps extraction failure retry disabled when no checklist evidence is available", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "empty-failed-fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1234,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/empty-failed-fba.pdf",
+              status: "extraction_failed",
+              extraction_error: "Extraction failed before usable checklist evidence was saved.",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "checklist-item-empty",
+              section_key: "behavior_summary",
+              label: "Behavior Summary",
+              placeholder_key: "behavior_summary",
+              required: true,
+              mode: "AUTO",
+              status: "drafted",
+              review_notes: null,
+              value_text: "   ",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <ProgramsGoalsTab client={buildClient()} />,
+      {
+        auth: {
+          role: "therapist",
+          organizationId: ORG_ID,
+          accessToken: "test-access-token",
+        },
+      },
+    );
+
+    await screen.findByText("empty-failed-fba.pdf");
     expect(
-      vi.mocked(callApi).mock.calls.some(
-        ([path, init]) => path === "/api/assessment-drafts" && (init?.method ?? "").toUpperCase() === "POST",
+      await screen.findByText(
+        "Extraction failed for this assessment, but no extracted checklist evidence is available for AI proposal generation. Replace the source document or add checklist evidence before retrying.",
       ),
+    ).toBeInTheDocument();
+
+    const generateButton = await screen.findByRole("button", { name: /Generate with AI from Uploaded FBA/i });
+    expect(generateButton).toBeDisabled();
+    expect(
+      vi.mocked(callApi).mock.calls.some(([path, init]) => path === "/api/assessment-drafts" && init?.method === "POST"),
     ).toBe(false);
   });
 
@@ -1482,76 +1584,6 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       expect(generateButton).toBeDisabled();
     });
     expect(await screen.findByText("Wait for extraction to complete before generating AI proposals.")).toBeInTheDocument();
-    expect(generateButton).toHaveAttribute("title", "Wait for extraction to complete before generating AI proposals.");
-
-    await user.click(generateButton);
-
-    expect(
-      vi.mocked(callApi).mock.calls.some(
-        ([path, init]) => path === "/api/assessment-drafts" && (init?.method ?? "").toUpperCase() === "POST",
-      ),
-    ).toBe(false);
-  });
-
-  it("shows extraction-failed guidance and disables uploaded FBA generation", async () => {
-    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
-      const method = (init?.method ?? "GET").toUpperCase();
-      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
-      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
-      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
-      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
-        return new Response(
-          JSON.stringify([
-            {
-              id: ASSESSMENT_ID,
-              organization_id: ORG_ID,
-              client_id: "client-1",
-              template_type: "caloptima_fba",
-              file_name: "synthetic-fba.pdf",
-              mime_type: "application/pdf",
-              file_size: 1234,
-              bucket_id: "client-documents",
-              object_path: "clients/client-1/assessments/synthetic-fba.pdf",
-              status: "extraction_failed",
-              extraction_error: "Extraction failed. Manual notes fallback or re-upload is required.",
-              created_at: "2026-02-11T00:00:00.000Z",
-            },
-          ]),
-          { status: 200 },
-        );
-      }
-      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
-        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
-      }
-      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
-    });
-
-    renderWithProviders(
-      <ProgramsGoalsTab client={buildClient()} />,
-      {
-        auth: {
-          role: "therapist",
-          organizationId: ORG_ID,
-          accessToken: "test-access-token",
-        },
-      },
-    );
-
-    const generateButton = await screen.findByRole("button", { name: /Generate with AI from Uploaded FBA/i });
-    await waitFor(() => {
-      expect(generateButton).toBeDisabled();
-    });
-    expect(
-      await screen.findByText("Extraction failed. Manual review/manual notes fallback or re-upload is required before generating AI proposals."),
-    ).toBeInTheDocument();
-    expect(generateButton).toHaveAttribute(
-      "title",
-      "Extraction failed. Manual review/manual notes fallback or re-upload is required before generating AI proposals.",
-    );
-    expect(screen.queryByText("Wait for extraction to complete before generating AI proposals.")).not.toBeInTheDocument();
 
     await user.click(generateButton);
 

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -199,7 +199,7 @@ describe("assessmentDraftsHandler", () => {
     expect(programPayload[0]?.confidence).toBe("medium");
   });
 
-  it("auto-generates staged drafts from extracted checklist values even when an extraction error is present", async () => {
+  it("auto-generates staged drafts from extracted checklist values", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -219,15 +219,7 @@ describe("assessmentDraftsHandler", () => {
         return {
           ok: true,
           status: 200,
-          data: [
-            {
-              id: "doc-1",
-              organization_id: "org-1",
-              client_id: "client-1",
-              status: "extracted",
-              extraction_error: "Automatic draft generation failed. You can retry with 'Generate with AI from Uploaded FBA'.",
-            },
-          ],
+          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
         };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?")) {
@@ -692,6 +684,120 @@ describe("assessmentDraftsHandler", () => {
       expect.stringContaining("/functions/v1/generate-program-goals"),
       expect.anything(),
     );
+  });
+
+  it("allows auto-generation retry after extraction failure and records the prior status", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extraction_failed" }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{ section_key: "summary", label: "Summary", status: "approved", value_text: "summary text", value_json: null }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_extractions?")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name")) {
+        return { ok: true, status: 200, data: [{ full_name: "Client One" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/ai_guidance_documents?")) {
+        return { ok: true, status: 200, data: [{ guidance_text: "Use concise ABA language." }] };
+      }
+      if (method === "POST" && url.includes("/functions/v1/generate-program-goals")) {
+        return {
+          ok: true,
+          status: 200,
+          data: {
+            programs: [
+              {
+                name: "Communication Program",
+                description: "Improve communication skills.",
+                rationale: "Program rationale.",
+                evidence_refs: [{ section_key: "assessment_summary", source_span: "Program evidence snippet" }],
+                review_flags: [],
+              },
+            ],
+            goals: buildTypedGoals(),
+            summary_rationale: "Generated from extracted field values.",
+            confidence: "medium",
+          },
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
+        return { ok: true, status: 201, data: [{ id: "draft-program-retry-1", name: "Communication Program" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_goals")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-1111-1111-111111111111",
+          auto_generate: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/generate-program-goals"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    const reviewEventCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(
+        ([url, init]) =>
+          typeof url === "string" &&
+          url.includes("/rest/v1/assessment_review_events") &&
+          (init?.method ?? "").toUpperCase() === "POST",
+      );
+    expect(reviewEventCall).toBeTruthy();
+    const reviewEventPayload = JSON.parse((reviewEventCall?.[1] as RequestInit).body as string) as Record<string, unknown>;
+    expect(reviewEventPayload).toMatchObject({
+      action: "drafts_generated",
+      from_status: "extraction_failed",
+      to_status: "drafted",
+      actor_id: "user-1",
+    });
   });
 
   it("keeps existing-draft conflict messaging for drafted assessments", async () => {

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -111,6 +111,8 @@ interface AssessmentDocumentScopeRow {
   status: string;
 }
 
+const AUTO_GENERATE_READY_DOCUMENT_STATUSES = new Set(["extracted", "extraction_failed"]);
+
 interface AssessmentDraftProgramRow {
   id: string;
   assessment_document_id: string;
@@ -359,7 +361,7 @@ const persistDraftRows = async (args: {
       item_type: "document",
       item_id: document.id,
       action: "drafts_generated",
-      from_status: "extracted",
+      from_status: document.status,
       to_status: "drafted",
       actor_id: actorId,
     }),
@@ -502,7 +504,7 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
       return json({ error: "Drafts already exist for this assessment. Review existing drafts instead of regenerating." }, 409);
     }
 
-    if (document.status !== "extracted") {
+    if (!AUTO_GENERATE_READY_DOCUMENT_STATUSES.has(document.status)) {
       return json({ error: "Assessment extraction must complete before AI proposals can be generated." }, 409);
     }
 


### PR DESCRIPTION
## Summary
- allow uploaded assessment AI draft retry after `extraction_failed` when checklist evidence is present
- keep the retry path disabled when no usable checklist evidence exists
- align the server assessment-drafts handler and audit event status tracking with the UI retry path

## Verification
- npm test -- --run src/components/__tests__/ProgramsGoalsTab.test.tsx src/server/__tests__/assessmentDraftsHandler.test.ts
- npm run verify:local

## Linear
- WIN-144

## Risk
- Protected-path touch: `src/server/api/assessment-drafts.ts`
- No auth, RLS, migration, CI, or secret handling changes
