### PR TITLE
WIN-156 Fix IEHP LE/KI partial extraction

### DIFF
--- a/docs/fill_docs/iehp_fba_field_extraction_checklist.json
+++ b/docs/fill_docs/iehp_fba_field_extraction_checklist.json
@@ -256,15 +256,15 @@
       "section": "behavior_background_services",
       "label": "BHT School Hours Matrix",
       "placeholder_key": "IEHP_FBA_BHT_SCHOOL_HOURS_MATRIX",
-      "mode": "MANUAL",
-      "source": "N/A",
+      "mode": "ASSISTED",
+      "source": "uploaded_assessment_document or clinician_manual_entry",
       "required": true,
-      "extraction_method": "clinician_manual_entry",
+      "extraction_method": "deterministic_docx_or_pdf_structured_extract",
       "validation_rule": "structured_payload_required",
       "status": "not_started",
       "extraction_owner": "ClinicalAuthor",
       "review_owner": "BCBAReviewer",
-      "review_notes": "M-F school-session matrix."
+      "review_notes": "Extract from BHT school-hours table when present; otherwise infer reviewable school hours from School Information narrative."
     },
     {
       "section": "behavior_background_services",

--- a/docs/fill_docs/iehp_fba_template_field_map.json
+++ b/docs/fill_docs/iehp_fba_template_field_map.json
@@ -125,9 +125,9 @@
       {
         "label": "BHT School Hours Matrix",
         "placeholder_key": "IEHP_FBA_BHT_SCHOOL_HOURS_MATRIX",
-        "mode": "MANUAL",
-        "source": "N/A",
-        "notes": "M/Tu/W/Th/F + total and session time."
+        "mode": "ASSISTED",
+        "source": "uploaded_assessment_document or clinician_manual_entry",
+        "notes": "M/Tu/W/Th/F + total and session time; infer reviewable rows from School Information narrative when the table is absent."
       },
       {
         "label": "Health and Medical Summary",

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -461,6 +461,40 @@ Deno.test("extractStructuredSections recognizes blank-template IEHP heading alia
   expect((byKey.get("IEHP_FBA_RECOMMENDATIONS_HCPCS_ROWS")?.payload.rows as unknown[]).length).toBe(1);
 });
 
+Deno.test("extractStructuredSections handles LE-style DOCX run-split IEHP headings and school-hours fallback", () => {
+  const sections = asSections(
+    "iehp_fba",
+    `
+      BACKGROUND INFORMATION:
+      Living Situation
+      Member lives with caregivers.
+      School Information
+      Member attends Arlington High School. Her daily schedule runs from 8:30 AM to 3:00 PM,
+      with an early release time of 2:00 PM on Wednesdays.
+      Health and Medica l
+      Member takes prescribed medications and wears corrective glasses.
+      Current Services and Activitie s
+      School-based services only; no community-based therapies are currently reported.
+      Intervention Histor y
+      Prior ABA services ended in 2020 and briefly resumed in 2023.
+      Availability for Behavior Health Treatment Services
+      Monday Tuesday Wednesday Thursday Friday Saturday
+      After 3:30 PM After 3:30 PM After 3:30 PM After 3:30 PM After 3:30 PM Starting 9:00 AM
+      MEMBER’S ENVIRONMENTAL ANALYSIS:
+    `,
+  );
+
+  const byKey = new Map(sections.map((section) => [section.field_key, section]));
+  expect(byKey.get("IEHP_FBA_HEALTH_MEDICAL_SUMMARY")?.payload.raw_text).toContain("prescribed medications");
+  expect(byKey.get("IEHP_FBA_CURRENT_SERVICES_ACTIVITIES")?.payload.raw_text).toContain("School-based services");
+  expect(byKey.get("IEHP_FBA_INTERVENTION_HISTORY")?.payload.raw_text).toContain("briefly resumed in 2023");
+
+  const schoolHours = byKey.get("IEHP_FBA_BHT_SCHOOL_HOURS_MATRIX")?.payload.rows as Array<Record<string, string>>;
+  expect(schoolHours).toHaveLength(5);
+  expect(schoolHours.find((row) => row.day === "Monday")?.end_time).toBe("3:00 PM");
+  expect(schoolHours.find((row) => row.day === "Wednesday")?.end_time).toBe("2:00 PM");
+});
+
 Deno.test("extractStructuredSections maps filled CalOptima redacted-report sections", () => {
   const sections = asSections("caloptima_fba", calOptimaRedactedStyleExcerpt);
   const byKey = new Map(sections.map((section) => [section.field_key, section]));
@@ -583,9 +617,23 @@ Deno.test("deterministicValueForRow keeps manual and assisted IEHP rows honest w
     },
     "Reason for Referral:\nCaregiver requested ABA assessment.\nBEHAVIORS",
   );
+  const assessorPhone = __TESTING__.deterministicValueForRow(
+    {
+      section: "identification_admin",
+      label: "Assessor's phone number",
+      placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+      required: true,
+      mode: "ASSISTED",
+    },
+    "Phone: (951) 224-7934",
+    { parent1_phone: "(951) 224-7934" },
+  );
 
   expect(assisted.mode).toBe("ASSISTED");
   expect(assisted.confidence ?? 1).toBeLessThan(0.8);
   expect(manual.mode).toBe("MANUAL");
   expect(manual.confidence ?? 1).toBeLessThan(0.6);
+  expect(assessorPhone.value_text).toBeNull();
+  expect(assessorPhone.status).toBe("not_started");
+  expect(assessorPhone.review_notes).toContain("reliable provider or organization source");
 });

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -396,6 +396,16 @@ const extractIeHpLabelSummary = (text: string, start: RegExp, end: RegExp[]): st
   return normalizeExtractedValue(sectionText);
 };
 
+const IEHP_HEALTH_AND_MEDICAL_HEADING = /\bHealth\s+and\s+Medica\s*l\b/i;
+const IEHP_CURRENT_SERVICES_HEADING = /\bCurrent\s+Services\s+and\s+Activitie\s*s\b/i;
+const IEHP_INTERVENTION_HISTORY_HEADING = /\bIntervention\s+Histor\s*y\b/i;
+const IEHP_BHT_SCHOOL_HOURS_HEADING = /\bBHT\s*\(?School\s+Hours\)?\b/i;
+const IEHP_SCHOOL_HOURS_TABLE_HEADING = /\bSchool\s+Hours\s+M\s+Tu\s+W\s+Th\s+F\b/i;
+const IEHP_BHT_AVAILABILITY_HEADING = /\bBHT\s+Availability\b/i;
+const IEHP_BHT_SERVICES_AVAILABILITY_HEADING = /\bAvailability\s+for\s+BHT\s+Services\b/i;
+const IEHP_BEHAVIOR_HEALTH_TREATMENT_AVAILABILITY_HEADING =
+  /\bAvailability\s+for\s+Behavior\s+Health\s+Treatment\s+Services\b/i;
+
 const extractIeHpSection = (
   text: string,
   startAnchors: RegExp[],
@@ -541,6 +551,35 @@ const parseIeHpRecommendations = (rawText: string): Array<Record<string, string>
   return rows;
 };
 
+const parseIeHpSchoolHoursRows = (rawText: string): Array<Record<string, string | null>> => {
+  const compact = compactDocumentText(rawText);
+  const schoolDays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
+  const timeRange = compact.match(/\b(?:runs?\s+)?from\s+(\d{1,2}:\d{2}\s*(?:AM|PM))\s+to\s+(\d{1,2}:\d{2}\s*(?:AM|PM))\b/i);
+  const earlyRelease = compact.match(/\bearly\s+release(?:\s+time)?\s+of\s+(\d{1,2}:\d{2}\s*(?:AM|PM))\s+on\s+Wednesdays?\b/i);
+  if (timeRange?.[1] && timeRange?.[2]) {
+    return schoolDays.map((day) => ({
+      day,
+      start_time: normalizeExtractedValue(timeRange[1] ?? ""),
+      end_time: day === "Wednesday" && earlyRelease?.[1]
+        ? normalizeExtractedValue(earlyRelease[1])
+        : normalizeExtractedValue(timeRange[2] ?? ""),
+      source: "school_information_narrative",
+    }));
+  }
+
+  const compactDays = ["M", "Tu", "W", "Th", "F"];
+  const timeMatches = [...compact.matchAll(/\b\d{1,2}:\d{2}\s*(?:AM|PM)\b/gi)].map((match) => normalizeExtractedValue(match[0]));
+  if (timeMatches.length >= 5 && /\bM\s+Tu\s+W\s+Th\s+F\b/i.test(compact)) {
+    return compactDays.map((day, index) => ({
+      day,
+      time: timeMatches[index] ?? null,
+      source: "school_hours_table",
+    }));
+  }
+
+  return [];
+};
+
 const normalizeIeHpSectionPayload = (fieldKey: string, rawText: string): Record<string, unknown> => {
   const compact = compactDocumentText(rawText);
   if (fieldKey === "IEHP_FBA_BEHAVIOR_SKILL_TARGETS") {
@@ -556,6 +595,9 @@ const normalizeIeHpSectionPayload = (fieldKey: string, rawText: string): Record<
       raw_text: compact,
       rows: seenDays.map((day, index) => ({ day, availability: timeMatches[index] ?? null })),
     };
+  }
+  if (fieldKey === "IEHP_FBA_BHT_SCHOOL_HOURS_MATRIX") {
+    return { raw_text: compact, rows: parseIeHpSchoolHoursRows(compact) };
   }
   if (fieldKey === "IEHP_FBA_ENVIRONMENTAL_ANALYSIS") {
     const environmentalPrompts = [
@@ -757,36 +799,44 @@ const extractIeHpGoalSections = (text: string): StructuredSectionResult[] => {
       field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
       section_key: "behavior_background_services",
       start: [/\bSchool Information\b/i],
-      end: [/BHT\s*\(?School Hours\)?/i, /\bHealth and Medical\b/i],
+      end: [IEHP_BHT_SCHOOL_HOURS_HEADING, IEHP_HEALTH_AND_MEDICAL_HEADING],
     },
     {
       field_key: "IEHP_FBA_BHT_SCHOOL_HOURS_MATRIX",
       section_key: "behavior_background_services",
-      start: [/BHT\s*\(?School Hours\)?/i, /School\s+Hours\s+M\s+Tu\s+W\s+Th\s+F/i],
-      end: [/\bHealth and Medical\b/i],
+      start: [IEHP_BHT_SCHOOL_HOURS_HEADING, IEHP_SCHOOL_HOURS_TABLE_HEADING],
+      end: [IEHP_HEALTH_AND_MEDICAL_HEADING],
     },
     {
       field_key: "IEHP_FBA_HEALTH_MEDICAL_SUMMARY",
       section_key: "behavior_background_services",
-      start: [/\bHealth and Medical\b/i],
-      end: [/\bCurrent Services and Activities\b/i],
+      start: [IEHP_HEALTH_AND_MEDICAL_HEADING],
+      end: [IEHP_CURRENT_SERVICES_HEADING],
     },
     {
       field_key: "IEHP_FBA_CURRENT_SERVICES_ACTIVITIES",
       section_key: "behavior_background_services",
-      start: [/\bCurrent Services and Activities\b/i],
-      end: [/\bIntervention History\b/i],
+      start: [IEHP_CURRENT_SERVICES_HEADING],
+      end: [IEHP_INTERVENTION_HISTORY_HEADING],
     },
     {
       field_key: "IEHP_FBA_INTERVENTION_HISTORY",
       section_key: "behavior_background_services",
-      start: [/\bIntervention History\b/i],
-      end: [/\bBHT Availability\b/i, /\bAvailability for BHT Services\b/i, /\bAvailability for Behavior Health Treatment Services\b/i],
+      start: [IEHP_INTERVENTION_HISTORY_HEADING],
+      end: [
+        IEHP_BHT_AVAILABILITY_HEADING,
+        IEHP_BHT_SERVICES_AVAILABILITY_HEADING,
+        IEHP_BEHAVIOR_HEALTH_TREATMENT_AVAILABILITY_HEADING,
+      ],
     },
     {
       field_key: "IEHP_FBA_BHT_AVAILABILITY_GRID",
       section_key: "behavior_background_services",
-      start: [/\bBHT Availability\b/i, /\bAvailability for BHT Services\b/i, /\bAvailability for Behavior Health Treatment Services\b/i],
+      start: [
+        IEHP_BHT_AVAILABILITY_HEADING,
+        IEHP_BHT_SERVICES_AVAILABILITY_HEADING,
+        IEHP_BEHAVIOR_HEALTH_TREATMENT_AVAILABILITY_HEADING,
+      ],
       end: [/MEMBER’S ENVIRONMENTAL ANALYSIS/i],
     },
     {
@@ -865,6 +915,28 @@ const extractIeHpGoalSections = (text: string): StructuredSectionResult[] => {
       return { ...section, section_index };
     });
   });
+  const hasSchoolHoursSection = sections.some((section) => section.field_key === "IEHP_FBA_BHT_SCHOOL_HOURS_MATRIX");
+  const schoolInformationSection = sections.find((section) => section.field_key === "IEHP_FBA_SCHOOL_INFORMATION_BLOCK");
+  const schoolInformationText =
+    typeof schoolInformationSection?.payload.raw_text === "string" ? schoolInformationSection.payload.raw_text : "";
+  const schoolHoursRows = hasSchoolHoursSection ? [] : parseIeHpSchoolHoursRows(schoolInformationText);
+  if (schoolHoursRows.length > 0) {
+    const section_index = sectionIndexByFieldKey.get("IEHP_FBA_BHT_SCHOOL_HOURS_MATRIX") ?? 0;
+    sectionIndexByFieldKey.set("IEHP_FBA_BHT_SCHOOL_HOURS_MATRIX", section_index + 1);
+    sections.push({
+      section_key: "behavior_background_services",
+      field_key: "IEHP_FBA_BHT_SCHOOL_HOURS_MATRIX",
+      section_index,
+      payload: {
+        raw_text: schoolInformationText,
+        rows: schoolHoursRows,
+      },
+      source_span: { method: "iehp_school_information_hours_fallback" },
+      status: "drafted",
+      required: true,
+      review_notes: "Deterministic IEHP school-hours fallback extracted from School Information narrative.",
+    });
+  }
   sections.push(...extractIeHpProgramGoalSections(text, sectionIndexByFieldKey));
 
   const legacyTreatmentGoalSpan = extractIeHpSection(
@@ -1256,6 +1328,18 @@ const deterministicValueForRow = (
         review_notes: "Auto-filled from guardian snapshot.",
       };
     }
+  }
+  if (/ASSESSOR_PHONE/u.test(key)) {
+    return {
+      placeholder_key: key,
+      value_text: null,
+      value_json: null,
+      confidence: null,
+      mode: row.mode ?? "ASSISTED",
+      status: "not_started",
+      source_span: null,
+      review_notes: "Assessor phone requires a reliable provider or organization source.",
+    };
   }
   if (/CONTACT_PHONE|PHONE/u.test(key) && (client.parent1_phone || client.phone)) {
     return {


### PR DESCRIPTION
## Summary
- Fix IEHP LE/KI DOCX partial extraction by tolerating Word run-split headings for Health/Medical, Current Services/Activities, and Intervention History.
- Infer reviewable BHT school-hours rows from School Information narrative when the explicit school-hours table is absent.
- Prevent assessor phone from being populated from guardian/client phone without a reliable provider/org source.
- Add focused Edge Function regression coverage and align IEHP mapping docs for school-hours assisted extraction.

Linear: WIN-156

## Verification
- `deno test --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts`
- local actual LE/KI DOCX extraction simulation: BHT school hours, health/medical, current services, and intervention history extracted; 31/34 resolved with assessor phone/referring provider/reason for referral intentionally manual or assisted
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`
- `npm test -- src/server/__tests__/assessmentTemplateLayout.test.ts`
- `npm run verify:local`

## Deployment note
Direct `supabase functions deploy extract-assessment-fields --project-ref wnnjeqheqxxyrgsjmygy --use-api` is blocked locally because `SUPABASE_ACCESS_TOKEN` is present but not a valid `sbp_` personal access token. The existing CI edge deploy bundle includes `extract-assessment-fields`.

## Risk
Critical protected path: `supabase/functions/extract-assessment-fields/index.ts`. Existing IEHP and CalOptima behavior should be preserved; this change only broadens IEHP heading matching, adds school-hours fallback, and avoids an unsafe assessor-phone prefill.