### PR TITLE
WIN-147 Report rendered PDF filled pages

### DIFF
--- a/src/server/__tests__/assessmentPlanPdfHandler.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfHandler.test.ts
@@ -173,6 +173,7 @@ describe("assessmentPlanPdfHandler", () => {
             },
           ],
           overflow_keys: ["CALOPTIMA_FBA_CHIEF_COMPLAINT"],
+          filled_pages: [2],
         },
       })
       .mockResolvedValueOnce({ ok: true, status: 201, data: null });
@@ -191,7 +192,7 @@ describe("assessmentPlanPdfHandler", () => {
     expect(body.fill_mode).toBe("overlay");
     expect(body.overflow_keys).toEqual(["CALOPTIMA_FBA_CHIEF_COMPLAINT"]);
     expect(body.layout_warnings).toHaveLength(1);
-    expect(body.filled_pages).toEqual([1]);
+    expect(body.filled_pages).toEqual([2]);
     expect(fetchJson).toHaveBeenLastCalledWith(
       "https://example.supabase.co/rest/v1/assessment_review_events",
       expect.objectContaining({

--- a/src/server/api/assessment-plan-pdf.ts
+++ b/src/server/api/assessment-plan-pdf.ts
@@ -100,6 +100,7 @@ interface GeneratePdfFunctionResponse {
     max_lines: number;
   }>;
   overflow_keys?: string[];
+  filled_pages?: number[];
 }
 
 const CALOPTIMA_TEMPLATE_PATH = resolve(process.cwd(), "CalOptima Health FBA Template (2).pdf");
@@ -310,17 +311,6 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
   });
 
   const layoutWarnings = functionResult.data.layout_warnings ?? [];
-  const filledPages = Array.from(
-    new Set(
-      renderMap
-        .filter((entry) => {
-          const value = payloadResult.values[entry.placeholder_key];
-          return typeof value === "string" ? value.trim().length > 0 : Boolean(value);
-        })
-        .map((entry) => entry.fallback.page),
-    ),
-  ).sort((left, right) => left - right);
-
   return json({
     assessment_document_id: assessmentDocument.id,
     fill_mode: functionResult.data.fill_mode,
@@ -329,6 +319,6 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
     signed_url: functionResult.data.signed_url,
     layout_warnings: layoutWarnings,
     overflow_keys: functionResult.data.overflow_keys ?? layoutWarnings.map((warning) => warning.placeholder_key),
-    filled_pages: filledPages,
+    filled_pages: functionResult.data.filled_pages ?? [],
   });
 }

--- a/supabase/functions/generate-assessment-plan-pdf/index.test.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "jsr:@std/expect";
+import { PDFDocument } from "npm:pdf-lib@1.17.1";
 
 import { layoutOverlayText, wrapOverlayText } from "./overlay-layout.ts";
 import {
@@ -86,6 +87,38 @@ const createAdminStorage = () => ({
     }),
   },
 });
+
+const createPdfWithFieldsBase64 = async (): Promise<string> => {
+  const pdfDoc = await PDFDocument.create();
+  const textPage = pdfDoc.addPage([612, 792]);
+  const checkboxPage = pdfDoc.addPage([612, 792]);
+  pdfDoc.addPage([612, 792]);
+  pdfDoc.addPage([612, 792]);
+
+  const form = pdfDoc.getForm();
+  const textField = form.createTextField("Member Name");
+  textField.addToPage(textPage, {
+    x: 10,
+    y: 740,
+    width: 120,
+    height: 20,
+  });
+
+  const checkbox = form.createCheckBox("Has IEP");
+  checkbox.addToPage(checkboxPage, {
+    x: 10,
+    y: 740,
+    width: 12,
+    height: 12,
+  });
+
+  const bytes = await pdfDoc.save();
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+};
 
 type TestDocumentResult = {
   data: {
@@ -276,4 +309,87 @@ Deno.test("generateAssessmentPlanPdfHandler rejects invalid generated PDF storag
   expect(await response.json()).toEqual({
     error: "Invalid generated PDF storage target.",
   });
+});
+
+Deno.test("generateAssessmentPlanPdfHandler reports filled_pages from visible rendered fields only", async () => {
+  const templatePdfBase64 = await createPdfWithFieldsBase64();
+  const payload = {
+    ...validPayload,
+    template_pdf_base64: templatePdfBase64,
+    render_map_entries: [
+      {
+        placeholder_key: "VISIBLE_TEXT",
+        form_field_candidates: ["Member Name"],
+        fallback: {
+          page: 1,
+          x: 10,
+          y: 740,
+          font_size: 10,
+          max_width: 120,
+          height: 20,
+          line_height: 12,
+          max_lines: 1,
+          field_kind: "text",
+        },
+      },
+      {
+        placeholder_key: "UNCHECKED_BOX",
+        form_field_candidates: ["Has IEP"],
+        fallback: {
+          page: 2,
+          x: 10,
+          y: 740,
+          font_size: 10,
+          max_width: 12,
+          height: 12,
+          line_height: 12,
+          max_lines: 1,
+          field_kind: "checkbox",
+        },
+      },
+      {
+        placeholder_key: "SANITIZED_EMPTY_OVERLAY",
+        form_field_candidates: ["Missing Sanitized Empty"],
+        fallback: {
+          page: 3,
+          x: 10,
+          y: 740,
+          font_size: 10,
+          max_width: 120,
+          height: 20,
+          line_height: 12,
+          max_lines: 1,
+          field_kind: "text",
+        },
+      },
+      {
+        placeholder_key: "VISIBLE_OVERLAY",
+        form_field_candidates: ["Missing Overlay"],
+        fallback: {
+          page: 4,
+          x: 10,
+          y: 740,
+          font_size: 10,
+          max_width: 120,
+          height: 20,
+          line_height: 12,
+          max_lines: 1,
+          field_kind: "text",
+        },
+      },
+    ],
+    field_values: {
+      VISIBLE_TEXT: "Client One",
+      UNCHECKED_BOX: "no",
+      SANITIZED_EMPTY_OVERLAY: "☢",
+      VISIBLE_OVERLAY: "Overlay text",
+    },
+  };
+  const handler = createTestHandler();
+  const response = await handler(postRequest(payload));
+
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.filled_pages).toEqual([1, 4]);
+  expect(body.fill_mode).toBe("mixed");
 });

--- a/supabase/functions/generate-assessment-plan-pdf/index.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.ts
@@ -210,6 +210,7 @@ export const createGenerateAssessmentPlanPdfHandler =
       );
       let filledAcroFormCount = 0;
       const acroFormFilledKeys = new Set<string>();
+      const filledPages = new Set<number>();
 
       for (const entry of parsed.data.render_map_entries) {
         const rawValue = parsed.data.field_values[entry.placeholder_key];
@@ -229,6 +230,7 @@ export const createGenerateAssessmentPlanPdfHandler =
           if (checkboxValue === null) continue;
           if (checkboxValue) {
             match.check();
+            filledPages.add(entry.fallback.page);
           } else {
             match.uncheck();
           }
@@ -244,6 +246,7 @@ export const createGenerateAssessmentPlanPdfHandler =
           match.setText(value);
           filledAcroFormCount += 1;
           acroFormFilledKeys.add(entry.placeholder_key);
+          filledPages.add(entry.fallback.page);
           continue;
         }
       }
@@ -273,6 +276,7 @@ export const createGenerateAssessmentPlanPdfHandler =
           }
           if (layout.lines.length > 0) {
             overlayFilledCount += 1;
+            filledPages.add(entry.fallback.page);
           }
           layout.lines.forEach((line, lineIndex) => {
             page.drawText(line, {
@@ -332,6 +336,9 @@ export const createGenerateAssessmentPlanPdfHandler =
           layout_warnings: layoutWarnings,
           overflow_keys: layoutWarnings.map((warning) =>
             warning.placeholder_key
+          ),
+          filled_pages: Array.from(filledPages).sort((left, right) =>
+            left - right
           ),
         }),
         {


### PR DESCRIPTION
## Summary
- make the edge PDF generator return `filled_pages` from fields it actually renders visibly
- pass generator-reported `filled_pages` through the server handler instead of deriving it from raw payload truthiness
- add regression coverage for text rendering, unchecked checkbox values, sanitized-empty values, and overlay-only rendering

## Route
- classification: high-risk human-reviewed
- lane: critical
- issue: WIN-147
- rationale: touches protected `src/server/**` and `supabase/functions/**` PDF generation behavior

## Verification
- PASS `npx vitest run src/server/__tests__/assessmentPlanPdfHandler.test.ts`
- PASS `deno test --allow-env --node-modules-dir=auto --no-lock supabase/functions/generate-assessment-plan-pdf/index.test.ts`
- PASS `npm run typecheck`
- PASS `npm run lint`
- PASS `deno check --node-modules-dir=auto --no-lock supabase/functions/generate-assessment-plan-pdf/index.ts`
- PASS `npm run ci:check-focused`
- PASS `npm run validate:tenant`
- PASS `npm run build`
- FAIL `npm run test:ci` in aggregate due unrelated/local issues: `src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts` missing local `VITE_SUPABASE_URL`, plus invite-flow timeout/state leak on first aggregate run and runtime-migration timeout on `verify:local`
- PASS isolated reruns for failed files: `src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts` with dummy Supabase env, `tests/admins/invite_flow.spec.ts`, and `tests/runtime-migration-parity.test.ts`
- FAIL `npm run verify:local` because it includes the same local `test:ci` aggregate failure before later gates

## Residual Risk
- Critical human review required before merge because this changes server/edge PDF generation contract.
- CI should be treated as authoritative for the aggregate `test:ci` gate; local isolated failures pass and touched tests pass.
