### PR TITLE
WIN-139 harden Programs & Goals publish promotion path

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -1011,7 +1011,12 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       if (!response.ok) {
         throw new Error(await parseApiErrorMessage(response, "Assessment cannot be promoted yet."));
       }
-      return parseJson<{ created_program_count: number; created_goal_count: number }>(response);
+      return parseJson<{
+        created_program_count: number;
+        created_goal_count: number;
+        promoted_program_count?: number;
+        promoted_goal_count?: number;
+      }>(response);
     },
     onSuccess: (result) => {
       queryClient.invalidateQueries({
@@ -1023,8 +1028,10 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       queryClient.invalidateQueries({
         queryKey: ["program-goals", resolvedProgramId, organizationId ?? "MISSING_ORG"],
       });
+      const publishedProgramCount = result.promoted_program_count ?? result.created_program_count;
+      const publishedGoalCount = result.promoted_goal_count ?? result.created_goal_count;
       showSuccess(
-        `Published to live records. Created ${formatCountLabel(result.created_program_count, "production program", "production programs")} and ${formatCountLabel(result.created_goal_count, "goal", "goals")}.`,
+        `Published to live records. Created ${formatCountLabel(publishedProgramCount, "production program", "production programs")} and ${formatCountLabel(publishedGoalCount, "goal", "goals")}.`,
       );
     },
     onError: showError,

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -2213,6 +2213,81 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     confirmSpy.mockRestore();
   });
 
+  it("prefers promoted draft counts over raw created-row counts in the publish success toast", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [{ id: "p1", name: "Program A", description: null, accept_state: "accepted", review_notes: null }],
+            goals: buildAcceptedDraftGoals(),
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/fba.pdf",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "POST" && path === "/api/assessment-promote") {
+        return new Response(
+          JSON.stringify({
+            created_program_count: 1,
+            created_goal_count: 27,
+            promoted_program_count: 1,
+            promoted_goal_count: 26,
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("fba.pdf");
+    const publishButton = screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i });
+    await waitFor(() => {
+      expect(publishButton).not.toBeDisabled();
+    });
+    await user.click(publishButton);
+
+    await waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith(
+        "Published to live records. Created 1 production program and 26 goals.",
+      );
+    });
+    confirmSpy.mockRestore();
+  });
+
   it("shows draft-vs-live status messaging in review panel", async () => {
     renderWithProviders(
       <ProgramsGoalsTab client={buildClient()} />,

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -15,6 +15,7 @@ const mockUseDropdownData = vi.fn(() => ({
 const mockUseActiveOrganizationId = vi.fn(() => "org-1");
 const mockPrefetchScheduleRange = vi.fn();
 let sessionModalModuleLoads = 0;
+const originalMatchMedia = window.matchMedia;
 
 const scheduleFixtures = {
   sessions: [
@@ -203,6 +204,8 @@ describe("Schedule", () => {
   });
   
   afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    vi.useRealTimers();
     if (defaultRpcImplementation) {
       vi.mocked(supabase.rpc as any).mockImplementation(defaultRpcImplementation);
     } else {
@@ -220,7 +223,7 @@ describe("Schedule", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Day view/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Week view/i })).toBeInTheDocument();
-  }, 15000);
+  }, 30000);
 
   it("renders schedule interface elements", async () => {
     renderWithProviders(<Schedule />);
@@ -231,7 +234,9 @@ describe("Schedule", () => {
     });
     
     // Check for key interface elements
-    expect(screen.getByText(/Jun 30 - Jul 5, 2025/i)).toBeInTheDocument();
+    expect(
+      screen.getByText((content) => /^[A-Z][a-z]{2} \d{1,2} - [A-Z][a-z]{2} \d{1,2}, \d{4}$/.test(content)),
+    ).toBeInTheDocument();
   });
 
   it("shows loading state initially", async () => {
@@ -380,7 +385,7 @@ describe("Schedule", () => {
     expect(screen.getByLabelText(/End date/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Preview week-forward schedule/i })).toBeInTheDocument();
     expect(screen.getByText(/Single-session recurrence/i)).toBeInTheDocument();
-  }, 15000);
+  }, 30000);
 
   it("previews and applies the visible week with the displayed week payload", async () => {
     const capturedRequests: Array<Record<string, unknown>> = [];

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -125,6 +125,20 @@ describe("assessmentPromoteHandler", () => {
       created_goal_count: 26,
       created_program_ids: ["prod-program-1", "prod-program-2"],
     });
+    const createEventCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(([url, init]) => typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && init?.method === "POST");
+    expect(createEventCall).toBeTruthy();
+    const createEventPayload = JSON.parse((createEventCall?.[1] as RequestInit).body as string) as {
+      event_payload: Record<string, unknown>;
+    };
+    expect(createEventPayload.event_payload).toMatchObject({
+      created_program_count: 2,
+      created_goal_count: 26,
+      created_program_ids: ["prod-program-1", "prod-program-2"],
+      promoted_program_count: 2,
+      promoted_goal_count: 26,
+    });
     const createGoalsCall = vi
       .mocked(fetchJson)
       .mock.calls.find(([url, init]) => typeof url === "string" && url.includes("/rest/v1/goals") && init?.method === "POST");
@@ -367,6 +381,89 @@ describe("assessmentPromoteHandler", () => {
     );
   });
 
+  it("returns created and promoted goal counts separately when the goal insert response includes extra live rows", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
+        return { ok: true, status: 200, data: [{ id: "draft-program-1", name: "Draft Program", description: "x", accept_state: "accepted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: buildAcceptedGoals().map((goal) => ({ ...goal, draft_program_id: "draft-program-1" })),
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/programs")) {
+        return { ok: true, status: 201, data: [{ id: "prod-program-1" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/goals")) {
+        return {
+          ok: true,
+          status: 201,
+          data: [
+            ...buildAcceptedGoals().map((goal, index) => ({ id: `prod-goal-${index + 1}`, title: goal.title })),
+            { id: "prod-goal-extra", title: "Unexpected extra goal" },
+          ],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/goal_data_points")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      created_program_count: 1,
+      created_goal_count: 27,
+      promoted_program_count: 1,
+      promoted_goal_count: 26,
+    });
+    const createEventCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(([url, init]) => typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && init?.method === "POST");
+    expect(createEventCall).toBeTruthy();
+    const createEventPayload = JSON.parse((createEventCall?.[1] as RequestInit).body as string) as {
+      event_payload: Record<string, unknown>;
+    };
+    expect(createEventPayload.event_payload).toMatchObject({
+      created_program_count: 1,
+      created_goal_count: 27,
+      promoted_program_count: 1,
+      promoted_goal_count: 26,
+    });
+  });
+
   it("rolls back already-created programs when a later program create fails", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -597,5 +694,75 @@ describe("assessmentPromoteHandler", () => {
         body: expect.stringContaining('"status":"drafted"'),
       }),
     );
+  });
+
+  it("surfaces rollback failure details when review-event cleanup cannot fully unwind live writes", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
+        return { ok: true, status: 200, data: [{ id: "draft-program-1", name: "Draft Program", description: "x", accept_state: "accepted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: buildAcceptedGoals().map((goal) => ({ ...goal, draft_program_id: "draft-program-1" })),
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/programs")) {
+        return { ok: true, status: 201, data: [{ id: "prod-program-1" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/goals")) {
+        return {
+          ok: true,
+          status: 201,
+          data: buildAcceptedGoals().map((goal, index) => ({ id: `prod-goal-${index + 1}`, title: goal.title })),
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/goal_data_points")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: false, status: 500, data: null };
+      }
+      if (method === "DELETE" && url.includes("/rest/v1/goals?program_id=in.(prod-program-1)&organization_id=eq.org-1&client_id=eq.client-1")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "DELETE" && url.includes("/rest/v1/programs?id=in.(prod-program-1)&organization_id=eq.org-1&client_id=eq.client-1")) {
+        return { ok: false, status: 500, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error).toContain("rollback did not complete cleanly");
+    expect(body.rollback_failed_steps).toEqual(["delete_programs"]);
   });
 });

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -146,6 +146,8 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   const acceptedGoals = (draftGoalsResult.data ?? []).filter(
     (goal) => goal.accept_state === "accepted" || goal.accept_state === "edited",
   );
+  const promotedProgramCount = acceptedPrograms.length;
+  const promotedGoalCount = acceptedGoals.length;
 
   if (acceptedPrograms.length === 0) {
     return json({ error: "At least one accepted draft program is required before promotion." }, 409);
@@ -315,8 +317,16 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   }));
 
   if (createGoalsPayload.some((goal) => !goal.program_id)) {
-    await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
-    return json({ error: "Accepted goals could not be matched to the promoted programs." }, 409);
+    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+    return json(
+      {
+        error: rollback.ok
+          ? "Accepted goals could not be matched to the promoted programs. Promotion rolled back safely."
+          : "Accepted goals could not be matched to the promoted programs, and rollback did not complete cleanly.",
+        rollback_failed_steps: rollback.ok ? undefined : rollback.failedSteps,
+      },
+      409,
+    );
   }
 
   const createGoalsResult = await fetchJson<Array<{ id: string; title: string }>>(`${supabaseUrl}/rest/v1/goals`, {
@@ -440,6 +450,8 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
         created_program_count: createdProgramIds.length,
         created_program_ids: createdProgramIds,
         created_goal_count: createdGoals.length || acceptedGoals.length,
+        promoted_program_count: promotedProgramCount,
+        promoted_goal_count: promotedGoalCount,
         created_goal_data_point_count: goalDataPointPayload.length,
       },
     }),
@@ -462,6 +474,8 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     created_program_count: createdProgramIds.length,
     created_program_ids: createdProgramIds,
     created_goal_count: createdGoals.length || acceptedGoals.length,
+    promoted_program_count: promotedProgramCount,
+    promoted_goal_count: promotedGoalCount,
     created_goal_data_point_count: goalDataPointPayload.length,
   });
 }


### PR DESCRIPTION
## Summary
- align live publish success messaging with accepted draft program/goal counts while preserving created-row audit fields
- harden live-promotion rollback/error handling so partial failures do not leave live records in an unsafe half-published state
- stabilize the Schedule page TSX tests around matchMedia cleanup and visible-range assertions

## Verification
- 
px vitest run --reporter=verbose src/pages/__tests__/Schedule.test.tsx
- 
px vitest run --reporter=verbose src/components/__tests__/ProgramsGoalsTab.test.tsx src/server/__tests__/assessmentPromoteHandler.test.ts src/pages/__tests__/Schedule.test.tsx
- 
pm run ci:check-focused
- 
pm run lint
- 
pm run typecheck
- 
pm run build
- 
pm run test:ci currently fails outside this slice in src/lib/__tests__/idempotencyService.test.ts > hashResponse > produces a stable hash for identical payloads
- 
pm run verify:local fails because it includes the same 	est:ci failure

## Notes
- Protected-path server changes are included in this branch and still require human review before merge.
- Unrelated local file AGENTS.md remains modified and is intentionally excluded from this PR.