### PR TITLE
Fix assessment upload extraction and draft workflow

### DIFF
--- a/netlify/functions/assessment-documents.ts
+++ b/netlify/functions/assessment-documents.ts
@@ -2,6 +2,7 @@ import { Handler } from "@netlify/functions";
 import {
   assessmentDocumentsHandler,
 } from "../../src/server/api/assessment-documents";
+import { fetchJson } from "../../src/server/api/shared";
 
 type BackgroundScheduleArgs = Parameters<
   NonNullable<Parameters<typeof assessmentDocumentsHandler>[1]["scheduleCaloptimaExtraction"]>
@@ -35,16 +36,32 @@ const scheduleBackgroundExtraction = async (
     backgroundHeaders.set("origin", requestOrigin);
   }
 
-  const response = await fetch(`${origin}/.netlify/functions/assessment-documents-extract-background`, {
-    method: "POST",
-    headers: backgroundHeaders,
-    body: JSON.stringify({
-      assessment_document_id: args.createdDocumentId,
-      client_id: args.clientId,
-    }),
-  });
+  try {
+    const response = await fetch(`${origin}/.netlify/functions/assessment-documents-extract-background`, {
+      method: "POST",
+      headers: backgroundHeaders,
+      body: JSON.stringify({
+        assessment_document_id: args.createdDocumentId,
+        client_id: args.clientId,
+      }),
+    });
+    if (response.ok) {
+      return true;
+    }
+  } catch {
+    // Fall through to a status probe so we do not overwrite a job that was accepted despite a transport error.
+  }
 
-  return response.ok;
+  const statusProbe = await fetchJson<Array<{ status?: string | null }>>(
+    `${args.supabaseUrl}/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(args.createdDocumentId)}&limit=1`,
+    {
+      method: "GET",
+      headers: args.headers,
+    },
+  );
+  const latestStatus =
+    statusProbe.ok && Array.isArray(statusProbe.data) ? statusProbe.data[0]?.status?.trim() ?? null : null;
+  return latestStatus !== null && latestStatus !== "extracting";
 };
 
 export const handler: Handler = async (event) => {

--- a/netlify/functions/assessment-documents.ts
+++ b/netlify/functions/assessment-documents.ts
@@ -1,9 +1,6 @@
-import { Handler, HandlerContext } from "@netlify/functions";
-import { fetchJson } from "../../src/server/api/shared";
+import { Handler } from "@netlify/functions";
 import {
-  assessmentDocumentsExtractionBackgroundHandler,
   assessmentDocumentsHandler,
-  persistCaloptimaExtractionScheduleFailure,
 } from "../../src/server/api/assessment-documents";
 
 type BackgroundScheduleArgs = Parameters<
@@ -24,57 +21,10 @@ const toNetlifyResponse = async (response: Response) => {
   };
 };
 
-const shouldPersistScheduleFailure = async (args: BackgroundScheduleArgs): Promise<boolean> => {
-  try {
-    const documentResult = await fetchJson<Array<{ status?: string | null }>>(
-      `${args.supabaseUrl}/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(
-        args.createdDocumentId,
-      )}&organization_id=eq.${encodeURIComponent(args.organizationId)}&limit=1`,
-      {
-        method: "GET",
-        headers: args.headers,
-      },
-    );
-
-    const documentStatus =
-      documentResult.ok && Array.isArray(documentResult.data) && documentResult.data[0]
-        ? documentResult.data[0].status
-        : null;
-
-    if (!documentResult.ok) {
-      return true;
-    }
-
-    return documentStatus === "extracting" || documentStatus === "extraction_running";
-  } catch {
-    return true;
-  }
-};
-
-const persistScheduleFailureIfPending = async (args: BackgroundScheduleArgs): Promise<void> => {
-  if (!(await shouldPersistScheduleFailure(args))) {
-    return;
-  }
-
-  await persistCaloptimaExtractionScheduleFailure({
-    supabaseUrl: args.supabaseUrl,
-    headers: args.headers,
-    organizationId: args.organizationId,
-    actorId: args.actorId,
-    createdDocumentId: args.createdDocumentId,
-    clientId: args.clientId,
-  });
-};
-
-const scheduleBackgroundExtraction = (
-  context: HandlerContext,
+const scheduleBackgroundExtraction = async (
   request: Request,
   args: BackgroundScheduleArgs,
-): boolean => {
-  if (typeof context.waitUntil !== "function") {
-    return false;
-  }
-
+): Promise<boolean> => {
   const origin = new URL(request.url).origin;
   const backgroundHeaders = new Headers({
     "Content-Type": "application/json",
@@ -85,32 +35,19 @@ const scheduleBackgroundExtraction = (
     backgroundHeaders.set("origin", requestOrigin);
   }
 
-  const trigger = (async () => {
-    try {
-      const response = await assessmentDocumentsExtractionBackgroundHandler(
-        new Request(`${origin}/.netlify/functions/assessment-documents-extract-background`, {
-          method: "POST",
-          headers: backgroundHeaders,
-          body: JSON.stringify({
-            assessment_document_id: args.createdDocumentId,
-            client_id: args.clientId,
-          }),
-        }),
-      );
+  const response = await fetch(`${origin}/.netlify/functions/assessment-documents-extract-background`, {
+    method: "POST",
+    headers: backgroundHeaders,
+    body: JSON.stringify({
+      assessment_document_id: args.createdDocumentId,
+      client_id: args.clientId,
+    }),
+  });
 
-      if (!response.ok) {
-        throw new Error("background extraction enqueue failed");
-      }
-    } catch {
-      await persistScheduleFailureIfPending(args);
-    }
-  })();
-
-  context.waitUntil(trigger);
-  return true;
+  return response.ok;
 };
 
-export const handler: Handler = async (event, context) => {
+export const handler: Handler = async (event) => {
   try {
     const bodyNeeded = event.httpMethod !== "GET" && event.httpMethod !== "HEAD";
     const body =
@@ -128,7 +65,7 @@ export const handler: Handler = async (event, context) => {
 
     const response = await assessmentDocumentsHandler(request, {
       scheduleCaloptimaExtraction: async (args) => {
-        const scheduled = scheduleBackgroundExtraction(context, request, args);
+        const scheduled = await scheduleBackgroundExtraction(request, args);
         return { ok: scheduled, status: scheduled ? 202 : 500 };
       },
     });

--- a/scripts/playwright-assessment-upload-promote-smoke.ts
+++ b/scripts/playwright-assessment-upload-promote-smoke.ts
@@ -305,10 +305,11 @@ const waitForExtractedOrDraftedAssessment = async (args: {
 }): Promise<AssessmentDocumentRecord> => {
   const deadline = Date.now() + EXTRACTION_TIMEOUT_MS;
   let latest: AssessmentDocumentRecord | null = null;
+  const inProgressStatuses = new Set(["uploaded", "extracting", "extraction_running"]);
   while (Date.now() < deadline) {
     const documents = await fetchAssessmentDocuments(args.baseUrl, args.accessToken, args.clientId);
     latest = documents.find((document) => document.file_name === args.uploadFileName) ?? null;
-    if (latest && !["uploaded", "extracting"].includes(latest.status)) {
+    if (latest && !inProgressStatuses.has(latest.status)) {
       break;
     }
     await pause(2_000);

--- a/scripts/playwright-assessment-upload-promote-smoke.ts
+++ b/scripts/playwright-assessment-upload-promote-smoke.ts
@@ -213,6 +213,13 @@ const buildSyntheticAssessmentPdf = async (): Promise<Buffer> => {
 
 const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
+const shouldRetryAppTimeout = (url: string, status: number): boolean =>
+  status === 504 &&
+  (
+    url.includes("/api/assessment-checklist") ||
+    url.includes("/api/assessment-drafts")
+  );
+
 const assertOk = async (response: Response, message: string): Promise<void> => {
   if (response.ok) return;
   const body = await response.text().catch(() => "");
@@ -224,7 +231,7 @@ const fetchJson = async <T>(
   init: RequestInit & { accessToken?: string; anonKey?: string } = {},
 ): Promise<T> => {
   const { accessToken, anonKey, headers, ...rest } = init;
-  const response = await fetch(url, {
+  const requestInit: RequestInit = {
     ...rest,
     headers: {
       ...(anonKey ? { apikey: anonKey } : {}),
@@ -232,10 +239,22 @@ const fetchJson = async <T>(
       ...(rest.body ? { "Content-Type": "application/json" } : {}),
       ...headers,
     },
-  });
-  await assertOk(response, `Request failed for ${url}`);
-  const text = await response.text();
-  return text ? (JSON.parse(text) as T) : ([] as T);
+  };
+  let lastResponse: Response | null = null;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const response = await fetch(url, requestInit);
+    if (response.ok) {
+      const text = await response.text();
+      return text ? (JSON.parse(text) as T) : ([] as T);
+    }
+    lastResponse = response;
+    if (!shouldRetryAppTimeout(url, response.status) || attempt === 2) {
+      break;
+    }
+    await pause(1_000 * (attempt + 1));
+  }
+  await assertOk(lastResponse ?? new Response(null, { status: 599 }), `Request failed for ${url}`);
+  return [] as T;
 };
 
 const callAppJson = async <T>(

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -484,7 +484,7 @@ describe("assessmentDocumentsHandler", () => {
     expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
   });
 
-  it("Netlify upload wrapper schedules extraction with waitUntil without using an outbound fetch hop", async () => {
+  it("Netlify upload wrapper enqueues the background extraction endpoint over fetch", async () => {
     const documentId = "71111111-1111-4111-8111-111111111111";
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -500,8 +500,7 @@ describe("assessmentDocumentsHandler", () => {
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
     mockNetlifyWrapperFlowResponses(documentId);
-    const waitUntilPromises: Promise<unknown>[] = [];
-    globalThis.fetch = vi.fn() as typeof fetch;
+    globalThis.fetch = vi.fn(async () => new Response(null, { status: 202 })) as typeof fetch;
 
     const response = await assessmentDocumentsNetlifyHandler(
       {
@@ -521,11 +520,7 @@ describe("assessmentDocumentsHandler", () => {
         }),
         isBase64Encoded: false,
       } as never,
-      {
-        waitUntil: (promise: Promise<unknown>) => {
-          waitUntilPromises.push(promise);
-        },
-      } as never,
+      {} as never,
       undefined as never,
     );
 
@@ -534,21 +529,24 @@ describe("assessmentDocumentsHandler", () => {
       id: documentId,
       status: "extracting",
     });
-    expect(waitUntilPromises).toHaveLength(1);
-    expect(globalThis.fetch).not.toHaveBeenCalled();
-    await waitUntilPromises[0];
-    expect(fetchJson).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path,updated_at&id=eq.${encodeURIComponent(
-          documentId,
-        )}`,
-      ),
-      expect.objectContaining({ method: "GET" }),
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://app.example.com/.netlify/functions/assessment-documents-extract-background",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.any(Headers),
+      }),
     );
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
+    const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer token");
+    expect(JSON.parse(String(init?.body ?? "{}"))).toMatchObject({
+      assessment_document_id: documentId,
+      client_id: "11111111-1111-1111-1111-111111111111",
+    });
   });
 
-  it("Netlify upload wrapper fails closed when waitUntil is unavailable", async () => {
-    globalThis.fetch = vi.fn() as typeof fetch;
+  it("Netlify upload wrapper no longer depends on waitUntil being available", async () => {
+    const documentId = "75555555-5555-4555-8555-555555555555";
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
@@ -562,7 +560,61 @@ describe("assessmentDocumentsHandler", () => {
     });
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
-    mockNetlifyWrapperFlowResponses("75555555-5555-4555-8555-555555555555");
+    mockNetlifyWrapperFlowResponses(documentId);
+    globalThis.fetch = vi.fn(async () => new Response(null, { status: 202 })) as typeof fetch;
+
+    const response = await assessmentDocumentsNetlifyHandler(
+      {
+        httpMethod: "POST",
+        headers: {
+          host: "app.example.com",
+          authorization: "Bearer token",
+        },
+        path: "/api/assessment-documents",
+        rawUrl: "https://app.example.com/api/assessment-documents",
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+        isBase64Encoded: false,
+      } as never,
+      {} as never,
+      undefined as never,
+    );
+
+    expect(response.statusCode).toBe(201);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const documentStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(
+        ([url]) => typeof url === "string" && url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`),
+      )
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(false);
+  });
+
+  it("Netlify upload wrapper persists extraction_background_schedule_failed when enqueue returns non-ok", async () => {
+    const documentId = "73333333-3333-4333-8333-333333333333";
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    mockNetlifyWrapperFlowResponses(documentId);
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({ error: "enqueue failed" }), { status: 500 })) as typeof fetch;
+
     const response = await assessmentDocumentsNetlifyHandler(
       {
         httpMethod: "POST",
@@ -586,132 +638,6 @@ describe("assessmentDocumentsHandler", () => {
     );
 
     expect(response.statusCode).toBe(500);
-    expect(globalThis.fetch).not.toHaveBeenCalled();
-    const documentStatusBodies = vi
-      .mocked(fetchJson)
-      .mock.calls.filter(
-        ([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.75555555-5555-4555-8555-555555555555"),
-      )
-      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
-    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
-    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
-  });
-
-  it("Netlify upload wrapper preserves extraction_running when a post-claim background error is handled in-worker", async () => {
-    const documentId = "72222222-2222-4222-8222-222222222222";
-    vi.mocked(getAccessToken).mockReturnValue("token");
-    vi.mocked(resolveOrgAndRole).mockResolvedValue({
-      organizationId: "org-1",
-      isTherapist: true,
-      isAdmin: false,
-      isSuperAdmin: false,
-    });
-    vi.mocked(getSupabaseConfig).mockReturnValue({
-      supabaseUrl: "https://example.supabase.co",
-      anonKey: "anon",
-    });
-    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
-    vi.mocked(loadChecklistTemplateRows)
-      .mockResolvedValueOnce([])
-      .mockRejectedValueOnce(new Error("background load failed"));
-    const waitUntilPromises: Promise<unknown>[] = [];
-    mockNetlifyWrapperFlowResponses(documentId);
-    globalThis.fetch = vi.fn() as typeof fetch;
-
-    const response = await assessmentDocumentsNetlifyHandler(
-      {
-        httpMethod: "POST",
-        headers: {
-          host: "app.example.com",
-          authorization: "Bearer token",
-        },
-        path: "/api/assessment-documents",
-        rawUrl: "https://app.example.com/api/assessment-documents",
-        body: JSON.stringify({
-          client_id: "11111111-1111-1111-1111-111111111111",
-          file_name: "fba.pdf",
-          mime_type: "application/pdf",
-          file_size: 1234,
-          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
-        }),
-        isBase64Encoded: false,
-      } as never,
-      {
-        waitUntil: (promise: Promise<unknown>) => {
-          waitUntilPromises.push(promise);
-        },
-      } as never,
-      undefined as never,
-    );
-
-    expect(response.statusCode).toBe(201);
-    expect(waitUntilPromises).toHaveLength(1);
-    expect(globalThis.fetch).not.toHaveBeenCalled();
-    await waitUntilPromises[0];
-    const documentStatusBodies = vi
-      .mocked(fetchJson)
-      .mock.calls.filter(([url]) => typeof url === "string" && url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`))
-      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
-    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extracting\""))).toBe(true);
-    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(true);
-    const failureEventBodies = vi
-      .mocked(fetchJson)
-      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_review_events"))
-      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""))
-      .filter((body) => body.includes(documentId) && body.includes("\"action\":\"extraction_failed\""));
-    expect(failureEventBodies).toHaveLength(1);
-    expect(failureEventBodies[0]).toContain("\"from_status\":\"extraction_running\"");
-  });
-
-  it("Netlify upload wrapper persists extraction_background_schedule_failed when the direct background handler returns non-ok", async () => {
-    const documentId = "73333333-3333-4333-8333-333333333333";
-    vi.mocked(getAccessToken).mockReturnValue("token");
-    vi.mocked(resolveOrgAndRole).mockResolvedValue({
-      organizationId: "org-1",
-      isTherapist: true,
-      isAdmin: false,
-      isSuperAdmin: false,
-    });
-    vi.mocked(getSupabaseConfig).mockReturnValue({
-      supabaseUrl: "https://example.supabase.co",
-      anonKey: "anon",
-    });
-    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
-    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
-    mockNetlifyWrapperFlowResponses(documentId, "lookup-empty");
-    const waitUntilPromises: Promise<unknown>[] = [];
-    globalThis.fetch = vi.fn() as typeof fetch;
-
-    const response = await assessmentDocumentsNetlifyHandler(
-      {
-        httpMethod: "POST",
-        headers: {
-          host: "app.example.com",
-          authorization: "Bearer token",
-        },
-        path: "/api/assessment-documents",
-        rawUrl: "https://app.example.com/api/assessment-documents",
-        body: JSON.stringify({
-          client_id: "11111111-1111-1111-1111-111111111111",
-          file_name: "fba.pdf",
-          mime_type: "application/pdf",
-          file_size: 1234,
-          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
-        }),
-        isBase64Encoded: false,
-      } as never,
-      {
-        waitUntil: (promise: Promise<unknown>) => {
-          waitUntilPromises.push(promise);
-        },
-      } as never,
-      undefined as never,
-    );
-
-    expect(response.statusCode).toBe(201);
-    expect(waitUntilPromises).toHaveLength(1);
-    expect(globalThis.fetch).not.toHaveBeenCalled();
-    await waitUntilPromises[0];
     const documentStatusBodies = vi
       .mocked(fetchJson)
       .mock.calls.filter(([url]) => typeof url === "string" && url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`))
@@ -725,7 +651,7 @@ describe("assessmentDocumentsHandler", () => {
     expect(failureEventCall).toBeDefined();
   });
 
-  it("Netlify upload wrapper persists extraction_background_schedule_failed when status lookup throws", async () => {
+  it("Netlify upload wrapper persists extraction_background_schedule_failed when enqueue throws", async () => {
     const documentId = "73444444-4444-4344-8344-444444444444";
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -740,184 +666,10 @@ describe("assessmentDocumentsHandler", () => {
     });
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
-    mockNetlifyWrapperFlowResponses(documentId, "lookup-empty");
-    const baseImpl = vi.mocked(fetchJson).getMockImplementation();
-    if (!baseImpl) {
-      throw new Error("Missing Netlify wrapper fetchJson mock implementation.");
-    }
-    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
-      if (
-        (init?.method ?? "GET").toUpperCase() === "GET" &&
-        typeof url === "string" &&
-        url.includes(`/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(documentId)}`)
-      ) {
-        throw new Error("temporary status lookup failure");
-      }
-      return baseImpl(url, init);
-    });
-    const waitUntilPromises: Promise<unknown>[] = [];
-    globalThis.fetch = vi.fn() as typeof fetch;
-
-    const response = await assessmentDocumentsNetlifyHandler(
-      {
-        httpMethod: "POST",
-        headers: {
-          host: "app.example.com",
-          authorization: "Bearer token",
-        },
-        path: "/api/assessment-documents",
-        rawUrl: "https://app.example.com/api/assessment-documents",
-        body: JSON.stringify({
-          client_id: "11111111-1111-1111-1111-111111111111",
-          file_name: "fba.pdf",
-          mime_type: "application/pdf",
-          file_size: 1234,
-          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
-        }),
-        isBase64Encoded: false,
-      } as never,
-      {
-        waitUntil: (promise: Promise<unknown>) => {
-          waitUntilPromises.push(promise);
-        },
-      } as never,
-      undefined as never,
-    );
-
-    expect(response.statusCode).toBe(201);
-    expect(waitUntilPromises).toHaveLength(1);
-    expect(globalThis.fetch).not.toHaveBeenCalled();
-    await waitUntilPromises[0];
-    const failedStatusBodies = vi
-      .mocked(fetchJson)
-      .mock.calls.filter(([url, init]) => {
-        const body = String((init as RequestInit | undefined)?.body ?? "");
-        return (
-          typeof url === "string" &&
-          url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`) &&
-          body.includes("\"status\":\"extraction_failed\"")
-        );
-      });
-    expect(failedStatusBodies).toHaveLength(1);
-    const failureEventCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
-      const body = String((init as RequestInit | undefined)?.body ?? "");
-      return (
-        typeof url === "string" &&
-        url.includes("/rest/v1/assessment_review_events") &&
-        body.includes(documentId) &&
-        body.includes("extraction_background_schedule_failed")
-      );
-    });
-    expect(failureEventCalls).toHaveLength(1);
-  });
-
-  it("Netlify upload wrapper does not duplicate persistence when the background worker already handles terminal failure", async () => {
-    const documentId = "74444444-4444-4444-8444-444444444444";
-    vi.mocked(getAccessToken).mockReturnValue("token");
-    vi.mocked(resolveOrgAndRole).mockResolvedValue({
-      organizationId: "org-1",
-      isTherapist: true,
-      isAdmin: false,
-      isSuperAdmin: false,
-    });
-    vi.mocked(getSupabaseConfig).mockReturnValue({
-      supabaseUrl: "https://example.supabase.co",
-      anonKey: "anon",
-    });
-    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
-    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
-    mockNetlifyWrapperFlowResponses(documentId, "lookup-fails");
-    const waitUntilPromises: Promise<unknown>[] = [];
-    globalThis.fetch = vi.fn() as typeof fetch;
-
-    const response = await assessmentDocumentsNetlifyHandler(
-      {
-        httpMethod: "POST",
-        headers: {
-          host: "app.example.com",
-          authorization: "Bearer token",
-        },
-        path: "/api/assessment-documents",
-        rawUrl: "https://app.example.com/api/assessment-documents",
-        body: JSON.stringify({
-          client_id: "11111111-1111-1111-1111-111111111111",
-          file_name: "fba.pdf",
-          mime_type: "application/pdf",
-          file_size: 1234,
-          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
-        }),
-        isBase64Encoded: false,
-      } as never,
-      {
-        waitUntil: (promise: Promise<unknown>) => {
-          waitUntilPromises.push(promise);
-        },
-      } as never,
-      undefined as never,
-    );
-
-    expect(response.statusCode).toBe(201);
-    expect(waitUntilPromises).toHaveLength(1);
-    expect(globalThis.fetch).not.toHaveBeenCalled();
-    await waitUntilPromises[0];
-    const failedStatusBodies = vi
-      .mocked(fetchJson)
-      .mock.calls.filter(([url, init]) => {
-        const body = String((init as RequestInit | undefined)?.body ?? "");
-        return (
-          typeof url === "string" &&
-          url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`) &&
-          body.includes("\"status\":\"extraction_failed\"")
-        );
-      });
-    expect(failedStatusBodies).toHaveLength(1);
-    const failureEventCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
-      const body = String((init as RequestInit | undefined)?.body ?? "");
-      return (
-        typeof url === "string" &&
-        url.includes("/rest/v1/assessment_review_events") &&
-        body.includes(documentId) &&
-        body.includes("extraction_background_schedule_failed")
-      );
-    });
-    expect(failureEventCalls).toHaveLength(1);
-  });
-
-  it("Netlify upload wrapper does not overwrite terminal failure state when worker review-event persistence throws", async () => {
-    const documentId = "76666666-6666-4666-8666-666666666666";
-    vi.mocked(getAccessToken).mockReturnValue("token");
-    vi.mocked(resolveOrgAndRole).mockResolvedValue({
-      organizationId: "org-1",
-      isTherapist: true,
-      isAdmin: false,
-      isSuperAdmin: false,
-    });
-    vi.mocked(getSupabaseConfig).mockReturnValue({
-      supabaseUrl: "https://example.supabase.co",
-      anonKey: "anon",
-    });
-    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
-    vi.mocked(loadChecklistTemplateRows)
-      .mockResolvedValueOnce([])
-      .mockRejectedValueOnce(new Error("background load failed"));
     mockNetlifyWrapperFlowResponses(documentId);
-    const baseImpl = vi.mocked(fetchJson).getMockImplementation();
-    if (!baseImpl) {
-      throw new Error("Missing Netlify wrapper fetchJson mock implementation.");
-    }
-    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
-      const method = (init?.method ?? "GET").toUpperCase();
-      const body = String((init as RequestInit | undefined)?.body ?? "");
-      if (method === "POST" && url.includes("/rest/v1/assessment_review_events") && body.includes(documentId) && body.includes("\"action\":\"extraction_failed\"")) {
-        return { ok: false, status: 500, data: null };
-      }
-      if (method === "GET" && url.includes(`/rest/v1/assessment_documents?select=status&id=eq.${encodeURIComponent(documentId)}`)) {
-        return { ok: true, status: 200, data: [{ status: "extraction_failed" }] };
-      }
-      return baseImpl(url, init);
-    });
-    const waitUntilPromises: Promise<unknown>[] = [];
-    globalThis.fetch = vi.fn() as typeof fetch;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network enqueue failure");
+    }) as typeof fetch;
 
     const response = await assessmentDocumentsNetlifyHandler(
       {
@@ -937,22 +689,21 @@ describe("assessmentDocumentsHandler", () => {
         }),
         isBase64Encoded: false,
       } as never,
-      {
-        waitUntil: (promise: Promise<unknown>) => {
-          waitUntilPromises.push(promise);
-        },
-      } as never,
+      {} as never,
       undefined as never,
     );
 
-    expect(response.statusCode).toBe(201);
-    expect(waitUntilPromises).toHaveLength(1);
-    await waitUntilPromises[0];
-    const failedStatusWrites = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
+    expect(response.statusCode).toBe(500);
+    const failureEventCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
       const body = String((init as RequestInit | undefined)?.body ?? "");
-      return typeof url === "string" && url.includes(`/rest/v1/assessment_documents?id=eq.${documentId}`) && body.includes("\"status\":\"extraction_failed\"");
+      return (
+        typeof url === "string" &&
+        url.includes("/rest/v1/assessment_review_events") &&
+        body.includes(documentId) &&
+        body.includes("extraction_background_schedule_failed")
+      );
     });
-    expect(failedStatusWrites).toHaveLength(1);
+    expect(failureEventCalls).toHaveLength(1);
   });
 
   it("runs CalOptima extraction from the background worker only for scoped extracting documents", async () => {
@@ -2441,8 +2192,8 @@ describe("assessmentDocumentsHandler", () => {
       init?.method === "POST"
     );
     expect(structuredInsert?.[1]?.headers).toMatchObject({
-      apikey: "service-role",
-      Authorization: "Bearer service-role",
+      apikey: "anon",
+      Authorization: "Bearer token",
     });
     const successEvent = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
       const body = typeof init?.body === "string" ? init.body : "";

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -651,6 +651,54 @@ describe("assessmentDocumentsHandler", () => {
     expect(failureEventCall).toBeDefined();
   });
 
+  it("Netlify upload wrapper preserves in-flight extraction when enqueue transport fails after the worker already advanced status", async () => {
+    const documentId = "73333333-3333-4333-8333-333333333334";
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    mockNetlifyWrapperFlowResponses(documentId, "lookup-fails");
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({ error: "enqueue failed" }), { status: 500 })) as typeof fetch;
+
+    const response = await assessmentDocumentsNetlifyHandler(
+      {
+        httpMethod: "POST",
+        headers: {
+          host: "app.example.com",
+          authorization: "Bearer token",
+        },
+        path: "/api/assessment-documents",
+        rawUrl: "https://app.example.com/api/assessment-documents",
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "fba.pdf",
+          mime_type: "application/pdf",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/fba.pdf",
+        }),
+        isBase64Encoded: false,
+      } as never,
+      {} as never,
+      undefined as never,
+    );
+
+    expect(response.statusCode).toBe(201);
+    const failureEventCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
+      const body = String((init as RequestInit | undefined)?.body ?? "");
+      return typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && body.includes(documentId) && body.includes("extraction_background_schedule_failed");
+    });
+    expect(failureEventCall).toBeUndefined();
+  });
+
   it("Netlify upload wrapper persists extraction_background_schedule_failed when enqueue throws", async () => {
     const documentId = "73444444-4444-4344-8344-444444444444";
     vi.mocked(getAccessToken).mockReturnValue("token");

--- a/src/server/api/assessment-checklist.ts
+++ b/src/server/api/assessment-checklist.ts
@@ -8,7 +8,6 @@ import {
   json,
   resolveOrgAndRole,
 } from "./shared";
-import { getRequiredServerEnv } from "../env";
 
 const reviewStatusSchema = z.enum(["not_started", "drafted", "verified", "approved", "rejected"]);
 
@@ -127,16 +126,10 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
     }
 
     if (parsed.data.structured_section_id) {
-      const serviceRoleKey = getRequiredServerEnv("SUPABASE_SERVICE_ROLE_KEY");
-      const serviceHeaders = {
-        "Content-Type": "application/json",
-        apikey: serviceRoleKey,
-        Authorization: `Bearer ${serviceRoleKey}`,
-      };
       const lookupUrl = `${supabaseUrl}/rest/v1/assessment_structured_sections?select=id,assessment_document_id,organization_id,client_id,status&id=eq.${encodeURIComponent(
         parsed.data.structured_section_id,
       )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`;
-      const lookup = await fetchJson<ChecklistRow[]>(lookupUrl, { method: "GET", headers: serviceHeaders });
+      const lookup = await fetchJson<ChecklistRow[]>(lookupUrl, { method: "GET", headers });
       const existing = Array.isArray(lookup.data) ? lookup.data[0] : null;
       if (!lookup.ok || !existing) {
         return json({ error: "Structured section not found in organization scope" }, 404);
@@ -182,7 +175,7 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
       )}&organization_id=eq.${encodeURIComponent(organizationId)}`;
       const updateResult = await fetchJson<Array<Record<string, unknown>>>(updateUrl, {
         method: "PATCH",
-        headers: { ...serviceHeaders, Prefer: "return=representation" },
+        headers: { ...headers, Prefer: "return=representation" },
         body: JSON.stringify(updatePayload),
       });
 
@@ -192,7 +185,7 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
 
       await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
         method: "POST",
-        headers: serviceHeaders,
+        headers,
         body: JSON.stringify({
           assessment_document_id: existing.assessment_document_id,
           organization_id: organizationId,

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -14,7 +14,6 @@ import {
   type AssessmentTemplateType,
 } from "../assessmentChecklistTemplate";
 import { buildDeterministicDraftPayload, persistDraftRows } from "./assessment-drafts";
-import { getRequiredServerEnv } from "../env";
 import { serverLogger } from "../../lib/logger/server";
 
 const SUPPORTED_TEMPLATE_TYPES = ["caloptima_fba", "iehp_fba"] as const;
@@ -456,15 +455,9 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
       });
       const structuredSections = extractionData.structured_sections ?? [];
       if (structuredSections.length > 0) {
-        const serviceRoleKey = getRequiredServerEnv("SUPABASE_SERVICE_ROLE_KEY");
-        const serviceHeaders = {
-          "Content-Type": "application/json",
-          apikey: serviceRoleKey,
-          Authorization: `Bearer ${serviceRoleKey}`,
-        };
         const structuredInsertResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_structured_sections`, {
           method: "POST",
-          headers: serviceHeaders,
+          headers,
           signal,
           body: JSON.stringify(
             structuredSections.map((section) => ({

--- a/supabase/migrations/20260518061000_assessment_structured_sections_authenticated_manage.sql
+++ b/supabase/migrations/20260518061000_assessment_structured_sections_authenticated_manage.sql
@@ -1,0 +1,33 @@
+-- @migration-intent: Allow tenant-scoped authenticated clinicians and admins to insert/update/delete structured assessment sections.
+-- @migration-dependencies: 20260512143000_caloptima_assessment_structured_sections.sql
+-- @migration-rollback: Drop policy public.assessment_structured_sections.assessment_structured_sections_org_manage to restore service-role-only writes.
+
+begin;
+
+set local search_path = public;
+
+drop policy if exists assessment_structured_sections_org_manage
+  on public.assessment_structured_sections;
+
+create policy assessment_structured_sections_org_manage
+  on public.assessment_structured_sections
+  for all
+  to authenticated
+  using (
+    organization_id = app.current_user_organization_id()
+    and (
+      app.user_has_role_for_org('therapist', organization_id)
+      or app.user_has_role_for_org('admin', organization_id)
+      or app.user_has_role_for_org('super_admin', organization_id)
+    )
+  )
+  with check (
+    organization_id = app.current_user_organization_id()
+    and (
+      app.user_has_role_for_org('therapist', organization_id)
+      or app.user_has_role_for_org('admin', organization_id)
+      or app.user_has_role_for_org('super_admin', organization_id)
+    )
+  );
+
+commit;

--- a/supabase/migrations/20260518072000_assessment_structured_sections_authenticated_write_scope.sql
+++ b/supabase/migrations/20260518072000_assessment_structured_sections_authenticated_write_scope.sql
@@ -1,0 +1,50 @@
+-- @migration-intent: Narrow authenticated structured-section write access to the insert/update operations used by assessment extraction and review.
+-- @migration-dependencies: 20260518061000_assessment_structured_sections_authenticated_manage.sql
+-- @migration-rollback: Restore the broader authenticated manage policy if write-scoped policies must be reverted.
+
+begin;
+
+set local search_path = public;
+
+drop policy if exists assessment_structured_sections_org_manage
+  on public.assessment_structured_sections;
+
+drop policy if exists assessment_structured_sections_org_insert
+  on public.assessment_structured_sections;
+create policy assessment_structured_sections_org_insert
+  on public.assessment_structured_sections
+  for insert
+  to authenticated
+  with check (
+    organization_id = app.current_user_organization_id()
+    and (
+      app.user_has_role_for_org('therapist', organization_id)
+      or app.user_has_role_for_org('admin', organization_id)
+      or app.user_has_role_for_org('super_admin', organization_id)
+    )
+  );
+
+drop policy if exists assessment_structured_sections_org_update
+  on public.assessment_structured_sections;
+create policy assessment_structured_sections_org_update
+  on public.assessment_structured_sections
+  for update
+  to authenticated
+  using (
+    organization_id = app.current_user_organization_id()
+    and (
+      app.user_has_role_for_org('therapist', organization_id)
+      or app.user_has_role_for_org('admin', organization_id)
+      or app.user_has_role_for_org('super_admin', organization_id)
+    )
+  )
+  with check (
+    organization_id = app.current_user_organization_id()
+    and (
+      app.user_has_role_for_org('therapist', organization_id)
+      or app.user_has_role_for_org('admin', organization_id)
+      or app.user_has_role_for_org('super_admin', organization_id)
+    )
+  );
+
+commit;

--- a/supabase/migrations/20260518074500_assessment_structured_sections_authenticated_write_grants.sql
+++ b/supabase/migrations/20260518074500_assessment_structured_sections_authenticated_write_grants.sql
@@ -1,0 +1,11 @@
+-- @migration-intent: Explicitly grant authenticated insert/update privileges for structured assessment sections in fresh environments.
+-- @migration-dependencies: 20260518072000_assessment_structured_sections_authenticated_write_scope.sql
+-- @migration-rollback: Revoke authenticated insert/update privileges on public.assessment_structured_sections if write grants must be removed.
+
+begin;
+
+set local search_path = public;
+
+grant insert, update on table public.assessment_structured_sections to authenticated;
+
+commit;


### PR DESCRIPTION
## Summary
- enqueue assessment background extraction through the deployed Netlify background endpoint instead of relying on in-process scheduling
- persist structured assessment sections with authenticated tenant-scoped writes and add the required Supabase RLS migrations
- update the production smoke to wait through extraction_running and verify the upload-to-draft-to-promotion workflow end to end

## Verification
- npm test -- --runInBand src/server/__tests__/assessmentDocumentsHandler.test.ts src/server/__tests__/assessmentChecklistHandler.test.ts
- npm run verify:local
- npm run playwright:assessment-upload-promote-smoke
- applied Supabase migrations on project wnnjeqheqxxyrgsjmygy
- deployed production site on Netlify and re-ran the smoke successfully against https://app.allincompassing.ai
