### PR TITLE
Disable AI proposals in Programs & Goals

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
+++ b/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
@@ -83,6 +83,7 @@ export const EMPTY_CHECKLIST_RESPONSE: AssessmentChecklistResponse = {
 };
 export const EMPTY_ASSESSMENT_DRAFTS: AssessmentDraftResponse = { programs: [], goals: [] };
 export const ENABLE_CHECKLIST_MAPPING_UI = true;
+export const ENABLE_PROGRAMS_GOALS_AI_PROPOSALS = false;
 
 export const TEMPLATE_LABELS: Record<AssessmentTemplateType, string> = {
   caloptima_fba: "CalOptima FBA",
@@ -97,7 +98,10 @@ export const statusToneByAssessment: Record<
   extracting: { label: "extracting", className: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200" },
   extraction_running: { label: "extracting", className: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200" },
   extracted: { label: "extracted", className: "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-200" },
-  drafted: { label: "ai proposal ready", className: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-200" },
+  drafted: {
+    label: ENABLE_PROGRAMS_GOALS_AI_PROPOSALS ? "ai proposal ready" : "structured review ready",
+    className: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-200",
+  },
   approved: { label: "approved", className: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200" },
   rejected: { label: "rejected", className: "bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-200" },
   extraction_failed: {

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -5,7 +5,6 @@ import type { Client, Goal, Program, ProgramNote } from "../../types";
 import { callApi, callEdgeFunctionHttp } from "../../lib/api";
 import { showError, showInfo, showSuccess } from "../../lib/toast";
 import { useActiveOrganizationId } from "../../lib/organization";
-import { generateProgramGoalDraft, type ProgramGoalDraftResponse } from "../../lib/ai";
 import { useAuth } from "../../lib/authContext";
 import {
   registerAssessmentDocument,
@@ -18,6 +17,7 @@ import {
   EMPTY_ASSESSMENT_DRAFTS,
   EMPTY_CHECKLIST_RESPONSE,
   ENABLE_CHECKLIST_MAPPING_UI,
+  ENABLE_PROGRAMS_GOALS_AI_PROPOSALS,
   formatGoalTimelineCriteria,
   parseApiErrorMessage,
   parseGoalTimelineCriteria,
@@ -49,18 +49,6 @@ const ACTIVE_ASSESSMENT_POLL_STATUSES: ReadonlySet<AssessmentDocumentRecord["sta
   "uploaded",
   "extracting",
   "extraction_running",
-]);
-const AI_GENERATION_READY_STATUSES: ReadonlySet<AssessmentDocumentRecord["status"]> = new Set([
-  "extracted",
-  "extraction_failed",
-]);
-const MIN_ASSESSMENT_TEXT_CHARS_FOR_AI_GENERATION = 20;
-const STRUCTURED_GOAL_FIELD_KEYS = new Set([
-  "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
-  "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
-  "CALOPTIMA_FBA_PARENT_GOALS",
-  "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
-  "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
 ]);
 
 const isStructuredChildGoalSection = (section: AssessmentStructuredSection): boolean =>
@@ -172,19 +160,10 @@ const callEdgeWithSupabaseFallback = async (params: {
   }
 };
 
-const hasSufficientChecklistTextForAiGeneration = (items: AssessmentChecklistItem[]): boolean =>
-  items
-    .map((item) => item.value_text?.trim() ?? "")
-    .filter(Boolean)
-    .join("\n").length >= MIN_ASSESSMENT_TEXT_CHARS_FOR_AI_GENERATION;
-
 const isSupportedAssessmentFile = (file: File): boolean => {
   const lowerFileName = file.name.trim().toLowerCase();
   return SUPPORTED_ASSESSMENT_FILE_EXTENSIONS.some((extension) => lowerFileName.endsWith(extension));
 };
-
-const formatCountLabel = (count: number, singular: string, plural: string): string =>
-  `${count} ${count === 1 ? singular : plural}`;
 
 interface ProgramsGoalsTabProps {
   client: Client;
@@ -215,8 +194,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const [goalMaintenanceCriteria, setGoalMaintenanceCriteria] = useState("");
   const [goalGeneralizationCriteria, setGoalGeneralizationCriteria] = useState("");
   const [goalObjectiveDataPoints, setGoalObjectiveDataPoints] = useState("[]");
-  const [assessmentInput, setAssessmentInput] = useState("");
-  const [draftPlan, setDraftPlan] = useState<ProgramGoalDraftResponse | null>(null);
   const [checklistEdits, setChecklistEdits] = useState<
     Record<string, { status: AssessmentChecklistItem["status"]; reviewNotes: string; valueText: string }>
   >({});
@@ -255,22 +232,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const [archivingGoalId, setArchivingGoalId] = useState<string | null>(null);
   const [isUploadProcessing, setIsUploadProcessing] = useState(false);
   const [assessmentDocumentsNeedsRetry, setAssessmentDocumentsNeedsRetry] = useState(false);
-
-  const applyDraftGoal = (goal: ProgramGoalDraftResponse["goals"][number]) => {
-    const parsedTargetCriteria = parseGoalTimelineCriteria(goal.target_criteria);
-    setGoalTitle(goal.title);
-    setGoalDescription(goal.description);
-    setGoalOriginalText(goal.original_text);
-    setGoalMeasurementType(goal.measurement_type ?? "");
-    setGoalBaselineData(goal.baseline_data ?? "");
-    setGoalShortTermGoal(parsedTargetCriteria.shortTermGoal);
-    setGoalIntermediateGoal(parsedTargetCriteria.intermediateGoal);
-    setGoalLongTermGoal(parsedTargetCriteria.longTermGoal);
-    setGoalMasteryCriteria(goal.mastery_criteria ?? "");
-    setGoalMaintenanceCriteria(goal.maintenance_criteria ?? "");
-    setGoalGeneralizationCriteria(goal.generalization_criteria ?? "");
-    setGoalObjectiveDataPoints(JSON.stringify(goal.objective_data_points ?? [], null, 2));
-  };
 
   const {
     data: programs = [],
@@ -549,12 +510,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     (checklistReviewUnavailable ||
       checklistItems.some((item) => item.required && item.status !== "approved") ||
       structuredSections.some((section) => section.required && section.status !== "approved"));
-  const hasAcceptedDraftProgram = (assessmentDrafts?.programs ?? []).some(
-    (program) => program.accept_state === "accepted" || program.accept_state === "edited",
-  );
-  const hasAcceptedDraftGoal = (assessmentDrafts?.goals ?? []).some(
-    (goal) => goal.accept_state === "accepted" || goal.accept_state === "edited",
-  );
   const hasExistingDrafts = (assessmentDrafts?.programs?.length ?? 0) > 0 || (assessmentDrafts?.goals?.length ?? 0) > 0;
   const extractedChecklistValueCount = checklistItems.filter((item) => item.value_text?.trim()).length;
   const structuredChildGoalCount = structuredSections.filter(isStructuredChildGoalSection).length;
@@ -564,64 +519,10 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const draftSaveHelperText = selectedAssessmentAlreadyPublished
     ? "Draft retained for audit after approval. Live records are already published."
     : "Saves to draft only. Not visible in live records until published.";
-  const selectedAssessmentReadyForAiGeneration = selectedAssessmentDocument
-    ? AI_GENERATION_READY_STATUSES.has(selectedAssessmentDocument.status)
-    : false;
-  const selectedFailedExtractionHasChecklistEvidence =
-    selectedAssessmentDocument?.status !== "extraction_failed" || hasSufficientChecklistTextForAiGeneration(checklistItems);
-  const hasApprovedStructuredGoalSections = structuredSections.some(
-    (section) =>
-      section.status === "approved" &&
-      STRUCTURED_GOAL_FIELD_KEYS.has(section.field_key),
-  );
-  const acceptedDraftChildGoalCount = (assessmentDrafts?.goals ?? []).filter(
-    (goal) => (goal.accept_state === "accepted" || goal.accept_state === "edited") && goal.goal_type === "child",
-  ).length;
-  const acceptedDraftParentGoalCount = (assessmentDrafts?.goals ?? []).filter(
-    (goal) => (goal.accept_state === "accepted" || goal.accept_state === "edited") && goal.goal_type === "parent",
-  ).length;
-  const canGenerateUploadedAssessmentDraft =
-    canQuerySelectedAssessment &&
-    selectedAssessmentReadyForAiGeneration &&
-    selectedFailedExtractionHasChecklistEvidence &&
-    hasApprovedStructuredGoalSections &&
-    !hasExistingDrafts;
-  const canPromoteAssessment =
-    canQuerySelectedAssessment &&
-    !selectedAssessmentAlreadyPublished &&
-    !hasPendingRequiredChecklistItems &&
-    hasAcceptedDraftProgram &&
-    hasAcceptedDraftGoal;
   const unresolvedRequiredCount = ENABLE_CHECKLIST_MAPPING_UI
     ? checklistItems.filter((item) => item.required && item.status !== "approved").length +
       structuredSections.filter((section) => section.required && section.status !== "approved").length
     : 0;
-  const promoteDisabledReason = !canQuerySelectedAssessment
-    ? "Select a valid assessment first."
-    : selectedAssessmentAlreadyPublished
-      ? "This assessment has already been approved and published."
-    : checklistReviewUnavailable
-      ? "Checklist review must load before publishing."
-    : hasPendingRequiredChecklistItems
-      ? `${unresolvedRequiredCount} required checklist row${unresolvedRequiredCount === 1 ? "" : "s"} must be approved before publishing.`
-    : !hasAcceptedDraftProgram
-        ? "Accept or edit at least one draft program before publishing."
-        : !hasAcceptedDraftGoal
-          ? "Accept or edit at least one draft goal before publishing."
-          : null;
-  const uploadedAssessmentGenerateDisabledReason = !canQuerySelectedAssessment
-    ? "Select a valid uploaded assessment before creating deterministic drafts."
-    : hasExistingDrafts
-      ? "Drafts already exist for this assessment. Review/edit current drafts instead of regenerating."
-    : selectedAssessmentDocument?.status === "extraction_failed" && !selectedFailedExtractionHasChecklistEvidence
-      ? "Extraction failed for this assessment, but no extracted checklist evidence is available for draft generation. Replace the source document or add checklist evidence before retrying."
-    : selectedAssessmentDocument?.status === "extraction_failed"
-      ? "Extraction failed for this assessment. Retry deterministic draft generation using the extracted checklist evidence, or replace the source document if it needs correction."
-    : !selectedAssessmentReadyForAiGeneration
-      ? "Wait for extraction to complete before generating drafts."
-    : !hasApprovedStructuredGoalSections
-      ? "Approve at least one structured goal section before generating drafts."
-      : null;
 
   useEffect(() => {
     const firstAssessmentId = assessmentDocuments[0]?.id ?? null;
@@ -890,68 +791,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     },
   });
 
-  const persistAssessmentDrafts = useMutation({
-    mutationFn: async () => {
-      if (!draftPlan) {
-        throw new Error("Generate drafts first.");
-      }
-      if (!selectedAssessmentId) {
-        throw new Error("Select an uploaded assessment before saving drafts.");
-      }
-      const response = await callApi("/api/assessment-drafts", {
-        method: "POST",
-        body: JSON.stringify({
-          assessment_document_id: selectedAssessmentId,
-          programs: draftPlan.programs,
-          goals: draftPlan.goals,
-          summary_rationale: draftPlan.summary_rationale,
-          confidence: draftPlan.confidence,
-        }),
-      });
-      if (!response.ok) {
-        throw new Error("Failed to save draft program and goals to staged review.");
-      }
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["assessment-drafts", selectedAssessmentId, organizationId ?? "MISSING_ORG"],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["assessment-documents", client.id, organizationId ?? "MISSING_ORG"],
-      });
-      showSuccess("AI proposal saved to assessment queue for review.");
-    },
-    onError: showError,
-  });
-
-  const generateDraftsFromUploadedAssessment = useMutation({
-    mutationFn: async () => {
-      if (!selectedAssessmentId) {
-        throw new Error("Select an uploaded assessment first.");
-      }
-      const response = await callApi("/api/assessment-drafts", {
-        method: "POST",
-        body: JSON.stringify({
-          assessment_document_id: selectedAssessmentId,
-          auto_generate: true,
-        }),
-      });
-      if (!response.ok) {
-        throw new Error(await parseApiErrorMessage(response, "Failed to generate drafts from uploaded assessment."));
-      }
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["assessment-drafts", selectedAssessmentId, organizationId ?? "MISSING_ORG"],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["assessment-documents", client.id, organizationId ?? "MISSING_ORG"],
-      });
-      showSuccess("Draft program and goals generated from reviewed structured FBA data.");
-    },
-    onError: showError,
-  });
-
   const updateDraftProgram = useMutation({
     mutationFn: async (programId: string) => {
       const edit = draftProgramEdits[programId];
@@ -1026,67 +865,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     },
     onError: showError,
   });
-
-  const promoteAssessment = useMutation({
-    mutationFn: async () => {
-      if (!selectedAssessmentId) {
-        throw new Error("Select an assessment first.");
-      }
-      const response = await callApi("/api/assessment-promote", {
-        method: "POST",
-        body: JSON.stringify({ assessment_document_id: selectedAssessmentId }),
-      });
-      if (!response.ok) {
-        throw new Error(await parseApiErrorMessage(response, "Assessment cannot be promoted yet."));
-      }
-      return parseJson<{
-        created_program_count: number;
-        created_goal_count: number;
-        promoted_program_count?: number;
-        promoted_goal_count?: number;
-      }>(response);
-    },
-    onSuccess: (result) => {
-      queryClient.invalidateQueries({
-        queryKey: ["assessment-documents", client.id, organizationId ?? "MISSING_ORG"],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["client-programs", client.id, organizationId ?? "MISSING_ORG"],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["client-goals", client.id, organizationId ?? "MISSING_ORG"],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["program-goals", resolvedProgramId, organizationId ?? "MISSING_ORG"],
-      });
-      const publishedProgramCount = result.promoted_program_count ?? result.created_program_count;
-      const publishedGoalCount = result.promoted_goal_count ?? result.created_goal_count;
-      showSuccess(
-        `Published to live records. Created ${formatCountLabel(publishedProgramCount, "production program", "production programs")} and ${formatCountLabel(publishedGoalCount, "goal", "goals")}.`,
-      );
-    },
-    onError: showError,
-  });
-
-  const handlePublishApprovedRecords = () => {
-    const acceptedProgramCount = (assessmentDrafts?.programs ?? []).filter(
-      (program) => program.accept_state === "accepted" || program.accept_state === "edited",
-    ).length;
-    const acceptedGoalCount = (assessmentDrafts?.goals ?? []).filter(
-      (goal) => goal.accept_state === "accepted" || goal.accept_state === "edited",
-    ).length;
-    const selectedAssessmentLabel = selectedAssessmentDocument?.file_name ?? "selected assessment";
-    const confirmationMessage = `Publish accepted drafts from ${selectedAssessmentLabel} to live Programs & Goals?\n\nThis will make ${acceptedProgramCount} program(s) and ${acceptedGoalCount} goal(s) visible in the live care plan.`;
-
-    if (typeof window !== "undefined") {
-      const confirmed = window.confirm(confirmationMessage);
-      if (!confirmed) {
-        return;
-      }
-    }
-
-    promoteAssessment.mutate();
-  };
 
   const generateAssessmentPlanPdf = useMutation({
     mutationFn: async () => {
@@ -1412,35 +1190,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     onError: showError,
   });
 
-  const generateDraftPlan = useMutation({
-    mutationFn: async () => {
-      if (!session?.access_token) {
-        throw new Error("An active login session is required to generate drafts.");
-      }
-      return generateProgramGoalDraft(
-        assessmentInput,
-        { accessToken: session.access_token },
-        {
-          clientName: client.full_name,
-          clientId: client.id,
-          organizationId: organizationId ?? undefined,
-          assessmentDocumentId: selectedAssessmentId ?? undefined,
-        },
-      );
-    },
-    onSuccess: (draft) => {
-      setDraftPlan(draft);
-      const primaryProgram = draft.programs[0];
-      setProgramName(primaryProgram?.name ?? "");
-      setProgramDescription(primaryProgram?.description ?? "");
-      if (draft.goals[0]) {
-        applyDraftGoal(draft.goals[0]);
-      }
-      showSuccess("Draft program and goals generated. Review and create when ready.");
-    },
-    onError: showError,
-  });
-
   if (!organizationId) {
     return (
       <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-100">
@@ -1457,7 +1206,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
             Live care plan: <span className="font-semibold">{livePrograms.length}</span> program(s) and{" "}
             <span className="font-semibold">{liveGoals.length}</span> active goal(s) in the selected program.
           </p>
-          {hasDraftsButNoLivePrograms && (
+          {ENABLE_PROGRAMS_GOALS_AI_PROPOSALS && hasDraftsButNoLivePrograms && (
             <button
               type="button"
               onClick={() => publishSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })}
@@ -1467,7 +1216,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
             </button>
           )}
         </div>
-        {hasDraftsButNoLivePrograms && (
+        {ENABLE_PROGRAMS_GOALS_AI_PROPOSALS && hasDraftsButNoLivePrograms && (
           <p className="mt-2 text-xs text-sky-800/90 dark:text-sky-100/90">
             Uploaded assessments and draft proposals stay in review until you publish them to live Programs & Goals.
           </p>
@@ -1478,7 +1227,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
           <div ref={publishSectionRef} className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3 flex items-center gap-2">
               <UploadCloud className="w-4 h-4" />
-              CalOptima FBA Upload + AI Workflow
+              CalOptima FBA Upload Workflow
             </h3>
             <div className="space-y-3">
               <label htmlFor="programs-goals-fba-template" className="block text-xs font-medium text-gray-700 dark:text-gray-200">
@@ -1606,42 +1355,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
               </div>
               <button
                 type="button"
-                onClick={handlePublishApprovedRecords}
-                disabled={!canPromoteAssessment || promoteAssessment.isLoading}
-                title={promoteDisabledReason ?? undefined}
-                className="w-full px-3 py-2 text-sm font-medium text-white bg-emerald-600 rounded-md hover:bg-emerald-700 disabled:opacity-50"
-              >
-                {promoteAssessment.isLoading ? "Publishing..." : "Publish to Live Programs + Goals"}
-              </button>
-              <p className="text-xs text-gray-500 dark:text-gray-300">
-                Publishing makes accepted drafts live in Programs and Goals.
-              </p>
-              {promoteDisabledReason && !promoteAssessment.isLoading && (
-                <p className="text-xs text-amber-700 dark:text-amber-300">{promoteDisabledReason}</p>
-              )}
-              {!promoteAssessment.isLoading && (
-                <p className="text-xs text-gray-500 dark:text-gray-300">
-                  Accepted draft goals: {acceptedDraftChildGoalCount} child / {acceptedDraftParentGoalCount} parent
-                </p>
-              )}
-              <button
-                type="button"
-                onClick={() => generateDraftsFromUploadedAssessment.mutate()}
-                disabled={!canGenerateUploadedAssessmentDraft || generateDraftsFromUploadedAssessment.isLoading}
-                title={uploadedAssessmentGenerateDisabledReason ?? undefined}
-                className="w-full px-3 py-2 text-sm font-medium text-white bg-cyan-600 rounded-md hover:bg-cyan-700 disabled:opacity-50"
-              >
-                {generateDraftsFromUploadedAssessment.isLoading
-                  ? "Generating Drafts..."
-                  : "Generate Drafts from Uploaded FBA"}
-              </button>
-              {uploadedAssessmentGenerateDisabledReason && !generateDraftsFromUploadedAssessment.isLoading && (
-                <p className="text-xs text-gray-500 dark:text-gray-300">
-                  {uploadedAssessmentGenerateDisabledReason}
-                </p>
-              )}
-              <button
-                type="button"
                 onClick={() => generateAssessmentPlanPdf.mutate()}
                 disabled={!canQuerySelectedAssessment || hasPendingRequiredChecklistItems || generateAssessmentPlanPdf.isLoading}
                 title={hasPendingRequiredChecklistItems ? "Approve all required checklist and structured fields before export." : undefined}
@@ -1653,65 +1366,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
           </div>
 
           <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">
-              Generate with AI from Manual Notes (Optional Fallback)
-            </h3>
-            <div className="space-y-3">
-              <textarea
-                value={assessmentInput}
-                onChange={(event) => setAssessmentInput(event.target.value)}
-                placeholder="Paste assessment summary or White Bible-aligned notes to draft a program and measurable goals."
-                rows={6}
-                className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
-              />
-              <button
-                type="button"
-                onClick={() => generateDraftPlan.mutate()}
-                disabled={assessmentInput.trim().length < 20 || generateDraftPlan.isLoading}
-                className="w-full px-3 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 disabled:opacity-50"
-              >
-                {generateDraftPlan.isLoading ? "Generating..." : "Generate AI Proposal Program + Goals"}
-              </button>
-            </div>
-
-            {draftPlan && (
-              <div className="mt-4 space-y-3 rounded-md border border-indigo-200 bg-indigo-50 p-3 text-xs text-indigo-900 dark:border-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-100">
-                <p className="font-semibold">
-                  Draft programs: {draftPlan.programs.map((program) => program.name).join(", ")}
-                </p>
-                <p>
-                  {draftPlan.summary_rationale}
-                </p>
-                <div className="space-y-2">
-                  {draftPlan.goals.map((goal, index) => (
-                    <div key={`${goal.title}-${index}`} className="rounded border border-indigo-200 bg-white px-2 py-2 dark:border-indigo-700 dark:bg-dark-lighter">
-                      <p className="font-medium">{goal.title}</p>
-                      <button
-                        type="button"
-                        onClick={() => applyDraftGoal(goal)}
-                        className="mt-1 text-indigo-700 underline hover:text-indigo-900 dark:text-indigo-300 dark:hover:text-indigo-100"
-                      >
-                        Load into goal form
-                      </button>
-                    </div>
-                  ))}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => persistAssessmentDrafts.mutate()}
-                  disabled={!canQuerySelectedAssessment || persistAssessmentDrafts.isLoading}
-                  className="w-full px-3 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 disabled:opacity-50"
-                >
-                  {persistAssessmentDrafts.isLoading ? "Saving..." : "Save AI Proposal to Selected Assessment"}
-                </button>
-              </div>
-            )}
-          </div>
-
-          <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">Programs</h3>
             <p className="mb-3 text-xs text-gray-500 dark:text-gray-300">
-              Live records only. Uploaded assessment drafts appear here after you publish.
+              Live records only. Uploaded assessments stay in structured review until you add live programs manually.
             </p>
             <div className="space-y-2">
               {programsLoading && (
@@ -2032,7 +1689,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                                   </button>
                                   {isApprovedStatusLocked && (
                                     <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-300">
-                                      Approved structured sections are locked because they can feed drafts and PDF export.
+                                      Approved structured sections are locked to preserve reviewed document data for export.
                                     </p>
                                   )}
                                 </div>
@@ -2048,7 +1705,8 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
             </div>
           )}
 
-          <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+          {ENABLE_PROGRAMS_GOALS_AI_PROPOSALS && (
+            <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">
               Draft Review (Approve / Reject / Edit)
             </h3>
@@ -2398,7 +2056,8 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 )}
               </div>
             )}
-          </div>
+            </div>
+          )}
 
           <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3 flex items-center gap-2">

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1070,7 +1070,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     ).toBeInTheDocument();
   });
 
-  it("generates program/goals proposal and saves it for review", async () => {
+  it("hides the manual AI proposal workflow", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -1117,35 +1117,13 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     );
 
-    const assessmentInput = await screen.findByPlaceholderText(
-      /Paste assessment summary or White Bible-aligned notes/i,
-    );
-    fireEvent.change(assessmentInput, {
-      target: {
-        value: "Assessment shows deficits in functional communication and WH-question responding with moderate prompt dependence.",
-      },
-    });
-    await user.click(screen.getByRole("button", { name: /Generate AI Proposal Program \+ Goals/i }));
-
-    await waitFor(() => {
-      expect(generateProgramGoalDraft).toHaveBeenCalledTimes(1);
-    });
-    expect(screen.getByPlaceholderText("Program name")).toHaveValue("Communication Program");
-    expect(screen.getByText(/Requesting preferred items with 2-word phrase/i)).toBeInTheDocument();
-
-    expect(screen.queryByRole("button", { name: /Legacy Quick Create/i })).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /Save AI Proposal to Selected Assessment/i }));
-
-    await waitFor(() => {
-      expect(callApi).toHaveBeenCalledWith(
-        "/api/assessment-drafts",
-        expect.objectContaining({ method: "POST" }),
-      );
-    });
-    expect(showSuccess).toHaveBeenCalledWith("AI proposal saved to assessment queue for review.");
+    expect(screen.queryByPlaceholderText(/Paste assessment summary or White Bible-aligned notes/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Generate AI Proposal Program \+ Goals/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Save AI Proposal to Selected Assessment/i })).not.toBeInTheDocument();
+    expect(generateProgramGoalDraft).not.toHaveBeenCalled();
   });
 
-  it("uses canonical programs array values when generating a draft proposal", async () => {
+  it("does not render manual AI proposal results", async () => {
     vi.mocked(generateProgramGoalDraft).mockResolvedValueOnce({
       programs: [
         {
@@ -1195,21 +1173,13 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     });
 
-    const assessmentInput = await screen.findByPlaceholderText(/Paste assessment summary or White Bible-aligned notes/i);
-    await user.type(assessmentInput, "Assessment evidence supports one focused communication program and one child goal.");
-    await user.click(screen.getByRole("button", { name: /Generate AI Proposal Program \+ Goals/i }));
-
-    await waitFor(() => {
-      expect(generateProgramGoalDraft).toHaveBeenCalledTimes(1);
-    });
-    expect(screen.getByPlaceholderText("Program name")).toHaveValue("Primary Program");
-    expect(screen.getByText(/Draft programs: Primary Program/i)).toBeInTheDocument();
-    expect(screen.getByText("Primary rationale")).toBeInTheDocument();
-    expect(screen.queryByText(/Legacy Program/i)).not.toBeInTheDocument();
-    expect(screen.queryByText("Legacy rationale")).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/Paste assessment summary or White Bible-aligned notes/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Draft programs:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Primary rationale")).not.toBeInTheDocument();
+    expect(generateProgramGoalDraft).not.toHaveBeenCalled();
   });
 
-  it("saves only canonical programs array payloads for generated drafts", async () => {
+  it("does not expose manual AI draft persistence controls", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -1253,42 +1223,13 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     });
 
-    const assessmentInput = await screen.findByPlaceholderText(/Paste assessment summary or White Bible-aligned notes/i);
-    await user.type(
-      assessmentInput,
-      "Assessment evidence supports one focused communication program and one child goal.",
-    );
-    await user.click(screen.getByRole("button", { name: /Generate AI Proposal Program \+ Goals/i }));
-
-    await waitFor(() => {
-      expect(generateProgramGoalDraft).toHaveBeenCalledTimes(1);
-    });
-
-    await user.click(screen.getByRole("button", { name: /Save AI Proposal to Selected Assessment/i }));
-
-    await waitFor(() => {
-      expect(callApi).toHaveBeenCalledWith("/api/assessment-drafts", expect.objectContaining({ method: "POST" }));
-    });
-
-    const saveDraftCall = vi
-      .mocked(callApi)
-      .mock.calls.find(([path, init]) => path === "/api/assessment-drafts" && init?.method === "POST");
-    expect(saveDraftCall).toBeDefined();
-    const saveDraftPayload = JSON.parse(String(saveDraftCall?.[1]?.body));
-    expect(saveDraftPayload.assessment_document_id).toBe(ASSESSMENT_ID);
-    expect(saveDraftPayload.programs).toEqual([
-      {
-        name: "Communication Program",
-        description: "Build requesting and social communication skills.",
-        rationale: "Communication deficits and prompt dependence from the source assessment.",
-        evidence_refs: [{ section_key: "summary", source_span: "communication deficits with prompt dependence" }],
-        review_flags: [],
-      },
-    ]);
-    expect(saveDraftPayload.summary_rationale).toBe("Derived from assessment deficits and ABA measurement guidelines.");
-    expect(saveDraftPayload.confidence).toBe("medium");
-    expect(Array.isArray(saveDraftPayload.goals)).toBe(true);
-    expect(saveDraftPayload).not.toHaveProperty("program");
+    expect(screen.queryByRole("button", { name: /Save AI Proposal to Selected Assessment/i })).not.toBeInTheDocument();
+    expect(
+      vi.mocked(callApi).mock.calls.some(
+        ([path, init]) => path === "/api/assessment-drafts" && (init?.method ?? "").toUpperCase() === "POST",
+      ),
+    ).toBe(false);
+    expect(generateProgramGoalDraft).not.toHaveBeenCalled();
   });
 
   it("supports both CalOptima and IEHP upload templates", async () => {
@@ -1331,7 +1272,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     );
 
-    await screen.findByText(/CalOptima FBA Upload \+ AI Workflow/i);
+    await screen.findByText(/CalOptima FBA Upload Workflow/i);
     const templateSelect = screen.getByRole("combobox", { name: /FBA template/i });
     expect(within(templateSelect).getByRole("option", { name: "CalOptima FBA" })).toBeInTheDocument();
     expect(within(templateSelect).getByRole("option", { name: "IEHP FBA" })).toBeInTheDocument();
@@ -1397,7 +1338,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     );
 
-    await screen.findByText(/CalOptima FBA Upload \+ AI Workflow/i);
+    await screen.findByText(/CalOptima FBA Upload Workflow/i);
     const templateSelect = screen.getByRole("combobox", { name: /FBA template/i });
     await user.selectOptions(templateSelect, "iehp_fba");
     const uploadInput = screen.getByLabelText(/FBA file \(PDF or DOCX\)/i);
@@ -1430,12 +1371,12 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     });
 
-    await screen.findByText(/FBA Upload \+ AI Workflow/i);
+    await screen.findByText(/FBA Upload Workflow/i);
     const uploadInput = screen.getByLabelText(/FBA file \(PDF or DOCX\)/i);
     expect(uploadInput.getAttribute("accept")).toBe(".pdf,.docx");
   });
 
-  it("generates staged drafts from selected uploaded assessment", async () => {
+  it("hides uploaded-assessment AI draft generation controls", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) {
@@ -1499,27 +1440,15 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
 
     await screen.findByText("fba.docx");
     expect(await screen.findByText("Previous extraction warning should not block generation.")).toBeInTheDocument();
-    const generateButton = await screen.findByRole("button", { name: /(Generate|Retry).*Uploaded FBA/i });
-    await waitFor(() => {
-      expect(generateButton).not.toBeDisabled();
-    });
-    await user.click(generateButton);
-
-    await waitFor(() => {
-      expect(
-        vi.mocked(callApi).mock.calls.some(
-          ([path, init]) =>
-            path === "/api/assessment-drafts" &&
-            init?.method === "POST" &&
-            JSON.parse(String(init.body)).assessment_document_id === ASSESSMENT_ID &&
-            JSON.parse(String(init.body)).auto_generate === true,
-        ),
-      ).toBe(true);
-    });
-    expect(showSuccess).toHaveBeenCalledWith("Draft program and goals generated from reviewed structured FBA data.");
+    expect(screen.queryByRole("button", { name: /(Generate|Retry).*Uploaded FBA/i })).not.toBeInTheDocument();
+    expect(
+      vi.mocked(callApi).mock.calls.some(
+        ([path, init]) => path === "/api/assessment-drafts" && (init?.method ?? "").toUpperCase() === "POST",
+      ),
+    ).toBe(false);
   });
 
-  it("allows retry generation after extraction failure and shows retry guidance", async () => {
+  it("does not expose retry generation after extraction failure", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -1591,30 +1520,15 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(
       await screen.findByText("Extraction failed. Review the checklist manually or upload a cleaner FBA."),
     ).toBeInTheDocument();
-    expect(
-      await screen.findByText(
-        "Extraction failed for this assessment. Retry deterministic draft generation using the extracted checklist evidence, or replace the source document if it needs correction.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.queryByText(/Retry deterministic draft generation/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Wait for extraction to complete before generating drafts.")).not.toBeInTheDocument();
 
-    const generateButton = await screen.findByRole("button", { name: /Generate Drafts from Uploaded FBA/i });
-    await waitFor(() => {
-      expect(generateButton).not.toBeDisabled();
-    });
-    await user.click(generateButton);
-    await waitFor(() => {
-      expect(
-        vi.mocked(callApi).mock.calls.some(
-          ([path, init]) =>
-            path === "/api/assessment-drafts" &&
-            (init?.method ?? "").toUpperCase() === "POST" &&
-            JSON.parse(String(init?.body)).assessment_document_id === ASSESSMENT_ID &&
-            JSON.parse(String(init?.body)).auto_generate === true,
-        ),
-      ).toBe(true);
-    });
-    expect(showSuccess).toHaveBeenCalledWith("Draft program and goals generated from reviewed structured FBA data.");
+    expect(screen.queryByRole("button", { name: /Generate Drafts from Uploaded FBA/i })).not.toBeInTheDocument();
+    expect(
+      vi.mocked(callApi).mock.calls.some(
+        ([path, init]) => path === "/api/assessment-drafts" && (init?.method ?? "").toUpperCase() === "POST",
+      ),
+    ).toBe(false);
   });
 
   it("keeps extraction failure retry disabled when no checklist evidence is available", async () => {
@@ -1680,20 +1594,14 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     );
 
     await screen.findByText("empty-failed-fba.pdf");
-    expect(
-      await screen.findByText(
-        "Extraction failed for this assessment, but no extracted checklist evidence is available for draft generation. Replace the source document or add checklist evidence before retrying.",
-      ),
-    ).toBeInTheDocument();
-
-    const generateButton = await screen.findByRole("button", { name: /Generate Drafts from Uploaded FBA/i });
-    expect(generateButton).toBeDisabled();
+    expect(screen.queryByText(/draft generation/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Generate Drafts from Uploaded FBA/i })).not.toBeInTheDocument();
     expect(
       vi.mocked(callApi).mock.calls.some(([path, init]) => path === "/api/assessment-drafts" && init?.method === "POST"),
     ).toBe(false);
   });
 
-  it("shows structured goal readiness counts and blocks draft generation below minimums", async () => {
+  it("shows structured goal readiness counts without AI draft controls", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -1759,8 +1667,8 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     ).toBeInTheDocument();
     expect(screen.getByText((_content, node) => node?.textContent === "Child goals: 0")).toBeInTheDocument();
     expect(screen.getByText((_content, node) => node?.textContent === "Parent goals: 0")).toBeInTheDocument();
-    expect(screen.getByText("Approve at least one structured goal section before generating drafts.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Generate Drafts from Uploaded FBA/i })).toBeDisabled();
+    expect(screen.queryByText("Approve at least one structured goal section before generating drafts.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Generate Drafts from Uploaded FBA/i })).not.toBeInTheDocument();
   });
 
   it("shows extraction-failed guidance instead of generic waiting copy for uploaded assessments", async () => {
@@ -1815,11 +1723,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       await screen.findByText("Extraction failed. Review the checklist manually or upload a cleaner FBA."),
     ).toBeInTheDocument();
     expect(screen.queryByText("Wait for extraction to complete before generating AI proposals.")).not.toBeInTheDocument();
-
-    const generateButton = await screen.findByRole("button", { name: /(Generate|Retry).*Uploaded FBA/i });
-    await waitFor(() => {
-      expect(generateButton).toBeDisabled();
-    });
+    expect(screen.queryByRole("button", { name: /(Generate|Retry).*Uploaded FBA/i })).not.toBeInTheDocument();
     expect(
       vi.mocked(callApi).mock.calls.some(
         ([path, init]) => path === "/api/assessment-drafts" && (init?.method ?? "").toUpperCase() === "POST",
@@ -1827,7 +1731,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     ).toBe(false);
   });
 
-  it("waits for extraction before generating staged drafts from an uploaded assessment", async () => {
+  it("keeps AI draft generation absent while extraction is still running", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -1873,14 +1777,8 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     );
 
-    const generateButton = await screen.findByRole("button", { name: /Generate Drafts from Uploaded FBA/i });
-    await waitFor(() => {
-      expect(generateButton).toBeDisabled();
-    });
-    expect(await screen.findByText("Wait for extraction to complete before generating drafts.")).toBeInTheDocument();
-
-    await user.click(generateButton);
-
+    expect(screen.queryByRole("button", { name: /Generate Drafts from Uploaded FBA/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Wait for extraction to complete before generating drafts.")).not.toBeInTheDocument();
     expect(
       vi.mocked(callApi).mock.calls.some(
         ([path, init]) => path === "/api/assessment-drafts" && (init?.method ?? "").toUpperCase() === "POST",
@@ -1888,7 +1786,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     ).toBe(false);
   });
 
-  it("keeps draft generation disabled until a structured goal section is approved", async () => {
+  it("keeps AI draft generation absent even when structured goals are only verified", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -1937,14 +1835,11 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     });
 
-    const generateButton = await screen.findByRole("button", { name: /Generate Drafts from Uploaded FBA/i });
-    await waitFor(() => {
-      expect(generateButton).toBeDisabled();
-    });
-    expect(await screen.findByText("Approve at least one structured goal section before generating drafts.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Generate Drafts from Uploaded FBA/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Approve at least one structured goal section before generating drafts.")).not.toBeInTheDocument();
   });
 
-  it("shows existing-draft guidance for drafted uploaded assessments", async () => {
+  it("shows drafted uploads as structured review ready without AI guidance", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -1996,13 +1891,11 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     );
 
-    const generateButton = await screen.findByRole("button", { name: /Generate Drafts from Uploaded FBA/i });
-    await waitFor(() => {
-      expect(generateButton).toBeDisabled();
-    });
+    expect(await screen.findByText("structured review ready")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Generate Drafts from Uploaded FBA/i })).not.toBeInTheDocument();
     expect(
-      await screen.findByText("Drafts already exist for this assessment. Review/edit current drafts instead of regenerating."),
-    ).toBeInTheDocument();
+      screen.queryByText("Drafts already exist for this assessment. Review/edit current drafts instead of regenerating."),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("Wait for extraction to complete before generating drafts.")).not.toBeInTheDocument();
   });
 
@@ -2362,19 +2255,9 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     );
 
     await screen.findByText("fba.pdf");
-    const publishButton = screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i });
-    await waitFor(() => {
-      expect(publishButton).not.toBeDisabled();
-    });
-    await user.click(publishButton);
-
-    await waitFor(() => {
-      expect(showError).toHaveBeenCalled();
-    });
-    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining("to live Programs & Goals"));
-    const firstErrorArg = vi.mocked(showError).mock.calls[0]?.[0];
-    expect(firstErrorArg).toBeInstanceOf(Error);
-    expect((firstErrorArg as Error).message).toBe("Required checklist items must be approved before promotion.");
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
+    expect(showError).not.toHaveBeenCalled();
+    expect(confirmSpy).not.toHaveBeenCalled();
     confirmSpy.mockRestore();
   });
 
@@ -2435,26 +2318,10 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
 
     await screen.findByText("fba.pdf");
-    const publishButton = screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i });
-    await waitFor(() => {
-      expect(publishButton).not.toBeDisabled();
-    });
-    await user.click(publishButton);
-
-    await waitFor(() => {
-      expect(showSuccess).toHaveBeenCalledWith(
-        "Published to live records. Created 2 production programs and 26 goals.",
-      );
-    });
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-      queryKey: ["assessment-drafts", ASSESSMENT_ID, ORG_ID],
-    });
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-      queryKey: ["assessment-checklist", ASSESSMENT_ID, ORG_ID],
-    });
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-      queryKey: ["client-goals", "client-1", ORG_ID],
-    });
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
+    expect(showSuccess).not.toHaveBeenCalledWith(
+      "Published to live records. Created 2 production programs and 26 goals.",
+    );
     invalidateQueriesSpy.mockRestore();
     confirmSpy.mockRestore();
   });
@@ -2512,17 +2379,10 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
 
     await screen.findByText("fba.pdf");
-    const publishButton = screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i });
-    await waitFor(() => {
-      expect(publishButton).not.toBeDisabled();
-    });
-    await user.click(publishButton);
-
-    await waitFor(() => {
-      expect(showSuccess).toHaveBeenCalledWith(
-        "Published to live records. Created 1 production program and 26 goals.",
-      );
-    });
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
+    expect(showSuccess).not.toHaveBeenCalledWith(
+      "Published to live records. Created 1 production program and 26 goals.",
+    );
     confirmSpy.mockRestore();
   });
 
@@ -2587,17 +2447,10 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
 
     await screen.findByText("fba.pdf");
-    const publishButton = screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i });
-    await waitFor(() => {
-      expect(publishButton).not.toBeDisabled();
-    });
-    await user.click(publishButton);
-
-    await waitFor(() => {
-      expect(showSuccess).toHaveBeenCalledWith(
-        "Published to live records. Created 1 production program and 26 goals.",
-      );
-    });
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
+    expect(showSuccess).not.toHaveBeenCalledWith(
+      "Published to live records. Created 1 production program and 26 goals.",
+    );
     confirmSpy.mockRestore();
   });
 
@@ -2613,8 +2466,9 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     );
 
-    expect(await screen.findByText("All changes published.")).toBeInTheDocument();
-    expect(screen.getByText("Publishing makes accepted drafts live in Programs and Goals.")).toBeInTheDocument();
+    expect(screen.queryByText("All changes published.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publishing makes accepted drafts live in Programs and Goals.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Draft Review/i)).not.toBeInTheDocument();
   });
 
   it("shows retained-draft messaging and blocks republish after approval", async () => {
@@ -2665,13 +2519,10 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
 
     expect(await screen.findByText("approved-fba.pdf")).toBeInTheDocument();
-    expect(screen.getByText("Drafts retained after publication.")).toBeInTheDocument();
-    expect(
-      screen.getByText("This assessment has already been approved and published."),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i })).toBeDisabled();
-    expect(await screen.findAllByText("Draft retained for audit after approval. Live records are already published.")).not.toHaveLength(0);
-    expect(screen.queryByText("Saves to draft only. Not visible in live records until published.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Drafts retained after publication.")).not.toBeInTheDocument();
+    expect(screen.queryByText("This assessment has already been approved and published.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Draft retained for audit after approval. Live records are already published.")).not.toBeInTheDocument();
   });
 
   it("saves a program draft and shows draft-only messaging", async () => {
@@ -2738,20 +2589,8 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     );
 
-    await screen.findByText("Draft changes pending publication.");
-    await user.click(await screen.findByRole("button", { name: /Save Program Draft/i }));
-
-    await waitFor(() => {
-      expect(callApi).toHaveBeenCalledWith(
-        "/api/assessment-drafts",
-        expect.objectContaining({
-          method: "PATCH",
-          body: expect.stringContaining("\"draft_type\":\"program\""),
-        }),
-      );
-    });
-    expect(showSuccess).toHaveBeenCalledWith("Program draft saved. Not published yet.");
-    expect(screen.getByText("Saves to draft only. Not visible in live records until published.")).toBeInTheDocument();
+    expect(screen.queryByText("Draft changes pending publication.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Save Program Draft/i })).not.toBeInTheDocument();
   });
 
   it("hydrates legacy target criteria into the short-term goal field and saves all three goals back into target_criteria", async () => {
@@ -2832,44 +2671,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     });
 
-    const shortTermField = await screen.findByDisplayValue("Legacy target criteria text");
-    expect(shortTermField).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("Intermediate goal")).toHaveValue("");
-    expect(screen.getByPlaceholderText("Long-term goal")).toHaveValue("");
-
-    fireEvent.change(screen.getByPlaceholderText("Intermediate goal"), {
-      target: { value: "Intermediate draft goal" },
-    });
-    fireEvent.change(screen.getByPlaceholderText("Long-term goal"), {
-      target: { value: "Long-term draft goal" },
-    });
-
-    await user.click(screen.getByRole("button", { name: /Save Goal Draft/i }));
-
-    await waitFor(() => {
-      expect(callApi).toHaveBeenCalledWith(
-        "/api/assessment-drafts",
-        expect.objectContaining({
-          method: "PATCH",
-          body: expect.stringContaining("\"draft_type\":\"goal\""),
-        }),
-      );
-    });
-
-    const saveGoalDraftCall = vi
-      .mocked(callApi)
-      .mock.calls.find(
-        ([path, requestInit]) => path === "/api/assessment-drafts" && requestInit?.method === "PATCH",
-      );
-
-    expect(saveGoalDraftCall).toBeTruthy();
-    const [, requestInit] = saveGoalDraftCall!;
-    const body = JSON.parse(String(requestInit?.body)) as { target_criteria?: string };
-    expect(body.target_criteria).toBe(
-      "Short-term: Legacy target criteria text\n" +
-        "Intermediate: Intermediate draft goal\n" +
-        "Long-term: Long-term draft goal",
-    );
+    expect(screen.queryByRole("button", { name: /Save Goal Draft/i })).not.toBeInTheDocument();
   });
 
   it("shows inline helper when promote is disabled", async () => {
@@ -2884,7 +2686,8 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     );
 
-    expect(await screen.findByText("Select a valid assessment first.")).toBeInTheDocument();
+    expect(screen.queryByText("Select a valid assessment first.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
   });
 
   it("blocks publish with explicit checklist guidance when required rows are unresolved", async () => {
@@ -2951,8 +2754,8 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     });
 
-    expect(await screen.findByText("1 required checklist row must be approved before publishing.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i })).toBeDisabled();
+    expect(screen.queryByText("1 required checklist row must be approved before publishing.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
   });
 
   it("shows approved checklist rows as locked from status downgrades", async () => {
@@ -3071,8 +2874,8 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(
       await screen.findByText("Checklist review failed to load. Publishing stays blocked until checklist rows can be reviewed."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Checklist review must load before publishing.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Publish to Live Programs \+ Goals/i })).toBeDisabled();
+    expect(screen.queryByText("Checklist review must load before publishing.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
   });
 
   it("allows publish with smaller accepted draft sets once checklist review is complete", async () => {
@@ -3171,9 +2974,8 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
 
     await screen.findByText("fba.pdf");
-    const publishButton = await screen.findByRole("button", { name: /Publish to Live Programs \+ Goals/i });
-    await waitFor(() => expect(publishButton).toBeEnabled());
-    expect(screen.getByText("Accepted draft goals: 2 child / 1 parent")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Accepted draft goals: 2 child / 1 parent")).not.toBeInTheDocument();
   });
 
   it("shows add-goal prerequisites when create goal is disabled", async () => {


### PR DESCRIPTION
## Summary
- disable AI proposal UI in Programs & Goals so the tab only exposes document upload and structured review
- rename the drafted assessment badge from `ai proposal ready` to `structured review ready`
- remove user-facing publish, proposal generation, and draft review controls; update tests accordingly

## Routing
- classification: low-risk autonomous
- lane: standard
- why: non-trivial UI/component change limited to `src/components/**` and tests, outside protected paths
- triggering paths: `src/components/ClientDetails/ProgramsGoalsTab.tsx`, `src/components/ClientDetails/ProgramsGoalsTab.helpers.ts`, `src/components/__tests__/ProgramsGoalsTab.test.tsx`

## Scope
- task intent: shut off AI proposals in the Programs & Goals workflow so only document upload remains user-facing
- files touched: the Programs & Goals component, helpers, and focused component tests
- single-purpose diff: yes

## Agents
- agents used: tester, reviewer
- reviewer: completed

## Verification Card
- required checks:
  - `npm run lint`
  - `npm run typecheck`
  - `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx`
  - `npm run build`
- executed checks:
  - `npm run lint`: pass
  - `npm run typecheck`: pass
  - `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx`: pass
  - `npm run build`: pass
- blocked checks:
  - none
- result: pass
- residual risk: low; hidden draft-query/mutation paths still exist behind the disabled UI and could be cleaned up later

## PR Hygiene
- branch-ready: yes
- linear-ready: no; waived by task owner for this PR request
- protected-path drift: none
- unrelated changes: none
- generated artifact drift: none
- verification summary: present
- pr-ready: yes
- required follow-up:
  - optional cleanup: skip `assessment-drafts` fetch/mutations entirely when AI proposals are disabled
