### PR TITLE
Prefer .env.local for Playwright env loading

### DIFF
--- a/scripts/lib/load-playwright-env.ts
+++ b/scripts/lib/load-playwright-env.ts
@@ -5,8 +5,8 @@ import path from 'node:path';
 export const loadPlaywrightEnv = (): void => {
   const explicitEnvFile = process.env.PLAYWRIGHT_ENV_FILE?.trim();
   const candidates = explicitEnvFile
-    ? [explicitEnvFile, '.env', '.env.local', '.env.codex']
-    : ['.env', '.env.local', '.env.codex'];
+    ? [explicitEnvFile, '.env.local', '.env.codex', '.env']
+    : ['.env.local', '.env.codex', '.env'];
 
   const loaded = new Set<string>();
   for (const candidate of candidates) {


### PR DESCRIPTION
## Summary
- make Playwright env loading prefer .env.local over .env
- keep PLAYWRIGHT_ENV_FILE as the highest-priority explicit override
- preserve fallback loading from .env.codex and .env

## Verification
- focused tsx precedence check for loadPlaywrightEnv
- npm run lint
- npm run typecheck
- npm run build
- ci:check-focused ran from git commit hook and passed with expected environment-based skips