### PR TITLE
WIN-153 Fix assessment PDF smoke state handling

### DIFF
--- a/scripts/lib/assessment-pdf-smoke-document.ts
+++ b/scripts/lib/assessment-pdf-smoke-document.ts
@@ -11,6 +11,7 @@ import { assertSmokeClientMarker, requireSmokeClientId } from "./assessment-uplo
 type AssessmentStatus =
   | "uploaded"
   | "extracting"
+  | "extraction_running"
   | "extracted"
   | "drafted"
   | "approved"

--- a/scripts/lib/assessment-pdf-smoke-document.ts
+++ b/scripts/lib/assessment-pdf-smoke-document.ts
@@ -92,6 +92,21 @@ const DEFAULT_SAMPLE_FILE = path.resolve(
 );
 const DEFAULT_BUCKET_ID = "client-documents";
 const EXTRACTION_TIMEOUT_MS = 180_000;
+const PENDING_PDF_SMOKE_EXTRACTION_STATUSES = new Set<AssessmentStatus>([
+  "uploaded",
+  "extracting",
+  "extraction_running",
+]);
+const COMPLETED_PDF_SMOKE_EXTRACTION_STATUSES = new Set<AssessmentStatus>([
+  "extracted",
+  "drafted",
+  "approved",
+]);
+
+export const isPendingPdfSmokeExtractionStatus = (status: AssessmentStatus): boolean =>
+  PENDING_PDF_SMOKE_EXTRACTION_STATUSES.has(status);
+export const isCompletedPdfSmokeExtractionStatus = (status: AssessmentStatus): boolean =>
+  COMPLETED_PDF_SMOKE_EXTRACTION_STATUSES.has(status);
 
 const pause = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms));
@@ -123,6 +138,9 @@ const assertOk = async (response: Response, message: string): Promise<void> => {
   const body = await escapeBody(response);
   throw new Error(`${message}: ${response.status}${body ? ` ${body}` : ""}`);
 };
+
+export const isDraftAlreadyExistsResponse = (status: number, body: string): boolean =>
+  status === 409 && /Drafts already exist for this assessment/i.test(body);
 
 const fetchJson = async <T>(
   url: string,
@@ -369,7 +387,7 @@ const waitForExtractedAssessment = async (args: {
   let latest: AssessmentDocumentRecord | null = null;
   while (Date.now() < deadline) {
     latest = await fetchAssessmentDocument(args);
-    if (!["uploaded", "extracting"].includes(latest.status)) {
+    if (!isPendingPdfSmokeExtractionStatus(latest.status)) {
       break;
     }
     await pause(2_000);
@@ -377,7 +395,7 @@ const waitForExtractedAssessment = async (args: {
   if (!latest) {
     throw new Error(`Provisioned assessment document ${args.assessmentDocumentId} was not found.`);
   }
-  if (latest.status !== "extracted") {
+  if (!isCompletedPdfSmokeExtractionStatus(latest.status)) {
     throw new Error(
       `Provisioned assessment document ${latest.id} ended with ${latest.status}.`,
     );
@@ -421,13 +439,25 @@ const approveChecklistAndStructuredSections = async (args: {
 };
 
 const generateDrafts = async (baseUrl: string, accessToken: string, assessmentDocumentId: string): Promise<void> => {
-  await callAppJson(baseUrl, accessToken, "/api/assessment-drafts", {
+  const response = await fetch(`${baseUrl}/api/assessment-drafts`, {
     method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
     body: JSON.stringify({
       assessment_document_id: assessmentDocumentId,
       auto_generate: true,
     }),
   });
+  if (response.ok) {
+    return;
+  }
+  const body = await escapeBody(response);
+  if (isDraftAlreadyExistsResponse(response.status, body)) {
+    return;
+  }
+  throw new Error(`Request failed for ${baseUrl}/api/assessment-drafts: ${response.status}${body ? ` ${body}` : ""}`);
 };
 
 const acceptDrafts = async (baseUrl: string, accessToken: string, drafts: DraftResponse): Promise<void> => {

--- a/src/scripts/__tests__/assessment-pdf-smoke-document.test.ts
+++ b/src/scripts/__tests__/assessment-pdf-smoke-document.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { evaluatePdfSmokeAssessmentReadiness } from "../../../scripts/lib/assessment-pdf-smoke-document";
+import {
+  evaluatePdfSmokeAssessmentReadiness,
+  isCompletedPdfSmokeExtractionStatus,
+  isDraftAlreadyExistsResponse,
+  isPendingPdfSmokeExtractionStatus,
+} from "../../../scripts/lib/assessment-pdf-smoke-document";
 
 describe("assessment pdf smoke document readiness", () => {
   it("accepts an extracted CalOptima assessment with approved required rows and accepted drafts", () => {
@@ -117,6 +122,28 @@ describe("assessment pdf smoke document readiness", () => {
         "accepted_goal_missing",
       ],
     });
+  });
+
+  it("treats extraction_running as an in-progress smoke extraction status", () => {
+    expect(isPendingPdfSmokeExtractionStatus("uploaded")).toBe(true);
+    expect(isPendingPdfSmokeExtractionStatus("extracting")).toBe(true);
+    expect(isPendingPdfSmokeExtractionStatus("extraction_running")).toBe(true);
+    expect(isPendingPdfSmokeExtractionStatus("drafted")).toBe(false);
+    expect(isPendingPdfSmokeExtractionStatus("extraction_failed")).toBe(false);
+  });
+
+  it("treats drafted as a completed smoke extraction status", () => {
+    expect(isCompletedPdfSmokeExtractionStatus("extracted")).toBe(true);
+    expect(isCompletedPdfSmokeExtractionStatus("drafted")).toBe(true);
+    expect(isCompletedPdfSmokeExtractionStatus("approved")).toBe(true);
+    expect(isCompletedPdfSmokeExtractionStatus("extraction_running")).toBe(false);
+    expect(isCompletedPdfSmokeExtractionStatus("extraction_failed")).toBe(false);
+  });
+
+  it("recognizes the existing-drafts response as safe to continue", () => {
+    expect(isDraftAlreadyExistsResponse(409, '{"error":"Drafts already exist for this assessment. Review existing drafts instead of regenerating."}')).toBe(true);
+    expect(isDraftAlreadyExistsResponse(409, '{"error":"Accepted draft program and goals are required"}')).toBe(false);
+    expect(isDraftAlreadyExistsResponse(500, '{"error":"Drafts already exist for this assessment."}')).toBe(false);
   });
 
   it("rejects non-CalOptima templates even when the rest of the fixture looks ready", () => {


### PR DESCRIPTION
## Summary
- Fixes the CalOptima completed-PDF smoke harness to wait through the live `extraction_running` state.
- Treats `drafted`/`approved` as valid extraction-complete states for provisioned smoke documents.
- Treats the expected `409 Drafts already exist` response as safe to continue when extraction already created drafts.

## Debug findings
- The original smoke did not reach completed-PDF generation reliably because its state model was stale.
- After this local harness fix, the smoke reaches `POST /api/assessment-plan-pdf`; production currently returns wrapper `500`.
- Local invocation of `assessmentPlanPdfHandler` against a temporary hosted smoke assessment succeeds with status 200 and returns overlay PDF metadata plus layout warnings.
- Netlify production is still deployed at commit `2ca04270`, while `origin/main` is `3fc72923`; no production deploy for merged PR #559 is current.

## Verification
- `npm test -- src/scripts/__tests__/assessment-pdf-smoke-document.test.ts --runInBand`
- `npm run typecheck`
- `npm run ci:check-focused`
- commit hook `npm run ci:check-focused`

## Safety
- Temporary smoke/debug assessment records and generated PDF objects were cleaned up.
- No production client workflow records were intentionally preserved.