### PR TITLE
Fix CalOptima PDF overlay placement smoke

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -89,13 +89,17 @@ npx vitest run \
   src/server/__tests__/assessmentPlanPdfHandler.test.ts \
   src/server/__tests__/assessmentPlanPdfTemplate.test.ts \
   src/components/__tests__/ProgramsGoalsTab.test.tsx
+npm run playwright:assessment-pdf-smoke
 ```
 
 This covers:
 
 - API precondition gating for `/api/assessment-plan-pdf`
 - checklist-to-render-map parity validation
-- UI trigger behavior for `Generate Completed CalOptima PDF`
+- overlay warning propagation for `Generate Completed CalOptima PDF`
+- visual placement smoke for generated CalOptima PDF pages with mapped fields
+
+`npm run playwright:assessment-pdf-smoke` requires authenticated Playwright/Supabase env plus `PW_ASSESSMENT_DOCUMENT_ID` for an approved CalOptima assessment with accepted program/goals.
 
 ## Agent eval smoke (edge functions)
 

--- a/docs/fill_docs/CALOPTIMA_PDF_GENERATION_RUNBOOK.md
+++ b/docs/fill_docs/CALOPTIMA_PDF_GENERATION_RUNBOOK.md
@@ -19,6 +19,7 @@ Before generation can succeed:
 - At least one draft program and one draft goal are in `accepted` or `edited` state.
 - The CalOptima render map exists and is valid:
   - `docs/fill_docs/caloptima_fba_pdf_render_map.json`
+- Every exported render map fallback has bounded overlay metadata: `height`, `line_height`, `max_lines`, and `field_kind`.
 
 If any precondition fails, API returns `409` with details.
 
@@ -29,7 +30,9 @@ If any precondition fails, API returns `409` with details.
 3. Confirm checklist required fields are approved.
 4. Confirm draft program/goals are accepted or edited.
 5. Click **Generate Completed CalOptima PDF**.
-6. Verify a success toast appears and the signed URL opens/downloads.
+6. Verify the signed URL opens/downloads.
+7. If the app reports layout warnings, review the PDF before sending and recalibrate the affected render-map keys.
+8. Run the visual smoke check before marking the second-stage workflow client-ready.
 
 ## API behavior summary
 
@@ -41,10 +44,12 @@ If any precondition fails, API returns `409` with details.
 - Calls the Edge function for PDF generation.
 - Writes `assessment_review_events` action `plan_pdf_generated`.
 - Returns:
-  - `fill_mode` (`acroform` or `overlay`)
+  - `fill_mode` (`acroform`, `overlay`, or `mixed`)
   - `bucket_id`
   - `object_path`
   - `signed_url`
+  - `layout_warnings`
+  - `overflow_keys`
 
 ## Fill-mode behavior
 
@@ -52,7 +57,10 @@ If any precondition fails, API returns `409` with details.
   - Used when matching PDF form fields are found from render map candidates.
 - `overlay` mode:
   - Automatic fallback when no matching form fields are available.
-  - Draws text using configured page/x/y/font metadata.
+  - Draws text inside configured page/x/y/font/box metadata.
+  - Stops rendering before text crosses the configured box and returns layout warnings for any overflow.
+- `mixed` mode:
+  - Used when some fields are filled through AcroForm and remaining fields are rendered through bounded overlay.
 
 ## Common failures and fixes
 
@@ -66,6 +74,10 @@ If any precondition fails, API returns `409` with details.
   - Check edge function logs and confirm template base64 payload and render map validity.
 - `500 Failed to create download URL`
   - Validate storage bucket permissions and service role access.
+- PDF opens but app reports layout warnings
+  - Do not send it to the client. Update the specific render-map boxes listed in `overflow_keys`, regenerate, and rerun the smoke check.
+- PDF values overlap labels, borders, or adjacent fields
+  - Treat the workflow as not client-ready. Recalibrate `docs/fill_docs/caloptima_fba_pdf_render_map.json` and rerun `npm run playwright:assessment-pdf-smoke`.
 
 ## Verification commands
 
@@ -78,7 +90,10 @@ npx vitest run \
   src/server/__tests__/assessmentPlanPdfHandler.test.ts \
   src/server/__tests__/assessmentPlanPdfTemplate.test.ts \
   src/components/__tests__/ProgramsGoalsTab.test.tsx
+npm run playwright:assessment-pdf-smoke
 ```
+
+`npm run playwright:assessment-pdf-smoke` requires `PW_ADMIN_EMAIL`, `PW_ADMIN_PASSWORD`, Supabase URL/key env, and `PW_ASSESSMENT_DOCUMENT_ID` pointing to an approved CalOptima assessment with accepted program/goals. The smoke generates through `POST /api/assessment-plan-pdf`, downloads the signed PDF, renders mapped pages to screenshots, and fails if generated pixels appear outside allowed boxes or the renderer reports overflow.
 
 ## Audit and traceability
 
@@ -89,3 +104,5 @@ npx vitest run \
   - `generated_bucket_id`
   - `generated_object_path`
   - `missing_required_count`
+  - `layout_warning_count`
+  - `overflow_keys`

--- a/docs/fill_docs/caloptima_fba_pdf_render_map.json
+++ b/docs/fill_docs/caloptima_fba_pdf_render_map.json
@@ -2,7 +2,7 @@
   "template_type": "caloptima_fba",
   "template_name": "CalOptima Health Functional Behavior Assessment / Initial Treatment Plan",
   "source_document": "CalOptima Health FBA Template (2).pdf",
-  "version": "2026-02-19",
+  "version": "2026-05-13",
   "entries": [
     {
       "placeholder_key": "CALOPTIMA_FBA_MEMBER_NAME",
@@ -15,7 +15,11 @@
         "x": 95,
         "y": 694,
         "font_size": 10,
-        "max_width": 210
+        "max_width": 210,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -31,7 +35,11 @@
         "x": 95,
         "y": 678,
         "font_size": 10,
-        "max_width": 120
+        "max_width": 120,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "date"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -48,7 +56,11 @@
         "x": 245,
         "y": 678,
         "font_size": 10,
-        "max_width": 120
+        "max_width": 120,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -64,7 +76,11 @@
         "x": 95,
         "y": 647,
         "font_size": 9,
-        "max_width": 430
+        "max_width": 430,
+        "height": 36,
+        "line_height": 11,
+        "max_lines": 3,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -80,7 +96,11 @@
         "x": 95,
         "y": 618,
         "font_size": 10,
-        "max_width": 230
+        "max_width": 230,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -97,7 +117,11 @@
         "x": 350,
         "y": 618,
         "font_size": 10,
-        "max_width": 160
+        "max_width": 160,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "phone"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -113,7 +137,11 @@
         "x": 95,
         "y": 602,
         "font_size": 10,
-        "max_width": 230
+        "max_width": 230,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -129,7 +157,11 @@
         "x": 350,
         "y": 602,
         "font_size": 10,
-        "max_width": 160
+        "max_width": 160,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -145,7 +177,11 @@
         "x": 95,
         "y": 586,
         "font_size": 9,
-        "max_width": 230
+        "max_width": 230,
+        "height": 36,
+        "line_height": 11,
+        "max_lines": 3,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -161,7 +197,11 @@
         "x": 350,
         "y": 586,
         "font_size": 9,
-        "max_width": 160
+        "max_width": 160,
+        "height": 36,
+        "line_height": 11,
+        "max_lines": 3,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -174,10 +214,14 @@
       ],
       "fallback": {
         "page": 2,
-        "x": 95,
-        "y": 665,
+        "x": 64,
+        "y": 655,
         "font_size": 10,
-        "max_width": 170
+        "max_width": 208,
+        "height": 12,
+        "max_lines": 1,
+        "field_kind": "date",
+        "line_height": 12
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -190,10 +234,14 @@
       ],
       "fallback": {
         "page": 2,
-        "x": 280,
-        "y": 665,
+        "x": 306,
+        "y": 655,
         "font_size": 10,
-        "max_width": 170
+        "max_width": 210,
+        "height": 12,
+        "max_lines": 1,
+        "field_kind": "date",
+        "line_height": 12
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -206,10 +254,14 @@
       ],
       "fallback": {
         "page": 2,
-        "x": 95,
-        "y": 634,
-        "font_size": 9,
-        "max_width": 430
+        "x": 64,
+        "y": 628,
+        "font_size": 8,
+        "max_width": 455,
+        "height": 13,
+        "max_lines": 1,
+        "field_kind": "text",
+        "line_height": 10
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -222,10 +274,14 @@
       ],
       "fallback": {
         "page": 2,
-        "x": 95,
-        "y": 603,
-        "font_size": 10,
-        "max_width": 190
+        "x": 64,
+        "y": 591,
+        "font_size": 8,
+        "max_width": 214,
+        "height": 12,
+        "max_lines": 1,
+        "field_kind": "text",
+        "line_height": 10
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -238,10 +294,14 @@
       ],
       "fallback": {
         "page": 2,
-        "x": 300,
-        "y": 603,
-        "font_size": 10,
-        "max_width": 110
+        "x": 302,
+        "y": 591,
+        "font_size": 8,
+        "max_width": 104,
+        "height": 12,
+        "max_lines": 1,
+        "field_kind": "phone",
+        "line_height": 10
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -254,10 +314,14 @@
       ],
       "fallback": {
         "page": 2,
-        "x": 420,
-        "y": 603,
-        "font_size": 10,
-        "max_width": 110
+        "x": 417,
+        "y": 591,
+        "font_size": 8,
+        "max_width": 102,
+        "height": 12,
+        "max_lines": 1,
+        "field_kind": "phone",
+        "line_height": 10
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -270,10 +334,14 @@
       ],
       "fallback": {
         "page": 2,
-        "x": 95,
-        "y": 560,
-        "font_size": 9,
-        "max_width": 430
+        "x": 64,
+        "y": 541,
+        "font_size": 7,
+        "max_width": 455,
+        "height": 26,
+        "max_lines": 3,
+        "line_height": 8,
+        "field_kind": "multiline_text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -286,10 +354,14 @@
       ],
       "fallback": {
         "page": 2,
-        "x": 95,
-        "y": 470,
-        "font_size": 8,
-        "max_width": 430
+        "x": 64,
+        "y": 457,
+        "font_size": 7,
+        "max_width": 455,
+        "height": 47,
+        "max_lines": 5,
+        "line_height": 8,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -302,10 +374,14 @@
       ],
       "fallback": {
         "page": 2,
-        "x": 95,
-        "y": 380,
-        "font_size": 8,
-        "max_width": 430
+        "x": 64,
+        "y": 361,
+        "font_size": 7,
+        "max_width": 455,
+        "height": 48,
+        "max_lines": 6,
+        "line_height": 8,
+        "field_kind": "multiline_text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -318,10 +394,14 @@
       ],
       "fallback": {
         "page": 2,
-        "x": 95,
-        "y": 306,
-        "font_size": 8,
-        "max_width": 430
+        "x": 64,
+        "y": 287,
+        "font_size": 7,
+        "max_width": 455,
+        "height": 48,
+        "max_lines": 6,
+        "line_height": 8,
+        "field_kind": "multiline_text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -337,7 +417,11 @@
         "x": 95,
         "y": 336,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -353,7 +437,11 @@
         "x": 95,
         "y": 584,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -369,7 +457,11 @@
         "x": 95,
         "y": 508,
         "font_size": 10,
-        "max_width": 200
+        "max_width": 200,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -385,7 +477,11 @@
         "x": 95,
         "y": 480,
         "font_size": 10,
-        "max_width": 200
+        "max_width": 200,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "date"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -401,7 +497,11 @@
         "x": 95,
         "y": 236,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -417,7 +517,11 @@
         "x": 95,
         "y": 380,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -433,7 +537,11 @@
         "x": 95,
         "y": 480,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -449,7 +557,11 @@
         "x": 95,
         "y": 690,
         "font_size": 10,
-        "max_width": 430
+        "max_width": 430,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -465,7 +577,11 @@
         "x": 95,
         "y": 620,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -481,7 +597,11 @@
         "x": 95,
         "y": 650,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -497,7 +617,11 @@
         "x": 95,
         "y": 650,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -513,7 +637,11 @@
         "x": 95,
         "y": 650,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -529,7 +657,11 @@
         "x": 95,
         "y": 650,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -545,7 +677,11 @@
         "x": 95,
         "y": 562,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -561,7 +697,11 @@
         "x": 95,
         "y": 610,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -577,7 +717,11 @@
         "x": 95,
         "y": 486,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -593,7 +737,11 @@
         "x": 95,
         "y": 574,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 120,
+        "line_height": 10,
+        "max_lines": 12,
+        "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -609,7 +757,11 @@
         "x": 95,
         "y": 416,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 36,
+        "line_height": 10,
+        "max_lines": 3,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -625,7 +777,11 @@
         "x": 95,
         "y": 388,
         "font_size": 10,
-        "max_width": 430
+        "max_width": 430,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -641,7 +797,11 @@
         "x": 95,
         "y": 366,
         "font_size": 10,
-        "max_width": 430
+        "max_width": 430,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -657,7 +817,11 @@
         "x": 95,
         "y": 248,
         "font_size": 10,
-        "max_width": 220
+        "max_width": 220,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -673,7 +837,11 @@
         "x": 330,
         "y": 248,
         "font_size": 10,
-        "max_width": 190
+        "max_width": 190,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -689,7 +857,11 @@
         "x": 95,
         "y": 231,
         "font_size": 10,
-        "max_width": 140
+        "max_width": 140,
+        "height": 14,
+        "line_height": 12,
+        "max_lines": 1,
+        "field_kind": "date"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false
@@ -705,7 +877,11 @@
         "x": 95,
         "y": 206,
         "font_size": 8,
-        "max_width": 430
+        "max_width": 430,
+        "height": 36,
+        "line_height": 10,
+        "max_lines": 3,
+        "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "playwright:therapist-authorization": "tsx scripts/playwright-therapist-authorization.ts",
     "playwright:authorizations-read-scope": "tsx scripts/playwright-authorizations-read-scope-smoke.ts",
     "playwright:assessment-import-smoke": "tsx scripts/playwright-assessment-import-smoke.ts",
+    "playwright:assessment-pdf-smoke": "tsx scripts/playwright-assessment-pdf-smoke.ts",
     "playwright:mobile-role-smoke": "tsx scripts/playwright-mobile-role-smoke.ts",
     "playwright:preflight": "tsx scripts/playwright-preflight.ts",
     "playwright:session-lifecycle": "tsx scripts/playwright-session-lifecycle.ts",

--- a/scripts/playwright-assessment-pdf-smoke.ts
+++ b/scripts/playwright-assessment-pdf-smoke.ts
@@ -1,0 +1,265 @@
+import { createClient } from '@supabase/supabase-js';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { chromium, type Page } from 'playwright';
+
+import { loadPlaywrightEnv } from './lib/load-playwright-env';
+import { ensureArtifactsDir, preflightCredentials } from './lib/playwright-smoke';
+
+type RenderMapEntry = {
+  placeholder_key: string;
+  fallback: {
+    page: number;
+    x: number;
+    y: number;
+    font_size: number;
+    max_width: number;
+    height?: number;
+  };
+};
+
+type GeneratePdfResponse = {
+  signed_url: string;
+  fill_mode: 'acroform' | 'overlay' | 'mixed';
+  object_path: string;
+  layout_warnings?: Array<{ placeholder_key: string; page: number; reason: string }>;
+  overflow_keys?: string[];
+};
+
+type PageReport = {
+  page: number;
+  changedPixels: number;
+  outsideAllowedPixels: number;
+  screenshot: string;
+  diff: string;
+};
+
+const DEFAULT_BASE_URL = 'https://app.allincompassing.ai';
+const PDF_PAGE_WIDTH_POINTS = 612;
+const PDF_PAGE_HEIGHT_POINTS = 792;
+const SCREENSHOT_WIDTH = 816;
+const SCREENSHOT_HEIGHT = 1056;
+const OUTSIDE_ALLOWED_PIXEL_TOLERANCE = 350;
+
+const getRequiredEnv = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required for assessment PDF visual smoke.`);
+  }
+  return value;
+};
+
+const resolveSupabaseUrl = (): string => process.env.VITE_SUPABASE_URL?.trim() || getRequiredEnv('SUPABASE_URL');
+const resolveSupabaseAnonKey = (): string =>
+  process.env.VITE_SUPABASE_ANON_KEY?.trim() || getRequiredEnv('SUPABASE_ANON_KEY');
+
+const dataUrlForFile = (filePath: string, mimeType: string): string => {
+  const encoded = readFileSync(filePath).toString('base64');
+  return `data:${mimeType};base64,${encoded}`;
+};
+
+const renderPdfPageScreenshot = async (page: Page, pdfDataUrl: string, pageNumber: number, outputPath: string) => {
+  await page.setViewportSize({ width: SCREENSHOT_WIDTH, height: SCREENSHOT_HEIGHT });
+  await page.setContent(
+    `<html><body style="margin:0;overflow:hidden;background:#fff"><iframe title="pdf" src="${pdfDataUrl}#toolbar=0&page=${pageNumber}&zoom=100" style="border:0;width:${SCREENSHOT_WIDTH}px;height:${SCREENSHOT_HEIGHT}px"></iframe></body></html>`,
+  );
+  await page.waitForTimeout(1_500);
+  await page.screenshot({ path: outputPath, fullPage: false });
+};
+
+const compareScreenshots = async (
+  page: Page,
+  blankScreenshot: string,
+  generatedScreenshot: string,
+  entries: RenderMapEntry[],
+  diffPath: string,
+) => {
+  const blankUrl = dataUrlForFile(blankScreenshot, 'image/png');
+  const generatedUrl = dataUrlForFile(generatedScreenshot, 'image/png');
+  return page.evaluate(
+    async ({ blankUrl: blank, generatedUrl: generated, entries: fieldEntries, diffPath: ignoredDiffPath, pageWidth, pageHeight }) => {
+      const browserGlobal = globalThis as Record<string, any>;
+      const loadImage = async (src: string): Promise<any> => {
+        const response = await browserGlobal.fetch(src);
+        const blob = await response.blob();
+        return browserGlobal.createImageBitmap(blob);
+      };
+      const [blankImage, generatedImage] = await Promise.all([loadImage(blank), loadImage(generated)]);
+      const width = Number((generatedImage as { width: number }).width);
+      const height = Number((generatedImage as { height: number }).height);
+      const canvas = new browserGlobal.OffscreenCanvas(width, height);
+      const context = canvas.getContext('2d');
+      if (!context) throw new Error('Could not create screenshot comparison canvas.');
+      context.drawImage(blankImage, 0, 0);
+      const blankPixels = context.getImageData(0, 0, width, height);
+      context.clearRect(0, 0, width, height);
+      context.drawImage(generatedImage, 0, 0);
+      const generatedPixels = context.getImageData(0, 0, width, height);
+      const diffPixels = context.createImageData(width, height);
+
+      const allowed = new Uint8Array(width * height);
+      const scaleX = width / pageWidth;
+      const scaleY = height / pageHeight;
+      for (const entry of fieldEntries) {
+        const box = entry.fallback;
+        const left = Math.max(0, Math.floor(box.x * scaleX) - 3);
+        const top = Math.max(0, Math.floor((pageHeight - (box.y + box.font_size)) * scaleY) - 3);
+        const right = Math.min(width, Math.ceil((box.x + box.max_width) * scaleX) + 3);
+        const bottom = Math.min(height, Math.ceil((pageHeight - box.y + (box.height ?? 14)) * scaleY) + 3);
+        for (let y = top; y < bottom; y += 1) {
+          for (let x = left; x < right; x += 1) {
+            allowed[y * width + x] = 1;
+          }
+        }
+      }
+
+      let changedPixels = 0;
+      let outsideAllowedPixels = 0;
+      for (let index = 0; index < generatedPixels.data.length; index += 4) {
+        const delta =
+          Math.abs(generatedPixels.data[index] - blankPixels.data[index]) +
+          Math.abs(generatedPixels.data[index + 1] - blankPixels.data[index + 1]) +
+          Math.abs(generatedPixels.data[index + 2] - blankPixels.data[index + 2]);
+        const pixelIndex = index / 4;
+        if (delta <= 45) {
+          diffPixels.data[index + 3] = 255;
+          continue;
+        }
+        changedPixels += 1;
+        const isAllowed = allowed[pixelIndex] === 1;
+        if (!isAllowed) outsideAllowedPixels += 1;
+        diffPixels.data[index] = isAllowed ? 0 : 220;
+        diffPixels.data[index + 1] = isAllowed ? 160 : 0;
+        diffPixels.data[index + 2] = isAllowed ? 0 : 0;
+        diffPixels.data[index + 3] = 255;
+      }
+
+      context.putImageData(diffPixels, 0, 0);
+      const blob = await canvas.convertToBlob({ type: 'image/png' });
+      const diffDataUrl = await new Promise<string>((resolve, reject) => {
+        const reader = new browserGlobal.FileReader();
+        reader.onload = () => resolve(String(reader.result));
+        reader.onerror = () => reject(reader.error ?? new Error('Could not encode diff image.'));
+        reader.readAsDataURL(blob);
+      });
+      return {
+        changedPixels,
+        outsideAllowedPixels,
+        diffDataUrl,
+        diffPath: ignoredDiffPath,
+      };
+    },
+    { blankUrl, generatedUrl, entries, diffPath, pageWidth: PDF_PAGE_WIDTH_POINTS, pageHeight: PDF_PAGE_HEIGHT_POINTS },
+  );
+};
+
+async function run() {
+  loadPlaywrightEnv();
+
+  const baseUrl = (process.env.PW_BASE_URL?.trim() || DEFAULT_BASE_URL).replace(/\/$/, '');
+  const assessmentDocumentId =
+    process.env.PW_ASSESSMENT_DOCUMENT_ID?.trim() || process.env.ASSESSMENT_DOCUMENT_ID?.trim();
+  if (!assessmentDocumentId) {
+    throw new Error('PW_ASSESSMENT_DOCUMENT_ID is required so the smoke can generate a deterministic PDF.');
+  }
+
+  const credentials = preflightCredentials([
+    {
+      email: process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL,
+      password: process.env.PW_ADMIN_PASSWORD ?? process.env.PLAYWRIGHT_ADMIN_PASSWORD,
+      label: 'PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD',
+    },
+  ]);
+  const supabase = createClient(resolveSupabaseUrl(), resolveSupabaseAnonKey());
+  const { data: authData, error: authError } = await supabase.auth.signInWithPassword(credentials);
+  if (authError || !authData.session) {
+    throw authError ?? new Error('Could not authenticate PDF visual smoke user.');
+  }
+
+  const generateResponse = await fetch(`${baseUrl}/api/assessment-plan-pdf`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${authData.session.access_token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ assessment_document_id: assessmentDocumentId }),
+  });
+  if (!generateResponse.ok) {
+    throw new Error(`PDF generation failed with status ${generateResponse.status}: ${await generateResponse.text()}`);
+  }
+  const generated = (await generateResponse.json()) as GeneratePdfResponse;
+  const overflowKeys = generated.overflow_keys ?? generated.layout_warnings?.map((warning) => warning.placeholder_key) ?? [];
+  if (overflowKeys.length > 0) {
+    throw new Error(`PDF renderer reported layout overflow: ${overflowKeys.join(', ')}`);
+  }
+
+  const latestDir = ensureArtifactsDir();
+  const outputDir = path.join(latestDir, `assessment-pdf-smoke-${Date.now()}`);
+  mkdirSync(outputDir, { recursive: true });
+
+  const generatedPdfResponse = await fetch(generated.signed_url);
+  if (!generatedPdfResponse.ok) {
+    throw new Error(`Could not download generated PDF: ${generatedPdfResponse.status}`);
+  }
+  const generatedPdfPath = path.join(outputDir, 'generated-caloptima.pdf');
+  writeFileSync(generatedPdfPath, Buffer.from(await generatedPdfResponse.arrayBuffer()));
+
+  const templatePath = path.resolve(process.cwd(), 'CalOptima Health FBA Template (2).pdf');
+  const renderMap = JSON.parse(readFileSync(path.resolve(process.cwd(), 'docs/fill_docs/caloptima_fba_pdf_render_map.json'), 'utf8')) as {
+    entries: RenderMapEntry[];
+  };
+  const pages = Array.from(new Set(renderMap.entries.map((entry) => entry.fallback.page))).sort((left, right) => left - right);
+  if (!pages.includes(2)) {
+    throw new Error('CalOptima PDF visual smoke requires page 2 coverage.');
+  }
+
+  const browser = await chromium.launch({ headless: process.env.HEADLESS !== 'false' });
+  const page = await browser.newPage();
+  const templateDataUrl = dataUrlForFile(templatePath, 'application/pdf');
+  const generatedDataUrl = dataUrlForFile(generatedPdfPath, 'application/pdf');
+  const reportPages: PageReport[] = [];
+
+  try {
+    for (const pageNumber of pages) {
+      const blankScreenshot = path.join(outputDir, `blank-page-${pageNumber}.png`);
+      const generatedScreenshot = path.join(outputDir, `generated-page-${pageNumber}.png`);
+      const diffPath = path.join(outputDir, `diff-page-${pageNumber}.png`);
+      await renderPdfPageScreenshot(page, templateDataUrl, pageNumber, blankScreenshot);
+      await renderPdfPageScreenshot(page, generatedDataUrl, pageNumber, generatedScreenshot);
+      const pageEntries = renderMap.entries.filter((entry) => entry.fallback.page === pageNumber);
+      const comparison = await compareScreenshots(page, blankScreenshot, generatedScreenshot, pageEntries, diffPath);
+      writeFileSync(diffPath, Buffer.from(comparison.diffDataUrl.split(',')[1] ?? '', 'base64'));
+      reportPages.push({
+        page: pageNumber,
+        changedPixels: comparison.changedPixels,
+        outsideAllowedPixels: comparison.outsideAllowedPixels,
+        screenshot: generatedScreenshot,
+        diff: diffPath,
+      });
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const failingPages = reportPages.filter((entry) => entry.outsideAllowedPixels > OUTSIDE_ALLOWED_PIXEL_TOLERANCE);
+  const report = {
+    ok: failingPages.length === 0,
+    assessmentDocumentId,
+    fillMode: generated.fill_mode,
+    objectPath: generated.object_path,
+    outputDir,
+    outsideAllowedPixelTolerance: OUTSIDE_ALLOWED_PIXEL_TOLERANCE,
+    pages: reportPages,
+  };
+  const reportPath = path.join(outputDir, 'report.json');
+  writeFileSync(reportPath, JSON.stringify(report, null, 2));
+  console.log(JSON.stringify(report, null, 2));
+  if (failingPages.length > 0) {
+    throw new Error(`PDF visual smoke found changed pixels outside mapped boxes. Report: ${reportPath}`);
+  }
+}
+
+run().catch((error) => {
+  console.error('Playwright assessment PDF smoke failed', error);
+  process.exit(1);
+});

--- a/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
+++ b/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
@@ -60,9 +60,18 @@ export interface AssessmentDraftResponse {
 }
 
 export interface AssessmentPlanPdfResponse {
-  fill_mode: "acroform" | "overlay";
+  fill_mode: "acroform" | "overlay" | "mixed";
   signed_url: string;
   object_path: string;
+  layout_warnings?: Array<{
+    placeholder_key: string;
+    page: number;
+    reason: "overflow";
+    rendered_line_count: number;
+    total_line_count: number;
+    max_lines: number;
+  }>;
+  overflow_keys?: string[];
 }
 
 export const EMPTY_ASSESSMENT_DOCUMENTS: AssessmentDocumentRecord[] = [];

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -1076,7 +1076,15 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       if (typeof window !== "undefined" && result.signed_url) {
         window.open(result.signed_url, "_blank", "noopener,noreferrer");
       }
-      const modeLabel = result.fill_mode === "acroform" ? "AcroForm" : "overlay";
+      const modeLabel =
+        result.fill_mode === "acroform" ? "AcroForm" : result.fill_mode === "mixed" ? "mixed AcroForm/overlay" : "overlay";
+      const overflowKeys = result.overflow_keys ?? result.layout_warnings?.map((warning) => warning.placeholder_key) ?? [];
+      if (overflowKeys.length > 0) {
+        showInfo(
+          `Completed CalOptima PDF generated (${modeLabel} mode) with ${overflowKeys.length} layout warning(s). Review before sending.`,
+        );
+        return;
+      }
       showSuccess(`Completed CalOptima PDF generated (${modeLabel} mode).`);
     },
     onError: showError,

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1862,6 +1862,90 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     openSpy.mockRestore();
   });
 
+  it("warns operators when generated CalOptima PDF has layout overflow warnings", async () => {
+    const user = userEvent.setup();
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify({ items: [], structured_sections: [] }), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/fba.pdf",
+              status: "uploaded",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "POST" && path === "/api/assessment-plan-pdf") {
+        return new Response(
+          JSON.stringify({
+            fill_mode: "overlay",
+            signed_url: "https://example.com/generated-plan.pdf",
+            object_path: "clients/client-1/assessments/generated.pdf",
+            overflow_keys: ["CALOPTIMA_FBA_CHIEF_COMPLAINT"],
+            layout_warnings: [
+              {
+                placeholder_key: "CALOPTIMA_FBA_CHIEF_COMPLAINT",
+                page: 2,
+                reason: "overflow",
+                rendered_line_count: 3,
+                total_line_count: 5,
+                max_lines: 3,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("fba.pdf");
+    const exportPdfButton = screen.getByRole("button", { name: /Optional: Export Completed CalOptima PDF/i });
+    await waitFor(() => {
+      expect(exportPdfButton).not.toBeDisabled();
+    });
+    await user.click(exportPdfButton);
+
+    await waitFor(() => {
+      expect(showInfo).toHaveBeenCalledWith(
+        "Completed CalOptima PDF generated (overlay mode) with 1 layout warning(s). Review before sending.",
+      );
+    });
+    expect(showSuccess).not.toHaveBeenCalledWith("Completed CalOptima PDF generated (overlay mode).");
+    expect(openSpy).toHaveBeenCalledWith("https://example.com/generated-plan.pdf", "_blank", "noopener,noreferrer");
+    openSpy.mockRestore();
+  });
+
   it("shows a visible extracting indicator for assessment processing", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();

--- a/src/server/__tests__/assessmentPlanPdfHandler.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfHandler.test.ts
@@ -46,7 +46,7 @@ describe("assessmentPlanPdfHandler", () => {
       {
         placeholder_key: "CALOPTIMA_FBA_MEMBER_NAME",
         form_field_candidates: ["Member Name"],
-        fallback: { page: 1, x: 10, y: 10, font_size: 10, max_width: 100 },
+        fallback: { page: 1, x: 10, y: 10, font_size: 10, max_width: 100, height: 14, line_height: 12, max_lines: 1 },
       },
     ]);
   });
@@ -162,6 +162,17 @@ describe("assessmentPlanPdfHandler", () => {
           bucket_id: "client-documents",
           object_path: "clients/client-1/assessments/generated.pdf",
           signed_url: "https://example.com/generated.pdf",
+          layout_warnings: [
+            {
+              placeholder_key: "CALOPTIMA_FBA_CHIEF_COMPLAINT",
+              page: 2,
+              reason: "overflow",
+              rendered_line_count: 3,
+              total_line_count: 5,
+              max_lines: 3,
+            },
+          ],
+          overflow_keys: ["CALOPTIMA_FBA_CHIEF_COMPLAINT"],
         },
       })
       .mockResolvedValueOnce({ ok: true, status: 201, data: null });
@@ -178,5 +189,13 @@ describe("assessmentPlanPdfHandler", () => {
     const body = await response.json();
     expect(body.signed_url).toBe("https://example.com/generated.pdf");
     expect(body.fill_mode).toBe("overlay");
+    expect(body.overflow_keys).toEqual(["CALOPTIMA_FBA_CHIEF_COMPLAINT"]);
+    expect(body.layout_warnings).toHaveLength(1);
+    expect(fetchJson).toHaveBeenLastCalledWith(
+      "https://example.supabase.co/rest/v1/assessment_review_events",
+      expect.objectContaining({
+        body: expect.stringContaining("layout_warning_count"),
+      }),
+    );
   });
 });

--- a/src/server/__tests__/assessmentPlanPdfTemplate.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfTemplate.test.ts
@@ -43,6 +43,22 @@ describe("CalOptima PDF render map", () => {
     expect(missingKeys).toEqual([]);
   });
 
+  it("bounds every exported PDF overlay fallback so rendered text cannot cross template fields", async () => {
+    const renderMap = await loadCalOptimaPdfRenderMap();
+
+    renderMap.forEach((entry) => {
+      expect(entry.fallback.page).toBeGreaterThanOrEqual(1);
+      expect(entry.fallback.page).toBeLessThanOrEqual(28);
+      expect(entry.fallback.x).toBeGreaterThanOrEqual(0);
+      expect(entry.fallback.y).toBeGreaterThanOrEqual(0);
+      expect(entry.fallback.max_width).toBeGreaterThan(0);
+      expect(entry.fallback.height).toBeGreaterThan(0);
+      expect(entry.fallback.line_height).toBeGreaterThan(0);
+      expect(entry.fallback.max_lines).toBeGreaterThan(0);
+      expect(entry.fallback.field_kind).toEqual(expect.any(String));
+    });
+  });
+
   it("keeps registry, checklist, and render placeholder keys in parity", async () => {
     const [registry, checklist, renderMap] = await Promise.all([
       readJsonFile(registryPath),

--- a/src/server/api/assessment-plan-pdf.ts
+++ b/src/server/api/assessment-plan-pdf.ts
@@ -87,10 +87,19 @@ interface TherapistRow {
 }
 
 interface GeneratePdfFunctionResponse {
-  fill_mode: "acroform" | "overlay";
+  fill_mode: "acroform" | "overlay" | "mixed";
   bucket_id: string;
   object_path: string;
   signed_url: string;
+  layout_warnings?: Array<{
+    placeholder_key: string;
+    page: number;
+    reason: "overflow";
+    rendered_line_count: number;
+    total_line_count: number;
+    max_lines: number;
+  }>;
+  overflow_keys?: string[];
 }
 
 const CALOPTIMA_TEMPLATE_PATH = resolve(process.cwd(), "CalOptima Health FBA Template (2).pdf");
@@ -294,15 +303,20 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
         generated_bucket_id: functionResult.data.bucket_id,
         generated_object_path: functionResult.data.object_path,
         missing_required_count: payloadResult.missing_required_keys.length,
+        layout_warning_count: functionResult.data.layout_warnings?.length ?? 0,
+        overflow_keys: functionResult.data.overflow_keys ?? [],
       },
     }),
   });
 
+  const layoutWarnings = functionResult.data.layout_warnings ?? [];
   return json({
     assessment_document_id: assessmentDocument.id,
     fill_mode: functionResult.data.fill_mode,
     bucket_id: functionResult.data.bucket_id,
     object_path: functionResult.data.object_path,
     signed_url: functionResult.data.signed_url,
+    layout_warnings: layoutWarnings,
+    overflow_keys: functionResult.data.overflow_keys ?? layoutWarnings.map((warning) => warning.placeholder_key),
   });
 }

--- a/src/server/assessmentPlanPdf.ts
+++ b/src/server/assessmentPlanPdf.ts
@@ -7,6 +7,10 @@ interface PdfFallbackCoordinates {
   y: number;
   font_size: number;
   max_width: number;
+  height?: number;
+  line_height?: number;
+  max_lines?: number;
+  field_kind?: string;
 }
 
 export interface PdfRenderMapEntry {
@@ -134,7 +138,11 @@ const normalizeMapEntry = (entry: unknown): PdfRenderMapEntry | null => {
     typeof fallback.x !== "number" ||
     typeof fallback.y !== "number" ||
     typeof fallback.font_size !== "number" ||
-    typeof fallback.max_width !== "number"
+    typeof fallback.max_width !== "number" ||
+    (fallback.height !== undefined && typeof fallback.height !== "number") ||
+    (fallback.line_height !== undefined && typeof fallback.line_height !== "number") ||
+    (fallback.max_lines !== undefined && typeof fallback.max_lines !== "number") ||
+    (fallback.field_kind !== undefined && typeof fallback.field_kind !== "string")
   ) {
     return null;
   }
@@ -153,6 +161,10 @@ const normalizeMapEntry = (entry: unknown): PdfRenderMapEntry | null => {
       y: fallback.y,
       font_size: fallback.font_size,
       max_width: fallback.max_width,
+      ...(typeof fallback.height === "number" ? { height: fallback.height } : {}),
+      ...(typeof fallback.line_height === "number" ? { line_height: fallback.line_height } : {}),
+      ...(typeof fallback.max_lines === "number" ? { max_lines: fallback.max_lines } : {}),
+      ...(typeof fallback.field_kind === "string" ? { field_kind: fallback.field_kind } : {}),
     },
   };
 };

--- a/supabase/functions/generate-assessment-plan-pdf/index.test.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "jsr:@std/expect";
 
-import { resolvePdfCheckboxValue, sanitizePdfText } from "./pdf-text.ts";
+import { layoutOverlayText, wrapOverlayText } from "./overlay-layout.ts";
+import { isPdfCheckboxNotApplicableValue, resolvePdfCheckboxValue, sanitizePdfText } from "./pdf-text.ts";
 
 Deno.test("sanitizePdfText normalizes unsupported glyphs for PDF rendering", () => {
   const raw =
@@ -21,4 +22,48 @@ Deno.test("resolvePdfCheckboxValue preserves explicit unchecked behavior for uns
   expect(resolvePdfCheckboxValue("☐")).toBe(false);
   expect(resolvePdfCheckboxValue("✗")).toBe(false);
   expect(resolvePdfCheckboxValue("   ")).toBeNull();
+});
+
+Deno.test("isPdfCheckboxNotApplicableValue preserves N/A as a distinct checkbox fallback case", () => {
+  expect(isPdfCheckboxNotApplicableValue("N/A")).toBe(true);
+  expect(isPdfCheckboxNotApplicableValue("not applicable")).toBe(true);
+  expect(isPdfCheckboxNotApplicableValue("No")).toBe(false);
+});
+
+Deno.test("layoutOverlayText fits text inside the configured field box and flags overflow", () => {
+  const font = {
+    widthOfTextAtSize: (value: string, size: number) => value.length * size * 0.5,
+  };
+
+  const layout = layoutOverlayText(
+    {
+      placeholder_key: "CALOPTIMA_FBA_CHIEF_COMPLAINT",
+      fallback: {
+        page: 2,
+        x: 64,
+        y: 541,
+        font_size: 8,
+        max_width: 80,
+        height: 18,
+        line_height: 9,
+      },
+    },
+    "This long complaint must wrap across more than two lines without drawing beyond the box.",
+    font,
+  );
+
+  expect(layout.lines.length).toBe(2);
+  expect(layout.warning?.placeholder_key).toBe("CALOPTIMA_FBA_CHIEF_COMPLAINT");
+  expect(layout.warning?.reason).toBe("overflow");
+});
+
+Deno.test("wrapOverlayText does not insert spaces into long unbroken tokens", () => {
+  const font = {
+    widthOfTextAtSize: (value: string, size: number) => value.length * size,
+  };
+  const rawToken = "CIN1234567890";
+  const lines = wrapOverlayText(rawToken, 36, font, 6);
+
+  expect(lines.join("")).toBe(rawToken);
+  expect(lines.join(" ")).not.toBe(rawToken);
 });

--- a/supabase/functions/generate-assessment-plan-pdf/index.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.ts
@@ -2,7 +2,8 @@ import { PDFCheckBox, PDFDocument, PDFTextField, StandardFonts, rgb } from "npm:
 import { z } from "npm:zod@3.23.8";
 import { createProtectedRoute, corsHeaders, RouteOptions } from "../_shared/auth-middleware.ts";
 import { supabaseAdmin } from "../_shared/database.ts";
-import { resolvePdfCheckboxValue, sanitizePdfText } from "./pdf-text.ts";
+import { layoutOverlayText, type OverlayLayoutWarning } from "./overlay-layout.ts";
+import { isPdfCheckboxNotApplicableValue, resolvePdfCheckboxValue, sanitizePdfText } from "./pdf-text.ts";
 
 const renderMapEntrySchema = z.object({
   placeholder_key: z.string().trim().min(1),
@@ -13,6 +14,10 @@ const renderMapEntrySchema = z.object({
     y: z.number(),
     font_size: z.number().positive(),
     max_width: z.number().positive(),
+    height: z.number().positive().optional(),
+    line_height: z.number().positive().optional(),
+    max_lines: z.number().int().positive().optional(),
+    field_kind: z.string().trim().min(1).optional(),
   }),
 });
 
@@ -33,26 +38,6 @@ const toUint8Array = (base64Value: string): Uint8Array => {
     bytes[index] = binary.charCodeAt(index);
   }
   return bytes;
-};
-
-const wrapText = (text: string, maxWidth: number, font: { widthOfTextAtSize: (value: string, size: number) => number }, fontSize: number): string[] => {
-  const words = text.split(/\s+/).filter((word) => word.length > 0);
-  if (words.length === 0) return [];
-
-  const lines: string[] = [];
-  let currentLine = words[0];
-  for (let index = 1; index < words.length; index += 1) {
-    const nextWord = words[index];
-    const candidate = `${currentLine} ${nextWord}`;
-    if (font.widthOfTextAtSize(candidate, fontSize) <= maxWidth) {
-      currentLine = candidate;
-    } else {
-      lines.push(currentLine);
-      currentLine = nextWord;
-    }
-  }
-  lines.push(currentLine);
-  return lines;
 };
 
 export default createProtectedRoute(async (req) => {
@@ -89,6 +74,7 @@ export default createProtectedRoute(async (req) => {
     const fields = form.getFields();
     const fieldsByName = new Map(fields.map((field) => [field.getName(), field]));
     let filledAcroFormCount = 0;
+    const acroFormFilledKeys = new Set<string>();
 
     for (const entry of parsed.data.render_map_entries) {
       const rawValue = parsed.data.field_values[entry.placeholder_key];
@@ -100,6 +86,10 @@ export default createProtectedRoute(async (req) => {
       if (!match) continue;
 
       if (match instanceof PDFCheckBox) {
+        if (isPdfCheckboxNotApplicableValue(rawText)) {
+          match.uncheck();
+          continue;
+        }
         const checkboxValue = resolvePdfCheckboxValue(rawText);
         if (checkboxValue === null) continue;
         if (checkboxValue) {
@@ -108,6 +98,7 @@ export default createProtectedRoute(async (req) => {
           match.uncheck();
         }
         filledAcroFormCount += 1;
+        acroFormFilledKeys.add(entry.placeholder_key);
         continue;
       }
 
@@ -117,28 +108,39 @@ export default createProtectedRoute(async (req) => {
       if (match instanceof PDFTextField) {
         match.setText(value);
         filledAcroFormCount += 1;
+        acroFormFilledKeys.add(entry.placeholder_key);
         continue;
       }
     }
 
-    const fillMode: "acroform" | "overlay" = filledAcroFormCount > 0 ? "acroform" : "overlay";
-    if (fillMode === "overlay") {
+    const layoutWarnings: OverlayLayoutWarning[] = [];
+    let overlayFilledCount = 0;
+    if (acroFormFilledKeys.size < parsed.data.render_map_entries.length) {
       const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
 
       for (const entry of parsed.data.render_map_entries) {
+        if (acroFormFilledKeys.has(entry.placeholder_key)) continue;
+
         const rawValue = parsed.data.field_values[entry.placeholder_key];
         const value = typeof rawValue === "string" ? sanitizePdfText(rawValue) : "";
         if (!value) continue;
 
         const pageIndex = entry.fallback.page - 1;
+        if (pageIndex < 0 || pageIndex >= pdfDoc.getPageCount()) continue;
         const page = pdfDoc.getPage(pageIndex);
         if (!page) continue;
 
-        const lines = wrapText(value, entry.fallback.max_width, regularFont, entry.fallback.font_size);
-        lines.forEach((line, lineIndex) => {
+        const layout = layoutOverlayText(entry, value, regularFont);
+        if (layout.warning) {
+          layoutWarnings.push(layout.warning);
+        }
+        if (layout.lines.length > 0) {
+          overlayFilledCount += 1;
+        }
+        layout.lines.forEach((line, lineIndex) => {
           page.drawText(line, {
             x: entry.fallback.x,
-            y: entry.fallback.y - lineIndex * (entry.fallback.font_size + 2),
+            y: entry.fallback.y - lineIndex * layout.line_height,
             size: entry.fallback.font_size,
             font: regularFont,
             color: rgb(0.12, 0.12, 0.12),
@@ -146,6 +148,8 @@ export default createProtectedRoute(async (req) => {
         });
       }
     }
+    const fillMode: "acroform" | "overlay" | "mixed" =
+      filledAcroFormCount > 0 && overlayFilledCount > 0 ? "mixed" : filledAcroFormCount > 0 ? "acroform" : "overlay";
 
     const pdfBytes = await pdfDoc.save();
 
@@ -178,6 +182,8 @@ export default createProtectedRoute(async (req) => {
         bucket_id: parsed.data.output_bucket_id,
         object_path: parsed.data.output_object_path,
         signed_url: signedResult.data.signedUrl,
+        layout_warnings: layoutWarnings,
+        overflow_keys: layoutWarnings.map((warning) => warning.placeholder_key),
       }),
       {
         status: 200,

--- a/supabase/functions/generate-assessment-plan-pdf/overlay-layout.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/overlay-layout.ts
@@ -1,0 +1,125 @@
+export interface OverlayFallbackBox {
+  page: number;
+  x: number;
+  y: number;
+  font_size: number;
+  max_width: number;
+  height?: number;
+  line_height?: number;
+  max_lines?: number;
+  field_kind?: string;
+}
+
+export interface OverlayRenderMapEntry {
+  placeholder_key: string;
+  fallback: OverlayFallbackBox;
+}
+
+export interface OverlayLayoutWarning {
+  placeholder_key: string;
+  page: number;
+  reason: "overflow";
+  rendered_line_count: number;
+  total_line_count: number;
+  max_lines: number;
+}
+
+export interface OverlayLayoutResult {
+  lines: string[];
+  line_height: number;
+  warning: OverlayLayoutWarning | null;
+}
+
+interface PdfFontLike {
+  widthOfTextAtSize: (value: string, size: number) => number;
+}
+
+const DEFAULT_FIELD_HEIGHT_MULTIPLIER = 1.4;
+
+interface WrappedToken {
+  text: string;
+  continuesPreviousToken: boolean;
+}
+
+const splitLongWord = (word: string, maxWidth: number, font: PdfFontLike, fontSize: number): WrappedToken[] => {
+  if (font.widthOfTextAtSize(word, fontSize) <= maxWidth) {
+    return [{ text: word, continuesPreviousToken: false }];
+  }
+
+  const chunks: WrappedToken[] = [];
+  let current = "";
+  for (const character of word) {
+    const candidate = `${current}${character}`;
+    if (current && font.widthOfTextAtSize(candidate, fontSize) > maxWidth) {
+      chunks.push({ text: current, continuesPreviousToken: chunks.length > 0 });
+      current = character;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) chunks.push({ text: current, continuesPreviousToken: chunks.length > 0 });
+  return chunks;
+};
+
+export const wrapOverlayText = (
+  text: string,
+  maxWidth: number,
+  font: PdfFontLike,
+  fontSize: number,
+): string[] => {
+  const paragraphs = text
+    .split(/\r?\n/)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0);
+  const lines: string[] = [];
+
+  for (const paragraph of paragraphs) {
+    const words = paragraph.split(/\s+/).flatMap((word) => splitLongWord(word, maxWidth, font, fontSize));
+    if (words.length === 0) continue;
+
+    let currentLine = words[0].text;
+    for (let index = 1; index < words.length; index += 1) {
+      const nextWord = words[index];
+      const candidate = `${currentLine}${nextWord.continuesPreviousToken ? "" : " "}${nextWord.text}`;
+      if (font.widthOfTextAtSize(candidate, fontSize) <= maxWidth) {
+        currentLine = candidate;
+      } else {
+        lines.push(currentLine);
+        currentLine = nextWord.text;
+      }
+    }
+    lines.push(currentLine);
+  }
+
+  return lines;
+};
+
+export const layoutOverlayText = (
+  entry: OverlayRenderMapEntry,
+  value: string,
+  font: PdfFontLike,
+): OverlayLayoutResult => {
+  const { fallback } = entry;
+  const lineHeight = fallback.line_height ?? fallback.font_size + 2;
+  const fieldHeight = fallback.height ?? fallback.font_size * DEFAULT_FIELD_HEIGHT_MULTIPLIER;
+  const heightBoundedMaxLines = Math.max(1, Math.floor(fieldHeight / lineHeight));
+  const maxLines = Math.max(1, Math.min(fallback.max_lines ?? heightBoundedMaxLines, heightBoundedMaxLines));
+  const lines = wrapOverlayText(value, fallback.max_width, font, fallback.font_size);
+  const renderedLines = lines.slice(0, maxLines);
+
+  return {
+    lines: renderedLines,
+    line_height: lineHeight,
+    warning:
+      lines.length > renderedLines.length
+        ? {
+            placeholder_key: entry.placeholder_key,
+            page: fallback.page,
+            reason: "overflow",
+            rendered_line_count: renderedLines.length,
+            total_line_count: lines.length,
+            max_lines: maxLines,
+          }
+        : null,
+  };
+};

--- a/supabase/functions/generate-assessment-plan-pdf/pdf-text.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/pdf-text.ts
@@ -33,3 +33,8 @@ export const resolvePdfCheckboxValue = (rawValue: string): boolean | null => {
   const sanitizedValue = sanitizePdfText(trimmedRawValue);
   return normalizeCheckboxValue(sanitizedValue || trimmedRawValue);
 };
+
+export const isPdfCheckboxNotApplicableValue = (rawValue: string): boolean => {
+  const normalized = rawValue.trim().toLowerCase();
+  return normalized === "n/a" || normalized === "na" || normalized === "not applicable";
+};


### PR DESCRIPTION
## Summary
- Recalibrates the CalOptima PDF overlay render map with bounded field boxes for all exported entries, including tighter page 2 placement.
- Updates the PDF edge renderer to fit overlay text inside field boxes, report overflow warnings, support `mixed` AcroForm/overlay mode, and preserve `N/A` checkbox values distinctly through bounded overlay fallback.
- Propagates layout warnings through the server/UI and adds `npm run playwright:assessment-pdf-smoke` for page-level visual placement evidence.

## Risk / Route
- Linear: WIN-147
- Route-task: `critical` / `high-risk human-reviewed`
- Trigger paths: `supabase/functions/**`, `src/server/**`, client workflow, Playwright smoke harness.
- Human review required before merge.

## Verification
- `npm run typecheck` passed.
- `deno test --allow-env --no-lock --no-check supabase/functions/generate-assessment-plan-pdf/index.test.ts` passed.
- `npx vitest run src/server/__tests__/assessmentPlanPdfHandler.test.ts src/server/__tests__/assessmentPlanPdfTemplate.test.ts src/components/__tests__/ProgramsGoalsTab.test.tsx` passed.
- `npm run lint` passed.
- `npm run ci:check-focused` passed with existing env-dependent skips.
- `npm run build` passed.
- `npm run validate:tenant` passed.
- `npm run playwright:assessment-import-smoke` passed with `PLAYWRIGHT_ENV_FILE` pointed at the primary local env file.
- Reviewer re-review completed with no blocking findings.

## Blocked / Follow-up Checks
- `npm run playwright:assessment-pdf-smoke` is added but blocked locally because current env files do not provide `PW_ASSESSMENT_DOCUMENT_ID` for an approved CalOptima assessment with accepted program/goals.
- Full `npm run test:ci` initially failed due missing `VITE_SUPABASE_URL`; the failing file passes with synthetic env. A full synthetic-env rerun timed out at 5 minutes before completion.
