### PR TITLE
WIN-147 Validate CalOptima assessment upload/import smoke path

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "playwright:therapist-onboarding": "tsx scripts/playwright-therapist-onboarding.ts",
     "playwright:therapist-authorization": "tsx scripts/playwright-therapist-authorization.ts",
     "playwright:authorizations-read-scope": "tsx scripts/playwright-authorizations-read-scope-smoke.ts",
+    "playwright:assessment-import-smoke": "tsx scripts/playwright-assessment-import-smoke.ts",
     "playwright:mobile-role-smoke": "tsx scripts/playwright-mobile-role-smoke.ts",
     "playwright:preflight": "tsx scripts/playwright-preflight.ts",
     "playwright:session-lifecycle": "tsx scripts/playwright-session-lifecycle.ts",

--- a/scripts/playwright-assessment-import-smoke.ts
+++ b/scripts/playwright-assessment-import-smoke.ts
@@ -1,0 +1,253 @@
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { chromium } from 'playwright';
+
+import { loadPlaywrightEnv } from './lib/load-playwright-env';
+import {
+  captureFailureScreenshot,
+  ensureArtifactsDir,
+  loginAndAssertSession,
+  preflightCredentials,
+} from './lib/playwright-smoke';
+
+type AssessmentDocumentRecord = {
+  id: string;
+  client_id: string;
+  file_name: string;
+  object_path: string;
+  status: 'uploaded' | 'extracting' | 'extracted' | 'drafted' | 'approved' | 'rejected' | 'extraction_failed';
+  extraction_error?: string | null;
+};
+
+const DEFAULT_BASE_URL = 'https://app.allincompassing.ai';
+const DEFAULT_SAMPLE_FILE = path.resolve(
+  process.cwd(),
+  '7.21.2025_RoVa_CalOptima_FBA_FINAL (1).Redacted.docx.pdf',
+);
+const EXTRACTION_TIMEOUT_MS = 120_000;
+
+const getRequiredEnv = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required for assessment import smoke.`);
+  }
+  return value;
+};
+
+const resolveSupabaseUrl = (): string => process.env.VITE_SUPABASE_URL?.trim() || getRequiredEnv('SUPABASE_URL');
+const resolveSupabaseAnonKey = (): string =>
+  process.env.VITE_SUPABASE_ANON_KEY?.trim() || getRequiredEnv('SUPABASE_ANON_KEY');
+
+const resolveMimeType = (filePath: string): string => {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === '.pdf') {
+    return 'application/pdf';
+  }
+  if (extension === '.docx') {
+    return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+  }
+  return 'application/octet-stream';
+};
+
+const pause = async (ms: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const fetchAssessmentDocuments = async (
+  baseUrl: string,
+  accessToken: string,
+  clientId: string,
+): Promise<AssessmentDocumentRecord[]> => {
+  const response = await fetch(`${baseUrl}/api/assessment-documents?client_id=${encodeURIComponent(clientId)}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Assessment document query failed with status ${response.status}.`);
+  }
+
+  return (await response.json()) as AssessmentDocumentRecord[];
+};
+
+const deleteAssessmentDocument = async (
+  baseUrl: string,
+  accessToken: string,
+  assessmentDocumentId: string,
+): Promise<void> => {
+  const response = await fetch(
+    `${baseUrl}/api/assessment-documents?assessment_document_id=${encodeURIComponent(assessmentDocumentId)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Cleanup failed for ${assessmentDocumentId}: ${response.status} ${body}`);
+  }
+};
+
+const selectClientForSmoke = async (
+  supabaseUrl: string,
+  supabaseAnonKey: string,
+  email: string,
+  password: string,
+): Promise<{ accessToken: string; clientId: string; clientName: string }> => {
+  const supabase = createClient(supabaseUrl, supabaseAnonKey);
+  const { data: authData, error: authError } = await supabase.auth.signInWithPassword({ email, password });
+  if (authError || !authData.session || !authData.user) {
+    throw authError ?? new Error('Could not authenticate assessment import smoke user.');
+  }
+
+  const configuredClientId = process.env.PW_ASSESSMENT_CLIENT_ID?.trim();
+  if (configuredClientId) {
+    const { data: client, error } = await supabase
+      .from('clients')
+      .select('id, full_name')
+      .eq('id', configuredClientId)
+      .maybeSingle();
+    if (error || !client) {
+      throw error ?? new Error(`Configured PW_ASSESSMENT_CLIENT_ID is not accessible: ${configuredClientId}`);
+    }
+    return {
+      accessToken: authData.session.access_token,
+      clientId: client.id,
+      clientName: client.full_name ?? client.id,
+    };
+  }
+
+  const { data: clients, error: clientsError } = await supabase
+    .from('clients')
+    .select('id, full_name')
+    .limit(1);
+  if (clientsError || !clients || clients.length === 0) {
+    throw clientsError ?? new Error('No accessible clients available for assessment import smoke.');
+  }
+
+  return {
+    accessToken: authData.session.access_token,
+    clientId: clients[0].id,
+    clientName: clients[0].full_name ?? clients[0].id,
+  };
+};
+
+async function run() {
+  loadPlaywrightEnv();
+
+  const baseUrl = (process.env.PW_BASE_URL?.trim() || DEFAULT_BASE_URL).replace(/\/$/, '');
+  const sampleFilePath = process.env.PW_ASSESSMENT_SAMPLE_FILE?.trim()
+    ? path.resolve(process.cwd(), process.env.PW_ASSESSMENT_SAMPLE_FILE.trim())
+    : DEFAULT_SAMPLE_FILE;
+  const sourceFileBuffer = readFileSync(sampleFilePath);
+  const sourceExtension = path.extname(sampleFilePath).toLowerCase();
+  const uploadFileName = `${path.basename(sampleFilePath, sourceExtension)}-smoke-${Date.now()}${sourceExtension}`;
+  const uploadMimeType = resolveMimeType(sampleFilePath);
+  const credentials = preflightCredentials([
+    {
+      email: process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL,
+      password: process.env.PW_ADMIN_PASSWORD ?? process.env.PLAYWRIGHT_ADMIN_PASSWORD,
+      label: 'PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD',
+    },
+  ]);
+  const { accessToken, clientId, clientName } = await selectClientForSmoke(
+    resolveSupabaseUrl(),
+    resolveSupabaseAnonKey(),
+    credentials.email,
+    credentials.password,
+  );
+
+  const browser = await chromium.launch({ headless: process.env.HEADLESS !== 'false' });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const latestDir = ensureArtifactsDir();
+
+  let createdAssessment: AssessmentDocumentRecord | null = null;
+
+  try {
+    await loginAndAssertSession(page, baseUrl, credentials.email, credentials.password);
+    await page.goto(`${baseUrl}/clients/${clientId}?tab=programs-goals`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+    await page.waitForLoadState('networkidle').catch(() => undefined);
+    await page.getByText('FBA Upload + AI Workflow').waitFor({ timeout: 20_000 });
+
+    await page.locator('#programs-goals-fba-file-upload').setInputFiles({
+      name: uploadFileName,
+      mimeType: uploadMimeType,
+      buffer: sourceFileBuffer,
+    });
+    await page.getByRole('button', { name: /Upload CalOptima FBA/i }).click();
+    await page.getByText('Uploading and processing your FBA. This can take a moment.').waitFor({ timeout: 20_000 });
+
+    const deadline = Date.now() + EXTRACTION_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const documents = await fetchAssessmentDocuments(baseUrl, accessToken, clientId);
+      createdAssessment = documents.find((document) => document.file_name === uploadFileName) ?? null;
+      if (createdAssessment && !['uploaded', 'extracting'].includes(createdAssessment.status)) {
+        break;
+      }
+      await pause(2_000);
+    }
+
+    if (!createdAssessment) {
+      throw new Error(`Uploaded assessment document ${uploadFileName} was not found in the queue.`);
+    }
+    if (createdAssessment.status !== 'extracted') {
+      throw new Error(
+        `Assessment import smoke ended with ${createdAssessment.status}${
+          createdAssessment.extraction_error ? `: ${createdAssessment.extraction_error}` : ''
+        }`,
+      );
+    }
+
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
+    await page.waitForLoadState('networkidle').catch(() => undefined);
+    await page.getByRole('button', { name: new RegExp(uploadFileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') })
+      .first()
+      .waitFor({ timeout: 20_000 });
+
+    const screenshotPath = path.join(latestDir, `assessment-import-smoke-${Date.now()}.png`);
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          clientId,
+          clientName,
+          assessmentDocumentId: createdAssessment.id,
+          fileName: uploadFileName,
+          status: createdAssessment.status,
+          screenshot: screenshotPath,
+          url: page.url(),
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    const screenshot = await captureFailureScreenshot(page, 'playwright-assessment-import-smoke-failure');
+    console.error(`Assessment import smoke failed. Screenshot: ${screenshot}`);
+    throw error;
+  } finally {
+    if (createdAssessment) {
+      await deleteAssessmentDocument(baseUrl, accessToken, createdAssessment.id).catch((cleanupError) => {
+        console.error('Assessment import smoke cleanup failed', cleanupError);
+      });
+    }
+    await context.close();
+    await browser.close();
+  }
+}
+
+run().catch((error) => {
+  console.error('Playwright assessment import smoke failed', error);
+  process.exit(1);
+});

--- a/scripts/test-assessment-upload.ts
+++ b/scripts/test-assessment-upload.ts
@@ -10,8 +10,13 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+import { config as loadEnv } from 'dotenv';
 import { readFileSync } from 'fs';
-import { basename } from 'path';
+import { basename, extname, resolve } from 'path';
+
+for (const envPath of ['.env', '.env.local', '.env.codex']) {
+  loadEnv({ path: resolve(process.cwd(), envPath), override: false });
+}
 
 const resolveRequiredEnv = (name: string): string => {
   const value = process.env[name];
@@ -24,6 +29,18 @@ const resolveRequiredEnv = (name: string): string => {
 const resolveSupabaseUrl = (): string => process.env.VITE_SUPABASE_URL || resolveRequiredEnv('SUPABASE_URL');
 const resolveSupabaseAnonKey = (): string =>
   process.env.VITE_SUPABASE_ANON_KEY || resolveRequiredEnv('SUPABASE_ANON_KEY');
+const resolveApiBaseUrl = (): string => (process.env.PW_BASE_URL || process.env.APP_BASE_URL || 'https://app.allincompassing.ai').trim();
+
+const resolveFileMimeType = (filePath: string): string => {
+  const extension = extname(filePath).toLowerCase();
+  if (extension === '.pdf') {
+    return 'application/pdf';
+  }
+  if (extension === '.docx') {
+    return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+  }
+  return 'application/octet-stream';
+};
 
 type AssessmentTemplateType = 'caloptima_fba' | 'iehp_fba';
 
@@ -38,10 +55,13 @@ async function main() {
     process.exit(1);
   }
 
-  const testUserEmail = resolveRequiredEnv('TEST_USER_EMAIL');
-  const testUserPassword = resolveRequiredEnv('TEST_USER_PASSWORD');
+  const testUserEmail = process.env.TEST_USER_EMAIL?.trim() || process.env.PW_ADMIN_EMAIL?.trim() || resolveRequiredEnv('TEST_USER_EMAIL');
+  const testUserPassword =
+    process.env.TEST_USER_PASSWORD?.trim() || process.env.PW_ADMIN_PASSWORD?.trim() || resolveRequiredEnv('TEST_USER_PASSWORD');
   const supabaseUrl = resolveSupabaseUrl();
   const supabaseAnonKey = resolveSupabaseAnonKey();
+  const apiBaseUrl = resolveApiBaseUrl();
+  const mimeType = resolveFileMimeType(filePath);
 
   console.log('=== Assessment Upload Test ===');
   console.log(`Client ID: ${clientId}`);
@@ -91,7 +111,7 @@ async function main() {
   const { error: uploadError } = await supabase.storage
     .from('client-documents')
     .upload(objectPath, fileBuffer, {
-      contentType: 'application/pdf',
+      contentType: mimeType,
       upsert: false,
     });
 
@@ -107,7 +127,6 @@ async function main() {
 
   // Register assessment document
   console.log('[4/5] Registering assessment document...');
-  const apiBaseUrl = 'https://app.allincompassing.ai';
   const response = await fetch(`${apiBaseUrl}/api/assessment-documents`, {
     method: 'POST',
     headers: {
@@ -117,7 +136,7 @@ async function main() {
     body: JSON.stringify({
       client_id: clientId,
       file_name: fileName,
-      mime_type: 'application/pdf',
+      mime_type: mimeType,
       file_size: fileBuffer.length,
       bucket_id: 'client-documents',
       object_path: objectPath,

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -135,15 +135,13 @@ const summarizeTextQuality = (text: string): "high" | "medium" | "low" => {
   return "high";
 };
 
-const extractLineNearLabel = (text: string, label: string): string | null => {
-  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`${escapedLabel}\\s*[:\\-]?\\s*([^\\n]{2,180})`, "i");
+const extractLineNearLabel = (text: string, label: string, stopLabels: string[] = []): string | null => {
+  const pattern = new RegExp(`${flexibleLabelPattern(label)}\\s*[:\\-]?\\s*([^\\n]{2,260})`, "i");
   const match = text.match(pattern);
   if (!match?.[1]) {
     return null;
   }
-  const value = match[1].trim();
-  return value.length > 0 ? value : null;
+  return trimAtInlineBoundary(match[1], stopLabels);
 };
 
 const clampConfidence = (value: number): number => {
@@ -164,6 +162,10 @@ const compactForContains = (value: string): string =>
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "");
 
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const flexibleLabelPattern = (label: string): string => escapeRegExp(label.trim()).replace(/\s+/g, "\\s+");
+
 const normalizeInlineText = (value: string): string =>
   value
     .replace(/\r/g, "\n")
@@ -172,6 +174,86 @@ const normalizeInlineText = (value: string): string =>
     .trim();
 
 const compactDocumentText = (text: string): string => normalizeInlineText(text).replace(/\s+/g, " ").trim();
+
+const normalizeExtractedValue = (value: string): string =>
+  value
+    .replace(/\s+/g, " ")
+    .replace(/^[\s:|-]+/g, "")
+    .replace(/[\s|,;:.-]+$/g, "")
+    .trim();
+
+const CALOPTIMA_INLINE_STOP_LABELS = [
+  "Member Name",
+  "Member DOB",
+  "CIN #",
+  "Diagnoses/with ICD Code",
+  "Guardian Name",
+  "Phone",
+  "Primary Care Provider",
+  "Known Allergies",
+  "Current Medications/Dosage",
+  "Dietary Restrictions",
+  "LMHP",
+  "Contact Number",
+  "Service Initiation Date",
+  "Date ABA first began",
+  "Prior Applied Behavioral Health Agencies",
+  "Full Name and Title",
+  "Phone Number",
+  "Fax Number",
+  "Chief Complaint/Reason for Seeking Applied Behavior Analysis (ABA) Treatment",
+  "Chief Complaint/Reason for Seeking ABA Treatment",
+  "Records Reviewed",
+  "Interviews Conducted",
+  "Daily School Schedule",
+  "Date of the current IEP/equivalent",
+  "Individualized Educational Plan (IEP/equivalent) Information",
+  "Title, License/Certificate #",
+  "Date of Report Completed",
+];
+
+const CALOPTIMA_SECTION_STOP_PATTERNS = [
+  /\b[IVX]{1,6}\.\s+[A-Z][A-Z /-]{3,}/i,
+  /\b\d+\.\s+(?:Are|Does|If|Date|Did|Was|Is)\b/i,
+];
+
+const collectStopLabels = (
+  currentLabels: string[],
+  allRows?: Array<z.infer<typeof checklistRowSchema>>,
+): string[] => {
+  const current = new Set(currentLabels.map((label) => normalizeForContains(label)));
+  const labels = new Set(CALOPTIMA_INLINE_STOP_LABELS);
+  for (const row of allRows ?? []) {
+    [row.label, ...(row.extraction_aliases ?? [])].forEach((label) => {
+      const normalized = normalizeForContains(label);
+      if (normalized.length >= 3 && !current.has(normalized)) {
+        labels.add(label);
+      }
+    });
+  }
+  return [...labels].filter((label) => !current.has(normalizeForContains(label)));
+};
+
+const trimAtInlineBoundary = (value: string, stopLabels: string[]): string | null => {
+  let earliest = value.length;
+  for (const label of stopLabels) {
+    if (label.trim().length < 3) {
+      continue;
+    }
+    const match = value.match(new RegExp(`(?:^|\\s)${flexibleLabelPattern(label)}\\s*[:\\-]?`, "i"));
+    if (match?.index !== undefined && match.index >= 0) {
+      earliest = Math.min(earliest, match.index);
+    }
+  }
+  for (const pattern of CALOPTIMA_SECTION_STOP_PATTERNS) {
+    const match = value.match(pattern);
+    if (match?.index !== undefined && match.index >= 0) {
+      earliest = Math.min(earliest, match.index);
+    }
+  }
+  const trimmed = normalizeExtractedValue(value.slice(0, earliest));
+  return trimmed.length > 0 ? trimmed : null;
+};
 
 const findAnchor = (text: string, anchors: RegExp[]): RegExpMatchArray | null => {
   for (const anchor of anchors) {
@@ -202,6 +284,167 @@ const extractSectionText = (text: string, startAnchors: RegExp[], endAnchors: Re
   return sectionText.length >= 20 ? sectionText : null;
 };
 
+const makeAutoField = (
+  row: z.infer<typeof checklistRowSchema>,
+  valueText: string,
+  sourceSpan: Record<string, unknown>,
+  text: string,
+): ExtractedFieldResult => {
+  const confidence = calibrateDeterministicConfidence(row.label, valueText, text);
+  return {
+    placeholder_key: row.placeholder_key,
+    value_text: valueText,
+    value_json: null,
+    confidence,
+    mode: "AUTO",
+    status: "drafted",
+    source_span: sourceSpan,
+    review_notes: `Deterministic extraction from document text. (Calibrated confidence ${confidence.toFixed(2)})`,
+  };
+};
+
+const extractSelectedYesNo = (afterQuestion: string): "Yes" | "No" | null => {
+  const normalized = afterQuestion.replace(/\s+/g, " ");
+  const markerPattern = "(☒|â˜’|þ|\\[x\\]|x|☐|â˜|□|\\[\\s\\])";
+  const pair = normalized.match(new RegExp(`${markerPattern}\\s*Yes\\s+${markerPattern}\\s*No`, "i"));
+  const isSelected = (marker: string): boolean => /^(?:☒|â˜’|þ|\[x\]|x)$/i.test(marker.trim());
+  if (pair?.[1] && pair?.[2]) {
+    if (isSelected(pair[1]) && !isSelected(pair[2])) {
+      return "Yes";
+    }
+    if (!isSelected(pair[1]) && isSelected(pair[2])) {
+      return "No";
+    }
+  }
+  const noOnly = normalized.match(new RegExp(`Yes\\s+${markerPattern}\\s*No`, "i"));
+  if (noOnly?.[1]) {
+    return isSelected(noOnly[1]) ? "No" : "Yes";
+  }
+  return null;
+};
+
+const extractCheckboxScalarByKey = (key: string, text: string): string | null => {
+  const compact = compactDocumentText(text);
+  const questionSpecs = [
+    {
+      key: "CALOPTIMA_FBA_HAS_IEP",
+      question: /Does\s+the\s+member\s+have\s+a\s+current\s+Individualized\s+Educational\s+Plan\s+\(IEP\/equivalent\)\?/i,
+      end: /If\s+No,\s+please\s+explain|3\.\s+If\s+yes/i,
+    },
+    {
+      key: "CALOPTIMA_FBA_PARENT_INVOLVEMENT",
+      question: /Was\s+the\s+Parent\/guardian\s+involved\s+in\s+the\s+development\s+of\s+the\s+treatment\s+plan\?/i,
+      end: /If\s+No\s+to\s+any\s+response|XVIII\.\s+SIGNATURES/i,
+      followUpQuestion: /Is\s+the\s+parent\/guardian\s+in\s+agreement\s+with\s+the\s+submitted\s+treatment\s+plan\?/i,
+    },
+    {
+      key: "CALOPTIMA_FBA_TELEHEALTH_CONSENT",
+      question: /Telehealth\s+Consent\s+Confirmation/i,
+      end: /XXI\.\s+PARENT\/CAREGIVER|XVIII\.\s+SIGNATURES/i,
+    },
+  ] as const;
+  const spec = questionSpecs.find((candidate) => candidate.key === key);
+  if (!spec) {
+    return null;
+  }
+  const questionMatch = compact.match(spec.question);
+  if (!questionMatch || questionMatch.index === undefined) {
+    return null;
+  }
+  const afterQuestion = compact.slice(questionMatch.index + questionMatch[0].length);
+  const endMatch = afterQuestion.match(spec.end);
+  const bounded = afterQuestion.slice(0, endMatch?.index ?? Math.min(afterQuestion.length, 600));
+  const primary = extractSelectedYesNo(bounded);
+  if (!primary) {
+    return null;
+  }
+  if (!("followUpQuestion" in spec)) {
+    return primary;
+  }
+  const followUpMatch = bounded.match(spec.followUpQuestion);
+  if (!followUpMatch || followUpMatch.index === undefined) {
+    return `development: ${primary}`;
+  }
+  const secondary = extractSelectedYesNo(bounded.slice(followUpMatch.index + followUpMatch[0].length));
+  return secondary ? `development: ${primary}; agreement: ${secondary}` : `development: ${primary}`;
+};
+
+const extractScalarSectionByKey = (key: string, text: string): string | null => {
+  const specs: Record<string, { start: RegExp[]; end: RegExp[] }> = {
+    CALOPTIMA_FBA_CHIEF_COMPLAINT: {
+      start: [/Chief\s+Complaint\/Reason\s+for\s+Seeking\s+Applied\s+Behavior\s+Analysis\s+\(ABA\)\s+Treatment:?\s*/i],
+      end: [/II\.\s+DATA\s+SOURCES/i, /Records\s+Reviewed/i],
+    },
+    CALOPTIMA_FBA_GENERALIZATION_MAINTENANCE_PLAN: {
+      start: [
+        /XVII\.\s+PLAN\s+FOR\s+GENERALIZATION\s+\(INCLUDING\s+TRANSITION\s+TO\s+NATURAL\s+MEDIATORS\)\s+AND\s+MAINTENANCE/i,
+        /PLAN\s+FOR\s+GENERALIZATION\s+\(INCLUDING\s+TRANSITION\s+TO\s+NATURAL\s+MEDIATORS\)\s+AND\s+MAINTENANCE/i,
+        /PLAN\s+FOR\s+GENERALIZATION/i,
+      ],
+      end: [/XVIII\.\s+CRISIS\s+PLAN/i, /CRISIS\s+PLAN/i, /XX\.\s+SERVICE\s+RECOMMENDATIONS/i],
+    },
+    CALOPTIMA_FBA_TRANSITION_PLAN: {
+      start: [/XIII\.\s+TRANSITION\s+PLAN/i, /\bTRANSITION\s+PLAN\s+AND\s+EXIT\s+CRITERIA\b/i],
+      end: [/XIV\.\s+/i, /CRISIS\s+PLAN/i, /SERVICE\s+RECOMMENDATIONS/i],
+    },
+  };
+  const spec = specs[key];
+  if (!spec) {
+    return null;
+  }
+  const sectionText = extractSectionText(text, spec.start, spec.end);
+  if (!sectionText) {
+    return null;
+  }
+  const withoutHeading = spec.start.reduce((current, pattern) => current.replace(pattern, ""), sectionText);
+  const cleaned = normalizeExtractedValue(withoutHeading);
+  return cleaned.length >= 10 ? cleaned : null;
+};
+
+const extractSignatureScalarByKey = (key: string, text: string): string | null => {
+  const sectionText = extractSectionText(
+    text,
+    [/XVIII\.\s+SIGNATURES/i],
+    [/\*\*\s+By\s+signing/i],
+  );
+  if (!sectionText) {
+    return null;
+  }
+  const compact = compactDocumentText(sectionText);
+  if (key === "CALOPTIMA_FBA_REPORT_COMPLETED_DATE") {
+    const match = compact.match(/Date\s+of\s+Report\s+Completed\s*:\s*([0-9]{1,2}\/[0-9]{1,2}\/[0-9]{2,4})/i);
+    return match?.[1] ? normalizeExtractedValue(match[1]) : null;
+  }
+  if (key === "CALOPTIMA_FBA_REPORT_WRITTEN_BY") {
+    const match = compact.match(/Report\s+written\s+by:\s*(?:\([^)]*\)\s*)?(?:(?:BCa?BA\/BMA\s+or\s+)?BCBA\/BMC\s+professional\s+level\s*)?(.+?)(?=Title,\s+License\/Certificate|Date\s+of\s+Report\s+Completed|Signature:)/i);
+    return match?.[1] ? normalizeExtractedValue(match[1]) : null;
+  }
+  return null;
+};
+
+const extractSpecialScalarByKey = (
+  row: z.infer<typeof checklistRowSchema>,
+  text: string,
+): ExtractedFieldResult | null => {
+  const key = row.placeholder_key;
+  const checkbox = extractCheckboxScalarByKey(key, text);
+  if (checkbox) {
+    return makeAutoField(row, checkbox, { method: "checkbox_yes_no", key }, text);
+  }
+  const signature = extractSignatureScalarByKey(key, text);
+  if (signature) {
+    return makeAutoField(row, signature, { method: "signature_section", key }, text);
+  }
+  const section = extractScalarSectionByKey(key, text);
+  if (section) {
+    return makeAutoField(row, section, { method: "section_anchor", key }, text);
+  }
+  if (key === "CALOPTIMA_FBA_TRANSITION_PLAN") {
+    return null;
+  }
+  return null;
+};
+
 const calibrateDeterministicConfidence = (rowLabel: string, valueText: string, text: string): number => {
   const normalizedText = normalizeForContains(text);
   const normalizedValue = normalizeForContains(valueText);
@@ -223,21 +466,22 @@ const calibrateDeterministicConfidence = (rowLabel: string, valueText: string, t
   return clampConfidence(confidence);
 };
 
-const extractLineNearLabels = (text: string, labels: string[]): { value: string; label: string } | null => {
+const extractLineNearLabels = (
+  text: string,
+  labels: string[],
+  stopLabels: string[] = [],
+): { value: string; label: string } | null => {
   const normalizedText = compactDocumentText(text);
   for (const label of labels) {
-    const direct = extractLineNearLabel(text, label);
+    const direct = extractLineNearLabel(text, label, stopLabels);
     if (direct) {
       return { value: direct, label };
     }
 
-    const escapedLabel = label
-      .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-      .replace(/\s+/g, "\\s+");
-    const normalizedMatch = normalizedText.match(new RegExp(`${escapedLabel}\\s*[:\\-]?\\s*(.{2,220})`, "i"));
+    const normalizedMatch = normalizedText.match(new RegExp(`${flexibleLabelPattern(label)}\\s*[:\\-]?\\s*(.{2,320})`, "i"));
     if (normalizedMatch?.[1]) {
-      const value = normalizedMatch[1].trim();
-      if (value.length > 0) {
+      const value = trimAtInlineBoundary(normalizedMatch[1], stopLabels);
+      if (value) {
         return { value, label };
       }
     }
@@ -249,10 +493,27 @@ const deterministicValueForRow = (
   row: z.infer<typeof checklistRowSchema>,
   text: string,
   clientSnapshot?: z.infer<typeof requestSchema.shape.client_snapshot>,
+  allRows?: Array<z.infer<typeof checklistRowSchema>>,
 ): ExtractedFieldResult => {
   const key = row.placeholder_key;
+  const special = extractSpecialScalarByKey(row, text);
+  if (special) {
+    return special;
+  }
+  if (key === "CALOPTIMA_FBA_TRANSITION_PLAN") {
+    return {
+      placeholder_key: key,
+      value_text: null,
+      value_json: null,
+      confidence: null,
+      mode: "MANUAL",
+      status: "not_started",
+      source_span: null,
+      review_notes: null,
+    };
+  }
   const labels = [row.label, ...(row.extraction_aliases ?? [])];
-  const fromLabel = extractLineNearLabels(text, labels);
+  const fromLabel = extractLineNearLabels(text, labels, collectStopLabels(labels, allRows));
   if (fromLabel) {
     const confidence = calibrateDeterministicConfidence(fromLabel.label, fromLabel.value, text);
     return {
@@ -442,6 +703,68 @@ const extractStructuredTableSections = (text: string): StructuredSectionResult[]
   });
 };
 
+const extractScheduleSections = (text: string): StructuredSectionResult[] => {
+  const specs = [
+    {
+      field_key: "CALOPTIMA_FBA_DAILY_ACTIVITY_SCHEDULE",
+      section_key: "daily_schedules",
+      start: [/Daily\s+schedule\s+of\s+all\s+activities/i],
+      end: [/IV\.\s+SCHOOL\s+INFORMATION/i, /Currently\s+being\s+assessed/i],
+    },
+    {
+      field_key: "CALOPTIMA_FBA_SCHOOL_SCHEDULE",
+      section_key: "daily_schedules",
+      start: [/Daily\s+School\s+Schedule/i],
+      end: [/\b1\.\s+Are\s+ABA\s+services/i, /Individualized\s+Educational\s+Plan\s+\(IEP\/equivalent\)\s+Information/i],
+    },
+  ] as const;
+
+  return specs.flatMap((spec) => {
+    const sectionText = extractSectionText(text, [...spec.start], [...spec.end]);
+    if (!sectionText) {
+      return [];
+    }
+    const rawText = normalizeExtractedValue(spec.start.reduce((current, pattern) => current.replace(pattern, ""), sectionText));
+    if (rawText.length < 5) {
+      return [];
+    }
+    return [{
+      section_key: spec.section_key,
+      field_key: spec.field_key,
+      section_index: 0,
+      payload: { rows: [{ raw_text: rawText }], raw_text: rawText },
+      source_span: { method: "deterministic_schedule_section" },
+      status: "drafted" as const,
+      required: true,
+      review_notes: "Deterministic schedule section extracted from CalOptima document text for manual table review.",
+    }];
+  });
+};
+
+const parseSignaturePayload = (rawText: string): Record<string, unknown> => {
+  const compact = compactDocumentText(rawText);
+  const writerMatch = compact.match(/Report\s+written\s+by:\s*(?:\([^)]*\)\s*)?(?:(?:BCa?BA\/BMA\s+or\s+)?BCBA\/BMC\s+professional\s+level\s*)?(.+?)(?=Title,\s+License\/Certificate|Date\s+of\s+Report\s+Completed|Signature:)/i);
+  const writerTitleMatch = compact.match(/Title,\s+License\/Certificate\s+#:\s*(.+?)(?=Date\s+of\s+Report\s+Completed|Signature:|B\.\s+Report\s+reviewed\s+by:)/i);
+  const completedDates = [...compact.matchAll(/Date\s+of\s+Report\s+Completed\s*:\s*([0-9]{1,2}\/[0-9]{1,2}\/[0-9]{2,4})?/gi)]
+    .map((match) => normalizeExtractedValue(match[1] ?? ""))
+    .filter(Boolean);
+  const signatureDates = [...compact.matchAll(/Signature:\s*(?:\*\*)?\s*Date:\s*([0-9]{1,2}\/[0-9]{1,2}\/[0-9]{2,4})?/gi)]
+    .map((match) => normalizeExtractedValue(match[1] ?? ""))
+    .filter(Boolean);
+  const reviewerMatch = compact.match(/Report\s+reviewed\s+by:\s*(?:\([^)]*\)\s*)?(?:BCBA\/BMC\s+professional\s+level\s*)?(.+?)(?=Title,\s+License\/Certificate|Date\s+of\s+Report\s+Completed|Signature:|$)/i);
+
+  return {
+    raw_text: rawText,
+    written_by: writerMatch?.[1] ? normalizeExtractedValue(writerMatch[1]) : null,
+    writer_title_license: writerTitleMatch?.[1] ? normalizeExtractedValue(writerTitleMatch[1]) : null,
+    report_completed_date: completedDates[0] ?? null,
+    writer_signature_date: signatureDates[0] ?? null,
+    reviewed_by: reviewerMatch?.[1] ? normalizeExtractedValue(reviewerMatch[1]) : null,
+    reviewer_completed_date: completedDates[1] ?? null,
+    reviewer_signature_date: signatureDates[1] ?? null,
+  };
+};
+
 const extractHcpcsRowsFromNarrative = (text: string): StructuredSectionResult[] => {
   const sectionText = extractSectionText(
     text,
@@ -519,11 +842,14 @@ const extractNarrativeStructuredSections = (text: string): StructuredSectionResu
     if (!sectionText) {
       return [];
     }
+    const payload = spec.field_key === "CALOPTIMA_FBA_SIGNATURES"
+      ? parseSignaturePayload(sectionText)
+      : { raw_text: sectionText };
     return [{
       section_key: spec.section_key,
       field_key: spec.field_key,
       section_index: 0,
-      payload: { raw_text: sectionText },
+      payload,
       source_span: { method: "deterministic_section_anchor", anchor_count: spec.start.length },
       status: "drafted" as const,
       required: true,
@@ -536,8 +862,24 @@ const extractStructuredSections = (text: string): StructuredSectionResult[] => [
   ...extractNarrativeStructuredSections(text),
   ...extractStructuredGoalSections(text),
   ...extractStructuredTableSections(text),
+  ...extractScheduleSections(text),
   ...extractHcpcsRowsFromNarrative(text),
-];
+].reduce<StructuredSectionResult[]>((deduped, section) => {
+  const existingIndex = deduped.findIndex((existing) =>
+    existing.field_key === section.field_key && existing.section_index === section.section_index
+  );
+  if (existingIndex === -1) {
+    deduped.push(section);
+    return deduped;
+  }
+  const existing = deduped[existingIndex];
+  const existingRaw = typeof existing.payload.raw_text === "string" ? existing.payload.raw_text : "";
+  const incomingRaw = typeof section.payload.raw_text === "string" ? section.payload.raw_text : "";
+  if (incomingRaw.length > existingRaw.length) {
+    deduped[existingIndex] = section;
+  }
+  return deduped;
+}, []);
 
 export const __TESTING__ = {
   deterministicValueForRow,
@@ -614,7 +956,9 @@ Deno.serve(async (req) => {
       : await decodePdfText(fileBytes);
     const textQuality = summarizeTextQuality(documentText);
 
-    const deterministic = data.checklist_rows.map((row) => deterministicValueForRow(row, documentText, data.client_snapshot));
+    const deterministic = data.checklist_rows.map((row) =>
+      deterministicValueForRow(row, documentText, data.client_snapshot, data.checklist_rows)
+    );
     const structuredSections = extractStructuredSections(documentText);
     const structuredSummaryByKey = new Map<string, { count: number; firstPayload: Record<string, unknown> }>();
     structuredSections.forEach((section) => {

--- a/tests/edge/extract-assessment-fields.caloptima.test.ts
+++ b/tests/edge/extract-assessment-fields.caloptima.test.ts
@@ -3,6 +3,37 @@ import { describe, expect, it } from "vitest";
 import { __TESTING__ } from "../../supabase/functions/extract-assessment-fields/index.ts";
 
 describe("extract-assessment-fields CalOptima parser", () => {
+  const inlineRows = [
+    {
+      section: "identification_admin",
+      label: "Administrative Contact Full Name and Title",
+      placeholder_key: "CALOPTIMA_FBA_ADMIN_CONTACT_NAME_TITLE",
+      required: true,
+      extraction_aliases: ["Full Name and Title"],
+    },
+    {
+      section: "identification_admin",
+      label: "Administrative Contact Phone Number",
+      placeholder_key: "CALOPTIMA_FBA_ADMIN_CONTACT_PHONE",
+      required: true,
+      extraction_aliases: ["Phone Number"],
+    },
+    {
+      section: "identification_admin",
+      label: "Administrative Contact Fax Number",
+      placeholder_key: "CALOPTIMA_FBA_ADMIN_CONTACT_FAX",
+      required: true,
+      extraction_aliases: ["Fax Number"],
+    },
+    {
+      section: "identification_admin",
+      label: "Chief Complaint/Reason for Seeking ABA Treatment",
+      placeholder_key: "CALOPTIMA_FBA_CHIEF_COMPLAINT",
+      required: true,
+      extraction_aliases: ["Chief Complaint/Reason for Seeking Applied Behavior Analysis (ABA) Treatment"],
+    },
+  ];
+
   it("uses registry aliases for scalar extraction from redacted-template labels", () => {
     const result = __TESTING__.deterministicValueForRow(
       {
@@ -18,6 +49,105 @@ describe("extract-assessment-fields CalOptima parser", () => {
     expect(result.status).toBe("drafted");
     expect(result.value_text).toBe("Redacted Client");
     expect(result.source_span).toMatchObject({ method: "label_regex", label: "Member full legal name" });
+  });
+
+  it("smoke-tests inline redacted-PDF label boundaries for admin contact fields", () => {
+    const text = [
+      "Administrative Contact for Current Authorization Request Full Name and Title Example Reviewer BCBA Phone Number (951) 706-0028 Fax Number (714) 494-8028",
+      "Chief Complaint/Reason for Seeking Applied Behavior Analysis (ABA) Treatment: The family is seeking ABA support across home and community settings.",
+      "II. DATA SOURCES Records Reviewed Record Type Author of Record Date of Record",
+    ].join(" ");
+
+    const byKey = new Map(
+      inlineRows.map((row) => [
+        row.placeholder_key,
+        __TESTING__.deterministicValueForRow(row, text, undefined, inlineRows),
+      ]),
+    );
+
+    expect(byKey.get("CALOPTIMA_FBA_ADMIN_CONTACT_NAME_TITLE")?.value_text).toBe("Example Reviewer BCBA");
+    expect(byKey.get("CALOPTIMA_FBA_ADMIN_CONTACT_PHONE")?.value_text).toBe("(951) 706-0028");
+    expect(byKey.get("CALOPTIMA_FBA_ADMIN_CONTACT_FAX")?.value_text).toBe("(714) 494-8028");
+    expect(byKey.get("CALOPTIMA_FBA_CHIEF_COMPLAINT")?.value_text).toBe(
+      "The family is seeking ABA support across home and community settings",
+    );
+  });
+
+  it("does not truncate narrative scalar content on ordinary date or signature words", () => {
+    const result = __TESTING__.deterministicValueForRow(
+      {
+        section: "identification_admin",
+        label: "Prior Applied Behavioral Health Agencies",
+        placeholder_key: "CALOPTIMA_FBA_PRIOR_ABA_AGENCIES",
+        required: true,
+        extraction_aliases: [],
+      },
+      "Prior Applied Behavioral Health Agencies: No prior services. Parent will sign a release at a later date if needed. Full Name and Title Reviewer",
+      undefined,
+      inlineRows,
+    );
+
+    expect(result.value_text).toBe(
+      "No prior services. Parent will sign a release at a later date if needed",
+    );
+  });
+
+  it("extracts checkbox yes/no values and leaves strict transition plan fields manual when no heading exists", () => {
+    const text = [
+      "2. Does the member have a current Individualized Educational Plan (IEP/equivalent)?",
+      "☐ Yes      ☒ No If No, please explain:",
+      "XXI. PARENT/CAREGIVER OR LEGAL GUARDIAN INVOLVEMENT",
+      "1. Was the Parent/guardian involved in the development of the treatment plan?",
+      "☒ Yes      ☐ No",
+      "2. Is the parent/guardian in agreement with the submitted treatment plan? ☒ Yes      ☐ No",
+      "XVII. PLAN FOR GENERALIZATION (INCLUDING TRANSITION TO NATURAL MEDIATORS) AND MAINTENANCE",
+      "This is a generalization plan and must not be treated as the strict transition plan.",
+    ].join(" ");
+
+    expect(__TESTING__.deterministicValueForRow(
+      {
+        section: "background_school_history",
+        label: "Current IEP/equivalent",
+        placeholder_key: "CALOPTIMA_FBA_HAS_IEP",
+        required: true,
+        extraction_aliases: ["Does the member have a current Individualized Educational Plan (IEP/equivalent)?"],
+      },
+      text,
+    ).value_text).toBe("No");
+    expect(__TESTING__.deterministicValueForRow(
+      {
+        section: "summary_recommendations_signatures",
+        label: "Parent/guardian involvement",
+        placeholder_key: "CALOPTIMA_FBA_PARENT_INVOLVEMENT",
+        required: true,
+        extraction_aliases: [
+          "Was the Parent/guardian involved in the development of the treatment plan",
+          "Is the parent/guardian in agreement with the submitted treatment plan",
+        ],
+      },
+      text,
+    ).value_text).toBe("development: Yes; agreement: Yes");
+    expect(__TESTING__.deterministicValueForRow(
+      {
+        section: "goals_treatment_planning",
+        label: "Transition plan and exit criteria",
+        placeholder_key: "CALOPTIMA_FBA_TRANSITION_PLAN",
+        required: true,
+        extraction_aliases: ["Transition to Natural Mediators"],
+      },
+      text,
+    ).status).toBe("not_started");
+
+    expect(__TESTING__.deterministicValueForRow(
+      {
+        section: "goals_treatment_planning",
+        label: "Transition plan and exit criteria",
+        placeholder_key: "CALOPTIMA_FBA_TRANSITION_PLAN",
+        required: true,
+        extraction_aliases: ["XIII. TRANSITION PLAN"],
+      },
+      "XIII. TRANSITION PLAN Please list exit plan/criteria: Step down when goals are mastered. XIV. TARGET AND REPLACEMENT BEHAVIOR GOALS",
+    ).value_text).toContain("Step down when goals are mastered");
   });
 
   it("extracts redacted-style structured sections without misclassifying goals or over-capturing boundaries", () => {
@@ -71,5 +201,50 @@ describe("extract-assessment-fields CalOptima parser", () => {
       expect.objectContaining({ hcpcs_code: "H0032-HN" }),
       expect.objectContaining({ hcpcs_code: "H2019" }),
     ]);
+  });
+
+  it("extracts schedule raw text and split signature/date payloads for review", () => {
+    const text = [
+      "Daily schedule of all activities Use the table below excluding school.",
+      "Monday Tuesday Wednesday Thursday Friday Saturday Sunday Daycare 7:40am 5:00pm Daycare 7:40am 5:00pm",
+      "IV. SCHOOL INFORMATION",
+      "Daily School Schedule Anything that pertains to when member is on school premises Monday Tuesday Wednesday Thursday Friday NA NA NA NA Friday",
+      "1. Are ABA services being requested for authorization from CalOptima Health at the school setting?",
+      "XVIII. SIGNATURES A. Report written by: (printed name, credentials) BCBA/BMC professional level",
+      "Example Author M.S., BCBA",
+      "Title, License/Certificate #: Behavior Analyst, BACB #:1-00-00000",
+      "Date of Report Completed: 07/21/2025 Signature: Date: 07/21/2025",
+      "B. Report reviewed by: (printed name, credentials) BCBA/BMC professional level",
+      "Example Reviewer BCBA Title, License/Certificate #: Date of Report Completed:",
+      "Signature: ** Date:",
+      "** By signing, I attest that I have read, reviewed, and approved this proposed treatment plan.",
+    ].join("\n");
+
+    const sections = __TESTING__.extractStructuredSections(text);
+    const byKey = new Map(sections.map((section) => [section.field_key, section]));
+
+    expect(byKey.get("CALOPTIMA_FBA_DAILY_ACTIVITY_SCHEDULE")?.payload.raw_text).toContain("Daycare 7:40am");
+    expect(byKey.get("CALOPTIMA_FBA_SCHOOL_SCHEDULE")?.payload.raw_text).toContain("NA NA NA");
+    expect(byKey.get("CALOPTIMA_FBA_SIGNATURES")?.payload).toMatchObject({
+      written_by: "Example Author M.S., BCBA",
+      report_completed_date: "07/21/2025",
+      writer_signature_date: "07/21/2025",
+    });
+    expect(byKey.get("CALOPTIMA_FBA_SIGNATURES")?.payload.raw_text).not.toContain("By signing");
+  });
+
+  it("deduplicates legacy schedule lines and anchored schedule sections by field key", () => {
+    const text = [
+      "daily activity schedule: Monday: Daycare 7:40am-5:00pm",
+      "Daily schedule of all activities Use the table below excluding school.",
+      "Monday Tuesday Wednesday Thursday Friday Daycare 7:40am 5:00pm",
+      "IV. SCHOOL INFORMATION",
+    ].join("\n");
+
+    const sections = __TESTING__.extractStructuredSections(text)
+      .filter((section) => section.field_key === "CALOPTIMA_FBA_DAILY_ACTIVITY_SCHEDULE");
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].payload.raw_text).toContain("Daycare 7:40am");
   });
 });


### PR DESCRIPTION
## Summary
- harden the direct assessment upload probe so it self-loads repo env, uses the right MIME type, and respects the configured app base URL
- add a Playwright assessment import smoke that uploads through the Programs & Goals UI, waits for extraction, captures visual evidence, and cleans up the created assessment
- extend CalOptima extraction coverage for inline label boundaries, checkbox parsing, schedules, signature payloads, and transition-plan handling

## Verification
- `npm run playwright:assessment-import-smoke`
- `npx tsx scripts/test-assessment-upload.ts af87b28a-d0cf-4c73-8bce-8f1889b77c34 "./7.21.2025_RoVa_CalOptima_FBA_FINAL (1).Redacted.docx.pdf" caloptima_fba`
- `npx vitest run tests/edge/extract-assessment-fields.caloptima.test.ts`
- `npm run verify:local`
- `npm run validate:tenant`
- `npm run ci:playwright`

## Linear
- WIN-147