### PR TITLE
Fix CalOptima PDF generation for unsupported Unicode

### DIFF
--- a/supabase/functions/generate-assessment-plan-pdf/index.test.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "jsr:@std/expect";
 
-import { sanitizePdfText } from "./pdf-text.ts";
+import { resolvePdfCheckboxValue, sanitizePdfText } from "./pdf-text.ts";
 
 Deno.test("sanitizePdfText normalizes unsupported glyphs for PDF rendering", () => {
   const raw =
@@ -15,4 +15,10 @@ Deno.test("sanitizePdfText preserves supported Latin-1 characters", () => {
   const raw = "José François Åsa Zoë Crème brûlée";
 
   expect(sanitizePdfText(raw)).toBe(raw);
+});
+
+Deno.test("resolvePdfCheckboxValue preserves explicit unchecked behavior for unsupported glyphs", () => {
+  expect(resolvePdfCheckboxValue("☐")).toBe(false);
+  expect(resolvePdfCheckboxValue("✗")).toBe(false);
+  expect(resolvePdfCheckboxValue("   ")).toBeNull();
 });

--- a/supabase/functions/generate-assessment-plan-pdf/index.test.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.test.ts
@@ -1,0 +1,18 @@
+import { expect } from "jsr:@std/expect";
+
+import { sanitizePdfText } from "./pdf-text.ts";
+
+Deno.test("sanitizePdfText normalizes unsupported glyphs for PDF rendering", () => {
+  const raw =
+    "Caregiver goals ● improve transitions — maintain consistency\n“Smart quotes” and ellipsis…";
+
+  expect(sanitizePdfText(raw)).toBe(
+    'Caregiver goals - improve transitions - maintain consistency\n"Smart quotes" and ellipsis...',
+  );
+});
+
+Deno.test("sanitizePdfText preserves supported Latin-1 characters", () => {
+  const raw = "José François Åsa Zoë Crème brûlée";
+
+  expect(sanitizePdfText(raw)).toBe(raw);
+});

--- a/supabase/functions/generate-assessment-plan-pdf/index.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.ts
@@ -2,7 +2,7 @@ import { PDFCheckBox, PDFDocument, PDFTextField, StandardFonts, rgb } from "npm:
 import { z } from "npm:zod@3.23.8";
 import { createProtectedRoute, corsHeaders, RouteOptions } from "../_shared/auth-middleware.ts";
 import { supabaseAdmin } from "../_shared/database.ts";
-import { sanitizePdfText } from "./pdf-text.ts";
+import { resolvePdfCheckboxValue, sanitizePdfText } from "./pdf-text.ts";
 
 const renderMapEntrySchema = z.object({
   placeholder_key: z.string().trim().min(1),
@@ -55,11 +55,6 @@ const wrapText = (text: string, maxWidth: number, font: { widthOfTextAtSize: (va
   return lines;
 };
 
-const normalizeCheckboxValue = (value: string): boolean => {
-  const normalized = value.trim().toLowerCase();
-  return normalized === "yes" || normalized === "true" || normalized === "checked" || normalized === "1";
-};
-
 export default createProtectedRoute(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { status: 204, headers: corsHeaders });
   if (req.method !== "POST") {
@@ -97,27 +92,32 @@ export default createProtectedRoute(async (req) => {
 
     for (const entry of parsed.data.render_map_entries) {
       const rawValue = parsed.data.field_values[entry.placeholder_key];
-      const value = typeof rawValue === "string" ? sanitizePdfText(rawValue) : "";
-      if (!value) continue;
+      const rawText = typeof rawValue === "string" ? rawValue : "";
 
       const match = entry.form_field_candidates
         .map((candidate) => fieldsByName.get(candidate))
         .find((field) => Boolean(field));
       if (!match) continue;
 
-      if (match instanceof PDFTextField) {
-        match.setText(value);
-        filledAcroFormCount += 1;
-        continue;
-      }
-
       if (match instanceof PDFCheckBox) {
-        if (normalizeCheckboxValue(value)) {
+        const checkboxValue = resolvePdfCheckboxValue(rawText);
+        if (checkboxValue === null) continue;
+        if (checkboxValue) {
           match.check();
         } else {
           match.uncheck();
         }
         filledAcroFormCount += 1;
+        continue;
+      }
+
+      const value = sanitizePdfText(rawText);
+      if (!value) continue;
+
+      if (match instanceof PDFTextField) {
+        match.setText(value);
+        filledAcroFormCount += 1;
+        continue;
       }
     }
 

--- a/supabase/functions/generate-assessment-plan-pdf/index.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.ts
@@ -2,6 +2,7 @@ import { PDFCheckBox, PDFDocument, PDFTextField, StandardFonts, rgb } from "npm:
 import { z } from "npm:zod@3.23.8";
 import { createProtectedRoute, corsHeaders, RouteOptions } from "../_shared/auth-middleware.ts";
 import { supabaseAdmin } from "../_shared/database.ts";
+import { sanitizePdfText } from "./pdf-text.ts";
 
 const renderMapEntrySchema = z.object({
   placeholder_key: z.string().trim().min(1),
@@ -96,7 +97,7 @@ export default createProtectedRoute(async (req) => {
 
     for (const entry of parsed.data.render_map_entries) {
       const rawValue = parsed.data.field_values[entry.placeholder_key];
-      const value = typeof rawValue === "string" ? rawValue.trim() : "";
+      const value = typeof rawValue === "string" ? sanitizePdfText(rawValue) : "";
       if (!value) continue;
 
       const match = entry.form_field_candidates
@@ -126,7 +127,7 @@ export default createProtectedRoute(async (req) => {
 
       for (const entry of parsed.data.render_map_entries) {
         const rawValue = parsed.data.field_values[entry.placeholder_key];
-        const value = typeof rawValue === "string" ? rawValue.trim() : "";
+        const value = typeof rawValue === "string" ? sanitizePdfText(rawValue) : "";
         if (!value) continue;
 
         const pageIndex = entry.fallback.page - 1;

--- a/supabase/functions/generate-assessment-plan-pdf/pdf-text.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/pdf-text.ts
@@ -20,3 +20,16 @@ export const sanitizePdfText = (value: string): string =>
     .replace(/[ \t]+/g, " ")
     .replace(/ *\n */g, "\n")
     .trim();
+
+const normalizeCheckboxValue = (value: string): boolean => {
+  const normalized = value.trim().toLowerCase();
+  return normalized === "yes" || normalized === "true" || normalized === "checked" || normalized === "1";
+};
+
+export const resolvePdfCheckboxValue = (rawValue: string): boolean | null => {
+  const trimmedRawValue = rawValue.trim();
+  if (!trimmedRawValue) return null;
+
+  const sanitizedValue = sanitizePdfText(trimmedRawValue);
+  return normalizeCheckboxValue(sanitizedValue || trimmedRawValue);
+};

--- a/supabase/functions/generate-assessment-plan-pdf/pdf-text.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/pdf-text.ts
@@ -1,0 +1,22 @@
+const PUNCTUATION_SUBSTITUTIONS: Array<[RegExp, string]> = [
+  [/[\u2018\u2019\u201A\u201B]/g, "'"],
+  [/[\u201C\u201D\u201E]/g, '"'],
+  [/[\u2013\u2014\u2212]/g, "-"],
+  [/[\u2022\u25CF\u25CB\u25A0]/g, "-"],
+  [/\u2026/g, "..."],
+];
+
+const isAllowedPdfCharacter = (character: string): boolean => {
+  if (character === "\n" || character === "\r" || character === "\t") return true;
+  const codePoint = character.codePointAt(0) ?? 0;
+  return (codePoint >= 0x20 && codePoint <= 0x7e) || (codePoint >= 0xa0 && codePoint <= 0xff);
+};
+
+export const sanitizePdfText = (value: string): string =>
+  PUNCTUATION_SUBSTITUTIONS.reduce((current, [pattern, replacement]) => current.replace(pattern, replacement), value)
+    .split("")
+    .map((character) => (isAllowedPdfCharacter(character) ? character : " "))
+    .join("")
+    .replace(/[ \t]+/g, " ")
+    .replace(/ *\n */g, "\n")
+    .trim();


### PR DESCRIPTION
## Summary
- sanitize unsupported punctuation before CalOptima PDF AcroForm/overlay writes
- keep supported Latin-1 characters intact instead of decomposing them
- add isolated Deno coverage for punctuation normalization and Latin-1 preservation

## Validation
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run build
- deno test --allow-env --no-check supabase/functions/generate-assessment-plan-pdf/index.test.ts
- npx vitest run src/server/__tests__/assessmentPlanPdfHandler.test.ts
- npm run test:ci (fails on unrelated env-sensitive orgRoleRpcEquivalence tests in this branch; see run output)

## Context
- Hosted assessment document 41df4f57-1a22-4df1-b05f-cf8f3675267c was advanced past the missing-value gate.
- Production PDF generation currently still returns 500 until this fix is reviewed and deployed.
- Linear: WIN-147