### PR TITLE
Fix therapist client detail authorization

### DIFF
--- a/src/lib/clients/__tests__/fetchers.test.ts
+++ b/src/lib/clients/__tests__/fetchers.test.ts
@@ -5,10 +5,12 @@ import { CLIENT_DETAIL_SELECT, CLIENT_LIST_SELECT } from '../select';
 import type { ClientsSupabaseClient } from '../fetchers';
 import {
   fetchClientById,
+  fetchClientByIdForViewer,
   fetchClientNotes,
   fetchClients,
   fetchGuardianClientById,
   fetchGuardianClients,
+  fetchTherapistIdsForUser,
 } from '../fetchers';
 
 describe('clients fetchers', () => {
@@ -117,6 +119,146 @@ describe('clients fetchers', () => {
     expect(firstEq).toHaveBeenCalledWith('organization_id', 'org-1');
     expect(secondEq).toHaveBeenCalledWith('id', 'client-123');
     expect(single).toHaveBeenCalled();
+  });
+
+  it('resolves therapist row ids from user therapist links', async () => {
+    const eq = vi.fn().mockResolvedValue({
+      data: [
+        { therapist_id: 'therapist-row-id' },
+        { therapist_id: 'therapist-row-id' },
+      ],
+      error: null,
+    });
+    const select = vi.fn().mockReturnValue({ eq });
+    const from = vi.fn().mockReturnValue({ select });
+
+    const result = await fetchTherapistIdsForUser('auth-user-id', { from } as any);
+
+    expect(from).toHaveBeenCalledWith('user_therapist_links');
+    expect(select).toHaveBeenCalledWith('therapist_id');
+    expect(eq).toHaveBeenCalledWith('user_id', 'auth-user-id');
+    expect(result).toEqual(['therapist-row-id']);
+  });
+
+  it('scopes therapist client-detail access to primary therapist row assignment', async () => {
+    const clientRow = {
+      id: 'client-1',
+      full_name: 'Primary Client',
+      organization_id: 'org-1',
+      therapist_id: 'therapist-row-id',
+    } as Client;
+
+    const userLinkEq = vi.fn().mockResolvedValue({
+      data: [{ therapist_id: 'therapist-row-id' }],
+      error: null,
+    });
+    const linkClientEq = vi.fn().mockResolvedValue({ data: [], error: null });
+    const maybeSingle = vi.fn().mockResolvedValue({ data: clientRow, error: null });
+    const therapistIn = vi.fn().mockReturnValue({ maybeSingle });
+    const idEq = vi.fn().mockReturnValue({ in: therapistIn });
+    const orgEq = vi.fn().mockReturnValue({ eq: idEq });
+    const clientsSelect = vi.fn().mockReturnValue({ eq: orgEq });
+
+    const from = vi.fn((table: string) => {
+      if (table === 'user_therapist_links') {
+        return { select: vi.fn().mockReturnValue({ eq: userLinkEq }) };
+      }
+      if (table === 'client_therapist_links') {
+        return { select: vi.fn().mockReturnValue({ eq: linkClientEq }) };
+      }
+      return { select: clientsSelect };
+    });
+
+    const result = await fetchClientByIdForViewer({
+      clientId: 'client-1',
+      organizationId: 'org-1',
+      viewerRole: 'therapist',
+      userId: 'auth-user-id',
+      client: { from } as any,
+    });
+
+    expect(result).toBe(clientRow);
+    expect(from).toHaveBeenCalledWith('user_therapist_links');
+    expect(from).toHaveBeenCalledWith('client_therapist_links');
+    expect(from).toHaveBeenCalledWith('clients');
+    expect(therapistIn).toHaveBeenCalledWith('therapist_id', ['therapist-row-id']);
+  });
+
+  it('returns null for therapist client-detail access when not primary-assigned or linked', async () => {
+    const userLinkEq = vi.fn().mockResolvedValue({
+      data: [{ therapist_id: 'therapist-row-id' }],
+      error: null,
+    });
+    const linkClientEq = vi.fn().mockResolvedValue({ data: [], error: null });
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+    const therapistIn = vi.fn().mockReturnValue({ maybeSingle });
+    const idEq = vi.fn().mockReturnValue({ in: therapistIn });
+    const orgEq = vi.fn().mockReturnValue({ eq: idEq });
+    const clientsSelect = vi.fn().mockReturnValue({ eq: orgEq });
+
+    const from = vi.fn((table: string) => {
+      if (table === 'user_therapist_links') {
+        return { select: vi.fn().mockReturnValue({ eq: userLinkEq }) };
+      }
+      if (table === 'client_therapist_links') {
+        return { select: vi.fn().mockReturnValue({ eq: linkClientEq }) };
+      }
+      return { select: clientsSelect };
+    });
+
+    const result = await fetchClientByIdForViewer({
+      clientId: 'client-foreign',
+      organizationId: 'org-1',
+      viewerRole: 'therapist',
+      userId: 'auth-user-id',
+      client: { from } as any,
+    });
+
+    expect(result).toBeNull();
+    expect(therapistIn).toHaveBeenCalledWith('therapist_id', ['therapist-row-id']);
+  });
+
+  it('allows therapist client-detail access through client therapist links', async () => {
+    const clientRow = {
+      id: 'client-linked',
+      full_name: 'Linked Client',
+      organization_id: 'org-1',
+      therapist_id: null,
+    } as Client;
+
+    const userLinkEq = vi.fn().mockResolvedValue({
+      data: [{ therapist_id: 'therapist-row-id' }],
+      error: null,
+    });
+    const linkClientEq = vi.fn().mockResolvedValue({
+      data: [{ client_id: 'client-linked' }],
+      error: null,
+    });
+    const maybeSingle = vi.fn().mockResolvedValue({ data: clientRow, error: null });
+    const idEq = vi.fn().mockReturnValue({ maybeSingle });
+    const orgEq = vi.fn().mockReturnValue({ eq: idEq });
+    const clientsSelect = vi.fn().mockReturnValue({ eq: orgEq });
+
+    const from = vi.fn((table: string) => {
+      if (table === 'user_therapist_links') {
+        return { select: vi.fn().mockReturnValue({ eq: userLinkEq }) };
+      }
+      if (table === 'client_therapist_links') {
+        return { select: vi.fn().mockReturnValue({ eq: linkClientEq }) };
+      }
+      return { select: clientsSelect };
+    });
+
+    const result = await fetchClientByIdForViewer({
+      clientId: 'client-linked',
+      organizationId: 'org-1',
+      viewerRole: 'therapist',
+      userId: 'auth-user-id',
+      client: { from } as any,
+    });
+
+    expect(result).toBe(clientRow);
+    expect(idEq).toHaveBeenCalledWith('id', 'client-linked');
   });
 
   it('retrieves guardian portal clients via RPC', async () => {

--- a/src/lib/clients/fetchers.ts
+++ b/src/lib/clients/fetchers.ts
@@ -176,6 +176,36 @@ interface FetchClientsOptions {
   allowAll?: boolean;
 }
 
+type ClientRecordViewerRole = 'client' | 'therapist' | 'admin' | 'super_admin';
+
+interface FetchClientByIdForViewerOptions {
+  readonly clientId: string;
+  readonly organizationId: string;
+  readonly viewerRole: ClientRecordViewerRole;
+  readonly userId?: string | null;
+  readonly client?: ClientsSupabaseClient;
+}
+
+export const fetchTherapistIdsForUser = async (
+  userId: string,
+  client: ClientsSupabaseClient = supabase,
+): Promise<string[]> => {
+  const { data, error } = await client
+    .from('user_therapist_links')
+    .select('therapist_id')
+    .eq('user_id', userId);
+
+  if (error) {
+    throw error;
+  }
+
+  const linkedIds = (data ?? [])
+    .map((row) => row.therapist_id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  return Array.from(new Set(linkedIds));
+};
+
 export const fetchClients = async (
   options: FetchClientsOptions
 ): Promise<Client[]> => {
@@ -267,6 +297,57 @@ export const fetchClientById = async (
     .eq('organization_id', organizationId)
     .eq('id', clientId)
     .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? null) as Client | null;
+};
+
+export const fetchClientByIdForViewer = async ({
+  clientId,
+  organizationId,
+  viewerRole,
+  userId,
+  client: overrideClient,
+}: FetchClientByIdForViewerOptions): Promise<Client | null> => {
+  if (!organizationId) {
+    throw new Error('organizationId is required to fetch a client record');
+  }
+
+  const clientRef = overrideClient ?? supabase;
+
+  if (viewerRole !== 'therapist') {
+    return fetchClientById(clientId, organizationId, clientRef);
+  }
+
+  if (!userId) {
+    return null;
+  }
+
+  const therapistIds = await fetchTherapistIdsForUser(userId, clientRef);
+  if (therapistIds.length === 0) {
+    return null;
+  }
+
+  const linkedClientIdsByTherapist = await Promise.all(
+    therapistIds.map((therapistId) => fetchLinkedClientIdsForTherapist(clientRef, therapistId)),
+  );
+  const linkedClientIds = new Set(linkedClientIdsByTherapist.flat());
+  const isLinkedClient = linkedClientIds.has(clientId);
+
+  let query = clientRef
+    .from('clients')
+    .select(CLIENT_DETAIL_SELECT)
+    .eq('organization_id', organizationId)
+    .eq('id', clientId);
+
+  if (!isLinkedClient) {
+    query = query.in('therapist_id', therapistIds);
+  }
+
+  const { data, error } = await query.maybeSingle();
 
   if (error) {
     throw error;

--- a/src/pages/ClientDetails.tsx
+++ b/src/pages/ClientDetails.tsx
@@ -3,7 +3,7 @@ import { useLocation, useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { User, FileText, ClipboardCheck, Contact as FileContract, ArrowLeft, Calendar, AlertCircle, Clock } from 'lucide-react';
 import { supabase } from '../lib/supabase';
-import { fetchClientById } from '../lib/clients/fetchers';
+import { fetchClientByIdForViewer } from '../lib/clients/fetchers';
 import { ProfileTab } from '../components/ClientDetails/ProfileTab';
 import { SessionNotesTab } from '../components/ClientDetails/SessionNotesTab';
 import { PreAuthTab } from '../components/ClientDetails/PreAuthTab';
@@ -40,12 +40,17 @@ export function ClientDetails() {
   }, [initialTab]);
 
   const { data: client, isLoading, error: clientError } = useQuery({
-    queryKey: ['client', clientId, activeOrganizationId ?? 'MISSING_ORG'],
+    queryKey: ['client', clientId, activeOrganizationId ?? 'MISSING_ORG', effectiveRole, profile?.id ?? 'anonymous'],
     queryFn: async () => {
       if (!clientId) throw new Error('Client ID is required');
       if (!activeOrganizationId) throw new Error('Organization context is required to view client details');
 
-      return fetchClientById(clientId, activeOrganizationId);
+      return fetchClientByIdForViewer({
+        clientId,
+        organizationId: activeOrganizationId,
+        viewerRole: effectiveRole,
+        userId: profile?.id ?? null,
+      });
     },
     enabled: Boolean(clientId && activeOrganizationId),
   });
@@ -53,10 +58,8 @@ export function ClientDetails() {
   const isTherapistViewer = effectiveRole === 'therapist';
   const isClientViewer = effectiveRole === 'client';
   const viewingOwnClientRecord = Boolean(isClientViewer && client?.id === profile?.id);
-  const therapistOwnsClient = Boolean(isTherapistViewer && client?.therapist_id === profile?.id);
   const canViewClientRecord = Boolean(
     client &&
-      (!isTherapistViewer || therapistOwnsClient) &&
       (!isClientViewer || viewingOwnClientRecord),
   );
 
@@ -186,25 +189,7 @@ export function ClientDetails() {
     );
   }
 
-  if (!client) {
-    return (
-      <div className="bg-white dark:bg-dark-lighter rounded-lg shadow p-8 text-center">
-        <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Client Not Found</h2>
-        <p className="text-gray-600 dark:text-gray-400 mb-6">
-          The client you're looking for doesn't exist or you don't have permission to view it.
-        </p>
-        <button
-          onClick={() => navigate('/clients')}
-          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-        >
-          Return to Clients
-        </button>
-      </div>
-    );
-  }
-
-  if (isTherapistViewer && !therapistOwnsClient) {
+  if (!client && isTherapistViewer) {
     return (
       <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900/40 rounded-lg shadow p-8 text-red-700 dark:text-red-200">
         <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
@@ -219,6 +204,24 @@ export function ClientDetails() {
           className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
         >
           Back to Clients
+        </button>
+      </div>
+    );
+  }
+
+  if (!client) {
+    return (
+      <div className="bg-white dark:bg-dark-lighter rounded-lg shadow p-8 text-center">
+        <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">Client Not Found</h2>
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          The client you're looking for doesn't exist or you don't have permission to view it.
+        </p>
+        <button
+          onClick={() => navigate('/clients')}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+        >
+          Return to Clients
         </button>
       </div>
     );

--- a/src/pages/__tests__/ClientDetails.test.tsx
+++ b/src/pages/__tests__/ClientDetails.test.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor } from '@testing-library/react';
 import { renderWithProviders, userEvent } from '../../test/utils';
 import { ClientDetails } from '../ClientDetails';
 import { supabase } from '../../lib/supabase';
-import { fetchClientById } from '../../lib/clients/fetchers';
+import { fetchClientByIdForViewer } from '../../lib/clients/fetchers';
 
 let mockLocationSearch = '';
 
@@ -24,7 +24,7 @@ vi.mock('react-router-dom', async () => {
 });
 
 vi.mock('../../lib/clients/fetchers', () => ({
-  fetchClientById: vi.fn(async () => ({
+  fetchClientByIdForViewer: vi.fn(async () => ({
     id: 'client-1',
     full_name: 'Alyana Perez',
     therapist_id: 'admin-user-id',
@@ -77,7 +77,7 @@ describe('ClientDetails page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLocationSearch = '';
-    vi.mocked(fetchClientById).mockResolvedValue({
+    vi.mocked(fetchClientByIdForViewer).mockResolvedValue({
       id: 'client-1',
       full_name: 'Alyana Perez',
       therapist_id: 'admin-user-id',
@@ -134,12 +134,7 @@ describe('ClientDetails page', () => {
 
   it('does not render Programs & Goals or summary queries for an unassigned therapist deeplink', async () => {
     mockLocationSearch = '?tab=programs-goals';
-    vi.mocked(fetchClientById).mockResolvedValue({
-      id: 'client-1',
-      full_name: 'Alyana Perez',
-      therapist_id: 'different-therapist-id',
-      authorized_hours_per_month: 12,
-    });
+    vi.mocked(fetchClientByIdForViewer).mockResolvedValue(null);
 
     renderWithProviders(<ClientDetails />, {
       auth: { role: 'therapist', userId: 'therapist-user-id' },
@@ -149,6 +144,37 @@ describe('ClientDetails page', () => {
 
     expect(screen.queryByText('ProgramsGoalsTabContent')).not.toBeInTheDocument();
     expect(supabase.from).not.toHaveBeenCalled();
+    expect(fetchClientByIdForViewer).toHaveBeenCalledWith({
+      clientId: 'client-1',
+      organizationId: '5238e88b-6198-4862-80a2-dbe15bbeabdd',
+      viewerRole: 'therapist',
+      userId: 'therapist-user-id',
+    });
+  });
+
+  it('allows a therapist whose auth user maps to a separate therapist row id', async () => {
+    mockLocationSearch = '?tab=programs-goals';
+    vi.mocked(fetchClientByIdForViewer).mockResolvedValue({
+      id: 'client-1',
+      full_name: 'Alyana Perez',
+      therapist_id: 'therapist-row-id',
+      authorized_hours_per_month: 12,
+    });
+
+    renderWithProviders(<ClientDetails />, {
+      auth: { role: 'therapist', userId: 'therapist-user-id' },
+    });
+
+    await waitFor(() => expect(screen.getByText('ProgramsGoalsTabContent')).toBeInTheDocument());
+
+    expect(fetchClientByIdForViewer).toHaveBeenCalledWith({
+      clientId: 'client-1',
+      organizationId: '5238e88b-6198-4862-80a2-dbe15bbeabdd',
+      viewerRole: 'therapist',
+      userId: 'therapist-user-id',
+    });
+    expect(supabase.from).toHaveBeenCalledWith('sessions');
+    expect(supabase.from).toHaveBeenCalledWith('client_issues');
   });
 
   it('does not render Programs & Goals or summary queries for a client viewing another record', async () => {


### PR DESCRIPTION
## Summary
- Scope therapist client-detail loads through explicit `user_therapist_links` identity resolution
- Allow detail access only for primary-assigned or `client_therapist_links` caseload clients
- Add regression coverage for auth-user-id vs therapist-row-id mapping, linked-client access, and unassigned therapist blocking

## Verification
- `npm test -- src/lib/clients/__tests__/fetchers.test.ts src/pages/__tests__/ClientDetails.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run ci:check-focused`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:ci`
- `npm run test:routes:tier0`
- `npm run playwright:therapist-authorization`

## Blocked / Follow-up
- Full `npm run ci:playwright` was attempted locally and timed out at 15 minutes. The specific therapist authorization Playwright smoke passed; remaining smoke matrix should be treated as CI-authoritative.
- Critical auth/tenant path: requires human review before merge.

Linear: WIN-155
Closes #563
