### PR TITLE
WIN-146 Harden CalOptima redacted FBA extraction

### DIFF
--- a/docs/fill_docs/CALOPTIMA_FBA_FIELD_EXTRACTION_CHECKLIST.md
+++ b/docs/fill_docs/CALOPTIMA_FBA_FIELD_EXTRACTION_CHECKLIST.md
@@ -4,7 +4,6 @@ Template: `CalOptima Health Functional Behavior Assessment / Initial Treatment P
 
 Source mapping: `docs/fill_docs/caloptima_fba_template_field_map.json`
 Source document reviewed: `7.21.2025_RoVa_CalOptima_FBA_FINAL (1).Redacted.docx.pdf`
-PDF render map (for completed PDF output): `docs/fill_docs/caloptima_fba_pdf_render_map.json`
 
 ## Checklist schema and workflow rules
 
@@ -65,25 +64,25 @@ PDF render map (for completed PDF output): `docs/fill_docs/caloptima_fba_pdf_ren
 
 | Label | Placeholder key | Mode | Required | Extraction method | Validation rule | Extraction owner | Review owner | Status | Review notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Coordination of care sections | `CALOPTIMA_FBA_COORDINATION_OF_CARE` | MANUAL | true | clinician_manual_entry | non_empty_text | ClinicalAuthor | BCBAReviewer | not_started | Parent/school/regional center/speech-OT-PT/PCP/MH narratives. |
-| Vineland domain score table | `CALOPTIMA_FBA_VINELAND_DOMAIN_SCORES` | MANUAL | true | clinician_manual_entry | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Structured instrument output. |
+| Coordination of care sections | `CALOPTIMA_FBA_COORDINATION_OF_CARE` | MANUAL | true | deterministic_structured_extraction_plus_review | non_empty_text | ClinicalAuthor | BCBAReviewer | not_started | Parent/school/regional center/speech-OT-PT/PCP/MH narratives. |
+| Vineland domain score table | `CALOPTIMA_FBA_VINELAND_DOMAIN_SCORES` | MANUAL | true | deterministic_structured_extraction_plus_review | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Structured instrument output. |
 
 ## Diagnostic and Behavior Analysis
 
 | Label | Placeholder key | Mode | Required | Extraction method | Validation rule | Extraction owner | Review owner | Status | Review notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Current diagnosis code(s) | `CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES` | AUTO | true | database_prefill | non_empty_text | IntakeCoordinator | ClinicalReviewer | not_started |  |
-| Target behavior blocks | `CALOPTIMA_FBA_TARGET_BEHAVIOR_BLOCKS` | MANUAL | true | clinician_manual_entry | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Includes identifying behavior/history/ABC/function. |
-| Behavior intervention plan blocks | `CALOPTIMA_FBA_BIP_BLOCKS` | MANUAL | true | clinician_manual_entry | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Ecological/replacement/focused/reactive/data procedures. |
+| Target behavior blocks | `CALOPTIMA_FBA_TARGET_BEHAVIOR_BLOCKS` | MANUAL | true | deterministic_structured_extraction_plus_review | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Includes identifying behavior/history/ABC/function. |
+| Behavior intervention plan blocks | `CALOPTIMA_FBA_BIP_BLOCKS` | MANUAL | true | deterministic_structured_extraction_plus_review | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Ecological/replacement/focused/reactive/data procedures. |
 | Crisis plan | `CALOPTIMA_FBA_CRISIS_PLAN` | MANUAL | true | clinician_manual_entry | non_empty_text | ClinicalAuthor | BCBAReviewer | not_started | Preventative, response, and post-crisis protocol narrative. |
 
 ## Goals and Treatment Planning
 
 | Label | Placeholder key | Mode | Required | Extraction method | Validation rule | Extraction owner | Review owner | Status | Review notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Target and replacement behavior goals | `CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS` | MANUAL | true | clinician_manual_entry | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Repeating LT/IT/ST goals plus baseline and settings. |
-| Skill acquisition goals | `CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS` | MANUAL | true | clinician_manual_entry | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Communication/daily living/social/self-direction blocks. |
-| Parent/Caregiver goals | `CALOPTIMA_FBA_PARENT_GOALS` | MANUAL | true | clinician_manual_entry | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Repeating LT/IT/ST goals with baseline and setting. |
+| Target and replacement behavior goals | `CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS` | MANUAL | true | deterministic_structured_extraction_plus_review | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Repeating LT/IT/ST goals plus baseline and settings. |
+| Skill acquisition goals | `CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS` | MANUAL | true | deterministic_structured_extraction_plus_review | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Communication/daily living/social/self-direction blocks. |
+| Parent/Caregiver goals | `CALOPTIMA_FBA_PARENT_GOALS` | MANUAL | true | deterministic_structured_extraction_plus_review | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Repeating LT/IT/ST goals with baseline and setting. |
 | Generalization and maintenance plan | `CALOPTIMA_FBA_GENERALIZATION_MAINTENANCE_PLAN` | MANUAL | true | clinician_manual_entry | non_empty_text | ClinicalAuthor | BCBAReviewer | not_started | Includes procedural reliability, reinforcement thinning, family training. |
 | Transition plan and exit criteria | `CALOPTIMA_FBA_TRANSITION_PLAN` | MANUAL | true | clinician_manual_entry | non_empty_text | ClinicalAuthor | BCBAReviewer | not_started | Checkboxes + required prompts. |
 
@@ -92,11 +91,11 @@ PDF render map (for completed PDF output): `docs/fill_docs/caloptima_fba_pdf_ren
 | Label | Placeholder key | Mode | Required | Extraction method | Validation rule | Extraction owner | Review owner | Status | Review notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Summary and recommendations | `CALOPTIMA_FBA_SUMMARY_RECOMMENDATIONS` | MANUAL | true | clinician_manual_entry | non_empty_text | ClinicalAuthor | BCBAReviewer | not_started | Clinical rationale for requested hours. |
-| HCPCS recommendation rows | `CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS` | ASSISTED | true | assisted_draft_plus_review | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Structured code/units/hours/location rows. |
+| HCPCS recommendation rows | `CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS` | ASSISTED | true | deterministic_structured_extraction_plus_review | structured_payload_required | ClinicalAuthor | BCBAReviewer | not_started | Structured code/units/hours/location rows. |
 | Telehealth consent confirmation | `CALOPTIMA_FBA_TELEHEALTH_CONSENT` | MANUAL | true | clinician_manual_entry | checkbox_yes_no_or_na | ClinicalAuthor | BCBAReviewer | not_started | Checkbox + consent date. |
 | Parent/guardian involvement | `CALOPTIMA_FBA_PARENT_INVOLVEMENT` | MANUAL | true | clinician_manual_entry | checkbox_yes_no_or_na | ClinicalAuthor | BCBAReviewer | not_started | Yes/No responses + explanation. |
 | Report written by | `CALOPTIMA_FBA_REPORT_WRITTEN_BY` | AUTO | true | database_prefill | non_empty_text | IntakeCoordinator | ClinicalReviewer | not_started |  |
 | Title, License/Certificate # | `CALOPTIMA_FBA_WRITER_CREDENTIALS` | AUTO | true | database_prefill | non_empty_text | IntakeCoordinator | ClinicalReviewer | not_started |  |
 | Date of Report Completed | `CALOPTIMA_FBA_REPORT_COMPLETED_DATE` | AUTO | true | database_prefill | date_mm_dd_yyyy_or_na | IntakeCoordinator | ClinicalReviewer | not_started |  |
-| Writer and reviewer signatures | `CALOPTIMA_FBA_SIGNATURES` | MANUAL | true | clinician_manual_entry | signature_and_date_present | ClinicalAuthor | BCBAReviewer | not_started | Signature capture/approval workflow. |
+| Writer and reviewer signatures | `CALOPTIMA_FBA_SIGNATURES` | MANUAL | true | deterministic_structured_extraction_plus_review | signature_and_date_present | ClinicalAuthor | BCBAReviewer | not_started | Signature capture/approval workflow. |
 

--- a/docs/fill_docs/caloptima_fba_field_extraction_checklist.json
+++ b/docs/fill_docs/caloptima_fba_field_extraction_checklist.json
@@ -138,7 +138,11 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "prefill_verify_when_source_exists"
+      "review_behavior": "prefill_verify_when_source_exists",
+      "extraction_aliases": [
+        "Phone",
+        "Guardian Name Phone"
+      ]
     },
     {
       "section": "identification_admin",
@@ -306,7 +310,11 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "prefill_verify_when_source_exists"
+      "review_behavior": "prefill_verify_when_source_exists",
+      "extraction_aliases": [
+        "Administrative Contact for Current Authorization Request Full Name and Title",
+        "Full Name and Title"
+      ]
     },
     {
       "section": "identification_admin",
@@ -327,7 +335,11 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "prefill_verify_when_source_exists"
+      "review_behavior": "prefill_verify_when_source_exists",
+      "extraction_aliases": [
+        "Administrative Contact for Current Authorization Request Phone Number",
+        "Phone Number"
+      ]
     },
     {
       "section": "identification_admin",
@@ -348,7 +360,11 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "clinician_verify_assisted_draft"
+      "review_behavior": "clinician_verify_assisted_draft",
+      "extraction_aliases": [
+        "Administrative Contact for Current Authorization Request Fax Number",
+        "Fax Number"
+      ]
     },
     {
       "section": "identification_admin",
@@ -369,7 +385,11 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "clinician_manual_entry_required"
+      "review_behavior": "clinician_manual_entry_required",
+      "extraction_aliases": [
+        "Chief Complaint/Reason for Seeking Applied Behavior Analysis (ABA) Treatment",
+        "Chief Complaint/Reason for Seeking ABA Treatment"
+      ]
     },
     {
       "section": "data_sources_interviews",
@@ -391,7 +411,10 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "structured_clinical_review_required"
+      "review_behavior": "structured_clinical_review_required",
+      "extraction_aliases": [
+        "Records Reviewed"
+      ]
     },
     {
       "section": "data_sources_interviews",
@@ -496,7 +519,10 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "clinician_manual_entry_required"
+      "review_behavior": "clinician_manual_entry_required",
+      "extraction_aliases": [
+        "Does the member have a current Individualized Educational Plan (IEP/equivalent)?"
+      ]
     },
     {
       "section": "background_school_history",
@@ -517,7 +543,11 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "clinician_verify_assisted_draft"
+      "review_behavior": "clinician_verify_assisted_draft",
+      "extraction_aliases": [
+        "Date of the current IEP/equivalent",
+        "Date of current IEP/equivalent"
+      ]
     },
     {
       "section": "background_school_history",
@@ -548,7 +578,7 @@
       "mode": "MANUAL",
       "source": "N/A",
       "required": true,
-      "extraction_method": "clinician_manual_entry",
+      "extraction_method": "deterministic_structured_extraction_plus_review",
       "validation_rule": "non_empty_text",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
@@ -561,7 +591,14 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "structured_clinical_review_required"
+      "review_behavior": "structured_clinical_review_required",
+      "extraction_aliases": [
+        "IV. COORDINATION OF CARE",
+        "COORDINATION OF CARE",
+        "Parent/Caregiver:",
+        "Speech/OT/PT:",
+        "Primary Care Provider/Specialist:"
+      ]
     },
     {
       "section": "coordination_adaptive_testing",
@@ -570,7 +607,7 @@
       "mode": "MANUAL",
       "source": "N/A",
       "required": true,
-      "extraction_method": "clinician_manual_entry",
+      "extraction_method": "deterministic_structured_extraction_plus_review",
       "validation_rule": "structured_payload_required",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
@@ -583,7 +620,13 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "structured_clinical_review_required"
+      "review_behavior": "structured_clinical_review_required",
+      "extraction_aliases": [
+        "Vineland Adaptive Behavior Scales, Third Edition",
+        "Domain Raw Score Standard Score V-Scale Score Age Equivalent",
+        "Vineland-3 Scoring Information",
+        "Domain Raw Score Standard Score/V-Scale Score Age Equivalent"
+      ]
     },
     {
       "section": "diagnostic_behavior_analysis",
@@ -604,21 +647,27 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "prefill_verify_when_source_exists"
+      "review_behavior": "prefill_verify_when_source_exists",
+      "extraction_aliases": [
+        "Diagnosis description Date of diagnosis/report Diagnosed by",
+        "Diagnosed by (Full Name & credential)",
+        "F84.0 Autism",
+        "Current diagnosis code"
+      ]
     },
     {
       "section": "diagnostic_behavior_analysis",
       "label": "Target behavior blocks",
       "placeholder_key": "CALOPTIMA_FBA_TARGET_BEHAVIOR_BLOCKS",
-      "mode": "ASSISTED",
-      "source": "uploaded_assessment_document",
+      "mode": "MANUAL",
+      "source": "N/A",
       "required": true,
-      "extraction_method": "ai_structured_recommendation",
+      "extraction_method": "deterministic_structured_extraction_plus_review",
       "validation_rule": "structured_payload_required",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
       "review_owner": "BCBAReviewer",
-      "review_notes": "AI-assisted structured extraction for behavior/history/ABC/function, with clinician verification.",
+      "review_notes": "Includes identifying behavior/history/ABC/function.",
       "input_type": "structured_section",
       "destination": "assessment_checklist.value_json",
       "structured_section": "target_behavior_blocks",
@@ -626,7 +675,13 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "structured_clinical_review_required"
+      "review_behavior": "structured_clinical_review_required",
+      "extraction_aliases": [
+        "X. FUNCTIONAL ASSESSMENT OR ANALYSIS OF TARGET BEHAVIORS",
+        "Target Behavior 1:",
+        "Operational Definition",
+        "Antecedent Analysis"
+      ]
     },
     {
       "section": "diagnostic_behavior_analysis",
@@ -635,7 +690,7 @@
       "mode": "MANUAL",
       "source": "N/A",
       "required": true,
-      "extraction_method": "clinician_manual_entry",
+      "extraction_method": "deterministic_structured_extraction_plus_review",
       "validation_rule": "structured_payload_required",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
@@ -648,21 +703,27 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "structured_clinical_review_required"
+      "review_behavior": "structured_clinical_review_required",
+      "extraction_aliases": [
+        "XI. BEHAVIOR INTERVENTION PLAN",
+        "Ecological interventions",
+        "Focused intervention strategies",
+        "Data collection procedures"
+      ]
     },
     {
       "section": "goals_treatment_planning",
       "label": "Target and replacement behavior goals",
       "placeholder_key": "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
-      "mode": "ASSISTED",
-      "source": "uploaded_assessment_document",
+      "mode": "MANUAL",
+      "source": "N/A",
       "required": true,
-      "extraction_method": "ai_structured_recommendation",
+      "extraction_method": "deterministic_structured_extraction_plus_review",
       "validation_rule": "structured_payload_required",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
       "review_owner": "BCBAReviewer",
-      "review_notes": "AI-assisted extraction for goals, baseline, criteria, and data settings; BCBA review required.",
+      "review_notes": "Repeating LT/IT/ST goals plus baseline and settings.",
       "input_type": "structured_section",
       "destination": "assessment_checklist.value_json",
       "structured_section": "target_replacement_goals",
@@ -670,21 +731,26 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "structured_clinical_review_required"
+      "review_behavior": "structured_clinical_review_required",
+      "extraction_aliases": [
+        "XIV. TARGET AND REPLACEMENT BEHAVIOR GOALS",
+        "Target Behavior Goal",
+        "Replacement Behavior Goal"
+      ]
     },
     {
       "section": "goals_treatment_planning",
       "label": "Skill acquisition goals",
       "placeholder_key": "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
-      "mode": "ASSISTED",
-      "source": "uploaded_assessment_document",
+      "mode": "MANUAL",
+      "source": "N/A",
       "required": true,
-      "extraction_method": "ai_structured_recommendation",
+      "extraction_method": "deterministic_structured_extraction_plus_review",
       "validation_rule": "structured_payload_required",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
       "review_owner": "BCBAReviewer",
-      "review_notes": "AI-assisted extraction for skill goals and objective data points; BCBA review required.",
+      "review_notes": "Communication/daily living/social/self-direction blocks.",
       "input_type": "structured_section",
       "destination": "assessment_checklist.value_json",
       "structured_section": "skill_acquisition_goals",
@@ -692,21 +758,26 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "structured_clinical_review_required"
+      "review_behavior": "structured_clinical_review_required",
+      "extraction_aliases": [
+        "Skill Acquisition Goal",
+        "A. Intervention Area",
+        "Location/setting of skill acquisition goal"
+      ]
     },
     {
       "section": "goals_treatment_planning",
       "label": "Parent/Caregiver goals",
       "placeholder_key": "CALOPTIMA_FBA_PARENT_GOALS",
-      "mode": "ASSISTED",
-      "source": "uploaded_assessment_document",
+      "mode": "MANUAL",
+      "source": "N/A",
       "required": true,
-      "extraction_method": "ai_structured_recommendation",
+      "extraction_method": "deterministic_structured_extraction_plus_review",
       "validation_rule": "structured_payload_required",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
       "review_owner": "BCBAReviewer",
-      "review_notes": "AI-assisted extraction for caregiver goals with baseline/settings and data-point context.",
+      "review_notes": "Repeating LT/IT/ST goals with baseline and setting.",
       "input_type": "structured_section",
       "destination": "assessment_checklist.value_json",
       "structured_section": "parent_caregiver_goals",
@@ -714,28 +785,38 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "structured_clinical_review_required"
+      "review_behavior": "structured_clinical_review_required",
+      "extraction_aliases": [
+        "XVI. PARENT/CAREGIVER GOALS",
+        "Parent/Caregiver Goal",
+        "Participants in Parent Training"
+      ]
     },
     {
       "section": "goals_treatment_planning",
       "label": "Generalization and maintenance plan",
       "placeholder_key": "CALOPTIMA_FBA_GENERALIZATION_MAINTENANCE_PLAN",
-      "mode": "ASSISTED",
-      "source": "uploaded_assessment_document",
+      "mode": "MANUAL",
+      "source": "N/A",
       "required": true,
-      "extraction_method": "ai_structured_recommendation",
+      "extraction_method": "clinician_manual_entry",
       "validation_rule": "non_empty_text",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
       "review_owner": "BCBAReviewer",
-      "review_notes": "AI-assisted extraction for maintenance/generalization criteria and plan details.",
+      "review_notes": "Includes procedural reliability, reinforcement thinning, family training.",
       "input_type": "multiline_text",
       "destination": "assessment_checklist.value_text",
       "pdf_render": {
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "clinician_verify_assisted_draft"
+      "review_behavior": "clinician_manual_entry_required",
+      "extraction_aliases": [
+        "PLAN FOR GENERALIZATION",
+        "Generalization and Maintenance Plan",
+        "Transition to Natural Mediators"
+      ]
     },
     {
       "section": "goals_treatment_planning",
@@ -756,7 +837,12 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "clinician_manual_entry_required"
+      "review_behavior": "clinician_manual_entry_required",
+      "extraction_aliases": [
+        "XIII. TRANSITION PLAN",
+        "Please list exit plan/criteria",
+        "Final treatment report"
+      ]
     },
     {
       "section": "diagnostic_behavior_analysis",
@@ -807,7 +893,7 @@
       "mode": "ASSISTED",
       "source": "authorization/planning payload",
       "required": true,
-      "extraction_method": "assisted_draft_plus_review",
+      "extraction_method": "deterministic_structured_extraction_plus_review",
       "validation_rule": "structured_payload_required",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
@@ -820,7 +906,12 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "structured_clinical_review_required"
+      "review_behavior": "structured_clinical_review_required",
+      "extraction_aliases": [
+        "HCPCS Code and Modifiers Description",
+        "Total Hours Requested Per Month",
+        "Total Units Requested Per 6 Month"
+      ]
     },
     {
       "section": "summary_recommendations_signatures",
@@ -862,7 +953,12 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "clinician_manual_entry_required"
+      "review_behavior": "clinician_manual_entry_required",
+      "extraction_aliases": [
+        "XXI. PARENT/CAREGIVER OR LEGAL GUARDIAN INVOLVEMENT",
+        "Was the Parent/guardian involved in the development of the treatment plan",
+        "Is the parent/guardian in agreement with the submitted treatment plan"
+      ]
     },
     {
       "section": "summary_recommendations_signatures",
@@ -934,7 +1030,7 @@
       "mode": "MANUAL",
       "source": "N/A",
       "required": true,
-      "extraction_method": "clinician_manual_entry",
+      "extraction_method": "deterministic_structured_extraction_plus_review",
       "validation_rule": "signature_and_date_present",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
@@ -947,7 +1043,14 @@
         "target": "caloptima_fba_pdf_render_map",
         "not_exported": false
       },
-      "review_behavior": "structured_clinical_review_required"
+      "review_behavior": "structured_clinical_review_required",
+      "extraction_aliases": [
+        "XVIII. SIGNATURES",
+        "Report written by:",
+        "Report reviewed by:",
+        "Signature:",
+        "Date of Report Completed"
+      ]
     }
   ]
 }

--- a/docs/fill_docs/caloptima_fba_template_field_map.json
+++ b/docs/fill_docs/caloptima_fba_template_field_map.json
@@ -85,7 +85,11 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "prefill_verify_when_source_exists"
+        "review_behavior": "prefill_verify_when_source_exists",
+        "extraction_aliases": [
+          "Phone",
+          "Guardian Name Phone"
+        ]
       },
       {
         "label": "Primary Care Provider",
@@ -197,7 +201,11 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "prefill_verify_when_source_exists"
+        "review_behavior": "prefill_verify_when_source_exists",
+        "extraction_aliases": [
+          "Administrative Contact for Current Authorization Request Full Name and Title",
+          "Full Name and Title"
+        ]
       },
       {
         "label": "Administrative Contact Phone Number",
@@ -211,7 +219,11 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "prefill_verify_when_source_exists"
+        "review_behavior": "prefill_verify_when_source_exists",
+        "extraction_aliases": [
+          "Administrative Contact for Current Authorization Request Phone Number",
+          "Phone Number"
+        ]
       },
       {
         "label": "Administrative Contact Fax Number",
@@ -225,7 +237,11 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "clinician_verify_assisted_draft"
+        "review_behavior": "clinician_verify_assisted_draft",
+        "extraction_aliases": [
+          "Administrative Contact for Current Authorization Request Fax Number",
+          "Fax Number"
+        ]
       },
       {
         "label": "Chief Complaint/Reason for Seeking ABA Treatment",
@@ -239,7 +255,11 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "clinician_manual_entry_required"
+        "review_behavior": "clinician_manual_entry_required",
+        "extraction_aliases": [
+          "Chief Complaint/Reason for Seeking Applied Behavior Analysis (ABA) Treatment",
+          "Chief Complaint/Reason for Seeking ABA Treatment"
+        ]
       },
       {
         "label": "Records Reviewed (table)",
@@ -254,7 +274,10 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "structured_clinical_review_required"
+        "review_behavior": "structured_clinical_review_required",
+        "extraction_aliases": [
+          "Records Reviewed"
+        ]
       },
       {
         "label": "Initial Interview/Observation",
@@ -324,7 +347,10 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "clinician_manual_entry_required"
+        "review_behavior": "clinician_manual_entry_required",
+        "extraction_aliases": [
+          "Does the member have a current Individualized Educational Plan (IEP/equivalent)?"
+        ]
       },
       {
         "label": "Date of current IEP/equivalent",
@@ -338,7 +364,11 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "clinician_verify_assisted_draft"
+        "review_behavior": "clinician_verify_assisted_draft",
+        "extraction_aliases": [
+          "Date of the current IEP/equivalent",
+          "Date of current IEP/equivalent"
+        ]
       },
       {
         "label": "Previous interventions",
@@ -368,7 +398,14 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "structured_clinical_review_required"
+        "review_behavior": "structured_clinical_review_required",
+        "extraction_aliases": [
+          "IV. COORDINATION OF CARE",
+          "COORDINATION OF CARE",
+          "Parent/Caregiver:",
+          "Speech/OT/PT:",
+          "Primary Care Provider/Specialist:"
+        ]
       },
       {
         "label": "Vineland domain score table",
@@ -383,7 +420,13 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "structured_clinical_review_required"
+        "review_behavior": "structured_clinical_review_required",
+        "extraction_aliases": [
+          "Vineland Adaptive Behavior Scales, Third Edition",
+          "Domain Raw Score Standard Score V-Scale Score Age Equivalent",
+          "Vineland-3 Scoring Information",
+          "Domain Raw Score Standard Score/V-Scale Score Age Equivalent"
+        ]
       },
       {
         "label": "Current diagnosis code(s)",
@@ -397,7 +440,13 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "prefill_verify_when_source_exists"
+        "review_behavior": "prefill_verify_when_source_exists",
+        "extraction_aliases": [
+          "Diagnosis description Date of diagnosis/report Diagnosed by",
+          "Diagnosed by (Full Name & credential)",
+          "F84.0 Autism",
+          "Current diagnosis code"
+        ]
       },
       {
         "label": "Target behavior blocks",
@@ -412,7 +461,13 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "structured_clinical_review_required"
+        "review_behavior": "structured_clinical_review_required",
+        "extraction_aliases": [
+          "X. FUNCTIONAL ASSESSMENT OR ANALYSIS OF TARGET BEHAVIORS",
+          "Target Behavior 1:",
+          "Operational Definition",
+          "Antecedent Analysis"
+        ]
       },
       {
         "label": "Behavior intervention plan blocks",
@@ -427,7 +482,13 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "structured_clinical_review_required"
+        "review_behavior": "structured_clinical_review_required",
+        "extraction_aliases": [
+          "XI. BEHAVIOR INTERVENTION PLAN",
+          "Ecological interventions",
+          "Focused intervention strategies",
+          "Data collection procedures"
+        ]
       },
       {
         "label": "Target and replacement behavior goals",
@@ -442,7 +503,12 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "structured_clinical_review_required"
+        "review_behavior": "structured_clinical_review_required",
+        "extraction_aliases": [
+          "XIV. TARGET AND REPLACEMENT BEHAVIOR GOALS",
+          "Target Behavior Goal",
+          "Replacement Behavior Goal"
+        ]
       },
       {
         "label": "Skill acquisition goals",
@@ -457,7 +523,12 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "structured_clinical_review_required"
+        "review_behavior": "structured_clinical_review_required",
+        "extraction_aliases": [
+          "Skill Acquisition Goal",
+          "A. Intervention Area",
+          "Location/setting of skill acquisition goal"
+        ]
       },
       {
         "label": "Parent/Caregiver goals",
@@ -472,7 +543,12 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "structured_clinical_review_required"
+        "review_behavior": "structured_clinical_review_required",
+        "extraction_aliases": [
+          "XVI. PARENT/CAREGIVER GOALS",
+          "Parent/Caregiver Goal",
+          "Participants in Parent Training"
+        ]
       },
       {
         "label": "Generalization and maintenance plan",
@@ -486,7 +562,12 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "clinician_manual_entry_required"
+        "review_behavior": "clinician_manual_entry_required",
+        "extraction_aliases": [
+          "PLAN FOR GENERALIZATION",
+          "Generalization and Maintenance Plan",
+          "Transition to Natural Mediators"
+        ]
       },
       {
         "label": "Transition plan and exit criteria",
@@ -500,7 +581,12 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "clinician_manual_entry_required"
+        "review_behavior": "clinician_manual_entry_required",
+        "extraction_aliases": [
+          "XIII. TRANSITION PLAN",
+          "Please list exit plan/criteria",
+          "Final treatment report"
+        ]
       },
       {
         "label": "Crisis plan",
@@ -543,7 +629,12 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "structured_clinical_review_required"
+        "review_behavior": "structured_clinical_review_required",
+        "extraction_aliases": [
+          "HCPCS Code and Modifiers Description",
+          "Total Hours Requested Per Month",
+          "Total Units Requested Per 6 Month"
+        ]
       },
       {
         "label": "Telehealth consent confirmation",
@@ -571,7 +662,12 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "clinician_manual_entry_required"
+        "review_behavior": "clinician_manual_entry_required",
+        "extraction_aliases": [
+          "XXI. PARENT/CAREGIVER OR LEGAL GUARDIAN INVOLVEMENT",
+          "Was the Parent/guardian involved in the development of the treatment plan",
+          "Is the parent/guardian in agreement with the submitted treatment plan"
+        ]
       },
       {
         "label": "Report written by",
@@ -628,7 +724,14 @@
           "target": "caloptima_fba_pdf_render_map",
           "not_exported": false
         },
-        "review_behavior": "structured_clinical_review_required"
+        "review_behavior": "structured_clinical_review_required",
+        "extraction_aliases": [
+          "XVIII. SIGNATURES",
+          "Report written by:",
+          "Report reviewed by:",
+          "Signature:",
+          "Date of Report Completed"
+        ]
       }
     ],
     "existing_placeholders": []

--- a/docs/fill_docs/tools/generate_caloptima_checklist.py
+++ b/docs/fill_docs/tools/generate_caloptima_checklist.py
@@ -123,6 +123,23 @@ def infer_extraction_method(mode: str) -> str:
     return "clinician_manual_entry"
 
 
+def override_extraction_method(placeholder_key: str, inferred_method: str) -> str:
+    deterministic_structured_keys = {
+        "CALOPTIMA_FBA_COORDINATION_OF_CARE",
+        "CALOPTIMA_FBA_VINELAND_DOMAIN_SCORES",
+        "CALOPTIMA_FBA_TARGET_BEHAVIOR_BLOCKS",
+        "CALOPTIMA_FBA_BIP_BLOCKS",
+        "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+        "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+        "CALOPTIMA_FBA_PARENT_GOALS",
+        "CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS",
+        "CALOPTIMA_FBA_SIGNATURES",
+    }
+    if placeholder_key in deterministic_structured_keys:
+        return "deterministic_structured_extraction_plus_review"
+    return inferred_method
+
+
 def infer_required(mode: str, source: str) -> bool:
     if mode in {"ASSISTED", "MANUAL"}:
         return True
@@ -154,12 +171,18 @@ def build_rows(labels: list[dict[str, str]]) -> list[dict[str, object]]:
                 "mode": mode,
                 "source": source,
                 "required": infer_required(mode, source),
-                "extraction_method": infer_extraction_method(mode),
+                "extraction_method": override_extraction_method(placeholder_key, infer_extraction_method(mode)),
                 "validation_rule": infer_validation_rule(label, placeholder_key),
                 "status": "not_started",
                 "extraction_owner": extraction_owner,
                 "review_owner": review_owner,
                 "review_notes": item.get("notes", ""),
+                "input_type": item.get("input_type", ""),
+                "destination": item.get("destination", ""),
+                **({"structured_section": item["structured_section"]} if item.get("structured_section") else {}),
+                "pdf_render": item.get("pdf_render", {"target": "caloptima_fba_pdf_render_map", "not_exported": False}),
+                "review_behavior": item.get("review_behavior", ""),
+                **({"extraction_aliases": item["extraction_aliases"]} if item.get("extraction_aliases") else {}),
             }
         )
     return rows

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -214,6 +214,7 @@ describe("assessmentDocumentsHandler", () => {
         extraction_method: "database_prefill",
         validation_rule: "non_empty_text",
         status: "not_started",
+        extraction_aliases: ["Member full legal name"],
       },
     ]);
 
@@ -246,6 +247,13 @@ describe("assessmentDocumentsHandler", () => {
       expect.stringContaining("/functions/v1/extract-assessment-fields"),
       expect.objectContaining({ method: "POST" }),
     );
+    const extractionCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(([url]) => typeof url === "string" && url.includes("/functions/v1/extract-assessment-fields"));
+    const extractionPayload = JSON.parse(String((extractionCall?.[1] as RequestInit | undefined)?.body ?? "{}")) as {
+      checklist_rows?: Array<{ extraction_aliases?: string[] }>;
+    };
+    expect(extractionPayload.checklist_rows?.[0]?.extraction_aliases).toEqual(["Member full legal name"]);
     expect(loadChecklistTemplateRows).toHaveBeenCalledWith("caloptima_fba");
   });
 

--- a/src/server/__tests__/assessmentPlanPdfTemplate.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfTemplate.test.ts
@@ -7,6 +7,7 @@ import { buildCalOptimaTemplatePayload, loadCalOptimaPdfRenderMap } from "../ass
 const registryPath = resolve(process.cwd(), "docs", "fill_docs", "caloptima_fba_template_field_map.json");
 const checklistPath = resolve(process.cwd(), "docs", "fill_docs", "caloptima_fba_field_extraction_checklist.json");
 const renderMapPath = resolve(process.cwd(), "docs", "fill_docs", "caloptima_fba_pdf_render_map.json");
+const extractorPath = resolve(process.cwd(), "supabase", "functions", "extract-assessment-fields", "index.ts");
 
 const readJsonFile = async (path: string): Promise<Record<string, unknown>> => {
   return JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
@@ -18,6 +19,10 @@ const asRecord = (value: unknown): Record<string, unknown> => {
 
 const asRecordArray = (value: unknown): Record<string, unknown>[] => {
   return Array.isArray(value) ? value.map(asRecord) : [];
+};
+
+const asStringArray = (value: unknown): string[] => {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
 };
 
 const placeholderKeys = (entries: Record<string, unknown>[]): string[] => {
@@ -67,6 +72,72 @@ describe("CalOptima PDF render map", () => {
       expect(typeof pdfRender.not_exported).toBe("boolean");
       expect(label.review_behavior).toEqual(expect.any(String));
     });
+  });
+
+  it("keeps CalOptima extraction metadata deterministic and alias-backed for redacted report headings", async () => {
+    const [registry, checklist] = await Promise.all([readJsonFile(registryPath), readJsonFile(checklistPath)]);
+    const registryLabels = asRecordArray(asRecord(registry.FBA).labels);
+    const checklistRows = asRecordArray(checklist.rows);
+    const rowsByKey = new Map(checklistRows.map((row) => [row.placeholder_key, row]));
+    const aliasRequiredKeys = [
+      "CALOPTIMA_FBA_ADMIN_CONTACT_NAME_TITLE",
+      "CALOPTIMA_FBA_CHIEF_COMPLAINT",
+      "CALOPTIMA_FBA_RECORDS_REVIEWED",
+      "CALOPTIMA_FBA_HAS_IEP",
+      "CALOPTIMA_FBA_IEP_DATE",
+      "CALOPTIMA_FBA_COORDINATION_OF_CARE",
+      "CALOPTIMA_FBA_VINELAND_DOMAIN_SCORES",
+      "CALOPTIMA_FBA_TARGET_BEHAVIOR_BLOCKS",
+      "CALOPTIMA_FBA_BIP_BLOCKS",
+      "CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS",
+      "CALOPTIMA_FBA_PARENT_INVOLVEMENT",
+      "CALOPTIMA_FBA_SIGNATURES",
+    ];
+
+    checklistRows.forEach((row) => {
+      expect(JSON.stringify(row).toLowerCase()).not.toContain("openai");
+      expect(String(row.extraction_method).toLowerCase()).not.toContain("ai");
+    });
+
+    aliasRequiredKeys.forEach((key) => {
+      const registryLabel = asRecord(registryLabels.find((label) => label.placeholder_key === key));
+      const checklistRow = asRecord(rowsByKey.get(key));
+
+      expect(asStringArray(registryLabel.extraction_aliases).length).toBeGreaterThan(0);
+      expect(asStringArray(checklistRow.extraction_aliases).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("keeps deterministic structured extraction metadata aligned with runtime structured outputs", async () => {
+    const checklist = await readJsonFile(checklistPath);
+    const rowsByKey = new Map(asRecordArray(checklist.rows).map((row) => [row.placeholder_key, row]));
+    const deterministicStructuredKeys = [
+      "CALOPTIMA_FBA_COORDINATION_OF_CARE",
+      "CALOPTIMA_FBA_VINELAND_DOMAIN_SCORES",
+      "CALOPTIMA_FBA_TARGET_BEHAVIOR_BLOCKS",
+      "CALOPTIMA_FBA_BIP_BLOCKS",
+      "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+      "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+      "CALOPTIMA_FBA_PARENT_GOALS",
+      "CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS",
+      "CALOPTIMA_FBA_SIGNATURES",
+    ];
+
+    deterministicStructuredKeys.forEach((key) => {
+      expect(asRecord(rowsByKey.get(key)).extraction_method).toBe("deterministic_structured_extraction_plus_review");
+    });
+  });
+
+  it("guards CalOptima parser section boundaries for redacted-template headings", async () => {
+    const extractorSource = await readFile(extractorPath, "utf8");
+
+    expect(extractorSource).not.toContain("isTargetBehaviorBlock");
+    expect(extractorSource).not.toContain('field_key: "CALOPTIMA_FBA_TRANSITION_PLAN"');
+    expect(extractorSource).toContain('/XII\\.\\s+/i');
+    expect(extractorSource).toContain('/\\*\\*\\s+By\\s+signing/i');
+    expect(extractorSource).toContain('"CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS"');
+    expect(extractorSource).not.toContain("CALOPTIMA_FBA_HCPCS_RECOMMENDATIONS");
+    expect(extractorSource).not.toContain("CALOPTIMA_FBA_DAILY_SCHEDULES");
   });
 
   it("represents structured section keys consistently across registry, checklist, and render map", async () => {

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -148,6 +148,7 @@ const runCaloptimaExtractionWorkflow = async (args: {
           label: row.label,
           placeholder_key: row.placeholder_key,
           required: row.required,
+          extraction_aliases: row.extraction_aliases ?? [],
         })),
         client_snapshot: clientSnapshot,
       }),

--- a/src/server/assessmentChecklistTemplate.ts
+++ b/src/server/assessmentChecklistTemplate.ts
@@ -14,6 +14,7 @@ export interface AssessmentChecklistSeedRow {
   extraction_owner?: string;
   review_owner?: string;
   review_notes?: string;
+  extraction_aliases?: string[];
 }
 
 interface ChecklistTemplateFile {
@@ -70,6 +71,9 @@ const normalizeRow = (row: unknown): AssessmentChecklistSeedRow | null => {
     extraction_owner: typeof candidate.extraction_owner === "string" ? candidate.extraction_owner : undefined,
     review_owner: typeof candidate.review_owner === "string" ? candidate.review_owner : undefined,
     review_notes: typeof candidate.review_notes === "string" ? candidate.review_notes : undefined,
+    extraction_aliases: Array.isArray(candidate.extraction_aliases)
+      ? candidate.extraction_aliases.filter((alias): alias is string => typeof alias === "string" && alias.trim().length > 0)
+      : undefined,
   };
 };
 

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -16,6 +16,7 @@ const checklistRowSchema = z.object({
   label: z.string().min(1),
   placeholder_key: z.string().min(1),
   required: z.boolean(),
+  extraction_aliases: z.array(z.string().min(1)).optional(),
 });
 
 const requestSchema = z.object({
@@ -158,12 +159,59 @@ const normalizeForContains = (value: string): string =>
     .replace(/\s+/g, " ")
     .trim();
 
+const compactForContains = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+
+const normalizeInlineText = (value: string): string =>
+  value
+    .replace(/\r/g, "\n")
+    .replace(/[ \t\f\v]+/g, " ")
+    .replace(/ *\n+ */g, "\n")
+    .trim();
+
+const compactDocumentText = (text: string): string => normalizeInlineText(text).replace(/\s+/g, " ").trim();
+
+const findAnchor = (text: string, anchors: RegExp[]): RegExpMatchArray | null => {
+  for (const anchor of anchors) {
+    const match = text.match(anchor);
+    if (match) {
+      return match;
+    }
+  }
+  return null;
+};
+
+const extractSectionText = (text: string, startAnchors: RegExp[], endAnchors: RegExp[]): string | null => {
+  const normalized = compactDocumentText(text);
+  const start = findAnchor(normalized, startAnchors);
+  if (!start || start.index === undefined) {
+    return null;
+  }
+  const startIndex = start.index;
+  const afterStart = normalized.slice(startIndex);
+  let endIndex = afterStart.length;
+  for (const endAnchor of endAnchors) {
+    const match = afterStart.match(endAnchor);
+    if (match?.index !== undefined && match.index > 0) {
+      endIndex = Math.min(endIndex, match.index);
+    }
+  }
+  const sectionText = afterStart.slice(0, endIndex).trim();
+  return sectionText.length >= 20 ? sectionText : null;
+};
+
 const calibrateDeterministicConfidence = (rowLabel: string, valueText: string, text: string): number => {
   const normalizedText = normalizeForContains(text);
   const normalizedValue = normalizeForContains(valueText);
   const normalizedLabel = normalizeForContains(rowLabel);
+  const compactText = compactForContains(text);
+  const compactLabel = compactForContains(rowLabel);
   const hasValueInText = normalizedValue.length >= 3 && normalizedText.includes(normalizedValue);
-  const hasLabelInText = normalizedLabel.length >= 3 && normalizedText.includes(normalizedLabel);
+  const hasLabelInText =
+    (normalizedLabel.length >= 3 && normalizedText.includes(normalizedLabel)) ||
+    (compactLabel.length >= 3 && compactText.includes(compactLabel));
 
   let confidence = 0.88;
   if (hasValueInText) {
@@ -175,23 +223,46 @@ const calibrateDeterministicConfidence = (rowLabel: string, valueText: string, t
   return clampConfidence(confidence);
 };
 
+const extractLineNearLabels = (text: string, labels: string[]): { value: string; label: string } | null => {
+  const normalizedText = compactDocumentText(text);
+  for (const label of labels) {
+    const direct = extractLineNearLabel(text, label);
+    if (direct) {
+      return { value: direct, label };
+    }
+
+    const escapedLabel = label
+      .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+      .replace(/\s+/g, "\\s+");
+    const normalizedMatch = normalizedText.match(new RegExp(`${escapedLabel}\\s*[:\\-]?\\s*(.{2,220})`, "i"));
+    if (normalizedMatch?.[1]) {
+      const value = normalizedMatch[1].trim();
+      if (value.length > 0) {
+        return { value, label };
+      }
+    }
+  }
+  return null;
+};
+
 const deterministicValueForRow = (
   row: z.infer<typeof checklistRowSchema>,
   text: string,
   clientSnapshot?: z.infer<typeof requestSchema.shape.client_snapshot>,
 ): ExtractedFieldResult => {
   const key = row.placeholder_key;
-  const fromLabel = extractLineNearLabel(text, row.label);
+  const labels = [row.label, ...(row.extraction_aliases ?? [])];
+  const fromLabel = extractLineNearLabels(text, labels);
   if (fromLabel) {
-    const confidence = calibrateDeterministicConfidence(row.label, fromLabel, text);
+    const confidence = calibrateDeterministicConfidence(fromLabel.label, fromLabel.value, text);
     return {
       placeholder_key: key,
-      value_text: fromLabel,
+      value_text: fromLabel.value,
       value_json: null,
       confidence,
       mode: "AUTO",
       status: "drafted",
-      source_span: { method: "label_regex", label: row.label },
+      source_span: { method: "label_regex", label: fromLabel.label },
       review_notes: `Deterministic extraction from document label match. (Calibrated confidence ${confidence.toFixed(2)})`,
     };
   }
@@ -285,7 +356,9 @@ const extractStructuredGoalSections = (text: string): StructuredSectionResult[] 
   };
 
   lines.forEach((line, index) => {
-    const goalMatch = line.match(/^(child|parent|target\/replacement|target|replacement|skill acquisition|caregiver)\s+goal\s*\d*\s*[:-]\s*(.+)$/i);
+    const goalMatch = line.match(
+      /^(?:[A-Z]\.\s*)?(?:\d+\.\s*)?(child|parent\/caregiver|parent|target and replacement|target\/replacement|target behavior|replacement behavior|target|replacement|skill acquisition|caregiver)\s+goal\s*\d*\s*(?:\([^)]*\))?\s*[:-]\s*(.+)$/i,
+    );
     if (goalMatch?.[1] && goalMatch?.[2]) {
       flush(index);
       const label = goalMatch[1].toLowerCase();
@@ -335,8 +408,9 @@ const extractStructuredTableSections = (text: string): StructuredSectionResult[]
   const tableSpecs = [
     { field_key: "CALOPTIMA_FBA_RECORDS_REVIEWED", section_key: "records_reviewed", prefix: /^record reviewed\s*[:-]\s*(.+)$/i },
     { field_key: "CALOPTIMA_FBA_VINELAND_DOMAIN_SCORES", section_key: "assessment_results", prefix: /^vineland domain\s*[:-]\s*(.+)$/i },
-    { field_key: "CALOPTIMA_FBA_HCPCS_RECOMMENDATIONS", section_key: "service_recommendations", prefix: /^hcpcs\s*[:-]\s*(.+)$/i },
-    { field_key: "CALOPTIMA_FBA_DAILY_SCHEDULES", section_key: "daily_schedules", prefix: /^daily schedule\s*[:-]\s*(.+)$/i },
+    { field_key: "CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS", section_key: "service_recommendations", prefix: /^hcpcs\s*[:-]\s*(.+)$/i },
+    { field_key: "CALOPTIMA_FBA_DAILY_ACTIVITY_SCHEDULE", section_key: "daily_schedules", prefix: /^daily activity schedule\s*[:-]\s*(.+)$/i },
+    { field_key: "CALOPTIMA_FBA_SCHOOL_SCHEDULE", section_key: "daily_schedules", prefix: /^school schedule\s*[:-]\s*(.+)$/i },
   ];
   const rowsByKey = new Map<string, Record<string, unknown>[]>();
   text.split(/\n+/).forEach((line) => {
@@ -368,10 +442,107 @@ const extractStructuredTableSections = (text: string): StructuredSectionResult[]
   });
 };
 
+const extractHcpcsRowsFromNarrative = (text: string): StructuredSectionResult[] => {
+  const sectionText = extractSectionText(
+    text,
+    [/HCPCS\s+Code\s+and\s+Modifiers\s+Description/i],
+    [/Telehealth\s+Consent\s+Confirmation/i, /XXI\.\s+PARENT\/CAREGIVER/i, /XVIII\.\s+SIGNATURES/i],
+  );
+  if (!sectionText) {
+    return [];
+  }
+  const knownCodePattern = /\b(H0032-HN|H0032-HO|H2014-HQ|H2019|S5108|S5110)\b\s+([\s\S]*?)(?=\b(?:H0032-HN|H0032-HO|H2014-HQ|H2019|S5108|S5110)\b|Telehealth\s+Consent|$)/gi;
+  const rows: Record<string, unknown>[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = knownCodePattern.exec(sectionText)) !== null) {
+    rows.push({
+      hcpcs_code: match[1],
+      raw_text: `${match[1]} ${match[2] ?? ""}`.replace(/\s+/g, " ").trim(),
+    });
+  }
+  if (rows.length === 0) {
+    rows.push({ raw_text: sectionText });
+  }
+  return [{
+    section_key: "service_recommendations",
+    field_key: "CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS",
+    section_index: 0,
+    payload: { rows },
+    source_span: { method: "deterministic_hcpcs_section", row_count: rows.length },
+    status: "drafted",
+    required: true,
+    review_notes: "Deterministic HCPCS recommendation section extracted from CalOptima document text.",
+  }];
+};
+
+const extractNarrativeStructuredSections = (text: string): StructuredSectionResult[] => {
+  const specs = [
+    {
+      field_key: "CALOPTIMA_FBA_COORDINATION_OF_CARE",
+      section_key: "coordination_of_care",
+      start: [/IV\.\s+COORDINATION\s+OF\s+CARE/i],
+      end: [/VII\.\s+ADAPTIVE\s+TESTING/i, /Vineland\s+Adaptive/i],
+    },
+    {
+      field_key: "CALOPTIMA_FBA_VINELAND_DOMAIN_SCORES",
+      section_key: "assessment_results",
+      start: [/Vineland\s+Adaptive\s+Behavior\s+Scales/i, /Domain\s+Raw\s+Score\s+Standard\s+Score/i],
+      end: [/IX\.\s+DIAGNOSTIC\s+INFORMATION/i, /X\.\s+FUNCTIONAL\s+ASSESSMENT/i],
+    },
+    {
+      field_key: "CALOPTIMA_FBA_TARGET_BEHAVIOR_BLOCKS",
+      section_key: "diagnostic_behavior_analysis",
+      start: [/X\.\s+FUNCTIONAL\s+ASSESSMENT\s+OR\s+ANALYSIS\s+OF\s+TARGET\s+BEHAVIORS/i],
+      end: [/XI\.\s+BEHAVIOR\s+INTERVENTION\s+PLAN/i],
+    },
+    {
+      field_key: "CALOPTIMA_FBA_BIP_BLOCKS",
+      section_key: "diagnostic_behavior_analysis",
+      start: [/XI\.\s+BEHAVIOR\s+INTERVENTION\s+PLAN/i],
+      end: [
+        /XII\.\s+/i,
+        /XIII\.\s+/i,
+        /XIV\.\s+TARGET\s+AND\s+REPLACEMENT\s+BEHAVIOR\s+GOALS/i,
+        /XV\.\s+SKILL\s+ACQUISITION/i,
+      ],
+    },
+    {
+      field_key: "CALOPTIMA_FBA_SIGNATURES",
+      section_key: "signatures",
+      start: [/XVIII\.\s+SIGNATURES/i],
+      end: [/\*\*\s+By\s+signing/i],
+    },
+  ] as const;
+
+  return specs.flatMap((spec) => {
+    const sectionText = extractSectionText(text, [...spec.start], [...spec.end]);
+    if (!sectionText) {
+      return [];
+    }
+    return [{
+      section_key: spec.section_key,
+      field_key: spec.field_key,
+      section_index: 0,
+      payload: { raw_text: sectionText },
+      source_span: { method: "deterministic_section_anchor", anchor_count: spec.start.length },
+      status: "drafted" as const,
+      required: true,
+      review_notes: "Deterministic anchored section extracted from CalOptima document text.",
+    }];
+  });
+};
+
 const extractStructuredSections = (text: string): StructuredSectionResult[] => [
+  ...extractNarrativeStructuredSections(text),
   ...extractStructuredGoalSections(text),
   ...extractStructuredTableSections(text),
+  ...extractHcpcsRowsFromNarrative(text),
 ];
+
+export const __TESTING__ = {
+  deterministicValueForRow,
+  extractStructuredSections,
+};
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {

--- a/tests/edge/extract-assessment-fields.caloptima.test.ts
+++ b/tests/edge/extract-assessment-fields.caloptima.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { __TESTING__ } from "../../supabase/functions/extract-assessment-fields/index.ts";
+
+describe("extract-assessment-fields CalOptima parser", () => {
+  it("uses registry aliases for scalar extraction from redacted-template labels", () => {
+    const result = __TESTING__.deterministicValueForRow(
+      {
+        section: "Client Information",
+        label: "Client name",
+        placeholder_key: "CALOPTIMA_FBA_CLIENT_NAME",
+        required: true,
+        extraction_aliases: ["Member full legal name"],
+      },
+      "Member full legal name: Redacted Client\nDate of birth: 01/01/2015",
+    );
+
+    expect(result.status).toBe("drafted");
+    expect(result.value_text).toBe("Redacted Client");
+    expect(result.source_span).toMatchObject({ method: "label_regex", label: "Member full legal name" });
+  });
+
+  it("extracts redacted-style structured sections without misclassifying goals or over-capturing boundaries", () => {
+    const text = [
+      "X. FUNCTIONAL ASSESSMENT OR ANALYSIS OF TARGET BEHAVIORS",
+      "Aggression occurred during transitions.",
+      "XI. BEHAVIOR INTERVENTION PLAN",
+      "Antecedent strategies and consequence procedures.",
+      "XII. PLAN FOR GENERALIZATION",
+      "This section should not be inside the BIP payload.",
+      "XIV. TARGET AND REPLACEMENT BEHAVIOR GOALS",
+      "Target Behavior Goal: Reduce aggression",
+      "Baseline: 8 episodes per day",
+      "Objective data point: date: 07/01/2025 | value: 8 | unit: episodes",
+      "Replacement Behavior Goal: Request a break",
+      "Measurement type: frequency",
+      "XV. SKILL ACQUISITION",
+      "Skill Acquisition Goal: Follow one-step directions",
+      "HCPCS Code and Modifiers Description",
+      "H0032-HN Treatment planning 4 units",
+      "H2019 Direct therapy 40 units",
+      "Telehealth Consent Confirmation",
+      "XVIII. SIGNATURES",
+      "Provider Signature: Redacted BCBA 07/21/2025",
+      "** By signing this report, the provider confirms review.",
+      "Do not include this attestation in the signature payload.",
+    ].join("\n");
+
+    const sections = __TESTING__.extractStructuredSections(text);
+    const byKey = new Map(sections.map((section) => [section.field_key, section]));
+    const goalSections = sections.filter((section) => section.field_key === "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS");
+
+    expect(byKey.get("CALOPTIMA_FBA_TARGET_BEHAVIOR_BLOCKS")?.payload.raw_text).toContain("Aggression occurred");
+    expect(byKey.get("CALOPTIMA_FBA_BIP_BLOCKS")?.payload.raw_text).toContain("Antecedent strategies");
+    expect(byKey.get("CALOPTIMA_FBA_BIP_BLOCKS")?.payload.raw_text).not.toContain("PLAN FOR GENERALIZATION");
+    expect(byKey.has("CALOPTIMA_FBA_TRANSITION_PLAN")).toBe(false);
+
+    expect(goalSections).toHaveLength(2);
+    expect(goalSections.map((section) => section.payload.title)).toEqual([
+      "Reduce aggression",
+      "Request a break",
+    ]);
+    expect(sections.some((section) => section.field_key === "CALOPTIMA_FBA_TARGET_BEHAVIOR_BLOCKS" && section.payload.title === "Reduce aggression")).toBe(false);
+
+    const signatures = byKey.get("CALOPTIMA_FBA_SIGNATURES");
+    expect(signatures?.payload.raw_text).toContain("Provider Signature");
+    expect(signatures?.payload.raw_text).not.toContain("Do not include this attestation");
+
+    const hcpcsRows = byKey.get("CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS")?.payload.rows;
+    expect(hcpcsRows).toEqual([
+      expect.objectContaining({ hcpcs_code: "H0032-HN" }),
+      expect.objectContaining({ hcpcs_code: "H2019" }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds redacted CalOptima heading aliases to the canonical FBA registry and regenerated checklist artifacts.
- Propagates `extraction_aliases` from assessment checklist seeds into the deterministic CalOptima extraction edge function.
- Hardens deterministic parsing for target/replacement goals, BIP/signature section boundaries, Vineland/HCPCS/records-style sections, and no-AI metadata parity.
- Adds executable edge parser coverage for redacted-style alias extraction and structured-section boundaries.

## Linear
- WIN-146: https://linear.app/winningedgeai/issue/WIN-146/caloptima-redacted-template-parser-alias-and-boundary-hardening

## Route
- classification: high-risk human-reviewed
- lane: critical
- protected paths: `src/server/**`, `supabase/functions/**`

## Verification
- PASS `npm test -- --run tests/edge/extract-assessment-fields.caloptima.test.ts src/server/__tests__/assessmentPlanPdfTemplate.test.ts src/server/__tests__/assessmentDocumentsHandler.test.ts`
- PASS `deno check --node-modules-dir=auto supabase/functions/extract-assessment-fields/index.ts`
- PASS `npm run ci:check-focused` (DB-backed checks skipped locally because `SUPABASE_DB_URL`/`DATABASE_URL` not configured; branch protection skipped outside CI)
- PASS `npm run lint`
- PASS `npm run typecheck`
- PASS `npm run test:ci` (286 files / 1606 tests)
- PASS `npm run validate:tenant`
- PASS `npm run build`
- ATTEMPTED `npm run verify:local`: failed during embedded `test:ci` on unrelated timing-sensitive `tests/supabase-preview-drift.test.ts` and `src/pages/__tests__/Schedule.event.test.tsx`; both passed when rerun directly, and standalone full `npm run test:ci` passed before and after.

## Risk
- No schema/RLS/grant changes in this slice.
- Tenant boundary remains the existing assessment-document scoped access path before service-role storage download.
- Human visual comparison against the actual CalOptima template is still required before clinical release.