### PR TITLE
Preserve suffixed goal title uniqueness

### DIFF
--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -253,6 +253,20 @@ describe("assessmentDraftsHandler", () => {
             title: "Child Goal 1",
           },
         };
+        structuredGoals[3] = {
+          ...structuredGoals[3],
+          payload: {
+            ...(structuredGoals[3]?.payload as Record<string, unknown>),
+            title: "Transition Goal (2024)",
+          },
+        };
+        structuredGoals[4] = {
+          ...structuredGoals[4],
+          payload: {
+            ...(structuredGoals[4]?.payload as Record<string, unknown>),
+            title: "Transition Goal (2024)",
+          },
+        };
         return {
           ok: true,
           status: 200,
@@ -307,6 +321,8 @@ describe("assessmentDraftsHandler", () => {
     expect(goalPayload[0]?.title).toBe("Child Goal 1");
     expect(goalPayload[1]?.title).toBe("Child Goal 1 (2)");
     expect(goalPayload[2]?.title).toBe("Child Goal 1 (3)");
+    expect(goalPayload[3]?.title).toBe("Transition Goal (2024)");
+    expect(goalPayload[4]?.title).toBe("Transition Goal (2024) (2)");
     expect(goalPayload[0]?.mastery_criteria).toBe("Mastery criteria noted");
     expect(goalPayload[0]?.evidence_refs).toEqual([
       { section_key: "goals_treatment_planning", source_span: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS#0" },

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -243,6 +243,13 @@ describe("assessmentDraftsHandler", () => {
           ...structuredGoals[1],
           payload: {
             ...(structuredGoals[1]?.payload as Record<string, unknown>),
+            title: "Child Goal 1 (2)",
+          },
+        };
+        structuredGoals[2] = {
+          ...structuredGoals[2],
+          payload: {
+            ...(structuredGoals[2]?.payload as Record<string, unknown>),
             title: "Child Goal 1",
           },
         };
@@ -299,6 +306,7 @@ describe("assessmentDraftsHandler", () => {
     expect(parentGoalCount).toBe(6);
     expect(goalPayload[0]?.title).toBe("Child Goal 1");
     expect(goalPayload[1]?.title).toBe("Child Goal 1 (2)");
+    expect(goalPayload[2]?.title).toBe("Child Goal 1 (3)");
     expect(goalPayload[0]?.mastery_criteria).toBe("Mastery criteria noted");
     expect(goalPayload[0]?.evidence_refs).toEqual([
       { section_key: "goals_treatment_planning", source_span: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS#0" },

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -206,11 +206,43 @@ const getPayloadRows = (payload: Record<string, unknown>, keys: string[]): Array
   return [];
 };
 
+const normalizeGoalTitleKey = (title: string): string => title.trim().replace(/\s+/g, " ").toLowerCase();
+
+const splitGoalTitleSuffix = (title: string): { baseTitle: string; suffixIndex: number } => {
+  const trimmedTitle = title.trim();
+  const suffixMatch = trimmedTitle.match(/^(.*)\s+\((\d+)\)$/);
+  if (!suffixMatch) {
+    return { baseTitle: trimmedTitle, suffixIndex: 1 };
+  }
+
+  const parsedSuffix = Number.parseInt(suffixMatch[2] ?? "", 10);
+  if (!Number.isFinite(parsedSuffix) || parsedSuffix < 2) {
+    return { baseTitle: trimmedTitle, suffixIndex: 1 };
+  }
+
+  return { baseTitle: (suffixMatch[1] ?? trimmedTitle).trim(), suffixIndex: parsedSuffix };
+};
+
 const ensureUniqueGoalTitle = (title: string, seenTitles: Map<string, number>): string => {
-  const normalized = title.trim().toLowerCase();
-  const seenCount = seenTitles.get(normalized) ?? 0;
-  seenTitles.set(normalized, seenCount + 1);
-  return seenCount === 0 ? title : `${title} (${seenCount + 1})`;
+  const { baseTitle, suffixIndex } = splitGoalTitleSuffix(title);
+  const baseKey = `base:${normalizeGoalTitleKey(baseTitle)}`;
+  const titleKeyFor = (candidate: string) => `title:${normalizeGoalTitleKey(candidate)}`;
+  const formatTitle = (index: number) => (index === 1 ? baseTitle : `${baseTitle} (${index})`);
+
+  let candidateIndex = suffixIndex;
+  let candidateTitle = formatTitle(candidateIndex);
+  if (seenTitles.has(titleKeyFor(candidateTitle))) {
+    candidateIndex = Math.max((seenTitles.get(baseKey) ?? 1) + 1, suffixIndex + 1);
+    candidateTitle = formatTitle(candidateIndex);
+    while (seenTitles.has(titleKeyFor(candidateTitle))) {
+      candidateIndex += 1;
+      candidateTitle = formatTitle(candidateIndex);
+    }
+  }
+
+  seenTitles.set(titleKeyFor(candidateTitle), candidateIndex);
+  seenTitles.set(baseKey, Math.max(seenTitles.get(baseKey) ?? 0, candidateIndex));
+  return candidateTitle;
 };
 
 const buildDeterministicDraftPayload = (

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -208,7 +208,7 @@ const getPayloadRows = (payload: Record<string, unknown>, keys: string[]): Array
 
 const normalizeGoalTitleKey = (title: string): string => title.trim().replace(/\s+/g, " ").toLowerCase();
 
-const splitGoalTitleSuffix = (title: string): { baseTitle: string; suffixIndex: number } => {
+const splitGoalTitleSuffix = (title: string, seenTitles: Map<string, number>): { baseTitle: string; suffixIndex: number } => {
   const trimmedTitle = title.trim();
   const suffixMatch = trimmedTitle.match(/^(.*)\s+\((\d+)\)$/);
   if (!suffixMatch) {
@@ -220,11 +220,18 @@ const splitGoalTitleSuffix = (title: string): { baseTitle: string; suffixIndex: 
     return { baseTitle: trimmedTitle, suffixIndex: 1 };
   }
 
-  return { baseTitle: (suffixMatch[1] ?? trimmedTitle).trim(), suffixIndex: parsedSuffix };
+  const baseTitle = (suffixMatch[1] ?? trimmedTitle).trim();
+  const baseTitleKey = `title:${normalizeGoalTitleKey(baseTitle)}`;
+  const baseCounterKey = `base:${normalizeGoalTitleKey(baseTitle)}`;
+  if (!seenTitles.has(baseTitleKey) && !seenTitles.has(baseCounterKey)) {
+    return { baseTitle: trimmedTitle, suffixIndex: 1 };
+  }
+
+  return { baseTitle, suffixIndex: parsedSuffix };
 };
 
 const ensureUniqueGoalTitle = (title: string, seenTitles: Map<string, number>): string => {
-  const { baseTitle, suffixIndex } = splitGoalTitleSuffix(title);
+  const { baseTitle, suffixIndex } = splitGoalTitleSuffix(title, seenTitles);
   const baseKey = `base:${normalizeGoalTitleKey(baseTitle)}`;
   const titleKeyFor = (candidate: string) => `title:${normalizeGoalTitleKey(candidate)}`;
   const formatTitle = (index: number) => (index === 1 ? baseTitle : `${baseTitle} (${index})`);


### PR DESCRIPTION
## Summary
- reserve existing numeric suffixes when de-duping deterministic draft goal titles
- prevent extracted titles like "Child Goal 1", "Child Goal 1 (2)", then another "Child Goal 1" from producing duplicate "(2)" titles
- add regression coverage to the deterministic draft generation test

## Verification
- npx vitest run src/server/__tests__/assessmentDraftsHandler.test.ts --reporter=verbose
- npm run ci:check-focused
- npm run typecheck
- npm run lint
- npm run build
- npm run test:ci: failed on unrelated flaky Windows temp-dir cleanup and PDF template timeout; both failed tests passed on direct rerun
- npx vitest run tests/vitest.env-isolation.test.ts src/server/__tests__/assessmentPlanPdfTemplate.test.ts --reporter=verbose

## Risk
Critical lane because this touches src/server/** deterministic draft behavior. No schema, RLS, credential, Adobe extraction, or promotion persistence changes.