### PR TITLE
Fix assessment draft and publish truncation for extracted programs and goals

### DIFF
--- a/docs/ai/assessment-draft-publish-truncation-handoff-2026-05-15.md
+++ b/docs/ai/assessment-draft-publish-truncation-handoff-2026-05-15.md
@@ -1,0 +1,48 @@
+# Assessment Draft / Publish Truncation Handoff
+
+Issue: `WIN-148`
+Branch: `codex/fix-assessment-program-goal-truncation`
+Route-task: `classification=high-risk human-reviewed`, `lane=critical`
+
+## Scope
+
+- Removed artificial `20` child / `6` parent goal gates from:
+  - deterministic/manual draft creation
+  - draft promotion to live Programs/Goals
+  - Programs/Goals UI readiness and disabled-state messaging
+- Removed AI generation schema/prompt caps that truncated larger extracted sets.
+- Updated the assessment upload/promote Playwright smoke harness to expect an above-cap synthetic fixture.
+- Added regression coverage for:
+  - smaller valid draft/promotion sets
+  - deterministic persistence of more than `20` goals / more than `6` programs
+  - AI parser acceptance of above-cap outputs
+
+## Non-goals
+
+- No auth, routing, or session-flow behavior changes.
+- No schema, RLS, grants, RPC exposure, or migration changes.
+- No deploy or Netlify config changes.
+
+## Verification
+
+- Passed:
+  - `npx vitest run src/server/__tests__/assessmentDraftsHandler.test.ts src/server/__tests__/assessmentPromoteHandler.test.ts src/components/__tests__/ProgramsGoalsTab.test.tsx`
+  - `deno test --node-modules-dir=auto --allow-env supabase/functions/generate-program-goals/index.test.ts`
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+- Blocked / failed outside this slice:
+  - `npm run test:ci`
+    - unrelated timeout in `tests/vitest.env-isolation.test.ts`
+    - unrelated timeout in `tests/edge/initiate-client-onboarding.utils.test.ts`
+    - one Vitest worker timeout surfaced during the same full-suite run
+  - `npm run playwright:assessment-upload-promote-smoke`
+    - blocked locally because `PW_ASSESSMENT_CLIENT_ID` is not configured
+
+## Residual Risk
+
+- The targeted workflow code is covered, but the full repo test suite is not green because of unrelated timeouts.
+- The dedicated live upload/promote smoke could not be executed locally without the required smoke-client env binding.

--- a/scripts/playwright-assessment-upload-promote-smoke.ts
+++ b/scripts/playwright-assessment-upload-promote-smoke.ts
@@ -117,8 +117,8 @@ type LiveGoal = {
 
 const DEFAULT_BASE_URL = "https://app.allincompassing.ai";
 const EXTRACTION_TIMEOUT_MS = 180_000;
-const MIN_CHILD_GOALS = 20;
-const MIN_PARENT_GOALS = 6;
+const EXPECTED_CHILD_GOALS = 21;
+const EXPECTED_PARENT_GOALS = 7;
 const GOAL_FIELD_KEYS = new Set([
   "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
   "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
@@ -166,7 +166,7 @@ const buildSyntheticAssessmentPdf = async (): Promise<Buffer> => {
     lines.push(`Target Criteria: 80% across 4 consecutive weeks.`);
   }
   lines.push("XV. SKILL ACQUISITION GOALS");
-  for (let index = 1; index <= 10; index += 1) {
+  for (let index = 1; index <= 11; index += 1) {
     lines.push(
       `Skill Acquisition Goal ${index}: By August 2026, the client will complete synthetic adaptive skill ${index} in 80% of opportunities across people and settings.`,
     );
@@ -176,7 +176,7 @@ const buildSyntheticAssessmentPdf = async (): Promise<Buffer> => {
     lines.push(`Target Criteria: 80% across 4 consecutive weeks.`);
   }
   lines.push("XVI. PARENT/CAREGIVER GOALS");
-  for (let index = 1; index <= 6; index += 1) {
+  for (let index = 1; index <= 7; index += 1) {
     lines.push(
       `Parent/Caregiver Goal ${index}: By August 2026, the caregiver will implement synthetic parent training strategy ${index} in 90% of opportunities across 4 consecutive weeks.`,
     );
@@ -367,9 +367,9 @@ const approveChecklistAndStructuredSections = async (args: {
   const parentGoalStructuredSectionCount = goalSections.filter((section) =>
     section.field_key === "CALOPTIMA_FBA_PARENT_GOALS" || section.payload?.goal_type === "parent"
   ).length;
-  if (childGoalStructuredSectionCount < MIN_CHILD_GOALS || parentGoalStructuredSectionCount < MIN_PARENT_GOALS) {
+  if (childGoalStructuredSectionCount < EXPECTED_CHILD_GOALS || parentGoalStructuredSectionCount < EXPECTED_PARENT_GOALS) {
     throw new Error(
-      `Structured goal extraction produced ${childGoalStructuredSectionCount}/${MIN_CHILD_GOALS} child goals and ${parentGoalStructuredSectionCount}/${MIN_PARENT_GOALS} parent goals.`,
+      `Structured goal extraction produced ${childGoalStructuredSectionCount}/${EXPECTED_CHILD_GOALS} child goals and ${parentGoalStructuredSectionCount}/${EXPECTED_PARENT_GOALS} parent goals.`,
     );
   }
 
@@ -431,7 +431,7 @@ const acceptDrafts = async (baseUrl: string, accessToken: string, drafts: DraftR
   if (drafts.programs.length === 0) {
     throw new Error("Deterministic draft generation did not create any draft programs.");
   }
-  if (childCount < MIN_CHILD_GOALS || parentCount < MIN_PARENT_GOALS) {
+  if (childCount < EXPECTED_CHILD_GOALS || parentCount < EXPECTED_PARENT_GOALS) {
     throw new Error(
       `Fixture produced insufficient draft goals for promotion: ${childCount} child / ${parentCount} parent.`,
     );
@@ -739,7 +739,7 @@ async function run() {
     const acceptedParentGoalCount = acceptedDrafts.goals.filter(
       (goal) => goal.accept_state === "accepted" && goal.goal_type === "parent",
     ).length;
-    if (acceptedChildGoalCount < MIN_CHILD_GOALS || acceptedParentGoalCount < MIN_PARENT_GOALS) {
+    if (acceptedChildGoalCount < EXPECTED_CHILD_GOALS || acceptedParentGoalCount < EXPECTED_PARENT_GOALS) {
       throw new Error(
         `Accepted draft goal counts are insufficient: ${acceptedChildGoalCount} child / ${acceptedParentGoalCount} parent.`,
       );
@@ -747,7 +747,7 @@ async function run() {
 
     const promotion = await promoteAssessment(baseUrl, accessToken, createdAssessment.id);
     promotedProgramIds = promotion.created_program_ids;
-    if (promotion.created_program_count < 1 || promotion.created_goal_count < MIN_CHILD_GOALS + MIN_PARENT_GOALS) {
+    if (promotion.created_program_count < 1 || promotion.created_goal_count < EXPECTED_CHILD_GOALS + EXPECTED_PARENT_GOALS) {
       throw new Error(
         `Promotion created insufficient live records: ${promotion.created_program_count} programs / ${promotion.created_goal_count} goals.`,
       );
@@ -764,8 +764,8 @@ async function run() {
     if (liveRecords.programs.length !== promotedProgramIds.length) {
       throw new Error(`Expected ${promotedProgramIds.length} live programs, found ${liveRecords.programs.length}.`);
     }
-    if (liveRecords.goals.length < MIN_CHILD_GOALS + MIN_PARENT_GOALS) {
-      throw new Error(`Expected at least ${MIN_CHILD_GOALS + MIN_PARENT_GOALS} live goals, found ${liveRecords.goals.length}.`);
+    if (liveRecords.goals.length < EXPECTED_CHILD_GOALS + EXPECTED_PARENT_GOALS) {
+      throw new Error(`Expected at least ${EXPECTED_CHILD_GOALS + EXPECTED_PARENT_GOALS} live goals, found ${liveRecords.goals.length}.`);
     }
     promotedGoalIds = liveRecords.goals.map((goal) => goal.id);
     const visiblePair = selectVisibleProgramGoalPair(liveRecords);

--- a/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
+++ b/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
@@ -83,8 +83,6 @@ export const EMPTY_CHECKLIST_RESPONSE: AssessmentChecklistResponse = {
 };
 export const EMPTY_ASSESSMENT_DRAFTS: AssessmentDraftResponse = { programs: [], goals: [] };
 export const ENABLE_CHECKLIST_MAPPING_UI = true;
-export const MIN_CHILD_GOALS = 20;
-export const MIN_PARENT_GOALS = 6;
 
 export const TEMPLATE_LABELS: Record<AssessmentTemplateType, string> = {
   caloptima_fba: "CalOptima FBA",

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -18,8 +18,6 @@ import {
   EMPTY_ASSESSMENT_DRAFTS,
   EMPTY_CHECKLIST_RESPONSE,
   ENABLE_CHECKLIST_MAPPING_UI,
-  MIN_CHILD_GOALS,
-  MIN_PARENT_GOALS,
   formatGoalTimelineCriteria,
   parseApiErrorMessage,
   parseGoalTimelineCriteria,
@@ -544,24 +542,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const extractedChecklistValueCount = checklistItems.filter((item) => item.value_text?.trim()).length;
   const structuredChildGoalCount = structuredSections.filter(isStructuredChildGoalSection).length;
   const structuredParentGoalCount = structuredSections.filter(isStructuredParentGoalSection).length;
-  const approvedStructuredChildGoalCount = structuredSections.filter(
-    (section) => section.status === "approved" && isStructuredChildGoalSection(section),
-  ).length;
-  const approvedStructuredParentGoalCount = structuredSections.filter(
-    (section) => section.status === "approved" && isStructuredParentGoalSection(section),
-  ).length;
-  const hasExtractedStructuredGoalMinimums =
-    structuredChildGoalCount >= MIN_CHILD_GOALS && structuredParentGoalCount >= MIN_PARENT_GOALS;
-  const hasApprovedStructuredGoalMinimums =
-    approvedStructuredChildGoalCount >= MIN_CHILD_GOALS && approvedStructuredParentGoalCount >= MIN_PARENT_GOALS;
-  const acceptedDraftChildGoalCount = (assessmentDrafts?.goals ?? []).filter(
-    (goal) => (goal.accept_state === "accepted" || goal.accept_state === "edited") && goal.goal_type === "child",
-  ).length;
-  const acceptedDraftParentGoalCount = (assessmentDrafts?.goals ?? []).filter(
-    (goal) => (goal.accept_state === "accepted" || goal.accept_state === "edited") && goal.goal_type === "parent",
-  ).length;
-  const hasRequiredAcceptedGoalMix =
-    acceptedDraftChildGoalCount >= MIN_CHILD_GOALS && acceptedDraftParentGoalCount >= MIN_PARENT_GOALS;
   const hasStagedDraftChanges = hasExistingDrafts;
   const hasDraftsButNoLivePrograms = hasExistingDrafts && livePrograms.length === 0;
   const selectedAssessmentReadyForAiGeneration = selectedAssessmentDocument
@@ -574,19 +554,23 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       section.status === "approved" &&
       STRUCTURED_GOAL_FIELD_KEYS.has(section.field_key),
   );
+  const acceptedDraftChildGoalCount = (assessmentDrafts?.goals ?? []).filter(
+    (goal) => (goal.accept_state === "accepted" || goal.accept_state === "edited") && goal.goal_type === "child",
+  ).length;
+  const acceptedDraftParentGoalCount = (assessmentDrafts?.goals ?? []).filter(
+    (goal) => (goal.accept_state === "accepted" || goal.accept_state === "edited") && goal.goal_type === "parent",
+  ).length;
   const canGenerateUploadedAssessmentDraft =
     canQuerySelectedAssessment &&
     selectedAssessmentReadyForAiGeneration &&
     selectedFailedExtractionHasChecklistEvidence &&
     hasApprovedStructuredGoalSections &&
-    hasApprovedStructuredGoalMinimums &&
     !hasExistingDrafts;
   const canPromoteAssessment =
     canQuerySelectedAssessment &&
     !hasPendingRequiredChecklistItems &&
     hasAcceptedDraftProgram &&
-    hasAcceptedDraftGoal &&
-    hasRequiredAcceptedGoalMix;
+    hasAcceptedDraftGoal;
   const unresolvedRequiredCount = ENABLE_CHECKLIST_MAPPING_UI
     ? checklistItems.filter((item) => item.required && item.status !== "approved").length +
       structuredSections.filter((section) => section.required && section.status !== "approved").length
@@ -601,8 +585,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         ? "Accept or edit at least one draft program before publishing."
         : !hasAcceptedDraftGoal
           ? "Accept or edit at least one draft goal before publishing."
-          : !hasRequiredAcceptedGoalMix
-            ? `Accepted draft goals must include at least ${MIN_CHILD_GOALS} child and ${MIN_PARENT_GOALS} parent goals before publishing.`
           : null;
   const uploadedAssessmentGenerateDisabledReason = !canQuerySelectedAssessment
     ? "Select a valid uploaded assessment before creating deterministic drafts."
@@ -614,12 +596,8 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       ? "Extraction failed for this assessment. Retry deterministic draft generation using the extracted checklist evidence, or replace the source document if it needs correction."
     : !selectedAssessmentReadyForAiGeneration
       ? "Wait for extraction to complete before generating drafts."
-    : !hasExtractedStructuredGoalMinimums
-      ? `Adobe extraction found ${structuredChildGoalCount}/${MIN_CHILD_GOALS} child goals and ${structuredParentGoalCount}/${MIN_PARENT_GOALS} parent goals. Upload a richer source document or improve extraction before generating drafts.`
     : !hasApprovedStructuredGoalSections
       ? "Approve at least one structured CalOptima goal section before generating drafts."
-    : !hasApprovedStructuredGoalMinimums
-      ? `Approve at least ${MIN_CHILD_GOALS} child goals and ${MIN_PARENT_GOALS} parent goals before generating drafts.`
       : null;
 
   useEffect(() => {
@@ -1828,10 +1806,10 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                       Checklist values: <span className="font-semibold">{extractedChecklistValueCount}/{checklistItems.length}</span>
                     </div>
                     <div className="rounded border border-gray-200 px-2 py-1 dark:border-gray-700">
-                      Child goals: <span className="font-semibold">{structuredChildGoalCount}/{MIN_CHILD_GOALS}</span>
+                      Child goals: <span className="font-semibold">{structuredChildGoalCount}</span>
                     </div>
                     <div className="rounded border border-gray-200 px-2 py-1 dark:border-gray-700">
-                      Parent goals: <span className="font-semibold">{structuredParentGoalCount}/{MIN_PARENT_GOALS}</span>
+                      Parent goals: <span className="font-semibold">{structuredParentGoalCount}</span>
                     </div>
                   </div>
                 </div>

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1670,13 +1670,9 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(
       await screen.findByText((_content, node) => node?.textContent === "Checklist values: 1/1"),
     ).toBeInTheDocument();
-    expect(screen.getByText((_content, node) => node?.textContent === "Child goals: 0/20")).toBeInTheDocument();
-    expect(screen.getByText((_content, node) => node?.textContent === "Parent goals: 0/6")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Adobe extraction found 0/20 child goals and 0/6 parent goals. Upload a richer source document or improve extraction before generating drafts.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText((_content, node) => node?.textContent === "Child goals: 0")).toBeInTheDocument();
+    expect(screen.getByText((_content, node) => node?.textContent === "Parent goals: 0")).toBeInTheDocument();
+    expect(screen.getByText("Approve at least one structured CalOptima goal section before generating drafts.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Generate Drafts from Uploaded FBA/i })).toBeDisabled();
   });
 
@@ -2922,6 +2918,107 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Checklist review must load before publishing.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i })).toBeDisabled();
+  });
+
+  it("allows publish with smaller accepted draft sets once checklist review is complete", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "checklist-item-1",
+                section_key: "assessment_summary",
+                label: "Assessment summary",
+                placeholder_key: "summary",
+                required: true,
+                mode: "ASSISTED",
+                status: "approved",
+                review_notes: null,
+                value_text: "Synthetic assessment summary",
+              },
+            ],
+            structured_sections: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/fba.pdf",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [{ id: "p1", name: "Program A", description: null, accept_state: "accepted", review_notes: null }],
+            goals: [
+              {
+                id: "child-1",
+                title: "Child Goal 1",
+                description: "Child goal description 1",
+                original_text: "Child goal original text 1",
+                goal_type: "child",
+                accept_state: "accepted",
+                review_notes: null,
+              },
+              {
+                id: "child-2",
+                title: "Child Goal 2",
+                description: "Child goal description 2",
+                original_text: "Child goal original text 2",
+                goal_type: "child",
+                accept_state: "accepted",
+                review_notes: null,
+              },
+              {
+                id: "parent-1",
+                title: "Parent Goal 1",
+                description: "Parent goal description 1",
+                original_text: "Parent goal original text 1",
+                goal_type: "parent",
+                accept_state: "accepted",
+                review_notes: null,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("fba.pdf");
+    const publishButton = await screen.findByRole("button", { name: /Publish to Live Programs \+ Goals/i });
+    expect(publishButton).toBeEnabled();
+    expect(screen.getByText("Accepted draft goals: 2 child / 1 parent")).toBeInTheDocument();
   });
 
   it("shows add-goal prerequisites when create goal is disabled", async () => {

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -21,9 +21,11 @@ import {
   resolveOrgAndRole,
 } from "../api/shared";
 
-const buildTypedGoals = (): Array<Record<string, unknown>> => [
-  ...Array.from({ length: 20 }, (_, index) => ({
-    program_name: "Communication Program",
+const buildTypedGoals = (
+  counts: { childCount?: number; parentCount?: number; programName?: string } = {},
+): Array<Record<string, unknown>> => [
+  ...Array.from({ length: counts.childCount ?? 20 }, (_, index) => ({
+    program_name: counts.programName ?? "Communication Program",
     title: `Child Goal ${index + 1}`,
     description: `Child goal description ${index + 1}`,
     original_text: `Child goal original text ${index + 1}`,
@@ -40,8 +42,8 @@ const buildTypedGoals = (): Array<Record<string, unknown>> => [
     evidence_refs: [{ section_key: "assessment_summary", source_span: "Child evidence snippet" }],
     review_flags: [],
   })),
-  ...Array.from({ length: 6 }, (_, index) => ({
-    program_name: "Communication Program",
+  ...Array.from({ length: counts.parentCount ?? 6 }, (_, index) => ({
+    program_name: counts.programName ?? "Communication Program",
     title: `Parent Goal ${index + 1}`,
     description: `Parent goal description ${index + 1}`,
     original_text: `Parent goal original text ${index + 1}`,
@@ -214,6 +216,55 @@ describe("assessmentDraftsHandler", () => {
     expect(programPayload[0]?.confidence).toBe("medium");
   });
 
+  it("accepts smaller manual draft goal sets without legacy minimum enforcement", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 201, data: [{ id: "draft-program-1", name: "Communication Program" }] })
+      .mockResolvedValueOnce({ ok: true, status: 201, data: null })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: null })
+      .mockResolvedValueOnce({ ok: true, status: 201, data: null });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-1111-1111-111111111111",
+          programs: [
+            {
+              name: "Communication Program",
+              description: "Program description",
+              rationale: "Program rationale",
+              evidence_refs: [{ section_key: "assessment_summary", source_span: "Program evidence snippet" }],
+              review_flags: [],
+            },
+          ],
+          summary_rationale: "Summary rationale",
+          confidence: "medium",
+          goals: buildTypedGoals({ childCount: 2, parentCount: 1 }),
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+  });
+
   it("deterministically creates staged drafts from approved structured sections", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
@@ -335,6 +386,117 @@ describe("assessmentDraftsHandler", () => {
       .mock.calls.find(([url]) => typeof url === "string" && url.includes("/rest/v1/goals"));
     expect(liveProgramWrite).toBeUndefined();
     expect(liveGoalWrite).toBeUndefined();
+  });
+
+  it("deterministically persists every approved structured program and goal beyond the legacy caps", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+
+    const programNames = Array.from({ length: 7 }, (_, index) => `Program ${index + 1}`);
+    const structuredGoals = [
+      ...Array.from({ length: 21 }, (_, index) => ({
+        id: `structured-child-${index + 1}`,
+        section_key: "goals_treatment_planning",
+        field_key: index % 2 === 0 ? "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS" : "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+        section_index: index,
+        payload: {
+          ...buildTypedGoals({ childCount: 1, parentCount: 0, programName: programNames[index % programNames.length] })[0],
+          title: `Child Goal ${index + 1}`,
+          objective_data_points: [{ metric_name: "Point A", metric_value: 1 }],
+        },
+        status: "approved",
+        required: true,
+      })),
+      ...Array.from({ length: 7 }, (_, index) => ({
+        id: `structured-parent-${index + 1}`,
+        section_key: "goals_treatment_planning",
+        field_key: "CALOPTIMA_FBA_PARENT_GOALS",
+        section_index: 100 + index,
+        payload: {
+          ...buildTypedGoals({ childCount: 0, parentCount: 1, programName: programNames[index] })[0],
+          title: `Parent Goal ${index + 1}`,
+          goal_type: "parent",
+          objective_data_points: [{ metric_name: "Point A", metric_value: 1 }],
+        },
+        status: "approved",
+        required: true,
+      })),
+    ];
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?")) {
+        return { ok: true, status: 200, data: structuredGoals };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
+        const body = JSON.parse(String(init?.body)) as Array<{ name: string }>;
+        return {
+          ok: true,
+          status: 201,
+          data: body.map((program, index) => ({ id: `draft-program-${index + 1}`, name: program.name })),
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_goals")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-1111-1111-111111111111",
+          auto_generate: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const programCreateCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(
+        ([url, init]) =>
+          typeof url === "string" &&
+          url.includes("/rest/v1/assessment_draft_programs") &&
+          (init?.method ?? "").toUpperCase() === "POST",
+      );
+    const goalCreateCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(
+        ([url, init]) =>
+          typeof url === "string" &&
+          url.includes("/rest/v1/assessment_draft_goals") &&
+          (init?.method ?? "").toUpperCase() === "POST",
+      );
+    const programPayload = JSON.parse((programCreateCall?.[1] as RequestInit).body as string) as Array<Record<string, unknown>>;
+    const goalPayload = JSON.parse((goalCreateCall?.[1] as RequestInit).body as string) as Array<Record<string, unknown>>;
+    expect(programPayload).toHaveLength(7);
+    expect(goalPayload).toHaveLength(28);
   });
 
   it("rolls back inserted draft programs when goal insert fails", async () => {

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -15,8 +15,10 @@ vi.mock("../api/shared", async () => {
 
 import { fetchJson, getAccessToken, getAccessTokenSubject, getSupabaseConfig, resolveOrgAndRole } from "../api/shared";
 
-const buildAcceptedGoals = (): Array<Record<string, unknown>> => [
-  ...Array.from({ length: 20 }, (_, index) => ({
+const buildAcceptedGoals = (
+  counts: { childCount?: number; parentCount?: number } = {},
+): Array<Record<string, unknown>> => [
+  ...Array.from({ length: counts.childCount ?? 20 }, (_, index) => ({
     id: `child-goal-${index + 1}`,
     title: `Child Goal ${index + 1}`,
     description: `Child goal description ${index + 1} with enough detail.`,
@@ -27,7 +29,7 @@ const buildAcceptedGoals = (): Array<Record<string, unknown>> => [
       : [],
     accept_state: "accepted",
   })),
-  ...Array.from({ length: 6 }, (_, index) => ({
+  ...Array.from({ length: counts.parentCount ?? 6 }, (_, index) => ({
     id: `parent-goal-${index + 1}`,
     title: `Parent Goal ${index + 1}`,
     description: `Parent goal description ${index + 1} with enough detail.`,
@@ -267,8 +269,9 @@ describe("assessmentPromoteHandler", () => {
     expect(body.error).toContain("minimally complete");
   });
 
-  it("blocks promotion when accepted parent/child minimums are not met", async () => {
+  it("promotes smaller accepted goal sets when draft content is otherwise valid", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
       isTherapist: true,
@@ -279,29 +282,42 @@ describe("assessmentPromoteHandler", () => {
       supabaseUrl: "https://example.supabase.co",
       anonKey: "anon",
     });
-    vi.mocked(fetchJson)
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        data: [{ id: "program-1", name: "Draft Program", description: "x", accept_state: "accepted" }],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        data: Array.from({ length: 26 }, (_, index) => ({
-          id: `child-goal-${index + 1}`,
-          title: `Child Goal ${index + 1}`,
-          description: `Child goal description ${index + 1} with enough detail.`,
-          original_text: `Child goal original text ${index + 1} with enough detail for validation.`,
-          goal_type: "child",
-          accept_state: "accepted",
-        })),
-      });
+    const acceptedGoals = buildAcceptedGoals({ childCount: 2, parentCount: 1 }).map((goal) => ({
+      ...goal,
+      draft_program_id: "program-1",
+    }));
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
+        return { ok: true, status: 200, data: [{ id: "program-1", name: "Draft Program", description: "x", accept_state: "accepted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        return { ok: true, status: 200, data: acceptedGoals };
+      }
+      if (method === "POST" && url.includes("/rest/v1/programs")) {
+        return { ok: true, status: 201, data: [{ id: "prod-program-1" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/goals")) {
+        return {
+          ok: true,
+          status: 201,
+          data: acceptedGoals.map((goal, index) => ({ id: `prod-goal-${index + 1}`, title: goal.title })),
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/goal_data_points")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
 
     const response = await assessmentPromoteHandler(
       new Request("http://localhost/api/assessment-promote", {
@@ -311,9 +327,12 @@ describe("assessmentPromoteHandler", () => {
       }),
     );
 
-    const body = await response.json();
-    expect(response.status).toBe(409);
-    expect(body.error).toContain("Promotion requires at least");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      created_program_count: 1,
+      created_goal_count: 3,
+      promoted_goal_count: 3,
+    });
   });
 
   it("rolls back created programs when production goal creation fails", async () => {

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -9,9 +9,6 @@ import {
   resolveOrgAndRole,
 } from "./shared";
 
-const MIN_CHILD_GOALS = 20;
-const MIN_PARENT_GOALS = 6;
-
 const evidenceRefSchema = z.object({
   section_key: z.string().trim().min(1),
   source_span: z.string().trim().min(1),
@@ -61,7 +58,7 @@ const draftCreateSchema = z.object({
     .min(1),
   summary_rationale: z.string().trim().min(1),
   confidence: z.enum(["low", "medium", "high"]),
-  goals: z.array(draftGoalSchema).min(MIN_CHILD_GOALS + MIN_PARENT_GOALS),
+  goals: z.array(draftGoalSchema).min(1),
 });
 
 const draftAutoGenerateSchema = z.object({
@@ -321,17 +318,6 @@ const buildDeterministicDraftPayload = (
     summary_rationale: "Drafts were created from approved CalOptima structured sections without AI generation.",
     confidence: "high",
   };
-};
-
-const validateGoalMinimums = (
-  goals: Array<{ goal_type: "child" | "parent" }>,
-): { valid: true } | { valid: false; childCount: number; parentCount: number } => {
-  const childCount = goals.filter((goal) => goal.goal_type === "child").length;
-  const parentCount = goals.filter((goal) => goal.goal_type === "parent").length;
-  if (childCount < MIN_CHILD_GOALS || parentCount < MIN_PARENT_GOALS) {
-    return { valid: false, childCount, parentCount };
-  }
-  return { valid: true };
 };
 
 const getAssessmentDocument = async (
@@ -602,17 +588,6 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
 
     const actorId = getAccessTokenSubject(accessToken);
     if (parsedManual.success) {
-      const minimumValidation = validateGoalMinimums(parsedManual.data.goals);
-      if (!minimumValidation.valid) {
-        return json(
-          {
-            error: `Draft must include at least ${MIN_CHILD_GOALS} child goals and ${MIN_PARENT_GOALS} parent goals.`,
-            child_goal_count: minimumValidation.childCount,
-            parent_goal_count: minimumValidation.parentCount,
-          },
-          409,
-        );
-      }
       const result = await persistDraftRows({
         supabaseUrl,
         headers,
@@ -661,17 +636,6 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
     const generatedPayload = buildDeterministicDraftPayload(structuredResult.data ?? []);
     if (!generatedPayload) {
       return json({ error: "No approved structured CalOptima goal sections are available for deterministic draft generation." }, 409);
-    }
-    const minimumValidation = validateGoalMinimums(generatedPayload.goals);
-    if (!minimumValidation.valid) {
-      return json(
-        {
-          error: `Deterministic draft must include at least ${MIN_CHILD_GOALS} child goals and ${MIN_PARENT_GOALS} parent goals.`,
-          child_goal_count: minimumValidation.childCount,
-          parent_goal_count: minimumValidation.parentCount,
-        },
-        409,
-      );
     }
 
     const persisted = await persistDraftRows({

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -9,9 +9,6 @@ import {
   resolveOrgAndRole,
 } from "./shared";
 
-const MIN_CHILD_GOALS = 20;
-const MIN_PARENT_GOALS = 6;
-
 const promoteSchema = z.object({
   assessment_document_id: z.string().uuid(),
 });
@@ -155,19 +152,6 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   if (acceptedGoals.length === 0) {
     return json({ error: "At least one accepted draft goal is required before promotion." }, 409);
   }
-  const acceptedChildGoalCount = acceptedGoals.filter((goal) => goal.goal_type === "child").length;
-  const acceptedParentGoalCount = acceptedGoals.filter((goal) => goal.goal_type === "parent").length;
-  if (acceptedChildGoalCount < MIN_CHILD_GOALS || acceptedParentGoalCount < MIN_PARENT_GOALS) {
-    return json(
-      {
-        error: `Promotion requires at least ${MIN_CHILD_GOALS} accepted child goals and ${MIN_PARENT_GOALS} accepted parent goals.`,
-        accepted_child_goal_count: acceptedChildGoalCount,
-        accepted_parent_goal_count: acceptedParentGoalCount,
-      },
-      409,
-    );
-  }
-
   const lowQualityGoals = acceptedGoals.filter((goal) => !isMinGoalQuality(goal));
   if (lowQualityGoals.length > 0) {
     return json(

--- a/supabase/functions/generate-program-goals/index.test.ts
+++ b/supabase/functions/generate-program-goals/index.test.ts
@@ -1,5 +1,11 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
-import { __TESTING__ } from "./index.ts";
+
+Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "test-service-key");
+Deno.env.set("SUPABASE_ANON_KEY", "test-anon-key");
+Deno.env.set("OPENAI_API_KEY", "test-openai-key");
+
+const { __TESTING__ } = await import("./index.ts");
 
 const buildValidResponse = () => {
   const programs = [
@@ -85,13 +91,134 @@ Deno.test("parseAndValidateCandidate enforces weak evidence review flags", () =>
   }
 });
 
-Deno.test("parseAndValidateCandidate rejects child parent mix mismatch", () => {
+Deno.test("parseAndValidateCandidate accepts responses above the legacy program and goal caps", () => {
+  const payload = {
+    programs: Array.from({ length: 7 }, (_, index) => ({
+      name: `Program ${index + 1}`,
+      description: `Program description ${index + 1} grounded in uploaded FBA evidence and clinical implementation details.`,
+      rationale: `Program rationale ${index + 1} tied to documented source evidence and replacement skill planning.`,
+      evidence_refs: [{
+        section_key: "assessment_summary",
+        source_span: `Evidence for program ${index + 1} with enough detail to satisfy evidence validation requirements.`,
+      }],
+      review_flags: [],
+    })),
+    goals: Array.from({ length: 28 }, (_, index) => ({
+      program_name: `Program ${(index % 7) + 1}`,
+      title: `Expanded Goal ${index + 1}`,
+      description: `Expanded goal description ${index + 1} with enough detail for validation and implementation.`,
+      original_text: `Expanded original text ${index + 1} with measurable detail and direct assessment grounding.`,
+      goal_type: index < 21 ? "child" as const : "parent" as const,
+      target_behavior: index < 21 ? "Functional communication response" : "Caregiver implementation fidelity",
+      measurement_type: "Frequency per opportunity",
+      baseline_data: "Baseline currently below expected level and documented in source evidence.",
+      target_criteria: "Target 80 percent opportunities across clearly defined sessions.",
+      mastery_criteria: "Mastery 85 percent across three consecutive sessions.",
+      maintenance_criteria: "Maintenance 80 percent across scheduled probes.",
+      generalization_criteria: "Generalize across home, clinic, and caregiver routines.",
+      objective_data_points: ["Track independent response count", "Track prompt level for each opportunity"],
+      rationale: `Expanded rationale ${index + 1} derived directly from assessment evidence and conservative clinical drafting.`,
+      evidence_refs: [{
+        section_key: "goals_treatment_planning",
+        source_span: `Expanded supporting evidence ${index + 1} with enough detail to satisfy evidence validation requirements.`,
+      }],
+      review_flags: [],
+    })),
+    summary_rationale: "Overall plan targets the full supported set of programs and goals from uploaded FBA evidence.",
+    confidence: "medium" as const,
+  };
+  const result = __TESTING__.parseAndValidateCandidate(JSON.stringify(payload));
+  assertEquals(result.ok, true);
+});
+
+Deno.test("parseAndValidateCandidate accepts smaller valid goal sets after legacy floor removal", () => {
+  const payload = {
+    programs: [
+      {
+        name: "Communication Program",
+        description: "Program description grounded in uploaded FBA evidence and clinical implementation details.",
+        rationale: "Program rationale tied to documented source evidence and replacement skill planning.",
+        evidence_refs: [{
+          section_key: "assessment_summary",
+          source_span: "Evidence for program with enough detail to satisfy evidence validation requirements.",
+        }],
+        review_flags: [],
+      },
+    ],
+    goals: [
+      {
+        program_name: "Communication Program",
+        title: "Child Goal 1",
+        description: "Expanded child goal description with enough detail for validation and implementation.",
+        original_text: "Expanded child original text with measurable detail and direct assessment grounding.",
+        goal_type: "child" as const,
+        target_behavior: "Functional communication response",
+        measurement_type: "Frequency per opportunity",
+        baseline_data: "Baseline currently below expected level and documented in source evidence.",
+        target_criteria: "Target 80 percent opportunities across clearly defined sessions.",
+        mastery_criteria: "Mastery 85 percent across three consecutive sessions.",
+        maintenance_criteria: "Maintenance 80 percent across scheduled probes.",
+        generalization_criteria: "Generalize across home, clinic, and caregiver routines.",
+        objective_data_points: ["Track independent response count", "Track prompt level for each opportunity"],
+        rationale: "Expanded rationale derived directly from assessment evidence and conservative clinical drafting.",
+        evidence_refs: [{
+          section_key: "goals_treatment_planning",
+          source_span: "Expanded supporting evidence with enough detail to satisfy evidence validation requirements.",
+        }],
+        review_flags: [],
+      },
+      {
+        program_name: "Communication Program",
+        title: "Parent Goal 1",
+        description: "Expanded parent goal description with enough detail for validation and implementation.",
+        original_text: "Expanded parent original text with measurable detail and direct assessment grounding.",
+        goal_type: "parent" as const,
+        target_behavior: "Caregiver implementation fidelity",
+        measurement_type: "Frequency per opportunity",
+        baseline_data: "Baseline currently below expected level and documented in source evidence.",
+        target_criteria: "Target 80 percent opportunities across clearly defined sessions.",
+        mastery_criteria: "Mastery 85 percent across three consecutive sessions.",
+        maintenance_criteria: "Maintenance 80 percent across scheduled probes.",
+        generalization_criteria: "Generalize across home, clinic, and caregiver routines.",
+        objective_data_points: ["Track independent response count", "Track prompt level for each opportunity"],
+        rationale: "Expanded rationale derived directly from assessment evidence and conservative clinical drafting.",
+        evidence_refs: [{
+          section_key: "parent_training",
+          source_span: "Expanded supporting evidence with enough detail to satisfy evidence validation requirements.",
+        }],
+        review_flags: [],
+      },
+    ],
+    summary_rationale: "Overall plan targets the supported smaller set of programs and goals from uploaded FBA evidence.",
+    confidence: "medium" as const,
+  };
+  const result = __TESTING__.parseAndValidateCandidate(JSON.stringify(payload));
+  assertEquals(result.ok, true);
+});
+
+Deno.test("parseAndValidateCandidate rejects responses above the non-legacy program ceiling", () => {
   const payload = buildValidResponse();
-  payload.goals = payload.goals.filter((goal) => goal.goal_type !== "parent");
+  payload.programs = Array.from({ length: 51 }, (_, index) => ({
+    ...payload.programs[0],
+    name: `Program ${index + 1}`,
+  }));
   const result = __TESTING__.parseAndValidateCandidate(JSON.stringify(payload));
   assertEquals(result.ok, false);
   if (!result.ok) {
-    assertEquals(result.reason, "goal_mix_mismatch");
+    assertEquals(result.reason, "schema_validation");
+  }
+});
+
+Deno.test("parseAndValidateCandidate rejects responses above the non-legacy goal ceiling", () => {
+  const payload = buildValidResponse();
+  payload.goals = Array.from({ length: 501 }, (_, index) => ({
+    ...payload.goals[index % payload.goals.length],
+    title: `Goal ${index + 1}`,
+  }));
+  const result = __TESTING__.parseAndValidateCandidate(JSON.stringify(payload));
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.reason, "schema_validation");
   }
 });
 
@@ -139,8 +266,9 @@ Deno.test("buildFallbackResponse remains schema-compliant and fully flagged", ()
       {
         section_key: "assessment_summary",
         label: "Summary",
+        placeholder_key: "assessment_summary",
         value_text: "Client presents with communication deficits.",
-        value_json: null,
+        value_json: {},
       },
     ],
     extracted_canonical_fields: {},

--- a/supabase/functions/generate-program-goals/index.ts
+++ b/supabase/functions/generate-program-goals/index.ts
@@ -9,11 +9,11 @@ const openai = new OpenAI({
   apiKey: Deno.env.get("OPENAI_API_KEY"),
 });
 
-const MIN_CHILD_GOALS = 20;
-const MIN_PARENT_GOALS = 6;
 const MAX_GENERATION_ATTEMPTS = 2;
 const OPENAI_ATTEMPT_TIMEOUT_MS = 20000;
 const MAX_TEXT_CHARS = 12000;
+const MAX_GENERATED_PROGRAMS = 50;
+const MAX_GENERATED_GOALS = 500;
 
 const REVIEW_FLAGS = [
   "missing_baseline",
@@ -140,7 +140,7 @@ const responseSchema = z
           .strict(),
       )
       .min(1)
-      .max(5),
+      .max(MAX_GENERATED_PROGRAMS),
     goals: z
       .array(
         z
@@ -165,7 +165,7 @@ const responseSchema = z
           .strict(),
       )
       .min(1)
-      .max(80),
+      .max(MAX_GENERATED_GOALS),
     summary_rationale: z.string().trim().min(10).max(2500),
     confidence: z.enum(["low", "medium", "high"]),
   })
@@ -184,8 +184,7 @@ type AttemptFailureReason =
   | "duplicate_goal_titles"
   | "missing_program_match"
   | "missing_evidence_refs"
-  | "weak_evidence_missing_flags"
-  | "goal_mix_mismatch";
+  | "weak_evidence_missing_flags";
 
 const normalizeTitle = (value: string): string => value.trim().toLowerCase().replace(/\s+/g, " ");
 
@@ -262,11 +261,6 @@ const hasMissingEvidenceRefs = (payload: ResponsePayload): boolean => {
   return payload.goals.some((goal) => goal.evidence_refs.length === 0);
 };
 
-const hasGoalMixMismatch = (payload: ResponsePayload): boolean => {
-  const { childCount, parentCount } = countGoalsByType(payload.goals);
-  return childCount < MIN_CHILD_GOALS || parentCount < MIN_PARENT_GOALS;
-};
-
 const trim = (value: string, max: number): string => {
   if (value.length <= max) {
     return value;
@@ -302,9 +296,10 @@ SOURCE_EVIDENCE_SNIPPETS:
 ${evidenceJson}
 
 Generation requirements:
-- Generate 1 to 5 programs only if clearly supported by the assessment.
+- Generate the full set of distinct programs clearly supported by the assessment evidence.
 - Generate both child and parent goals when the evidence supports them.
-- Prefer quality and evidence alignment over high goal volume.
+- Prefer quality and evidence alignment over arbitrary count limits.
+- Keep the result within ${MAX_GENERATED_PROGRAMS} programs and ${MAX_GENERATED_GOALS} goals by merging near-duplicates if necessary.
 - Do not create goals unsupported by the uploaded FBA.
 - Make each goal clinically specific, measurable, and implementation-ready.
 - Avoid duplicate goals across programs.
@@ -354,11 +349,14 @@ const buildFallbackResponse = (payload: RequestPayload, reason: string): Respons
     },
   ];
 
-  const goals: DraftGoal[] = [];
-  for (let index = 1; index <= MIN_CHILD_GOALS; index += 1) {
-    goals.push({
+  const evidenceText =
+    `${payload.assessment_summary}\n${payload.source_evidence_snippets.map((entry) => entry.snippet).join("\n")}`
+      .toLowerCase();
+  const shouldIncludeParentGoal = /\b(parent|caregiver|family|guardian)\b/.test(evidenceText);
+  const goals: DraftGoal[] = [
+    {
       program_name: programName,
-      title: `Child Goal ${index}: Functional Skill Target`,
+      title: "Child Goal: Functional Skill Target",
       description:
         `${learnerName} will demonstrate an observable replacement skill from assessment findings with clinician-confirmed criteria.`,
       original_text: `Fallback child goal based on source snippet: ${snippet}`,
@@ -377,12 +375,12 @@ const buildFallbackResponse = (payload: RequestPayload, reason: string): Respons
       rationale: "Conservative fallback target created to preserve draft workflow continuity.",
       evidence_refs: [{ section_key: sectionKey, source_span: snippet }],
       review_flags: ["clinician_confirmation_needed", "evidence_gap"],
-    });
-  }
-  for (let index = 1; index <= MIN_PARENT_GOALS; index += 1) {
+    },
+  ];
+  if (shouldIncludeParentGoal) {
     goals.push({
       program_name: programName,
-      title: `Parent Goal ${index}: Caregiver Implementation Fidelity`,
+      title: "Parent Goal: Caregiver Implementation Fidelity",
       description:
         "Caregiver will participate in implementation coaching and demonstrate procedural steps with BCBA-confirmed thresholds.",
       original_text: `Fallback parent goal based on source snippet: ${snippet}`,
@@ -443,10 +441,6 @@ const parseAndValidateCandidate = (
   if (hasWeakEvidenceWithoutFlags(payload)) {
     return { ok: false, reason: "weak_evidence_missing_flags" };
   }
-  if (hasGoalMixMismatch(payload)) {
-    return { ok: false, reason: "goal_mix_mismatch" };
-  }
-
   return { ok: true, payload };
 };
 
@@ -470,8 +464,6 @@ const buildRetryHint = (reason: AttemptFailureReason): string => {
       return "Every program and goal must include non-empty evidence_refs.";
     case "weak_evidence_missing_flags":
       return "Weakly supported items must include evidence_gap or clinician_confirmation_needed in review_flags.";
-    case "goal_mix_mismatch":
-      return `Ensure at least ${MIN_CHILD_GOALS} child goals and ${MIN_PARENT_GOALS} parent goals.`;
   }
 };
 
@@ -533,6 +525,14 @@ export async function handleGenerateProgramGoals(req: Request): Promise<Response
         continue;
       }
 
+      if (!("choices" in completion)) {
+        const reason: AttemptFailureReason = "empty_content";
+        attemptFailures.push(reason);
+        lastFailureReason = `attempt ${attempt} returned an unsupported streaming response`;
+        retryHint = buildRetryHint(reason);
+        continue;
+      }
+
       const rawContent = completion.choices[0]?.message?.content;
       if (!rawContent) {
         const reason: AttemptFailureReason = "empty_content";
@@ -583,4 +583,6 @@ export const __TESTING__ = {
   REVIEW_FLAGS,
 };
 
-Deno.serve(handleGenerateProgramGoals);
+if (import.meta.main) {
+  Deno.serve(handleGenerateProgramGoals);
+}


### PR DESCRIPTION
## Summary
- remove the legacy 20 child / 6 parent draft and publish gates from the assessment workflow
- stop the generate-program-goals edge function from pressuring extraction into the old caps while keeping bounded safety ceilings
- add regressions for small valid sets, above-legacy-cap deterministic drafts, and above-legacy-cap generation outputs

## Route / risk
- issue: `WIN-148`
- route-task: `classification=high-risk human-reviewed`, `lane=critical`
- protected surfaces touched: server draft/promotion handlers, assessment UI gating, Supabase edge-function generation logic
- no schema, RLS, grants, RPC exposure, migration, auth, routing, or deploy-config changes

## Verification
Passed:
- `npx vitest run src/server/__tests__/assessmentDraftsHandler.test.ts src/server/__tests__/assessmentPromoteHandler.test.ts src/components/__tests__/ProgramsGoalsTab.test.tsx`
- `deno test --node-modules-dir=auto --allow-env supabase/functions/generate-program-goals/index.test.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:routes:tier0`

Blocked / out of scope:
- `npm run test:ci`
  - unrelated timeout in `tests/vitest.env-isolation.test.ts`
  - unrelated timeout in `tests/edge/initiate-client-onboarding.utils.test.ts`
  - one Vitest worker timeout surfaced during the same run
- `npm run playwright:assessment-upload-promote-smoke`
  - blocked locally because `PW_ASSESSMENT_CLIENT_ID` is not configured

## Notes
- Supabase inspection did not show schema/RLS limits causing the cap
- Netlify inspection did not show runtime timeout/body-size truncation causing the cap
- Adobe extraction wiring persists context upstream; the cap was downstream in app and generation logic