### PR TITLE
WIN-147 Use Adobe PDF Extract for assessment PDFs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,18 @@ SUPABASE_DB_URL=****
 OPENAI_API_KEY=****
 OPENAI_ORGANIZATION=****
 
+# Adobe Acrobat Services / PDF Services API
+# These match the generated `pdfservices-api-credentials.json` fields from the
+# Adobe Node.js sample bundle. Keep them server-only.
+PDF_SERVICES_CLIENT_ID=****
+PDF_SERVICES_CLIENT_SECRET=****
+PDF_SERVICES_ORGANIZATION_ID=****
+# Optional descriptive aliases used by local helper code. Keep aliases aligned
+# with the Adobe-provided values above when both are configured.
+ADOBE_PDF_SERVICES_CLIENT_ID=****
+ADOBE_PDF_SERVICES_CLIENT_SECRET=****
+ADOBE_PDF_SERVICES_ORGANIZATION_ID=****
+
 # AWS / S3 configuration
 AWS_REGION=****
 AWS_S3_BUCKET=****

--- a/docs/api/ADOBE_ACROBAT_SERVICES.md
+++ b/docs/api/ADOBE_ACROBAT_SERVICES.md
@@ -1,0 +1,78 @@
+# Adobe Acrobat Services API Placeholders
+
+This repository uses server-only placeholders for Adobe Acrobat Services / PDF Services API credentials. Do not expose these values through Vite, runtime config, browser bundles, logs, or test fixtures.
+
+Current approved use: uploaded assessment **PDF extraction only** through Adobe PDF Extract API. Do not use Adobe for final CalOptima PDF generation, signing, embedded viewing, or overlay rendering.
+
+## Credentials
+
+The Adobe Node.js credential bundle includes `pdfservices-api-credentials.json` with:
+
+- `client_credentials.client_id`
+- `client_credentials.client_secret`
+- `service_principal_credentials.organization_id`
+
+Map those values to the server environment:
+
+```ini
+PDF_SERVICES_CLIENT_ID=****
+PDF_SERVICES_CLIENT_SECRET=****
+PDF_SERVICES_ORGANIZATION_ID=****
+```
+
+Optional descriptive aliases are also supported by `src/server/adobeAcrobat.ts`:
+
+```ini
+ADOBE_PDF_SERVICES_CLIENT_ID=****
+ADOBE_PDF_SERVICES_CLIENT_SECRET=****
+ADOBE_PDF_SERVICES_ORGANIZATION_ID=****
+```
+
+## Token Request
+
+Use the token endpoint with form-encoded credentials:
+
+```http
+POST https://pdf-services.adobe.io/token
+Content-Type: application/x-www-form-urlencoded
+```
+
+Body placeholders:
+
+```text
+client_id={{PDF_SERVICES_CLIENT_ID}}
+client_secret={{PDF_SERVICES_CLIENT_SECRET}}
+```
+
+## API Request Headers
+
+After receiving a short-lived access token, call Adobe REST operations with:
+
+```http
+X-API-Key: {{PDF_SERVICES_CLIENT_ID}}
+Authorization: Bearer {{ADOBE_ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+```
+
+`ADOBE_ACCESS_TOKEN` is intentionally not an environment placeholder. Treat it as short-lived runtime state from the token response.
+
+## Assessment PDF Extraction Flow
+
+Uploaded PDF assessments are processed only after the server/edge path confirms the authenticated user can access the stored `assessment_documents` row and the requested `bucket_id` / `object_path` match that row.
+
+The edge extraction flow is:
+
+1. `POST https://pdf-services.adobe.io/token`
+2. `POST https://pdf-services.adobe.io/assets`
+3. `PUT uploadUri` with `Content-Type: application/pdf`
+4. `POST https://pdf-services.adobe.io/operation/extractpdf` with `elementsToExtract: ["text", "tables"]`
+5. Poll the returned `location`
+6. Download the result ZIP from Adobe's returned pre-signed `downloadUri` and parse `structuredData.json`
+
+Adobe's `uploadUri` and result `downloadUri` may point at Adobe-managed cloud storage instead of an `adobe.io` host. The extraction adapter allows only HTTPS storage URLs on Adobe's documented PDF Services storage hosts:
+
+- `dcplatformstorageservice-prod-us-east-1.s3-accelerate.amazonaws.com`
+- `dcplatformstorageservice-prod-eu-west-1.s3.amazonaws.com`
+
+DOCX assessment uploads are still decoded locally. PDF uploads must use Adobe; missing credentials or Adobe failures produce `extraction_failed` with a redacted operator-facing error rather than falling back to legacy PDF parsing.

--- a/docs/fill_docs/ASSESSMENT_UPLOAD_STAGED_APPROVAL_PLAN.md
+++ b/docs/fill_docs/ASSESSMENT_UPLOAD_STAGED_APPROVAL_PLAN.md
@@ -47,7 +47,7 @@ Implement a staged workflow where uploaded payer assessments (PDF/DOCX) produce 
 ### 4) `ui-staged-review` (implemented)
 
 - `ProgramsGoalsTab` now includes:
-  - assessment upload action (PDF/DOC/DOCX)
+  - assessment upload action (PDF/DOCX)
   - assessment queue panel with status display
   - checklist section review/editor UI
   - draft program/goal review editor with accept/reject/edit states
@@ -64,6 +64,11 @@ Implement a staged workflow where uploaded payer assessments (PDF/DOCX) produce 
   - stores generated PDF and returns signed URL for download
 - Mapping artifact:
   - `docs/fill_docs/caloptima_fba_pdf_render_map.json`
+- Extraction behavior:
+  - uploaded PDF assessments use Adobe PDF Extract API only
+  - uploaded DOCX assessments continue to use the local DOCX text decoder
+  - Adobe is not used for completed-PDF generation, signing, embedded viewing, or overlay rendering
+  - missing Adobe credentials or Adobe API failures mark the document `extraction_failed` with a redacted operator-facing error
 
 ### 6) `tests-and-docs` (implemented)
 

--- a/docs/fill_docs/CALOPTIMA_PDF_GENERATION_RUNBOOK.md
+++ b/docs/fill_docs/CALOPTIMA_PDF_GENERATION_RUNBOOK.md
@@ -15,6 +15,7 @@ This runbook describes how to generate and troubleshoot the **completed CalOptim
 Before generation can succeed:
 
 - An assessment document exists for the client in `assessment_documents`.
+- PDF assessment extraction completed through Adobe PDF Extract API; DOCX assessment extraction completed through the local DOCX decoder.
 - Required checklist rows in `assessment_checklist_items` are `approved`.
 - At least one draft program and one draft goal are in `accepted` or `edited` state.
 - The CalOptima render map exists and is valid:
@@ -72,6 +73,9 @@ If any precondition fails, API returns `409` with details.
   - Populate missing checklist values listed in `missing_required_keys`.
 - `500 Failed to generate completed treatment plan PDF`
   - Check edge function logs and confirm template base64 payload and render map validity.
+- `extraction_failed` before checklist review
+  - For PDFs, confirm server-only Adobe PDF Services credentials are configured and Adobe PDF Extract API is operational. Do not bypass this with legacy PDF text parsing.
+  - For DOCX, confirm the uploaded document contains readable Word document text.
 - `500 Failed to create download URL`
   - Validate storage bucket permissions and service role access.
 - PDF opens but app reports layout warnings

--- a/src/server/__tests__/adobeAcrobat.test.ts
+++ b/src/server/__tests__/adobeAcrobat.test.ts
@@ -1,0 +1,132 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildAdobePdfServicesApiHeaders,
+  buildAdobePdfServicesTokenBody,
+  buildAdobePdfServicesTokenHeaders,
+  getAdobePdfServicesCredentials,
+} from "../adobeAcrobat";
+import { resetEnvCacheForTests } from "../env";
+
+const ORIGINAL_ENV = { ...process.env } as NodeJS.ProcessEnv;
+
+describe("server/adobeAcrobat", () => {
+  let tempDir = "";
+  let envPath = "";
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV } as NodeJS.ProcessEnv;
+    delete process.env.ADOBE_PDF_SERVICES_CLIENT_ID;
+    delete process.env.ADOBE_PDF_SERVICES_CLIENT_SECRET;
+    delete process.env.ADOBE_PDF_SERVICES_ORGANIZATION_ID;
+    delete process.env.PDF_SERVICES_CLIENT_ID;
+    delete process.env.PDF_SERVICES_CLIENT_SECRET;
+    delete process.env.PDF_SERVICES_ORGANIZATION_ID;
+    resetEnvCacheForTests();
+    tempDir = mkdtempSync(join(tmpdir(), "adobe-acrobat-tests-"));
+    envPath = join(tempDir, ".env.codex");
+  });
+
+  afterEach(() => {
+    resetEnvCacheForTests();
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(() => {
+    process.env = { ...ORIGINAL_ENV } as NodeJS.ProcessEnv;
+  });
+
+  it("loads Adobe PDF Services credentials from documented env aliases", () => {
+    writeFileSync(
+      envPath,
+      [
+        "ADOBE_PDF_SERVICES_CLIENT_ID=client-id",
+        "ADOBE_PDF_SERVICES_CLIENT_SECRET=client-secret",
+        "ADOBE_PDF_SERVICES_ORGANIZATION_ID=org-id",
+      ].join("\n"),
+    );
+
+    expect(getAdobePdfServicesCredentials({ envPath })).toEqual({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      organizationId: "org-id",
+    });
+  });
+
+  it("supports Adobe sample env names from the generated Node bundle", () => {
+    writeFileSync(
+      envPath,
+      [
+        "PDF_SERVICES_CLIENT_ID=sample-client-id",
+        "PDF_SERVICES_CLIENT_SECRET=sample-client-secret",
+        "PDF_SERVICES_ORGANIZATION_ID=sample-org-id",
+      ].join("\n"),
+    );
+
+    expect(getAdobePdfServicesCredentials({ envPath })).toEqual({
+      clientId: "sample-client-id",
+      clientSecret: "sample-client-secret",
+      organizationId: "sample-org-id",
+    });
+  });
+
+  it("builds token request headers and body without exposing the secret in headers", () => {
+    writeFileSync(
+      envPath,
+      [
+        "PDF_SERVICES_CLIENT_ID=token-client-id",
+        "PDF_SERVICES_CLIENT_SECRET=token-client-secret",
+      ].join("\n"),
+    );
+
+    expect(buildAdobePdfServicesTokenHeaders()).toEqual({
+      "Content-Type": "application/x-www-form-urlencoded",
+    });
+    expect(buildAdobePdfServicesTokenBody({ envPath }).toString()).toBe(
+      "client_id=token-client-id&client_secret=token-client-secret",
+    );
+  });
+
+  it("builds REST API headers using client id and a short-lived access token", () => {
+    writeFileSync(
+      envPath,
+      [
+        "PDF_SERVICES_CLIENT_ID=api-client-id",
+        "PDF_SERVICES_CLIENT_SECRET=api-client-secret",
+      ].join("\n"),
+    );
+
+    expect(
+      buildAdobePdfServicesApiHeaders({
+        envPath,
+        accessToken: " access-token ",
+      }),
+    ).toEqual({
+      "X-API-Key": "api-client-id",
+      Authorization: "Bearer access-token",
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    });
+  });
+
+  it("rejects blank access tokens before building REST API headers", () => {
+    writeFileSync(
+      envPath,
+      [
+        "PDF_SERVICES_CLIENT_ID=api-client-id",
+        "PDF_SERVICES_CLIENT_SECRET=api-client-secret",
+      ].join("\n"),
+    );
+
+    expect(() =>
+      buildAdobePdfServicesApiHeaders({
+        envPath,
+        accessToken: "   ",
+      }),
+    ).toThrow(/access token/i);
+  });
+});

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -134,6 +134,9 @@ describe("assessmentDocumentsHandler", () => {
           ok: true,
           status: 200,
           data: {
+            extraction_provider: "adobe_pdf_extract",
+            adobe_element_count: 42,
+            adobe_table_count: 3,
             fields: [
               {
                 placeholder_key: "CALOPTIMA_FBA_MEMBER_NAME",
@@ -229,7 +232,7 @@ describe("assessmentDocumentsHandler", () => {
           file_name: "fba.pdf",
           mime_type: "application/pdf",
           file_size: 1234,
-          object_path: "clients/client-1/assessments/fba.pdf",
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
         }),
       }),
     );
@@ -255,6 +258,17 @@ describe("assessmentDocumentsHandler", () => {
     };
     expect(extractionPayload.checklist_rows?.[0]?.extraction_aliases).toEqual(["Member full legal name"]);
     expect(loadChecklistTemplateRows).toHaveBeenCalledWith("caloptima_fba");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const completedEventCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
+      const body = String((init as RequestInit | undefined)?.body ?? "");
+      return typeof url === "string" && url.includes("/assessment_review_events") && body.includes("extraction_completed");
+    });
+    const completedEventPayload = JSON.parse(String((completedEventCall?.[1] as RequestInit | undefined)?.body ?? "{}"));
+    expect(completedEventPayload.event_payload).toMatchObject({
+      extraction_provider: "adobe_pdf_extract",
+      adobe_element_count: 42,
+      adobe_table_count: 3,
+    });
   });
 
   it("creates assessment document with IEHP template rows", async () => {
@@ -295,7 +309,7 @@ describe("assessmentDocumentsHandler", () => {
           file_name: "iehp-fba.docx",
           mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
           file_size: 2200,
-          object_path: "clients/client-1/assessments/iehp-fba.docx",
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/iehp-fba.docx",
           template_type: "iehp_fba",
         }),
       }),
@@ -327,13 +341,96 @@ describe("assessmentDocumentsHandler", () => {
           file_name: "fba.pdf",
           mime_type: "application/pdf",
           file_size: 1234,
-          object_path: "clients/client-1/assessments/fba.pdf",
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
           template_type: "unknown_template",
         }),
       }),
     );
 
     expect(response.status).toBe(400);
+  });
+
+  it("rejects assessment uploads outside the approved storage bucket", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          bucket_id: "private-documents",
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_documents"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("rejects assessment uploads outside the canonical client assessment path", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/other-client/assessments/fba.pdf",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_documents"),
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
   it.each(roleMatrix)("returns 403 for out-of-org assessment document POST as $label without side effects", async ({ role }) => {
@@ -364,7 +461,7 @@ describe("assessmentDocumentsHandler", () => {
           file_name: "fba.pdf",
           mime_type: "application/pdf",
           file_size: 1234,
-          object_path: "clients/client-1/assessments/fba.pdf",
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
         }),
       }),
     );
@@ -679,7 +776,7 @@ describe("assessmentDocumentsHandler", () => {
           file_name: "fba.pdf",
           mime_type: "application/pdf",
           file_size: 1234,
-          object_path: "clients/client-1/assessments/fba.pdf",
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
         }),
       }),
     );
@@ -750,7 +847,11 @@ describe("assessmentDocumentsHandler", () => {
         return { ok: true, status: 201, data: null };
       }
       if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
-        return { ok: false, status: 502, data: null };
+        return {
+          ok: false,
+          status: 502,
+          data: { error: "Adobe PDF extraction failed. Review checklist manually." },
+        };
       }
       if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-extract-non-ok")) {
         return { ok: true, status: 200, data: null };
@@ -770,7 +871,7 @@ describe("assessmentDocumentsHandler", () => {
           file_name: "fba.pdf",
           mime_type: "application/pdf",
           file_size: 1234,
-          object_path: "clients/client-1/assessments/fba.pdf",
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
         }),
       }),
     );
@@ -803,7 +904,7 @@ describe("assessmentDocumentsHandler", () => {
     ) as Record<string, unknown>;
     expectExtractionFailedStatusWriteInvariants(
       extractionFailedDocumentPatchPayload,
-      "Field extraction failed. Review checklist manually.",
+      "Adobe PDF extraction failed. Review checklist manually.",
     );
     const extractionFailedReviewEventCalls = vi
       .mocked(fetchJson)
@@ -973,7 +1074,7 @@ describe("assessmentDocumentsHandler", () => {
           file_name: "fba.pdf",
           mime_type: "application/pdf",
           file_size: 1234,
-          object_path: "clients/client-1/assessments/fba.pdf",
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
         }),
       }),
     );
@@ -1046,7 +1147,7 @@ describe("assessmentDocumentsHandler", () => {
           file_name: "fba.pdf",
           mime_type: "application/pdf",
           file_size: 1234,
-          object_path: "clients/client-1/assessments/fba.pdf",
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
         }),
       }),
     );
@@ -1351,7 +1452,7 @@ describe("assessmentDocumentsHandler", () => {
           file_name: "fba.pdf",
           mime_type: "application/pdf",
           file_size: 1234,
-          object_path: "clients/client-1/assessments/fba.pdf",
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
         }),
       }),
     );
@@ -1477,7 +1578,7 @@ describe("assessmentDocumentsHandler", () => {
               organization_id: "org-1",
               client_id: "client-1",
               bucket_id: "client-documents",
-              object_path: "clients/client-1/assessments/fba.pdf",
+              object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
             },
           ],
         };

--- a/src/server/adobeAcrobat.ts
+++ b/src/server/adobeAcrobat.ts
@@ -1,0 +1,78 @@
+import { getOptionalServerEnv, getRequiredServerEnv } from "./env";
+
+type EnvLoadOptions = {
+  readonly envPath?: string;
+};
+
+type AdobePdfServicesCredentials = {
+  clientId: string;
+  clientSecret: string;
+  organizationId?: string;
+};
+
+type AdobePdfServicesHeadersOptions = EnvLoadOptions & {
+  readonly accessToken: string;
+  readonly contentType?: string;
+  readonly accept?: string;
+};
+
+export const ADOBE_PDF_SERVICES_BASE_URL = "https://pdf-services.adobe.io";
+export const ADOBE_PDF_SERVICES_TOKEN_URL = `${ADOBE_PDF_SERVICES_BASE_URL}/token`;
+
+const getAliasedRequiredEnv = (
+  primaryKey: string,
+  fallbackKey: string,
+  options?: EnvLoadOptions,
+): string => getOptionalServerEnv(primaryKey, options) ?? getRequiredServerEnv(fallbackKey, options);
+
+export function getAdobePdfServicesCredentials(options?: EnvLoadOptions): AdobePdfServicesCredentials {
+  const clientId = getAliasedRequiredEnv(
+    "ADOBE_PDF_SERVICES_CLIENT_ID",
+    "PDF_SERVICES_CLIENT_ID",
+    options,
+  );
+  const clientSecret = getAliasedRequiredEnv(
+    "ADOBE_PDF_SERVICES_CLIENT_SECRET",
+    "PDF_SERVICES_CLIENT_SECRET",
+    options,
+  );
+  const organizationId =
+    getOptionalServerEnv("ADOBE_PDF_SERVICES_ORGANIZATION_ID", options) ??
+    getOptionalServerEnv("PDF_SERVICES_ORGANIZATION_ID", options);
+
+  return { clientId, clientSecret, organizationId };
+}
+
+export function buildAdobePdfServicesTokenHeaders(): Record<string, string> {
+  return {
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+}
+
+export function buildAdobePdfServicesTokenBody(options?: EnvLoadOptions): URLSearchParams {
+  const { clientId, clientSecret } = getAdobePdfServicesCredentials(options);
+  return new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+}
+
+export function buildAdobePdfServicesApiHeaders({
+  accessToken,
+  contentType = "application/json",
+  accept = "application/json",
+  ...options
+}: AdobePdfServicesHeadersOptions): Record<string, string> {
+  const token = accessToken.trim();
+  if (!token) {
+    throw new Error("Missing Adobe PDF Services access token.");
+  }
+
+  const { clientId } = getAdobePdfServicesCredentials(options);
+  return {
+    "X-API-Key": clientId,
+    Authorization: `Bearer ${token}`,
+    "Content-Type": contentType,
+    Accept: accept,
+  };
+}

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -16,6 +16,7 @@ import {
 import { serverLogger } from "../../lib/logger/server";
 
 const SUPPORTED_TEMPLATE_TYPES = ["caloptima_fba", "iehp_fba"] as const;
+const ASSESSMENT_DOCUMENT_BUCKET_ID = "client-documents";
 
 const templateTypeSchema = z.enum(SUPPORTED_TEMPLATE_TYPES);
 
@@ -30,6 +31,13 @@ const assessmentDocumentCreateSchema = z.object({
 });
 
 const isUuid = (value: string): boolean => z.string().uuid().safeParse(value).success;
+
+const isAllowedAssessmentObjectPath = (objectPath: string, clientId: string): boolean => {
+  const normalized = objectPath.trim();
+  if (normalized.includes("..") || normalized.includes("\\")) return false;
+  return /^clients\/[^/]+\/assessments\/[^/]+\.(pdf|docx)$/i.test(normalized) &&
+    normalized.startsWith(`clients/${clientId}/assessments/`);
+};
 
 interface AssessmentDocumentRow {
   id: string;
@@ -75,6 +83,10 @@ interface ExtractionFieldResult {
 }
 
 interface ExtractionFunctionResponse {
+  error?: string;
+  extraction_provider?: string;
+  adobe_element_count?: number | null;
+  adobe_table_count?: number | null;
   fields: ExtractionFieldResult[];
   structured_sections?: Array<{
     section_key: string;
@@ -260,13 +272,19 @@ const runCaloptimaExtractionWorkflow = async (args: {
             unresolved_count: extractionResult.data.unresolved_count,
             unresolved_keys: extractionResult.data.unresolved_keys,
             structured_section_count: structuredSections.length,
+            extraction_provider: extractionResult.data.extraction_provider ?? null,
+            adobe_element_count: extractionResult.data.adobe_element_count ?? null,
+            adobe_table_count: extractionResult.data.adobe_table_count ?? null,
           },
         }),
       });
       return;
     }
 
-    const extractionError = "Field extraction failed. Review checklist manually.";
+    const extractionError =
+      typeof extractionResult.data?.error === "string" && extractionResult.data.error.trim().length > 0
+        ? extractionResult.data.error
+        : "Field extraction failed. Review checklist manually.";
     await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocumentId)}`, {
       method: "PATCH",
       headers,
@@ -412,6 +430,12 @@ export async function assessmentDocumentsHandler(request: Request): Promise<Resp
     if (!clientExists) {
       return jsonForRequest(request, { error: "client_id is not in scope for this organization" }, 403);
     }
+    if (parsed.data.bucket_id && parsed.data.bucket_id !== ASSESSMENT_DOCUMENT_BUCKET_ID) {
+      return jsonForRequest(request, { error: "Assessment documents must be uploaded to the approved bucket." }, 400);
+    }
+    if (!isAllowedAssessmentObjectPath(parsed.data.object_path, parsed.data.client_id)) {
+      return jsonForRequest(request, { error: "Assessment document path is outside the allowed client scope." }, 400);
+    }
 
     const actorId = getAccessTokenSubject(accessToken);
     const templateType = parsed.data.template_type ?? "caloptima_fba";
@@ -423,7 +447,7 @@ export async function assessmentDocumentsHandler(request: Request): Promise<Resp
       file_name: parsed.data.file_name,
       mime_type: parsed.data.mime_type,
       file_size: parsed.data.file_size,
-      bucket_id: parsed.data.bucket_id ?? "client-documents",
+      bucket_id: ASSESSMENT_DOCUMENT_BUCKET_ID,
       object_path: parsed.data.object_path,
       status: "uploaded",
     };

--- a/supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts
+++ b/supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts
@@ -1,0 +1,436 @@
+import { expect } from "jsr:@std/expect";
+import {
+  AdobePdfExtractError,
+  extractPdfWithAdobe,
+  getAdobePdfExtractCredentials,
+  normalizeAdobeExtractZip,
+  normalizeAdobeStructuredData,
+} from "./adobe-pdf-extract.ts";
+
+const ADOBE_US_STORAGE_URL =
+  "https://dcplatformstorageservice-prod-us-east-1.s3-accelerate.amazonaws.com/upload.pdf?X-Amz-Signature=test";
+
+const envFrom = (values: Record<string, string | undefined>) => ({
+  get(name: string): string | undefined {
+    return values[name];
+  },
+});
+
+const zipStructuredData = async (
+  structuredData: unknown,
+): Promise<Uint8Array> => {
+  const { default: JSZip } = await import("npm:jszip@3.10.1");
+  const zip = new JSZip();
+  zip.file("structuredData.json", JSON.stringify(structuredData));
+  return await zip.generateAsync({ type: "uint8array" });
+};
+
+const successfulFetchForDownloadUri = (
+  downloadUri: string,
+  zipBytes: Uint8Array,
+): ((input: RequestInfo | URL) => Promise<Response>) => {
+  return async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    if (url.endsWith("/token")) {
+      return Response.json({ access_token: "token-1" });
+    }
+    if (url.endsWith("/assets")) {
+      return Response.json({
+        uploadUri: ADOBE_US_STORAGE_URL,
+        assetID: "asset-1",
+      });
+    }
+    if (url === ADOBE_US_STORAGE_URL) {
+      return new Response(null, { status: 200 });
+    }
+    if (url.endsWith("/operation/extractpdf")) {
+      return new Response(null, {
+        status: 201,
+        headers: {
+          location:
+            "https://pdf-services.adobe.io/operation/extractpdf/job-1/status",
+        },
+      });
+    }
+    if (url.endsWith("/job-1/status")) {
+      return Response.json({ status: "done", downloadUri });
+    }
+    if (url === downloadUri) {
+      return new Response(
+        zipBytes.buffer.slice(
+          zipBytes.byteOffset,
+          zipBytes.byteOffset + zipBytes.byteLength,
+        ) as ArrayBuffer,
+        { status: 200 },
+      );
+    }
+    return new Response("unexpected", { status: 500 });
+  };
+};
+
+Deno.test("getAdobePdfExtractCredentials supports Adobe aliases and sample env names", () => {
+  expect(
+    getAdobePdfExtractCredentials(
+      envFrom({
+        ADOBE_PDF_SERVICES_CLIENT_ID: " alias-client ",
+        ADOBE_PDF_SERVICES_CLIENT_SECRET: " alias-secret ",
+        PDF_SERVICES_CLIENT_ID: "sample-client",
+        PDF_SERVICES_CLIENT_SECRET: "sample-secret",
+      }),
+    ),
+  ).toEqual({ clientId: "alias-client", clientSecret: "alias-secret" });
+
+  expect(
+    getAdobePdfExtractCredentials(
+      envFrom({
+        PDF_SERVICES_CLIENT_ID: "sample-client",
+        PDF_SERVICES_CLIENT_SECRET: "sample-secret",
+      }),
+    ),
+  ).toEqual({ clientId: "sample-client", clientSecret: "sample-secret" });
+});
+
+Deno.test("getAdobePdfExtractCredentials fails closed when Adobe credentials are missing", () => {
+  expect(() => getAdobePdfExtractCredentials(envFrom({}))).toThrow(
+    AdobePdfExtractError,
+  );
+});
+
+Deno.test("normalizeAdobeStructuredData builds ordered text and counts table elements", () => {
+  const normalized = normalizeAdobeStructuredData({
+    elements: [
+      { Path: "//Document/H1", Text: "Assessment Title" },
+      { Path: "//Document/P", Text: "Member Name: Redacted Client" },
+      { Path: "//Document/Table/TR/TD", Text: "H2019 Direct therapy" },
+      { Path: "//Document/P", Text: "Date ABA first began: 07/01/2025" },
+    ],
+  });
+
+  expect(normalized.text).toBe(
+    "Assessment Title\nMember Name: Redacted Client\nH2019 Direct therapy\nDate ABA first began: 07/01/2025",
+  );
+  expect(normalized.element_count).toBe(4);
+  expect(normalized.table_count).toBe(1);
+});
+
+Deno.test("normalizeAdobeExtractZip reads structuredData.json from Adobe result zip", async () => {
+  const zipBytes = await zipStructuredData({
+    elements: [{
+      Path: "//Document/P",
+      Text: "Chief Complaint: Needs support",
+    }],
+  });
+
+  const normalized = await normalizeAdobeExtractZip(zipBytes);
+
+  expect(normalized.text).toBe("Chief Complaint: Needs support");
+  expect(normalized.element_count).toBe(1);
+});
+
+Deno.test("extractPdfWithAdobe uses PDF Extract REST flow and requests text plus tables", async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const zipBytes = await zipStructuredData({
+    elements: [
+      { Path: "//Document/P", Text: "Member Name: Redacted Client" },
+      { Path: "//Document/Table/TR/TD", Text: "H0032-HN Treatment planning" },
+    ],
+  });
+  const fetchImpl = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = String(input);
+    calls.push({ url, init });
+    if (url.endsWith("/token")) {
+      return Response.json({ access_token: "token-1" });
+    }
+    if (url.endsWith("/assets")) {
+      return Response.json({
+        uploadUri: ADOBE_US_STORAGE_URL,
+        assetID: "asset-1",
+      });
+    }
+    if (url === ADOBE_US_STORAGE_URL) {
+      return new Response(null, { status: 200 });
+    }
+    if (url.endsWith("/operation/extractpdf")) {
+      return new Response(null, {
+        status: 201,
+        headers: {
+          location:
+            "https://pdf-services.adobe.io/operation/extractpdf/job-1/status",
+        },
+      });
+    }
+    if (url.endsWith("/job-1/status")) {
+      return Response.json({
+        status: "done",
+        asset: {
+          downloadUri:
+            "https://dcplatformstorageservice-prod-us-east-1.s3-accelerate.amazonaws.com/result.zip?X-Amz-Signature=test",
+        },
+      });
+    }
+    if (
+      url ===
+        "https://dcplatformstorageservice-prod-us-east-1.s3-accelerate.amazonaws.com/result.zip?X-Amz-Signature=test"
+    ) {
+      return new Response(
+        zipBytes.buffer.slice(
+          zipBytes.byteOffset,
+          zipBytes.byteOffset + zipBytes.byteLength,
+        ) as ArrayBuffer,
+        { status: 200 },
+      );
+    }
+    return new Response("unexpected", { status: 500 });
+  };
+
+  const extracted = await extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+    env: envFrom({
+      PDF_SERVICES_CLIENT_ID: "client-id",
+      PDF_SERVICES_CLIENT_SECRET: "client-secret",
+    }),
+    fetchImpl,
+    sleep: () => Promise.resolve(),
+    maxPollAttempts: 1,
+  });
+
+  const jobCall = calls.find((call) =>
+    call.url.endsWith("/operation/extractpdf")
+  );
+  expect(JSON.parse(String(jobCall?.init?.body))).toEqual({
+    assetID: "asset-1",
+    elementsToExtract: ["text", "tables"],
+  });
+  expect(extracted.text).toContain("Member Name: Redacted Client");
+  expect(extracted.table_count).toBe(1);
+});
+
+Deno.test("extractPdfWithAdobe accepts Adobe Europe storage download hosts", async () => {
+  const zipBytes = await zipStructuredData({
+    elements: [{ Path: "//Document/P", Text: "Europe region result" }],
+  });
+  const uploadUri =
+    "https://dcplatformstorageservice-prod-eu-west-1.s3.amazonaws.com/upload.pdf?X-Amz-Signature=test";
+  const downloadUri =
+    "https://dcplatformstorageservice-prod-eu-west-1.s3.amazonaws.com/result.zip?X-Amz-Signature=test";
+  const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    if (url.endsWith("/token")) {
+      return Response.json({ access_token: "token-1" });
+    }
+    if (url.endsWith("/assets")) {
+      return Response.json({
+        uploadUri,
+        assetID: "asset-1",
+      });
+    }
+    if (url === uploadUri) {
+      return new Response(null, { status: 200 });
+    }
+    if (url.endsWith("/operation/extractpdf")) {
+      return new Response(null, {
+        status: 201,
+        headers: {
+          location:
+            "https://pdf-services-ew1.adobe.io/operation/extractpdf/job-1/status",
+        },
+      });
+    }
+    if (url.endsWith("/job-1/status")) {
+      return Response.json({ status: "done", downloadUri });
+    }
+    if (url === downloadUri) {
+      return new Response(
+        zipBytes.buffer.slice(
+          zipBytes.byteOffset,
+          zipBytes.byteOffset + zipBytes.byteLength,
+        ) as ArrayBuffer,
+        { status: 200 },
+      );
+    }
+    return new Response("unexpected", { status: 500 });
+  };
+
+  const extracted = await extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+    env: envFrom({
+      PDF_SERVICES_CLIENT_ID: "client-id",
+      PDF_SERVICES_CLIENT_SECRET: "client-secret",
+    }),
+    fetchImpl,
+    sleep: () => Promise.resolve(),
+    maxPollAttempts: 1,
+  });
+
+  expect(extracted.text).toBe("Europe region result");
+});
+
+Deno.test("extractPdfWithAdobe accepts Adobe service result download hosts", async () => {
+  const zipBytes = await zipStructuredData({
+    elements: [{ Path: "//Document/P", Text: "Adobe service result" }],
+  });
+  const downloadUri =
+    "https://pdf-services.adobe.io/operation/extractpdf/job-1/result";
+
+  const extracted = await extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+    env: envFrom({
+      PDF_SERVICES_CLIENT_ID: "client-id",
+      PDF_SERVICES_CLIENT_SECRET: "client-secret",
+    }),
+    fetchImpl: successfulFetchForDownloadUri(downloadUri, zipBytes),
+    sleep: () => Promise.resolve(),
+    maxPollAttempts: 1,
+  });
+
+  expect(extracted.text).toBe("Adobe service result");
+});
+
+Deno.test("extractPdfWithAdobe rejects unexpected Adobe upload hosts", async () => {
+  const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    if (url.endsWith("/token")) {
+      return Response.json({ access_token: "token-1" });
+    }
+    if (url.endsWith("/assets")) {
+      return Response.json({
+        uploadUri: "https://attacker.example.test/upload.pdf",
+        assetID: "asset-1",
+      });
+    }
+    return new Response("unexpected", { status: 500 });
+  };
+
+  await expect(
+    extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+      env: envFrom({
+        PDF_SERVICES_CLIENT_ID: "client-id",
+        PDF_SERVICES_CLIENT_SECRET: "client-secret",
+      }),
+      fetchImpl,
+      sleep: () => Promise.resolve(),
+    }),
+  ).rejects.toThrow(AdobePdfExtractError);
+});
+
+Deno.test("extractPdfWithAdobe rejects unexpected Adobe polling hosts", async () => {
+  const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    if (url.endsWith("/token")) {
+      return Response.json({ access_token: "token-1" });
+    }
+    if (url.endsWith("/assets")) {
+      return Response.json({
+        uploadUri: ADOBE_US_STORAGE_URL,
+        assetID: "asset-1",
+      });
+    }
+    if (url === ADOBE_US_STORAGE_URL) {
+      return new Response(null, { status: 200 });
+    }
+    if (url.endsWith("/operation/extractpdf")) {
+      return new Response(null, {
+        status: 201,
+        headers: { location: "https://attacker.example.test/status" },
+      });
+    }
+    return new Response("unexpected", { status: 500 });
+  };
+
+  await expect(
+    extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+      env: envFrom({
+        PDF_SERVICES_CLIENT_ID: "client-id",
+        PDF_SERVICES_CLIENT_SECRET: "client-secret",
+      }),
+      fetchImpl,
+      sleep: () => Promise.resolve(),
+    }),
+  ).rejects.toThrow(AdobePdfExtractError);
+});
+
+Deno.test("extractPdfWithAdobe rejects unexpected Adobe download hosts", async () => {
+  const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    if (url.endsWith("/token")) {
+      return Response.json({ access_token: "token-1" });
+    }
+    if (url.endsWith("/assets")) {
+      return Response.json({
+        uploadUri: ADOBE_US_STORAGE_URL,
+        assetID: "asset-1",
+      });
+    }
+    if (url === ADOBE_US_STORAGE_URL) {
+      return new Response(null, { status: 200 });
+    }
+    if (url.endsWith("/operation/extractpdf")) {
+      return new Response(null, {
+        status: 201,
+        headers: {
+          location:
+            "https://pdf-services.adobe.io/operation/extractpdf/job-1/status",
+        },
+      });
+    }
+    if (url.endsWith("/job-1/status")) {
+      return Response.json({
+        status: "done",
+        downloadUri: "https://attacker.example.test/result.zip",
+      });
+    }
+    return new Response("unexpected", { status: 500 });
+  };
+
+  await expect(
+    extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+      env: envFrom({
+        PDF_SERVICES_CLIENT_ID: "client-id",
+        PDF_SERVICES_CLIENT_SECRET: "client-secret",
+      }),
+      fetchImpl,
+      sleep: () => Promise.resolve(),
+      maxPollAttempts: 1,
+    }),
+  ).rejects.toThrow(AdobePdfExtractError);
+});
+
+Deno.test("extractPdfWithAdobe rejects non-HTTPS Adobe download URLs", async () => {
+  const zipBytes = await zipStructuredData({
+    elements: [{ Path: "//Document/P", Text: "Should not download" }],
+  });
+  const downloadUri =
+    "http://dcplatformstorageservice-prod-us-east-1.s3-accelerate.amazonaws.com/result.zip";
+
+  await expect(
+    extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+      env: envFrom({
+        PDF_SERVICES_CLIENT_ID: "client-id",
+        PDF_SERVICES_CLIENT_SECRET: "client-secret",
+      }),
+      fetchImpl: successfulFetchForDownloadUri(downloadUri, zipBytes),
+      sleep: () => Promise.resolve(),
+      maxPollAttempts: 1,
+    }),
+  ).rejects.toThrow(AdobePdfExtractError);
+});
+
+Deno.test("extractPdfWithAdobe rejects Adobe download URLs with embedded credentials", async () => {
+  const zipBytes = await zipStructuredData({
+    elements: [{ Path: "//Document/P", Text: "Should not download" }],
+  });
+  const downloadUri =
+    "https://user:pass@dcplatformstorageservice-prod-us-east-1.s3-accelerate.amazonaws.com/result.zip";
+
+  await expect(
+    extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+      env: envFrom({
+        PDF_SERVICES_CLIENT_ID: "client-id",
+        PDF_SERVICES_CLIENT_SECRET: "client-secret",
+      }),
+      fetchImpl: successfulFetchForDownloadUri(downloadUri, zipBytes),
+      sleep: () => Promise.resolve(),
+      maxPollAttempts: 1,
+    }),
+  ).rejects.toThrow(AdobePdfExtractError);
+});

--- a/supabase/functions/extract-assessment-fields/adobe-pdf-extract.ts
+++ b/supabase/functions/extract-assessment-fields/adobe-pdf-extract.ts
@@ -1,0 +1,494 @@
+const ADOBE_PDF_SERVICES_BASE_URL = "https://pdf-services.adobe.io";
+const ADOBE_PDF_SERVICES_TOKEN_URL = `${ADOBE_PDF_SERVICES_BASE_URL}/token`;
+
+type FetchLike = typeof fetch;
+
+type AdobeEnv = {
+  get: (name: string) => string | undefined;
+};
+
+type AdobePdfExtractOptions = {
+  fetchImpl?: FetchLike;
+  env?: AdobeEnv;
+  sleep?: (ms: number) => Promise<void>;
+  pollIntervalMs?: number;
+  maxPollAttempts?: number;
+};
+
+type AdobeCredentials = {
+  clientId: string;
+  clientSecret: string;
+};
+
+type AdobeStructuredElement = Record<string, unknown>;
+
+export type NormalizedAdobePdfExtract = {
+  text: string;
+  element_count: number;
+  table_count: number;
+};
+
+export class AdobePdfExtractError extends Error {
+  readonly code: string;
+  readonly status: number;
+  readonly publicMessage: string;
+
+  constructor(code: string, message: string, status = 502) {
+    super(message);
+    this.name = "AdobePdfExtractError";
+    this.code = code;
+    this.status = status;
+    this.publicMessage = code === "adobe_pdf_extract_not_configured"
+      ? "Adobe PDF extraction is not configured. Review checklist manually."
+      : "Adobe PDF extraction failed. Review checklist manually.";
+  }
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const getDefaultEnv = (): AdobeEnv => ({
+  get(name: string): string | undefined {
+    const denoEnv = (globalThis as { Deno?: { env?: AdobeEnv } }).Deno?.env;
+    return denoEnv?.get(name);
+  },
+});
+
+const getAliasedEnv = (
+  env: AdobeEnv,
+  primaryKey: string,
+  fallbackKey: string,
+): string | undefined => {
+  const primary = env.get(primaryKey)?.trim();
+  if (primary) return primary;
+  const fallback = env.get(fallbackKey)?.trim();
+  return fallback || undefined;
+};
+
+export const getAdobePdfExtractCredentials = (
+  env: AdobeEnv = getDefaultEnv(),
+): AdobeCredentials => {
+  const clientId = getAliasedEnv(
+    env,
+    "ADOBE_PDF_SERVICES_CLIENT_ID",
+    "PDF_SERVICES_CLIENT_ID",
+  );
+  const clientSecret = getAliasedEnv(
+    env,
+    "ADOBE_PDF_SERVICES_CLIENT_SECRET",
+    "PDF_SERVICES_CLIENT_SECRET",
+  );
+
+  if (!clientId || !clientSecret) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_not_configured",
+      "Adobe PDF Services credentials are missing.",
+      500,
+    );
+  }
+
+  return { clientId, clientSecret };
+};
+
+const parseJsonResponse = async <T>(
+  response: Response,
+  operation: string,
+): Promise<T> => {
+  const text = await response.text();
+  if (!response.ok) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract ${operation} failed with status ${response.status}.`,
+      502,
+    );
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract ${operation} returned invalid JSON.`,
+      502,
+    );
+  }
+};
+
+const ADOBE_SERVICE_HOST_PATTERN = /^pdf-services(?:-[a-z0-9]+)?\.adobe\.io$/i;
+const ADOBE_RESULT_DOWNLOAD_HOSTS = new Set([
+  "dcplatformstorageservice-prod-us-east-1.s3-accelerate.amazonaws.com",
+  "dcplatformstorageservice-prod-eu-west-1.s3.amazonaws.com",
+]);
+
+const parseHttpsUrl = (
+  url: string,
+  context: "polling" | "upload" | "download",
+): URL => {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract returned an invalid ${context} URL.`,
+      502,
+    );
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract returned a non-HTTPS ${context} URL.`,
+      502,
+    );
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract returned a ${context} URL with credentials.`,
+      502,
+    );
+  }
+
+  return parsed;
+};
+
+const assertAdobePollingUrl = (url: string): void => {
+  const parsed = parseHttpsUrl(url, "polling");
+
+  if (!ADOBE_SERVICE_HOST_PATTERN.test(parsed.hostname)) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      "Adobe PDF Extract returned an unexpected polling host.",
+      502,
+    );
+  }
+};
+
+const assertAdobeStorageUrl = (url: string, context: "upload" | "download"): void => {
+  const parsed = parseHttpsUrl(url, context);
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (!ADOBE_RESULT_DOWNLOAD_HOSTS.has(hostname)) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract returned an unexpected ${context} host.`,
+      502,
+    );
+  }
+};
+
+const assertAdobeResultDownloadUrl = (url: string): void => {
+  const parsed = parseHttpsUrl(url, "download");
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (
+    !ADOBE_SERVICE_HOST_PATTERN.test(hostname) &&
+    !ADOBE_RESULT_DOWNLOAD_HOSTS.has(hostname)
+  ) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      "Adobe PDF Extract returned an unexpected download host.",
+      502,
+    );
+  }
+};
+
+const requestAccessToken = async (
+  credentials: AdobeCredentials,
+  fetchImpl: FetchLike,
+): Promise<string> => {
+  const response = await fetchImpl(ADOBE_PDF_SERVICES_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: credentials.clientId,
+      client_secret: credentials.clientSecret,
+    }),
+  });
+  const body = await parseJsonResponse<{ access_token?: unknown }>(
+    response,
+    "token request",
+  );
+  if (typeof body.access_token !== "string" || !body.access_token.trim()) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      "Adobe PDF Extract token response did not include an access token.",
+      502,
+    );
+  }
+  return body.access_token.trim();
+};
+
+const buildAdobeHeaders = (
+  credentials: AdobeCredentials,
+  accessToken: string,
+  contentType = "application/json",
+): Record<string, string> => ({
+  "X-API-Key": credentials.clientId,
+  Authorization: `Bearer ${accessToken}`,
+  "Content-Type": contentType,
+});
+
+const createAsset = async (
+  credentials: AdobeCredentials,
+  accessToken: string,
+  fetchImpl: FetchLike,
+): Promise<{ uploadUri: string; assetID: string }> => {
+  const response = await fetchImpl(`${ADOBE_PDF_SERVICES_BASE_URL}/assets`, {
+    method: "POST",
+    headers: buildAdobeHeaders(credentials, accessToken),
+    body: JSON.stringify({ mediaType: "application/pdf" }),
+  });
+  const body = await parseJsonResponse<{
+    uploadUri?: unknown;
+    assetID?: unknown;
+  }>(response, "asset creation");
+  if (typeof body.uploadUri !== "string" || typeof body.assetID !== "string") {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      "Adobe PDF Extract asset response was incomplete.",
+      502,
+    );
+  }
+  return { uploadUri: body.uploadUri, assetID: body.assetID };
+};
+
+const uploadAsset = async (
+  uploadUri: string,
+  pdfBytes: Uint8Array,
+  fetchImpl: FetchLike,
+): Promise<void> => {
+  assertAdobeStorageUrl(uploadUri, "upload");
+
+  const body = pdfBytes.buffer.slice(
+    pdfBytes.byteOffset,
+    pdfBytes.byteOffset + pdfBytes.byteLength,
+  ) as ArrayBuffer;
+  const response = await fetchImpl(uploadUri, {
+    method: "PUT",
+    headers: { "Content-Type": "application/pdf" },
+    body,
+  });
+  if (!response.ok) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract asset upload failed with status ${response.status}.`,
+      502,
+    );
+  }
+};
+
+const submitExtractJob = async (
+  credentials: AdobeCredentials,
+  accessToken: string,
+  assetID: string,
+  fetchImpl: FetchLike,
+): Promise<string> => {
+  const response = await fetchImpl(
+    `${ADOBE_PDF_SERVICES_BASE_URL}/operation/extractpdf`,
+    {
+      method: "POST",
+      headers: buildAdobeHeaders(credentials, accessToken),
+      body: JSON.stringify({
+        assetID,
+        elementsToExtract: ["text", "tables"],
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract job submission failed with status ${response.status}.`,
+      502,
+    );
+  }
+  const location = response.headers.get("location")?.trim();
+  if (!location) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      "Adobe PDF Extract job response did not include a polling location.",
+      502,
+    );
+  }
+  return location;
+};
+
+const resolveDownloadUri = (body: Record<string, unknown>): string | null => {
+  const readDownloadUri = (value: unknown): string | null => {
+    if (!value || typeof value !== "object") return null;
+    const record = value as Record<string, unknown>;
+    const uri = record.downloadUri ?? record.dowloadUri;
+    return typeof uri === "string" && uri.trim() ? uri.trim() : null;
+  };
+
+  const direct = body.downloadUri ?? body.dowloadUri;
+  if (typeof direct === "string" && direct.trim()) return direct.trim();
+  const assetDownloadUri = readDownloadUri(body.asset);
+  if (assetDownloadUri) return assetDownloadUri;
+  const result = body.result;
+  if (result && typeof result === "object") {
+    const resource = (result as Record<string, unknown>).resource;
+    const resourceDownloadUri = readDownloadUri(resource);
+    if (resourceDownloadUri) return resourceDownloadUri;
+  }
+  return null;
+};
+
+const pollExtractJob = async (
+  pollingUrl: string,
+  credentials: AdobeCredentials,
+  accessToken: string,
+  fetchImpl: FetchLike,
+  sleep: (ms: number) => Promise<void>,
+  pollIntervalMs: number,
+  maxPollAttempts: number,
+): Promise<string> => {
+  assertAdobePollingUrl(pollingUrl);
+
+  for (let attempt = 0; attempt < maxPollAttempts; attempt += 1) {
+    const response = await fetchImpl(pollingUrl, {
+      method: "GET",
+      headers: buildAdobeHeaders(credentials, accessToken),
+    });
+    const body = await parseJsonResponse<Record<string, unknown>>(
+      response,
+      "job status",
+    );
+    const status = typeof body.status === "string"
+      ? body.status.toLowerCase()
+      : "";
+    if (status === "done") {
+      const downloadUri = resolveDownloadUri(body);
+      if (!downloadUri) {
+        throw new AdobePdfExtractError(
+          "adobe_pdf_extract_failed",
+          "Adobe PDF Extract completed without a download URI.",
+          502,
+        );
+      }
+      return downloadUri;
+    }
+    if (status === "failed") {
+      throw new AdobePdfExtractError(
+        "adobe_pdf_extract_failed",
+        "Adobe PDF Extract job failed.",
+        502,
+      );
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  throw new AdobePdfExtractError(
+    "adobe_pdf_extract_failed",
+    "Adobe PDF Extract job did not complete before polling timed out.",
+    504,
+  );
+};
+
+const downloadResultZip = async (
+  downloadUri: string,
+  fetchImpl: FetchLike,
+): Promise<Uint8Array> => {
+  assertAdobeResultDownloadUrl(downloadUri);
+
+  const response = await fetchImpl(downloadUri, { method: "GET" });
+  if (!response.ok) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract result download failed with status ${response.status}.`,
+      502,
+    );
+  }
+  return new Uint8Array(await response.arrayBuffer());
+};
+
+const getElementText = (element: AdobeStructuredElement): string => {
+  const text = element.Text ?? element.text;
+  return typeof text === "string" ? text.trim() : "";
+};
+
+const isTableElement = (element: AdobeStructuredElement): boolean => {
+  const path = element.Path ?? element.path;
+  return typeof path === "string" && /\/Table(?:\/|$)/i.test(path);
+};
+
+const normalizeText = (value: string): string =>
+  value
+    .replace(/\r/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+export const normalizeAdobeStructuredData = (
+  structuredData: unknown,
+): NormalizedAdobePdfExtract => {
+  const record = structuredData && typeof structuredData === "object"
+    ? structuredData as Record<string, unknown>
+    : {};
+  const elements = Array.isArray(record.elements)
+    ? record.elements as AdobeStructuredElement[]
+    : [];
+  const lines = elements
+    .map(getElementText)
+    .filter((text) => text.length > 0);
+
+  return {
+    text: normalizeText(lines.join("\n")),
+    element_count: elements.length,
+    table_count: elements.filter(isTableElement).length,
+  };
+};
+
+export const normalizeAdobeExtractZip = async (
+  zipBytes: Uint8Array,
+): Promise<NormalizedAdobePdfExtract> => {
+  const { default: JSZip } = await import("npm:jszip@3.10.1");
+  const zip = await JSZip.loadAsync(zipBytes);
+  const structuredDataFile = zip.file("structuredData.json");
+  if (!structuredDataFile) {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      "Adobe PDF Extract result is missing structuredData.json.",
+      502,
+    );
+  }
+  const rawStructuredData = await structuredDataFile.async("string");
+  try {
+    return normalizeAdobeStructuredData(JSON.parse(rawStructuredData));
+  } catch {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      "Adobe PDF Extract structuredData.json is invalid.",
+      502,
+    );
+  }
+};
+
+export const extractPdfWithAdobe = async (
+  pdfBytes: Uint8Array,
+  options: AdobePdfExtractOptions = {},
+): Promise<NormalizedAdobePdfExtract> => {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const credentials = getAdobePdfExtractCredentials(options.env);
+  const accessToken = await requestAccessToken(credentials, fetchImpl);
+  const asset = await createAsset(credentials, accessToken, fetchImpl);
+  await uploadAsset(asset.uploadUri, pdfBytes, fetchImpl);
+  const pollingUrl = await submitExtractJob(
+    credentials,
+    accessToken,
+    asset.assetID,
+    fetchImpl,
+  );
+  const downloadUri = await pollExtractJob(
+    pollingUrl,
+    credentials,
+    accessToken,
+    fetchImpl,
+    options.sleep ?? defaultSleep,
+    options.pollIntervalMs ?? 1_000,
+    options.maxPollAttempts ?? 45,
+  );
+  const zipBytes = await downloadResultZip(downloadUri, fetchImpl);
+  return normalizeAdobeExtractZip(zipBytes);
+};

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -1,7 +1,7 @@
 import { createClient } from "npm:@supabase/supabase-js@2.50.0";
 import { z } from "npm:zod@3.23.8";
-import { Buffer } from "node:buffer";
 import { resolveAllowedOrigin } from "../_shared/cors.ts";
+import { AdobePdfExtractError, extractPdfWithAdobe, type NormalizedAdobePdfExtract } from "./adobe-pdf-extract.ts";
 
 const corsHeaders = (req: Request) => ({
   "Access-Control-Allow-Origin": resolveAllowedOrigin(req.headers.get("origin")),
@@ -64,6 +64,23 @@ interface StructuredSectionResult {
 }
 
 const MAX_DOCUMENT_BYTES = 10 * 1024 * 1024;
+const ASSESSMENT_DOCUMENT_BUCKET_ID = "client-documents";
+
+const isAllowedAssessmentDocumentStorageTarget = (
+  bucketId: string,
+  objectPath: string,
+  clientId: string,
+): boolean => {
+  const allowedObjectPathPattern = new RegExp(
+    `^clients/${escapeRegExp(clientId)}/assessments/[^/]+\\.(pdf|docx)$`,
+    "i",
+  );
+  return bucketId === ASSESSMENT_DOCUMENT_BUCKET_ID &&
+    !objectPath.includes("..") &&
+    !objectPath.includes("\\") &&
+    objectPath.startsWith(`clients/${clientId}/`) &&
+    allowedObjectPathPattern.test(objectPath);
+};
 
 const json = (req: Request, payload: unknown, status = 200): Response =>
   new Response(JSON.stringify(payload), {
@@ -97,27 +114,6 @@ const decodeDocxText = async (bytes: Uint8Array): Promise<string> => {
     return "";
   }
   return normalizeText(stripXmlTags(documentXml));
-};
-
-const decodePdfFallbackText = (bytes: Uint8Array): string => {
-  const decoded = new TextDecoder("latin1").decode(bytes);
-  return normalizeText(decoded.replace(/[^\x20-\x7E\n]/g, " "));
-};
-
-const decodePdfText = async (bytes: Uint8Array): Promise<string> => {
-  try {
-    const parsePdfModule = await import("npm:pdf-parse@1.1.1");
-    const parsePdf = parsePdfModule.default as (value: Buffer) => Promise<{ text?: string }>;
-    const parsed = await parsePdf(Buffer.from(bytes));
-    const text = typeof parsed?.text === "string" ? parsed.text : "";
-    const normalized = normalizeText(text);
-    if (normalized.length >= 80) {
-      return normalized;
-    }
-  } catch {
-    // Fall through to legacy fallback.
-  }
-  return decodePdfFallbackText(bytes);
 };
 
 const summarizeTextQuality = (text: string): "high" | "medium" | "low" => {
@@ -881,9 +877,21 @@ const extractStructuredSections = (text: string): StructuredSectionResult[] => [
   return deduped;
 }, []);
 
+const withExtractionProviderSource = <T extends { source_span: Record<string, unknown> | null }>(
+  item: T,
+  extractionProvider: string,
+): T => ({
+  ...item,
+  source_span: {
+    ...(item.source_span ?? {}),
+    extraction_provider: extractionProvider,
+  },
+});
+
 export const __TESTING__ = {
   deterministicValueForRow,
   extractStructuredSections,
+  isAllowedAssessmentDocumentStorageTarget,
 };
 
 Deno.serve(async (req) => {
@@ -930,9 +938,7 @@ Deno.serve(async (req) => {
     if (scopedAssessment.bucket_id !== data.bucket_id || scopedAssessment.object_path !== data.object_path) {
       return json(req, { error: "Assessment document storage location mismatch." }, 403);
     }
-
-    const expectedClientPrefix = `clients/${scopedAssessment.client_id}/`;
-    if (!data.object_path.startsWith(expectedClientPrefix)) {
+    if (!isAllowedAssessmentDocumentStorageTarget(data.bucket_id, data.object_path, scopedAssessment.client_id)) {
       return json(req, { error: "Assessment document path is outside the allowed client scope." }, 403);
     }
 
@@ -951,15 +957,19 @@ Deno.serve(async (req) => {
     }
 
     const fileBytes = new Uint8Array(await download.data.arrayBuffer());
+    let adobeExtraction: NormalizedAdobePdfExtract | null = null;
     const documentText = objectPathLower.endsWith(".docx")
       ? await decodeDocxText(fileBytes)
-      : await decodePdfText(fileBytes);
+      : (adobeExtraction = await extractPdfWithAdobe(fileBytes)).text;
+    const extractionProvider = adobeExtraction ? "adobe_pdf_extract" : "local_docx";
     const textQuality = summarizeTextQuality(documentText);
 
     const deterministic = data.checklist_rows.map((row) =>
       deterministicValueForRow(row, documentText, data.client_snapshot, data.checklist_rows)
     );
-    const structuredSections = extractStructuredSections(documentText);
+    const structuredSections = extractStructuredSections(documentText).map((section) =>
+      withExtractionProviderSource(section, extractionProvider)
+    );
     const structuredSummaryByKey = new Map<string, { count: number; firstPayload: Record<string, unknown> }>();
     structuredSections.forEach((section) => {
       const current = structuredSummaryByKey.get(section.field_key);
@@ -971,9 +981,9 @@ Deno.serve(async (req) => {
     const merged = deterministic.map((field) => {
       const structuredSummary = structuredSummaryByKey.get(field.placeholder_key);
       if (!structuredSummary) {
-        return field;
+        return withExtractionProviderSource(field, extractionProvider);
       }
-      return {
+      return withExtractionProviderSource({
         ...field,
         value_text: `${structuredSummary.count} structured section${structuredSummary.count === 1 ? "" : "s"} extracted`,
         value_json: structuredSummary.firstPayload,
@@ -982,12 +992,15 @@ Deno.serve(async (req) => {
         status: "drafted" as const,
         source_span: { method: "deterministic_structured_section_summary" },
         review_notes: "Deterministic structured extraction summary. Review full structured section payloads before approval.",
-      };
+      }, extractionProvider);
     });
 
     return json(req, {
       assessment_document_id: data.assessment_document_id,
       template_type: data.template_type,
+      extraction_provider: extractionProvider,
+      adobe_element_count: adobeExtraction?.element_count ?? null,
+      adobe_table_count: adobeExtraction?.table_count ?? null,
       fields: merged,
       structured_sections: structuredSections,
       unresolved_keys: merged.filter((field) => !field.value_text).map((field) => field.placeholder_key),
@@ -997,6 +1010,14 @@ Deno.serve(async (req) => {
       text_quality: textQuality,
     });
   } catch (error) {
+    if (error instanceof AdobePdfExtractError) {
+      console.error("extract-assessment-fields adobe extraction error", {
+        code: error.code,
+        status: error.status,
+        message: error.message,
+      });
+      return json(req, { error: error.publicMessage, code: error.code }, error.status);
+    }
     console.error("extract-assessment-fields error", error);
     return json(req, { error: "Failed to extract assessment fields." }, 500);
   }

--- a/tests/edge/extract-assessment-fields.caloptima.test.ts
+++ b/tests/edge/extract-assessment-fields.caloptima.test.ts
@@ -3,6 +3,35 @@ import { describe, expect, it } from "vitest";
 import { __TESTING__ } from "../../supabase/functions/extract-assessment-fields/index.ts";
 
 describe("extract-assessment-fields CalOptima parser", () => {
+  it("allows only the canonical assessment document storage target", () => {
+    const clientId = "11111111-1111-1111-1111-111111111111";
+    const objectPath = `clients/${clientId}/assessments/fba.pdf`;
+
+    expect(__TESTING__.isAllowedAssessmentDocumentStorageTarget("client-documents", objectPath, clientId)).toBe(true);
+    expect(__TESTING__.isAllowedAssessmentDocumentStorageTarget("private-documents", objectPath, clientId)).toBe(false);
+    expect(
+      __TESTING__.isAllowedAssessmentDocumentStorageTarget(
+        "client-documents",
+        "clients/other-client/assessments/fba.pdf",
+        clientId,
+      ),
+    ).toBe(false);
+    expect(
+      __TESTING__.isAllowedAssessmentDocumentStorageTarget(
+        "client-documents",
+        `clients/${clientId}/other/fba.pdf`,
+        clientId,
+      ),
+    ).toBe(false);
+    expect(
+      __TESTING__.isAllowedAssessmentDocumentStorageTarget(
+        "client-documents",
+        `clients/${clientId}/assessments/../secret.pdf`,
+        clientId,
+      ),
+    ).toBe(false);
+  });
+
   const inlineRows = [
     {
       section: "identification_admin",


### PR DESCRIPTION
## Summary
- Route uploaded assessment PDFs through Adobe PDF Extract only; DOCX remains on the existing local decoder.
- Preserve the staged review response shape while adding extraction provider/source metadata and redacted Adobe failure handling.
- Enforce canonical assessment storage bucket/path checks before service-role storage download and document server-only Adobe credential requirements.

## Risk / Routing
- Linear: WIN-147
- route-task: high-risk human-reviewed / critical
- Protected paths: supabase/functions/**, src/server/**, server-only external document-processing credentials, tenant-scoped extraction flow
- Non-goals: final PDF generation, signing, embedded viewing, overlay rendering, schema/RLS changes

## Verification
- PASS: npm run ci:check-focused
- PASS: npm run lint
- PASS: npm run typecheck
- PASS: npm run validate:tenant
- PASS: npm run build
- PASS: deno test --allow-env --no-lock supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts
- PASS: deno check --node-modules-dir=auto --no-lock supabase/functions/extract-assessment-fields/index.ts
- PASS: npx vitest run src/server/__tests__/assessmentDocumentsHandler.test.ts src/server/__tests__/adobeAcrobat.test.ts tests/edge/extract-assessment-fields.caloptima.test.ts
- PASS: npm run test:routes:tier0
- PARTIAL: npm run test:ci failed in unrelated/global-order suites; failed suites passed standalone with dummy Supabase test env. See PR notes before merge.
- BLOCKED: npm run playwright:assessment-import-smoke requires this branch's edge function deployed with server-side Adobe credentials; running it against production would not validate this branch.
- BLOCKED: npm run verify:local not rerun because it includes the currently failing full test:ci gate above.

## Reviewer Notes
- Reviewer found and rechecked SSRF risk on Adobe polling/download URLs; final pass confirmed no blocker remains.
- Human review remains required before merge due critical lane.