### PR TITLE
WIN-151 Include assessment extraction in edge deploy bundle

### DIFF
--- a/scripts/ci/deploy-session-edge-bundle.mjs
+++ b/scripts/ci/deploy-session-edge-bundle.mjs
@@ -15,6 +15,7 @@ const REQUIRED_FUNCTIONS = [
   "goals",
   "program-notes",
   "emails",
+  "extract-assessment-fields",
 ];
 
 const EXPECT_VERIFY_JWT = String(process.env.CI_EXPECT_VERIFY_JWT ?? "true").toLowerCase() !== "false";


### PR DESCRIPTION
## Summary
- Include `extract-assessment-fields` in the required Supabase edge deploy bundle so future bundle deploys keep assessment extraction current.
- Production hotfix already deployed `extract-assessment-fields` to Supabase project `wnnjeqheqxxyrgsjmygy`; deployed version is 13 and the live source accepts both `caloptima_fba` and `iehp_fba` template types.

## Root cause
The live IEHP upload was failing before extraction because production `extract-assessment-fields` was stale and rejected `template_type: "iehp_fba"` with HTTP 400. The existing failed assessment document was not reprocessed to avoid mutating production assessment data without explicit approval.

## Verification
- `node --check scripts/ci/deploy-session-edge-bundle.mjs`
- `git diff --check`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:ci`
- `npm run validate:tenant`
- `npm run verify:local`

## Notes
`verify:local` passed with expected local warnings/skips for missing DB URLs and non-CI branch protection checks. Tier-0 route coverage passed as part of `verify:local`.