### PR TITLE
Keep extracted objective data rows object typed

### DIFF
--- a/supabase/functions/extract-assessment-fields/structured-goals.test.ts
+++ b/supabase/functions/extract-assessment-fields/structured-goals.test.ts
@@ -25,8 +25,26 @@ Deno.test("extractStructuredGoalSections parses embedded CalOptima goal headings
   expect(sections[2].payload.goal_type).toBe("parent");
   expect(sections[2].payload.program_name).toBe("Parent Training");
   expect(sections[0].payload.baseline_data).toContain("0%");
-  expect(sections[0].payload.objective_data_points).toEqual(["date: 07/01/2025", "value: 8", "unit: episodes"]);
+  expect(sections[0].payload.objective_data_points).toEqual([
+    { date: "07/01/2025", value: "8", unit: "episodes" },
+  ]);
   expect(sections[0].payload.measurement_type).toContain("Percent");
+});
+
+Deno.test("extractStructuredGoalSections keeps multiple objective data points object-typed", () => {
+  const sections = extractStructuredGoalSections(`
+    Replacement Behavior Goal 1: Long-term The client will request help using functional communication.
+    Program: Behavior Treatment
+    Baseline: 0% of opportunities
+    Objective data points: date: 07/01/2025 | value: 8 | unit: episodes; date: 07/08/2025 | value: 6 | unit: episodes
+    Measurement Type: Frequency
+    Target Criteria: 80% across 4 consecutive weeks.
+  `);
+
+  expect(sections[0].payload.objective_data_points).toEqual([
+    { date: "07/01/2025", value: "8", unit: "episodes" },
+    { date: "07/08/2025", value: "6", unit: "episodes" },
+  ]);
 });
 
 Deno.test("summarizeStructuredGoalSections counts child and parent sections", () => {

--- a/supabase/functions/extract-assessment-fields/structured-goals.ts
+++ b/supabase/functions/extract-assessment-fields/structured-goals.ts
@@ -54,8 +54,47 @@ const titleFromGoalBody = (body: string): string => {
   return beforeMetadata.trim() || normalized;
 };
 
-const parseGoalFields = (body: string): Record<string, string | string[]> => {
-  const fields: Record<string, string | string[]> = {};
+const normalizeObjectKey = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+const parseObjectiveDataPoints = (value: string): Array<Record<string, string>> => {
+  const normalized = normalizeText(value);
+  const rowTexts = normalized
+    .split(/\s*(?:;|\n)\s*/)
+    .map((entry) => normalizeText(entry))
+    .filter(Boolean);
+
+  const rows = rowTexts.map((rowText) => {
+    const row: Record<string, string> = {};
+    const parts = rowText
+      .split(/\s*\|\s*/)
+      .map((part) => normalizeText(part))
+      .filter(Boolean);
+
+    for (const part of parts.length > 0 ? parts : [rowText]) {
+      const match = /^([A-Za-z][A-Za-z0-9 _/-]{0,40})\s*:\s*(.+)$/.exec(part);
+      if (match) {
+        const key = normalizeObjectKey(match[1] ?? "");
+        const fieldValue = normalizeText(match[2] ?? "");
+        if (key && fieldValue) {
+          row[key] = fieldValue;
+        }
+        continue;
+      }
+      row.raw_text = row.raw_text ? `${row.raw_text} | ${part}` : part;
+    }
+
+    return Object.keys(row).length > 0 ? row : { raw_text: rowText };
+  });
+
+  return rows.length > 0 ? rows : [{ raw_text: normalized }];
+};
+
+const parseGoalFields = (body: string): Record<string, string | Array<Record<string, string>>> => {
+  const fields: Record<string, string | Array<Record<string, string>>> = {};
   let match: RegExpExecArray | null;
   while ((match = FIELD_PATTERN.exec(body)) !== null) {
     const rawKey = match[1]?.toLowerCase().replace(/\s+/g, "_") ?? "";
@@ -68,11 +107,7 @@ const parseGoalFields = (body: string): Record<string, string | string[]> => {
       .replace(/^baseline(?:_data)?(?:_and_date|_with_dates)?$/, "baseline_data")
       .replace(/^objective_data_points?$/, "objective_data_points");
     if (key === "objective_data_points") {
-      const rows = value
-        .split(/\s*(?:\||;|\n)\s*/)
-        .map((entry) => normalizeText(entry))
-        .filter(Boolean);
-      fields.objective_data_points = rows.length > 0 ? rows : [value];
+      fields.objective_data_points = parseObjectiveDataPoints(value);
       continue;
     }
     fields[key === "behavior" || key === "skill" ? "target_behavior" : key] = value;


### PR DESCRIPTION
## Summary
- keep CalOptima structured goal objective data points as object rows in extraction payloads
- preserve draft generation compatibility with getPayloadRows filtering
- add Deno coverage for single and multiple objective data rows

## Verification
- deno test --allow-env --no-lock supabase/functions/extract-assessment-fields/structured-goals.test.ts
- deno test --allow-env --no-lock supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts supabase/functions/extract-assessment-fields/structured-goals.test.ts
- npx vitest run src/server/__tests__/assessmentDraftsHandler.test.ts src/server/__tests__/assessmentDocumentsHandler.test.ts --reporter=verbose
- npm run ci:check-focused
- npm run typecheck
- npm run lint
- npm run validate:tenant
- npm run build
- npx vitest run src/components/__tests__/SessionNotesTab.test.tsx src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx --reporter=verbose

## Hosted Deploy / Smoke
- Deployed extract-assessment-fields to Supabase project wnnjeqheqxxyrgsjmygy
- npm run playwright:assessment-upload-promote-smoke is blocked by missing Adobe PDF Services secrets in the hosted Edge runtime: Adobe PDF extraction is not configured
- Confirmed no promote-smoke assessment rows or storage objects remain after failed smoke cleanup

## Risk
Critical/high-risk human-reviewed: touches supabase/functions/extract-assessment-fields and hosted extraction behavior. Linked workstream: WIN-147.