### PR TITLE
Fix Adobe extraction result handling and structured section persistence

### DIFF
--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { assessmentDocumentsHandler } from "../api/assessment-documents";
 
 vi.mock("../api/shared", async () => {
@@ -26,9 +26,19 @@ import {
 } from "../api/shared";
 import { loadChecklistTemplateRows } from "../assessmentChecklistTemplate";
 
+const ORIGINAL_SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
 describe("assessmentDocumentsHandler", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    if (typeof ORIGINAL_SUPABASE_SERVICE_ROLE_KEY === "string") {
+      process.env.SUPABASE_SERVICE_ROLE_KEY = ORIGINAL_SUPABASE_SERVICE_ROLE_KEY;
+    } else {
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    }
   });
 
   const roleMatrix = [
@@ -980,6 +990,7 @@ describe("assessmentDocumentsHandler", () => {
   });
 
   it("marks extraction failed when structured section persistence fails", async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -1086,6 +1097,15 @@ describe("assessmentDocumentsHandler", () => {
       return typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-structured-fail") && body.includes("extraction_failed");
     });
     expect(statusPatch).toBeDefined();
+    const structuredInsert = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" &&
+      url.includes("/rest/v1/assessment_structured_sections") &&
+      init?.method === "POST"
+    );
+    expect(structuredInsert?.[1]?.headers).toMatchObject({
+      apikey: "service-role",
+      Authorization: "Bearer service-role",
+    });
     const successEvent = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
       const body = typeof init?.body === "string" ? init.body : "";
       return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes("extraction_completed");

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -238,10 +238,18 @@ describe("assessmentDraftsHandler", () => {
         };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?")) {
+        const structuredGoals = buildStructuredGoalSections();
+        structuredGoals[1] = {
+          ...structuredGoals[1],
+          payload: {
+            ...(structuredGoals[1]?.payload as Record<string, unknown>),
+            title: "Child Goal 1",
+          },
+        };
         return {
           ok: true,
           status: 200,
-          data: buildStructuredGoalSections(),
+          data: structuredGoals,
         };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
@@ -289,6 +297,8 @@ describe("assessmentDraftsHandler", () => {
     const parentGoalCount = goalPayload.filter((goal) => goal.goal_type === "parent").length;
     expect(childGoalCount).toBe(20);
     expect(parentGoalCount).toBe(6);
+    expect(goalPayload[0]?.title).toBe("Child Goal 1");
+    expect(goalPayload[1]?.title).toBe("Child Goal 1 (2)");
     expect(goalPayload[0]?.mastery_criteria).toBe("Mastery criteria noted");
     expect(goalPayload[0]?.evidence_refs).toEqual([
       { section_key: "goals_treatment_planning", source_span: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS#0" },

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -13,6 +13,7 @@ import {
   type AssessmentChecklistSeedRow,
   type AssessmentTemplateType,
 } from "../assessmentChecklistTemplate";
+import { getRequiredServerEnv } from "../env";
 import { serverLogger } from "../../lib/logger/server";
 
 const SUPPORTED_TEMPLATE_TYPES = ["caloptima_fba", "iehp_fba"] as const;
@@ -223,9 +224,15 @@ const runCaloptimaExtractionWorkflow = async (args: {
       });
       const structuredSections = extractionResult.data.structured_sections ?? [];
       if (structuredSections.length > 0) {
+        const serviceRoleKey = getRequiredServerEnv("SUPABASE_SERVICE_ROLE_KEY");
+        const serviceHeaders = {
+          "Content-Type": "application/json",
+          apikey: serviceRoleKey,
+          Authorization: `Bearer ${serviceRoleKey}`,
+        };
         const structuredInsertResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_structured_sections`, {
           method: "POST",
-          headers,
+          headers: serviceHeaders,
           body: JSON.stringify(
             structuredSections.map((section) => ({
               assessment_document_id: createdDocumentId,

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -206,6 +206,13 @@ const getPayloadRows = (payload: Record<string, unknown>, keys: string[]): Array
   return [];
 };
 
+const ensureUniqueGoalTitle = (title: string, seenTitles: Map<string, number>): string => {
+  const normalized = title.trim().toLowerCase();
+  const seenCount = seenTitles.get(normalized) ?? 0;
+  seenTitles.set(normalized, seenCount + 1);
+  return seenCount === 0 ? title : `${title} (${seenCount + 1})`;
+};
+
 const buildDeterministicDraftPayload = (
   structuredSections: AssessmentStructuredSectionRow[],
 ): GeneratedDraftPayload | null => {
@@ -224,6 +231,7 @@ const buildDeterministicDraftPayload = (
   }
 
   const programNames = new Set<string>();
+  const seenGoalTitles = new Map<string, number>();
   const goals = approvedGoalSections.map((section, index) => {
     const payload = section.payload ?? {};
     const isParentGoal =
@@ -231,7 +239,10 @@ const buildDeterministicDraftPayload = (
       getPayloadString(payload, ["goal_type"]).toLowerCase() === "parent";
     const programName = getPayloadString(payload, ["program_name", "program", "domain"], isParentGoal ? "Parent Training" : "Behavior Treatment");
     programNames.add(programName);
-    const title = getPayloadString(payload, ["title", "goal", "goal_title"], `${isParentGoal ? "Parent" : "Child"} Goal ${index + 1}`);
+    const title = ensureUniqueGoalTitle(
+      getPayloadString(payload, ["title", "goal", "goal_title"], `${isParentGoal ? "Parent" : "Child"} Goal ${index + 1}`),
+      seenGoalTitles,
+    );
     const description = getPayloadString(payload, ["description", "goal_description", "objective"], title);
     const originalText = getPayloadString(payload, ["original_text", "source_text", "raw_text"], description);
     return {

--- a/supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts
+++ b/supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts
@@ -266,6 +266,75 @@ Deno.test("extractPdfWithAdobe accepts Adobe Europe storage download hosts", asy
   expect(extracted.text).toBe("Europe region result");
 });
 
+Deno.test("extractPdfWithAdobe accepts top-level Adobe resource download URI", async () => {
+  const zipBytes = await zipStructuredData({
+    elements: [{ Path: "//Document/P", Text: "Top-level resource result" }],
+  });
+  const downloadUri =
+    "https://dcplatformstorageservice-prod-us-east-1.s3-accelerate.amazonaws.com/result.zip?X-Amz-Signature=test";
+  const fetchImpl = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = String(input);
+    if (url.endsWith("/token")) {
+      return Response.json({ access_token: "token-1" });
+    }
+    if (url.endsWith("/assets")) {
+      return Response.json({
+        uploadUri: ADOBE_US_STORAGE_URL,
+        assetID: "asset-1",
+      });
+    }
+    if (url === ADOBE_US_STORAGE_URL) {
+      return new Response(null, { status: 200 });
+    }
+    if (url.endsWith("/operation/extractpdf")) {
+      return new Response(null, {
+        status: 201,
+        headers: {
+          location:
+            "https://pdf-services-ue1.adobe.io/operation/extractpdf/job-1/status",
+        },
+      });
+    }
+    if (url.endsWith("/job-1/status")) {
+      return Response.json({
+        status: "done",
+        resource: {
+          metadata: { type: "application/zip", size: zipBytes.byteLength },
+          downloadUri,
+          assetID: "urn:aaid:AS:UE1:result-asset",
+        },
+      });
+    }
+    if (url === downloadUri) {
+      return new Response(
+        zipBytes.buffer.slice(
+          zipBytes.byteOffset,
+          zipBytes.byteOffset + zipBytes.byteLength,
+        ) as ArrayBuffer,
+        { status: 200 },
+      );
+    }
+    return new Response(`unexpected ${init?.method ?? "GET"} ${url}`, {
+      status: 500,
+    });
+  };
+
+  const extracted = await extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+    env: envFrom({
+      PDF_SERVICES_CLIENT_ID: "client-id",
+      PDF_SERVICES_CLIENT_SECRET: "client-secret",
+    }),
+    fetchImpl,
+    sleep: () => Promise.resolve(),
+    maxPollAttempts: 1,
+  });
+
+  expect(extracted.text).toBe("Top-level resource result");
+});
+
 Deno.test("extractPdfWithAdobe accepts Adobe service result download hosts", async () => {
   const zipBytes = await zipStructuredData({
     elements: [{ Path: "//Document/P", Text: "Adobe service result" }],

--- a/supabase/functions/extract-assessment-fields/adobe-pdf-extract.ts
+++ b/supabase/functions/extract-assessment-fields/adobe-pdf-extract.ts
@@ -324,13 +324,15 @@ const resolveDownloadUri = (body: Record<string, unknown>): string | null => {
 
   const direct = body.downloadUri ?? body.dowloadUri;
   if (typeof direct === "string" && direct.trim()) return direct.trim();
+  const resourceDownloadUri = readDownloadUri(body.resource);
+  if (resourceDownloadUri) return resourceDownloadUri;
   const assetDownloadUri = readDownloadUri(body.asset);
   if (assetDownloadUri) return assetDownloadUri;
   const result = body.result;
   if (result && typeof result === "object") {
     const resource = (result as Record<string, unknown>).resource;
-    const resourceDownloadUri = readDownloadUri(resource);
-    if (resourceDownloadUri) return resourceDownloadUri;
+    const nestedResourceDownloadUri = readDownloadUri(resource);
+    if (nestedResourceDownloadUri) return nestedResourceDownloadUri;
   }
   return null;
 };

--- a/supabase/functions/extract-assessment-fields/structured-goals.test.ts
+++ b/supabase/functions/extract-assessment-fields/structured-goals.test.ts
@@ -47,6 +47,18 @@ Deno.test("extractStructuredGoalSections keeps multiple objective data points ob
   ]);
 });
 
+Deno.test("extractStructuredGoalSections falls back from service-location checkbox titles", () => {
+  const sections = extractStructuredGoalSections(`
+    Skill Acquisition Goal 4: ☐ Telehealth ☒ Home ☐ School ☐ Clinic ☐ Community
+    Program: Skill Acquisition
+    Baseline: 0% independent responses
+    Measurement Type: Percent opportunities
+    Target Criteria: 80% across 4 consecutive weeks.
+  `);
+
+  expect(sections[0].payload.title).toBe("Skill Acquisition Goal 4");
+});
+
 Deno.test("summarizeStructuredGoalSections counts child and parent sections", () => {
   const sections = extractStructuredGoalSections(`
     Replacement Behavior Goal 1: Child target with enough narrative detail for extraction.

--- a/supabase/functions/extract-assessment-fields/structured-goals.ts
+++ b/supabase/functions/extract-assessment-fields/structured-goals.ts
@@ -54,6 +54,32 @@ const titleFromGoalBody = (body: string): string => {
   return beforeMetadata.trim() || normalized;
 };
 
+const titleLooksLikeServiceLocation = (title: string): boolean => {
+  const normalized = title.toLowerCase();
+  return (
+    /^[☐☑☒✓x\s]+/i.test(title) &&
+    ["telehealth", "home", "school", "clinic", "community"].some((location) => normalized.includes(location))
+  );
+};
+
+const titleFromHeading = (heading: string, headingNumber: string, sectionIndex: number): string => {
+  const normalizedHeading = normalizeText(heading)
+    .replace(/\btarget(?:\s+and\s+replacement)?(?:\s+behavior)?\s+goal\b/i, "Replacement Behavior Goal")
+    .replace(/\bskill\s+acquisition\s+goal\b/i, "Skill Acquisition Goal")
+    .replace(/\bparent\/caregiver\s+goal\b/i, "Parent/Caregiver Goal")
+    .replace(/\bparent\s+goal\b/i, "Parent/Caregiver Goal")
+    .replace(/\bcaregiver\s+goal\b/i, "Parent/Caregiver Goal");
+  return `${normalizedHeading} ${headingNumber || sectionIndex + 1}`.trim();
+};
+
+const resolveGoalTitle = (body: string, heading: string, headingNumber: string, sectionIndex: number): string => {
+  const parsedTitle = titleFromGoalBody(body);
+  if (!parsedTitle || titleLooksLikeServiceLocation(parsedTitle)) {
+    return titleFromHeading(heading, headingNumber, sectionIndex);
+  }
+  return parsedTitle;
+};
+
 const normalizeObjectKey = (value: string): string =>
   value
     .toLowerCase()
@@ -138,7 +164,7 @@ export const extractStructuredGoalSections = (text: string): StructuredGoalSecti
       field_key: classification.field_key,
       section_index: sections.filter((section) => section.field_key === classification.field_key).length,
       payload: {
-        title: titleFromGoalBody(body),
+        title: resolveGoalTitle(body, heading, headingNumber, index),
         goal_type: classification.goal_type,
         program_name: typeof parsedFields.program === "string" ? parsedFields.program : classification.program_name,
         original_text: originalText,


### PR DESCRIPTION
## Summary
- accept Adobe Extract job status responses with top-level resource.downloadUri
- add regression coverage for Adobe's current top-level resource download shape
- persist extracted structured sections with service-role headers after authenticated document scope checks, matching hosted RLS policy
- remove local untracked Adobe credential bundle from the workspace

## Verification
- deno test --allow-env --no-lock supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts supabase/functions/extract-assessment-fields/structured-goals.test.ts
- npx vitest run src/server/__tests__/assessmentDocumentsHandler.test.ts --reporter=verbose
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run validate:tenant
- npm run build

## Hosted validation
- Deployed extract-assessment-fields to Supabase project wnnjeqheqxxyrgsjmygy
- Production app smoke advanced past Adobe extraction, then failed in server post-processing because structured section insert used user-scoped headers against a service-role-only insert policy. This PR includes the server fix; rerun smoke against the Netlify preview when ready.

## Risk
Critical/high-risk human-reviewed. Touches supabase/functions and src/server API persistence boundaries. Workstream: WIN-147.