### PR TITLE
[codex] Harden CalOptima PDF smoke verification

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -99,7 +99,7 @@ This covers:
 - overlay warning propagation for `Generate Completed CalOptima PDF`
 - visual placement smoke for generated CalOptima PDF pages with mapped fields
 
-`npm run playwright:assessment-pdf-smoke` requires authenticated Playwright/Supabase env plus `PW_ASSESSMENT_DOCUMENT_ID` for an approved CalOptima assessment with accepted program/goals.
+`npm run playwright:assessment-pdf-smoke` requires authenticated Playwright/Supabase env. It now reuses `PW_ASSESSMENT_DOCUMENT_ID` only as an override; otherwise it first discovers a ready CalOptima assessment and, when `PW_ASSESSMENT_CLIENT_ID` points to a dedicated smoke client, can provision a temporary assessment fixture automatically.
 
 ## Agent eval smoke (edge functions)
 

--- a/docs/fill_docs/CALOPTIMA_PDF_GENERATION_RUNBOOK.md
+++ b/docs/fill_docs/CALOPTIMA_PDF_GENERATION_RUNBOOK.md
@@ -97,7 +97,7 @@ npx vitest run \
 npm run playwright:assessment-pdf-smoke
 ```
 
-`npm run playwright:assessment-pdf-smoke` requires `PW_ADMIN_EMAIL`, `PW_ADMIN_PASSWORD`, Supabase URL/key env, and `PW_ASSESSMENT_DOCUMENT_ID` pointing to an approved CalOptima assessment with accepted program/goals. The smoke generates through `POST /api/assessment-plan-pdf`, downloads the signed PDF, renders mapped pages to screenshots, and fails if generated pixels appear outside allowed boxes or the renderer reports overflow.
+`npm run playwright:assessment-pdf-smoke` requires `PW_ADMIN_EMAIL`, `PW_ADMIN_PASSWORD`, and Supabase URL/key env. `PW_ASSESSMENT_DOCUMENT_ID` remains available as an override, but the smoke now prefers to discover its own ready CalOptima assessment automatically and can provision a temporary fixture when `PW_ASSESSMENT_CLIENT_ID` is set to a dedicated smoke client. The smoke generates through `POST /api/assessment-plan-pdf`, downloads the signed PDF, renders mapped pages to screenshots, and fails if generated pixels appear outside allowed boxes or the renderer reports overflow.
 
 ## Audit and traceability
 

--- a/reports/test-reliability-latest.json
+++ b/reports/test-reliability-latest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-05T21:24:42.140Z",
+  "generatedAt": "2026-05-15T14:09:09.248Z",
   "slo": {
     "suitePassRatePctTarget": 99.5,
     "rollingWindowDays": 14

--- a/scripts/lib/assessment-pdf-smoke-document.ts
+++ b/scripts/lib/assessment-pdf-smoke-document.ts
@@ -1,0 +1,624 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  cleanupAssessmentImportArtifacts,
+  deleteAssessmentStorageObject,
+  type AssessmentImportCleanupTarget,
+} from "./assessment-import-cleanup";
+import { assertSmokeClientMarker, requireSmokeClientId } from "./assessment-upload-promote-smoke-guards";
+
+type AssessmentStatus =
+  | "uploaded"
+  | "extracting"
+  | "extracted"
+  | "drafted"
+  | "approved"
+  | "rejected"
+  | "extraction_failed";
+
+type ChecklistItemStatus = "not_started" | "drafted" | "verified" | "approved";
+type StructuredSectionStatus = "not_started" | "drafted" | "verified" | "approved" | "rejected";
+type AcceptState = "pending" | "accepted" | "rejected" | "edited";
+
+export type AssessmentDocumentRecord = {
+  id: string;
+  organization_id?: string | null;
+  client_id: string;
+  file_name: string;
+  bucket_id?: string | null;
+  object_path: string;
+  status: AssessmentStatus;
+  template_type?: string | null;
+  created_at?: string | null;
+};
+
+type ChecklistResponse = {
+  items: Array<{
+    id: string;
+    label: string;
+    placeholder_key: string;
+    required: boolean;
+    status: ChecklistItemStatus;
+    value_text: string | null;
+  }>;
+  structured_sections: Array<{
+    id: string;
+    field_key: string;
+    section_key: string;
+    section_index: number;
+    payload: Record<string, unknown> | null;
+    required: boolean;
+    status: StructuredSectionStatus;
+  }>;
+};
+
+type DraftResponse = {
+  programs: Array<{
+    id: string;
+    name: string;
+    description: string | null;
+    accept_state: AcceptState;
+  }>;
+  goals: Array<{
+    id: string;
+    title: string;
+    description: string;
+    original_text: string;
+    goal_type: "child" | "parent";
+    accept_state: AcceptState;
+  }>;
+};
+
+type ReadinessEvaluation = {
+  ready: boolean;
+  reasons: string[];
+};
+
+export type PdfSmokeAssessmentResolution = {
+  assessmentDocumentId: string;
+  source: "env" | "discovered" | "provisioned";
+  cleanupTarget?: AssessmentImportCleanupTarget;
+  cleanupGeneratedPdf?: {
+    bucketId: string;
+    objectPath: string;
+  };
+};
+
+const DEFAULT_SAMPLE_FILE = path.resolve(
+  process.cwd(),
+  "7.21.2025_RoVa_CalOptima_FBA_FINAL (1).Redacted.docx.pdf",
+);
+const DEFAULT_BUCKET_ID = "client-documents";
+const EXTRACTION_TIMEOUT_MS = 180_000;
+
+const pause = async (ms: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const resolveMimeType = (filePath: string): string => {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === ".pdf") return "application/pdf";
+  if (extension === ".docx") return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+  return "application/octet-stream";
+};
+
+const escapeBody = async (response: Response): Promise<string> => {
+  return response.text().catch(() => "");
+};
+
+const assertOk = async (response: Response, message: string): Promise<void> => {
+  if (response.ok) return;
+  const body = await escapeBody(response);
+  throw new Error(`${message}: ${response.status}${body ? ` ${body}` : ""}`);
+};
+
+const fetchJson = async <T>(
+  url: string,
+  init: RequestInit & { accessToken?: string; anonKey?: string } = {},
+): Promise<T> => {
+  const { accessToken, anonKey, headers, ...rest } = init;
+  const response = await fetch(url, {
+    ...rest,
+    headers: {
+      ...(anonKey ? { apikey: anonKey } : {}),
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      ...(rest.body ? { "Content-Type": "application/json" } : {}),
+      ...headers,
+    },
+  });
+  await assertOk(response, `Request failed for ${url}`);
+  const text = await response.text();
+  return text ? (JSON.parse(text) as T) : ([] as T);
+};
+
+const callAppJson = async <T>(
+  baseUrl: string,
+  accessToken: string,
+  pathValue: string,
+  init: RequestInit = {},
+): Promise<T> =>
+  fetchJson<T>(`${baseUrl}${pathValue}`, {
+    ...init,
+    accessToken,
+  });
+
+const loadChecklist = async (
+  baseUrl: string,
+  accessToken: string,
+  assessmentDocumentId: string,
+): Promise<ChecklistResponse> =>
+  callAppJson<ChecklistResponse>(
+    baseUrl,
+    accessToken,
+    `/api/assessment-checklist?assessment_document_id=${encodeURIComponent(assessmentDocumentId)}`,
+  );
+
+const loadDrafts = async (
+  baseUrl: string,
+  accessToken: string,
+  assessmentDocumentId: string,
+): Promise<DraftResponse> =>
+  callAppJson<DraftResponse>(
+    baseUrl,
+    accessToken,
+    `/api/assessment-drafts?assessment_document_id=${encodeURIComponent(assessmentDocumentId)}`,
+  );
+
+export const evaluatePdfSmokeAssessmentReadiness = (args: {
+  document: AssessmentDocumentRecord;
+  checklist: ChecklistResponse;
+  drafts: DraftResponse;
+}): ReadinessEvaluation => {
+  const reasons: string[] = [];
+  if (args.document.template_type && args.document.template_type !== "caloptima_fba") {
+    reasons.push("template_type_not_caloptima");
+  }
+  if (["uploaded", "extracting", "extraction_failed"].includes(args.document.status)) {
+    reasons.push(`document_status_${args.document.status}`);
+  }
+  const pendingChecklist = args.checklist.items.filter((item) => item.required && item.status !== "approved");
+  if (pendingChecklist.length > 0) {
+    reasons.push("required_checklist_pending");
+  }
+  const pendingStructuredSections = args.checklist.structured_sections.filter(
+    (section) => section.required && section.status !== "approved",
+  );
+  if (pendingStructuredSections.length > 0) {
+    reasons.push("required_structured_sections_pending");
+  }
+  if (!args.drafts.programs.some((program) => program.accept_state === "accepted" || program.accept_state === "edited")) {
+    reasons.push("accepted_program_missing");
+  }
+  if (!args.drafts.goals.some((goal) => goal.accept_state === "accepted" || goal.accept_state === "edited")) {
+    reasons.push("accepted_goal_missing");
+  }
+  return {
+    ready: reasons.length === 0,
+    reasons,
+  };
+};
+
+const fetchAssessmentDocuments = async (args: {
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  accessToken: string;
+  clientId?: string;
+}): Promise<AssessmentDocumentRecord[]> => {
+  const clientFilter = args.clientId ? `&client_id=eq.${encodeURIComponent(args.clientId)}` : "";
+  return fetchJson<AssessmentDocumentRecord[]>(
+    `${args.supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,file_name,bucket_id,object_path,status,template_type,created_at&template_type=eq.caloptima_fba${clientFilter}&order=created_at.desc&limit=25`,
+    {
+      method: "GET",
+      anonKey: args.supabaseAnonKey,
+      accessToken: args.accessToken,
+    },
+  );
+};
+
+const fetchAssessmentDocument = async (args: {
+  baseUrl: string;
+  accessToken: string;
+  assessmentDocumentId: string;
+}): Promise<AssessmentDocumentRecord> =>
+  callAppJson<AssessmentDocumentRecord>(
+    args.baseUrl,
+    args.accessToken,
+    `/api/assessment-documents?assessment_document_id=${encodeURIComponent(args.assessmentDocumentId)}`,
+  );
+
+const discoverReadyAssessmentDocument = async (args: {
+  baseUrl: string;
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  accessToken: string;
+  clientId?: string;
+}): Promise<AssessmentDocumentRecord | null> => {
+  const documents = await fetchAssessmentDocuments(args);
+  for (const document of documents) {
+    try {
+      const [checklist, drafts] = await Promise.all([
+        loadChecklist(args.baseUrl, args.accessToken, document.id),
+        loadDrafts(args.baseUrl, args.accessToken, document.id),
+      ]);
+      const readiness = evaluatePdfSmokeAssessmentReadiness({
+        document,
+        checklist,
+        drafts,
+      });
+      if (readiness.ready) {
+        return document;
+      }
+    } catch {
+      // Skip inaccessible or malformed candidates and keep discovery bounded.
+    }
+  }
+  return null;
+};
+
+const selectProvisionClient = async (args: {
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  accessToken: string;
+  requestedClientId: string;
+}): Promise<{ clientId: string; clientName: string }> => {
+  const clientId = requireSmokeClientId(args.requestedClientId);
+  const clients = await fetchJson<Array<{ id: string; full_name: string | null }>>(
+    `${args.supabaseUrl}/rest/v1/clients?select=id,full_name&id=eq.${encodeURIComponent(clientId)}&limit=1`,
+    {
+      method: "GET",
+      anonKey: args.supabaseAnonKey,
+      accessToken: args.accessToken,
+    },
+  );
+  const client = clients[0];
+  if (!client) {
+    throw new Error(`Configured PW_ASSESSMENT_CLIENT_ID is not accessible: ${clientId}`);
+  }
+  assertSmokeClientMarker(client.full_name, client.id);
+  return {
+    clientId: client.id,
+    clientName: client.full_name ?? client.id,
+  };
+};
+
+const uploadAssessmentSource = async (args: {
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  accessToken: string;
+  clientId: string;
+  sampleFilePath: string;
+}): Promise<{ fileName: string; mimeType: string; objectPath: string; fileSize: number }> => {
+  const sourceFileBuffer = readFileSync(args.sampleFilePath);
+  const sourceExtension = path.extname(args.sampleFilePath).toLowerCase();
+  const sourceBaseName = path.basename(args.sampleFilePath, sourceExtension);
+  const fileName = `${sourceBaseName}-pdf-smoke-${Date.now()}${sourceExtension}`;
+  const objectPath = `clients/${args.clientId}/assessments/${fileName}`;
+  const encodedObjectPath = objectPath
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const mimeType = resolveMimeType(args.sampleFilePath);
+  const uploadResponse = await fetch(
+    `${args.supabaseUrl}/storage/v1/object/${encodeURIComponent(DEFAULT_BUCKET_ID)}/${encodedObjectPath}`,
+    {
+      method: "POST",
+      headers: {
+        apikey: args.supabaseAnonKey,
+        Authorization: `Bearer ${args.accessToken}`,
+        "Content-Type": mimeType,
+        "x-upsert": "false",
+      },
+      body: sourceFileBuffer,
+    },
+  );
+  await assertOk(uploadResponse, "Assessment PDF smoke fixture upload failed");
+  return {
+    fileName,
+    mimeType,
+    objectPath,
+    fileSize: sourceFileBuffer.byteLength,
+  };
+};
+
+const createAssessmentDocument = async (args: {
+  baseUrl: string;
+  accessToken: string;
+  clientId: string;
+  fileName: string;
+  mimeType: string;
+  objectPath: string;
+  fileSize: number;
+}): Promise<AssessmentDocumentRecord> =>
+  callAppJson<AssessmentDocumentRecord>(args.baseUrl, args.accessToken, "/api/assessment-documents", {
+    method: "POST",
+    body: JSON.stringify({
+      client_id: args.clientId,
+      file_name: args.fileName,
+      mime_type: args.mimeType,
+      file_size: args.fileSize,
+      bucket_id: DEFAULT_BUCKET_ID,
+      object_path: args.objectPath,
+      template_type: "caloptima_fba",
+    }),
+  });
+
+const waitForExtractedAssessment = async (args: {
+  baseUrl: string;
+  accessToken: string;
+  assessmentDocumentId: string;
+}): Promise<AssessmentDocumentRecord> => {
+  const deadline = Date.now() + EXTRACTION_TIMEOUT_MS;
+  let latest: AssessmentDocumentRecord | null = null;
+  while (Date.now() < deadline) {
+    latest = await fetchAssessmentDocument(args);
+    if (!["uploaded", "extracting"].includes(latest.status)) {
+      break;
+    }
+    await pause(2_000);
+  }
+  if (!latest) {
+    throw new Error(`Provisioned assessment document ${args.assessmentDocumentId} was not found.`);
+  }
+  if (latest.status !== "extracted") {
+    throw new Error(
+      `Provisioned assessment document ${latest.id} ended with ${latest.status}.`,
+    );
+  }
+  return latest;
+};
+
+const approveChecklistAndStructuredSections = async (args: {
+  baseUrl: string;
+  accessToken: string;
+  checklist: ChecklistResponse;
+}): Promise<void> => {
+  for (const item of args.checklist.items) {
+    if (!item.required || item.status === "approved") continue;
+    await callAppJson(args.baseUrl, args.accessToken, "/api/assessment-checklist", {
+      method: "PATCH",
+      body: JSON.stringify({
+        item_id: item.id,
+        status: "approved",
+        review_notes: "PDF smoke auto-approved required checklist row from redacted fixture.",
+        value_text: item.value_text?.trim() || `PDF smoke reviewed value for ${item.label}`,
+      }),
+    });
+  }
+
+  for (const section of args.checklist.structured_sections) {
+    if (!section.required || section.status === "approved") continue;
+    if (!section.payload || Object.keys(section.payload).length === 0) {
+      throw new Error(`Structured section ${section.id} is required but has no payload.`);
+    }
+    await callAppJson(args.baseUrl, args.accessToken, "/api/assessment-checklist", {
+      method: "PATCH",
+      body: JSON.stringify({
+        structured_section_id: section.id,
+        status: "approved",
+        review_notes: "PDF smoke auto-approved required structured section from redacted fixture.",
+        payload: section.payload,
+      }),
+    });
+  }
+};
+
+const generateDrafts = async (baseUrl: string, accessToken: string, assessmentDocumentId: string): Promise<void> => {
+  await callAppJson(baseUrl, accessToken, "/api/assessment-drafts", {
+    method: "POST",
+    body: JSON.stringify({
+      assessment_document_id: assessmentDocumentId,
+      auto_generate: true,
+    }),
+  });
+};
+
+const acceptDrafts = async (baseUrl: string, accessToken: string, drafts: DraftResponse): Promise<void> => {
+  for (const program of drafts.programs) {
+    await callAppJson(baseUrl, accessToken, "/api/assessment-drafts", {
+      method: "PATCH",
+      body: JSON.stringify({
+        draft_type: "program",
+        id: program.id,
+        accept_state: "accepted",
+        review_notes: "PDF smoke accepted draft program.",
+        name: program.name,
+        description: program.description ?? "PDF smoke accepted draft program.",
+      }),
+    });
+  }
+
+  for (const goal of drafts.goals) {
+    await callAppJson(baseUrl, accessToken, "/api/assessment-drafts", {
+      method: "PATCH",
+      body: JSON.stringify({
+        draft_type: "goal",
+        id: goal.id,
+        accept_state: "accepted",
+        review_notes: "PDF smoke accepted draft goal.",
+        title: goal.title,
+        description: goal.description,
+        original_text: goal.original_text,
+        goal_type: goal.goal_type,
+      }),
+    });
+  }
+};
+
+const provisionReadyAssessmentDocument = async (args: {
+  baseUrl: string;
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  accessToken: string;
+  provisionClientId: string;
+  sampleFilePath?: string;
+}): Promise<PdfSmokeAssessmentResolution> => {
+  const { clientId, clientName } = await selectProvisionClient({
+    supabaseUrl: args.supabaseUrl,
+    supabaseAnonKey: args.supabaseAnonKey,
+    accessToken: args.accessToken,
+    requestedClientId: args.provisionClientId,
+  });
+  const sampleFilePath = args.sampleFilePath ? path.resolve(process.cwd(), args.sampleFilePath) : DEFAULT_SAMPLE_FILE;
+  let upload:
+    | {
+        fileName: string;
+        mimeType: string;
+        objectPath: string;
+        fileSize: number;
+      }
+    | null = null;
+  let createdAssessment: AssessmentDocumentRecord | null = null;
+
+  try {
+    upload = await uploadAssessmentSource({
+      supabaseUrl: args.supabaseUrl,
+      supabaseAnonKey: args.supabaseAnonKey,
+      accessToken: args.accessToken,
+      clientId,
+      sampleFilePath,
+    });
+    createdAssessment = await createAssessmentDocument({
+      baseUrl: args.baseUrl,
+      accessToken: args.accessToken,
+      clientId,
+      fileName: upload.fileName,
+      mimeType: upload.mimeType,
+      objectPath: upload.objectPath,
+      fileSize: upload.fileSize,
+    });
+    const extractedAssessment = await waitForExtractedAssessment({
+      baseUrl: args.baseUrl,
+      accessToken: args.accessToken,
+      assessmentDocumentId: createdAssessment.id,
+    });
+    const checklist = await loadChecklist(args.baseUrl, args.accessToken, extractedAssessment.id);
+    await approveChecklistAndStructuredSections({
+      baseUrl: args.baseUrl,
+      accessToken: args.accessToken,
+      checklist,
+    });
+    await generateDrafts(args.baseUrl, args.accessToken, extractedAssessment.id);
+    const drafts = await loadDrafts(args.baseUrl, args.accessToken, extractedAssessment.id);
+    if (drafts.programs.length === 0 || drafts.goals.length === 0) {
+      throw new Error(
+        `Provisioned PDF smoke fixture on ${clientName} did not generate any draft programs/goals.`,
+      );
+    }
+    await acceptDrafts(args.baseUrl, args.accessToken, drafts);
+    const acceptedDrafts = await loadDrafts(args.baseUrl, args.accessToken, extractedAssessment.id);
+    const readiness = evaluatePdfSmokeAssessmentReadiness({
+      document: extractedAssessment,
+      checklist: await loadChecklist(args.baseUrl, args.accessToken, extractedAssessment.id),
+      drafts: acceptedDrafts,
+    });
+    if (!readiness.ready) {
+      throw new Error(
+        `Provisioned PDF smoke fixture is not ready for generation: ${readiness.reasons.join(", ")}`,
+      );
+    }
+    return {
+      assessmentDocumentId: extractedAssessment.id,
+      source: "provisioned",
+      cleanupTarget: {
+        assessmentDocumentId: extractedAssessment.id,
+        bucketId: extractedAssessment.bucket_id?.trim() || DEFAULT_BUCKET_ID,
+        objectPath: extractedAssessment.object_path,
+      },
+    };
+  } catch (error) {
+    if (createdAssessment) {
+      await cleanupAssessmentImportArtifacts({
+        baseUrl: args.baseUrl,
+        supabaseUrl: args.supabaseUrl,
+        supabaseAnonKey: args.supabaseAnonKey,
+        accessToken: args.accessToken,
+        target: {
+          assessmentDocumentId: createdAssessment.id,
+          bucketId: createdAssessment.bucket_id?.trim() || DEFAULT_BUCKET_ID,
+          objectPath: createdAssessment.object_path,
+        },
+      }).catch(() => undefined);
+    } else if (upload) {
+      await deleteAssessmentStorageObject(fetch, {
+        supabaseUrl: args.supabaseUrl,
+        supabaseAnonKey: args.supabaseAnonKey,
+        accessToken: args.accessToken,
+        bucketId: DEFAULT_BUCKET_ID,
+        objectPath: upload.objectPath,
+      }).catch(() => undefined);
+    }
+    throw error;
+  }
+};
+
+export const resolveAssessmentDocumentForPdfSmoke = async (args: {
+  baseUrl: string;
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  accessToken: string;
+  preferredAssessmentDocumentId?: string;
+  provisionClientId?: string;
+  sampleFilePath?: string;
+}): Promise<PdfSmokeAssessmentResolution> => {
+  const preferredAssessmentDocumentId = args.preferredAssessmentDocumentId?.trim();
+  if (preferredAssessmentDocumentId) {
+    return {
+      assessmentDocumentId: preferredAssessmentDocumentId,
+      source: "env",
+    };
+  }
+
+  const discovered = await discoverReadyAssessmentDocument({
+    baseUrl: args.baseUrl,
+    supabaseUrl: args.supabaseUrl,
+    supabaseAnonKey: args.supabaseAnonKey,
+    accessToken: args.accessToken,
+    clientId: args.provisionClientId?.trim() || undefined,
+  });
+  if (discovered) {
+    return {
+      assessmentDocumentId: discovered.id,
+      source: "discovered",
+    };
+  }
+
+  const provisionClientId = args.provisionClientId?.trim();
+  if (!provisionClientId) {
+    throw new Error(
+      "No ready CalOptima assessment document was discovered for PDF smoke. Set PW_ASSESSMENT_CLIENT_ID to a dedicated smoke client so the harness can provision its own temporary fixture safely.",
+    );
+  }
+
+  return provisionReadyAssessmentDocument({
+    ...args,
+    provisionClientId,
+  });
+};
+
+export const cleanupProvisionedAssessmentPdfSmokeArtifacts = async (args: {
+  baseUrl: string;
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  accessToken: string;
+  resolution: PdfSmokeAssessmentResolution;
+}): Promise<void> => {
+  if (args.resolution.cleanupGeneratedPdf) {
+    await deleteAssessmentStorageObject(fetch, {
+      supabaseUrl: args.supabaseUrl,
+      supabaseAnonKey: args.supabaseAnonKey,
+      accessToken: args.accessToken,
+      bucketId: args.resolution.cleanupGeneratedPdf.bucketId,
+      objectPath: args.resolution.cleanupGeneratedPdf.objectPath,
+    });
+  }
+  if (args.resolution.cleanupTarget) {
+    await cleanupAssessmentImportArtifacts({
+      baseUrl: args.baseUrl,
+      supabaseUrl: args.supabaseUrl,
+      supabaseAnonKey: args.supabaseAnonKey,
+      accessToken: args.accessToken,
+      target: args.resolution.cleanupTarget,
+    });
+  }
+};

--- a/scripts/lib/assessment-pdf-smoke-document.ts
+++ b/scripts/lib/assessment-pdf-smoke-document.ts
@@ -41,6 +41,7 @@ type ChecklistResponse = {
     required: boolean;
     status: ChecklistItemStatus;
     value_text: string | null;
+    value_json?: unknown | null;
   }>;
   structured_sections: Array<{
     id: string;
@@ -94,6 +95,16 @@ const EXTRACTION_TIMEOUT_MS = 180_000;
 
 const pause = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const hasMeaningfulValue = (value: unknown): boolean => {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value === "boolean") return true;
+  if (Array.isArray(value)) return value.some((entry) => hasMeaningfulValue(entry));
+  if (typeof value === "object") return Object.values(value).some((entry) => hasMeaningfulValue(entry));
+  return false;
 };
 
 const resolveMimeType = (filePath: string): string => {
@@ -180,6 +191,12 @@ export const evaluatePdfSmokeAssessmentReadiness = (args: {
   const pendingChecklist = args.checklist.items.filter((item) => item.required && item.status !== "approved");
   if (pendingChecklist.length > 0) {
     reasons.push("required_checklist_pending");
+  }
+  const approvedRequiredChecklistWithoutValues = args.checklist.items.filter(
+    (item) => item.required && item.status === "approved" && !hasMeaningfulValue(item.value_text ?? item.value_json),
+  );
+  if (approvedRequiredChecklistWithoutValues.length > 0) {
+    reasons.push("required_checklist_value_missing");
   }
   const pendingStructuredSections = args.checklist.structured_sections.filter(
     (section) => section.required && section.status !== "approved",

--- a/scripts/playwright-assessment-pdf-smoke.ts
+++ b/scripts/playwright-assessment-pdf-smoke.ts
@@ -3,6 +3,11 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { chromium, type Page } from 'playwright';
 
+import {
+  cleanupProvisionedAssessmentPdfSmokeArtifacts,
+  resolveAssessmentDocumentForPdfSmoke,
+  type PdfSmokeAssessmentResolution,
+} from './lib/assessment-pdf-smoke-document';
 import { loadPlaywrightEnv } from './lib/load-playwright-env';
 import { ensureArtifactsDir, preflightCredentials } from './lib/playwright-smoke';
 
@@ -186,11 +191,6 @@ async function run() {
   }
 
   const baseUrl = (process.env.PW_BASE_URL?.trim() || DEFAULT_BASE_URL).replace(/\/$/, '');
-  const assessmentDocumentId =
-    process.env.PW_ASSESSMENT_DOCUMENT_ID?.trim() || process.env.ASSESSMENT_DOCUMENT_ID?.trim();
-  if (!assessmentDocumentId) {
-    throw new Error('PW_ASSESSMENT_DOCUMENT_ID is required so the smoke can generate a deterministic PDF.');
-  }
 
   const credentials = preflightCredentials([
     {
@@ -205,107 +205,139 @@ async function run() {
     throw authError ?? new Error('Could not authenticate PDF visual smoke user.');
   }
 
-  const generateResponse = await fetch(`${baseUrl}/api/assessment-plan-pdf`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${authData.session.access_token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ assessment_document_id: assessmentDocumentId }),
-  });
-  if (!generateResponse.ok) {
-    throw new Error(`PDF generation failed with status ${generateResponse.status}: ${await generateResponse.text()}`);
-  }
-  const generated = (await generateResponse.json()) as GeneratePdfResponse;
-  const overflowKeys = generated.overflow_keys ?? generated.layout_warnings?.map((warning) => warning.placeholder_key) ?? [];
-  if (overflowKeys.length > 0) {
-    throw new Error(`PDF renderer reported layout overflow: ${overflowKeys.join(', ')}`);
-  }
-
-  const latestDir = ensureArtifactsDir();
-  const outputDir = path.join(latestDir, `assessment-pdf-smoke-${Date.now()}`);
-  mkdirSync(outputDir, { recursive: true });
-
-  const generatedPdfResponse = await fetch(generated.signed_url);
-  if (!generatedPdfResponse.ok) {
-    throw new Error(`Could not download generated PDF: ${generatedPdfResponse.status}`);
-  }
-  const generatedPdfPath = path.join(outputDir, 'generated-caloptima.pdf');
-  writeFileSync(generatedPdfPath, Buffer.from(await generatedPdfResponse.arrayBuffer()));
-
-  const templatePath = path.resolve(process.cwd(), 'CalOptima Health FBA Template (2).pdf');
-  const renderMap = JSON.parse(readFileSync(path.resolve(process.cwd(), 'docs/fill_docs/caloptima_fba_pdf_render_map.json'), 'utf8')) as {
-    entries: RenderMapEntry[];
-  };
-  const expectedFilledPages = new Set(generated.filled_pages ?? []);
-  if (expectedFilledPages.size === 0) {
-    throw new Error('PDF visual smoke expected at least one filled page from the generation response.');
-  }
-  const pages = Array.from(new Set(renderMap.entries.map((entry) => entry.fallback.page))).sort((left, right) => left - right);
-  if (!pages.includes(2)) {
-    throw new Error('CalOptima PDF visual smoke requires page 2 coverage.');
-  }
-
-  const browser = await chromium.launch({ headless: false });
-  const page = await browser.newPage();
-  const templateDataUrl = dataUrlForFile(templatePath, 'application/pdf');
-  const generatedDataUrl = dataUrlForFile(generatedPdfPath, 'application/pdf');
-  const reportPages: PageReport[] = [];
-
+  let assessmentResolution: PdfSmokeAssessmentResolution | null = null;
   try {
-    for (const pageNumber of pages) {
-      const blankScreenshot = path.join(outputDir, `blank-page-${pageNumber}.png`);
-      const generatedScreenshot = path.join(outputDir, `generated-page-${pageNumber}.png`);
-      const diffPath = path.join(outputDir, `diff-page-${pageNumber}.png`);
-      await renderPdfPageScreenshot(page, templateDataUrl, pageNumber, blankScreenshot);
-      await renderPdfPageScreenshot(page, generatedDataUrl, pageNumber, generatedScreenshot);
-      const pageEntries = renderMap.entries.filter((entry) => entry.fallback.page === pageNumber);
-      const comparison = await compareScreenshots(page, blankScreenshot, generatedScreenshot, pageEntries, diffPath);
-      writeFileSync(diffPath, Buffer.from(comparison.diffDataUrl.split(',')[1] ?? '', 'base64'));
-      reportPages.push({
-        page: pageNumber,
-        changedPixels: comparison.changedPixels,
-        outsideAllowedPixels: comparison.outsideAllowedPixels,
-        screenshot: generatedScreenshot,
-        diff: diffPath,
-      });
+    assessmentResolution = await resolveAssessmentDocumentForPdfSmoke({
+      baseUrl,
+      supabaseUrl: resolveSupabaseUrl(),
+      supabaseAnonKey: resolveSupabaseAnonKey(),
+      accessToken: authData.session.access_token,
+      preferredAssessmentDocumentId:
+        process.env.PW_ASSESSMENT_DOCUMENT_ID?.trim() || process.env.ASSESSMENT_DOCUMENT_ID?.trim(),
+      provisionClientId: process.env.PW_ASSESSMENT_CLIENT_ID?.trim(),
+      sampleFilePath: process.env.PW_ASSESSMENT_SAMPLE_FILE?.trim(),
+    });
+    const assessmentDocumentId = assessmentResolution.assessmentDocumentId;
+
+    const generateResponse = await fetch(`${baseUrl}/api/assessment-plan-pdf`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${authData.session.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ assessment_document_id: assessmentDocumentId }),
+    });
+    if (!generateResponse.ok) {
+      throw new Error(`PDF generation failed with status ${generateResponse.status}: ${await generateResponse.text()}`);
+    }
+    const generated = (await generateResponse.json()) as GeneratePdfResponse;
+    if (assessmentResolution.cleanupTarget) {
+      assessmentResolution.cleanupGeneratedPdf = {
+        bucketId: 'client-documents',
+        objectPath: generated.object_path,
+      };
+    }
+    const overflowKeys = generated.overflow_keys ?? generated.layout_warnings?.map((warning) => warning.placeholder_key) ?? [];
+    if (overflowKeys.length > 0) {
+      throw new Error(`PDF renderer reported layout overflow: ${overflowKeys.join(', ')}`);
+    }
+
+    const latestDir = ensureArtifactsDir();
+    const outputDir = path.join(latestDir, `assessment-pdf-smoke-${Date.now()}`);
+    mkdirSync(outputDir, { recursive: true });
+
+    const generatedPdfResponse = await fetch(generated.signed_url);
+    if (!generatedPdfResponse.ok) {
+      throw new Error(`Could not download generated PDF: ${generatedPdfResponse.status}`);
+    }
+    const generatedPdfPath = path.join(outputDir, 'generated-caloptima.pdf');
+    writeFileSync(generatedPdfPath, Buffer.from(await generatedPdfResponse.arrayBuffer()));
+
+    const templatePath = path.resolve(process.cwd(), 'CalOptima Health FBA Template (2).pdf');
+    const renderMap = JSON.parse(readFileSync(path.resolve(process.cwd(), 'docs/fill_docs/caloptima_fba_pdf_render_map.json'), 'utf8')) as {
+      entries: RenderMapEntry[];
+    };
+    const expectedFilledPages = new Set(generated.filled_pages ?? []);
+    if (expectedFilledPages.size === 0) {
+      throw new Error('PDF visual smoke expected at least one filled page from the generation response.');
+    }
+    const pages = Array.from(new Set(renderMap.entries.map((entry) => entry.fallback.page))).sort((left, right) => left - right);
+    if (!pages.includes(2)) {
+      throw new Error('CalOptima PDF visual smoke requires page 2 coverage.');
+    }
+
+    const browser = await chromium.launch({ headless: false });
+    const page = await browser.newPage();
+    const templateDataUrl = dataUrlForFile(templatePath, 'application/pdf');
+    const generatedDataUrl = dataUrlForFile(generatedPdfPath, 'application/pdf');
+    const reportPages: PageReport[] = [];
+
+    try {
+      for (const pageNumber of pages) {
+        const blankScreenshot = path.join(outputDir, `blank-page-${pageNumber}.png`);
+        const generatedScreenshot = path.join(outputDir, `generated-page-${pageNumber}.png`);
+        const diffPath = path.join(outputDir, `diff-page-${pageNumber}.png`);
+        await renderPdfPageScreenshot(page, templateDataUrl, pageNumber, blankScreenshot);
+        await renderPdfPageScreenshot(page, generatedDataUrl, pageNumber, generatedScreenshot);
+        const pageEntries = renderMap.entries.filter((entry) => entry.fallback.page === pageNumber);
+        const comparison = await compareScreenshots(page, blankScreenshot, generatedScreenshot, pageEntries, diffPath);
+        writeFileSync(diffPath, Buffer.from(comparison.diffDataUrl.split(',')[1] ?? '', 'base64'));
+        reportPages.push({
+          page: pageNumber,
+          changedPixels: comparison.changedPixels,
+          outsideAllowedPixels: comparison.outsideAllowedPixels,
+          screenshot: generatedScreenshot,
+          diff: diffPath,
+        });
+      }
+    } finally {
+      await browser.close();
+    }
+
+    const failingPages = reportPages.filter((entry) => entry.outsideAllowedPixels > OUTSIDE_ALLOWED_PIXEL_TOLERANCE);
+    const totalChangedPixels = reportPages.reduce((sum, entry) => sum + entry.changedPixels, 0);
+    const missingFilledPages = reportPages.filter(
+      (entry) => expectedFilledPages.has(entry.page) && entry.changedPixels < MIN_CHANGED_PIXELS_PER_FILLED_PAGE,
+    );
+    const report = {
+      ok: failingPages.length === 0 && missingFilledPages.length === 0 && totalChangedPixels > 0,
+      assessmentDocumentId,
+      assessmentSource: assessmentResolution.source,
+      fillMode: generated.fill_mode,
+      objectPath: generated.object_path,
+      outputDir,
+      outsideAllowedPixelTolerance: OUTSIDE_ALLOWED_PIXEL_TOLERANCE,
+      minChangedPixelsPerFilledPage: MIN_CHANGED_PIXELS_PER_FILLED_PAGE,
+      totalChangedPixels,
+      expectedFilledPages: Array.from(expectedFilledPages).sort((left, right) => left - right),
+      pages: reportPages,
+    };
+    const reportPath = path.join(outputDir, 'report.json');
+    writeFileSync(reportPath, JSON.stringify(report, null, 2));
+    console.log(JSON.stringify(report, null, 2));
+    if (totalChangedPixels === 0) {
+      throw new Error(`PDF visual smoke could not detect rendered PDF changes. Report: ${reportPath}`);
+    }
+    if (missingFilledPages.length > 0) {
+      throw new Error(
+        `PDF visual smoke found mapped pages with non-empty fields but no rendered evidence: ${missingFilledPages
+          .map((entry) => entry.page)
+          .join(', ')}. Report: ${reportPath}`,
+      );
+    }
+    if (failingPages.length > 0) {
+      throw new Error(`PDF visual smoke found changed pixels outside mapped boxes. Report: ${reportPath}`);
     }
   } finally {
-    await browser.close();
-  }
-
-  const failingPages = reportPages.filter((entry) => entry.outsideAllowedPixels > OUTSIDE_ALLOWED_PIXEL_TOLERANCE);
-  const totalChangedPixels = reportPages.reduce((sum, entry) => sum + entry.changedPixels, 0);
-  const missingFilledPages = reportPages.filter(
-    (entry) => expectedFilledPages.has(entry.page) && entry.changedPixels < MIN_CHANGED_PIXELS_PER_FILLED_PAGE,
-  );
-  const report = {
-    ok: failingPages.length === 0 && missingFilledPages.length === 0 && totalChangedPixels > 0,
-    assessmentDocumentId,
-    fillMode: generated.fill_mode,
-    objectPath: generated.object_path,
-    outputDir,
-    outsideAllowedPixelTolerance: OUTSIDE_ALLOWED_PIXEL_TOLERANCE,
-    minChangedPixelsPerFilledPage: MIN_CHANGED_PIXELS_PER_FILLED_PAGE,
-    totalChangedPixels,
-    expectedFilledPages: Array.from(expectedFilledPages).sort((left, right) => left - right),
-    pages: reportPages,
-  };
-  const reportPath = path.join(outputDir, 'report.json');
-  writeFileSync(reportPath, JSON.stringify(report, null, 2));
-  console.log(JSON.stringify(report, null, 2));
-  if (totalChangedPixels === 0) {
-    throw new Error(`PDF visual smoke could not detect rendered PDF changes. Report: ${reportPath}`);
-  }
-  if (missingFilledPages.length > 0) {
-    throw new Error(
-      `PDF visual smoke found mapped pages with non-empty fields but no rendered evidence: ${missingFilledPages
-        .map((entry) => entry.page)
-        .join(', ')}. Report: ${reportPath}`,
-    );
-  }
-  if (failingPages.length > 0) {
-    throw new Error(`PDF visual smoke found changed pixels outside mapped boxes. Report: ${reportPath}`);
+    if (assessmentResolution?.cleanupTarget) {
+      await cleanupProvisionedAssessmentPdfSmokeArtifacts({
+        baseUrl,
+        supabaseUrl: resolveSupabaseUrl(),
+        supabaseAnonKey: resolveSupabaseAnonKey(),
+        accessToken: authData.session.access_token,
+        resolution: assessmentResolution,
+      });
+    }
   }
 }
 

--- a/src/components/__tests__/SessionNotesTab.test.tsx
+++ b/src/components/__tests__/SessionNotesTab.test.tsx
@@ -188,15 +188,22 @@ describe('SessionNotesTab — goal notes display', () => {
 
     renderWithProviders(<SessionNotesTab client={CLIENT} />, AUTH_OPTS);
 
-    // Goal labels should be rendered as interactive buttons.
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /eye contact goal/i }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', { name: /following instructions/i }),
-      ).toBeInTheDocument();
-    });
+    // Under the full coverage run, this render can settle later than the default
+    // waitFor budget even though the final UI is correct.
+    expect(
+      await screen.findByRole(
+        'button',
+        { name: /eye contact goal/i },
+        { timeout: 5000 },
+      ),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole(
+        'button',
+        { name: /following instructions/i },
+        { timeout: 5000 },
+      ),
+    ).toBeInTheDocument();
 
     // Note text must be hidden in the collapsed state.
     expect(

--- a/src/scripts/__tests__/assessment-pdf-smoke-document.test.ts
+++ b/src/scripts/__tests__/assessment-pdf-smoke-document.test.ts
@@ -23,6 +23,7 @@ describe("assessment pdf smoke document readiness", () => {
               required: true,
               status: "approved",
               value_text: "Redacted Client",
+              value_json: null,
             },
           ],
           structured_sections: [
@@ -77,6 +78,7 @@ describe("assessment pdf smoke document readiness", () => {
               required: true,
               status: "drafted",
               value_text: "Redacted Client",
+              value_json: null,
             },
           ],
           structured_sections: [
@@ -149,6 +151,96 @@ describe("assessment pdf smoke document readiness", () => {
     ).toEqual({
       ready: false,
       reasons: ["template_type_not_caloptima"],
+    });
+  });
+
+  it("rejects approved required checklist rows when text and json values are empty", () => {
+    expect(
+      evaluatePdfSmokeAssessmentReadiness({
+        document: {
+          id: "doc-1",
+          client_id: "client-1",
+          file_name: "fixture.pdf",
+          object_path: "clients/client-1/assessments/fixture.pdf",
+          status: "extracted",
+          template_type: "caloptima_fba",
+        },
+        checklist: {
+          items: [
+            {
+              id: "item-1",
+              label: "Chief Complaint",
+              placeholder_key: "CALOPTIMA_FBA_CHIEF_COMPLAINT",
+              required: true,
+              status: "approved",
+              value_text: "   ",
+              value_json: {},
+            },
+          ],
+          structured_sections: [],
+        },
+        drafts: {
+          programs: [{ id: "program-1", name: "Program", description: null, accept_state: "accepted" }],
+          goals: [
+            {
+              id: "goal-1",
+              title: "Goal",
+              description: "Goal description",
+              original_text: "Goal description",
+              goal_type: "child",
+              accept_state: "accepted",
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      ready: false,
+      reasons: ["required_checklist_value_missing"],
+    });
+  });
+
+  it("accepts approved required checklist rows backed by structured json values", () => {
+    expect(
+      evaluatePdfSmokeAssessmentReadiness({
+        document: {
+          id: "doc-1",
+          client_id: "client-1",
+          file_name: "fixture.pdf",
+          object_path: "clients/client-1/assessments/fixture.pdf",
+          status: "extracted",
+          template_type: "caloptima_fba",
+        },
+        checklist: {
+          items: [
+            {
+              id: "item-1",
+              label: "Prior ABA",
+              placeholder_key: "CALOPTIMA_FBA_PRIOR_ABA_AGENCIES",
+              required: true,
+              status: "approved",
+              value_text: null,
+              value_json: { provider: "Prior provider" },
+            },
+          ],
+          structured_sections: [],
+        },
+        drafts: {
+          programs: [{ id: "program-1", name: "Program", description: null, accept_state: "accepted" }],
+          goals: [
+            {
+              id: "goal-1",
+              title: "Goal",
+              description: "Goal description",
+              original_text: "Goal description",
+              goal_type: "child",
+              accept_state: "accepted",
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      ready: true,
+      reasons: [],
     });
   });
 });

--- a/src/scripts/__tests__/assessment-pdf-smoke-document.test.ts
+++ b/src/scripts/__tests__/assessment-pdf-smoke-document.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluatePdfSmokeAssessmentReadiness } from "../../../scripts/lib/assessment-pdf-smoke-document";
+
+describe("assessment pdf smoke document readiness", () => {
+  it("accepts an extracted CalOptima assessment with approved required rows and accepted drafts", () => {
+    expect(
+      evaluatePdfSmokeAssessmentReadiness({
+        document: {
+          id: "doc-1",
+          client_id: "client-1",
+          file_name: "fixture.pdf",
+          object_path: "clients/client-1/assessments/fixture.pdf",
+          status: "extracted",
+          template_type: "caloptima_fba",
+        },
+        checklist: {
+          items: [
+            {
+              id: "item-1",
+              label: "Member Name",
+              placeholder_key: "MEMBER_NAME",
+              required: true,
+              status: "approved",
+              value_text: "Redacted Client",
+            },
+          ],
+          structured_sections: [
+            {
+              id: "section-1",
+              field_key: "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+              section_key: "goals",
+              section_index: 0,
+              payload: { goal_type: "child" },
+              required: true,
+              status: "approved",
+            },
+          ],
+        },
+        drafts: {
+          programs: [{ id: "program-1", name: "Program", description: null, accept_state: "accepted" }],
+          goals: [
+            {
+              id: "goal-1",
+              title: "Goal",
+              description: "Goal description",
+              original_text: "Goal description",
+              goal_type: "child",
+              accept_state: "accepted",
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      ready: true,
+      reasons: [],
+    });
+  });
+
+  it("reports pending required rows and missing accepted drafts", () => {
+    expect(
+      evaluatePdfSmokeAssessmentReadiness({
+        document: {
+          id: "doc-1",
+          client_id: "client-1",
+          file_name: "fixture.pdf",
+          object_path: "clients/client-1/assessments/fixture.pdf",
+          status: "extracting",
+          template_type: "caloptima_fba",
+        },
+        checklist: {
+          items: [
+            {
+              id: "item-1",
+              label: "Member Name",
+              placeholder_key: "MEMBER_NAME",
+              required: true,
+              status: "drafted",
+              value_text: "Redacted Client",
+            },
+          ],
+          structured_sections: [
+            {
+              id: "section-1",
+              field_key: "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+              section_key: "goals",
+              section_index: 0,
+              payload: { goal_type: "child" },
+              required: true,
+              status: "not_started",
+            },
+          ],
+        },
+        drafts: {
+          programs: [{ id: "program-1", name: "Program", description: null, accept_state: "pending" }],
+          goals: [
+            {
+              id: "goal-1",
+              title: "Goal",
+              description: "Goal description",
+              original_text: "Goal description",
+              goal_type: "child",
+              accept_state: "pending",
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      ready: false,
+      reasons: [
+        "document_status_extracting",
+        "required_checklist_pending",
+        "required_structured_sections_pending",
+        "accepted_program_missing",
+        "accepted_goal_missing",
+      ],
+    });
+  });
+
+  it("rejects non-CalOptima templates even when the rest of the fixture looks ready", () => {
+    expect(
+      evaluatePdfSmokeAssessmentReadiness({
+        document: {
+          id: "doc-1",
+          client_id: "client-1",
+          file_name: "fixture.pdf",
+          object_path: "clients/client-1/assessments/fixture.pdf",
+          status: "approved",
+          template_type: "iehp_fba",
+        },
+        checklist: {
+          items: [],
+          structured_sections: [],
+        },
+        drafts: {
+          programs: [{ id: "program-1", name: "Program", description: null, accept_state: "edited" }],
+          goals: [
+            {
+              id: "goal-1",
+              title: "Goal",
+              description: "Goal description",
+              original_text: "Goal description",
+              goal_type: "child",
+              accept_state: "edited",
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      ready: false,
+      reasons: ["template_type_not_caloptima"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Harden `npm run playwright:assessment-pdf-smoke` so it can resolve a ready CalOptima assessment automatically, use `PW_ASSESSMENT_DOCUMENT_ID` as an override, or provision and clean up a temporary fixture for a dedicated smoke client.
- Add focused readiness coverage for the PDF smoke assessment resolver.
- Document the updated smoke requirements and include the Session Notes async assertion hardening that clears the prior `SessionNotesTab.test.tsx` full-suite failure.

## Linear

- WIN-147

## Verification

- `npx vitest run src/scripts/__tests__/assessment-pdf-smoke-document.test.ts src/components/__tests__/SessionNotesTab.test.tsx --reporter=verbose`
- `git diff --check`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Known blockers

- `npm run test:ci` now clears `src/components/__tests__/SessionNotesTab.test.tsx`, but still exits non-zero outside this PR scope in `src/pages/__tests__/Schedule.test.tsx` and later hits `coverage/.tmp/coverage-0.json` ENOENT during coverage processing.
- Local policy checks skip DB-backed grant/preview drift checks because `SUPABASE_DB_URL` or `DATABASE_URL` is not configured.