### PR TITLE
Open blocked-close smoke from rendered session

### DIFF
--- a/scripts/lib/playwright-inprogress-session-setup.ts
+++ b/scripts/lib/playwright-inprogress-session-setup.ts
@@ -14,6 +14,8 @@ export interface LifecycleIds {
   clientId: string;
   programId: string;
   goalId: string;
+  startIso?: string;
+  endIso?: string;
   noteId?: string;
 }
 
@@ -554,6 +556,8 @@ export async function bookSession(
         clientId: selected.clientId,
         programId: selected.programId,
         goalId: selected.goalId,
+        startIso: finalStartIso,
+        endIso: finalEndIso,
       };
     }
     throw new Error(
@@ -567,6 +571,8 @@ export async function bookSession(
     clientId: selected.clientId,
     programId: selected.programId,
     goalId: selected.goalId,
+    startIso: finalStartIso,
+    endIso: finalEndIso,
   };
 }
 

--- a/scripts/playwright-schedule-blocked-close.ts
+++ b/scripts/playwright-schedule-blocked-close.ts
@@ -240,6 +240,38 @@ async function getSessionOrganizationId(sessionId: string): Promise<string> {
   return data.organization_id;
 }
 
+async function openRenderedSessionCard(page: Page, sessionId: string): Promise<boolean> {
+  const card = page.locator(`[data-session-id="${sessionId}"]`).first();
+  const openCard = async (): Promise<boolean> => {
+    const visible = await card.isVisible().catch(() => false);
+    if (!visible) {
+      return false;
+    }
+    await card.click();
+    const dialog = page.getByRole("dialog", { name: /edit session|live session/i });
+    return dialog.waitFor({ state: "visible", timeout: 30_000 })
+      .then(() => true)
+      .catch(() => false);
+  };
+
+  await page.getByRole("button", { name: /Week view/i }).click().catch(() => undefined);
+  await page.waitForLoadState("networkidle").catch(() => undefined);
+  if (await openCard()) {
+    return true;
+  }
+
+  for (let step = 0; step < 8; step += 1) {
+    await page.getByRole("button", { name: /Next period/i }).click();
+    await page.waitForLoadState("networkidle").catch(() => undefined);
+    await page.waitForTimeout(500);
+    if (await openCard()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 async function run(): Promise<void> {
   loadPlaywrightEnv();
   const base = getEnv("PW_BASE_URL", "https://app.allincompassing.ai");
@@ -411,7 +443,15 @@ async function run(): Promise<void> {
         accessToken: token,
       }));
 
-    await withStepTimeout("open-edit-modal-via-url", async () => {
+    await withStepTimeout("open-edit-modal", async () => {
+      const openedFromRenderedCard = await openRenderedSessionCard(activePage, booked.sessionId);
+      if (openedFromRenderedCard) {
+        await activePage
+          .locator('[role="dialog"][data-session-status="in_progress"]')
+          .waitFor({ state: "visible", timeout: 90_000 });
+        return;
+      }
+
       let lastUrl = activePage.url();
       let lastBodyText = "";
 


### PR DESCRIPTION
## Summary
- Follow-up to PR #551 after main reproduced the blocked-close modal-opening failure.
- Preserve the existing modal URL fallback, but first open the real rendered Schedule session card across upcoming weeks.
- Carry booked start/end timestamps out of the shared in-progress setup helper for diagnostics/future routing.

## Verification
- npm run typecheck
- npm run lint
- npm run ci:check-focused
- npm run playwright:schedule-blocked-close

## Risk
Critical protected auth/session browser-smoke slice. Product code is unchanged; changes are limited to Playwright smoke/setup harness behavior.