### PR TITLE
Post-merge harden assessment import smoke cleanup

### DIFF
--- a/scripts/lib/assessment-import-cleanup.ts
+++ b/scripts/lib/assessment-import-cleanup.ts
@@ -1,0 +1,112 @@
+export type AssessmentImportCleanupTarget = {
+  assessmentDocumentId: string;
+  bucketId: string;
+  objectPath?: string | null;
+};
+
+type CleanupArgs = {
+  accessToken: string;
+  baseUrl: string;
+  supabaseAnonKey: string;
+  supabaseUrl: string;
+  target: AssessmentImportCleanupTarget;
+  fetchImpl?: typeof fetch;
+};
+
+const pause = async (ms: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const withRetry = async (operation: () => Promise<void>, attempts = 3): Promise<void> => {
+  let lastError: unknown;
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      await operation();
+      return;
+    } catch (error) {
+      lastError = error;
+      if (index < attempts - 1) {
+        await pause(500 * (index + 1));
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+};
+
+const deleteAssessmentDocument = async (
+  fetchImpl: typeof fetch,
+  baseUrl: string,
+  accessToken: string,
+  assessmentDocumentId: string,
+): Promise<void> => {
+  const response = await fetchImpl(
+    `${baseUrl}/api/assessment-documents?assessment_document_id=${encodeURIComponent(assessmentDocumentId)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Cleanup failed for ${assessmentDocumentId}: ${response.status} ${body}`);
+  }
+};
+
+export const deleteAssessmentStorageObject = async (
+  fetchImpl: typeof fetch,
+  args: {
+    supabaseUrl: string;
+    supabaseAnonKey: string;
+    accessToken: string;
+    bucketId: string;
+    objectPath: string;
+  },
+): Promise<void> => {
+  const { supabaseUrl, supabaseAnonKey, accessToken, bucketId, objectPath } = args;
+  const encodedPath = objectPath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  const response = await fetchImpl(`${supabaseUrl}/storage/v1/object/${encodeURIComponent(bucketId)}/${encodedPath}`, {
+    method: 'DELETE',
+    headers: {
+      apikey: supabaseAnonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (response.ok || response.status === 404) {
+    return;
+  }
+
+  const body = await response.text().catch(() => response.statusText);
+  throw new Error(`Storage cleanup failed for ${bucketId}/${objectPath}: ${response.status} ${body}`);
+};
+
+export const cleanupAssessmentImportArtifacts = async (args: CleanupArgs): Promise<void> => {
+  const fetchImpl = args.fetchImpl ?? fetch;
+  await withRetry(
+    () => deleteAssessmentDocument(fetchImpl, args.baseUrl, args.accessToken, args.target.assessmentDocumentId),
+    3,
+  );
+
+  const objectPath = args.target.objectPath?.trim();
+  if (!objectPath) {
+    return;
+  }
+
+  await withRetry(
+    () =>
+      deleteAssessmentStorageObject(fetchImpl, {
+        supabaseUrl: args.supabaseUrl,
+        supabaseAnonKey: args.supabaseAnonKey,
+        accessToken: args.accessToken,
+        bucketId: args.target.bucketId,
+        objectPath,
+      }),
+    3,
+  );
+};

--- a/scripts/playwright-assessment-import-smoke.ts
+++ b/scripts/playwright-assessment-import-smoke.ts
@@ -1,8 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { chromium } from 'playwright';
 
+import { cleanupAssessmentImportArtifacts } from './lib/assessment-import-cleanup';
 import { loadPlaywrightEnv } from './lib/load-playwright-env';
 import {
   captureFailureScreenshot,
@@ -15,6 +16,7 @@ type AssessmentDocumentRecord = {
   id: string;
   client_id: string;
   file_name: string;
+  bucket_id?: string | null;
   object_path: string;
   status: 'uploaded' | 'extracting' | 'extracted' | 'drafted' | 'approved' | 'rejected' | 'extraction_failed';
   extraction_error?: string | null;
@@ -54,6 +56,33 @@ const pause = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms));
 };
 
+const writeCleanupFailureManifest = (args: {
+  latestDir: string;
+  assessment: AssessmentDocumentRecord;
+  cleanupError: Error;
+  runError?: Error | null;
+}): string => {
+  const manifestPath = path.join(args.latestDir, `assessment-import-cleanup-failure-${Date.now()}.json`);
+  writeFileSync(
+    manifestPath,
+    JSON.stringify(
+      {
+        createdAt: new Date().toISOString(),
+        assessmentDocumentId: args.assessment.id,
+        clientId: args.assessment.client_id,
+        fileName: args.assessment.file_name,
+        bucketId: args.assessment.bucket_id?.trim() || 'client-documents',
+        objectPath: args.assessment.object_path,
+        cleanupError: args.cleanupError.message,
+        runError: args.runError?.message ?? null,
+      },
+      null,
+      2,
+    ),
+  );
+  return manifestPath;
+};
+
 const fetchAssessmentDocuments = async (
   baseUrl: string,
   accessToken: string,
@@ -70,27 +99,6 @@ const fetchAssessmentDocuments = async (
   }
 
   return (await response.json()) as AssessmentDocumentRecord[];
-};
-
-const deleteAssessmentDocument = async (
-  baseUrl: string,
-  accessToken: string,
-  assessmentDocumentId: string,
-): Promise<void> => {
-  const response = await fetch(
-    `${baseUrl}/api/assessment-documents?assessment_document_id=${encodeURIComponent(assessmentDocumentId)}`,
-    {
-      method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    },
-  );
-
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Cleanup failed for ${assessmentDocumentId}: ${response.status} ${body}`);
-  }
 };
 
 const selectClientForSmoke = async (
@@ -141,6 +149,8 @@ async function run() {
   loadPlaywrightEnv();
 
   const baseUrl = (process.env.PW_BASE_URL?.trim() || DEFAULT_BASE_URL).replace(/\/$/, '');
+  const supabaseUrl = resolveSupabaseUrl();
+  const supabaseAnonKey = resolveSupabaseAnonKey();
   const sampleFilePath = process.env.PW_ASSESSMENT_SAMPLE_FILE?.trim()
     ? path.resolve(process.cwd(), process.env.PW_ASSESSMENT_SAMPLE_FILE.trim())
     : DEFAULT_SAMPLE_FILE;
@@ -156,8 +166,8 @@ async function run() {
     },
   ]);
   const { accessToken, clientId, clientName } = await selectClientForSmoke(
-    resolveSupabaseUrl(),
-    resolveSupabaseAnonKey(),
+    supabaseUrl,
+    supabaseAnonKey,
     credentials.email,
     credentials.password,
   );
@@ -168,6 +178,10 @@ async function run() {
   const latestDir = ensureArtifactsDir();
 
   let createdAssessment: AssessmentDocumentRecord | null = null;
+  let cleanupFailure: Error | null = null;
+  let runFailure: Error | null = null;
+  let cleanupFailureManifestPath: string | null = null;
+  let cleanupFailureManifestError: Error | null = null;
 
   try {
     await loginAndAssertSession(page, baseUrl, credentials.email, credentials.password);
@@ -235,15 +249,59 @@ async function run() {
   } catch (error) {
     const screenshot = await captureFailureScreenshot(page, 'playwright-assessment-import-smoke-failure');
     console.error(`Assessment import smoke failed. Screenshot: ${screenshot}`);
-    throw error;
+    runFailure = error instanceof Error ? error : new Error(String(error));
   } finally {
     if (createdAssessment) {
-      await deleteAssessmentDocument(baseUrl, accessToken, createdAssessment.id).catch((cleanupError) => {
-        console.error('Assessment import smoke cleanup failed', cleanupError);
+      await cleanupAssessmentImportArtifacts({
+        accessToken,
+        baseUrl,
+        supabaseAnonKey,
+        supabaseUrl,
+        target: {
+          assessmentDocumentId: createdAssessment.id,
+          bucketId: createdAssessment.bucket_id?.trim() || 'client-documents',
+          objectPath: createdAssessment.object_path,
+        },
+      }).catch((cleanupError) => {
+        cleanupFailure = cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError));
+        console.error('Assessment import smoke cleanup failed', cleanupFailure);
       });
     }
     await context.close();
     await browser.close();
+    if (cleanupFailure && createdAssessment) {
+      try {
+        cleanupFailureManifestPath = writeCleanupFailureManifest({
+          latestDir,
+          assessment: createdAssessment,
+          cleanupError: cleanupFailure,
+          runError: runFailure,
+        });
+        console.error(`Assessment import smoke cleanup manifest written to ${cleanupFailureManifestPath}`);
+      } catch (manifestError) {
+        cleanupFailureManifestError =
+          manifestError instanceof Error ? manifestError : new Error(String(manifestError));
+        console.error('Assessment import smoke could not write cleanup manifest', cleanupFailureManifestError);
+      }
+    }
+    if (runFailure && cleanupFailure) {
+      throw new AggregateError(
+        [runFailure, cleanupFailure],
+        `Assessment import smoke failed and cleanup also failed: ${runFailure.message}; ${cleanupFailure.message}${
+          cleanupFailureManifestPath ? `; cleanup manifest: ${cleanupFailureManifestPath}` : ''
+        }${cleanupFailureManifestError ? `; cleanup manifest write failed: ${cleanupFailureManifestError.message}` : ''}`,
+      );
+    }
+    if (runFailure) {
+      throw runFailure;
+    }
+    if (cleanupFailure) {
+      throw new Error(
+        `${cleanupFailure.message}${
+          cleanupFailureManifestPath ? ` (cleanup manifest: ${cleanupFailureManifestPath})` : ''
+        }${cleanupFailureManifestError ? ` (cleanup manifest write failed: ${cleanupFailureManifestError.message})` : ''}`,
+      );
+    }
   }
 }
 

--- a/scripts/test-assessment-upload.ts
+++ b/scripts/test-assessment-upload.ts
@@ -203,7 +203,7 @@ async function main() {
         }
         
         process.exit(0);
-      } else if (statusData.status === 'failed') {
+      } else if (statusData.status === 'extraction_failed') {
         console.error('❌ Extraction failed');
         console.error(`  Error: ${statusData.extraction_error || 'Unknown error'}`);
         process.exit(1);

--- a/tests/scripts/assessment-import-cleanup.test.ts
+++ b/tests/scripts/assessment-import-cleanup.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { cleanupAssessmentImportArtifacts } from '../../scripts/lib/assessment-import-cleanup';
+
+describe('cleanupAssessmentImportArtifacts', () => {
+  const baseArgs = {
+    accessToken: 'token',
+    baseUrl: 'https://app.allincompassing.ai',
+    supabaseAnonKey: 'anon',
+    supabaseUrl: 'https://example.supabase.co',
+    target: {
+      assessmentDocumentId: 'doc-1',
+      bucketId: 'client-documents',
+      objectPath: 'clients/client-1/assessments/fba.pdf',
+    },
+  } as const;
+
+  it('deletes the assessment document row first, then removes the storage object', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await cleanupAssessmentImportArtifacts({ ...baseArgs, fetchImpl });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://app.allincompassing.ai/api/assessment-documents?assessment_document_id=doc-1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://example.supabase.co/storage/v1/object/client-documents/clients/client-1/assessments/fba.pdf',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('continues when the storage object is already gone', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response('not found', { status: 404 }));
+
+    await expect(cleanupAssessmentImportArtifacts({ ...baseArgs, fetchImpl })).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails and leaves storage untouched when DB cleanup cannot complete', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('delete failed', { status: 500 }))
+      .mockResolvedValueOnce(new Response('delete failed', { status: 500 }))
+      .mockResolvedValueOnce(new Response('delete failed', { status: 500 }));
+
+    await expect(cleanupAssessmentImportArtifacts({ ...baseArgs, fetchImpl })).rejects.toThrow(
+      'Cleanup failed for doc-1: 500 delete failed',
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries storage cleanup and then fails if the blob still cannot be removed', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }))
+      .mockResolvedValueOnce(new Response('boom', { status: 500 }));
+
+    await expect(cleanupAssessmentImportArtifacts({ ...baseArgs, fetchImpl })).rejects.toThrow(
+      'Storage cleanup failed for client-documents/clients/client-1/assessments/fba.pdf: 500 boom',
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
## Summary
- harden the Playwright assessment import smoke cleanup path so cleanup failures fail the run instead of being logged and ignored
- add a reusable cleanup helper with retries, durable cleanup-failure manifests, and focused cleanup tests
- align the direct upload helper with the real extraction terminal status (`extraction_failed`)

## Verification
- npx vitest run tests/scripts/assessment-import-cleanup.test.ts tests/edge/extract-assessment-fields.caloptima.test.ts src/server/__tests__/assessmentDocumentsHandler.test.ts
- npm run lint
- npm run typecheck
- npm run build
- npm run ci:check-focused

## Blocked / Notes
- `npm run playwright:assessment-import-smoke` is still blocked locally in this worktree because `PW_ADMIN_EMAIL` / `PW_ADMIN_PASSWORD` are not configured in process env.
- `npm run test:ci` still has an unrelated local failure in `src/components/__tests__/SessionNotesTab.test.tsx` after injecting placeholder Supabase env for the clean worktree; this diff does not touch that surface.
