### PR TITLE
WIN-147 Harden CalOptima PDF generation scope

### DIFF
--- a/docs/fill_docs/caloptima_fba_pdf_render_map.json
+++ b/docs/fill_docs/caloptima_fba_pdf_render_map.json
@@ -733,14 +733,14 @@
         "summary_recommendations"
       ],
       "fallback": {
-        "page": 26,
+        "page": 27,
         "x": 95,
-        "y": 574,
+        "y": 520,
         "font_size": 8,
         "max_width": 430,
-        "height": 120,
+        "height": 110,
         "line_height": 10,
-        "max_lines": 12,
+        "max_lines": 11,
         "field_kind": "structured_section"
       },
       "target": "caloptima_fba_pdf_overlay",
@@ -753,14 +753,14 @@
         "hcpcs_rows"
       ],
       "fallback": {
-        "page": 26,
+        "page": 27,
         "x": 95,
-        "y": 416,
-        "font_size": 8,
+        "y": 345,
+        "font_size": 6,
         "max_width": 430,
-        "height": 36,
-        "line_height": 10,
-        "max_lines": 3,
+        "height": 160,
+        "line_height": 8,
+        "max_lines": 20,
         "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
@@ -773,14 +773,14 @@
         "telehealth_consent"
       ],
       "fallback": {
-        "page": 26,
+        "page": 27,
         "x": 95,
-        "y": 388,
-        "font_size": 10,
+        "y": 72,
+        "font_size": 8,
         "max_width": 430,
-        "height": 14,
-        "line_height": 12,
-        "max_lines": 1,
+        "height": 18,
+        "line_height": 9,
+        "max_lines": 2,
         "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
@@ -793,14 +793,14 @@
         "parent_involvement"
       ],
       "fallback": {
-        "page": 26,
+        "page": 28,
         "x": 95,
-        "y": 366,
-        "font_size": 10,
+        "y": 535,
+        "font_size": 8,
         "max_width": 430,
-        "height": 14,
-        "line_height": 12,
-        "max_lines": 1,
+        "height": 40,
+        "line_height": 10,
+        "max_lines": 4,
         "field_kind": "text"
       },
       "target": "caloptima_fba_pdf_overlay",
@@ -813,7 +813,7 @@
         "report_written_by"
       ],
       "fallback": {
-        "page": 27,
+        "page": 28,
         "x": 95,
         "y": 248,
         "font_size": 10,
@@ -833,7 +833,7 @@
         "writer_credentials"
       ],
       "fallback": {
-        "page": 27,
+        "page": 28,
         "x": 330,
         "y": 248,
         "font_size": 10,
@@ -853,7 +853,7 @@
         "report_completed_date"
       ],
       "fallback": {
-        "page": 27,
+        "page": 28,
         "x": 95,
         "y": 231,
         "font_size": 10,
@@ -873,7 +873,7 @@
         "signatures"
       ],
       "fallback": {
-        "page": 27,
+        "page": 28,
         "x": 95,
         "y": 206,
         "font_size": 8,

--- a/scripts/playwright-assessment-pdf-smoke.ts
+++ b/scripts/playwright-assessment-pdf-smoke.ts
@@ -24,6 +24,7 @@ type GeneratePdfResponse = {
   object_path: string;
   layout_warnings?: Array<{ placeholder_key: string; page: number; reason: string }>;
   overflow_keys?: string[];
+  filled_pages?: number[];
 };
 
 type PageReport = {
@@ -40,6 +41,7 @@ const PDF_PAGE_HEIGHT_POINTS = 792;
 const SCREENSHOT_WIDTH = 816;
 const SCREENSHOT_HEIGHT = 1056;
 const OUTSIDE_ALLOWED_PIXEL_TOLERANCE = 350;
+const MIN_CHANGED_PIXELS_PER_FILLED_PAGE = 25;
 
 const getRequiredEnv = (name: string): string => {
   const value = process.env[name]?.trim();
@@ -76,17 +78,20 @@ const compareScreenshots = async (
 ) => {
   const blankUrl = dataUrlForFile(blankScreenshot, 'image/png');
   const generatedUrl = dataUrlForFile(generatedScreenshot, 'image/png');
-  return page.evaluate(
-    async ({ blankUrl: blank, generatedUrl: generated, entries: fieldEntries, diffPath: ignoredDiffPath, pageWidth, pageHeight }) => {
-      const browserGlobal = globalThis as Record<string, any>;
-      const loadImage = async (src: string): Promise<any> => {
+  const compareInBrowser = new Function(
+    'arg',
+    `
+    return (async () => {
+      const { blankUrl: blank, generatedUrl: generated, entries: fieldEntries, diffPath: ignoredDiffPath, pageWidth, pageHeight } = arg;
+      const browserGlobal = globalThis;
+      const loadImage = async (src) => {
         const response = await browserGlobal.fetch(src);
         const blob = await response.blob();
         return browserGlobal.createImageBitmap(blob);
       };
       const [blankImage, generatedImage] = await Promise.all([loadImage(blank), loadImage(generated)]);
-      const width = Number((generatedImage as { width: number }).width);
-      const height = Number((generatedImage as { height: number }).height);
+      const width = Number(generatedImage.width);
+      const height = Number(generatedImage.height);
       const canvas = new browserGlobal.OffscreenCanvas(width, height);
       const context = canvas.getContext('2d');
       if (!context) throw new Error('Could not create screenshot comparison canvas.');
@@ -136,7 +141,7 @@ const compareScreenshots = async (
 
       context.putImageData(diffPixels, 0, 0);
       const blob = await canvas.convertToBlob({ type: 'image/png' });
-      const diffDataUrl = await new Promise<string>((resolve, reject) => {
+      const diffDataUrl = await new Promise((resolve, reject) => {
         const reader = new browserGlobal.FileReader();
         reader.onload = () => resolve(String(reader.result));
         reader.onerror = () => reject(reader.error ?? new Error('Could not encode diff image.'));
@@ -148,13 +153,37 @@ const compareScreenshots = async (
         diffDataUrl,
         diffPath: ignoredDiffPath,
       };
+    })();
+    `,
+  ) as (
+    arg: {
+      blankUrl: string;
+      generatedUrl: string;
+      entries: RenderMapEntry[];
+      diffPath: string;
+      pageWidth: number;
+      pageHeight: number;
     },
+  ) => Promise<{
+    changedPixels: number;
+    outsideAllowedPixels: number;
+    diffDataUrl: string;
+    diffPath: string;
+  }>;
+  return page.evaluate(
+    compareInBrowser,
     { blankUrl, generatedUrl, entries, diffPath, pageWidth: PDF_PAGE_WIDTH_POINTS, pageHeight: PDF_PAGE_HEIGHT_POINTS },
   );
 };
 
 async function run() {
   loadPlaywrightEnv();
+
+  if (process.env.HEADLESS !== 'false') {
+    throw new Error(
+      'Assessment PDF visual smoke must run with HEADLESS=false because Chromium headless does not render PDF viewer screenshots reliably.',
+    );
+  }
 
   const baseUrl = (process.env.PW_BASE_URL?.trim() || DEFAULT_BASE_URL).replace(/\/$/, '');
   const assessmentDocumentId =
@@ -208,12 +237,16 @@ async function run() {
   const renderMap = JSON.parse(readFileSync(path.resolve(process.cwd(), 'docs/fill_docs/caloptima_fba_pdf_render_map.json'), 'utf8')) as {
     entries: RenderMapEntry[];
   };
+  const expectedFilledPages = new Set(generated.filled_pages ?? []);
+  if (expectedFilledPages.size === 0) {
+    throw new Error('PDF visual smoke expected at least one filled page from the generation response.');
+  }
   const pages = Array.from(new Set(renderMap.entries.map((entry) => entry.fallback.page))).sort((left, right) => left - right);
   if (!pages.includes(2)) {
     throw new Error('CalOptima PDF visual smoke requires page 2 coverage.');
   }
 
-  const browser = await chromium.launch({ headless: process.env.HEADLESS !== 'false' });
+  const browser = await chromium.launch({ headless: false });
   const page = await browser.newPage();
   const templateDataUrl = dataUrlForFile(templatePath, 'application/pdf');
   const generatedDataUrl = dataUrlForFile(generatedPdfPath, 'application/pdf');
@@ -242,18 +275,35 @@ async function run() {
   }
 
   const failingPages = reportPages.filter((entry) => entry.outsideAllowedPixels > OUTSIDE_ALLOWED_PIXEL_TOLERANCE);
+  const totalChangedPixels = reportPages.reduce((sum, entry) => sum + entry.changedPixels, 0);
+  const missingFilledPages = reportPages.filter(
+    (entry) => expectedFilledPages.has(entry.page) && entry.changedPixels < MIN_CHANGED_PIXELS_PER_FILLED_PAGE,
+  );
   const report = {
-    ok: failingPages.length === 0,
+    ok: failingPages.length === 0 && missingFilledPages.length === 0 && totalChangedPixels > 0,
     assessmentDocumentId,
     fillMode: generated.fill_mode,
     objectPath: generated.object_path,
     outputDir,
     outsideAllowedPixelTolerance: OUTSIDE_ALLOWED_PIXEL_TOLERANCE,
+    minChangedPixelsPerFilledPage: MIN_CHANGED_PIXELS_PER_FILLED_PAGE,
+    totalChangedPixels,
+    expectedFilledPages: Array.from(expectedFilledPages).sort((left, right) => left - right),
     pages: reportPages,
   };
   const reportPath = path.join(outputDir, 'report.json');
   writeFileSync(reportPath, JSON.stringify(report, null, 2));
   console.log(JSON.stringify(report, null, 2));
+  if (totalChangedPixels === 0) {
+    throw new Error(`PDF visual smoke could not detect rendered PDF changes. Report: ${reportPath}`);
+  }
+  if (missingFilledPages.length > 0) {
+    throw new Error(
+      `PDF visual smoke found mapped pages with non-empty fields but no rendered evidence: ${missingFilledPages
+        .map((entry) => entry.page)
+        .join(', ')}. Report: ${reportPath}`,
+    );
+  }
   if (failingPages.length > 0) {
     throw new Error(`PDF visual smoke found changed pixels outside mapped boxes. Report: ${reportPath}`);
   }

--- a/src/server/__tests__/assessmentPlanPdfHandler.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfHandler.test.ts
@@ -191,6 +191,7 @@ describe("assessmentPlanPdfHandler", () => {
     expect(body.fill_mode).toBe("overlay");
     expect(body.overflow_keys).toEqual(["CALOPTIMA_FBA_CHIEF_COMPLAINT"]);
     expect(body.layout_warnings).toHaveLength(1);
+    expect(body.filled_pages).toEqual([1]);
     expect(fetchJson).toHaveBeenLastCalledWith(
       "https://example.supabase.co/rest/v1/assessment_review_events",
       expect.objectContaining({

--- a/src/server/__tests__/assessmentPlanPdfTemplate.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfTemplate.test.ts
@@ -59,6 +59,20 @@ describe("CalOptima PDF render map", () => {
     });
   });
 
+  it("keeps tail-section overlay fields anchored to their actual template pages", async () => {
+    const renderMap = await loadCalOptimaPdfRenderMap();
+    const entriesByKey = new Map(renderMap.map((entry) => [entry.placeholder_key, entry]));
+
+    expect(entriesByKey.get("CALOPTIMA_FBA_SUMMARY_RECOMMENDATIONS")?.fallback.page).toBe(27);
+    expect(entriesByKey.get("CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS")?.fallback.page).toBe(27);
+    expect(entriesByKey.get("CALOPTIMA_FBA_TELEHEALTH_CONSENT")?.fallback.page).toBe(27);
+    expect(entriesByKey.get("CALOPTIMA_FBA_PARENT_INVOLVEMENT")?.fallback.page).toBe(28);
+    expect(entriesByKey.get("CALOPTIMA_FBA_REPORT_WRITTEN_BY")?.fallback.page).toBe(28);
+    expect(entriesByKey.get("CALOPTIMA_FBA_WRITER_CREDENTIALS")?.fallback.page).toBe(28);
+    expect(entriesByKey.get("CALOPTIMA_FBA_REPORT_COMPLETED_DATE")?.fallback.page).toBe(28);
+    expect(entriesByKey.get("CALOPTIMA_FBA_SIGNATURES")?.fallback.page).toBe(28);
+  });
+
   it("keeps registry, checklist, and render placeholder keys in parity", async () => {
     const [registry, checklist, renderMap] = await Promise.all([
       readJsonFile(registryPath),

--- a/src/server/api/assessment-plan-pdf.ts
+++ b/src/server/api/assessment-plan-pdf.ts
@@ -310,6 +310,17 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
   });
 
   const layoutWarnings = functionResult.data.layout_warnings ?? [];
+  const filledPages = Array.from(
+    new Set(
+      renderMap
+        .filter((entry) => {
+          const value = payloadResult.values[entry.placeholder_key];
+          return typeof value === "string" ? value.trim().length > 0 : Boolean(value);
+        })
+        .map((entry) => entry.fallback.page),
+    ),
+  ).sort((left, right) => left - right);
+
   return json({
     assessment_document_id: assessmentDocument.id,
     fill_mode: functionResult.data.fill_mode,
@@ -318,5 +329,6 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
     signed_url: functionResult.data.signed_url,
     layout_warnings: layoutWarnings,
     overflow_keys: functionResult.data.overflow_keys ?? layoutWarnings.map((warning) => warning.placeholder_key),
+    filled_pages: filledPages,
   });
 }

--- a/supabase/functions/_shared/auth-middleware.ts
+++ b/supabase/functions/_shared/auth-middleware.ts
@@ -147,7 +147,7 @@ export async function createSupabaseClientForRequest(req: Request): Promise<{
         }
       : undefined
   );
-  return { supabase, token };
+  return { supabase: supabase as ReturnType<SupabaseModule["createClient"]>, token };
 }
 
 /**
@@ -200,8 +200,9 @@ export async function getUserContext(req: Request): Promise<UserContext | null> 
         email: user.email ?? null,
       },
       profile: {
-        ...profile,
-        email: profile.email ?? null,
+        id: user.id,
+        email: typeof profile.email === "string" ? profile.email : null,
+        is_active: profile.is_active === true,
         role,
       },
     };

--- a/supabase/functions/_shared/org.ts
+++ b/supabase/functions/_shared/org.ts
@@ -131,5 +131,7 @@ export function orgScopedQuery(
   table: string,
   orgId: string,
 ) {
-  return db.from(table).eq("organization_id", orgId);
+  return (db.from(table) as unknown as {
+    eq: (column: string, value: string) => unknown;
+  }).eq("organization_id", orgId);
 }

--- a/supabase/functions/generate-assessment-plan-pdf/index.test.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.test.ts
@@ -1,7 +1,126 @@
 import { expect } from "jsr:@std/expect";
 
 import { layoutOverlayText, wrapOverlayText } from "./overlay-layout.ts";
-import { isPdfCheckboxNotApplicableValue, resolvePdfCheckboxValue, sanitizePdfText } from "./pdf-text.ts";
+import {
+  isPdfCheckboxNotApplicableValue,
+  resolvePdfCheckboxValue,
+  sanitizePdfText,
+} from "./pdf-text.ts";
+import { isAllowedAssessmentPlanPdfOutputTarget } from "./storage-scope.ts";
+
+Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+
+const { createGenerateAssessmentPlanPdfHandler } = await import("./index.ts");
+
+const validPayload = {
+  assessment_document_id: "41df4f57-1a22-4df1-b05f-cf8f3675267c",
+  template_type: "caloptima_fba",
+  template_pdf_base64: "JVBERi0xLjQK",
+  render_map_entries: [
+    {
+      placeholder_key: "CALOPTIMA_FBA_MEMBER_NAME",
+      form_field_candidates: ["Member Name"],
+      fallback: {
+        page: 1,
+        x: 10,
+        y: 10,
+        font_size: 10,
+        max_width: 100,
+        height: 14,
+        line_height: 12,
+        max_lines: 1,
+        field_kind: "text",
+      },
+    },
+  ],
+  field_values: { CALOPTIMA_FBA_MEMBER_NAME: "Client One" },
+  output_bucket_id: "client-documents",
+  output_object_path:
+    "clients/af87b28a-d0cf-4c73-8bce-8f1889b77c34/assessments/generated-caloptima-plan-41df4f57-1a22-4df1-b05f-cf8f3675267c-1778712054626.pdf",
+};
+
+const postRequest = (payload: unknown): Request =>
+  new Request("https://edge.test/generate-assessment-plan-pdf", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-token",
+      apikey: "anon",
+    },
+    body: JSON.stringify(payload),
+  });
+
+const createRequestClientForDocument = (
+  documentResult: {
+    data: {
+      id: string;
+      organization_id: string;
+      client_id: string;
+      template_type: string;
+    } | null;
+    error: unknown | null;
+  },
+) =>
+() => ({
+  from: () => ({
+    select: () => ({
+      eq: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve(documentResult),
+        }),
+      }),
+    }),
+  }),
+});
+
+const createAdminStorage = () => ({
+  storage: {
+    from: () => ({
+      upload: () => Promise.resolve({ data: {}, error: null }),
+      createSignedUrl: () =>
+        Promise.resolve({
+          data: { signedUrl: "https://example.supabase.co/generated.pdf" },
+          error: null,
+        }),
+    }),
+  },
+});
+
+type TestDocumentResult = {
+  data: {
+    id: string;
+    organization_id: string;
+    client_id: string;
+    template_type: string;
+  } | null;
+  error: unknown | null;
+};
+
+const validDocumentResult = {
+  data: {
+    id: validPayload.assessment_document_id,
+    organization_id: "org-1",
+    client_id: "af87b28a-d0cf-4c73-8bce-8f1889b77c34",
+    template_type: "caloptima_fba",
+  },
+  error: null,
+};
+
+const createTestHandler = ({
+  organizationId = "org-1",
+  documentResult = validDocumentResult,
+  admin = createAdminStorage(),
+}: {
+  organizationId?: string | null;
+  documentResult?: TestDocumentResult;
+  admin?: ReturnType<typeof createAdminStorage>;
+} = {}) =>
+  createGenerateAssessmentPlanPdfHandler({
+    createRequestClient: createRequestClientForDocument(documentResult),
+    resolveOrgId: () => Promise.resolve(organizationId),
+    supabaseAdmin: admin,
+  });
 
 Deno.test("sanitizePdfText normalizes unsupported glyphs for PDF rendering", () => {
   const raw =
@@ -32,7 +151,8 @@ Deno.test("isPdfCheckboxNotApplicableValue preserves N/A as a distinct checkbox 
 
 Deno.test("layoutOverlayText fits text inside the configured field box and flags overflow", () => {
   const font = {
-    widthOfTextAtSize: (value: string, size: number) => value.length * size * 0.5,
+    widthOfTextAtSize: (value: string, size: number) =>
+      value.length * size * 0.5,
   };
 
   const layout = layoutOverlayText(
@@ -66,4 +186,94 @@ Deno.test("wrapOverlayText does not insert spaces into long unbroken tokens", ()
 
   expect(lines.join("")).toBe(rawToken);
   expect(lines.join(" ")).not.toBe(rawToken);
+});
+
+Deno.test("isAllowedAssessmentPlanPdfOutputTarget only allows scoped generated assessment PDFs", () => {
+  const clientId = "af87b28a-d0cf-4c73-8bce-8f1889b77c34";
+  const assessmentDocumentId = "41df4f57-1a22-4df1-b05f-cf8f3675267c";
+  const objectPath =
+    `clients/${clientId}/assessments/generated-caloptima-plan-${assessmentDocumentId}-1778712054626.pdf`;
+
+  expect(
+    isAllowedAssessmentPlanPdfOutputTarget({
+      bucketId: "client-documents",
+      objectPath,
+      clientId,
+      assessmentDocumentId,
+    }),
+  ).toBe(true);
+  expect(
+    isAllowedAssessmentPlanPdfOutputTarget({
+      bucketId: "avatars",
+      objectPath,
+      clientId,
+      assessmentDocumentId,
+    }),
+  ).toBe(false);
+  expect(
+    isAllowedAssessmentPlanPdfOutputTarget({
+      bucketId: "client-documents",
+      objectPath: objectPath.replace(clientId, "different-client"),
+      clientId,
+      assessmentDocumentId,
+    }),
+  ).toBe(false);
+  expect(
+    isAllowedAssessmentPlanPdfOutputTarget({
+      bucketId: "client-documents",
+      objectPath:
+        `clients/${clientId}/assessments/generated-caloptima-plan-${assessmentDocumentId}-../escape.pdf`,
+      clientId,
+      assessmentDocumentId,
+    }),
+  ).toBe(false);
+});
+
+Deno.test("generateAssessmentPlanPdfHandler requires organization context", async () => {
+  const handler = createTestHandler({ organizationId: null });
+  const response = await handler(postRequest(validPayload));
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toEqual({
+    error: "Organization context required",
+  });
+});
+
+Deno.test("generateAssessmentPlanPdfHandler rejects out-of-scope assessment documents", async () => {
+  const handler = createTestHandler({
+    documentResult: { data: null, error: null },
+  });
+  const response = await handler(postRequest(validPayload));
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toEqual({
+    error: "assessment_document_id is not in scope for this organization",
+  });
+});
+
+Deno.test("generateAssessmentPlanPdfHandler rejects mismatched template types", async () => {
+  const handler = createTestHandler({
+    documentResult: {
+      data: { ...validDocumentResult.data, template_type: "iehp_fba" },
+      error: null,
+    },
+  });
+  const response = await handler(postRequest(validPayload));
+
+  expect(response.status).toBe(409);
+  expect(await response.json()).toEqual({
+    error: "PDF generation is not supported for this assessment template.",
+  });
+});
+
+Deno.test("generateAssessmentPlanPdfHandler rejects invalid generated PDF storage targets", async () => {
+  const handler = createTestHandler();
+  const response = await handler(
+    postRequest({ ...validPayload, output_bucket_id: "avatars" }),
+  );
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toEqual({
+    error: "Invalid generated PDF storage target.",
+  });
 });

--- a/supabase/functions/generate-assessment-plan-pdf/index.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.ts
@@ -1,9 +1,31 @@
-import { PDFCheckBox, PDFDocument, PDFTextField, StandardFonts, rgb } from "npm:pdf-lib@1.17.1";
+import {
+  PDFCheckBox,
+  PDFDocument,
+  PDFTextField,
+  rgb,
+  StandardFonts,
+} from "npm:pdf-lib@1.17.1";
 import { z } from "npm:zod@3.23.8";
-import { createProtectedRoute, corsHeaders, RouteOptions } from "../_shared/auth-middleware.ts";
-import { supabaseAdmin } from "../_shared/database.ts";
-import { layoutOverlayText, type OverlayLayoutWarning } from "./overlay-layout.ts";
-import { isPdfCheckboxNotApplicableValue, resolvePdfCheckboxValue, sanitizePdfText } from "./pdf-text.ts";
+import {
+  corsHeaders,
+  createProtectedRoute,
+  RouteOptions,
+} from "../_shared/auth-middleware.ts";
+import { createRequestClient, supabaseAdmin } from "../_shared/database.ts";
+import { resolveOrgId } from "../_shared/org.ts";
+import {
+  layoutOverlayText,
+  type OverlayLayoutWarning,
+} from "./overlay-layout.ts";
+import {
+  isPdfCheckboxNotApplicableValue,
+  resolvePdfCheckboxValue,
+  sanitizePdfText,
+} from "./pdf-text.ts";
+import {
+  ASSESSMENT_PLAN_PDF_BUCKET_ID,
+  isAllowedAssessmentPlanPdfOutputTarget,
+} from "./storage-scope.ts";
 
 const renderMapEntrySchema = z.object({
   placeholder_key: z.string().trim().min(1),
@@ -31,6 +53,53 @@ const requestSchema = z.object({
   output_object_path: z.string().trim().min(1),
 });
 
+interface AssessmentDocumentScopeRow {
+  id: string;
+  organization_id: string;
+  client_id: string;
+  template_type: string;
+}
+
+interface AssessmentDocumentQueryBuilder {
+  from: (table: "assessment_documents") => {
+    select: (columns: string) => {
+      eq: (column: string, value: string) => {
+        eq: (column: string, value: string) => {
+          maybeSingle: () => Promise<
+            { data: AssessmentDocumentScopeRow | null; error: unknown | null }
+          >;
+        };
+      };
+    };
+  };
+}
+
+interface AssessmentPlanPdfStorageClient {
+  storage: {
+    from: (bucketId: string) => {
+      upload: (
+        objectPath: string,
+        bytes: Uint8Array,
+        options: { contentType: string; upsert: boolean },
+      ) => Promise<{ data: unknown; error: unknown | null }>;
+      createSignedUrl: (
+        objectPath: string,
+        expiresIn: number,
+      ) => Promise<
+        { data: { signedUrl?: string } | null; error: unknown | null }
+      >;
+    };
+  };
+}
+
+interface GenerateAssessmentPlanPdfDeps {
+  createRequestClient: (req: Request) => AssessmentDocumentQueryBuilder;
+  resolveOrgId: (
+    client: AssessmentDocumentQueryBuilder,
+  ) => Promise<string | null>;
+  supabaseAdmin: AssessmentPlanPdfStorageClient;
+}
+
 const toUint8Array = (base64Value: string): Uint8Array => {
   const binary = atob(base64Value);
   const bytes = new Uint8Array(binary.length);
@@ -40,161 +109,263 @@ const toUint8Array = (base64Value: string): Uint8Array => {
   return bytes;
 };
 
-export default createProtectedRoute(async (req) => {
-  if (req.method === "OPTIONS") return new Response(null, { status: 204, headers: corsHeaders });
-  if (req.method !== "POST") {
-    return new Response(JSON.stringify({ error: "Method not allowed" }), {
-      status: 405,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
-  }
-
-  let payload: unknown;
-  try {
-    payload = await req.json();
-  } catch {
-    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
-      status: 400,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
-  }
-
-  const parsed = requestSchema.safeParse(payload);
-  if (!parsed.success) {
-    return new Response(JSON.stringify({ error: "Invalid request body" }), {
-      status: 400,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
-  }
-
-  try {
-    const templateBytes = toUint8Array(parsed.data.template_pdf_base64);
-    const pdfDoc = await PDFDocument.load(templateBytes);
-    const form = pdfDoc.getForm();
-    const fields = form.getFields();
-    const fieldsByName = new Map(fields.map((field) => [field.getName(), field]));
-    let filledAcroFormCount = 0;
-    const acroFormFilledKeys = new Set<string>();
-
-    for (const entry of parsed.data.render_map_entries) {
-      const rawValue = parsed.data.field_values[entry.placeholder_key];
-      const rawText = typeof rawValue === "string" ? rawValue : "";
-
-      const match = entry.form_field_candidates
-        .map((candidate) => fieldsByName.get(candidate))
-        .find((field) => Boolean(field));
-      if (!match) continue;
-
-      if (match instanceof PDFCheckBox) {
-        if (isPdfCheckboxNotApplicableValue(rawText)) {
-          match.uncheck();
-          continue;
-        }
-        const checkboxValue = resolvePdfCheckboxValue(rawText);
-        if (checkboxValue === null) continue;
-        if (checkboxValue) {
-          match.check();
-        } else {
-          match.uncheck();
-        }
-        filledAcroFormCount += 1;
-        acroFormFilledKeys.add(entry.placeholder_key);
-        continue;
-      }
-
-      const value = sanitizePdfText(rawText);
-      if (!value) continue;
-
-      if (match instanceof PDFTextField) {
-        match.setText(value);
-        filledAcroFormCount += 1;
-        acroFormFilledKeys.add(entry.placeholder_key);
-        continue;
-      }
+export const createGenerateAssessmentPlanPdfHandler =
+  (deps: GenerateAssessmentPlanPdfDeps) =>
+  async (req: Request): Promise<Response> => {
+    if (req.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: corsHeaders });
+    }
+    if (req.method !== "POST") {
+      return new Response(JSON.stringify({ error: "Method not allowed" }), {
+        status: 405,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
-    const layoutWarnings: OverlayLayoutWarning[] = [];
-    let overlayFilledCount = 0;
-    if (acroFormFilledKeys.size < parsed.data.render_map_entries.length) {
-      const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch {
+      return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const parsed = requestSchema.safeParse(payload);
+    if (!parsed.success) {
+      return new Response(JSON.stringify({ error: "Invalid request body" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    try {
+      const requestClient = deps.createRequestClient(req);
+      const organizationId = await deps.resolveOrgId(requestClient);
+      if (!organizationId) {
+        return new Response(
+          JSON.stringify({ error: "Organization context required" }),
+          {
+            status: 403,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      const documentResult = await requestClient
+        .from("assessment_documents")
+        .select("id,organization_id,client_id,template_type")
+        .eq("id", parsed.data.assessment_document_id)
+        .eq("organization_id", organizationId)
+        .maybeSingle();
+
+      if (documentResult.error || !documentResult.data) {
+        return new Response(
+          JSON.stringify({
+            error:
+              "assessment_document_id is not in scope for this organization",
+          }),
+          {
+            status: 403,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (documentResult.data.template_type !== parsed.data.template_type) {
+        return new Response(
+          JSON.stringify({
+            error:
+              "PDF generation is not supported for this assessment template.",
+          }),
+          {
+            status: 409,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (
+        !isAllowedAssessmentPlanPdfOutputTarget({
+          bucketId: parsed.data.output_bucket_id,
+          objectPath: parsed.data.output_object_path,
+          clientId: documentResult.data.client_id,
+          assessmentDocumentId: documentResult.data.id,
+        })
+      ) {
+        return new Response(
+          JSON.stringify({ error: "Invalid generated PDF storage target." }),
+          {
+            status: 403,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      const templateBytes = toUint8Array(parsed.data.template_pdf_base64);
+      const pdfDoc = await PDFDocument.load(templateBytes);
+      const form = pdfDoc.getForm();
+      const fields = form.getFields();
+      const fieldsByName = new Map(
+        fields.map((field) => [field.getName(), field]),
+      );
+      let filledAcroFormCount = 0;
+      const acroFormFilledKeys = new Set<string>();
 
       for (const entry of parsed.data.render_map_entries) {
-        if (acroFormFilledKeys.has(entry.placeholder_key)) continue;
-
         const rawValue = parsed.data.field_values[entry.placeholder_key];
-        const value = typeof rawValue === "string" ? sanitizePdfText(rawValue) : "";
+        const rawText = typeof rawValue === "string" ? rawValue : "";
+
+        const match = entry.form_field_candidates
+          .map((candidate) => fieldsByName.get(candidate))
+          .find((field) => Boolean(field));
+        if (!match) continue;
+
+        if (match instanceof PDFCheckBox) {
+          if (isPdfCheckboxNotApplicableValue(rawText)) {
+            match.uncheck();
+            continue;
+          }
+          const checkboxValue = resolvePdfCheckboxValue(rawText);
+          if (checkboxValue === null) continue;
+          if (checkboxValue) {
+            match.check();
+          } else {
+            match.uncheck();
+          }
+          filledAcroFormCount += 1;
+          acroFormFilledKeys.add(entry.placeholder_key);
+          continue;
+        }
+
+        const value = sanitizePdfText(rawText);
         if (!value) continue;
 
-        const pageIndex = entry.fallback.page - 1;
-        if (pageIndex < 0 || pageIndex >= pdfDoc.getPageCount()) continue;
-        const page = pdfDoc.getPage(pageIndex);
-        if (!page) continue;
-
-        const layout = layoutOverlayText(entry, value, regularFont);
-        if (layout.warning) {
-          layoutWarnings.push(layout.warning);
+        if (match instanceof PDFTextField) {
+          match.setText(value);
+          filledAcroFormCount += 1;
+          acroFormFilledKeys.add(entry.placeholder_key);
+          continue;
         }
-        if (layout.lines.length > 0) {
-          overlayFilledCount += 1;
-        }
-        layout.lines.forEach((line, lineIndex) => {
-          page.drawText(line, {
-            x: entry.fallback.x,
-            y: entry.fallback.y - lineIndex * layout.line_height,
-            size: entry.fallback.font_size,
-            font: regularFont,
-            color: rgb(0.12, 0.12, 0.12),
-          });
-        });
       }
-    }
-    const fillMode: "acroform" | "overlay" | "mixed" =
-      filledAcroFormCount > 0 && overlayFilledCount > 0 ? "mixed" : filledAcroFormCount > 0 ? "acroform" : "overlay";
 
-    const pdfBytes = await pdfDoc.save();
+      const layoutWarnings: OverlayLayoutWarning[] = [];
+      let overlayFilledCount = 0;
+      if (acroFormFilledKeys.size < parsed.data.render_map_entries.length) {
+        const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
 
-    const uploadResult = await supabaseAdmin.storage
-      .from(parsed.data.output_bucket_id)
-      .upload(parsed.data.output_object_path, pdfBytes, {
-        contentType: "application/pdf",
-        upsert: true,
-      });
-    if (uploadResult.error) {
-      return new Response(JSON.stringify({ error: "Failed to upload generated PDF." }), {
+        for (const entry of parsed.data.render_map_entries) {
+          if (acroFormFilledKeys.has(entry.placeholder_key)) continue;
+
+          const rawValue = parsed.data.field_values[entry.placeholder_key];
+          const value = typeof rawValue === "string"
+            ? sanitizePdfText(rawValue)
+            : "";
+          if (!value) continue;
+
+          const pageIndex = entry.fallback.page - 1;
+          if (pageIndex < 0 || pageIndex >= pdfDoc.getPageCount()) continue;
+          const page = pdfDoc.getPage(pageIndex);
+          if (!page) continue;
+
+          const layout = layoutOverlayText(entry, value, regularFont);
+          if (layout.warning) {
+            layoutWarnings.push(layout.warning);
+          }
+          if (layout.lines.length > 0) {
+            overlayFilledCount += 1;
+          }
+          layout.lines.forEach((line, lineIndex) => {
+            page.drawText(line, {
+              x: entry.fallback.x,
+              y: entry.fallback.y - lineIndex * layout.line_height,
+              size: entry.fallback.font_size,
+              font: regularFont,
+              color: rgb(0.12, 0.12, 0.12),
+            });
+          });
+        }
+      }
+      const fillMode: "acroform" | "overlay" | "mixed" =
+        filledAcroFormCount > 0 && overlayFilledCount > 0
+          ? "mixed"
+          : filledAcroFormCount > 0
+          ? "acroform"
+          : "overlay";
+
+      const pdfBytes = await pdfDoc.save();
+
+      const uploadResult = await deps.supabaseAdmin.storage
+        .from(ASSESSMENT_PLAN_PDF_BUCKET_ID)
+        .upload(parsed.data.output_object_path, pdfBytes, {
+          contentType: "application/pdf",
+          upsert: true,
+        });
+      if (uploadResult.error) {
+        return new Response(
+          JSON.stringify({ error: "Failed to upload generated PDF." }),
+          {
+            status: 500,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      const signedResult = await deps.supabaseAdmin.storage
+        .from(ASSESSMENT_PLAN_PDF_BUCKET_ID)
+        .createSignedUrl(parsed.data.output_object_path, 60 * 10);
+      if (signedResult.error || !signedResult.data?.signedUrl) {
+        return new Response(
+          JSON.stringify({ error: "Failed to create download URL." }),
+          {
+            status: 500,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          fill_mode: fillMode,
+          bucket_id: ASSESSMENT_PLAN_PDF_BUCKET_ID,
+          object_path: parsed.data.output_object_path,
+          signed_url: signedResult.data.signedUrl,
+          layout_warnings: layoutWarnings,
+          overflow_keys: layoutWarnings.map((warning) =>
+            warning.placeholder_key
+          ),
+        }),
+        {
+          status: 200,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    } catch (error) {
+      console.error("generate-assessment-plan-pdf error", error);
+      return new Response(JSON.stringify({ error: "Internal server error" }), {
         status: 500,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
+  };
 
-    const signedResult = await supabaseAdmin.storage
-      .from(parsed.data.output_bucket_id)
-      .createSignedUrl(parsed.data.output_object_path, 60 * 10);
-    if (signedResult.error || !signedResult.data?.signedUrl) {
-      return new Response(JSON.stringify({ error: "Failed to create download URL." }), {
-        status: 500,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
+export const generateAssessmentPlanPdfHandler =
+  createGenerateAssessmentPlanPdfHandler({
+    createRequestClient: createRequestClient as unknown as (
+      req: Request,
+    ) => AssessmentDocumentQueryBuilder,
+    resolveOrgId: resolveOrgId as unknown as (
+      client: AssessmentDocumentQueryBuilder,
+    ) => Promise<string | null>,
+    supabaseAdmin: supabaseAdmin as unknown as AssessmentPlanPdfStorageClient,
+  });
 
-    return new Response(
-      JSON.stringify({
-        fill_mode: fillMode,
-        bucket_id: parsed.data.output_bucket_id,
-        object_path: parsed.data.output_object_path,
-        signed_url: signedResult.data.signedUrl,
-        layout_warnings: layoutWarnings,
-        overflow_keys: layoutWarnings.map((warning) => warning.placeholder_key),
-      }),
-      {
-        status: 200,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      },
-    );
-  } catch (error) {
-    console.error("generate-assessment-plan-pdf error", error);
-    return new Response(JSON.stringify({ error: "Internal server error" }), {
-      status: 500,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
-  }
-}, RouteOptions.therapist);
+const handler = createProtectedRoute(
+  generateAssessmentPlanPdfHandler,
+  RouteOptions.therapist,
+);
+
+if (import.meta.main) {
+  Deno.serve(handler);
+}
+
+export default handler;

--- a/supabase/functions/generate-assessment-plan-pdf/storage-scope.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/storage-scope.ts
@@ -1,0 +1,23 @@
+export const ASSESSMENT_PLAN_PDF_BUCKET_ID = "client-documents";
+
+interface AssessmentPlanPdfOutputTarget {
+  bucketId: string;
+  objectPath: string;
+  clientId: string;
+  assessmentDocumentId: string;
+}
+
+export const isAllowedAssessmentPlanPdfOutputTarget = ({
+  bucketId,
+  objectPath,
+  clientId,
+  assessmentDocumentId,
+}: AssessmentPlanPdfOutputTarget): boolean => {
+  if (bucketId !== ASSESSMENT_PLAN_PDF_BUCKET_ID) return false;
+
+  const prefix = `clients/${clientId}/assessments/generated-caloptima-plan-${assessmentDocumentId}-`;
+  if (!objectPath.startsWith(prefix) || !objectPath.endsWith(".pdf")) return false;
+
+  const generatedSuffix = objectPath.slice(prefix.length, -".pdf".length);
+  return /^\d{8,}$/.test(generatedSuffix);
+};


### PR DESCRIPTION
## Summary
- scope generated CalOptima assessment-plan PDFs to the authenticated organization's assessment document and fixed client-documents storage target
- expose filled_pages for the PDF visual smoke and tighten smoke detection for pages with mapped non-empty fields
- recalibrate tail CalOptima overlay fields to their actual template pages and add focused handler/render-map coverage

## Route
- classification: high-risk human-reviewed
- lane: critical
- issue: WIN-147
- rationale: touches protected server/API and Supabase Edge Function paths (`src/server/**`, `supabase/functions/**`) plus client-facing PDF generation behavior

## Review Notes
- restored the merged Adobe extraction behavior from `origin/main`; this PR does not change Adobe PDF extraction
- removed unrelated post-merge churn before commit; remaining shared helper edits are limited to Deno type compatibility needed by the edge-function check
- visual smoke now requires `HEADLESS=false` because Chromium headless PDF viewer screenshots were not reliable for page comparison

## Verification
- PASS `npm run typecheck`
- PASS `deno check --node-modules-dir=auto --no-lock supabase/functions/generate-assessment-plan-pdf/index.ts`
- PASS `deno test --allow-env --no-lock supabase/functions/generate-assessment-plan-pdf/index.test.ts`
- PASS `npx vitest run src/server/__tests__/assessmentPlanPdfHandler.test.ts src/server/__tests__/assessmentPlanPdfTemplate.test.ts`
- PASS `npm run lint`
- PASS `npm run ci:check-focused`
- PASS `npm run validate:tenant`
- PASS `npm run build`
- PASS `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=test-anon-key npm run test:routes:tier0`
- FAIL `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=test-anon-key npm run test:ci` once due unrelated `src/pages/__tests__/Schedule.test.tsx` timeout; the exact failed test passed standalone afterward
- PASS standalone `npx vitest run src/pages/__tests__/Schedule.test.tsx -t "previews and applies the visible week with the displayed week payload"`

## Blocked / Not Run
- `npm run playwright:assessment-pdf-smoke`: requires a running authenticated app/session plus `HEADLESS=false` and live assessment document context
- `npm run playwright:assessment-import-smoke`: not part of this final PDF generation slice and requires hosted/authenticated smoke environment
- `npm run verify:local`: not run after the full `test:ci` suite timeout; CI should be treated as authoritative for the full gate

## Residual Risk
- high-risk human review is required before merge because this changes edge function authorization/storage behavior
- CI should confirm whether the full Vitest timeout reproduces under Actions or was local suite timing noise
