### PR TITLE
Document Playwright env loading precedence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,10 +91,11 @@ SLACK_ALERTS_CHANNEL=#deployments
 # Playwright therapist authorization smoke (no secrets here)
 # Deterministic reliability contract:
 # - `npm run playwright:preflight` requires all vars below (non-placeholder values).
-# - Loader order defaults to `.env` -> `.env.local` -> `.env.codex`.
+# - Loader order defaults to `.env.local` -> `.env` -> `.env.codex`.
 # - Set `PLAYWRIGHT_ENV_FILE` to pin one file first, then fallback order applies.
 # Provide account identifiers in plaintext; keep passwords in your secret store.
 # ---------------------------------------------------------------------------
+# Leave blank to use the Playwright script default (`https://app.allincompassing.ai`).
 PW_BASE_URL=
 PW_THERAPIST_EMAIL=therapist.playwright+preview@example.com
 PW_THERAPIST_PASSWORD=****
@@ -131,5 +132,5 @@ APP_ENV=development
 DASHBOARD_ALLOW_DEFAULT_ORG_FALLBACK=false
 
 # Optional override for Playwright script env loading order.
-# If set, this file is loaded first, followed by `.env`, `.env.local`, `.env.codex`.
+# If set, this file is loaded first, followed by `.env.local`, `.env`, `.env.codex`.
 # PLAYWRIGHT_ENV_FILE=.env

--- a/.env.example
+++ b/.env.example
@@ -95,7 +95,7 @@ SLACK_ALERTS_CHANNEL=#deployments
 # - Set `PLAYWRIGHT_ENV_FILE` to pin one file first, then fallback order applies.
 # Provide account identifiers in plaintext; keep passwords in your secret store.
 # ---------------------------------------------------------------------------
-PW_BASE_URL=https://app.allincompassing.ai
+PW_BASE_URL=
 PW_THERAPIST_EMAIL=therapist.playwright+preview@example.com
 PW_THERAPIST_PASSWORD=****
 # Optional explicit actor for schedule-conflict smoke. If omitted, script tries

--- a/docs/ENVIRONMENT_MATRIX.md
+++ b/docs/ENVIRONMENT_MATRIX.md
@@ -4,7 +4,7 @@ The matrix below summarizes how we manage credentials, deployments, and rollback
 
 | Environment | Git Branch | Hosting Surface | Supabase Project | Auth Keys | Smoke Tests |
 |-------------|------------|-----------------|------------------|-----------|-------------|
-| Local       | feature/*  | Vite dev server | Hosted project `wnnjeqheqxxyrgsjmygy` (single clinic) | `.env` (preferred for Playwright scripts) or `.env.local` from 1Password (anon + service role + DEFAULT_ORGANIZATION_ID); validate Playwright contract with `npm run playwright:preflight` | `npm run test` with `RUN_DB_IT=1` |
+| Local       | feature/*  | Vite dev server | Hosted project `wnnjeqheqxxyrgsjmygy` (single clinic) | `.env.local` from 1Password is preferred for Playwright scripts, with `.env` as fallback (anon + service role + DEFAULT_ORGANIZATION_ID); validate Playwright contract with `npm run playwright:preflight` | `npm run test` with `RUN_DB_IT=1` |
 | Preview     | Pull request | Netlify deploy previews | Same hosted project (request-scoped clients + tenant safety tooling) | GitHub Actions secrets (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `DEFAULT_ORGANIZATION_ID`) | `npm run preview:smoke` against the deploy preview URL |
 | Staging     | `develop`  | Netlify staging context | Same hosted project (single-tenant) | Netlify staging env vars synced from 1Password | GitHub Actions staging smoke (`preview:smoke:remote`) |
 | Production  | `main`     | Netlify production | Same hosted project | Netlify production env vars | Manual post-deploy checks + monitoring |

--- a/scripts/lib/load-playwright-env.ts
+++ b/scripts/lib/load-playwright-env.ts
@@ -2,6 +2,8 @@ import { config as loadEnv } from 'dotenv';
 import fs from 'node:fs';
 import path from 'node:path';
 
+export const DEFAULT_PLAYWRIGHT_BASE_URL = 'https://app.allincompassing.ai';
+
 export const loadPlaywrightEnv = (): void => {
   const explicitEnvFile = process.env.PLAYWRIGHT_ENV_FILE?.trim();
   const candidates = explicitEnvFile
@@ -31,3 +33,6 @@ export const loadPlaywrightEnv = (): void => {
     }
   }
 };
+
+export const resolvePlaywrightBaseUrl = (): string =>
+  process.env.PW_BASE_URL?.trim() || DEFAULT_PLAYWRIGHT_BASE_URL;

--- a/scripts/playwright-auth-smoke.ts
+++ b/scripts/playwright-auth-smoke.ts
@@ -1,6 +1,6 @@
 import { chromium } from 'playwright';
 
-import { loadPlaywrightEnv } from './lib/load-playwright-env';
+import { loadPlaywrightEnv, resolvePlaywrightBaseUrl } from './lib/load-playwright-env';
 import {
   assertRouteAccessible,
   captureFailureScreenshot,
@@ -15,7 +15,7 @@ async function run() {
   const context = await browser.newContext();
   const page = await context.newPage();
 
-  const base = process.env.PW_BASE_URL ?? 'https://app.allincompassing.ai';
+  const base = resolvePlaywrightBaseUrl();
   const credentials = preflightCredentials([
     {
       email: process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL,

--- a/scripts/playwright-authorizations-read-scope-smoke.ts
+++ b/scripts/playwright-authorizations-read-scope-smoke.ts
@@ -6,7 +6,7 @@
  */
 import { chromium } from "playwright";
 
-import { loadPlaywrightEnv } from "./lib/load-playwright-env";
+import { loadPlaywrightEnv, resolvePlaywrightBaseUrl } from "./lib/load-playwright-env";
 import { loginAndAssertSession, preflightCredentials } from "./lib/playwright-smoke";
 
 type CountPayload = { persona: string; url: string; authorizationsRows: number; restStatus?: number };
@@ -58,7 +58,7 @@ const countAuthorizationsFromPage = async (
 async function run(): Promise<void> {
   loadPlaywrightEnv();
   const headless = process.env.HEADLESS !== "false";
-  const baseUrl = process.env.PW_BASE_URL ?? "https://app.allincompassing.ai";
+  const baseUrl = resolvePlaywrightBaseUrl();
 
   const therapistCreds = preflightCredentials([
     {

--- a/scripts/playwright-client-routes-audit.ts
+++ b/scripts/playwright-client-routes-audit.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { chromium, type Page } from 'playwright';
 
-import { loadPlaywrightEnv } from './lib/load-playwright-env';
+import { loadPlaywrightEnv, resolvePlaywrightBaseUrl } from './lib/load-playwright-env';
 
 type RouteStatus = 'passed' | 'failed' | 'skipped' | 'blocked';
 
@@ -321,7 +321,7 @@ const runRouteChecks = async (
 async function run(): Promise<void> {
   loadPlaywrightEnv();
 
-  const baseUrl = process.env.PW_BASE_URL ?? 'https://app.allincompassing.ai';
+  const baseUrl = resolvePlaywrightBaseUrl();
   const { email, password } = resolveAuthEnv();
   const timestamp = new Date().toISOString();
   const safeTimestamp = timestamp.replace(/[:.]/g, '-');

--- a/scripts/playwright-mobile-logout-visibility.ts
+++ b/scripts/playwright-mobile-logout-visibility.ts
@@ -1,12 +1,12 @@
 import { chromium, devices } from "playwright";
 
-import { loadPlaywrightEnv } from "./lib/load-playwright-env";
+import { loadPlaywrightEnv, resolvePlaywrightBaseUrl } from "./lib/load-playwright-env";
 import { captureFailureScreenshot, loginAndAssertSession, preflightCredentials } from "./lib/playwright-smoke";
 
 async function run(): Promise<void> {
   loadPlaywrightEnv();
 
-  const baseUrl = process.env.PW_BASE_URL ?? "https://app.allincompassing.ai";
+  const baseUrl = resolvePlaywrightBaseUrl();
   const credentials = preflightCredentials([
     {
       email: process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL,

--- a/scripts/playwright-mobile-role-smoke.ts
+++ b/scripts/playwright-mobile-role-smoke.ts
@@ -1,6 +1,6 @@
 import { chromium, devices } from 'playwright';
 
-import { loadPlaywrightEnv } from './lib/load-playwright-env';
+import { loadPlaywrightEnv, resolvePlaywrightBaseUrl } from './lib/load-playwright-env';
 
 const login = async (page: import('playwright').Page, baseUrl: string, email: string, password: string) => {
   await page.goto(`${baseUrl}/login`, { waitUntil: 'domcontentloaded' });
@@ -17,7 +17,7 @@ const login = async (page: import('playwright').Page, baseUrl: string, email: st
 async function run(): Promise<void> {
   loadPlaywrightEnv();
 
-  const baseUrl = process.env.PW_BASE_URL ?? 'https://app.allincompassing.ai';
+  const baseUrl = resolvePlaywrightBaseUrl();
   const adminEmail = process.env.PW_ADMIN_EMAIL ?? process.env.PW_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL;
   const adminPassword =
     process.env.PW_ADMIN_PASSWORD ?? process.env.PW_PASSWORD ?? process.env.PLAYWRIGHT_ADMIN_PASSWORD;

--- a/scripts/playwright-therapist-authorization.ts
+++ b/scripts/playwright-therapist-authorization.ts
@@ -2,7 +2,7 @@ import { chromium } from 'playwright';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { loadPlaywrightEnv } from './lib/load-playwright-env';
+import { loadPlaywrightEnv, resolvePlaywrightBaseUrl } from './lib/load-playwright-env';
 import {
   assertUuid,
   captureFailureScreenshot,
@@ -89,7 +89,7 @@ async function run(): Promise<void> {
   ensureDir(latestDir);
 
   const headless = process.env.HEADLESS !== 'false';
-  const baseUrl = process.env.PW_BASE_URL ?? 'https://app.allincompassing.ai';
+  const baseUrl = resolvePlaywrightBaseUrl();
   const credentials = preflightCredentials([
     {
       email: process.env.PW_THERAPIST_EMAIL ?? process.env.PLAYWRIGHT_THERAPIST_EMAIL,

--- a/scripts/playwright-therapist-onboarding.ts
+++ b/scripts/playwright-therapist-onboarding.ts
@@ -2,7 +2,7 @@ import { chromium } from 'playwright';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { loadPlaywrightEnv } from './lib/load-playwright-env';
+import { loadPlaywrightEnv, resolvePlaywrightBaseUrl } from './lib/load-playwright-env';
 import {
   assertRouteAccessible,
   captureFailureScreenshot,
@@ -33,7 +33,7 @@ async function run(): Promise<void> {
   ensureDir(latestDir);
 
   const headless = process.env.HEADLESS !== 'false';
-  const baseUrl = process.env.PW_BASE_URL ?? 'https://app.allincompassing.ai';
+  const baseUrl = resolvePlaywrightBaseUrl();
   const credentialCandidates = [
     {
       email: process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL,
@@ -222,5 +222,4 @@ run().catch((error) => {
   );
   process.exit(1);
 });
-
 


### PR DESCRIPTION
## Summary
- update .env.example to document the current Playwright env loader order
- clarify that blank PW_BASE_URL falls back to the default app URL
- update the environment matrix so local Playwright guidance prefers .env.local with .env as fallback

## Included files
- .env.example
- docs/ENVIRONMENT_MATRIX.md

## Verification
- manually verified .env.example comments now match scripts/lib/load-playwright-env.ts
- manually verified docs/ENVIRONMENT_MATRIX.md matches the loader precedence
- ci:check-focused passed via commit hook