### PR TITLE
Auto-persist extracted structured Programs/Goals as drafts, add deterministic draft persistence and rollbacks; invalidate queries on publish

### DIFF
--- a/scripts/playwright-assessment-upload-promote-smoke.ts
+++ b/scripts/playwright-assessment-upload-promote-smoke.ts
@@ -297,7 +297,7 @@ const fetchAssessmentDocuments = async (
     `/api/assessment-documents?client_id=${encodeURIComponent(clientId)}`,
   );
 
-const waitForExtractedAssessment = async (args: {
+const waitForExtractedOrDraftedAssessment = async (args: {
   baseUrl: string;
   accessToken: string;
   clientId: string;
@@ -317,7 +317,7 @@ const waitForExtractedAssessment = async (args: {
   if (!latest) {
     throw new Error(`Uploaded assessment document ${args.uploadFileName} was not found in the queue.`);
   }
-  if (latest.status !== "extracted") {
+  if (latest.status !== "extracted" && latest.status !== "drafted") {
     throw new AssessmentExtractionStatusError(latest);
   }
   return latest;
@@ -703,7 +703,7 @@ async function run() {
     await page.getByRole("button", { name: /Upload CalOptima FBA/i }).click();
     await page.getByText("Uploading and processing your FBA. This can take a moment.").waitFor({ timeout: 20_000 });
 
-    createdAssessment = await waitForExtractedAssessment({
+    createdAssessment = await waitForExtractedOrDraftedAssessment({
       baseUrl,
       accessToken,
       clientId,
@@ -730,14 +730,27 @@ async function run() {
       throw new Error("Extraction did not persist checklist and extraction rows.");
     }
 
+    let drafts = await loadDrafts(baseUrl, accessToken, createdAssessment.id);
+    if (createdAssessment.status === "drafted") {
+      const pendingProgramCount = drafts.programs.filter((program) => program.accept_state === "pending").length;
+      const pendingGoalCount = drafts.goals.filter((goal) => goal.accept_state === "pending").length;
+      if (pendingProgramCount === 0 || pendingGoalCount < EXPECTED_CHILD_GOALS + EXPECTED_PARENT_GOALS) {
+        throw new Error(
+          `Drafted assessment did not expose pending auto-generated drafts: ${pendingProgramCount} programs / ${pendingGoalCount} goals.`,
+        );
+      }
+    }
+
     const approvalSummary = await approveChecklistAndStructuredSections({
       baseUrl,
       accessToken,
       checklist,
     });
 
-    await generateDrafts(baseUrl, accessToken, createdAssessment.id);
-    const drafts = await loadDrafts(baseUrl, accessToken, createdAssessment.id);
+    if (drafts.programs.length === 0 && drafts.goals.length === 0) {
+      await generateDrafts(baseUrl, accessToken, createdAssessment.id);
+      drafts = await loadDrafts(baseUrl, accessToken, createdAssessment.id);
+    }
     await acceptDrafts(baseUrl, accessToken, drafts);
     const acceptedDrafts = await loadDrafts(baseUrl, accessToken, createdAssessment.id);
     const acceptedChildGoalCount = acceptedDrafts.goals.filter(

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -527,6 +527,17 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const selectedAssessmentTemplateLabel = selectedAssessmentDocument
     ? TEMPLATE_LABELS[selectedAssessmentDocument.template_type]
     : TEMPLATE_LABELS[assessmentTemplateType];
+  useEffect(() => {
+    if (!selectedAssessmentId || selectedAssessmentDocument?.status !== "drafted") {
+      return;
+    }
+    queryClient.invalidateQueries({
+      queryKey: ["assessment-drafts", selectedAssessmentId, organizationId ?? "MISSING_ORG"],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["assessment-checklist", selectedAssessmentId, organizationId ?? "MISSING_ORG"],
+    });
+  }, [organizationId, queryClient, selectedAssessmentDocument?.status, selectedAssessmentId]);
   const selectedAssessmentAlreadyPublished = selectedAssessmentDocument
     ? selectedAssessmentDocument.status === "approved" || String(selectedAssessmentDocument.status) === "promoted"
     : false;

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -2387,6 +2387,12 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       );
     });
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["assessment-drafts", ASSESSMENT_ID, ORG_ID],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["assessment-checklist", ASSESSMENT_ID, ORG_ID],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: ["client-goals", "client-1", ORG_ID],
     });
     invalidateQueriesSpy.mockRestore();

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -2345,6 +2345,279 @@ describe("assessmentDocumentsHandler", () => {
     expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracted\""))).toBe(false);
   });
 
+
+  it("auto-persists every extracted structured Program and Goal as pending drafts after Adobe extraction", async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+
+    const programNames = Array.from({ length: 7 }, (_, index) => `Program ${index + 1}`);
+    const structuredSections = [
+      ...Array.from({ length: 21 }, (_, index) => ({
+        section_key: "goals_treatment_planning",
+        field_key: index % 2 === 0 ? "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS" : "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+        section_index: index,
+        payload: {
+          program_name: programNames[index % programNames.length],
+          title: `Child Goal ${index + 1}`,
+          description: `Child description ${index + 1}`,
+          original_text: `Child original text ${index + 1}`,
+          goal_type: "child",
+          target_behavior: "Functional communication",
+          measurement_type: "Frequency",
+          baseline_data: "Baseline",
+          target_criteria: "Target",
+          mastery_criteria: "Mastery",
+          maintenance_criteria: "Maintenance",
+          generalization_criteria: "Generalization",
+          objective_data_points: [{ metric_name: "independent_response", metric_value: index + 1 }],
+          rationale: "Goal rationale",
+        },
+        source_span: { method: "adobe_pdf_extract", index },
+        status: "drafted",
+        required: true,
+        review_notes: null,
+      })),
+      ...Array.from({ length: 7 }, (_, index) => ({
+        section_key: "goals_treatment_planning",
+        field_key: "CALOPTIMA_FBA_PARENT_GOALS",
+        section_index: 100 + index,
+        payload: {
+          program_name: programNames[index],
+          title: `Parent Goal ${index + 1}`,
+          description: `Parent description ${index + 1}`,
+          original_text: `Parent original text ${index + 1}`,
+          goal_type: "parent",
+          target_behavior: "Caregiver fidelity",
+          measurement_type: "Percent fidelity",
+          baseline_data: "Baseline",
+          target_criteria: "Target",
+          mastery_criteria: "Mastery",
+          maintenance_criteria: "Maintenance",
+          generalization_criteria: "Generalization",
+          objective_data_points: [{ metric_name: "fidelity", metric_value: index + 1 }],
+          rationale: "Goal rationale",
+        },
+        source_span: { method: "adobe_pdf_extract", index: 100 + index },
+        status: "drafted",
+        required: true,
+        review_notes: null,
+      })),
+    ];
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name")) {
+        return { ok: true, status: 200, data: [{ full_name: "Client One" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
+        return {
+          ok: true,
+          status: 201,
+          data: [{ id: "doc-full-workflow", organization_id: "org-1", client_id: "11111111-1111-1111-1111-111111111111" }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return {
+          ok: true,
+          status: 200,
+          data: {
+            extraction_provider: "adobe_pdf_extract",
+            adobe_element_count: 250,
+            adobe_table_count: 4,
+            fields: [],
+            structured_sections: structuredSections,
+            unresolved_keys: [],
+            extracted_count: 0,
+            unresolved_count: 0,
+          },
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_structured_sections")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
+        const body = JSON.parse(String(init?.body)) as Array<{ name: string }>;
+        return {
+          ok: true,
+          status: 201,
+          data: body.map((program, index) => ({ id: `draft-program-${index + 1}`, name: program.name })),
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_goals")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const programCreateCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" &&
+      url.includes("/rest/v1/assessment_draft_programs") &&
+      (init?.method ?? "").toUpperCase() === "POST"
+    );
+    const goalCreateCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" &&
+      url.includes("/rest/v1/assessment_draft_goals") &&
+      (init?.method ?? "").toUpperCase() === "POST"
+    );
+    expect(programCreateCall).toBeDefined();
+    expect(goalCreateCall).toBeDefined();
+
+    const programPayload = JSON.parse((programCreateCall?.[1] as RequestInit).body as string) as Array<Record<string, unknown>>;
+    const goalPayload = JSON.parse((goalCreateCall?.[1] as RequestInit).body as string) as Array<Record<string, unknown>>;
+    expect(programPayload).toHaveLength(7);
+    expect(goalPayload).toHaveLength(28);
+    expect(programPayload.every((program) => program.accept_state === "pending")).toBe(true);
+    expect(goalPayload.every((goal) => goal.accept_state === "pending")).toBe(true);
+    expect(goalPayload.filter((goal) => goal.goal_type === "child")).toHaveLength(21);
+    expect(goalPayload.filter((goal) => goal.goal_type === "parent")).toHaveLength(7);
+    expect(new Set(goalPayload.map((goal) => goal.draft_program_id)).size).toBe(7);
+
+    const draftedStatusPatchCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
+      const body = typeof init?.body === "string" ? init.body : "";
+      return typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-full-workflow") && body.includes('"status":"drafted"');
+    });
+    expect(draftedStatusPatchCall).toBeDefined();
+  });
+
+
+  it("does not record extraction_completed before deterministic draft persistence succeeds", async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({ supabaseUrl: "https://example.supabase.co", anonKey: "anon" });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+
+    const structuredSections = [
+      {
+        section_key: "goals_treatment_planning",
+        field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+        section_index: 0,
+        payload: {
+          program_name: "Communication Program",
+          title: "Child Goal 1",
+          description: "Child description",
+          original_text: "Child original text",
+          goal_type: "child",
+          target_behavior: "Functional communication",
+          measurement_type: "Frequency",
+          baseline_data: "Baseline",
+          target_criteria: "Target",
+          mastery_criteria: "Mastery",
+          maintenance_criteria: "Maintenance",
+          generalization_criteria: "Generalization",
+          objective_data_points: [{ metric_name: "independent_response", metric_value: 1 }],
+          rationale: "Goal rationale",
+        },
+        source_span: { method: "adobe_pdf_extract", index: 0 },
+        status: "drafted",
+        required: true,
+        review_notes: null,
+      },
+    ];
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 201, data: [{ id: "doc-draft-fail", organization_id: "org-1", client_id: "11111111-1111-1111-1111-111111111111" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return { ok: true, status: 200, data: { fields: [], structured_sections: structuredSections, unresolved_keys: [], extracted_count: 0, unresolved_count: 0 } };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_structured_sections")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) return { ok: false, status: 500, data: null };
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) return { ok: true, status: 200, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) return { ok: true, status: 201, data: null };
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const extractionCompletedEventCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
+      const body = typeof init?.body === "string" ? init.body : "";
+      return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes('"action":"extraction_completed"');
+    });
+    expect(extractionCompletedEventCalls).toHaveLength(0);
+
+    const failedPatchCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
+      const body = typeof init?.body === "string" ? init.body : "";
+      return typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-draft-fail") && body.includes('"status":"extraction_failed"');
+    });
+    expect(failedPatchCall).toBeDefined();
+  });
+
   it("keeps the document extracted and does not run legacy draft generation on extraction completion", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -2521,8 +2521,134 @@ describe("assessmentDocumentsHandler", () => {
       return typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-full-workflow") && body.includes('"status":"drafted"');
     });
     expect(draftedStatusPatchCall).toBeDefined();
+
+    const draftGeneratedEventCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
+      const body = typeof init?.body === "string" ? init.body : "";
+      return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes('"action":"drafts_generated"');
+    });
+    const extractionFunctionCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" &&
+      url.includes("/functions/v1/extract-assessment-fields") &&
+      (init?.method ?? "").toUpperCase() === "POST"
+    );
+    const extractionSignal = (extractionFunctionCall?.[1] as RequestInit | undefined)?.signal;
+    expect(extractionSignal).toBeInstanceOf(AbortSignal);
+    const draftPersistenceCalls = [programCreateCall, goalCreateCall, draftedStatusPatchCall, draftGeneratedEventCall];
+    const draftPersistenceSignals = draftPersistenceCalls.map((call) => (call?.[1] as RequestInit | undefined)?.signal);
+    expect(draftPersistenceSignals.every((signal) => signal === extractionSignal)).toBe(true);
   });
 
+  it("preserves drafted status when extraction completion event recording fails after auto-draft persistence", async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({ supabaseUrl: "https://example.supabase.co", anonKey: "anon" });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+
+    const structuredSections = [
+      {
+        section_key: "goals_treatment_planning",
+        field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+        section_index: 0,
+        payload: {
+          program_name: "Communication Program",
+          title: "Child Goal 1",
+          description: "Child description",
+          original_text: "Child original text",
+          goal_type: "child",
+          target_behavior: "Functional communication",
+          measurement_type: "Frequency",
+          baseline_data: "Baseline",
+          target_criteria: "Target",
+          mastery_criteria: "Mastery",
+          maintenance_criteria: "Maintenance",
+          generalization_criteria: "Generalization",
+          objective_data_points: [{ metric_name: "independent_response", metric_value: 1 }],
+          rationale: "Goal rationale",
+        },
+        source_span: { method: "adobe_pdf_extract", index: 0 },
+        status: "drafted",
+        required: true,
+        review_notes: null,
+      },
+    ];
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name")) return { ok: true, status: 200, data: [] };
+      if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 201, data: [{ id: "doc-event-fail", organization_id: "org-1", client_id: "11111111-1111-1111-1111-111111111111" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return { ok: true, status: 200, data: { fields: [], structured_sections: structuredSections, unresolved_keys: [], extracted_count: 0, unresolved_count: 0 } };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_structured_sections")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
+        return { ok: true, status: 201, data: [{ id: "draft-program-1", name: "Communication Program" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_goals")) return { ok: true, status: 201, data: null };
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) return { ok: true, status: 200, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        const body = typeof init?.body === "string" ? init.body : "";
+        if (body.includes('"action":"extraction_completed"')) throw new TypeError("review event network failure");
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const documentStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-event-fail"))
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentStatusBodies.some((body) => body.includes('"status":"drafted"'))).toBe(true);
+    expect(documentStatusBodies.some((body) => body.includes('"status":"extraction_failed"'))).toBe(false);
+
+    const extractionCompletedEventCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
+      const body = typeof init?.body === "string" ? init.body : "";
+      return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes('"action":"extraction_completed"');
+    });
+    expect(extractionCompletedEventCalls).toHaveLength(1);
+
+    const extractionFailedEventCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
+      const body = typeof init?.body === "string" ? init.body : "";
+      return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes('"action":"extraction_failed"');
+    });
+    expect(extractionFailedEventCall).toBeUndefined();
+
+    const rollbackCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) =>
+      typeof url === "string" &&
+      (url.includes("/rest/v1/assessment_draft_goals?draft_program_id=in.") ||
+        url.includes("/rest/v1/assessment_draft_programs?id=in.")) &&
+      (init?.method ?? "").toUpperCase() === "DELETE"
+    );
+    expect(rollbackCalls).toHaveLength(0);
+  });
 
   it("does not record extraction_completed before deterministic draft persistence succeeds", async () => {
     process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
@@ -2610,6 +2736,12 @@ describe("assessmentDocumentsHandler", () => {
       return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes('"action":"extraction_completed"');
     });
     expect(extractionCompletedEventCalls).toHaveLength(0);
+
+    const draftedPatchCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
+      const body = typeof init?.body === "string" ? init.body : "";
+      return typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-draft-fail") && body.includes('"status":"drafted"');
+    });
+    expect(draftedPatchCall).toBeUndefined();
 
     const failedPatchCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
       const body = typeof init?.body === "string" ? init.body : "";

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -497,6 +497,102 @@ describe("assessmentDraftsHandler", () => {
     const goalPayload = JSON.parse((goalCreateCall?.[1] as RequestInit).body as string) as Array<Record<string, unknown>>;
     expect(programPayload).toHaveLength(7);
     expect(goalPayload).toHaveLength(28);
+    expect(programPayload.every((program) => program.accept_state === "pending")).toBe(true);
+    expect(goalPayload.every((goal) => goal.accept_state === "pending")).toBe(true);
+  });
+
+
+  it("auto-generates fewer-than-cap structured drafts without padding or truncation", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+
+    const structuredGoals = [
+      ...Array.from({ length: 3 }, (_, index) => ({
+        id: `structured-small-child-${index + 1}`,
+        section_key: "goals_treatment_planning",
+        field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+        section_index: index,
+        payload: {
+          ...buildTypedGoals({ childCount: 1, parentCount: 0, programName: "Small Program" })[0],
+          title: `Small Child Goal ${index + 1}`,
+          objective_data_points: [{ metric_name: "Point A", metric_value: 1 }],
+        },
+        status: "approved",
+        required: true,
+      })),
+      {
+        id: "structured-small-parent-1",
+        section_key: "goals_treatment_planning",
+        field_key: "CALOPTIMA_FBA_PARENT_GOALS",
+        section_index: 10,
+        payload: {
+          ...buildTypedGoals({ childCount: 0, parentCount: 1, programName: "Parent Program" })[0],
+          title: "Small Parent Goal 1",
+          goal_type: "parent",
+          objective_data_points: [{ metric_name: "Point A", metric_value: 1 }],
+        },
+        status: "approved",
+        required: true,
+      },
+    ];
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?select=id")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?select=id")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?")) {
+        return { ok: true, status: 200, data: structuredGoals };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
+        const body = JSON.parse(String(init?.body)) as Array<{ name: string }>;
+        return { ok: true, status: 201, data: body.map((program, index) => ({ id: `draft-small-program-${index + 1}`, name: program.name })) };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_goals")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111", auto_generate: true }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const goalCreateCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" && url.includes("/rest/v1/assessment_draft_goals") && (init?.method ?? "").toUpperCase() === "POST"
+    );
+    const goalPayload = JSON.parse((goalCreateCall?.[1] as RequestInit).body as string) as Array<Record<string, unknown>>;
+    expect(goalPayload).toHaveLength(4);
+    expect(goalPayload.filter((goal) => goal.goal_type === "child")).toHaveLength(3);
+    expect(goalPayload.filter((goal) => goal.goal_type === "parent")).toHaveLength(1);
+    expect(goalPayload.every((goal) => goal.accept_state === "pending")).toBe(true);
   });
 
   it("rolls back inserted draft programs when goal insert fails", async () => {
@@ -613,9 +709,90 @@ describe("assessmentDraftsHandler", () => {
 
     expect(response.status).toBe(500);
     expect(fetchJson).toHaveBeenCalledWith(
-      expect.stringContaining("/rest/v1/assessment_draft_programs?id=in.(draft-program-rollback-1)"),
+      expect.stringContaining("/rest/v1/assessment_draft_programs?id=in.(draft-program-rollback-1)&organization_id=eq.org-1"),
       expect.objectContaining({ method: "DELETE" }),
     );
+  });
+
+
+  it("rolls back inserted draft rows when marking the document drafted fails", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({ organizationId: "org-1", isTherapist: true, isAdmin: false, isSuperAdmin: false });
+    vi.mocked(getSupabaseConfig).mockReturnValue({ supabaseUrl: "https://example.supabase.co", anonKey: "anon" });
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
+        return { ok: true, status: 201, data: [{ id: "draft-program-1", name: "Communication Program" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_goals")) return { ok: true, status: 201, data: null };
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) return { ok: false, status: 500, data: null };
+      if (method === "DELETE") return { ok: true, status: 200, data: null };
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-1111-1111-111111111111",
+          programs: [{ name: "Communication Program", description: "Program description", rationale: "Program rationale", evidence_refs: [{ section_key: "assessment_summary", source_span: "Program evidence snippet" }], review_flags: [] }],
+          summary_rationale: "Summary rationale",
+          confidence: "medium",
+          goals: [buildTypedGoals({ childCount: 1, parentCount: 0 })[0]],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(fetchJson).toHaveBeenCalledWith(expect.stringContaining("/rest/v1/assessment_draft_goals?draft_program_id=in.(draft-program-1)&organization_id=eq.org-1"), expect.objectContaining({ method: "DELETE" }));
+    expect(fetchJson).toHaveBeenCalledWith(expect.stringContaining("/rest/v1/assessment_draft_programs?id=in.(draft-program-1)&organization_id=eq.org-1"), expect.objectContaining({ method: "DELETE" }));
+  });
+
+  it("rolls back draft rows and restores document status when draft event persistence fails", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({ organizationId: "org-1", isTherapist: true, isAdmin: false, isSuperAdmin: false });
+    vi.mocked(getSupabaseConfig).mockReturnValue({ supabaseUrl: "https://example.supabase.co", anonKey: "anon" });
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
+        return { ok: true, status: 201, data: [{ id: "draft-program-1", name: "Communication Program" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_draft_goals")) return { ok: true, status: 201, data: null };
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) return { ok: true, status: 200, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) return { ok: false, status: 500, data: null };
+      if (method === "DELETE") return { ok: true, status: 200, data: null };
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-1111-1111-111111111111",
+          programs: [{ name: "Communication Program", description: "Program description", rationale: "Program rationale", evidence_refs: [{ section_key: "assessment_summary", source_span: "Program evidence snippet" }], review_flags: [] }],
+          summary_rationale: "Summary rationale",
+          confidence: "medium",
+          goals: [buildTypedGoals({ childCount: 1, parentCount: 0 })[0]],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(fetchJson).toHaveBeenCalledWith(expect.stringContaining("/rest/v1/assessment_draft_goals?draft_program_id=in.(draft-program-1)&organization_id=eq.org-1"), expect.objectContaining({ method: "DELETE" }));
+    expect(fetchJson).toHaveBeenCalledWith(expect.stringContaining("/rest/v1/assessment_draft_programs?id=in.(draft-program-1)&organization_id=eq.org-1"), expect.objectContaining({ method: "DELETE" }));
+    expect(fetchJson).toHaveBeenCalledWith(expect.stringContaining("/rest/v1/assessment_documents?id=eq.doc-1&organization_id=eq.org-1"), expect.objectContaining({ method: "PATCH", body: expect.stringContaining('"status":"extracted"') }));
   });
 
   it("rejects deterministic draft creation when approved structured goal sections are missing", async () => {

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -161,7 +161,7 @@ const extractionFunctionResponseSchema: z.ZodType<ExtractionFunctionResponse> = 
 });
 
 type ExtractionWorkflowResult = {
-  status: "extracted" | "extraction_failed";
+  status: "extracted" | "drafted" | "extraction_failed";
   extractionError: string | null;
 };
 
@@ -509,6 +509,7 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
           document: { id: createdDocumentId, organization_id: organizationId, client_id: clientId, status: fromStatus },
           assessmentDocumentId: createdDocumentId,
           payload: deterministicDraftPayload,
+          signal,
         });
         assertExtractionNotAborted(signal);
         if (!draftResult.ok) {
@@ -536,7 +537,7 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
         assertFetchOk(documentExtractedResult, "assessment_status_update_failed");
       }
 
-      const reviewEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
+      const extractionCompletedEventInit: RequestInit = {
         method: "POST",
         headers,
         signal,
@@ -560,9 +561,30 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
             adobe_table_count: extractionData.adobe_table_count ?? null,
           },
         }),
-      });
-      assertExtractionNotAborted(signal);
-      assertFetchOk(reviewEventResult, "review_event_persistence_failed");
+      };
+      try {
+        const reviewEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, extractionCompletedEventInit);
+        assertExtractionNotAborted(signal);
+        if (!reviewEventResult.ok && finalStatus === "drafted") {
+          serverLogger.error("assessment-documents extraction completion event failed after draft persistence", {
+            reasonCode: "review_event_persistence_failed",
+            status: reviewEventResult.status ?? null,
+            assessmentDocumentId: createdDocumentId,
+          });
+          return { status: finalStatus, extractionError: null };
+        }
+        assertFetchOk(reviewEventResult, "review_event_persistence_failed");
+      } catch (eventError) {
+        if (finalStatus === "drafted") {
+          serverLogger.error("assessment-documents extraction completion event failed after draft persistence", {
+            reasonCode: "review_event_persistence_failed",
+            status: eventError instanceof ExtractionWorkflowError ? eventError.status ?? null : null,
+            assessmentDocumentId: createdDocumentId,
+          });
+          return { status: finalStatus, extractionError: null };
+        }
+        throw eventError;
+      }
       return { status: finalStatus, extractionError: null };
     }
 

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -13,6 +13,7 @@ import {
   type AssessmentChecklistSeedRow,
   type AssessmentTemplateType,
 } from "../assessmentChecklistTemplate";
+import { buildDeterministicDraftPayload, persistDraftRows } from "./assessment-drafts";
 import { getRequiredServerEnv } from "../env";
 import { serverLogger } from "../../lib/logger/server";
 
@@ -21,6 +22,7 @@ const ASSESSMENT_DOCUMENT_BUCKET_ID = "client-documents";
 const EXTRACTION_WORKFLOW_TIMEOUT_MS = 55_000;
 const EXTRACTION_RUNNING_STATUS = "extraction_running";
 const EXTRACTION_RUNNING_STALE_MS = EXTRACTION_WORKFLOW_TIMEOUT_MS * 2;
+const AUTO_DRAFT_STRUCTURED_SECTION_STATUSES = new Set(["drafted", "approved"] as const);
 
 const templateTypeSchema = z.enum(SUPPORTED_TEMPLATE_TYPES);
 
@@ -484,19 +486,55 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
         assertFetchOk(structuredInsertResult, "structured_section_persistence_failed");
       }
 
-      const documentExtractedResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocumentId)}`, {
-        method: "PATCH",
-        headers,
-        signal,
-        body: JSON.stringify({
-          status: "extracted",
-          extracted_at: new Date().toISOString(),
-          extraction_error: null,
-          updated_at: new Date().toISOString(),
-        }),
-      });
-      assertExtractionNotAborted(signal);
-      assertFetchOk(documentExtractedResult, "assessment_status_update_failed");
+      const deterministicDraftPayload = buildDeterministicDraftPayload(
+        structuredSections.map((section) => ({
+          id: `${createdDocumentId}:${section.field_key}:${section.section_index}`,
+          section_key: section.section_key,
+          field_key: section.field_key,
+          section_index: section.section_index,
+          payload: section.payload,
+          status: section.status,
+          required: section.required,
+        })),
+        AUTO_DRAFT_STRUCTURED_SECTION_STATUSES,
+      );
+      let finalStatus: "extracted" | "drafted" = "extracted";
+
+      if (deterministicDraftPayload) {
+        const draftResult = await persistDraftRows({
+          supabaseUrl,
+          headers,
+          organizationId,
+          actorId,
+          document: { id: createdDocumentId, organization_id: organizationId, client_id: clientId, status: fromStatus },
+          assessmentDocumentId: createdDocumentId,
+          payload: deterministicDraftPayload,
+        });
+        assertExtractionNotAborted(signal);
+        if (!draftResult.ok) {
+          throw new ExtractionWorkflowError(
+            "draft_persistence_failed",
+            draftResult.error,
+            draftResult.status,
+            "Extraction completed, but draft Programs and Goals could not be persisted.",
+          );
+        }
+        finalStatus = "drafted";
+      } else {
+        const documentExtractedResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(createdDocumentId)}`, {
+          method: "PATCH",
+          headers,
+          signal,
+          body: JSON.stringify({
+            status: "extracted",
+            extracted_at: new Date().toISOString(),
+            extraction_error: null,
+            updated_at: new Date().toISOString(),
+          }),
+        });
+        assertExtractionNotAborted(signal);
+        assertFetchOk(documentExtractedResult, "assessment_status_update_failed");
+      }
 
       const reviewEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
         method: "POST",
@@ -510,7 +548,7 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
           item_id: createdDocumentId,
           action: "extraction_completed",
           from_status: fromStatus,
-          to_status: "extracted",
+          to_status: finalStatus,
           actor_id: actorId,
           event_payload: {
             extracted_count: extractionData.extracted_count,
@@ -525,7 +563,7 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
       });
       assertExtractionNotAborted(signal);
       assertFetchOk(reviewEventResult, "review_event_persistence_failed");
-      return { status: "extracted", extractionError: null };
+      return { status: finalStatus, extractionError: null };
     }
 
     const edgeError =

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -372,8 +372,9 @@ export const persistDraftRows = async (args: {
   document: AssessmentDocumentScopeRow;
   assessmentDocumentId: string;
   payload: GeneratedDraftPayload;
+  signal?: AbortSignal;
 }) => {
-  const { supabaseUrl, headers, organizationId, actorId, document, assessmentDocumentId, payload } = args;
+  const { supabaseUrl, headers, organizationId, actorId, document, assessmentDocumentId, payload, signal } = args;
   const createProgramPayload = payload.programs.map((program) => ({
     assessment_document_id: assessmentDocumentId,
     organization_id: organizationId,
@@ -393,6 +394,7 @@ export const persistDraftRows = async (args: {
     {
       method: "POST",
       headers: { ...headers, Prefer: "return=representation" },
+      signal,
       body: JSON.stringify(createProgramPayload),
     },
   );
@@ -414,7 +416,7 @@ export const persistDraftRows = async (args: {
         `${supabaseUrl}/rest/v1/assessment_draft_programs?id=in.(${insertedProgramIds.join(",")})&organization_id=eq.${encodeURIComponent(
           organizationId,
         )}`,
-        { method: "DELETE", headers },
+        { method: "DELETE", headers, signal },
       );
     }
     return {
@@ -458,19 +460,20 @@ export const persistDraftRows = async (args: {
       `${supabaseUrl}/rest/v1/assessment_draft_goals?draft_program_id=in.(${encodedProgramIds})&organization_id=eq.${encodeURIComponent(
         organizationId,
       )}`,
-      { method: "DELETE", headers },
+      { method: "DELETE", headers, signal },
     );
     await fetchJson(
       `${supabaseUrl}/rest/v1/assessment_draft_programs?id=in.(${encodedProgramIds})&organization_id=eq.${encodeURIComponent(
         organizationId,
       )}`,
-      { method: "DELETE", headers },
+      { method: "DELETE", headers, signal },
     );
   };
 
   const createGoalsResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_draft_goals`, {
     method: "POST",
     headers: { ...headers, Prefer: "return=representation" },
+    signal,
     body: JSON.stringify(createGoalsPayload),
   });
 
@@ -486,6 +489,7 @@ export const persistDraftRows = async (args: {
     {
       method: "PATCH",
       headers,
+      signal,
       body: JSON.stringify({
         status: "drafted",
         extraction_error: null,
@@ -501,6 +505,7 @@ export const persistDraftRows = async (args: {
   const reviewEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
     method: "POST",
     headers,
+    signal,
     body: JSON.stringify({
       assessment_document_id: document.id,
       organization_id: organizationId,
@@ -522,6 +527,7 @@ export const persistDraftRows = async (args: {
       {
         method: "PATCH",
         headers,
+        signal,
         body: JSON.stringify({
           status: document.status,
           updated_at: new Date().toISOString(),

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -117,7 +117,7 @@ interface AssessmentDraftGoalRow {
   accept_state: "pending" | "accepted" | "rejected" | "edited";
 }
 
-interface GeneratedDraftPayload {
+export interface GeneratedDraftPayload {
   programs: Array<{
     name: string;
     description: string;
@@ -249,12 +249,13 @@ const ensureUniqueGoalTitle = (title: string, seenTitles: Map<string, number>): 
   return candidateTitle;
 };
 
-const buildDeterministicDraftPayload = (
+export const buildDeterministicDraftPayload = (
   structuredSections: AssessmentStructuredSectionRow[],
+  eligibleStatuses: ReadonlySet<AssessmentStructuredSectionRow["status"]> = new Set(["approved"]),
 ): GeneratedDraftPayload | null => {
   const approvedGoalSections = structuredSections.filter(
     (section) =>
-      section.status === "approved" &&
+      eligibleStatuses.has(section.status) &&
       section.payload &&
       [
         "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
@@ -363,7 +364,7 @@ const draftsAlreadyExistForDocument = async (args: {
   return hasPrograms || hasGoals;
 };
 
-const persistDraftRows = async (args: {
+export const persistDraftRows = async (args: {
   supabaseUrl: string;
   headers: Record<string, string>;
   organizationId: string;
@@ -447,36 +448,57 @@ const persistDraftRows = async (args: {
     accept_state: "pending",
   }));
 
+  const insertedProgramIds = createProgramResult.data.map((row) => row.id).filter(Boolean);
+  const rollbackInsertedDraftRows = async (): Promise<void> => {
+    if (insertedProgramIds.length === 0) {
+      return;
+    }
+    const encodedProgramIds = insertedProgramIds.map((id) => encodeURIComponent(id)).join(",");
+    await fetchJson(
+      `${supabaseUrl}/rest/v1/assessment_draft_goals?draft_program_id=in.(${encodedProgramIds})&organization_id=eq.${encodeURIComponent(
+        organizationId,
+      )}`,
+      { method: "DELETE", headers },
+    );
+    await fetchJson(
+      `${supabaseUrl}/rest/v1/assessment_draft_programs?id=in.(${encodedProgramIds})&organization_id=eq.${encodeURIComponent(
+        organizationId,
+      )}`,
+      { method: "DELETE", headers },
+    );
+  };
+
   const createGoalsResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_draft_goals`, {
     method: "POST",
-    headers,
+    headers: { ...headers, Prefer: "return=representation" },
     body: JSON.stringify(createGoalsPayload),
   });
 
   if (!createGoalsResult.ok) {
-    const insertedProgramIds = createProgramResult.data.map((row) => row.id);
-    if (insertedProgramIds.length > 0) {
-      await fetchJson(
-        `${supabaseUrl}/rest/v1/assessment_draft_programs?id=in.(${insertedProgramIds.join(",")})&organization_id=eq.${encodeURIComponent(
-          organizationId,
-        )}`,
-        { method: "DELETE", headers },
-      );
-    }
+    await rollbackInsertedDraftRows();
     return { ok: false as const, status: createGoalsResult.status || 500, error: "Failed to create draft goals" };
   }
 
-  await fetchJson(`${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}`, {
-    method: "PATCH",
-    headers,
-    body: JSON.stringify({
-      status: "drafted",
-      extraction_error: null,
-      updated_at: new Date().toISOString(),
-    }),
-  });
+  const documentDraftedResult = await fetchJson(
+    `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}&organization_id=eq.${encodeURIComponent(
+      organizationId,
+    )}`,
+    {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({
+        status: "drafted",
+        extraction_error: null,
+        updated_at: new Date().toISOString(),
+      }),
+    },
+  );
+  if (!documentDraftedResult.ok) {
+    await rollbackInsertedDraftRows();
+    return { ok: false as const, status: documentDraftedResult.status || 500, error: "Failed to mark assessment document drafted" };
+  }
 
-  await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
+  const reviewEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
     method: "POST",
     headers,
     body: JSON.stringify({
@@ -491,6 +513,23 @@ const persistDraftRows = async (args: {
       actor_id: actorId,
     }),
   });
+  if (!reviewEventResult.ok) {
+    await rollbackInsertedDraftRows();
+    await fetchJson(
+      `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}&organization_id=eq.${encodeURIComponent(
+        organizationId,
+      )}`,
+      {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({
+          status: document.status,
+          updated_at: new Date().toISOString(),
+        }),
+      },
+    );
+    return { ok: false as const, status: reviewEventResult.status || 500, error: "Failed to record draft generation event" };
+  }
 
   return { ok: true as const, draftProgramId: createProgramResult.data[0].id };
 };


### PR DESCRIPTION
### Motivation
- Persist structured Programs and Goals deterministically as pending drafts immediately after successful Adobe extraction so extracted content is preserved and available for review. 
- Ensure draft persistence is robust with transactional rollbacks when any step (goal insert, document patch, or event persistence) fails. 
- Ensure the UI invalidates relevant query caches after publishing so downstream views refresh.

### Description
- Add deterministic draft generation and persistence: export `buildDeterministicDraftPayload` and `persistDraftRows` in `src/server/api/assessment-drafts.ts` and wire them into the extraction workflow in `src/server/api/assessment-documents.ts` so extracted structured sections can automatically produce draft Programs and Goals. 
- Make `persistDraftRows` create draft programs and goals with `accept_state: "pending"`, mark the assessment document status to `drafted`, emit a `drafts_generated` review event, and perform rollback deletes of inserted draft rows when subsequent steps fail. 
- Update extraction workflow to call the draft persistence path when a deterministic payload exists, to set the final document status to `drafted` (otherwise `extracted`), and to reflect that status in the `extraction_completed` review event. 
- Improve query/delete URLs to include `organization_id` where needed, add Prefer header for goal creation, and export the generated payload type `GeneratedDraftPayload`. 
- UI: add an effect in `ProgramsGoalsTab` to invalidate `assessment-drafts` and `assessment-checklist` queries for the selected assessment when a drafted document is selected. 
- Tests: add and update unit tests around deterministic draft generation, auto-persistence after Adobe extraction, rollback behavior on various failures, and assert `accept_state: "pending"` for generated drafts; update `ProgramsGoalsTab` test to expect cache invalidation calls.

### Testing
- Ran component unit tests including `ProgramsGoalsTab.test.tsx` which now expects `invalidateQueries` for `assessment-drafts` and `assessment-checklist`, and they succeeded. 
- Ran server handler tests in `assessmentDocumentsHandler.test.ts` and `assessmentDraftsHandler.test.ts` that cover auto-persistence, rollback cases, and event/status semantics, and they succeeded. 
- All updated and added automated tests passed in CI (mocked `fetchJson` and token/org resolution used where appropriate).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07cbcc6d0483249f14159bbbee2907)