### PR TITLE
Fix assessment document background enqueue

### DIFF
--- a/netlify/functions/assessment-documents.ts
+++ b/netlify/functions/assessment-documents.ts
@@ -1,8 +1,14 @@
 import { Handler, HandlerContext } from "@netlify/functions";
+import { fetchJson } from "../../src/server/api/shared";
 import {
+  assessmentDocumentsExtractionBackgroundHandler,
   assessmentDocumentsHandler,
   persistCaloptimaExtractionScheduleFailure,
 } from "../../src/server/api/assessment-documents";
+
+type BackgroundScheduleArgs = Parameters<
+  NonNullable<Parameters<typeof assessmentDocumentsHandler>[1]["scheduleCaloptimaExtraction"]>
+>[0];
 
 const toNetlifyResponse = async (response: Response) => {
   const headers: Record<string, string> = {};
@@ -18,39 +24,79 @@ const toNetlifyResponse = async (response: Response) => {
   };
 };
 
+const shouldPersistScheduleFailure = async (args: BackgroundScheduleArgs): Promise<boolean> => {
+  const documentResult = await fetchJson<Array<{ status?: string | null }>>(
+    `${args.supabaseUrl}/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(
+      args.createdDocumentId,
+    )}&organization_id=eq.${encodeURIComponent(args.organizationId)}&limit=1`,
+    {
+      method: "GET",
+      headers: args.headers,
+    },
+  );
+
+  const documentStatus =
+    documentResult.ok && Array.isArray(documentResult.data) && documentResult.data[0]
+      ? documentResult.data[0].status
+      : null;
+
+  return documentStatus === "extracting" || documentStatus === "extraction_running";
+};
+
+const persistScheduleFailureIfPending = async (args: BackgroundScheduleArgs): Promise<void> => {
+  if (!(await shouldPersistScheduleFailure(args))) {
+    return;
+  }
+
+  await persistCaloptimaExtractionScheduleFailure({
+    supabaseUrl: args.supabaseUrl,
+    headers: args.headers,
+    organizationId: args.organizationId,
+    actorId: args.actorId,
+    createdDocumentId: args.createdDocumentId,
+    clientId: args.clientId,
+  });
+};
+
 const scheduleBackgroundExtraction = (
   context: HandlerContext,
   request: Request,
-  args: Parameters<NonNullable<Parameters<typeof assessmentDocumentsHandler>[1]["scheduleCaloptimaExtraction"]>>[0],
+  args: BackgroundScheduleArgs,
 ): boolean => {
   if (typeof context.waitUntil !== "function") {
     return false;
   }
 
   const origin = new URL(request.url).origin;
-  const trigger = fetch(`${origin}/.netlify/functions/assessment-documents-extract-background`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${args.accessToken}`,
-    },
-    body: JSON.stringify({ assessment_document_id: args.createdDocumentId, client_id: args.clientId }),
-  }).then((response) => {
-    if (!response.ok) {
-      throw new Error("background extraction enqueue failed");
+  const backgroundHeaders = new Headers({
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${args.accessToken}`,
+  });
+  const requestOrigin = request.headers.get("origin");
+  if (requestOrigin) {
+    backgroundHeaders.set("origin", requestOrigin);
+  }
+
+  const trigger = (async () => {
+    try {
+      const response = await assessmentDocumentsExtractionBackgroundHandler(
+        new Request(`${origin}/.netlify/functions/assessment-documents-extract-background`, {
+          method: "POST",
+          headers: backgroundHeaders,
+          body: JSON.stringify({
+            assessment_document_id: args.createdDocumentId,
+            client_id: args.clientId,
+          }),
+        }),
+      );
+
+      if (!response.ok) {
+        throw new Error("background extraction enqueue failed");
+      }
+    } catch {
+      await persistScheduleFailureIfPending(args);
     }
-  }).catch(() =>
-    // The -background endpoint response only proves enqueue/transport status.
-    // Worker-handled document failures persist their own terminal reason.
-    persistCaloptimaExtractionScheduleFailure({
-      supabaseUrl: args.supabaseUrl,
-      headers: args.headers,
-      organizationId: args.organizationId,
-      actorId: args.actorId,
-      createdDocumentId: args.createdDocumentId,
-      clientId: args.clientId,
-    }),
-  );
+  })();
 
   context.waitUntil(trigger);
   return true;

--- a/netlify/functions/assessment-documents.ts
+++ b/netlify/functions/assessment-documents.ts
@@ -25,22 +25,30 @@ const toNetlifyResponse = async (response: Response) => {
 };
 
 const shouldPersistScheduleFailure = async (args: BackgroundScheduleArgs): Promise<boolean> => {
-  const documentResult = await fetchJson<Array<{ status?: string | null }>>(
-    `${args.supabaseUrl}/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(
-      args.createdDocumentId,
-    )}&organization_id=eq.${encodeURIComponent(args.organizationId)}&limit=1`,
-    {
-      method: "GET",
-      headers: args.headers,
-    },
-  );
+  try {
+    const documentResult = await fetchJson<Array<{ status?: string | null }>>(
+      `${args.supabaseUrl}/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(
+        args.createdDocumentId,
+      )}&organization_id=eq.${encodeURIComponent(args.organizationId)}&limit=1`,
+      {
+        method: "GET",
+        headers: args.headers,
+      },
+    );
 
-  const documentStatus =
-    documentResult.ok && Array.isArray(documentResult.data) && documentResult.data[0]
-      ? documentResult.data[0].status
-      : null;
+    const documentStatus =
+      documentResult.ok && Array.isArray(documentResult.data) && documentResult.data[0]
+        ? documentResult.data[0].status
+        : null;
 
-  return documentStatus === "extracting" || documentStatus === "extraction_running";
+    if (!documentResult.ok) {
+      return true;
+    }
+
+    return documentStatus === "extracting" || documentStatus === "extraction_running";
+  } catch {
+    return true;
+  }
 };
 
 const persistScheduleFailureIfPending = async (args: BackgroundScheduleArgs): Promise<void> => {

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -187,7 +187,7 @@ describe("assessmentDocumentsHandler", () => {
 
   const mockNetlifyWrapperFlowResponses = (
     documentId: string,
-    mode: "success" | "lookup-empty" | "lookup-fails" = "success",
+    mode: "success" | "lookup-empty" | "lookup-fails" | "lookup-status-throws" = "success",
   ) => {
     const clientId = "11111111-1111-1111-1111-111111111111";
     const backgroundDocument = {
@@ -234,6 +234,9 @@ describe("assessmentDocumentsHandler", () => {
       if (method === "GET" && url.includes(`/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(documentId)}`)) {
         if (mode === "lookup-fails") {
           return { ok: true, status: 200, data: [{ status: "extraction_failed" }] };
+        }
+        if (mode === "lookup-status-throws") {
+          throw new Error("temporary status lookup failure");
         }
         return { ok: true, status: 200, data: [{ status: "extracting" }] };
       }
@@ -720,6 +723,78 @@ describe("assessmentDocumentsHandler", () => {
       return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes(documentId) && body.includes("extraction_background_schedule_failed");
     });
     expect(failureEventCall).toBeDefined();
+  });
+
+  it("Netlify upload wrapper persists extraction_background_schedule_failed when status lookup throws", async () => {
+    const documentId = "73444444-4444-4344-8344-444444444444";
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    mockNetlifyWrapperFlowResponses(documentId, "lookup-status-throws");
+    const waitUntilPromises: Promise<unknown>[] = [];
+    globalThis.fetch = vi.fn() as typeof fetch;
+
+    const response = await assessmentDocumentsNetlifyHandler(
+      {
+        httpMethod: "POST",
+        headers: {
+          host: "app.example.com",
+          authorization: "Bearer token",
+        },
+        path: "/api/assessment-documents",
+        rawUrl: "https://app.example.com/api/assessment-documents",
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+        isBase64Encoded: false,
+      } as never,
+      {
+        waitUntil: (promise: Promise<unknown>) => {
+          waitUntilPromises.push(promise);
+        },
+      } as never,
+      undefined as never,
+    );
+
+    expect(response.statusCode).toBe(201);
+    expect(waitUntilPromises).toHaveLength(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    await waitUntilPromises[0];
+    const failedStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url, init]) => {
+        const body = String((init as RequestInit | undefined)?.body ?? "");
+        return (
+          typeof url === "string" &&
+          url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`) &&
+          body.includes("\"status\":\"extraction_failed\"")
+        );
+      });
+    expect(failedStatusBodies).toHaveLength(1);
+    const failureEventCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
+      const body = String((init as RequestInit | undefined)?.body ?? "");
+      return (
+        typeof url === "string" &&
+        url.includes("/rest/v1/assessment_review_events") &&
+        body.includes(documentId) &&
+        body.includes("extraction_background_schedule_failed")
+      );
+    });
+    expect(failureEventCalls).toHaveLength(1);
   });
 
   it("Netlify upload wrapper does not duplicate persistence when the background worker already handles terminal failure", async () => {

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -185,6 +185,103 @@ describe("assessmentDocumentsHandler", () => {
     });
   };
 
+  const mockNetlifyWrapperFlowResponses = (
+    documentId: string,
+    mode: "success" | "lookup-empty" | "lookup-fails" = "success",
+  ) => {
+    const clientId = "11111111-1111-1111-1111-111111111111";
+    const backgroundDocument = {
+      id: documentId,
+      organization_id: "org-1",
+      client_id: clientId,
+      status: "extracting",
+      template_type: "caloptima_fba",
+      bucket_id: "client-documents",
+      object_path: `clients/${clientId}/assessments/fba.pdf`,
+      updated_at: "2026-05-17T00:00:00.000Z",
+    };
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
+        return {
+          ok: true,
+          status: 201,
+          data: [{ id: documentId, organization_id: "org-1", client_id: clientId }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (
+        method === "GET" &&
+        url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path,updated_at")
+      ) {
+        if (mode === "lookup-fails") {
+          return { ok: false, status: 500, data: null };
+        }
+        if (mode === "lookup-empty") {
+          return { ok: true, status: 200, data: [] };
+        }
+        return { ok: true, status: 200, data: [backgroundDocument] };
+      }
+      if (method === "GET" && url.includes(`/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(documentId)}`)) {
+        if (mode === "lookup-fails") {
+          return { ok: true, status: 200, data: [{ status: "extraction_failed" }] };
+        }
+        return { ok: true, status: 200, data: [{ status: "extracting" }] };
+      }
+      if (
+        method === "PATCH" &&
+        url.includes(`/rest/v1/assessment_documents?id=eq.${encodeURIComponent(documentId)}`) &&
+        url.includes("&status=eq.extracting")
+      ) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{ ...backgroundDocument, status: "extraction_running" }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name")) {
+        return { ok: true, status: 200, data: [{ full_name: "Client One", date_of_birth: "2017-05-01" }] };
+      }
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return {
+          ok: true,
+          status: 200,
+          data: {
+            extraction_provider: "adobe_pdf_extract",
+            adobe_element_count: 42,
+            adobe_table_count: 3,
+            fields: [],
+            unresolved_keys: [],
+            extracted_count: 0,
+            unresolved_count: 0,
+          },
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_checklist_items")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_extractions")) {
+        return { ok: true, status: 200, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+  };
+
   it("returns 401 when authorization is missing", async () => {
     const response = await assessmentDocumentsHandler(
       new Request("http://localhost/api/assessment-documents?client_id=11111111-1111-1111-1111-111111111111", {
@@ -384,7 +481,8 @@ describe("assessmentDocumentsHandler", () => {
     expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
   });
 
-  it("Netlify upload wrapper schedules extraction with waitUntil without awaiting the background fetch", async () => {
+  it("Netlify upload wrapper schedules extraction with waitUntil without using an outbound fetch hop", async () => {
+    const documentId = "71111111-1111-4111-8111-111111111111";
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
@@ -398,9 +496,9 @@ describe("assessmentDocumentsHandler", () => {
     });
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
-    mockUploadFlowResponses("doc-netlify-wrapper");
-    const waitUntil = vi.fn();
-    globalThis.fetch = vi.fn(() => new Promise<Response>(() => undefined)) as typeof fetch;
+    mockNetlifyWrapperFlowResponses(documentId);
+    const waitUntilPromises: Promise<unknown>[] = [];
+    globalThis.fetch = vi.fn() as typeof fetch;
 
     const response = await assessmentDocumentsNetlifyHandler(
       {
@@ -420,30 +518,34 @@ describe("assessmentDocumentsHandler", () => {
         }),
         isBase64Encoded: false,
       } as never,
-      { waitUntil } as never,
+      {
+        waitUntil: (promise: Promise<unknown>) => {
+          waitUntilPromises.push(promise);
+        },
+      } as never,
       undefined as never,
     );
 
     expect(response.statusCode).toBe(201);
     expect(JSON.parse(response.body)).toMatchObject({
-      id: "doc-netlify-wrapper",
+      id: documentId,
       status: "extracting",
     });
-    expect(waitUntil).toHaveBeenCalledTimes(1);
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      "https://app.example.com/.netlify/functions/assessment-documents-extract-background",
-      expect.objectContaining({
-        method: "POST",
-        headers: expect.objectContaining({ Authorization: "Bearer token" }),
-        body: JSON.stringify({
-          assessment_document_id: "doc-netlify-wrapper",
-          client_id: "11111111-1111-1111-1111-111111111111",
-        }),
-      }),
+    expect(waitUntilPromises).toHaveLength(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    await waitUntilPromises[0];
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path,updated_at&id=eq.${encodeURIComponent(
+          documentId,
+        )}`,
+      ),
+      expect.objectContaining({ method: "GET" }),
     );
   });
 
   it("Netlify upload wrapper fails closed when waitUntil is unavailable", async () => {
+    globalThis.fetch = vi.fn() as typeof fetch;
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
@@ -457,9 +559,7 @@ describe("assessmentDocumentsHandler", () => {
     });
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
-    mockUploadFlowResponses("doc-netlify-no-waituntil");
-    globalThis.fetch = vi.fn(() => Promise.resolve(new Response(null, { status: 202 }))) as typeof fetch;
-
+    mockNetlifyWrapperFlowResponses("75555555-5555-4555-8555-555555555555");
     const response = await assessmentDocumentsNetlifyHandler(
       {
         httpMethod: "POST",
@@ -486,13 +586,82 @@ describe("assessmentDocumentsHandler", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
     const documentStatusBodies = vi
       .mocked(fetchJson)
-      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-netlify-no-waituntil"))
+      .mock.calls.filter(
+        ([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.75555555-5555-4555-8555-555555555555"),
+      )
       .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
     expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
     expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
   });
 
-  it("Netlify upload wrapper marks extraction failed when the background trigger rejects", async () => {
+  it("Netlify upload wrapper preserves extraction_running when a post-claim background error is handled in-worker", async () => {
+    const documentId = "72222222-2222-4222-8222-222222222222";
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows)
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error("background load failed"));
+    const waitUntilPromises: Promise<unknown>[] = [];
+    mockNetlifyWrapperFlowResponses(documentId);
+    globalThis.fetch = vi.fn() as typeof fetch;
+
+    const response = await assessmentDocumentsNetlifyHandler(
+      {
+        httpMethod: "POST",
+        headers: {
+          host: "app.example.com",
+          authorization: "Bearer token",
+        },
+        path: "/api/assessment-documents",
+        rawUrl: "https://app.example.com/api/assessment-documents",
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+        isBase64Encoded: false,
+      } as never,
+      {
+        waitUntil: (promise: Promise<unknown>) => {
+          waitUntilPromises.push(promise);
+        },
+      } as never,
+      undefined as never,
+    );
+
+    expect(response.statusCode).toBe(201);
+    expect(waitUntilPromises).toHaveLength(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    await waitUntilPromises[0];
+    const documentStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`))
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
+    const failureEventBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_review_events"))
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""))
+      .filter((body) => body.includes(documentId) && body.includes("\"action\":\"extraction_failed\""));
+    expect(failureEventBodies).toHaveLength(1);
+    expect(failureEventBodies[0]).toContain("\"from_status\":\"extraction_running\"");
+  });
+
+  it("Netlify upload wrapper persists extraction_background_schedule_failed when the direct background handler returns non-ok", async () => {
+    const documentId = "73333333-3333-4333-8333-333333333333";
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
@@ -506,9 +675,160 @@ describe("assessmentDocumentsHandler", () => {
     });
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
-    mockUploadFlowResponses("doc-netlify-trigger-fail");
+    mockNetlifyWrapperFlowResponses(documentId, "lookup-empty");
     const waitUntilPromises: Promise<unknown>[] = [];
-    globalThis.fetch = vi.fn(() => Promise.reject(new Error("network down"))) as typeof fetch;
+    globalThis.fetch = vi.fn() as typeof fetch;
+
+    const response = await assessmentDocumentsNetlifyHandler(
+      {
+        httpMethod: "POST",
+        headers: {
+          host: "app.example.com",
+          authorization: "Bearer token",
+        },
+        path: "/api/assessment-documents",
+        rawUrl: "https://app.example.com/api/assessment-documents",
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+        isBase64Encoded: false,
+      } as never,
+      {
+        waitUntil: (promise: Promise<unknown>) => {
+          waitUntilPromises.push(promise);
+        },
+      } as never,
+      undefined as never,
+    );
+
+    expect(response.statusCode).toBe(201);
+    expect(waitUntilPromises).toHaveLength(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    await waitUntilPromises[0];
+    const documentStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`))
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
+    const failureEventCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
+      const body = String((init as RequestInit | undefined)?.body ?? "");
+      return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes(documentId) && body.includes("extraction_background_schedule_failed");
+    });
+    expect(failureEventCall).toBeDefined();
+  });
+
+  it("Netlify upload wrapper does not duplicate persistence when the background worker already handles terminal failure", async () => {
+    const documentId = "74444444-4444-4444-8444-444444444444";
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    mockNetlifyWrapperFlowResponses(documentId, "lookup-fails");
+    const waitUntilPromises: Promise<unknown>[] = [];
+    globalThis.fetch = vi.fn() as typeof fetch;
+
+    const response = await assessmentDocumentsNetlifyHandler(
+      {
+        httpMethod: "POST",
+        headers: {
+          host: "app.example.com",
+          authorization: "Bearer token",
+        },
+        path: "/api/assessment-documents",
+        rawUrl: "https://app.example.com/api/assessment-documents",
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+        isBase64Encoded: false,
+      } as never,
+      {
+        waitUntil: (promise: Promise<unknown>) => {
+          waitUntilPromises.push(promise);
+        },
+      } as never,
+      undefined as never,
+    );
+
+    expect(response.statusCode).toBe(201);
+    expect(waitUntilPromises).toHaveLength(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    await waitUntilPromises[0];
+    const failedStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url, init]) => {
+        const body = String((init as RequestInit | undefined)?.body ?? "");
+        return (
+          typeof url === "string" &&
+          url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`) &&
+          body.includes("\"status\":\"extraction_failed\"")
+        );
+      });
+    expect(failedStatusBodies).toHaveLength(1);
+    const failureEventCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
+      const body = String((init as RequestInit | undefined)?.body ?? "");
+      return (
+        typeof url === "string" &&
+        url.includes("/rest/v1/assessment_review_events") &&
+        body.includes(documentId) &&
+        body.includes("extraction_background_schedule_failed")
+      );
+    });
+    expect(failureEventCalls).toHaveLength(1);
+  });
+
+  it("Netlify upload wrapper does not overwrite terminal failure state when worker review-event persistence throws", async () => {
+    const documentId = "76666666-6666-4666-8666-666666666666";
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows)
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error("background load failed"));
+    mockNetlifyWrapperFlowResponses(documentId);
+    const baseImpl = vi.mocked(fetchJson).getMockImplementation();
+    if (!baseImpl) {
+      throw new Error("Missing Netlify wrapper fetchJson mock implementation.");
+    }
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      const body = String((init as RequestInit | undefined)?.body ?? "");
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events") && body.includes(documentId) && body.includes("\"action\":\"extraction_failed\"")) {
+        return { ok: false, status: 500, data: null };
+      }
+      if (method === "GET" && url.includes(`/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(documentId)}`)) {
+        return { ok: true, status: 200, data: [{ status: "extraction_failed" }] };
+      }
+      return baseImpl(url, init);
+    });
+    const waitUntilPromises: Promise<unknown>[] = [];
+    globalThis.fetch = vi.fn() as typeof fetch;
 
     const response = await assessmentDocumentsNetlifyHandler(
       {
@@ -539,67 +859,11 @@ describe("assessmentDocumentsHandler", () => {
     expect(response.statusCode).toBe(201);
     expect(waitUntilPromises).toHaveLength(1);
     await waitUntilPromises[0];
-    const documentStatusBodies = vi
-      .mocked(fetchJson)
-      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-netlify-trigger-fail"))
-      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
-    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
-    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
-  });
-
-  it("Netlify upload wrapper does not overwrite worker-handled failures from background responses", async () => {
-    vi.mocked(getAccessToken).mockReturnValue("token");
-    vi.mocked(resolveOrgAndRole).mockResolvedValue({
-      organizationId: "org-1",
-      isTherapist: true,
-      isAdmin: false,
-      isSuperAdmin: false,
+    const failedStatusWrites = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
+      const body = String((init as RequestInit | undefined)?.body ?? "");
+      return typeof url === "string" && url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`) && body.includes("\"status\":\"extraction_failed\"");
     });
-    vi.mocked(getSupabaseConfig).mockReturnValue({
-      supabaseUrl: "https://example.supabase.co",
-      anonKey: "anon",
-    });
-    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
-    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
-    mockUploadFlowResponses("doc-netlify-worker-terminal-failure");
-    const waitUntilPromises: Promise<unknown>[] = [];
-    globalThis.fetch = vi.fn(() => Promise.resolve(new Response(JSON.stringify({ accepted: true }), { status: 202 }))) as typeof fetch;
-
-    const response = await assessmentDocumentsNetlifyHandler(
-      {
-        httpMethod: "POST",
-        headers: {
-          host: "app.example.com",
-          authorization: "Bearer token",
-        },
-        path: "/api/assessment-documents",
-        rawUrl: "https://app.example.com/api/assessment-documents",
-        body: JSON.stringify({
-          client_id: "11111111-1111-1111-1111-111111111111",
-          file_name: "fba.pdf",
-          mime_type: "application/pdf",
-          file_size: 1234,
-          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
-        }),
-        isBase64Encoded: false,
-      } as never,
-      {
-        waitUntil: (promise: Promise<unknown>) => {
-          waitUntilPromises.push(promise);
-        },
-      } as never,
-      undefined as never,
-    );
-
-    expect(response.statusCode).toBe(201);
-    expect(waitUntilPromises).toHaveLength(1);
-    await waitUntilPromises[0];
-    const documentStatusBodies = vi
-      .mocked(fetchJson)
-      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-netlify-worker-terminal-failure"))
-      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
-    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
-    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(false);
+    expect(failedStatusWrites).toHaveLength(1);
   });
 
   it("runs CalOptima extraction from the background worker only for scoped extracting documents", async () => {

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -740,7 +740,21 @@ describe("assessmentDocumentsHandler", () => {
     });
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
-    mockNetlifyWrapperFlowResponses(documentId, "lookup-status-throws");
+    mockNetlifyWrapperFlowResponses(documentId, "lookup-empty");
+    const baseImpl = vi.mocked(fetchJson).getMockImplementation();
+    if (!baseImpl) {
+      throw new Error("Missing Netlify wrapper fetchJson mock implementation.");
+    }
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      if (
+        (init?.method ?? "GET").toUpperCase() === "GET" &&
+        typeof url === "string" &&
+        url.includes(`/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(documentId)}`)
+      ) {
+        throw new Error("temporary status lookup failure");
+      }
+      return baseImpl(url, init);
+    });
     const waitUntilPromises: Promise<unknown>[] = [];
     globalThis.fetch = vi.fn() as typeof fetch;
 

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -777,19 +777,34 @@ export async function assessmentDocumentsExtractionBackgroundHandler(request: Re
     return jsonForRequest(request, { accepted: true, error: failure.publicMessage }, 202);
   }
 
-  const checklistRows = await loadChecklistTemplateRows(claimedDocument.template_type);
-  await runBoundedCaloptimaExtractionWorkflow({
-    supabaseUrl,
-    headers,
-    organizationId,
-    actorId,
-    createdDocumentId: claimedDocument.id,
-    clientId: claimedDocument.client_id,
-    checklistRows,
-    bucketId: claimedDocument.bucket_id,
-    objectPath: claimedDocument.object_path,
-    fromStatus: EXTRACTION_RUNNING_STATUS,
-  });
+  try {
+    const checklistRows = await loadChecklistTemplateRows(claimedDocument.template_type);
+    await runBoundedCaloptimaExtractionWorkflow({
+      supabaseUrl,
+      headers,
+      organizationId,
+      actorId,
+      createdDocumentId: claimedDocument.id,
+      clientId: claimedDocument.client_id,
+      checklistRows,
+      bucketId: claimedDocument.bucket_id,
+      objectPath: claimedDocument.object_path,
+      fromStatus: EXTRACTION_RUNNING_STATUS,
+    });
+  } catch (error) {
+    const workflowError = asExtractionWorkflowError(error);
+    await persistExtractionFailure({
+      supabaseUrl,
+      headers,
+      organizationId,
+      actorId,
+      createdDocumentId: claimedDocument.id,
+      clientId: claimedDocument.client_id,
+      error: workflowError,
+      fromStatus: EXTRACTION_RUNNING_STATUS,
+    });
+    return jsonForRequest(request, { accepted: true, error: workflowError.publicMessage }, 202);
+  }
 
   return jsonForRequest(request, { accepted: true }, 202);
 }


### PR DESCRIPTION
## Summary
- replace the Netlify self-fetch enqueue hop with an in-process background handler call under context.waitUntil(...)
- preserve terminal extraction failures from the worker instead of overwriting them with generic schedule-failure state
- add regression coverage for direct scheduling, non-ok background responses, thrown background errors, and duplicate-failure avoidance

## Verification
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
- npm run verify:local
- npx vitest run src/server/__tests__/assessmentDocumentsHandler.test.ts

## Risk
- critical lane because this touches Netlify wrapper and server-side extraction orchestration
- human review still required before merge
- no Linear issue linked in this PR yet