### PR TITLE
Stabilize blocked-close auth smoke deep link

### DIFF
--- a/scripts/lib/playwright-inprogress-session-setup.ts
+++ b/scripts/lib/playwright-inprogress-session-setup.ts
@@ -345,6 +345,14 @@ const toDatetimeLocal = (date: Date): string => {
   return local.toISOString().slice(0, 16);
 };
 
+const buildBookingBaseStart = (): Date => {
+  const runSeed = Number(process.env.GITHUB_RUN_ID ?? Date.now());
+  const offsetHours = Number.isFinite(runSeed) ? Math.abs(Math.trunc(runSeed)) % 12 : 0;
+  const start = new Date();
+  start.setHours(start.getHours() + 4 + offsetHours, 0, 0, 0);
+  return start;
+};
+
 async function openSessionModal(page: Page) {
   await page.evaluate(() => {
     const browserGlobal = globalThis as unknown as {
@@ -449,15 +457,14 @@ export async function bookSession(
 
   const selected = await chooseSessionTargets(page, { allowedTherapistIds });
 
-  const start = new Date();
-  start.setHours(start.getHours() + 4, 0, 0, 0);
+  const start = buildBookingBaseStart();
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC";
   let finalStartIso = "";
   let finalEndIso = "";
   let payload: BrowserFetchResult<Record<string, unknown>> | null = null;
   let payloadBody: { success?: boolean; data?: { session?: { id?: string } } } | null = null;
 
-  for (let attempt = 0; attempt < 12; attempt += 1) {
+  for (let attempt = 0; attempt < 48; attempt += 1) {
     const attemptStart = new Date(start.getTime() + attempt * 2 * 60 * 60 * 1000);
     const attemptEnd = new Date(attemptStart.getTime() + 60 * 60 * 1000);
     const startIso = attemptStart.toISOString();

--- a/scripts/playwright-schedule-blocked-close.ts
+++ b/scripts/playwright-schedule-blocked-close.ts
@@ -139,6 +139,85 @@ async function waitForSessionStatus(sessionId: string, status: string, timeoutMs
   throw new Error(`Timed out waiting for session ${sessionId} status=${status} in DB`);
 }
 
+async function waitForBrowserVisibleSession({
+  page,
+  sessionId,
+  organizationId,
+  supabaseUrl,
+  anonKey,
+  accessToken,
+  timeoutMs = 120_000,
+}: {
+  page: Page;
+  sessionId: string;
+  organizationId: string;
+  supabaseUrl: string;
+  anonKey: string;
+  accessToken: string;
+  timeoutMs?: number;
+}): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus: string | null = null;
+  let lastError: string | null = null;
+
+  while (Date.now() < deadline) {
+    const result = await page.evaluate(
+      async ({
+        sessionId,
+        organizationId,
+        supabaseUrl,
+        anonKey,
+        accessToken,
+      }: {
+        sessionId: string;
+        organizationId: string;
+        supabaseUrl: string;
+        anonKey: string;
+        accessToken: string;
+      }) => {
+        const params = new URLSearchParams({
+          id: `eq.${sessionId}`,
+          organization_id: `eq.${organizationId}`,
+          select: "id,status",
+        });
+        const res = await fetch(`${supabaseUrl}/rest/v1/sessions?${params.toString()}`, {
+          headers: {
+            apikey: anonKey,
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        if (!res.ok) {
+          return { visible: false, status: null, error: `${res.status} ${await res.text()}` };
+        }
+        const rows = (await res.json()) as Array<{ id?: string; status?: string }>;
+        return {
+          visible: rows.some((row) => row.id === sessionId),
+          status: rows.find((row) => row.id === sessionId)?.status ?? null,
+          error: null,
+        };
+      },
+      {
+        sessionId,
+        organizationId,
+        supabaseUrl,
+        anonKey,
+        accessToken,
+      },
+    );
+
+    lastStatus = result.status;
+    lastError = result.error;
+    if (result.visible) {
+      return;
+    }
+    await page.waitForTimeout(1000);
+  }
+
+  throw new Error(
+    `Timed out waiting for browser-visible session row ${sessionId}; lastStatus=${lastStatus ?? "missing"} lastError=${lastError ?? "none"}`,
+  );
+}
+
 async function getSessionOrganizationId(sessionId: string): Promise<string> {
   const supabaseUrl = getEnv("VITE_SUPABASE_URL");
   const serviceRole = getEnv("SUPABASE_SERVICE_ROLE_KEY");
@@ -317,20 +396,53 @@ async function run(): Promise<void> {
       );
     }
 
-    const expiresAt = Date.now() + 30 * 60 * 1000;
-    const editUrl = `${base}/schedule?scheduleModal=edit&scheduleSessionId=${encodeURIComponent(
-      booked.sessionId,
-    )}&scheduleExp=${expiresAt}`;
+    await withStepTimeout("wait-browser-visible-session", () =>
+      waitForBrowserVisibleSession({
+        page: activePage,
+        sessionId: booked.sessionId,
+        organizationId: userOrgId,
+        supabaseUrl: getEnv("VITE_SUPABASE_URL"),
+        anonKey: getEnv("VITE_SUPABASE_ANON_KEY", process.env.SUPABASE_ANON_KEY),
+        accessToken: token,
+      }));
 
     await withStepTimeout("open-edit-modal-via-url", async () => {
-      await activePage.goto(editUrl, { waitUntil: "domcontentloaded", timeout: 90_000 });
-      await activePage.waitForLoadState("networkidle").catch(() => undefined);
-      await activePage
-        .getByRole("dialog", { name: /edit session|live session/i })
-        .waitFor({ state: "visible", timeout: 60_000 });
-      await activePage
-        .locator('[role="dialog"][data-session-status="in_progress"]')
-        .waitFor({ state: "visible", timeout: 90_000 });
+      let lastUrl = activePage.url();
+      let lastBodyText = "";
+
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        const expiresAt = Date.now() + 30 * 60 * 1000;
+        const editUrl = `${base}/schedule?scheduleModal=edit&scheduleSessionId=${encodeURIComponent(
+          booked.sessionId,
+        )}&scheduleExp=${expiresAt}`;
+
+        await activePage.goto(editUrl, { waitUntil: "domcontentloaded", timeout: 90_000 });
+        await activePage.waitForLoadState("networkidle").catch(() => undefined);
+
+        const dialog = activePage.getByRole("dialog", { name: /edit session|live session/i });
+        const dialogVisible = await dialog.waitFor({ state: "visible", timeout: 30_000 })
+          .then(() => true)
+          .catch(() => false);
+        lastUrl = activePage.url();
+        lastBodyText = await activePage.evaluate(() => document.body.innerText.slice(0, 1000)).catch(() => "");
+
+        if (!dialogVisible) {
+          console.warn(
+            `[blocked-close] edit modal did not open on attempt ${attempt}; url=${lastUrl}`,
+          );
+          await activePage.waitForTimeout(1000);
+          continue;
+        }
+
+        await activePage
+          .locator('[role="dialog"][data-session-status="in_progress"]')
+          .waitFor({ state: "visible", timeout: 90_000 });
+        return;
+      }
+
+      throw new Error(
+        `Edit modal did not open for browser-visible in-progress session ${booked.sessionId}; url=${lastUrl}; body=${JSON.stringify(lastBodyText)}`,
+      );
     });
 
     await withStepTimeout("assert-api-session-in-progress", async () => {

--- a/scripts/playwright-schedule-blocked-close.ts
+++ b/scripts/playwright-schedule-blocked-close.ts
@@ -45,11 +45,16 @@ const getEnv = (key: string, fallback?: string): string => {
 const isTruthy = (value: string | undefined): boolean => /^(1|true|yes)$/i.test(value ?? "");
 
 const STEP_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_STEP_TIMEOUT_MS ?? "120000");
+const BOOK_SESSION_STEP_TIMEOUT_MS = Number(process.env.PW_BOOK_SESSION_STEP_TIMEOUT_MS ?? "240000");
 
-const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): Promise<T> => {
+const withStepTimeout = async <T>(
+  label: string,
+  operation: () => Promise<T>,
+  timeoutMs = STEP_TIMEOUT_MS,
+): Promise<T> => {
   console.log(`[blocked-close] start ${label}`);
   const timeout = new Promise<never>((_, reject) => {
-    setTimeout(() => reject(new Error(`Step timed out: ${label} (${STEP_TIMEOUT_MS}ms)`)), STEP_TIMEOUT_MS);
+    setTimeout(() => reject(new Error(`Step timed out: ${label} (${timeoutMs}ms)`)), timeoutMs);
   });
   const result = await Promise.race([operation(), timeout]);
   console.log(`[blocked-close] ok ${label}`);
@@ -319,13 +324,13 @@ async function run(): Promise<void> {
     let booked: LifecycleIds;
     try {
       booked = await withStepTimeout("book-session", () =>
-        bookSession(activePage, token, strictParityMode, bookOpts));
+        bookSession(activePage, token, strictParityMode, bookOpts), BOOK_SESSION_STEP_TIMEOUT_MS);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (strictParityMode && message.includes("Organization context required") && authenticatedCredential) {
         token = await fetchAccessTokenForCredentials(authenticatedCredential.email, authenticatedCredential.password);
         booked = await withStepTimeout("book-session retry", () =>
-          bookSession(activePage, token, strictParityMode, bookOpts));
+          bookSession(activePage, token, strictParityMode, bookOpts), BOOK_SESSION_STEP_TIMEOUT_MS);
       } else {
         throw error;
       }

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -460,7 +460,7 @@ async function bookSession(page: Page, _token: string, strictMode: boolean): Pro
     await page.locator("#end-time-input").fill(toDatetimeLocal(attemptEnd));
 
     page.once("dialog", (dialog) => {
-      void dialog.accept();
+      void dialog.accept().catch(() => undefined);
     });
     const responsePromise = page.waitForResponse(
       (res) => res.url().includes("/api/book") && res.request().method() === "POST",
@@ -741,7 +741,7 @@ async function markTerminalViaScheduleModal(
   const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
   await page.locator("#status-select").selectOption(terminalStatus);
   page.once("dialog", (dialog) => {
-    void dialog.accept();
+    void dialog.accept().catch(() => undefined);
   });
   try {
     const terminalActionButton = terminalStatus === "completed"

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -330,6 +330,14 @@ const toDatetimeLocal = (date: Date): string => {
   return local.toISOString().slice(0, 16);
 };
 
+const buildBookingBaseStart = (): Date => {
+  const runSeed = Number(process.env.GITHUB_RUN_ID ?? Date.now());
+  const offsetHours = Number.isFinite(runSeed) ? Math.abs(Math.trunc(runSeed)) % 12 : 0;
+  const start = new Date();
+  start.setHours(start.getHours() + 4 + offsetHours, 0, 0, 0);
+  return start;
+};
+
 const buildScheduleEditSessionUrl = (scheduleUrl: string, sessionId: string): string => {
   const url = new URL(scheduleUrl);
   const expiresAtMs = Date.now() + SCHEDULE_MODAL_URL_TTL_MS;
@@ -434,14 +442,13 @@ async function bookSession(page: Page, _token: string, strictMode: boolean): Pro
 
   const selected = await chooseSessionTargets(page);
 
-  const start = new Date();
-  start.setHours(start.getHours() + 4, 0, 0, 0);
+  const start = buildBookingBaseStart();
   let finalStartIso = "";
   let finalEndIso = "";
   let payload: BrowserFetchResult<Record<string, unknown>> | null = null;
   let payloadBody: { success?: boolean; data?: { session?: { id?: string } }; code?: string } | null = null;
 
-  for (let attempt = 0; attempt < 12; attempt += 1) {
+  for (let attempt = 0; attempt < 48; attempt += 1) {
     const attemptStart = new Date(start.getTime() + attempt * 2 * 60 * 60 * 1000);
     const attemptEnd = new Date(attemptStart.getTime() + 60 * 60 * 1000);
     const startIso = attemptStart.toISOString();


### PR DESCRIPTION
## Summary
- Stabilize the blocked-close auth/session smoke by waiting for the browser-authenticated session row before opening the schedule modal deep link.
- Reduce CI booking collisions by widening booking attempts and deriving a run-specific booking base.
- Harden lifecycle dialog acceptance so duplicate/already-handled browser dialogs do not crash the smoke harness.
- Extend only the blocked-close booking setup timeout to 240s so the wider collision-resistant booking loop can complete in CI.

## Verification
- npm run typecheck
- npm run lint
- npm run ci:check-focused
- npm run playwright:session-no-show
- npm run playwright:session-complete
- npm run playwright:schedule-blocked-close
- npm run playwright:session-note-measurement-roundtrip
- npm run ci:playwright was attempted locally but timed out after 10 minutes; its component smoke scripts above passed individually.
- PR CI run 26000784820 passed: policy, lint-typecheck, unit-tests, build, tier0-browser, auth-browser-smoke, ci-gate.

## Risk
Critical protected auth/session browser-smoke slice. Product code is unchanged; changes are limited to Playwright smoke/setup harness behavior.