### PR TITLE
WIN-147 Preserve filled pages fallback

### DIFF
--- a/src/server/__tests__/assessmentPlanPdfHandler.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfHandler.test.ts
@@ -200,4 +200,143 @@ describe("assessmentPlanPdfHandler", () => {
       }),
     );
   });
+
+  it("derives filled_pages when an older edge function omits them", async () => {
+    vi.mocked(buildCalOptimaTemplatePayload).mockResolvedValue({
+      values: { CALOPTIMA_FBA_MEMBER_NAME: "Client One" },
+      missing_required_keys: [],
+    });
+
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "drafted",
+            template_type: "caloptima_fba",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "draft-program-1", name: "Program A", description: "Desc", accept_state: "accepted" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "goal-1", title: "Goal A", description: "Desc", original_text: "Original", accept_state: "accepted" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ full_name: "Client One" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ full_name: "Therapist One", title: "BCBA" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          fill_mode: "overlay",
+          bucket_id: "client-documents",
+          object_path: "clients/client-1/assessments/generated.pdf",
+          signed_url: "https://example.com/generated.pdf",
+          layout_warnings: [],
+          overflow_keys: [],
+        },
+      })
+      .mockResolvedValueOnce({ ok: true, status: 201, data: null });
+
+    const response = await assessmentPlanPdfHandler(
+      new Request("http://localhost/api/assessment-plan-pdf", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.filled_pages).toEqual([1]);
+  });
+
+  it("preserves explicit edge filled_pages even when the array is empty", async () => {
+    vi.mocked(buildCalOptimaTemplatePayload).mockResolvedValue({
+      values: { CALOPTIMA_FBA_MEMBER_NAME: "Client One" },
+      missing_required_keys: [],
+    });
+
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "drafted",
+            template_type: "caloptima_fba",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "draft-program-1", name: "Program A", description: "Desc", accept_state: "accepted" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "goal-1", title: "Goal A", description: "Desc", original_text: "Original", accept_state: "accepted" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ full_name: "Client One" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ full_name: "Therapist One", title: "BCBA" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          fill_mode: "overlay",
+          bucket_id: "client-documents",
+          object_path: "clients/client-1/assessments/generated.pdf",
+          signed_url: "https://example.com/generated.pdf",
+          layout_warnings: [],
+          overflow_keys: [],
+          filled_pages: [],
+        },
+      })
+      .mockResolvedValueOnce({ ok: true, status: 201, data: null });
+
+    const response = await assessmentPlanPdfHandler(
+      new Request("http://localhost/api/assessment-plan-pdf", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.filled_pages).toEqual([]);
+  });
 });

--- a/src/server/api/assessment-plan-pdf.ts
+++ b/src/server/api/assessment-plan-pdf.ts
@@ -105,6 +105,21 @@ interface GeneratePdfFunctionResponse {
 
 const CALOPTIMA_TEMPLATE_PATH = resolve(process.cwd(), "CalOptima Health FBA Template (2).pdf");
 
+const deriveFilledPagesFallback = (
+  renderMap: Awaited<ReturnType<typeof loadCalOptimaPdfRenderMap>>,
+  fieldValues: Record<string, string>,
+): number[] =>
+  Array.from(
+    new Set(
+      renderMap
+        .filter((entry) => {
+          const value = fieldValues[entry.placeholder_key];
+          return typeof value === "string" ? value.trim().length > 0 : Boolean(value);
+        })
+        .map((entry) => entry.fallback.page),
+    ),
+  ).sort((left, right) => left - right);
+
 export async function assessmentPlanPdfHandler(request: Request): Promise<Response> {
   if (request.method === "OPTIONS") {
     return new Response("ok", { status: 200, headers: { ...CORS_HEADERS } });
@@ -311,6 +326,10 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
   });
 
   const layoutWarnings = functionResult.data.layout_warnings ?? [];
+  const filledPages = Array.isArray(functionResult.data.filled_pages)
+    ? functionResult.data.filled_pages
+    : deriveFilledPagesFallback(renderMap, payloadResult.values);
+
   return json({
     assessment_document_id: assessmentDocument.id,
     fill_mode: functionResult.data.fill_mode,
@@ -319,6 +338,6 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
     signed_url: functionResult.data.signed_url,
     layout_warnings: layoutWarnings,
     overflow_keys: functionResult.data.overflow_keys ?? layoutWarnings.map((warning) => warning.placeholder_key),
-    filled_pages: functionResult.data.filled_pages ?? [],
+    filled_pages: filledPages,
   });
 }


### PR DESCRIPTION
## Summary
- Preserve legacy `filled_pages` compatibility when older `generate-assessment-plan-pdf` edge deployments omit the optional field.
- Keep explicit edge `filled_pages` arrays authoritative, including an intentional empty array.
- Add handler coverage for both version-skew fallback and explicit-empty edge responses.

## Route / Risk
- Issue: WIN-147
- Classification: critical
- Lane: high-risk human-reviewed
- Rationale: touches `src/server/**` API response behavior for the CalOptima PDF workflow.

## Verification
- `npm ci`
- `npx vitest run src/server/__tests__/assessmentPlanPdfHandler.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run ci:check-focused`
- `npm run build`
- `npm run validate:tenant`
- `$env:VITE_SUPABASE_URL='https://example.supabase.co'; $env:VITE_SUPABASE_ANON_KEY='test-anon-key'; npm run test:ci`
- `$env:VITE_SUPABASE_URL='https://example.supabase.co'; $env:VITE_SUPABASE_ANON_KEY='test-anon-key'; npm run verify:local`

## Notes
- `verify:local` passed; policy output still reports expected local skips for branch protection/DB-backed Supabase checks without `SUPABASE_DB_URL`.
- Fallback intentionally uses the prior raw payload/render-map derivation only when the edge response is missing `filled_pages`, not when it returns an array.
