### PR TITLE
Move assessment extraction off upload response

### DIFF
--- a/docs/api/netlify-function-allowlist.json
+++ b/docs/api/netlify-function-allowlist.json
@@ -15,6 +15,7 @@
     "sessions-start.ts"
   ],
   "boundaryExceptions": [
+    "assessment-documents-extract-background.ts",
     "sessions-complete.ts",
     "session-notes-upsert.ts"
   ]

--- a/netlify/functions/assessment-documents-extract-background.ts
+++ b/netlify/functions/assessment-documents-extract-background.ts
@@ -1,0 +1,40 @@
+import { Handler } from "@netlify/functions";
+import { assessmentDocumentsExtractionBackgroundHandler } from "../../src/server/api/assessment-documents";
+
+const toNetlifyResponse = async (response: Response) => {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  return {
+    statusCode: response.status,
+    headers,
+    body: await response.text(),
+    isBase64Encoded: false,
+  };
+};
+
+export const handler: Handler = async (event) => {
+  try {
+    const body =
+      event.body && event.isBase64Encoded
+        ? Buffer.from(event.body, "base64")
+        : event.body ?? undefined;
+
+    const request = new Request(event.rawUrl || `https://${event.headers.host}${event.path}`, {
+      method: event.httpMethod,
+      headers: event.headers as HeadersInit,
+      body,
+    });
+
+    const response = await assessmentDocumentsExtractionBackgroundHandler(request);
+    return toNetlifyResponse(response);
+  } catch {
+    return {
+      statusCode: 500,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ error: "Internal Server Error" }),
+    };
+  }
+};

--- a/netlify/functions/assessment-documents.ts
+++ b/netlify/functions/assessment-documents.ts
@@ -1,5 +1,8 @@
-import { Handler } from "@netlify/functions";
-import { assessmentDocumentsHandler } from "../../src/server/api/assessment-documents";
+import { Handler, HandlerContext } from "@netlify/functions";
+import {
+  assessmentDocumentsHandler,
+  persistCaloptimaExtractionScheduleFailure,
+} from "../../src/server/api/assessment-documents";
 
 const toNetlifyResponse = async (response: Response) => {
   const headers: Record<string, string> = {};
@@ -15,7 +18,43 @@ const toNetlifyResponse = async (response: Response) => {
   };
 };
 
-export const handler: Handler = async (event) => {
+const scheduleBackgroundExtraction = (
+  context: HandlerContext,
+  request: Request,
+  args: Parameters<NonNullable<Parameters<typeof assessmentDocumentsHandler>[1]["scheduleCaloptimaExtraction"]>>[0],
+): boolean => {
+  if (typeof context.waitUntil !== "function") {
+    return false;
+  }
+
+  const origin = new URL(request.url).origin;
+  const trigger = fetch(`${origin}/.netlify/functions/assessment-documents-extract-background`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${args.accessToken}`,
+    },
+    body: JSON.stringify({ assessment_document_id: args.createdDocumentId }),
+  }).then((response) => {
+    if (!response.ok) {
+      throw new Error("background extraction trigger failed");
+    }
+  }).catch(() =>
+    persistCaloptimaExtractionScheduleFailure({
+      supabaseUrl: args.supabaseUrl,
+      headers: args.headers,
+      organizationId: args.organizationId,
+      actorId: args.actorId,
+      createdDocumentId: args.createdDocumentId,
+      clientId: args.clientId,
+    }),
+  );
+
+  context.waitUntil(trigger);
+  return true;
+};
+
+export const handler: Handler = async (event, context) => {
   try {
     const bodyNeeded = event.httpMethod !== "GET" && event.httpMethod !== "HEAD";
     const body =
@@ -31,7 +70,12 @@ export const handler: Handler = async (event) => {
       body,
     });
 
-    const response = await assessmentDocumentsHandler(request);
+    const response = await assessmentDocumentsHandler(request, {
+      scheduleCaloptimaExtraction: async (args) => {
+        const scheduled = scheduleBackgroundExtraction(context, request, args);
+        return { ok: scheduled, status: scheduled ? 202 : 500 };
+      },
+    });
     return toNetlifyResponse(response);
   } catch {
     return {

--- a/netlify/functions/assessment-documents.ts
+++ b/netlify/functions/assessment-documents.ts
@@ -34,12 +34,14 @@ const scheduleBackgroundExtraction = (
       "Content-Type": "application/json",
       Authorization: `Bearer ${args.accessToken}`,
     },
-    body: JSON.stringify({ assessment_document_id: args.createdDocumentId }),
+    body: JSON.stringify({ assessment_document_id: args.createdDocumentId, client_id: args.clientId }),
   }).then((response) => {
     if (!response.ok) {
-      throw new Error("background extraction trigger failed");
+      throw new Error("background extraction enqueue failed");
     }
   }).catch(() =>
+    // The -background endpoint response only proves enqueue/transport status.
+    // Worker-handled document failures persist their own terminal reason.
     persistCaloptimaExtractionScheduleFailure({
       supabaseUrl: args.supabaseUrl,
       headers: args.headers,

--- a/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
+++ b/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
@@ -95,6 +95,7 @@ export const statusToneByAssessment: Record<
 > = {
   uploaded: { label: "uploaded", className: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200" },
   extracting: { label: "extracting", className: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200" },
+  extraction_running: { label: "extracting", className: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200" },
   extracted: { label: "extracted", className: "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-200" },
   drafted: { label: "ai proposal ready", className: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-200" },
   approved: { label: "approved", className: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200" },

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -49,6 +49,7 @@ const ASSESSMENT_DOCUMENT_POLL_INTERVAL_MS = 3_000;
 const ACTIVE_ASSESSMENT_POLL_STATUSES: ReadonlySet<AssessmentDocumentRecord["status"]> = new Set([
   "uploaded",
   "extracting",
+  "extraction_running",
 ]);
 const AI_GENERATION_READY_STATUSES: ReadonlySet<AssessmentDocumentRecord["status"]> = new Set([
   "extracted",
@@ -1532,7 +1533,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                             ? "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-200"
                             : "border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200"
                         } ${
-                          doc.status === "extracting"
+                          doc.status === "extracting" || doc.status === "extraction_running"
                             ? "border-amber-300 bg-amber-50/40 dark:border-amber-700/60 dark:bg-amber-900/20"
                             : ""
                         }`}
@@ -1546,7 +1547,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                             </span>
                             <span>• {new Date(doc.created_at).toLocaleDateString()}</span>
                           </div>
-                          {doc.status === "extracting" && (
+                          {(doc.status === "extracting" || doc.status === "extraction_running") && (
                             <div
                               className="mt-1 inline-flex animate-pulse items-center gap-1 text-[11px] font-medium text-amber-700 dark:text-amber-300"
                               role="status"

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -856,7 +856,12 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
               file_size: 1000,
               bucket_id: "client-documents",
               object_path: "clients/client-1/assessments/iehp-fba.docx",
-              status: assessmentFetchCount === 1 ? "extracting" : "drafted",
+              status:
+                assessmentFetchCount === 1
+                  ? "extracting"
+                  : assessmentFetchCount === 2
+                    ? "extraction_running"
+                    : "drafted",
               created_at: "2026-02-11T00:00:00.000Z",
             },
           ]),
@@ -875,10 +880,10 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
 
     await screen.findByText(/Extracting fields from uploaded file/i);
-    await new Promise((resolve) => setTimeout(resolve, 3_300));
+    await new Promise((resolve) => setTimeout(resolve, 6_600));
 
     await waitFor(() => {
-      expect(assessmentFetchCount).toBeGreaterThanOrEqual(2);
+      expect(assessmentFetchCount).toBeGreaterThanOrEqual(3);
     });
 
     const completedPollCount = assessmentFetchCount;

--- a/src/lib/assessment-documents.ts
+++ b/src/lib/assessment-documents.ts
@@ -22,7 +22,7 @@ export interface AssessmentDocumentRecord {
   file_size: number;
   bucket_id: string;
   object_path: string;
-  status: "uploaded" | "extracting" | "extracted" | "drafted" | "approved" | "rejected" | "extraction_failed";
+  status: "uploaded" | "extracting" | "extraction_running" | "extracted" | "drafted" | "approved" | "rejected" | "extraction_failed";
   extracted_at?: string | null;
   extraction_error?: string | null;
   created_at: string;

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { assessmentDocumentsHandler } from "../api/assessment-documents";
+import { assessmentDocumentsExtractionBackgroundHandler, assessmentDocumentsHandler } from "../api/assessment-documents";
+import { handler as assessmentDocumentsNetlifyHandler } from "../../../netlify/functions/assessment-documents";
 
 vi.mock("../api/shared", async () => {
   const actual = await vi.importActual<typeof import("../api/shared")>("../api/shared");
@@ -27,6 +28,7 @@ import {
 import { loadChecklistTemplateRows } from "../assessmentChecklistTemplate";
 
 const ORIGINAL_SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const ORIGINAL_FETCH = globalThis.fetch;
 
 describe("assessmentDocumentsHandler", () => {
   beforeEach(() => {
@@ -40,6 +42,7 @@ describe("assessmentDocumentsHandler", () => {
     } else {
       delete process.env.SUPABASE_SERVICE_ROLE_KEY;
     }
+    globalThis.fetch = ORIGINAL_FETCH;
   });
 
   const roleMatrix = [
@@ -249,6 +252,11 @@ describe("assessmentDocumentsHandler", () => {
     );
 
     expect(response.status).toBe(201);
+    await expect(response.clone().json()).resolves.toMatchObject({
+      id: "doc-1",
+      status: "extracting",
+      extraction_error: null,
+    });
     expect(fetchJson).toHaveBeenCalledWith(
       expect.stringContaining("/assessment_checklist_items"),
       expect.objectContaining({ method: "POST" }),
@@ -257,19 +265,16 @@ describe("assessmentDocumentsHandler", () => {
       expect.stringContaining("/assessment_extractions"),
       expect.objectContaining({ method: "POST" }),
     );
-    expect(fetchJson).toHaveBeenCalledWith(
-      expect.stringContaining("/functions/v1/extract-assessment-fields"),
-      expect.objectContaining({ method: "POST" }),
-    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
     const extractionCall = vi
       .mocked(fetchJson)
       .mock.calls.find(([url]) => typeof url === "string" && url.includes("/functions/v1/extract-assessment-fields"));
+    expect(extractionCall).toBeDefined();
     const extractionPayload = JSON.parse(String((extractionCall?.[1] as RequestInit | undefined)?.body ?? "{}")) as {
       checklist_rows?: Array<{ extraction_aliases?: string[] }>;
     };
     expect(extractionPayload.checklist_rows?.[0]?.extraction_aliases).toEqual(["Member full legal name"]);
     expect(loadChecklistTemplateRows).toHaveBeenCalledWith("caloptima_fba");
-    await new Promise((resolve) => setTimeout(resolve, 0));
     const completedEventCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
       const body = String((init as RequestInit | undefined)?.body ?? "");
       return typeof url === "string" && url.includes("/assessment_review_events") && body.includes("extraction_completed");
@@ -280,6 +285,500 @@ describe("assessmentDocumentsHandler", () => {
       adobe_element_count: 42,
       adobe_table_count: 3,
     });
+  });
+
+  it("returns upload response before starting the scheduled CalOptima extraction workflow", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    mockUploadFlowResponses("doc-scheduled");
+
+    const scheduled: string[] = [];
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+      }),
+      {
+        scheduleCaloptimaExtraction: async ({ createdDocumentId }) => {
+          scheduled.push(createdDocumentId);
+          return { ok: true, status: 202 };
+        },
+      },
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      id: "doc-scheduled",
+      status: "extracting",
+      extraction_error: null,
+    });
+    expect(scheduled).toEqual(["doc-scheduled"]);
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/extract-assessment-fields"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("fails closed when scheduling CalOptima extraction throws after marking the document extracting", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    mockUploadFlowResponses("doc-schedule-throw");
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+      }),
+      {
+        scheduleCaloptimaExtraction: async () => {
+          throw new Error("trigger failed");
+        },
+      },
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Unable to start extraction. Retry the upload or contact support.",
+    });
+    const documentStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-schedule-throw"))
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
+  });
+
+  it("Netlify upload wrapper schedules extraction with waitUntil without awaiting the background fetch", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    mockUploadFlowResponses("doc-netlify-wrapper");
+    const waitUntil = vi.fn();
+    globalThis.fetch = vi.fn(() => new Promise<Response>(() => undefined)) as typeof fetch;
+
+    const response = await assessmentDocumentsNetlifyHandler(
+      {
+        httpMethod: "POST",
+        headers: {
+          host: "app.example.com",
+          authorization: "Bearer token",
+        },
+        path: "/api/assessment-documents",
+        rawUrl: "https://app.example.com/api/assessment-documents",
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+        isBase64Encoded: false,
+      } as never,
+      { waitUntil } as never,
+      undefined as never,
+    );
+
+    expect(response.statusCode).toBe(201);
+    expect(JSON.parse(response.body)).toMatchObject({
+      id: "doc-netlify-wrapper",
+      status: "extracting",
+    });
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://app.example.com/.netlify/functions/assessment-documents-extract-background",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer token" }),
+        body: JSON.stringify({ assessment_document_id: "doc-netlify-wrapper" }),
+      }),
+    );
+  });
+
+  it("Netlify upload wrapper fails closed when waitUntil is unavailable", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    mockUploadFlowResponses("doc-netlify-no-waituntil");
+    globalThis.fetch = vi.fn(() => Promise.resolve(new Response(null, { status: 202 }))) as typeof fetch;
+
+    const response = await assessmentDocumentsNetlifyHandler(
+      {
+        httpMethod: "POST",
+        headers: {
+          host: "app.example.com",
+          authorization: "Bearer token",
+        },
+        path: "/api/assessment-documents",
+        rawUrl: "https://app.example.com/api/assessment-documents",
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+        isBase64Encoded: false,
+      } as never,
+      {} as never,
+      undefined as never,
+    );
+
+    expect(response.statusCode).toBe(500);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    const documentStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-netlify-no-waituntil"))
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
+  });
+
+  it("Netlify upload wrapper marks extraction failed when the background trigger rejects", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    mockUploadFlowResponses("doc-netlify-trigger-fail");
+    const waitUntilPromises: Promise<unknown>[] = [];
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error("network down"))) as typeof fetch;
+
+    const response = await assessmentDocumentsNetlifyHandler(
+      {
+        httpMethod: "POST",
+        headers: {
+          host: "app.example.com",
+          authorization: "Bearer token",
+        },
+        path: "/api/assessment-documents",
+        rawUrl: "https://app.example.com/api/assessment-documents",
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+        isBase64Encoded: false,
+      } as never,
+      {
+        waitUntil: (promise: Promise<unknown>) => {
+          waitUntilPromises.push(promise);
+        },
+      } as never,
+      undefined as never,
+    );
+
+    expect(response.statusCode).toBe(201);
+    expect(waitUntilPromises).toHaveLength(1);
+    await waitUntilPromises[0];
+    const documentStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-netlify-trigger-fail"))
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
+  });
+
+  it("runs CalOptima extraction from the background worker only for scoped extracting documents", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([
+      {
+        section: "identification_admin",
+        label: "Member Name",
+        placeholder_key: "CALOPTIMA_FBA_MEMBER_NAME",
+        mode: "AUTO",
+        source: "clients.full_name",
+        required: true,
+        extraction_method: "database_prefill",
+        validation_rule: "non_empty_text",
+        status: "not_started",
+      },
+    ]);
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              organization_id: "org-1",
+              client_id: "22222222-2222-4222-8222-222222222222",
+              status: "extracting",
+              template_type: "caloptima_fba",
+              bucket_id: "client-documents",
+              object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
+            },
+          ],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name")) {
+        return { ok: true, status: 200, data: [{ full_name: "Client One" }] };
+      }
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return {
+          ok: true,
+          status: 200,
+          data: {
+            fields: [
+              {
+                placeholder_key: "CALOPTIMA_FBA_MEMBER_NAME",
+                value_text: "Client One",
+                value_json: null,
+                confidence: 0.99,
+                mode: "AUTO",
+                status: "drafted",
+                source_span: null,
+                review_notes: null,
+              },
+            ],
+            structured_sections: [],
+            unresolved_keys: [],
+            extracted_count: 1,
+            unresolved_count: 0,
+          },
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_checklist_items")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_extractions")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/extract-assessment-fields"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111"),
+      expect.objectContaining({
+        method: "PATCH",
+        body: expect.stringContaining("\"status\":\"extracted\""),
+      }),
+    );
+  });
+
+  it("rejects unauthenticated background extraction requests", async () => {
+    const response = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("rejects out-of-org background extraction documents", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({ ok: true, status: 200, data: [] });
+
+    const response = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("organization_id=eq.org-1"),
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("rejects unsupported templates in the background extraction worker", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          organization_id: "org-1",
+          client_id: "22222222-2222-4222-8222-222222222222",
+          status: "extracting",
+          template_type: "iehp_fba",
+          bucket_id: "client-documents",
+          object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.docx",
+        },
+      ],
+    });
+
+    const response = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/extract-assessment-fields"),
+      expect.anything(),
+    );
+  });
+
+  it("skips background extraction for documents no longer in extracting status", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          organization_id: "org-1",
+          client_id: "22222222-2222-4222-8222-222222222222",
+          status: "extracted",
+          template_type: "caloptima_fba",
+          bucket_id: "client-documents",
+          object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
+        },
+      ],
+    });
+
+    const response = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({ skipped: true, status: "extracted" });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/extract-assessment-fields"),
+      expect.anything(),
+    );
   });
 
   it("blocks IEHP document extraction until the workflow is implemented", async () => {
@@ -1336,14 +1835,15 @@ describe("assessmentDocumentsHandler", () => {
       }),
     );
 
-    await vi.advanceTimersByTimeAsync(55_000);
     const response = await responsePromise;
 
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toMatchObject({
-      status: "extraction_failed",
-      extraction_error: "Extraction timed out before completion.",
+      status: "extracting",
+      extraction_error: null,
     });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(55_000);
     const documentStatusBodies = vi
       .mocked(fetchJson)
       .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-timeout"))

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -435,7 +435,10 @@ describe("assessmentDocumentsHandler", () => {
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({ Authorization: "Bearer token" }),
-        body: JSON.stringify({ assessment_document_id: "doc-netlify-wrapper" }),
+        body: JSON.stringify({
+          assessment_document_id: "doc-netlify-wrapper",
+          client_id: "11111111-1111-1111-1111-111111111111",
+        }),
       }),
     );
   });
@@ -544,6 +547,61 @@ describe("assessmentDocumentsHandler", () => {
     expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
   });
 
+  it("Netlify upload wrapper does not overwrite worker-handled failures from background responses", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    mockUploadFlowResponses("doc-netlify-worker-terminal-failure");
+    const waitUntilPromises: Promise<unknown>[] = [];
+    globalThis.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify({ accepted: true }), { status: 202 }))) as typeof fetch;
+
+    const response = await assessmentDocumentsNetlifyHandler(
+      {
+        httpMethod: "POST",
+        headers: {
+          host: "app.example.com",
+          authorization: "Bearer token",
+        },
+        path: "/api/assessment-documents",
+        rawUrl: "https://app.example.com/api/assessment-documents",
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+        isBase64Encoded: false,
+      } as never,
+      {
+        waitUntil: (promise: Promise<unknown>) => {
+          waitUntilPromises.push(promise);
+        },
+      } as never,
+      undefined as never,
+    );
+
+    expect(response.statusCode).toBe(201);
+    expect(waitUntilPromises).toHaveLength(1);
+    await waitUntilPromises[0];
+    const documentStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-netlify-worker-terminal-failure"))
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(false);
+  });
+
   it("runs CalOptima extraction from the background worker only for scoped extracting documents", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -585,6 +643,29 @@ describe("assessmentDocumentsHandler", () => {
               template_type: "caloptima_fba",
               bucket_id: "client-documents",
               object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
+              updated_at: "2026-05-15T20:00:00.000Z",
+            },
+          ],
+        };
+      }
+      if (
+        method === "PATCH" &&
+        url.includes("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111") &&
+        url.includes("status=eq.extracting")
+      ) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              organization_id: "org-1",
+              client_id: "22222222-2222-4222-8222-222222222222",
+              status: "extraction_running",
+              template_type: "caloptima_fba",
+              bucket_id: "client-documents",
+              object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
+              updated_at: "2026-05-15T20:00:01.000Z",
             },
           ],
         };
@@ -645,12 +726,403 @@ describe("assessmentDocumentsHandler", () => {
       expect.objectContaining({ method: "POST" }),
     );
     expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("status=eq.extracting"),
+      expect.objectContaining({
+        method: "PATCH",
+        body: expect.stringContaining("\"status\":\"extraction_running\""),
+      }),
+    );
+    expect(fetchJson).toHaveBeenCalledWith(
       expect.stringContaining("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111"),
       expect.objectContaining({
         method: "PATCH",
         body: expect.stringContaining("\"status\":\"extracted\""),
       }),
     );
+  });
+
+  it("skips background extraction when the atomic claim returns no document", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              organization_id: "org-1",
+              client_id: "22222222-2222-4222-8222-222222222222",
+              status: "extracting",
+              template_type: "caloptima_fba",
+              bucket_id: "client-documents",
+              object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
+              updated_at: "2026-05-15T20:00:00.000Z",
+            },
+          ],
+        };
+      }
+      if (method === "PATCH" && url.includes("status=eq.extracting")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({ skipped: true, status: "extracting" });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/extract-assessment-fields"),
+      expect.anything(),
+    );
+  });
+
+  it("skips fresh extraction_running documents but reclaims stale extraction_running documents", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    let documentLoadCount = 0;
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+        documentLoadCount += 1;
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              organization_id: "org-1",
+              client_id: "22222222-2222-4222-8222-222222222222",
+              status: "extraction_running",
+              template_type: "caloptima_fba",
+              bucket_id: "client-documents",
+              object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
+              updated_at: documentLoadCount === 1 ? new Date().toISOString() : "2020-01-01T00:00:00.000Z",
+            },
+          ],
+        };
+      }
+      if (method === "PATCH" && url.includes("status=eq.extraction_running")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              organization_id: "org-1",
+              client_id: "22222222-2222-4222-8222-222222222222",
+              status: "extraction_running",
+              template_type: "caloptima_fba",
+              bucket_id: "client-documents",
+              object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
+              updated_at: "2026-05-15T20:00:01.000Z",
+            },
+          ],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name")) {
+        return { ok: true, status: 200, data: [{ full_name: "Client One" }] };
+      }
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return {
+          ok: true,
+          status: 200,
+          data: {
+            fields: [],
+            structured_sections: [],
+            unresolved_keys: [],
+            extracted_count: 0,
+            unresolved_count: 0,
+          },
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const freshResponse = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+    expect(freshResponse.status).toBe(202);
+    await expect(freshResponse.json()).resolves.toMatchObject({ skipped: true, status: "extraction_running" });
+
+    const staleResponse = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+    expect(staleResponse.status).toBe(202);
+    const extractionCalls = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/functions/v1/extract-assessment-fields"));
+    expect(extractionCalls).toHaveLength(1);
+  });
+
+  it("marks extraction failed when the background worker cannot load the document after enqueue", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+        return { ok: false, status: 503, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-4111-8111-111111111111",
+          client_id: "22222222-2222-4222-8222-222222222222",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111"),
+      expect.objectContaining({
+        method: "PATCH",
+        body: expect.stringContaining("\"status\":\"extraction_failed\""),
+      }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/extract-assessment-fields"),
+      expect.anything(),
+    );
+  });
+
+  it("marks extraction failed when the background worker cannot claim the document", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      const body = String(init?.body ?? "");
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              organization_id: "org-1",
+              client_id: "22222222-2222-4222-8222-222222222222",
+              status: "extracting",
+              template_type: "caloptima_fba",
+              bucket_id: "client-documents",
+              object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
+              updated_at: "2026-05-15T20:00:00.000Z",
+            },
+          ],
+        };
+      }
+      if (method === "PATCH" && url.includes("status=eq.extracting")) {
+        return { ok: false, status: 503, data: null };
+      }
+      if (
+        method === "PATCH" &&
+        url.includes("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111") &&
+        body.includes("\"status\":\"extraction_failed\"")
+      ) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/extract-assessment-fields"),
+      expect.anything(),
+    );
+    const failedEvent = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
+      const body = String((init as RequestInit | undefined)?.body ?? "");
+      return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes("extraction_claim_failed");
+    });
+    expect(failedEvent).toBeDefined();
+  });
+
+  it("runs extraction once when duplicate background workers race for the same document", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    let claimAttempts = 0;
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              organization_id: "org-1",
+              client_id: "22222222-2222-4222-8222-222222222222",
+              status: "extracting",
+              template_type: "caloptima_fba",
+              bucket_id: "client-documents",
+              object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
+              updated_at: "2026-05-15T20:00:00.000Z",
+            },
+          ],
+        };
+      }
+      if (method === "PATCH" && url.includes("status=eq.extracting")) {
+        claimAttempts += 1;
+        return claimAttempts === 1
+          ? {
+              ok: true,
+              status: 200,
+              data: [
+                {
+                  id: "11111111-1111-4111-8111-111111111111",
+                  organization_id: "org-1",
+                  client_id: "22222222-2222-4222-8222-222222222222",
+                  status: "extraction_running",
+                  template_type: "caloptima_fba",
+                  bucket_id: "client-documents",
+                  object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
+                  updated_at: "2026-05-15T20:00:01.000Z",
+                },
+              ],
+            }
+          : { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name")) {
+        return { ok: true, status: 200, data: [{ full_name: "Client One" }] };
+      }
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return {
+          ok: true,
+          status: 200,
+          data: {
+            fields: [],
+            structured_sections: [],
+            unresolved_keys: [],
+            extracted_count: 0,
+            unresolved_count: 0,
+          },
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const requests = Array.from({ length: 2 }, () =>
+      assessmentDocumentsExtractionBackgroundHandler(
+        new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+          method: "POST",
+          headers: { Authorization: "Bearer token" },
+          body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+        }),
+      ),
+    );
+    const responses = await Promise.all(requests);
+
+    expect(responses.map((response) => response.status)).toEqual([202, 202]);
+    expect(claimAttempts).toBe(2);
+    const extractionCalls = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/functions/v1/extract-assessment-fields"));
+    expect(extractionCalls).toHaveLength(1);
+    const completedEvents = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
+      const body = String((init as RequestInit | undefined)?.body ?? "");
+      return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes("extraction_completed");
+    });
+    expect(completedEvents).toHaveLength(1);
   });
 
   it("rejects unauthenticated background extraction requests", async () => {
@@ -694,7 +1166,7 @@ describe("assessmentDocumentsHandler", () => {
     );
   });
 
-  it("rejects unsupported templates in the background extraction worker", async () => {
+  it("marks unsupported templates failed in the background extraction worker", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
@@ -706,20 +1178,34 @@ describe("assessmentDocumentsHandler", () => {
       supabaseUrl: "https://example.supabase.co",
       anonKey: "anon",
     });
-    vi.mocked(fetchJson).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      data: [
-        {
-          id: "11111111-1111-4111-8111-111111111111",
-          organization_id: "org-1",
-          client_id: "22222222-2222-4222-8222-222222222222",
-          status: "extracting",
-          template_type: "iehp_fba",
-          bucket_id: "client-documents",
-          object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.docx",
-        },
-      ],
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              organization_id: "org-1",
+              client_id: "22222222-2222-4222-8222-222222222222",
+              status: "extracting",
+              template_type: "iehp_fba",
+              bucket_id: "client-documents",
+              object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.docx",
+              updated_at: "2026-05-15T20:00:00.000Z",
+            },
+          ],
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
     });
 
     const response = await assessmentDocumentsExtractionBackgroundHandler(
@@ -730,10 +1216,17 @@ describe("assessmentDocumentsHandler", () => {
       }),
     );
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(202);
     expect(fetchJson).not.toHaveBeenCalledWith(
       expect.stringContaining("/functions/v1/extract-assessment-fields"),
       expect.anything(),
+    );
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111"),
+      expect.objectContaining({
+        method: "PATCH",
+        body: expect.stringContaining("\"status\":\"extraction_failed\""),
+      }),
     );
   });
 

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -49,6 +49,16 @@ interface AssessmentDocumentRow {
   created_at: string;
 }
 
+interface AssessmentDocumentExtractionRow {
+  id: string;
+  organization_id: string;
+  client_id: string;
+  status: string;
+  template_type: AssessmentTemplateType;
+  bucket_id: string | null;
+  object_path: string | null;
+}
+
 interface AssessmentDocumentDeleteRow {
   id: string;
   organization_id: string;
@@ -150,6 +160,33 @@ type ExtractionWorkflowResult = {
   extractionError: string | null;
 };
 
+type CaloptimaExtractionWorkflowArgs = {
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  organizationId: string;
+  actorId: string | null;
+  createdDocumentId: string;
+  clientId: string;
+  checklistRows: AssessmentChecklistSeedRow[];
+  bucketId: string;
+  objectPath: string;
+  signal?: AbortSignal;
+};
+
+type CaloptimaExtractionScheduleArgs = Omit<CaloptimaExtractionWorkflowArgs, "signal"> & {
+  request: Request;
+  accessToken: string;
+};
+
+type CaloptimaExtractionScheduleResult = {
+  ok: boolean;
+  status?: number;
+};
+
+type AssessmentDocumentsHandlerOptions = {
+  scheduleCaloptimaExtraction?: (args: CaloptimaExtractionScheduleArgs) => Promise<CaloptimaExtractionScheduleResult>;
+};
+
 class ExtractionWorkflowError extends Error {
   readonly reasonCode: string;
   readonly status?: number;
@@ -195,6 +232,40 @@ const processInBatches = async <T,>(
     const batch = items.slice(index, index + batchSize);
     await Promise.all(batch.map((item) => handler(item)));
   }
+};
+
+const runBoundedCaloptimaExtractionWorkflow = async (args: Omit<CaloptimaExtractionWorkflowArgs, "signal">): Promise<void> => {
+  const extractionController = new AbortController();
+  const extractionTimeoutId = setTimeout(() => {
+    extractionController.abort(
+      new ExtractionWorkflowError(
+        "extraction_workflow_timeout",
+        "extraction_workflow_timeout",
+        504,
+        "Extraction timed out before completion.",
+      ),
+    );
+  }, EXTRACTION_WORKFLOW_TIMEOUT_MS);
+
+  try {
+    await runCaloptimaExtractionWorkflow({ ...args, signal: extractionController.signal });
+  } finally {
+    clearTimeout(extractionTimeoutId);
+  }
+};
+
+const scheduleInProcessCaloptimaExtraction = async (
+  args: CaloptimaExtractionScheduleArgs,
+): Promise<CaloptimaExtractionScheduleResult> => {
+  setTimeout(() => {
+    void runBoundedCaloptimaExtractionWorkflow(args).catch((error) => {
+      serverLogger.error("assessment-documents scheduled extraction failed", {
+        reasonCode: error instanceof ExtractionWorkflowError ? error.reasonCode : "scheduled_extraction_failed",
+      });
+    });
+  }, 0);
+
+  return { ok: true, status: 202 };
 };
 
 const templateTypeToDisplayLabel = (templateType: AssessmentTemplateType): string => {
@@ -255,18 +326,20 @@ const persistExtractionFailure = async (args: {
   return { status: "extraction_failed", extractionError };
 };
 
-const runCaloptimaExtractionWorkflow = async (args: {
-  supabaseUrl: string;
-  headers: Record<string, string>;
-  organizationId: string;
-  actorId: string | null;
-  createdDocumentId: string;
-  clientId: string;
-  checklistRows: AssessmentChecklistSeedRow[];
-  bucketId: string;
-  objectPath: string;
-  signal?: AbortSignal;
-}): Promise<ExtractionWorkflowResult> => {
+export const persistCaloptimaExtractionScheduleFailure = async (
+  args: Omit<CaloptimaExtractionWorkflowArgs, "checklistRows" | "bucketId" | "objectPath" | "signal">,
+): Promise<ExtractionWorkflowResult> =>
+  persistExtractionFailure({
+    ...args,
+    error: new ExtractionWorkflowError(
+      "extraction_background_schedule_failed",
+      "extraction_background_schedule_failed",
+      500,
+      "Unable to start extraction. Retry the upload or contact support.",
+    ),
+  });
+
+const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowArgs): Promise<ExtractionWorkflowResult> => {
   const { supabaseUrl, headers, organizationId, actorId, createdDocumentId, clientId, checklistRows, bucketId, objectPath, signal } =
     args;
   try {
@@ -465,7 +538,101 @@ const runCaloptimaExtractionWorkflow = async (args: {
   }
 };
 
-export async function assessmentDocumentsHandler(request: Request): Promise<Response> {
+export async function assessmentDocumentsExtractionBackgroundHandler(request: Request): Promise<Response> {
+  if (request.method !== "POST") {
+    return jsonForRequest(request, { error: "Method not allowed" }, 405);
+  }
+
+  const accessToken = getAccessToken(request);
+  if (!accessToken) {
+    return jsonForRequest(request, { error: "Missing authorization token" }, 401, { "WWW-Authenticate": "Bearer" });
+  }
+
+  const { organizationId, isTherapist, isAdmin, isSuperAdmin } = await resolveOrgAndRole(accessToken);
+  if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin)) {
+    return jsonForRequest(request, { error: "Forbidden" }, 403);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return jsonForRequest(request, { error: "Invalid JSON body" }, 400);
+  }
+
+  const parsed = z.object({ assessment_document_id: z.string().uuid() }).safeParse(payload);
+  if (!parsed.success) {
+    return jsonForRequest(request, { error: "Invalid request body" }, 400);
+  }
+
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const headers = {
+    "Content-Type": "application/json",
+    apikey: anonKey,
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  const documentResult = await fetchJson<AssessmentDocumentExtractionRow[]>(
+    `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path&id=eq.${encodeURIComponent(
+      parsed.data.assessment_document_id,
+    )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
+    { method: "GET", headers },
+  );
+  if (!documentResult.ok) {
+    return jsonForRequest(request, { error: "Failed to load assessment document" }, documentResult.status || 500);
+  }
+
+  const document = Array.isArray(documentResult.data) ? documentResult.data[0] ?? null : null;
+  if (!document) {
+    return jsonForRequest(request, { error: "assessment_document_id is not in scope for this organization" }, 403);
+  }
+  if (document.template_type !== "caloptima_fba") {
+    return jsonForRequest(request, { error: "Only CalOptima FBA extraction can be run by this worker." }, 400);
+  }
+  if (document.status !== "extracting") {
+    return jsonForRequest(request, { skipped: true, status: document.status }, 202);
+  }
+  if (!document.bucket_id || !document.object_path) {
+    const actorId = getAccessTokenSubject(accessToken);
+    const failure = new ExtractionWorkflowError(
+      "assessment_document_storage_missing",
+      "assessment_document_storage_missing",
+      400,
+      "Assessment document storage metadata is missing.",
+    );
+    await persistExtractionFailure({
+      supabaseUrl,
+      headers,
+      organizationId,
+      actorId,
+      createdDocumentId: document.id,
+      clientId: document.client_id,
+      error: failure,
+    });
+    return jsonForRequest(request, { error: failure.publicMessage }, 400);
+  }
+
+  const actorId = getAccessTokenSubject(accessToken);
+  const checklistRows = await loadChecklistTemplateRows(document.template_type);
+  await runBoundedCaloptimaExtractionWorkflow({
+    supabaseUrl,
+    headers,
+    organizationId,
+    actorId,
+    createdDocumentId: document.id,
+    clientId: document.client_id,
+    checklistRows,
+    bucketId: document.bucket_id,
+    objectPath: document.object_path,
+  });
+
+  return jsonForRequest(request, { accepted: true }, 202);
+}
+
+export async function assessmentDocumentsHandler(
+  request: Request,
+  options: AssessmentDocumentsHandlerOptions = {},
+): Promise<Response> {
   if (request.method === "OPTIONS") {
     return new Response("ok", { status: 200, headers: { ...corsHeadersForRequest(request) } });
   }
@@ -688,8 +855,6 @@ export async function assessmentDocumentsHandler(request: Request): Promise<Resp
       return jsonForRequest(request, { error: "Failed to record assessment upload event" }, uploadedEventResult.status || 500);
     }
 
-    let finalStatus: string = "uploaded";
-    let extractionError: string | null = null;
     if (templateType === "caloptima_fba") {
       const extractingStatusResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocument.id)}`, {
         method: "PATCH",
@@ -700,36 +865,47 @@ export async function assessmentDocumentsHandler(request: Request): Promise<Resp
         return jsonForRequest(request, { error: "Failed to mark assessment document extracting" }, extractingStatusResult.status || 500);
       }
 
-      const extractionController = new AbortController();
-      const extractionTimeoutId = setTimeout(() => {
-        extractionController.abort(
-          new ExtractionWorkflowError(
-            "extraction_workflow_timeout",
-            "extraction_workflow_timeout",
-            504,
-            "Extraction timed out before completion.",
-          ),
+      let scheduleResult: CaloptimaExtractionScheduleResult;
+      try {
+        scheduleResult = await (options.scheduleCaloptimaExtraction ?? scheduleInProcessCaloptimaExtraction)({
+            request,
+            accessToken,
+            supabaseUrl,
+            headers,
+            organizationId,
+            actorId,
+            createdDocumentId: createdDocument.id,
+            clientId: parsed.data.client_id,
+            checklistRows,
+            bucketId: createPayload.bucket_id,
+            objectPath: createPayload.object_path,
+        });
+      } catch {
+        scheduleResult = { ok: false, status: 500 };
+      }
+      if (!scheduleResult.ok) {
+        const failure = new ExtractionWorkflowError(
+          "extraction_background_schedule_failed",
+          "extraction_background_schedule_failed",
+          scheduleResult.status,
+          "Unable to start extraction. Retry the upload or contact support.",
         );
-      }, EXTRACTION_WORKFLOW_TIMEOUT_MS);
-      const extractionWorkflowResult = await runCaloptimaExtractionWorkflow({
+        await persistExtractionFailure({
           supabaseUrl,
           headers,
           organizationId,
           actorId,
           createdDocumentId: createdDocument.id,
           clientId: parsed.data.client_id,
-          checklistRows,
-          bucketId: createPayload.bucket_id,
-          objectPath: createPayload.object_path,
-          signal: extractionController.signal,
-      }).finally(() => {
-        clearTimeout(extractionTimeoutId);
-      });
-      finalStatus = extractionWorkflowResult.status;
-      extractionError = extractionWorkflowResult.extractionError;
+          error: failure,
+        });
+        return jsonForRequest(request, { error: failure.publicMessage }, scheduleResult.status || 500);
+      }
+
+      return jsonForRequest(request, { ...createdDocument, status: "extracting", extraction_error: null }, 201);
     }
 
-    return jsonForRequest(request, { ...createdDocument, status: finalStatus, extraction_error: extractionError }, 201);
+    return jsonForRequest(request, { ...createdDocument, status: "uploaded", extraction_error: null }, 201);
   }
 
   if (request.method === "DELETE") {

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -19,6 +19,8 @@ import { serverLogger } from "../../lib/logger/server";
 const SUPPORTED_TEMPLATE_TYPES = ["caloptima_fba", "iehp_fba"] as const;
 const ASSESSMENT_DOCUMENT_BUCKET_ID = "client-documents";
 const EXTRACTION_WORKFLOW_TIMEOUT_MS = 55_000;
+const EXTRACTION_RUNNING_STATUS = "extraction_running";
+const EXTRACTION_RUNNING_STALE_MS = EXTRACTION_WORKFLOW_TIMEOUT_MS * 2;
 
 const templateTypeSchema = z.enum(SUPPORTED_TEMPLATE_TYPES);
 
@@ -57,6 +59,7 @@ interface AssessmentDocumentExtractionRow {
   template_type: AssessmentTemplateType;
   bucket_id: string | null;
   object_path: string | null;
+  updated_at: string | null;
 }
 
 interface AssessmentDocumentDeleteRow {
@@ -170,6 +173,7 @@ type CaloptimaExtractionWorkflowArgs = {
   checklistRows: AssessmentChecklistSeedRow[];
   bucketId: string;
   objectPath: string;
+  fromStatus?: string;
   signal?: AbortSignal;
 };
 
@@ -283,8 +287,9 @@ const persistExtractionFailure = async (args: {
   createdDocumentId: string;
   clientId: string;
   error: ExtractionWorkflowError;
+  fromStatus?: string;
 }): Promise<ExtractionWorkflowResult> => {
-  const { supabaseUrl, headers, organizationId, actorId, createdDocumentId, clientId, error } = args;
+  const { supabaseUrl, headers, organizationId, actorId, createdDocumentId, clientId, error, fromStatus = "extracting" } = args;
   const extractionError = error.publicMessage;
   const updatedAt = new Date().toISOString();
 
@@ -312,7 +317,7 @@ const persistExtractionFailure = async (args: {
       item_type: "document",
       item_id: createdDocumentId,
       action: "extraction_failed",
-      from_status: "extracting",
+      from_status: fromStatus,
       to_status: "extraction_failed",
       actor_id: actorId,
       event_payload: {
@@ -340,7 +345,7 @@ export const persistCaloptimaExtractionScheduleFailure = async (
   });
 
 const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowArgs): Promise<ExtractionWorkflowResult> => {
-  const { supabaseUrl, headers, organizationId, actorId, createdDocumentId, clientId, checklistRows, bucketId, objectPath, signal } =
+  const { supabaseUrl, headers, organizationId, actorId, createdDocumentId, clientId, checklistRows, bucketId, objectPath, fromStatus = "extracting", signal } =
     args;
   try {
     assertExtractionNotAborted(signal);
@@ -504,7 +509,7 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
           item_type: "document",
           item_id: createdDocumentId,
           action: "extraction_completed",
-          from_status: "extracting",
+          from_status: fromStatus,
           to_status: "extracted",
           actor_id: actorId,
           event_payload: {
@@ -534,8 +539,48 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
       reasonCode: workflowError.reasonCode,
       status: workflowError.status ?? null,
     });
-    return persistExtractionFailure({ ...args, error: workflowError });
+    return persistExtractionFailure({ ...args, error: workflowError, fromStatus });
   }
+};
+
+const isExtractionRunningStale = (updatedAt: string | null, now = Date.now()): boolean => {
+  if (!updatedAt) return false;
+  const updatedAtMs = Date.parse(updatedAt);
+  return Number.isFinite(updatedAtMs) && now - updatedAtMs >= EXTRACTION_RUNNING_STALE_MS;
+};
+
+const claimCaloptimaExtractionDocument = async (args: {
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  organizationId: string;
+  document: AssessmentDocumentExtractionRow;
+}): Promise<AssessmentDocumentExtractionRow | null> => {
+  const { supabaseUrl, headers, organizationId, document } = args;
+  const claimableStatus =
+    document.status === "extracting" || (document.status === EXTRACTION_RUNNING_STATUS && isExtractionRunningStale(document.updated_at))
+      ? document.status
+      : null;
+
+  if (!claimableStatus) {
+    return null;
+  }
+
+  const claimUrl = `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(
+    document.id,
+  )}&organization_id=eq.${encodeURIComponent(organizationId)}&status=eq.${encodeURIComponent(claimableStatus)}${
+    document.updated_at ? `&updated_at=eq.${encodeURIComponent(document.updated_at)}` : ""
+  }`;
+  const claimResult = await fetchJson<AssessmentDocumentExtractionRow[]>(claimUrl, {
+    method: "PATCH",
+    headers: { ...headers, Prefer: "return=representation" },
+    body: JSON.stringify({
+      status: EXTRACTION_RUNNING_STATUS,
+      extraction_error: null,
+      updated_at: new Date().toISOString(),
+    }),
+  });
+  assertFetchOk(claimResult, "extraction_claim_failed");
+  return Array.isArray(claimResult.data) ? claimResult.data[0] ?? null : null;
 };
 
 export async function assessmentDocumentsExtractionBackgroundHandler(request: Request): Promise<Response> {
@@ -560,7 +605,10 @@ export async function assessmentDocumentsExtractionBackgroundHandler(request: Re
     return jsonForRequest(request, { error: "Invalid JSON body" }, 400);
   }
 
-  const parsed = z.object({ assessment_document_id: z.string().uuid() }).safeParse(payload);
+  const parsed = z.object({
+    assessment_document_id: z.string().uuid(),
+    client_id: z.string().uuid().optional(),
+  }).safeParse(payload);
   if (!parsed.success) {
     return jsonForRequest(request, { error: "Invalid request body" }, 400);
   }
@@ -573,12 +621,23 @@ export async function assessmentDocumentsExtractionBackgroundHandler(request: Re
   };
 
   const documentResult = await fetchJson<AssessmentDocumentExtractionRow[]>(
-    `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path&id=eq.${encodeURIComponent(
+    `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path,updated_at&id=eq.${encodeURIComponent(
       parsed.data.assessment_document_id,
     )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
     { method: "GET", headers },
   );
   if (!documentResult.ok) {
+    if (parsed.data.client_id) {
+      await persistCaloptimaExtractionScheduleFailure({
+        supabaseUrl,
+        headers,
+        organizationId,
+        actorId: getAccessTokenSubject(accessToken),
+        createdDocumentId: parsed.data.assessment_document_id,
+        clientId: parsed.data.client_id,
+      });
+      return jsonForRequest(request, { accepted: true, error: "Failed to load assessment document" }, 202);
+    }
     return jsonForRequest(request, { error: "Failed to load assessment document" }, documentResult.status || 500);
   }
 
@@ -586,14 +645,59 @@ export async function assessmentDocumentsExtractionBackgroundHandler(request: Re
   if (!document) {
     return jsonForRequest(request, { error: "assessment_document_id is not in scope for this organization" }, 403);
   }
+  const actorId = getAccessTokenSubject(accessToken);
   if (document.template_type !== "caloptima_fba") {
-    return jsonForRequest(request, { error: "Only CalOptima FBA extraction can be run by this worker." }, 400);
+    if (document.status === "extracting" || document.status === EXTRACTION_RUNNING_STATUS) {
+      const failure = new ExtractionWorkflowError(
+        "unsupported_assessment_template",
+        "unsupported_assessment_template",
+        400,
+        "Only CalOptima FBA extraction is currently supported.",
+      );
+      await persistExtractionFailure({
+        supabaseUrl,
+        headers,
+        organizationId,
+        actorId,
+        createdDocumentId: document.id,
+        clientId: document.client_id,
+        error: failure,
+        fromStatus: document.status,
+      });
+    }
+    return jsonForRequest(request, { accepted: true, error: "Only CalOptima FBA extraction can be run by this worker." }, 202);
   }
-  if (document.status !== "extracting") {
+  let claimedDocument: AssessmentDocumentExtractionRow | null;
+  try {
+    claimedDocument = await claimCaloptimaExtractionDocument({
+      supabaseUrl,
+      headers,
+      organizationId,
+      document,
+    });
+  } catch {
+    const failure = new ExtractionWorkflowError(
+      "extraction_claim_failed",
+      "extraction_claim_failed",
+      500,
+      "Unable to start extraction. Retry the upload or contact support.",
+    );
+    await persistExtractionFailure({
+      supabaseUrl,
+      headers,
+      organizationId,
+      actorId,
+      createdDocumentId: document.id,
+      clientId: document.client_id,
+      error: failure,
+      fromStatus: document.status,
+    });
+    return jsonForRequest(request, { accepted: true, error: failure.publicMessage }, 202);
+  }
+  if (!claimedDocument) {
     return jsonForRequest(request, { skipped: true, status: document.status }, 202);
   }
-  if (!document.bucket_id || !document.object_path) {
-    const actorId = getAccessTokenSubject(accessToken);
+  if (!claimedDocument.bucket_id || !claimedDocument.object_path) {
     const failure = new ExtractionWorkflowError(
       "assessment_document_storage_missing",
       "assessment_document_storage_missing",
@@ -605,25 +709,26 @@ export async function assessmentDocumentsExtractionBackgroundHandler(request: Re
       headers,
       organizationId,
       actorId,
-      createdDocumentId: document.id,
-      clientId: document.client_id,
+      createdDocumentId: claimedDocument.id,
+      clientId: claimedDocument.client_id,
       error: failure,
+      fromStatus: EXTRACTION_RUNNING_STATUS,
     });
-    return jsonForRequest(request, { error: failure.publicMessage }, 400);
+    return jsonForRequest(request, { accepted: true, error: failure.publicMessage }, 202);
   }
 
-  const actorId = getAccessTokenSubject(accessToken);
-  const checklistRows = await loadChecklistTemplateRows(document.template_type);
+  const checklistRows = await loadChecklistTemplateRows(claimedDocument.template_type);
   await runBoundedCaloptimaExtractionWorkflow({
     supabaseUrl,
     headers,
     organizationId,
     actorId,
-    createdDocumentId: document.id,
-    clientId: document.client_id,
+    createdDocumentId: claimedDocument.id,
+    clientId: claimedDocument.client_id,
     checklistRows,
-    bucketId: document.bucket_id,
-    objectPath: document.object_path,
+    bucketId: claimedDocument.bucket_id,
+    objectPath: claimedDocument.object_path,
+    fromStatus: EXTRACTION_RUNNING_STATUS,
   });
 
   return jsonForRequest(request, { accepted: true }, 202);

--- a/supabase/migrations/20260515133000_assessment_extraction_running_status.sql
+++ b/supabase/migrations/20260515133000_assessment_extraction_running_status.sql
@@ -1,0 +1,19 @@
+-- @migration-intent: Add a transient assessment extraction worker status for atomic background claims.
+-- @migration-dependencies: 20260220103000_assessment_extraction_lifecycle_fields.sql
+-- @migration-rollback: Re-run the assessment_documents_status_check constraint without extraction_running after all rows leave that status.
+
+do $$
+begin
+  if exists (
+    select 1
+    from pg_constraint
+    where conname = 'assessment_documents_status_check'
+      and conrelid = 'public.assessment_documents'::regclass
+  ) then
+    alter table public.assessment_documents drop constraint assessment_documents_status_check;
+  end if;
+
+  alter table public.assessment_documents
+    add constraint assessment_documents_status_check
+    check (status in ('uploaded', 'extracting', 'extraction_running', 'extracted', 'drafted', 'approved', 'rejected', 'extraction_failed'));
+end $$;


### PR DESCRIPTION
## Summary
- return the CalOptima upload response after durable background extraction scheduling instead of awaiting the long extraction window in the synchronous Netlify request
- add a Netlify background extraction function that reuses the existing bounded extraction workflow with bearer-token auth and tenant-scoped document loading
- fail closed when scheduling cannot be confirmed and persist safe operational extraction errors instead of leaving documents stuck extracting
- cover upload scheduling, Netlify waitUntil behavior, background auth/org/template/status branches, and extraction failure persistence

## Verification
- npx vitest run src/server/__tests__/assessmentDocumentsHandler.test.ts
- npm run typecheck
- npm run lint
- npm run ci:check-focused
- npm run validate:tenant
- npm run build
- npx vitest run src/server/__tests__/assessmentDocumentsHandler.test.ts src/server/__tests__/assessmentPromoteHandler.test.ts src/components/__tests__/ProgramsGoalsTab.test.tsx tests/edge/assessment-upload-promote-smoke.fixture.test.ts

## Notes
- No schema/RLS/RPC migrations.
- No secrets read, printed, or committed.
- Full local npm run test:ci was not rerun on this clean branch because an earlier full-suite local run hit unrelated worker/resource timeouts; focused tests and hard gates above passed, and live PR CI should be treated as the full-suite source of truth.