### PR TITLE
Retain therapist self-id fallback

### DIFF
--- a/src/lib/clients/__tests__/fetchers.test.ts
+++ b/src/lib/clients/__tests__/fetchers.test.ts
@@ -121,7 +121,7 @@ describe('clients fetchers', () => {
     expect(single).toHaveBeenCalled();
   });
 
-  it('resolves therapist row ids from user therapist links', async () => {
+  it('resolves therapist row ids from user therapist links with a self-id fallback', async () => {
     const eq = vi.fn().mockResolvedValue({
       data: [
         { therapist_id: 'therapist-row-id' },
@@ -137,7 +137,7 @@ describe('clients fetchers', () => {
     expect(from).toHaveBeenCalledWith('user_therapist_links');
     expect(select).toHaveBeenCalledWith('therapist_id');
     expect(eq).toHaveBeenCalledWith('user_id', 'auth-user-id');
-    expect(result).toEqual(['therapist-row-id']);
+    expect(result).toEqual(['therapist-row-id', 'auth-user-id']);
   });
 
   it('scopes therapist client-detail access to primary therapist row assignment', async () => {
@@ -181,7 +181,45 @@ describe('clients fetchers', () => {
     expect(from).toHaveBeenCalledWith('user_therapist_links');
     expect(from).toHaveBeenCalledWith('client_therapist_links');
     expect(from).toHaveBeenCalledWith('clients');
-    expect(therapistIn).toHaveBeenCalledWith('therapist_id', ['therapist-row-id']);
+    expect(therapistIn).toHaveBeenCalledWith('therapist_id', ['therapist-row-id', 'auth-user-id']);
+  });
+
+  it('retains therapist client-detail access for legacy self-id primary assignments without a link row', async () => {
+    const clientRow = {
+      id: 'client-legacy',
+      full_name: 'Legacy Primary Client',
+      organization_id: 'org-1',
+      therapist_id: 'auth-user-id',
+    } as Client;
+
+    const userLinkEq = vi.fn().mockResolvedValue({ data: [], error: null });
+    const linkClientEq = vi.fn().mockResolvedValue({ data: [], error: null });
+    const maybeSingle = vi.fn().mockResolvedValue({ data: clientRow, error: null });
+    const therapistIn = vi.fn().mockReturnValue({ maybeSingle });
+    const idEq = vi.fn().mockReturnValue({ in: therapistIn });
+    const orgEq = vi.fn().mockReturnValue({ eq: idEq });
+    const clientsSelect = vi.fn().mockReturnValue({ eq: orgEq });
+
+    const from = vi.fn((table: string) => {
+      if (table === 'user_therapist_links') {
+        return { select: vi.fn().mockReturnValue({ eq: userLinkEq }) };
+      }
+      if (table === 'client_therapist_links') {
+        return { select: vi.fn().mockReturnValue({ eq: linkClientEq }) };
+      }
+      return { select: clientsSelect };
+    });
+
+    const result = await fetchClientByIdForViewer({
+      clientId: 'client-legacy',
+      organizationId: 'org-1',
+      viewerRole: 'therapist',
+      userId: 'auth-user-id',
+      client: { from } as any,
+    });
+
+    expect(result).toBe(clientRow);
+    expect(therapistIn).toHaveBeenCalledWith('therapist_id', ['auth-user-id']);
   });
 
   it('returns null for therapist client-detail access when not primary-assigned or linked', async () => {
@@ -215,7 +253,7 @@ describe('clients fetchers', () => {
     });
 
     expect(result).toBeNull();
-    expect(therapistIn).toHaveBeenCalledWith('therapist_id', ['therapist-row-id']);
+    expect(therapistIn).toHaveBeenCalledWith('therapist_id', ['therapist-row-id', 'auth-user-id']);
   });
 
   it('allows therapist client-detail access through client therapist links', async () => {

--- a/src/lib/clients/fetchers.ts
+++ b/src/lib/clients/fetchers.ts
@@ -203,7 +203,7 @@ export const fetchTherapistIdsForUser = async (
     .map((row) => row.therapist_id)
     .filter((id): id is string => typeof id === 'string' && id.length > 0);
 
-  return Array.from(new Set(linkedIds));
+  return Array.from(new Set([...linkedIds, userId]));
 };
 
 export const fetchClients = async (


### PR DESCRIPTION
## Summary
- Restore auth-user self-id as a therapist scope candidate for legacy caseload data without `user_therapist_links`
- Keep client detail access constrained to primary therapist or explicit client-therapist link membership
- Add regression coverage for legacy self-id primary assignments without a link row

## Verification
- `npm test -- src/lib/clients/__tests__/fetchers.test.ts src/pages/__tests__/ClientDetails.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run ci:check-focused`
- `npm run validate:tenant`
- `npm run build`
- `npm run playwright:therapist-authorization`
- `npm run test:routes:tier0`
- `npm run test:ci`

## Notes
- `npm run ci:playwright` not rerun in full locally because it timed out on the prior auth PR; the specific therapist authorization Playwright smoke passed.
- Critical auth/tenant path: keep draft until human review.

Related: WIN-155
