### PR TITLE
Migrate CI policy to ci-gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           CI_EDGE_ROUTE_PARITY_REQUIRED: "true"
           SUPABASE_FUNCTION_PARITY_SCOPE: "sessions-book,sessions-hold,sessions-confirm,sessions-start,sessions-cancel,generate-session-notes-pdf,session-notes-pdf-status,session-notes-pdf-download,programs,goals,program-notes"
           CI_RLS_OVERLAP_REQUIRED: ${{ secrets.SUPABASE_DB_URL != '' && 'true' || 'false' }}
-          CI_REQUIRED_CHECKS: "policy,lint-typecheck,unit-tests,build,tier0-browser,auth-browser-smoke"
+          CI_REQUIRED_CHECKS: "ci-gate"
           API_AUTHORITY_MODE: "edge"
           RATE_LIMIT_MODE: "memory"
 
@@ -308,7 +308,9 @@ jobs:
   tier0_browser:
     name: tier0-browser
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - build
+      - change_scope
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -388,7 +390,9 @@ jobs:
   auth_browser_smoke:
     name: auth-browser-smoke
     runs-on: ubuntu-latest
-    needs: policy
+    needs:
+      - policy
+      - change_scope
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/docs/DATABASE_PIPELINE.md
+++ b/docs/DATABASE_PIPELINE.md
@@ -70,7 +70,8 @@ The repository does not create per-PR Supabase branches automatically. Branch cr
 - `ci-gate` is the final required status gate for branch protection.
 - Current transition state:
   - branch protection should require `ci-gate`
-  - `policy` still validates `CI_REQUIRED_CHECKS` against the legacy set (`policy`, `lint-typecheck`, `unit-tests`, `build`, `tier0-browser`, `auth-browser-smoke`) until that migration is explicitly completed
+  - `policy` validates `CI_REQUIRED_CHECKS=ci-gate`
+  - keep the legacy required checks (`policy`, `lint-typecheck`, `unit-tests`, `build`, `tier0-browser`, `auth-browser-smoke`) only until the migration PR has merged and `main` is green
 
 ### `supabase-preview.yml`
 

--- a/docs/OPS_READINESS.md
+++ b/docs/OPS_READINESS.md
@@ -26,9 +26,9 @@ Document the minimum monitoring, alerting, and incident response requirements fo
 - [ ] Branch protection is enabled on `main` with required check `ci-gate`, and mirrored to `develop` when that branch is active
 - [ ] `docs-guard` is not configured as an independent required branch-protection check (it is enforced by `ci-gate` for docs-only changes)
 - [ ] Merge queue (`merge_group`) behavior is documented as full-chain CI before `ci-gate` (docs-only fast path applies to PR/push, not queue runs)
-- [ ] Legacy required-check set (`policy`, `lint-typecheck`, `unit-tests`, `build`, `tier0-browser`, `auth-browser-smoke`) is treated as transitional and removed once `ci-gate` migration is complete
-- [ ] Current-state note is understood: CI policy validation still enforces the legacy `CI_REQUIRED_CHECKS` set until the explicit migration step updates it to `ci-gate`
-- [ ] `ci-gate` is added to branch protection before CI policy expectations are updated to `CI_REQUIRED_CHECKS=ci-gate`
+- [ ] Legacy required-check set (`policy`, `lint-typecheck`, `unit-tests`, `build`, `tier0-browser`, `auth-browser-smoke`) is treated as transitional and removed after the `CI_REQUIRED_CHECKS=ci-gate` migration PR merges green
+- [ ] Current-state note is understood: CI policy validation enforces `CI_REQUIRED_CHECKS=ci-gate`
+- [ ] `ci-gate` remains in branch protection while CI policy expectations use `CI_REQUIRED_CHECKS=ci-gate`
 - [ ] Migration is validated with a non-doc test PR before legacy required checks are removed
 - [ ] `npm run test:routes:tier0` passes (browser route/role gate)
 - [ ] `npm run ci:playwright` passes (or, for focused parity, at minimum `npm run playwright:auth && npm run playwright:session-lifecycle && npm run playwright:session-complete && npm run playwright:schedule-blocked-close`)

--- a/docs/STAGING_OPERATIONS.md
+++ b/docs/STAGING_OPERATIONS.md
@@ -60,7 +60,7 @@ Merge queue note:
 - `auth-browser-smoke` can soft-skip for missing secrets on `pull_request`, but missing secrets fail the job on `merge_group`/`push`
 
 Legacy required checks (`policy`, `lint-typecheck`, `unit-tests`, `build`, `tier0-browser`, `auth-browser-smoke`) are transitional only while repositories migrate branch protection to `ci-gate`.
-Current-state note: policy validation still expects the legacy `CI_REQUIRED_CHECKS` set until a coordinated migration updates CI policy expectations to `ci-gate`.
+Current-state note: policy validation expects `CI_REQUIRED_CHECKS=ci-gate`; keep legacy required checks only until the migration PR merges and `main` is green.
 
 Migration order requirement:
 

--- a/docs/ai/pr-merge-queue-settings.md
+++ b/docs/ai/pr-merge-queue-settings.md
@@ -4,7 +4,7 @@ Use this document to distinguish the current live merge contract on `main` from 
 
 ## Current Live `main` Contract
 
-As of 2026-03-29, the live branch-protection contract on `main` is:
+As of 2026-05-16, the live branch-protection contract on `main` is in the supervised `ci-gate` migration window:
 
 - required status checks:
   - `policy`
@@ -13,6 +13,7 @@ As of 2026-03-29, the live branch-protection contract on `main` is:
   - `build`
   - `tier0-browser`
   - `auth-browser-smoke`
+  - `ci-gate`
 - branch-up-to-date requirement: enabled (`strict=true`)
 - required pull-request approvals configured in GitHub: `1`
 
@@ -47,15 +48,15 @@ The fast path applies only to markdown/governance documentation paths (for examp
 
 ## Required Checks Guidance
 
-Today, GitHub branch protection on `main` is enforced through the six global checks listed above. Treat those six checks as the merge-blocking source of truth until a separate supervised policy change intentionally replaces them.
+The intended steady-state branch-protection target is `ci-gate` as the single required CI check. During the supervised migration window, keep the six legacy checks and `ci-gate` required until the CI policy PR that sets `CI_REQUIRED_CHECKS=ci-gate` has merged and `main` is green.
 
 Internal workflow behavior still matters:
 
 - `docs-guard` is the docs-only fast-path validator.
-- `ci-gate` summarizes CI lane outcomes and remains useful operator signal.
-- docs-only PRs currently satisfy the six required checks by resolving them to `SKIPPED`, while `docs-guard` and `ci-gate` pass.
+- `ci-gate` summarizes CI lane outcomes and is the required-check target after migration.
+- docs-only PRs satisfy the browser/code-quality jobs by resolving them to `SKIPPED`, while `docs-guard` and `ci-gate` pass.
 
-Do not describe `ci-gate` as the current required branch-protection target unless live GitHub settings and CI policy have been updated together in the same rollout.
+Do not remove the six legacy required checks until the non-doc migration PR proves `ci-gate` is gating the full policy, lint/typecheck, unit, build, tier-0 browser, and auth browser smoke chain.
 
 ## Merge Queue Compatibility
 

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -141,6 +141,7 @@ const classifyFile = (file) => {
     /^cypress\/e2e\/routes_admin\.cy\.ts$/,
     /^src\/pages\/(Therapists|Billing|Monitoring|Reports|Settings|SuperAdmin)/,
     /^src\/components\/(Therapist|Billing|Monitoring|Reports|Settings|SuperAdmin)/,
+    /^src\/components\/(therapists?|billing|monitoring|reports|settings|super-?admin)\//,
     /^src\/lib\/(therapists|billing|reports|settings|featureFlags)/,
   ])) {
     return { specs: ["admin"], authSmoke: false, reason: "admin/back-office route" };


### PR DESCRIPTION
## Summary
- Switch CI policy branch-protection validation from the six legacy required checks to `ci-gate`.
- Add direct `change_scope` dependencies to `tier0-browser` and `auth-browser-smoke` so scoped browser jobs can read diff SHAs and skip quickly when appropriate.
- Expand admin route classification to nested lowercase admin component directories such as `src/components/settings/**`.
- Update CI/operations docs to describe the supervised migration window before removing legacy required checks.

## Verification
- `node scripts/ci/select-browser-checks.mjs --changed-file src/components/settings/AdminSettings.tsx`
- `node scripts/ci/select-browser-checks.mjs --changed-file src/components/UnrelatedWidget.tsx`
- `CI=true GITHUB_REPOSITORY=Jeduardo622/AllIincompassing CI_REQUIRED_CHECKS=ci-gate node scripts/ci/check-main-branch-protection.mjs`
- `npm run verify:local`
- `npm run playwright:preflight`
- `git diff --check`

## Risk / rollout
Critical CI-policy change. Branch protection currently requires the six legacy checks plus `ci-gate`; do not remove legacy required checks until this PR merges and `main` is green with `ci-gate` proving the full non-doc chain.

## Tracking
Linear issue not linked yet; keep draft until tracking/review requirements are satisfied.