### PR TITLE
Fix assessment upload extraction orchestration

### DIFF
--- a/scripts/playwright-assessment-upload-promote-smoke.ts
+++ b/scripts/playwright-assessment-upload-promote-smoke.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { chromium, type Page } from "playwright";
 
 import { cleanupAssessmentImportArtifacts } from "./lib/assessment-import-cleanup";
@@ -117,8 +118,8 @@ type LiveGoal = {
 
 const DEFAULT_BASE_URL = "https://app.allincompassing.ai";
 const EXTRACTION_TIMEOUT_MS = 180_000;
-const EXPECTED_CHILD_GOALS = 21;
-const EXPECTED_PARENT_GOALS = 7;
+export const EXPECTED_CHILD_GOALS = 21;
+export const EXPECTED_PARENT_GOALS = 7;
 const GOAL_FIELD_KEYS = new Set([
   "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
   "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
@@ -148,7 +149,7 @@ const resolveMimeType = (filePath: string): string => {
   return "application/octet-stream";
 };
 
-const buildSyntheticAssessmentPdf = async (): Promise<Buffer> => {
+export const buildSyntheticAssessmentFixtureText = (): string => {
   const lines: string[] = [
     "Synthetic CalOptima FBA smoke fixture",
     "Service Initiation Date: 07/21/2025",
@@ -185,6 +186,12 @@ const buildSyntheticAssessmentPdf = async (): Promise<Buffer> => {
     lines.push(`Measurement Type: Percent opportunities`);
     lines.push(`Target Criteria: 90% across 4 consecutive weeks.`);
   }
+
+  return lines.join("\n");
+};
+
+const buildSyntheticAssessmentPdf = async (): Promise<Buffer> => {
+  const lines = buildSyntheticAssessmentFixtureText().split("\n");
 
   const browser = await chromium.launch({ headless: true });
   try {
@@ -876,7 +883,11 @@ async function run() {
   }
 }
 
-run().catch((error) => {
-  console.error("Playwright assessment upload promote smoke failed", error);
-  process.exit(1);
-});
+const isDirectRun = process.argv[1] ? import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href : false;
+
+if (isDirectRun) {
+  run().catch((error) => {
+    console.error("Playwright assessment upload promote smoke failed", error);
+    process.exit(1);
+  });
+}

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -37,6 +37,7 @@ import {
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SUPPORTED_ASSESSMENT_FILE_EXTENSIONS = [".pdf", ".docx"] as const;
+const SUPPORTED_ASSESSMENT_WORKFLOW_TEMPLATE: AssessmentTemplateType = "caloptima_fba";
 const PROGRAMS_REQUEST_TIMEOUT_MS = 12_000;
 const GOALS_REQUEST_TIMEOUT_MS = 12_000;
 const PROGRAM_NOTES_REQUEST_TIMEOUT_MS = 12_000;
@@ -525,6 +526,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const selectedAssessmentTemplateLabel = selectedAssessmentDocument
     ? TEMPLATE_LABELS[selectedAssessmentDocument.template_type]
     : TEMPLATE_LABELS[assessmentTemplateType];
+  const selectedAssessmentAlreadyPublished = selectedAssessmentDocument
+    ? selectedAssessmentDocument.status === "approved" || String(selectedAssessmentDocument.status) === "promoted"
+    : false;
   const checklistReviewUnavailable =
     ENABLE_CHECKLIST_MAPPING_UI && canQuerySelectedAssessment && (checklistItemsLoading || checklistItemsError);
   const hasPendingRequiredChecklistItems =
@@ -542,8 +546,11 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const extractedChecklistValueCount = checklistItems.filter((item) => item.value_text?.trim()).length;
   const structuredChildGoalCount = structuredSections.filter(isStructuredChildGoalSection).length;
   const structuredParentGoalCount = structuredSections.filter(isStructuredParentGoalSection).length;
-  const hasStagedDraftChanges = hasExistingDrafts;
-  const hasDraftsButNoLivePrograms = hasExistingDrafts && livePrograms.length === 0;
+  const hasStagedDraftChanges = hasExistingDrafts && !selectedAssessmentAlreadyPublished;
+  const hasDraftsButNoLivePrograms = hasExistingDrafts && livePrograms.length === 0 && !selectedAssessmentAlreadyPublished;
+  const draftSaveHelperText = selectedAssessmentAlreadyPublished
+    ? "Draft retained for audit after approval. Live records are already published."
+    : "Saves to draft only. Not visible in live records until published.";
   const selectedAssessmentReadyForAiGeneration = selectedAssessmentDocument
     ? AI_GENERATION_READY_STATUSES.has(selectedAssessmentDocument.status)
     : false;
@@ -568,6 +575,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     !hasExistingDrafts;
   const canPromoteAssessment =
     canQuerySelectedAssessment &&
+    !selectedAssessmentAlreadyPublished &&
     !hasPendingRequiredChecklistItems &&
     hasAcceptedDraftProgram &&
     hasAcceptedDraftGoal;
@@ -577,6 +585,8 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     : 0;
   const promoteDisabledReason = !canQuerySelectedAssessment
     ? "Select a valid assessment first."
+    : selectedAssessmentAlreadyPublished
+      ? "This assessment has already been approved and published."
     : checklistReviewUnavailable
       ? "Checklist review must load before publishing."
     : hasPendingRequiredChecklistItems
@@ -706,6 +716,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     mutationFn: async () => {
       if (!assessmentFile) {
         throw new Error("Select a file before uploading.");
+      }
+      if (assessmentTemplateType !== SUPPORTED_ASSESSMENT_WORKFLOW_TEMPLATE) {
+        throw new Error("Only CalOptima FBA upload is supported in this workflow. IEHP upload is disabled here.");
       }
       if (!isSupportedAssessmentFile(assessmentFile)) {
         throw new Error("Unsupported file type. Upload a .pdf or .docx assessment.");
@@ -1029,6 +1042,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       });
       queryClient.invalidateQueries({
         queryKey: ["client-programs", client.id, organizationId ?? "MISSING_ORG"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["client-goals", client.id, organizationId ?? "MISSING_ORG"],
       });
       queryClient.invalidateQueries({
         queryKey: ["program-goals", resolvedProgramId, organizationId ?? "MISSING_ORG"],
@@ -1452,7 +1468,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
           <div ref={publishSectionRef} className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3 flex items-center gap-2">
               <UploadCloud className="w-4 h-4" />
-              FBA Upload + AI Workflow
+              CalOptima FBA Upload + AI Workflow
             </h3>
             <div className="space-y-3">
               <label htmlFor="programs-goals-fba-template" className="block text-xs font-medium text-gray-700 dark:text-gray-200">
@@ -1465,8 +1481,10 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
               >
                 <option value="caloptima_fba">CalOptima FBA</option>
-                <option value="iehp_fba">IEHP FBA</option>
               </select>
+              <p className="text-xs text-gray-500 dark:text-gray-300">
+                CalOptima FBA is the only upload supported in this promotion workflow. IEHP upload is disabled here.
+              </p>
               <label htmlFor="programs-goals-fba-file-upload" className="block text-xs font-medium text-gray-700 dark:text-gray-200">
                 FBA file (PDF or DOCX)
               </label>
@@ -1482,7 +1500,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 onClick={() => {
                   void handleUploadAssessment();
                 }}
-                disabled={!assessmentFile || isUploadProcessing}
+                disabled={!assessmentFile || assessmentTemplateType !== SUPPORTED_ASSESSMENT_WORKFLOW_TEMPLATE || isUploadProcessing}
                 className="w-full px-3 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
               >
                 {isUploadProcessing ? (
@@ -2024,7 +2042,11 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
               Draft Review (Approve / Reject / Edit)
             </h3>
             <p className="mb-2 text-xs font-medium text-gray-600 dark:text-gray-300" role="status" aria-live="polite">
-              {hasStagedDraftChanges ? "Draft changes pending publication." : "All changes published."}
+              {hasStagedDraftChanges
+                ? "Draft changes pending publication."
+                : selectedAssessmentAlreadyPublished
+                  ? "Drafts retained after publication."
+                  : "All changes published."}
             </p>
             {selectedAssessmentDocument && (
               <p className="mb-3 text-xs text-gray-500 dark:text-gray-300">
@@ -2117,7 +2139,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                         Save Program Draft
                       </button>
                       <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-300">
-                        Saves to draft only. Not visible in live records until published.
+                        {draftSaveHelperText}
                       </p>
                     </div>
                   );
@@ -2354,7 +2376,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                         Save Goal Draft
                       </button>
                       <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-300">
-                        Saves to draft only. Not visible in live records until published.
+                        {draftSaveHelperText}
                       </p>
                     </div>
                   );

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fireEvent, renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
+import { QueryClient } from "@tanstack/react-query";
+import { fireEvent, renderWithProviders, screen, userEvent, waitFor, within } from "../../test/utils";
 import { ProgramsGoalsTab } from "../ClientDetails/ProgramsGoalsTab";
 import { generateProgramGoalDraft } from "../../lib/ai";
 import { showError, showInfo, showSuccess } from "../../lib/toast";
@@ -1285,7 +1286,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(saveDraftPayload).not.toHaveProperty("program");
   });
 
-  it("uploads IEHP assessment with selected template type", async () => {
+  it("disables IEHP upload in the CalOptima-only promotion workflow", async () => {
     const baseCallApiImpl = vi.mocked(callApi).getMockImplementation();
     if (!baseCallApiImpl) {
       throw new Error("Missing base API mock implementation.");
@@ -1294,6 +1295,22 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "POST" && path === "/api/assessment-documents") {
         await new Promise((resolve) => setTimeout(resolve, 250));
+        return new Response(
+          JSON.stringify({
+            id: ASSESSMENT_ID,
+            organization_id: ORG_ID,
+            client_id: "client-1",
+            template_type: "caloptima_fba",
+            file_name: "caloptima-fba.docx",
+            mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            file_size: 1000,
+            bucket_id: "client-documents",
+            object_path: "clients/client-1/assessments/caloptima-fba.docx",
+            status: "uploaded",
+            created_at: "2026-02-11T00:00:00.000Z",
+          }),
+          { status: 201 },
+        );
       }
       return baseCallApiImpl(path, init);
     });
@@ -1309,14 +1326,19 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     );
 
-    await screen.findByText(/FBA Upload \+ AI Workflow/i);
-    await user.selectOptions(screen.getByRole("combobox", { name: /FBA template/i }), "iehp_fba");
+    await screen.findByText(/CalOptima FBA Upload \+ AI Workflow/i);
+    expect(
+      screen.getByText("CalOptima FBA is the only upload supported in this promotion workflow. IEHP upload is disabled here."),
+    ).toBeInTheDocument();
+    const templateSelect = screen.getByRole("combobox", { name: /FBA template/i });
+    expect(within(templateSelect).getByRole("option", { name: "CalOptima FBA" })).toBeInTheDocument();
+    expect(within(templateSelect).queryByRole("option", { name: "IEHP FBA" })).not.toBeInTheDocument();
     const uploadInput = screen.getByLabelText(/FBA file \(PDF or DOCX\)/i);
-    const file = new File(["mock iehp content"], "iehp-fba.docx", {
+    const file = new File(["mock caloptima content"], "caloptima-fba.docx", {
       type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     });
     await user.upload(uploadInput, file);
-    await user.click(screen.getByRole("button", { name: /Upload IEHP FBA/i }));
+    await user.click(screen.getByRole("button", { name: /Upload CalOptima FBA/i }));
     await screen.findByText(/Uploading and processing your FBA/i);
     expect(screen.getByRole("button", { name: /Uploading and processing/i })).toBeDisabled();
 
@@ -1325,12 +1347,12 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
         "/api/assessment-documents",
         expect.objectContaining({
           method: "POST",
-          body: expect.stringContaining("\"template_type\":\"iehp_fba\""),
+          body: expect.stringContaining("\"template_type\":\"caloptima_fba\""),
         }),
       );
     });
     await waitFor(() => {
-      expect(showSuccess).toHaveBeenCalledWith("IEHP FBA uploaded and checklist initialized.");
+      expect(showSuccess).toHaveBeenCalledWith("CalOptima FBA uploaded and checklist initialized.");
     });
   });
 
@@ -2292,6 +2314,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
   });
 
   it("shows plural publish success counts from the live-promotion response", async () => {
+    const invalidateQueriesSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -2358,6 +2381,10 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
         "Published to live records. Created 2 production programs and 26 goals.",
       );
     });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["client-goals", "client-1", ORG_ID],
+    });
+    invalidateQueriesSpy.mockRestore();
     confirmSpy.mockRestore();
   });
 
@@ -2517,6 +2544,63 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
 
     expect(await screen.findByText("All changes published.")).toBeInTheDocument();
     expect(screen.getByText("Publishing makes accepted drafts live in Programs and Goals.")).toBeInTheDocument();
+  });
+
+  it("shows retained-draft messaging and blocks republish after approval", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "caloptima_fba",
+              file_name: "approved-fba.pdf",
+              mime_type: "application/pdf",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/approved-fba.pdf",
+              status: "approved",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [{ id: "p1", name: "Program A", description: null, accept_state: "accepted", review_notes: null }],
+            goals: buildAcceptedDraftGoals(),
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findByText("approved-fba.pdf")).toBeInTheDocument();
+    expect(screen.getByText("Drafts retained after publication.")).toBeInTheDocument();
+    expect(
+      screen.getByText("This assessment has already been approved and published."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i })).toBeDisabled();
+    expect(await screen.findAllByText("Draft retained for audit after approval. Live records are already published.")).not.toHaveLength(0);
+    expect(screen.queryByText("Saves to draft only. Not visible in live records until published.")).not.toBeInTheDocument();
   });
 
   it("saves a program draft and shows draft-only messaging", async () => {
@@ -3017,7 +3101,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
 
     await screen.findByText("fba.pdf");
     const publishButton = await screen.findByRole("button", { name: /Publish to Live Programs \+ Goals/i });
-    expect(publishButton).toBeEnabled();
+    await waitFor(() => expect(publishButton).toBeEnabled());
     expect(screen.getByText("Accepted draft goals: 2 child / 1 parent")).toBeInTheDocument();
   });
 

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -34,6 +34,7 @@ describe("assessmentDocumentsHandler", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (typeof ORIGINAL_SUPABASE_SERVICE_ROLE_KEY === "string") {
       process.env.SUPABASE_SERVICE_ROLE_KEY = ORIGINAL_SUPABASE_SERVICE_ROLE_KEY;
     } else {
@@ -281,7 +282,7 @@ describe("assessmentDocumentsHandler", () => {
     });
   });
 
-  it("creates assessment document with IEHP template rows", async () => {
+  it("blocks IEHP document extraction until the workflow is implemented", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
@@ -294,20 +295,6 @@ describe("assessmentDocumentsHandler", () => {
       anonKey: "anon",
     });
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
-    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([
-      {
-        section: "identification_admin",
-        label: "IEHP Member ID#",
-        placeholder_key: "IEHP_FBA_MEMBER_ID",
-        mode: "AUTO",
-        source: "authorizations.member_id",
-        required: true,
-        extraction_method: "database_prefill",
-        validation_rule: "non_empty_identifier",
-        status: "not_started",
-      },
-    ]);
-
     mockUploadFlowResponses("doc-2");
 
     const response = await assessmentDocumentsHandler(
@@ -325,8 +312,11 @@ describe("assessmentDocumentsHandler", () => {
       }),
     );
 
-    expect(response.status).toBe(201);
-    expect(loadChecklistTemplateRows).toHaveBeenCalledWith("iehp_fba");
+    expect(response.status).toBe(501);
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining("IEHP FBA upload extraction is not currently supported"),
+    });
+    expect(loadChecklistTemplateRows).not.toHaveBeenCalled();
   });
 
   it("rejects unsupported template_type", async () => {
@@ -914,7 +904,7 @@ describe("assessmentDocumentsHandler", () => {
     ) as Record<string, unknown>;
     expectExtractionFailedStatusWriteInvariants(
       extractionFailedDocumentPatchPayload,
-      "Adobe PDF extraction failed. Review checklist manually.",
+      "Field extraction failed. Review checklist manually.",
     );
     const extractionFailedReviewEventCalls = vi
       .mocked(fetchJson)
@@ -948,9 +938,12 @@ describe("assessmentDocumentsHandler", () => {
       from_status: "extracting",
       to_status: "extraction_failed",
       actor_id: "user-1",
+      event_payload: {
+        reason_code: "edge_extraction_failed",
+        status: 502,
+      },
     });
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("notes");
-    expect(extractionFailedReviewEventPayload).not.toHaveProperty("event_payload");
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("extracted_count");
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("unresolved_count");
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("unresolved_keys");
@@ -1234,9 +1227,12 @@ describe("assessmentDocumentsHandler", () => {
       from_status: "extracting",
       to_status: "extraction_failed",
       actor_id: "user-1",
+      event_payload: {
+        reason_code: "extraction_workflow_failed",
+        status: null,
+      },
     });
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("notes");
-    expect(extractionFailedReviewEventPayload).not.toHaveProperty("event_payload");
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("extracted_count");
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("unresolved_count");
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("unresolved_keys");
@@ -1273,6 +1269,87 @@ describe("assessmentDocumentsHandler", () => {
       return url.includes("/rest/v1/assessment_draft_programs") || url.includes("/rest/v1/assessment_draft_goals");
     });
     expect(draftWriteCalls).toHaveLength(0);
+  });
+
+  it("aborts bounded extraction on timeout and does not later mark the document extracted", async () => {
+    vi.useFakeTimers();
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
+        return {
+          ok: true,
+          status: 201,
+          data: [{ id: "doc-timeout", organization_id: "org-1", client_id: "11111111-1111-1111-1111-111111111111" }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return new Promise((_, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+        });
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-timeout")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const responsePromise = assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(55_000);
+    const response = await responsePromise;
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "extraction_failed",
+      extraction_error: "Extraction timed out before completion.",
+    });
+    const documentStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-timeout"))
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracted\""))).toBe(false);
   });
 
   it("keeps the document extracted and does not run legacy draft generation on extraction completion", async () => {

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -166,6 +166,18 @@ describe("assessmentPromoteHandler", () => {
       metric_name: "Legacy manual objective note",
       metric_payload: { label: "Legacy manual objective note", raw_text: "Legacy manual objective note" },
     });
+    const documentPatchCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      return typeof url === "string" && method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1");
+    });
+    expect(documentPatchCalls[0]?.[0]).toContain("status=eq.drafted");
+    expect(JSON.parse(String((documentPatchCalls[0]?.[1] as RequestInit | undefined)?.body))).toMatchObject({
+      status: "extracted",
+      approved_at: null,
+    });
+    expect(JSON.parse(String((documentPatchCalls.at(-1)?.[1] as RequestInit | undefined)?.body))).toMatchObject({
+      status: "approved",
+    });
   });
 
   it("blocks promotion when accepted goals contain duplicate titles", async () => {
@@ -258,6 +270,46 @@ describe("assessmentPromoteHandler", () => {
     );
   });
 
+  it("blocks promotion while an assessment is in the transient promotion lock status", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(409);
+    expect(body.error).toContain("drafts must be ready before promotion");
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/programs"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goals"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("blocks promotion when the conditional promotion lock finds the assessment already promoted", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -287,7 +339,7 @@ describe("assessmentPromoteHandler", () => {
       }
       if (
         method === "PATCH" &&
-        url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=not.in.(approved,promoted)")
+        url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.drafted")
       ) {
         return { ok: true, status: 200, data: [] };
       }
@@ -304,7 +356,7 @@ describe("assessmentPromoteHandler", () => {
 
     const body = await response.json();
     expect(response.status).toBe(409);
-    expect(body.error).toContain("already been approved and promoted");
+    expect(body.error).toContain("already being promoted or has been approved");
     expect(fetchJson).not.toHaveBeenCalledWith(
       expect.stringContaining("/rest/v1/programs"),
       expect.objectContaining({ method: "POST" }),
@@ -816,6 +868,15 @@ describe("assessmentPromoteHandler", () => {
         body: expect.stringContaining('"status":"drafted"'),
       }),
     );
+    const documentPatchBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url, init]) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        return typeof url === "string" && method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1");
+      })
+      .map(([, init]) => JSON.parse(String((init as RequestInit | undefined)?.body ?? "{}")) as Record<string, unknown>);
+    expect(documentPatchBodies[0]).toMatchObject({ status: "extracted", approved_at: null });
+    expect(documentPatchBodies.at(-1)).toMatchObject({ status: "drafted", approved_at: null });
   });
 
   it("surfaces rollback failure details when review-event cleanup cannot fully unwind live writes", async () => {

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -105,7 +105,7 @@ describe("assessmentPromoteHandler", () => {
         return { ok: true, status: 201, data: null };
       }
       if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
-        return { ok: true, status: 200, data: null };
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "approved" }] };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
         return { ok: true, status: 201, data: null };
@@ -218,6 +218,103 @@ describe("assessmentPromoteHandler", () => {
     expect(body.error).toContain("Duplicate accepted goal titles");
   });
 
+  it("blocks re-promotion of an already approved assessment before live rows are created", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "approved" }],
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(409);
+    expect(body.error).toContain("already been approved and promoted");
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/programs"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goals"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("blocks promotion when the conditional promotion lock finds the assessment already promoted", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
+        return { ok: true, status: 200, data: [{ id: "draft-program-1", name: "Draft Program", description: "x", accept_state: "accepted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: buildAcceptedGoals({ childCount: 1, parentCount: 0 }).map((goal) => ({ ...goal, draft_program_id: "draft-program-1" })),
+        };
+      }
+      if (
+        method === "PATCH" &&
+        url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=not.in.(approved,promoted)")
+      ) {
+        return { ok: true, status: 200, data: [] };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(409);
+    expect(body.error).toContain("already been approved and promoted");
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/programs"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goals"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("blocks promotion when accepted goals are missing minimum content", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -311,7 +408,7 @@ describe("assessmentPromoteHandler", () => {
         return { ok: true, status: 201, data: null };
       }
       if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
-        return { ok: true, status: 200, data: null };
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "approved" }] };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
         return { ok: true, status: 201, data: null };
@@ -367,6 +464,9 @@ describe("assessmentPromoteHandler", () => {
       }
       if (method === "POST" && url.includes("/rest/v1/goals")) {
         return { ok: false, status: 500, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "approved" }] };
       }
       if (
         method === "DELETE" &&
@@ -445,7 +545,7 @@ describe("assessmentPromoteHandler", () => {
         return { ok: true, status: 201, data: null };
       }
       if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
-        return { ok: true, status: 200, data: null };
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "approved" }] };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
         return { ok: true, status: 201, data: null };
@@ -531,6 +631,9 @@ describe("assessmentPromoteHandler", () => {
       }
       if (method === "DELETE" && url.includes("/rest/v1/programs?id=in.(prod-program-1)&organization_id=eq.org-1&client_id=eq.client-1")) {
         return { ok: true, status: 200, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "approved" }] };
       }
       return { ok: false, status: 500, data: null };
     });
@@ -681,7 +784,7 @@ describe("assessmentPromoteHandler", () => {
         return { ok: true, status: 201, data: null };
       }
       if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1")) {
-        return { ok: true, status: 200, data: null };
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "approved" }] };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
         return { ok: false, status: 500, data: null };
@@ -757,7 +860,7 @@ describe("assessmentPromoteHandler", () => {
         return { ok: true, status: 201, data: null };
       }
       if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1")) {
-        return { ok: true, status: 200, data: null };
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "approved" }] };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
         return { ok: false, status: 500, data: null };
@@ -783,5 +886,14 @@ describe("assessmentPromoteHandler", () => {
     expect(response.status).toBe(500);
     expect(body.error).toContain("rollback did not complete cleanly");
     expect(body.rollback_failed_steps).toEqual(["delete_programs"]);
+    const documentPatchBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url, init]) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        return typeof url === "string" && method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1");
+      })
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentPatchBodies.some((bodyText) => bodyText.includes('"status":"approved"'))).toBe(true);
+    expect(documentPatchBodies.some((bodyText) => bodyText.includes('"status":"drafted"'))).toBe(false);
   });
 });

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -18,6 +18,7 @@ import { serverLogger } from "../../lib/logger/server";
 
 const SUPPORTED_TEMPLATE_TYPES = ["caloptima_fba", "iehp_fba"] as const;
 const ASSESSMENT_DOCUMENT_BUCKET_ID = "client-documents";
+const EXTRACTION_WORKFLOW_TIMEOUT_MS = 55_000;
 
 const templateTypeSchema = z.enum(SUPPORTED_TEMPLATE_TYPES);
 
@@ -78,7 +79,7 @@ interface ExtractionFieldResult {
   value_json: Record<string, unknown> | null;
   confidence: number | null;
   mode: "AUTO" | "ASSISTED" | "MANUAL";
-  status: "not_started" | "drafted";
+  status: "not_started" | "drafted" | "verified" | "approved";
   source_span: Record<string, unknown> | null;
   review_notes: string | null;
 }
@@ -107,6 +108,84 @@ interface ExtractionFunctionResponse {
   unresolved_count: number;
 }
 
+const extractionFieldResultSchema = z.object({
+  placeholder_key: z.string().min(1),
+  value_text: z.string().nullable(),
+  value_json: z.record(z.unknown()).nullable(),
+  confidence: z.number().nullable(),
+  mode: z.enum(["AUTO", "ASSISTED", "MANUAL"]),
+  status: z.enum(["not_started", "drafted", "verified", "approved"]),
+  source_span: z.record(z.unknown()).nullable(),
+  review_notes: z.string().nullable(),
+});
+
+const structuredSectionResultSchema = z.object({
+  section_key: z.string().min(1),
+  field_key: z.string().min(1),
+  section_index: z.number().int().nonnegative(),
+  payload: z.record(z.unknown()),
+  source_span: z.record(z.unknown()).nullable(),
+  status: z.enum(["not_started", "drafted", "verified", "approved"]),
+  required: z.boolean(),
+  review_notes: z.string().nullable(),
+});
+
+const extractionFunctionResponseSchema: z.ZodType<ExtractionFunctionResponse> = z.object({
+  error: z.string().optional(),
+  extraction_provider: z.string().optional(),
+  adobe_element_count: z.number().nullable().optional(),
+  adobe_table_count: z.number().nullable().optional(),
+  structured_section_count: z.number().int().nonnegative().optional(),
+  structured_child_goal_count: z.number().int().nonnegative().optional(),
+  structured_parent_goal_count: z.number().int().nonnegative().optional(),
+  fields: z.array(extractionFieldResultSchema),
+  structured_sections: z.array(structuredSectionResultSchema).optional(),
+  unresolved_keys: z.array(z.string()),
+  extracted_count: z.number().int().nonnegative(),
+  unresolved_count: z.number().int().nonnegative(),
+});
+
+type ExtractionWorkflowResult = {
+  status: "extracted" | "extraction_failed";
+  extractionError: string | null;
+};
+
+class ExtractionWorkflowError extends Error {
+  readonly reasonCode: string;
+  readonly status?: number;
+  readonly publicMessage: string;
+
+  constructor(reasonCode: string, message = reasonCode, status?: number, publicMessage = "Field extraction failed. Review checklist manually.") {
+    super(message);
+    this.name = "ExtractionWorkflowError";
+    this.reasonCode = reasonCode;
+    this.status = status;
+    this.publicMessage = publicMessage;
+  }
+}
+
+const asExtractionWorkflowError = (error: unknown, signal?: AbortSignal): ExtractionWorkflowError => {
+  if (error instanceof ExtractionWorkflowError) return error;
+  if (signal?.aborted) {
+    return signal.reason instanceof ExtractionWorkflowError
+      ? signal.reason
+      : new ExtractionWorkflowError("extraction_workflow_timeout", "extraction_workflow_timeout", 504, "Extraction timed out before completion.");
+  }
+  return new ExtractionWorkflowError("extraction_workflow_failed", "Field extraction failed. Review checklist manually.");
+};
+
+const assertFetchOk = (result: { ok: boolean; status?: number }, reasonCode: string): void => {
+  if (!result.ok) {
+    throw new ExtractionWorkflowError(reasonCode, reasonCode, result.status);
+  }
+};
+
+const assertExtractionNotAborted = (signal?: AbortSignal): void => {
+  if (signal?.aborted) {
+    throw asExtractionWorkflowError(signal.reason, signal);
+  }
+};
+
 const processInBatches = async <T,>(
   items: T[],
   batchSize: number,
@@ -125,6 +204,57 @@ const templateTypeToDisplayLabel = (templateType: AssessmentTemplateType): strin
   return "CalOptima FBA";
 };
 
+const persistExtractionFailure = async (args: {
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  organizationId: string;
+  actorId: string | null;
+  createdDocumentId: string;
+  clientId: string;
+  error: ExtractionWorkflowError;
+}): Promise<ExtractionWorkflowResult> => {
+  const { supabaseUrl, headers, organizationId, actorId, createdDocumentId, clientId, error } = args;
+  const extractionError = error.publicMessage;
+  const updatedAt = new Date().toISOString();
+
+  const documentPatchResult = await fetchJson(
+    `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocumentId)}`,
+    {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({
+        status: "extraction_failed",
+        extraction_error: extractionError,
+        updated_at: updatedAt,
+      }),
+    },
+  );
+  assertFetchOk(documentPatchResult, "extraction_failure_status_update_failed");
+
+  const reviewEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      assessment_document_id: createdDocumentId,
+      organization_id: organizationId,
+      client_id: clientId,
+      item_type: "document",
+      item_id: createdDocumentId,
+      action: "extraction_failed",
+      from_status: "extracting",
+      to_status: "extraction_failed",
+      actor_id: actorId,
+      event_payload: {
+        reason_code: error.reasonCode,
+        status: error.status ?? null,
+      },
+    }),
+  });
+  assertFetchOk(reviewEventResult, "extraction_failure_review_event_failed");
+
+  return { status: "extraction_failed", extractionError };
+};
+
 const runCaloptimaExtractionWorkflow = async (args: {
   supabaseUrl: string;
   headers: Record<string, string>;
@@ -135,16 +265,20 @@ const runCaloptimaExtractionWorkflow = async (args: {
   checklistRows: AssessmentChecklistSeedRow[];
   bucketId: string;
   objectPath: string;
-}) => {
-  const { supabaseUrl, headers, organizationId, actorId, createdDocumentId, clientId, checklistRows, bucketId, objectPath } =
+  signal?: AbortSignal;
+}): Promise<ExtractionWorkflowResult> => {
+  const { supabaseUrl, headers, organizationId, actorId, createdDocumentId, clientId, checklistRows, bucketId, objectPath, signal } =
     args;
   try {
+    assertExtractionNotAborted(signal);
     const clientSnapshotResult = await fetchJson<ClientSnapshotRow[]>(
       `${supabaseUrl}/rest/v1/clients?select=full_name,first_name,last_name,date_of_birth,cin_number,client_id,phone,parent1_phone,parent1_first_name,parent1_last_name&id=eq.${encodeURIComponent(
         clientId,
       )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
-      { method: "GET", headers },
+      { method: "GET", headers, signal },
     );
+    assertFetchOk(clientSnapshotResult, "client_snapshot_load_failed");
+    assertExtractionNotAborted(signal);
     const clientSnapshotRow =
       clientSnapshotResult.ok && Array.isArray(clientSnapshotResult.data) && clientSnapshotResult.data[0]
         ? clientSnapshotResult.data[0]
@@ -154,6 +288,7 @@ const runCaloptimaExtractionWorkflow = async (args: {
     const extractionResult = await fetchJson<ExtractionFunctionResponse>(`${supabaseUrl}/functions/v1/extract-assessment-fields`, {
       method: "POST",
       headers,
+      signal,
       body: JSON.stringify({
         assessment_document_id: createdDocumentId,
         template_type: "caloptima_fba",
@@ -169,9 +304,21 @@ const runCaloptimaExtractionWorkflow = async (args: {
         client_snapshot: clientSnapshot,
       }),
     });
+    assertExtractionNotAborted(signal);
 
     if (extractionResult.ok && extractionResult.data) {
-      await processInBatches(extractionResult.data.fields, 10, async (field) => {
+      const parsedExtraction = extractionFunctionResponseSchema.safeParse(extractionResult.data);
+      if (!parsedExtraction.success) {
+        throw new ExtractionWorkflowError(
+          "invalid_extraction_response",
+          "invalid_extraction_response",
+          extractionResult.status,
+          "Extraction returned an unexpected response shape.",
+        );
+      }
+      const extractionData = parsedExtraction.data;
+
+      await processInBatches(extractionData.fields, 10, async (field) => {
         const reviewNotesParts = [
           field.review_notes ?? null,
           typeof field.confidence === "number" ? `Confidence: ${field.confidence.toFixed(2)}` : null,
@@ -180,7 +327,7 @@ const runCaloptimaExtractionWorkflow = async (args: {
         const mergedReviewNotes = reviewNotesParts.length > 0 ? reviewNotesParts.join(" | ") : null;
         const updatedAt = new Date().toISOString();
 
-        await Promise.all([
+        const [checklistPatchResult, extractionPatchResult] = await Promise.all([
           fetchJson(
             `${supabaseUrl}/rest/v1/assessment_checklist_items?assessment_document_id=eq.${encodeURIComponent(
               createdDocumentId,
@@ -190,6 +337,7 @@ const runCaloptimaExtractionWorkflow = async (args: {
             {
               method: "PATCH",
               headers,
+              signal,
               body: JSON.stringify({
                 value_text: field.value_text,
                 value_json: field.value_json,
@@ -208,6 +356,7 @@ const runCaloptimaExtractionWorkflow = async (args: {
             {
               method: "PATCH",
               headers,
+              signal,
               body: JSON.stringify({
                 value_text: field.value_text,
                 value_json: field.value_json,
@@ -221,8 +370,11 @@ const runCaloptimaExtractionWorkflow = async (args: {
             },
           ),
         ]);
+        assertExtractionNotAborted(signal);
+        assertFetchOk(checklistPatchResult, "checklist_patch_failed");
+        assertFetchOk(extractionPatchResult, "extraction_patch_failed");
       });
-      const structuredSections = extractionResult.data.structured_sections ?? [];
+      const structuredSections = extractionData.structured_sections ?? [];
       if (structuredSections.length > 0) {
         const serviceRoleKey = getRequiredServerEnv("SUPABASE_SERVICE_ROLE_KEY");
         const serviceHeaders = {
@@ -233,6 +385,7 @@ const runCaloptimaExtractionWorkflow = async (args: {
         const structuredInsertResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_structured_sections`, {
           method: "POST",
           headers: serviceHeaders,
+          signal,
           body: JSON.stringify(
             structuredSections.map((section) => ({
               assessment_document_id: createdDocumentId,
@@ -249,14 +402,14 @@ const runCaloptimaExtractionWorkflow = async (args: {
             })),
           ),
         });
-        if (!structuredInsertResult.ok) {
-          throw new Error("Structured section persistence failed.");
-        }
+        assertExtractionNotAborted(signal);
+        assertFetchOk(structuredInsertResult, "structured_section_persistence_failed");
       }
 
-      await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocumentId)}`, {
+      const documentExtractedResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocumentId)}`, {
         method: "PATCH",
         headers,
+        signal,
         body: JSON.stringify({
           status: "extracted",
           extracted_at: new Date().toISOString(),
@@ -264,9 +417,13 @@ const runCaloptimaExtractionWorkflow = async (args: {
           updated_at: new Date().toISOString(),
         }),
       });
-      await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
+      assertExtractionNotAborted(signal);
+      assertFetchOk(documentExtractedResult, "assessment_status_update_failed");
+
+      const reviewEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
         method: "POST",
         headers,
+        signal,
         body: JSON.stringify({
           assessment_document_id: createdDocumentId,
           organization_id: organizationId,
@@ -278,73 +435,33 @@ const runCaloptimaExtractionWorkflow = async (args: {
           to_status: "extracted",
           actor_id: actorId,
           event_payload: {
-            extracted_count: extractionResult.data.extracted_count,
-            unresolved_count: extractionResult.data.unresolved_count,
-            unresolved_keys: extractionResult.data.unresolved_keys,
+            extracted_count: extractionData.extracted_count,
+            unresolved_count: extractionData.unresolved_count,
+            unresolved_keys: extractionData.unresolved_keys,
             structured_section_count: structuredSections.length,
-            extraction_provider: extractionResult.data.extraction_provider ?? null,
-            adobe_element_count: extractionResult.data.adobe_element_count ?? null,
-            adobe_table_count: extractionResult.data.adobe_table_count ?? null,
+            extraction_provider: extractionData.extraction_provider ?? null,
+            adobe_element_count: extractionData.adobe_element_count ?? null,
+            adobe_table_count: extractionData.adobe_table_count ?? null,
           },
         }),
       });
-      return;
+      assertExtractionNotAborted(signal);
+      assertFetchOk(reviewEventResult, "review_event_persistence_failed");
+      return { status: "extracted", extractionError: null };
     }
 
-    const extractionError =
+    const edgeError =
       typeof extractionResult.data?.error === "string" && extractionResult.data.error.trim().length > 0
-        ? extractionResult.data.error
-        : "Field extraction failed. Review checklist manually.";
-    await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocumentId)}`, {
-      method: "PATCH",
-      headers,
-      body: JSON.stringify({
-        status: "extraction_failed",
-        extraction_error: extractionError,
-        updated_at: new Date().toISOString(),
-      }),
-    });
-    await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        assessment_document_id: createdDocumentId,
-        organization_id: organizationId,
-        client_id: clientId,
-        item_type: "document",
-        item_id: createdDocumentId,
-        action: "extraction_failed",
-        from_status: "extracting",
-        to_status: "extraction_failed",
-        actor_id: actorId,
-      }),
-    });
+        ? extractionResult.data.error.trim()
+        : "edge_extraction_failed";
+    throw new ExtractionWorkflowError("edge_extraction_failed", edgeError, extractionResult.status);
   } catch (error) {
-    serverLogger.error("assessment-documents extraction workflow failed", { error });
-    await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocumentId)}`, {
-      method: "PATCH",
-      headers,
-      body: JSON.stringify({
-        status: "extraction_failed",
-        extraction_error: "Field extraction failed. Review checklist manually.",
-        updated_at: new Date().toISOString(),
-      }),
+    const workflowError = asExtractionWorkflowError(error, signal);
+    serverLogger.error("assessment-documents extraction workflow failed", {
+      reasonCode: workflowError.reasonCode,
+      status: workflowError.status ?? null,
     });
-    await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        assessment_document_id: createdDocumentId,
-        organization_id: organizationId,
-        client_id: clientId,
-        item_type: "document",
-        item_id: createdDocumentId,
-        action: "extraction_failed",
-        from_status: "extracting",
-        to_status: "extraction_failed",
-        actor_id: actorId,
-      }),
-    });
+    return persistExtractionFailure({ ...args, error: workflowError });
   }
 };
 
@@ -449,6 +566,13 @@ export async function assessmentDocumentsHandler(request: Request): Promise<Resp
 
     const actorId = getAccessTokenSubject(accessToken);
     const templateType = parsed.data.template_type ?? "caloptima_fba";
+    if (templateType === "iehp_fba") {
+      return jsonForRequest(
+        request,
+        { error: "IEHP FBA upload extraction is not currently supported. Use CalOptima FBA for document upload extraction." },
+        501,
+      );
+    }
     const createPayload = {
       organization_id: organizationId,
       client_id: parsed.data.client_id,
@@ -536,27 +660,6 @@ export async function assessmentDocumentsHandler(request: Request): Promise<Resp
       return jsonForRequest(request, { error: "Failed to seed extraction records" }, extractionInsertResult.status || 500);
     }
 
-    let finalStatus: string = "uploaded";
-    if (templateType === "caloptima_fba") {
-      await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocument.id)}`, {
-        method: "PATCH",
-        headers,
-        body: JSON.stringify({ status: "extracting", updated_at: new Date().toISOString() }),
-      });
-      void runCaloptimaExtractionWorkflow({
-        supabaseUrl,
-        headers,
-        organizationId,
-        actorId,
-        createdDocumentId: createdDocument.id,
-        clientId: parsed.data.client_id,
-        checklistRows,
-        bucketId: createPayload.bucket_id,
-        objectPath: createPayload.object_path,
-      });
-      finalStatus = "extracting";
-    }
-
     const eventPayload = {
       assessment_document_id: createdDocument.id,
       organization_id: organizationId,
@@ -576,13 +679,57 @@ export async function assessmentDocumentsHandler(request: Request): Promise<Resp
       },
     };
 
-    await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
+    const uploadedEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
       method: "POST",
       headers,
       body: JSON.stringify(eventPayload),
     });
+    if (!uploadedEventResult.ok) {
+      return jsonForRequest(request, { error: "Failed to record assessment upload event" }, uploadedEventResult.status || 500);
+    }
 
-    return jsonForRequest(request, { ...createdDocument, status: finalStatus }, 201);
+    let finalStatus: string = "uploaded";
+    let extractionError: string | null = null;
+    if (templateType === "caloptima_fba") {
+      const extractingStatusResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocument.id)}`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({ status: "extracting", updated_at: new Date().toISOString() }),
+      });
+      if (!extractingStatusResult.ok) {
+        return jsonForRequest(request, { error: "Failed to mark assessment document extracting" }, extractingStatusResult.status || 500);
+      }
+
+      const extractionController = new AbortController();
+      const extractionTimeoutId = setTimeout(() => {
+        extractionController.abort(
+          new ExtractionWorkflowError(
+            "extraction_workflow_timeout",
+            "extraction_workflow_timeout",
+            504,
+            "Extraction timed out before completion.",
+          ),
+        );
+      }, EXTRACTION_WORKFLOW_TIMEOUT_MS);
+      const extractionWorkflowResult = await runCaloptimaExtractionWorkflow({
+          supabaseUrl,
+          headers,
+          organizationId,
+          actorId,
+          createdDocumentId: createdDocument.id,
+          clientId: parsed.data.client_id,
+          checklistRows,
+          bucketId: createPayload.bucket_id,
+          objectPath: createPayload.object_path,
+          signal: extractionController.signal,
+      }).finally(() => {
+        clearTimeout(extractionTimeoutId);
+      });
+      finalStatus = extractionWorkflowResult.status;
+      extractionError = extractionWorkflowResult.extractionError;
+    }
+
+    return jsonForRequest(request, { ...createdDocument, status: finalStatus, extraction_error: extractionError }, 201);
   }
 
   if (request.method === "DELETE") {

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -69,6 +69,8 @@ const toStringOrNull = (value: unknown): string | null =>
 const normalizeGoalDataPoint = (point: Record<string, unknown> | string): Record<string, unknown> =>
   typeof point === "string" ? { label: point, raw_text: point } : point;
 
+const PROMOTED_ASSESSMENT_STATUSES = new Set(["approved", "promoted"]);
+
 export async function assessmentPromoteHandler(request: Request): Promise<Response> {
   if (request.method === "OPTIONS") {
     return new Response("ok", { status: 200, headers: { ...CORS_HEADERS } });
@@ -116,6 +118,9 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   const document = Array.isArray(docLookup.data) ? docLookup.data[0] : null;
   if (!docLookup.ok || !document) {
     return json({ error: "assessment_document_id is not in scope for this organization" }, 403);
+  }
+  if (PROMOTED_ASSESSMENT_STATUSES.has(document.status)) {
+    return json({ error: "Assessment has already been approved and promoted to live records." }, 409);
   }
 
   const [draftProgramsResult, draftGoalsResult] = await Promise.all([
@@ -199,6 +204,28 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     return json({ error: "Accepted goals must keep their draft program link when promoting multiple programs." }, 409);
   }
 
+  const actorId = getAccessTokenSubject(accessToken);
+  const now = new Date().toISOString();
+  const promotionLockResult = await fetchJson<AssessmentDocumentRow[]>(
+    `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}&status=not.in.(approved,promoted)`,
+    {
+      method: "PATCH",
+      headers: { ...headers, Prefer: "return=representation" },
+      body: JSON.stringify({
+        status: "approved",
+        approved_at: now,
+        updated_at: now,
+      }),
+    },
+  );
+  const lockedDocument = Array.isArray(promotionLockResult.data) ? promotionLockResult.data[0] : null;
+  if (!promotionLockResult.ok) {
+    return json({ error: "Failed to lock assessment for promotion." }, promotionLockResult.status || 500);
+  }
+  if (!lockedDocument) {
+    return json({ error: "Assessment has already been approved and promoted to live records." }, 409);
+  }
+
   const rollbackLivePromotion = async (args: { createdProgramIds: string[]; restoreDocumentStatus: boolean }) => {
     const { createdProgramIds, restoreDocumentStatus } = args;
     const failedSteps: string[] = [];
@@ -226,7 +253,8 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
       }
     }
 
-    if (restoreDocumentStatus) {
+    const liveRollbackFailed = failedSteps.includes("delete_goals") || failedSteps.includes("delete_programs");
+    if (restoreDocumentStatus && !liveRollbackFailed) {
       const restoreDocumentResult = await fetchJson(
         `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}`,
         {
@@ -262,7 +290,7 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
       }),
     });
     if (!createProgramResult.ok || !Array.isArray(createProgramResult.data) || !createProgramResult.data[0]?.id) {
-      const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+      const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: true });
       return json(
         {
           error: rollback.ok
@@ -301,7 +329,7 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   }));
 
   if (createGoalsPayload.some((goal) => !goal.program_id)) {
-    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: true });
     return json(
       {
         error: rollback.ok
@@ -320,7 +348,7 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   });
 
   if (!createGoalsResult.ok) {
-    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: true });
     return json(
       {
         error: rollback.ok
@@ -332,13 +360,11 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     );
   }
 
-  const actorId = getAccessTokenSubject(accessToken);
-  const now = new Date().toISOString();
   const createdGoals = Array.isArray(createGoalsResult.data) ? createGoalsResult.data : [];
   const createdGoalByTitle = new Map(createdGoals.map((goal) => [normalizeTitle(goal.title), goal]));
   const missingCreatedGoal = acceptedGoals.find((goal) => !createdGoalByTitle.has(normalizeTitle(goal.title)));
   if (missingCreatedGoal) {
-    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: true });
     return json(
       {
         error: rollback.ok
@@ -383,7 +409,7 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
       body: JSON.stringify(goalDataPointPayload),
     });
     if (!createGoalDataPointsResult.ok) {
-      const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+      const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: true });
       return json(
         {
           error: rollback.ok
@@ -405,7 +431,7 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     }),
   });
   if (!updateDocumentResult.ok) {
-    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: false });
+    const rollback = await rollbackLivePromotion({ createdProgramIds, restoreDocumentStatus: true });
     return json(
       {
         error: rollback.ok

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -70,6 +70,8 @@ const normalizeGoalDataPoint = (point: Record<string, unknown> | string): Record
   typeof point === "string" ? { label: point, raw_text: point } : point;
 
 const PROMOTED_ASSESSMENT_STATUSES = new Set(["approved", "promoted"]);
+const PROMOTION_READY_STATUS = "drafted";
+const PROMOTION_LOCK_STATUS = "extracted";
 
 export async function assessmentPromoteHandler(request: Request): Promise<Response> {
   if (request.method === "OPTIONS") {
@@ -121,6 +123,9 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   }
   if (PROMOTED_ASSESSMENT_STATUSES.has(document.status)) {
     return json({ error: "Assessment has already been approved and promoted to live records." }, 409);
+  }
+  if (document.status !== PROMOTION_READY_STATUS) {
+    return json({ error: "Assessment drafts must be ready before promotion. Refresh and retry after draft generation completes." }, 409);
   }
 
   const [draftProgramsResult, draftGoalsResult] = await Promise.all([
@@ -207,13 +212,15 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   const actorId = getAccessTokenSubject(accessToken);
   const now = new Date().toISOString();
   const promotionLockResult = await fetchJson<AssessmentDocumentRow[]>(
-    `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}&status=not.in.(approved,promoted)`,
+    `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}&status=eq.${encodeURIComponent(
+      document.status,
+    )}`,
     {
       method: "PATCH",
       headers: { ...headers, Prefer: "return=representation" },
       body: JSON.stringify({
-        status: "approved",
-        approved_at: now,
+        status: PROMOTION_LOCK_STATUS,
+        approved_at: null,
         updated_at: now,
       }),
     },
@@ -223,7 +230,7 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     return json({ error: "Failed to lock assessment for promotion." }, promotionLockResult.status || 500);
   }
   if (!lockedDocument) {
-    return json({ error: "Assessment has already been approved and promoted to live records." }, 409);
+    return json({ error: "Assessment is already being promoted or has been approved. Refresh before trying again." }, 409);
   }
 
   const rollbackLivePromotion = async (args: { createdProgramIds: string[]; restoreDocumentStatus: boolean }) => {

--- a/tests/edge/assessment-upload-promote-smoke.fixture.test.ts
+++ b/tests/edge/assessment-upload-promote-smoke.fixture.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSyntheticAssessmentFixtureText,
+  EXPECTED_CHILD_GOALS,
+  EXPECTED_PARENT_GOALS,
+} from "../../scripts/playwright-assessment-upload-promote-smoke";
+import {
+  extractStructuredGoalSections,
+  summarizeStructuredGoalSections,
+} from "../../supabase/functions/extract-assessment-fields/structured-goals";
+
+describe("assessment upload promote smoke fixture structured goals", () => {
+  it("produces every above-cap child and parent goal section from synthetic CalOptima text", () => {
+    const sections = extractStructuredGoalSections(buildSyntheticAssessmentFixtureText());
+    const summary = summarizeStructuredGoalSections(sections);
+
+    expect(summary.childGoalCount).toBe(EXPECTED_CHILD_GOALS);
+    expect(summary.parentGoalCount).toBe(EXPECTED_PARENT_GOALS);
+    expect(summary.childGoalCount).toBeGreaterThan(20);
+    expect(summary.parentGoalCount).toBeGreaterThan(6);
+    expect(sections).toHaveLength(EXPECTED_CHILD_GOALS + EXPECTED_PARENT_GOALS);
+    expect(
+      sections.filter((section) => section.field_key === "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS"),
+    ).toHaveLength(10);
+    expect(
+      sections.filter((section) => section.field_key === "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS"),
+    ).toHaveLength(11);
+    expect(sections.filter((section) => section.field_key === "CALOPTIMA_FBA_PARENT_GOALS")).toHaveLength(7);
+    expect(sections.every((section) => section.payload.program_name)).toBe(true);
+    expect(sections.every((section) => section.payload.original_text)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- await CalOptima assessment extraction with an abortable bounded workflow and validate the edge response before persistence
- harden extraction persistence writes and keep user-facing extraction errors sanitized while preserving operational reason codes in review-event payloads
- block IEHP upload in this workflow, make assessment promotion idempotent with a conditional status lock, and invalidate `client-goals` after promotion
- update the synthetic upload/promote fixture/parser test to prove above-cap structured goals still extract completely

## Verification
- PASS `npx vitest run src/server/__tests__/assessmentDocumentsHandler.test.ts src/server/__tests__/assessmentDraftsHandler.test.ts src/server/__tests__/assessmentPromoteHandler.test.ts src/components/__tests__/ProgramsGoalsTab.test.tsx tests/edge/assessment-upload-promote-smoke.fixture.test.ts tests/edge/extract-assessment-fields.caloptima.test.ts`
- PASS `npm run ci:check-focused`
- PASS `npm run lint`
- PASS `npm run typecheck`
- PASS `npm run validate:tenant`
- PASS `npm run build`
- PASS `deno test --node-modules-dir=auto --allow-env supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts supabase/functions/extract-assessment-fields/structured-goals.test.ts`
- FAIL `npm run test:routes:tier0` due existing Cypress session restore `cy.then()` timeout in `role_access.cy.ts` hooks; unrelated to this workflow
- FAIL `npm run test:ci` due unrelated local timeout/MSW/coverage issues (`runtime-migration-parity`, `idempotencyService`, `/api/dashboard` MSW, coverage ENOENT)
- FAIL `npm run verify:local` at `test:ci` coverage ENOENT after earlier steps passed
- FAIL `npm run playwright:assessment-import-smoke` and `npm run playwright:assessment-upload-promote-smoke` against production/default `PW_BASE_URL`; both hit currently deployed code and ended at `extraction_failed`

## Notes
- Stacked on PR #542 / `codex/fix-assessment-program-goal-truncation`; base branch should be changed to `main` after #542 merges.
- Linear: WIN-148.