### PR TITLE
WIN-147 Fix CalOptima structured goal extraction

### DIFF
--- a/scripts/lib/assessment-import-cleanup.ts
+++ b/scripts/lib/assessment-import-cleanup.ts
@@ -83,6 +83,9 @@ export const deleteAssessmentStorageObject = async (
   }
 
   const body = await response.text().catch(() => response.statusText);
+  if (response.status === 400 && /"statusCode"\s*:\s*"404"|"error"\s*:\s*"not_found"/i.test(body)) {
+    return;
+  }
   throw new Error(`Storage cleanup failed for ${bucketId}/${objectPath}: ${response.status} ${body}`);
 };
 

--- a/scripts/playwright-assessment-upload-promote-smoke.ts
+++ b/scripts/playwright-assessment-upload-promote-smoke.ts
@@ -331,7 +331,13 @@ const approveChecklistAndStructuredSections = async (args: {
   baseUrl: string;
   accessToken: string;
   checklist: ChecklistResponse;
-}): Promise<{ checklistApproved: number; structuredApproved: number; goalStructuredSectionCount: number }> => {
+}): Promise<{
+  checklistApproved: number;
+  structuredApproved: number;
+  goalStructuredSectionCount: number;
+  childGoalStructuredSectionCount: number;
+  parentGoalStructuredSectionCount: number;
+}> => {
   let checklistApproved = 0;
   for (const item of args.checklist.items) {
     if (!item.required || item.status === "approved") continue;
@@ -352,6 +358,19 @@ const approveChecklistAndStructuredSections = async (args: {
   );
   if (goalSections.length === 0) {
     throw new Error("No structured CalOptima goal sections were extracted from the fixture.");
+  }
+  const childGoalStructuredSectionCount = goalSections.filter((section) =>
+    section.field_key === "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS" ||
+    section.field_key === "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS" ||
+    section.payload?.goal_type === "child"
+  ).length;
+  const parentGoalStructuredSectionCount = goalSections.filter((section) =>
+    section.field_key === "CALOPTIMA_FBA_PARENT_GOALS" || section.payload?.goal_type === "parent"
+  ).length;
+  if (childGoalStructuredSectionCount < MIN_CHILD_GOALS || parentGoalStructuredSectionCount < MIN_PARENT_GOALS) {
+    throw new Error(
+      `Structured goal extraction produced ${childGoalStructuredSectionCount}/${MIN_CHILD_GOALS} child goals and ${parentGoalStructuredSectionCount}/${MIN_PARENT_GOALS} parent goals.`,
+    );
   }
 
   let structuredApproved = 0;
@@ -376,6 +395,8 @@ const approveChecklistAndStructuredSections = async (args: {
     checklistApproved,
     structuredApproved,
     goalStructuredSectionCount: goalSections.length,
+    childGoalStructuredSectionCount,
+    parentGoalStructuredSectionCount,
   };
 };
 
@@ -768,6 +789,8 @@ async function run() {
           checklistRowCount: checklist.items.length,
           extractionRowCount: extractionRows.length,
           goalStructuredSectionCount: approvalSummary.goalStructuredSectionCount,
+          childGoalStructuredSectionCount: approvalSummary.childGoalStructuredSectionCount,
+          parentGoalStructuredSectionCount: approvalSummary.parentGoalStructuredSectionCount,
           checklistApproved: approvalSummary.checklistApproved,
           structuredApproved: approvalSummary.structuredApproved,
           draftProgramCount: drafts.programs.length,

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -56,6 +56,19 @@ const AI_GENERATION_READY_STATUSES: ReadonlySet<AssessmentDocumentRecord["status
   "extraction_failed",
 ]);
 const MIN_ASSESSMENT_TEXT_CHARS_FOR_AI_GENERATION = 20;
+const STRUCTURED_GOAL_FIELD_KEYS = new Set([
+  "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+  "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+  "CALOPTIMA_FBA_PARENT_GOALS",
+]);
+
+const isStructuredChildGoalSection = (section: AssessmentStructuredSection): boolean =>
+  section.field_key === "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS" ||
+  section.field_key === "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS" ||
+  section.payload?.goal_type === "child";
+
+const isStructuredParentGoalSection = (section: AssessmentStructuredSection): boolean =>
+  section.field_key === "CALOPTIMA_FBA_PARENT_GOALS" || section.payload?.goal_type === "parent";
 
 const withTimeout = async <T,>(
   promise: Promise<T>,
@@ -528,6 +541,19 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     (goal) => goal.accept_state === "accepted" || goal.accept_state === "edited",
   );
   const hasExistingDrafts = (assessmentDrafts?.programs?.length ?? 0) > 0 || (assessmentDrafts?.goals?.length ?? 0) > 0;
+  const extractedChecklistValueCount = checklistItems.filter((item) => item.value_text?.trim()).length;
+  const structuredChildGoalCount = structuredSections.filter(isStructuredChildGoalSection).length;
+  const structuredParentGoalCount = structuredSections.filter(isStructuredParentGoalSection).length;
+  const approvedStructuredChildGoalCount = structuredSections.filter(
+    (section) => section.status === "approved" && isStructuredChildGoalSection(section),
+  ).length;
+  const approvedStructuredParentGoalCount = structuredSections.filter(
+    (section) => section.status === "approved" && isStructuredParentGoalSection(section),
+  ).length;
+  const hasExtractedStructuredGoalMinimums =
+    structuredChildGoalCount >= MIN_CHILD_GOALS && structuredParentGoalCount >= MIN_PARENT_GOALS;
+  const hasApprovedStructuredGoalMinimums =
+    approvedStructuredChildGoalCount >= MIN_CHILD_GOALS && approvedStructuredParentGoalCount >= MIN_PARENT_GOALS;
   const acceptedDraftChildGoalCount = (assessmentDrafts?.goals ?? []).filter(
     (goal) => (goal.accept_state === "accepted" || goal.accept_state === "edited") && goal.goal_type === "child",
   ).length;
@@ -546,17 +572,14 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const hasApprovedStructuredGoalSections = structuredSections.some(
     (section) =>
       section.status === "approved" &&
-      [
-        "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
-        "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
-        "CALOPTIMA_FBA_PARENT_GOALS",
-      ].includes(section.field_key),
+      STRUCTURED_GOAL_FIELD_KEYS.has(section.field_key),
   );
   const canGenerateUploadedAssessmentDraft =
     canQuerySelectedAssessment &&
     selectedAssessmentReadyForAiGeneration &&
     selectedFailedExtractionHasChecklistEvidence &&
     hasApprovedStructuredGoalSections &&
+    hasApprovedStructuredGoalMinimums &&
     !hasExistingDrafts;
   const canPromoteAssessment =
     canQuerySelectedAssessment &&
@@ -591,8 +614,12 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       ? "Extraction failed for this assessment. Retry deterministic draft generation using the extracted checklist evidence, or replace the source document if it needs correction."
     : !selectedAssessmentReadyForAiGeneration
       ? "Wait for extraction to complete before generating drafts."
+    : !hasExtractedStructuredGoalMinimums
+      ? `Adobe extraction found ${structuredChildGoalCount}/${MIN_CHILD_GOALS} child goals and ${structuredParentGoalCount}/${MIN_PARENT_GOALS} parent goals. Upload a richer source document or improve extraction before generating drafts.`
     : !hasApprovedStructuredGoalSections
       ? "Approve at least one structured CalOptima goal section before generating drafts."
+    : !hasApprovedStructuredGoalMinimums
+      ? `Approve at least ${MIN_CHILD_GOALS} child goals and ${MIN_PARENT_GOALS} parent goals before generating drafts.`
       : null;
 
   useEffect(() => {
@@ -1787,14 +1814,27 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 {selectedAssessmentTemplateLabel} Checklist Review
               </h3>
               {selectedAssessmentDocument && (
-                <p className="mb-3 text-xs text-gray-500 dark:text-gray-300">
-                  Document status:{" "}
-                  <span className={`rounded px-1.5 py-0.5 font-semibold ${statusToneByAssessment[selectedAssessmentDocument.status].className}`}>
-                    {statusToneByAssessment[selectedAssessmentDocument.status].label}
-                  </span>
-                  {" • "}
-                  Unresolved required rows: {unresolvedRequiredCount}
-                </p>
+                <div className="mb-3 space-y-2 text-xs text-gray-500 dark:text-gray-300">
+                  <p>
+                    Document status:{" "}
+                    <span className={`rounded px-1.5 py-0.5 font-semibold ${statusToneByAssessment[selectedAssessmentDocument.status].className}`}>
+                      {statusToneByAssessment[selectedAssessmentDocument.status].label}
+                    </span>
+                    {" • "}
+                    Unresolved required rows: {unresolvedRequiredCount}
+                  </p>
+                  <div className="grid gap-2 sm:grid-cols-3">
+                    <div className="rounded border border-gray-200 px-2 py-1 dark:border-gray-700">
+                      Checklist values: <span className="font-semibold">{extractedChecklistValueCount}/{checklistItems.length}</span>
+                    </div>
+                    <div className="rounded border border-gray-200 px-2 py-1 dark:border-gray-700">
+                      Child goals: <span className="font-semibold">{structuredChildGoalCount}/{MIN_CHILD_GOALS}</span>
+                    </div>
+                    <div className="rounded border border-gray-200 px-2 py-1 dark:border-gray-700">
+                      Parent goals: <span className="font-semibold">{structuredParentGoalCount}/{MIN_PARENT_GOALS}</span>
+                    </div>
+                  </div>
+                </div>
               )}
               {!selectedAssessmentId ? (
                 <p className="text-sm text-gray-500">Upload and select an assessment to review checklist items.</p>

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -48,6 +48,37 @@ const buildAcceptedDraftGoals = () => [
   })),
 ];
 
+const buildStructuredGoalSections = (status: "approved" | "verified" | "drafted" = "approved") => [
+  ...Array.from({ length: 20 }, (_, index) => ({
+    id: `structured-child-${index + 1}`,
+    section_key: "goals_treatment_planning",
+    field_key: index % 2 === 0 ? "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS" : "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+    section_index: index,
+    payload: {
+      title: `Child Goal ${index + 1}`,
+      goal_type: "child",
+      program_name: index % 2 === 0 ? "Skill Acquisition" : "Behavior Treatment",
+    },
+    status,
+    required: true,
+    review_notes: null,
+  })),
+  ...Array.from({ length: 6 }, (_, index) => ({
+    id: `structured-parent-${index + 1}`,
+    section_key: "goals_treatment_planning",
+    field_key: "CALOPTIMA_FBA_PARENT_GOALS",
+    section_index: index,
+    payload: {
+      title: `Parent Goal ${index + 1}`,
+      goal_type: "parent",
+      program_name: "Parent Training",
+    },
+    status,
+    required: true,
+    review_notes: null,
+  })),
+];
+
 vi.mock("../../lib/ai", async () => {
   const actual = await vi.importActual<typeof import("../../lib/ai")>("../../lib/ai");
   return {
@@ -152,16 +183,26 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
           JSON.stringify({
             items: [],
             structured_sections: [
-              {
-                id: "structured-goal-1",
+              ...Array.from({ length: 20 }, (_, index) => ({
+                id: `structured-child-goal-${index}`,
                 section_key: "goals_treatment_planning",
                 field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
-                section_index: 0,
-                payload: { title: "Goal" },
+                section_index: index,
+                payload: { title: `Child Goal ${index + 1}`, goal_type: "child" },
                 status: "approved",
                 required: true,
                 review_notes: null,
-              },
+              })),
+              ...Array.from({ length: 6 }, (_, index) => ({
+                id: `structured-parent-goal-${index}`,
+                section_key: "goals_treatment_planning",
+                field_key: "CALOPTIMA_FBA_PARENT_GOALS",
+                section_index: index,
+                payload: { title: `Parent Goal ${index + 1}`, goal_type: "parent" },
+                status: "approved",
+                required: true,
+                review_notes: null,
+              })),
             ],
           }),
           { status: 200 },
@@ -736,18 +777,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
         return new Response(
           JSON.stringify({
             items: [],
-            structured_sections: [
-              {
-                id: "structured-goal-1",
-                section_key: "goals_treatment_planning",
-                field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
-                section_index: 0,
-                payload: { title: "Goal" },
-                status: "approved",
-                required: true,
-                review_notes: null,
-              },
-            ],
+            structured_sections: buildStructuredGoalSections("approved"),
           }),
           { status: 200 },
         );
@@ -1355,18 +1385,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
         return new Response(
           JSON.stringify({
             items: [],
-            structured_sections: [
-              {
-                id: "structured-goal-1",
-                section_key: "goals_treatment_planning",
-                field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
-                section_index: 0,
-                payload: { title: "Goal" },
-                status: "approved",
-                required: true,
-                review_notes: null,
-              },
-            ],
+            structured_sections: buildStructuredGoalSections("approved"),
           }),
           { status: 200 },
         );
@@ -1456,18 +1475,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
                 value_text: "Aggression occurs during transitions and denied access.",
               },
             ],
-            structured_sections: [
-              {
-                id: "structured-goal-1",
-                section_key: "goals_treatment_planning",
-                field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
-                section_index: 0,
-                payload: { title: "Goal" },
-                status: "approved",
-                required: true,
-                review_notes: null,
-              },
-            ],
+            structured_sections: buildStructuredGoalSections("approved"),
           }),
           { status: 200 },
         );
@@ -1596,6 +1604,80 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(
       vi.mocked(callApi).mock.calls.some(([path, init]) => path === "/api/assessment-drafts" && init?.method === "POST"),
     ).toBe(false);
+  });
+
+  it("shows structured goal readiness counts and blocks draft generation below minimums", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1234,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/fba.pdf",
+              status: "extracted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "checklist-item-1",
+                section_key: "behavior_summary",
+                label: "Behavior Summary",
+                placeholder_key: "behavior_summary",
+                required: true,
+                mode: "AUTO",
+                status: "drafted",
+                review_notes: null,
+                value_text: "Extracted behavior summary",
+              },
+            ],
+            structured_sections: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(
+      await screen.findByText((_content, node) => node?.textContent === "Checklist values: 1/1"),
+    ).toBeInTheDocument();
+    expect(screen.getByText((_content, node) => node?.textContent === "Child goals: 0/20")).toBeInTheDocument();
+    expect(screen.getByText((_content, node) => node?.textContent === "Parent goals: 0/6")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Adobe extraction found 0/20 child goals and 0/6 parent goals. Upload a richer source document or improve extraction before generating drafts.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Generate Drafts from Uploaded FBA/i })).toBeDisabled();
   });
 
   it("shows extraction-failed guidance instead of generic waiting copy for uploaded assessments", async () => {
@@ -1753,18 +1835,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
         return new Response(
           JSON.stringify({
             items: [],
-            structured_sections: [
-              {
-                id: "structured-goal-1",
-                section_key: "goals_treatment_planning",
-                field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
-                section_index: 0,
-                payload: { title: "Goal" },
-                status: "verified",
-                required: true,
-                review_notes: null,
-              },
-            ],
+            structured_sections: buildStructuredGoalSections("verified"),
           }),
           { status: 200 },
         );

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -87,6 +87,9 @@ interface ExtractionFunctionResponse {
   extraction_provider?: string;
   adobe_element_count?: number | null;
   adobe_table_count?: number | null;
+  structured_section_count?: number;
+  structured_child_goal_count?: number;
+  structured_parent_goal_count?: number;
   fields: ExtractionFieldResult[];
   structured_sections?: Array<{
     section_key: string;

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -2,6 +2,10 @@ import { createClient } from "npm:@supabase/supabase-js@2.50.0";
 import { z } from "npm:zod@3.23.8";
 import { resolveAllowedOrigin } from "../_shared/cors.ts";
 import { AdobePdfExtractError, extractPdfWithAdobe, type NormalizedAdobePdfExtract } from "./adobe-pdf-extract.ts";
+import {
+  extractStructuredGoalSections,
+  summarizeStructuredGoalSections,
+} from "./structured-goals.ts";
 
 const corsHeaders = (req: Request) => ({
   "Access-Control-Allow-Origin": resolveAllowedOrigin(req.headers.get("origin")),
@@ -585,82 +589,6 @@ const parseKeyValueSegments = (value: string): Record<string, string> => {
   return payload;
 };
 
-const extractStructuredGoalSections = (text: string): StructuredSectionResult[] => {
-  const lines = text.split(/\n+/).map((line) => line.trim()).filter(Boolean);
-  const sections: StructuredSectionResult[] = [];
-  let current: {
-    field_key: string;
-    section_key: string;
-    payload: Record<string, unknown>;
-    start_line: number;
-  } | null = null;
-
-  const flush = (endLine: number) => {
-    if (!current) {
-      return;
-    }
-    sections.push({
-      section_key: current.section_key,
-      field_key: current.field_key,
-      section_index: sections.filter((section) => section.field_key === current?.field_key).length,
-      payload: current.payload,
-      source_span: { method: "deterministic_goal_block", start_line: current.start_line, end_line: endLine },
-      status: "drafted",
-      required: true,
-      review_notes: "Deterministic structured goal block extracted from CalOptima document text.",
-    });
-    current = null;
-  };
-
-  lines.forEach((line, index) => {
-    const goalMatch = line.match(
-      /^(?:[A-Z]\.\s*)?(?:\d+\.\s*)?(child|parent\/caregiver|parent|target and replacement|target\/replacement|target behavior|replacement behavior|target|replacement|skill acquisition|caregiver)\s+goal\s*\d*\s*(?:\([^)]*\))?\s*[:-]\s*(.+)$/i,
-    );
-    if (goalMatch?.[1] && goalMatch?.[2]) {
-      flush(index);
-      const label = goalMatch[1].toLowerCase();
-      const isParent = label.includes("parent") || label.includes("caregiver");
-      const isSkill = label.includes("skill");
-      current = {
-        field_key: isParent
-          ? "CALOPTIMA_FBA_PARENT_GOALS"
-          : isSkill
-            ? "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS"
-            : "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
-        section_key: "goals_treatment_planning",
-        start_line: index + 1,
-        payload: {
-          title: goalMatch[2].trim(),
-          goal_type: isParent ? "parent" : "child",
-          program_name: isParent ? "Parent Training" : "Behavior Treatment",
-          original_text: line,
-        },
-      };
-      return;
-    }
-    if (!current) {
-      return;
-    }
-    const fieldMatch = line.match(/^(program|description|target behavior|behavior|skill|measurement type|measure|baseline|target criteria|criteria|mastery criteria|maintenance criteria|generalization criteria|rationale|objective data points?)\s*[:-]\s*(.+)$/i);
-    if (!fieldMatch?.[1] || !fieldMatch?.[2]) {
-      current.payload.original_text = `${String(current.payload.original_text ?? "")}\n${line}`.trim();
-      return;
-    }
-    const key = fieldMatch[1].toLowerCase().replace(/\s+/g, "_").replace(/^measure$/, "measurement_type");
-    const value = fieldMatch[2].trim();
-    if (key.startsWith("objective_data_point")) {
-      const currentRows = Array.isArray(current.payload.objective_data_points)
-        ? current.payload.objective_data_points as Record<string, unknown>[]
-        : [];
-      current.payload.objective_data_points = [...currentRows, { ...parseKeyValueSegments(value), raw_text: value }];
-      return;
-    }
-    current.payload[key === "behavior" || key === "skill" ? "target_behavior" : key] = value;
-  });
-  flush(lines.length);
-  return sections;
-};
-
 const extractStructuredTableSections = (text: string): StructuredSectionResult[] => {
   const tableSpecs = [
     { field_key: "CALOPTIMA_FBA_RECORDS_REVIEWED", section_key: "records_reviewed", prefix: /^record reviewed\s*[:-]\s*(.+)$/i },
@@ -970,6 +898,7 @@ Deno.serve(async (req) => {
     const structuredSections = extractStructuredSections(documentText).map((section) =>
       withExtractionProviderSource(section, extractionProvider)
     );
+    const structuredGoalSummary = summarizeStructuredGoalSections(structuredSections);
     const structuredSummaryByKey = new Map<string, { count: number; firstPayload: Record<string, unknown> }>();
     structuredSections.forEach((section) => {
       const current = structuredSummaryByKey.get(section.field_key);
@@ -1001,6 +930,9 @@ Deno.serve(async (req) => {
       extraction_provider: extractionProvider,
       adobe_element_count: adobeExtraction?.element_count ?? null,
       adobe_table_count: adobeExtraction?.table_count ?? null,
+      structured_section_count: structuredSections.length,
+      structured_child_goal_count: structuredGoalSummary.childGoalCount,
+      structured_parent_goal_count: structuredGoalSummary.parentGoalCount,
       fields: merged,
       structured_sections: structuredSections,
       unresolved_keys: merged.filter((field) => !field.value_text).map((field) => field.placeholder_key),

--- a/supabase/functions/extract-assessment-fields/structured-goals.test.ts
+++ b/supabase/functions/extract-assessment-fields/structured-goals.test.ts
@@ -1,0 +1,43 @@
+import { expect } from "jsr:@std/expect";
+
+import {
+  extractStructuredGoalSections,
+  summarizeStructuredGoalSections,
+} from "./structured-goals.ts";
+
+Deno.test("extractStructuredGoalSections parses embedded CalOptima goal headings", () => {
+  const text = `
+    XIV. TARGET AND REPLACEMENT BEHAVIOR GOALS intro text Replacement Behavior Goal 1 - Long-term By August 2026, the client will request access using functional communication in 80% of opportunities. Program: Behavior Treatment Baseline: 0% of opportunities Objective data point: date: 07/01/2025 | value: 8 | unit: episodes Measurement Type: Percent opportunities Target Criteria: 80% across 4 consecutive weeks.
+    N/A 2. Skill Acquisition Goal 2: Long-term By December 2026, the client will point to pictures in a book in 80% of opportunities. Program: Skill Acquisition Baseline Data with dates: 0% of opportunities Measurement Type: Percent opportunities Target Criteria: 80% across 4 consecutive weeks.
+    XVI. PARENT/CAREGIVER GOALS A. Parent/Caregiver Goal 1: Long-term by August 2026, caregiver will prompt functional communication in 90% of opportunities. Program: Parent Training Baseline Data and Date: 0% of opportunities Measurement Type: Percent opportunities Target Criteria: 90% across 4 consecutive weeks.
+  `;
+
+  const sections = extractStructuredGoalSections(text);
+  expect(sections.length).toBe(3);
+  expect(sections.map((section) => section.field_key)).toEqual([
+    "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+    "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+    "CALOPTIMA_FBA_PARENT_GOALS",
+  ]);
+  expect(sections[0].payload.goal_type).toBe("child");
+  expect(sections[0].payload.program_name).toBe("Behavior Treatment");
+  expect(sections[1].payload.program_name).toBe("Skill Acquisition");
+  expect(sections[2].payload.goal_type).toBe("parent");
+  expect(sections[2].payload.program_name).toBe("Parent Training");
+  expect(sections[0].payload.baseline_data).toContain("0%");
+  expect(sections[0].payload.objective_data_points).toEqual(["date: 07/01/2025", "value: 8", "unit: episodes"]);
+  expect(sections[0].payload.measurement_type).toContain("Percent");
+});
+
+Deno.test("summarizeStructuredGoalSections counts child and parent sections", () => {
+  const sections = extractStructuredGoalSections(`
+    Replacement Behavior Goal 1: Child target with enough narrative detail for extraction.
+    Skill Acquisition Goal 1: Child skill with enough narrative detail for extraction.
+    Parent/Caregiver Goal 1: Parent training with enough narrative detail for extraction.
+  `);
+
+  expect(summarizeStructuredGoalSections(sections)).toEqual({
+    childGoalCount: 2,
+    parentGoalCount: 1,
+  });
+});

--- a/supabase/functions/extract-assessment-fields/structured-goals.ts
+++ b/supabase/functions/extract-assessment-fields/structured-goals.ts
@@ -1,0 +1,138 @@
+export interface StructuredGoalSectionResult {
+  section_key: string;
+  field_key: string;
+  section_index: number;
+  payload: Record<string, unknown>;
+  source_span: Record<string, unknown> | null;
+  status: "not_started" | "drafted" | "verified" | "approved";
+  required: boolean;
+  review_notes: string | null;
+}
+
+const GOAL_HEADING_PATTERN =
+  /(?:^|\s)(?:[A-Z]\.\s*)?(?:\d+\.\s*)?((?:replacement\s+behavior|target(?:\s+and\s+replacement)?(?:\s+behavior)?|skill\s+acquisition|parent\/caregiver|parent|caregiver)\s+goal)\s*(\d+|[A-Z])?\s*(?:\([^)]*\))?\s*(?::|[-–—])\s*/gi;
+
+const FIELD_PATTERN =
+  /\b(program|description|target behavior|behavior|skill|measurement type|measure|baseline(?: data)?(?: and date| with dates)?|target criteria|criteria|mastery criteria|maintenance criteria|generalization criteria|rationale|objective data points?)\s*:\s*(.+?)(?=\s+\b(?:program|description|target behavior|behavior|skill|measurement type|measure|baseline(?: data)?(?: and date| with dates)?|target criteria|criteria|mastery criteria|maintenance criteria|generalization criteria|rationale|objective data points?)\s*:|$)/gi;
+
+const normalizeText = (value: string): string => value.replace(/\s+/g, " ").trim();
+
+const classifyHeading = (heading: string): {
+  field_key: string;
+  goal_type: "child" | "parent";
+  program_name: string;
+} => {
+  const normalized = heading.toLowerCase();
+  if (normalized.includes("parent") || normalized.includes("caregiver")) {
+    return {
+      field_key: "CALOPTIMA_FBA_PARENT_GOALS",
+      goal_type: "parent",
+      program_name: "Parent Training",
+    };
+  }
+  if (normalized.includes("skill")) {
+    return {
+      field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+      goal_type: "child",
+      program_name: "Skill Acquisition",
+    };
+  }
+  return {
+    field_key: "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+    goal_type: "child",
+    program_name: "Behavior Treatment",
+  };
+};
+
+const titleFromGoalBody = (body: string): string => {
+  const normalized = normalizeText(body);
+  const [beforeIntermediate] = normalized.split(/\s+-\s*Intermediate|\s+⇒\s*Intermediate|\s+Intermediate[-\s]Term/i);
+  const [beforeSection] = beforeIntermediate.split(/\s+(?:[IVXLCDM]{2,}|HCPCS Code|Telehealth Consent)\b/i);
+  const [beforeMetadata] = beforeSection.split(
+    /\s+(?:(?:a\.|b\.|c\.|\d+\.)\s*)?(?:Date|Location|Program|Description|Target Behavior|Behavior|Skill|Measurement Type|Measure|Baseline(?: Data)?(?: and Date| with Dates)?|Target Criteria|Criteria|Mastery Criteria|Maintenance Criteria|Generalization Criteria|Rationale|Objective data point)\b\s*:?/i,
+  );
+  return beforeMetadata.trim() || normalized;
+};
+
+const parseGoalFields = (body: string): Record<string, string | string[]> => {
+  const fields: Record<string, string | string[]> = {};
+  let match: RegExpExecArray | null;
+  while ((match = FIELD_PATTERN.exec(body)) !== null) {
+    const rawKey = match[1]?.toLowerCase().replace(/\s+/g, "_") ?? "";
+    const value = normalizeText(match[2] ?? "");
+    if (!rawKey || !value) {
+      continue;
+    }
+    const key = rawKey
+      .replace(/^measure$/, "measurement_type")
+      .replace(/^baseline(?:_data)?(?:_and_date|_with_dates)?$/, "baseline_data")
+      .replace(/^objective_data_points?$/, "objective_data_points");
+    if (key === "objective_data_points") {
+      const rows = value
+        .split(/\s*(?:\||;|\n)\s*/)
+        .map((entry) => normalizeText(entry))
+        .filter(Boolean);
+      fields.objective_data_points = rows.length > 0 ? rows : [value];
+      continue;
+    }
+    fields[key === "behavior" || key === "skill" ? "target_behavior" : key] = value;
+  }
+  return fields;
+};
+
+export const extractStructuredGoalSections = (text: string): StructuredGoalSectionResult[] => {
+  const matches = [...text.matchAll(GOAL_HEADING_PATTERN)];
+  const sections: StructuredGoalSectionResult[] = [];
+
+  matches.forEach((match, index) => {
+    const heading = normalizeText(match[1] ?? "");
+    const headingNumber = normalizeText(match[2] ?? "");
+    const bodyStart = match.index ?? 0;
+    const contentStart = bodyStart + match[0].length;
+    const nextStart = matches[index + 1]?.index ?? text.length;
+    const body = normalizeText(text.slice(contentStart, nextStart));
+    if (!heading || body.length < 20) {
+      return;
+    }
+    const classification = classifyHeading(heading);
+    const parsedFields = parseGoalFields(body);
+    const originalText = normalizeText(text.slice(bodyStart, nextStart));
+
+    sections.push({
+      section_key: "goals_treatment_planning",
+      field_key: classification.field_key,
+      section_index: sections.filter((section) => section.field_key === classification.field_key).length,
+      payload: {
+        title: titleFromGoalBody(body),
+        goal_type: classification.goal_type,
+        program_name: typeof parsedFields.program === "string" ? parsedFields.program : classification.program_name,
+        original_text: originalText,
+        ...parsedFields,
+      },
+      source_span: {
+        method: "deterministic_embedded_goal_heading",
+        heading,
+        heading_number: headingNumber || null,
+        start_offset: bodyStart,
+        end_offset: nextStart,
+      },
+      status: "drafted",
+      required: true,
+      review_notes: "Deterministic structured goal block extracted from embedded CalOptima goal heading.",
+    });
+  });
+
+  return sections;
+};
+
+export const summarizeStructuredGoalSections = (sections: Array<{ field_key: string; payload: Record<string, unknown> }>) => {
+  const childGoalCount = sections.filter((section) =>
+    section.field_key === "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS" ||
+    section.field_key === "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS" ||
+    section.payload.goal_type === "child"
+  ).length;
+  const parentGoalCount = sections.filter((section) =>
+    section.field_key === "CALOPTIMA_FBA_PARENT_GOALS" || section.payload.goal_type === "parent"
+  ).length;
+  return { childGoalCount, parentGoalCount };
+};

--- a/tests/scripts/assessment-import-cleanup.test.ts
+++ b/tests/scripts/assessment-import-cleanup.test.ts
@@ -45,6 +45,20 @@ describe('cleanupAssessmentImportArtifacts', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it('continues when Supabase Storage reports a missing object as a 400 not_found payload', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ statusCode: '404', error: 'not_found', message: 'Object not found' }), {
+          status: 400,
+        }),
+      );
+
+    await expect(cleanupAssessmentImportArtifacts({ ...baseArgs, fetchImpl })).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   it('fails and leaves storage untouched when DB cleanup cannot complete', async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()


### PR DESCRIPTION
## Summary
- Extract CalOptima structured goal sections from Adobe text with embedded headings, including colon and dash heading separators.
- Add structured child/parent goal counts through extraction metadata, UI readiness copy, and full-chain smoke assertions.
- Harden upload/promote smoke cleanup for Supabase Storage 400/not_found responses.

## Risk / Route
- WIN-147
- route-task: critical / high-risk human-reviewed
- Protected paths: `supabase/functions/**`, `src/server/**`, tenant-scoped workflow state and smoke cleanup.

## Verification
- PASS `deno test --allow-env --no-lock supabase/functions/extract-assessment-fields/structured-goals.test.ts`
- PASS `npx vitest run tests/edge/extract-assessment-fields.caloptima.test.ts src/server/__tests__/assessmentDocumentsHandler.test.ts src/server/__tests__/assessmentDraftsHandler.test.ts src/server/__tests__/assessmentPromoteHandler.test.ts src/components/__tests__/ProgramsGoalsTab.test.tsx tests/scripts/assessment-import-cleanup.test.ts --reporter=verbose`
- PASS `npm run ci:check-focused`
- PASS `npm run lint`
- PASS `npm run typecheck`
- PASS `npm run validate:tenant`
- PASS `npm run build`
- PARTIAL `npm run test:ci`: full suite hit unrelated timeouts in schedule/runtime migration tests on reruns; each failed test passed when rerun directly, and one full `test:ci` pass was observed earlier in this session before the final parser review fix.
- BLOCKED `npm run playwright:assessment-upload-promote-smoke`: hosted deployment currently still returns 0 structured sections for the real redacted 30-page fixture until this edge-function change is deployed. Smoke cleanup now leaves no `promote-smoke` assessment rows.

## Hosted Observation
- Current hosted extractor for the redacted fixture still shows `44` checklist rows, `28` extracted values, `0` structured sections, `0` child goals, `0` parent goals. This PR targets that blocker.

## Reviewer Notes
- Reviewer flagged dash-delimited heading and objective-data-point regressions; both were fixed and covered in `structured-goals.test.ts`.
- No diff-scoped findings remained for tenant/org scoping, service-role/adobe credential leakage, or cleanup broadening after the fixes.
