### PR TITLE
Preserve .env fallback ahead of .env.codex

### DIFF
--- a/scripts/lib/load-playwright-env.ts
+++ b/scripts/lib/load-playwright-env.ts
@@ -5,8 +5,8 @@ import path from 'node:path';
 export const loadPlaywrightEnv = (): void => {
   const explicitEnvFile = process.env.PLAYWRIGHT_ENV_FILE?.trim();
   const candidates = explicitEnvFile
-    ? [explicitEnvFile, '.env.local', '.env.codex', '.env']
-    : ['.env.local', '.env.codex', '.env'];
+    ? [explicitEnvFile, '.env.local', '.env', '.env.codex']
+    : ['.env.local', '.env', '.env.codex'];
 
   const loaded = new Set<string>();
   for (const candidate of candidates) {


### PR DESCRIPTION
## Summary
- keep .env.local as the highest-priority default env file for Playwright
- preserve the previous fallback relationship where .env stays ahead of .env.codex
- avoid the regression where .env.codex could silently override .env

## Verification
- focused tsx precedence check: .env.local beats fallback files
- focused tsx precedence check: .env beats .env.codex in fallback order
- npm run lint
- npm run typecheck
- npm run build