### PR TITLE
feat(ui): staff messaging inbox (Slice 3)

### DIFF
--- a/src/components/messages/MessageBubble.tsx
+++ b/src/components/messages/MessageBubble.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { format } from 'date-fns';
+import type { StaffMessage } from '../../lib/messages/types';
+
+interface MessageBubbleProps {
+  message: StaffMessage;
+  isOwnMessage: boolean;
+  senderLabel: string;
+}
+
+export function MessageBubble({ message, isOwnMessage, senderLabel }: MessageBubbleProps) {
+  return (
+    <div className={`flex ${isOwnMessage ? 'justify-end' : 'justify-start'}`}>
+      <div
+        className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
+          isOwnMessage
+            ? 'bg-blue-600 text-white'
+            : 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+        }`}
+      >
+        {!isOwnMessage ? (
+          <p className="mb-1 text-xs font-medium opacity-80">{senderLabel}</p>
+        ) : null}
+        <p className="whitespace-pre-wrap break-words">{message.body}</p>
+        <p className={`mt-1 text-xs ${isOwnMessage ? 'text-blue-100' : 'text-gray-500'}`}>
+          {format(new Date(message.createdAt), 'MMM d, h:mm a')}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/messages/MessageComposer.tsx
+++ b/src/components/messages/MessageComposer.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { Send } from 'lucide-react';
+import { MESSAGE_BODY_MAX_LENGTH, PHI_POLICY_COMPOSER_HINT } from '../../lib/messages/constants';
+
+interface MessageComposerProps {
+  onSend: (body: string) => Promise<void>;
+  isSending?: boolean;
+  disabled?: boolean;
+}
+
+export function MessageComposer({ onSend, isSending = false, disabled = false }: MessageComposerProps) {
+  const [body, setBody] = useState('');
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!body.trim() || isSending || disabled) {
+      return;
+    }
+    await onSend(body);
+    setBody('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 border-t border-gray-200 pt-4 dark:border-gray-700">
+      <p className="text-xs text-gray-500 dark:text-gray-400">{PHI_POLICY_COMPOSER_HINT}</p>
+      <textarea
+        value={body}
+        onChange={(event) => setBody(event.target.value)}
+        maxLength={MESSAGE_BODY_MAX_LENGTH}
+        rows={3}
+        disabled={disabled || isSending}
+        placeholder="Write a staff-only message"
+        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-dark-lighter"
+        aria-label="Message body"
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-gray-400">
+          {body.length}/{MESSAGE_BODY_MAX_LENGTH}
+        </span>
+        <button
+          type="submit"
+          disabled={disabled || isSending || !body.trim()}
+          className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Send className="h-4 w-4" aria-hidden="true" />
+          {isSending ? 'Sending…' : 'Send'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/messages/MessageList.tsx
+++ b/src/components/messages/MessageList.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useRef } from 'react';
+import type { StaffMessage, ThreadParticipantProfile } from '../../lib/messages/types';
+import { MessageBubble } from './MessageBubble';
+import { MessagesEmptyState } from './MessagesEmptyState';
+
+interface MessageListProps {
+  messages: StaffMessage[];
+  participants: ThreadParticipantProfile[];
+  currentUserId: string;
+}
+
+export function MessageList({ messages, participants, currentUserId }: MessageListProps) {
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView?.({ behavior: 'smooth' });
+  }, [messages.length]);
+
+  const labelByUserId = new Map(
+    participants.map((participant) => [participant.userId, participant.fullName]),
+  );
+
+  if (messages.length === 0) {
+    return <MessagesEmptyState title="No messages yet" description="Send the first message below." />;
+  }
+
+  return (
+    <div className="flex max-h-[28rem] flex-col gap-3 overflow-y-auto pr-1">
+      {messages.map((message) => (
+        <MessageBubble
+          key={message.id}
+          message={message}
+          isOwnMessage={message.senderId === currentUserId}
+          senderLabel={labelByUserId.get(message.senderId) ?? 'Staff member'}
+        />
+      ))}
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/src/components/messages/MessagesEmptyState.tsx
+++ b/src/components/messages/MessagesEmptyState.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { MessageSquare } from 'lucide-react';
+
+interface MessagesEmptyStateProps {
+  title: string;
+  description?: string;
+}
+
+export function MessagesEmptyState({ title, description }: MessagesEmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 px-6 py-12 text-center dark:border-gray-600">
+      <MessageSquare className="mb-3 h-10 w-10 text-gray-400" aria-hidden="true" />
+      <h3 className="text-base font-medium text-gray-900 dark:text-gray-100">{title}</h3>
+      {description ? (
+        <p className="mt-2 max-w-md text-sm text-gray-500 dark:text-gray-400">{description}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/messages/StaffMessagingPolicyBanner.tsx
+++ b/src/components/messages/StaffMessagingPolicyBanner.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { PHI_POLICY_BANNER } from '../../lib/messages/constants';
+
+export function StaffMessagingPolicyBanner() {
+  return (
+    <div
+      role="note"
+      className="mb-4 flex gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100"
+    >
+      <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" aria-hidden="true" />
+      <p>{PHI_POLICY_BANNER}</p>
+    </div>
+  );
+}

--- a/src/components/messages/StaffRecipientPicker.tsx
+++ b/src/components/messages/StaffRecipientPicker.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import type { MessageThreadType } from '../../lib/messages/types';
+import type { StaffMember } from '../../lib/messages/types';
+
+interface StaffRecipientPickerProps {
+  threadType: MessageThreadType;
+  staff: StaffMember[];
+  selectedIds: string[];
+  currentUserId: string;
+  onChange: (ids: string[]) => void;
+  isLoading?: boolean;
+}
+
+export function StaffRecipientPicker({
+  threadType,
+  staff,
+  selectedIds,
+  currentUserId,
+  onChange,
+  isLoading = false,
+}: StaffRecipientPickerProps) {
+  const selectableStaff = staff.filter((member) => member.id !== currentUserId);
+
+  const toggleRecipient = (userId: string) => {
+    if (threadType === 'direct') {
+      onChange(selectedIds.includes(userId) ? [] : [userId]);
+      return;
+    }
+    if (selectedIds.includes(userId)) {
+      onChange(selectedIds.filter((id) => id !== userId));
+      return;
+    }
+    onChange([...selectedIds, userId]);
+  };
+
+  if (isLoading) {
+    return <p className="text-sm text-gray-500">Loading staff…</p>;
+  }
+
+  if (selectableStaff.length === 0) {
+    return <p className="text-sm text-gray-500">No active staff recipients found in your organization.</p>;
+  }
+
+  return (
+    <div className="space-y-2" role="list" aria-label="Staff recipients">
+      {selectableStaff.map((member) => {
+        const inputType = threadType === 'direct' ? 'radio' : 'checkbox';
+        const isChecked = selectedIds.includes(member.id);
+        return (
+          <label
+            key={member.id}
+            className="flex cursor-pointer items-center gap-3 rounded-lg border border-gray-200 px-3 py-2 dark:border-gray-700"
+          >
+            <input
+              type={inputType}
+              name="staff-recipient"
+              checked={isChecked}
+              onChange={() => toggleRecipient(member.id)}
+            />
+            <span>
+              <span className="block text-sm font-medium text-gray-900 dark:text-gray-100">
+                {member.fullName}
+              </span>
+              <span className="block text-xs text-gray-500">{member.email}</span>
+            </span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/messages/ThreadList.tsx
+++ b/src/components/messages/ThreadList.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import type { ThreadListItem } from '../../lib/messages/types';
+import { ThreadRow } from './ThreadRow';
+import { MessagesEmptyState } from './MessagesEmptyState';
+
+interface ThreadListProps {
+  threads: ThreadListItem[];
+  activeThreadId?: string;
+  searchQuery: string;
+  onSearchQueryChange: (value: string) => void;
+  onSelectThread: (threadId: string) => void;
+}
+
+export function ThreadList({
+  threads,
+  activeThreadId,
+  searchQuery,
+  onSearchQueryChange,
+  onSelectThread,
+}: ThreadListProps) {
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const filtered = normalizedQuery
+    ? threads.filter((thread) => {
+        const subject = thread.subject?.toLowerCase() ?? '';
+        const preview = thread.latestMessageBody?.toLowerCase() ?? '';
+        return subject.includes(normalizedQuery) || preview.includes(normalizedQuery);
+      })
+    : threads;
+
+  return (
+    <div className="space-y-4">
+      <input
+        type="search"
+        value={searchQuery}
+        onChange={(event) => onSearchQueryChange(event.target.value)}
+        placeholder="Search conversations"
+        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-dark-lighter"
+        aria-label="Search conversations"
+      />
+      {filtered.length === 0 ? (
+        <MessagesEmptyState
+          title={threads.length === 0 ? 'No conversations yet' : 'No matching conversations'}
+          description={
+            threads.length === 0
+              ? 'Start a new message to coordinate with staff in your organization.'
+              : 'Try a different search term.'
+          }
+        />
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((thread) => (
+            <ThreadRow
+              key={thread.threadId}
+              thread={thread}
+              isActive={thread.threadId === activeThreadId}
+              onSelect={onSelectThread}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/messages/ThreadRow.tsx
+++ b/src/components/messages/ThreadRow.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import type { ThreadListItem } from '../../lib/messages/types';
+
+interface ThreadRowProps {
+  thread: ThreadListItem;
+  isActive?: boolean;
+  onSelect: (threadId: string) => void;
+}
+
+export function ThreadRow({ thread, isActive = false, onSelect }: ThreadRowProps) {
+  const label = thread.subject?.trim() || (thread.threadType === 'group' ? 'Group conversation' : 'Direct message');
+  const preview = thread.latestMessageBody?.trim() || 'No messages yet';
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(thread.threadId)}
+      className={`w-full rounded-lg border px-4 py-3 text-left transition ${
+        isActive
+          ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30'
+          : 'border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-dark-lighter dark:hover:border-gray-600'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-medium text-gray-900 dark:text-gray-100">{label}</p>
+          <p className="mt-1 truncate text-sm text-gray-500 dark:text-gray-400">{preview}</p>
+        </div>
+        <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+          {formatDistanceToNow(new Date(thread.updatedAt), { addSuffix: true })}
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/src/components/messages/__tests__/MessageComposer.test.tsx
+++ b/src/components/messages/__tests__/MessageComposer.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MessageComposer } from '../MessageComposer';
+import { PHI_POLICY_COMPOSER_HINT } from '../../../lib/messages/constants';
+
+describe('MessageComposer', () => {
+  it('renders PHI composer hint and sends trimmed body', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn().mockResolvedValue(undefined);
+
+    render(<MessageComposer onSend={onSend} />);
+
+    expect(screen.getByText(PHI_POLICY_COMPOSER_HINT)).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/message body/i), '  Hello team  ');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    expect(onSend).toHaveBeenCalledWith('  Hello team  ');
+  });
+});

--- a/src/components/messages/__tests__/StaffMessagingPolicyBanner.test.tsx
+++ b/src/components/messages/__tests__/StaffMessagingPolicyBanner.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StaffMessagingPolicyBanner } from '../StaffMessagingPolicyBanner';
+import { PHI_POLICY_BANNER } from '../../../lib/messages/constants';
+
+describe('StaffMessagingPolicyBanner', () => {
+  it('renders PHI policy copy', () => {
+    render(<StaffMessagingPolicyBanner />);
+    expect(screen.getByText(PHI_POLICY_BANNER)).toBeInTheDocument();
+  });
+});

--- a/src/components/messages/__tests__/StaffRecipientPicker.test.tsx
+++ b/src/components/messages/__tests__/StaffRecipientPicker.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StaffRecipientPicker } from '../StaffRecipientPicker';
+
+const staff = [
+  { id: 'user-self', fullName: 'Self', email: 'self@example.com' },
+  { id: 'user-other', fullName: 'Other Staff', email: 'other@example.com' },
+];
+
+describe('StaffRecipientPicker', () => {
+  it('uses radio selection for direct threads', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <StaffRecipientPicker
+        threadType="direct"
+        staff={staff}
+        selectedIds={[]}
+        currentUserId="user-self"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText(/Other Staff/i));
+    expect(onChange).toHaveBeenCalledWith(['user-other']);
+  });
+
+  it('uses checkbox selection for group threads', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <StaffRecipientPicker
+        threadType="group"
+        staff={staff}
+        selectedIds={[]}
+        currentUserId="user-self"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText(/Other Staff/i));
+    expect(onChange).toHaveBeenCalledWith(['user-other']);
+  });
+});

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -2332,6 +2332,121 @@ export type Database = {
         }
         Relationships: []
       }
+      message_thread_participants: {
+        Row: {
+          archived_at: string | null
+          joined_at: string
+          last_read_at: string | null
+          muted_at: string | null
+          organization_id: string
+          thread_id: string
+          user_id: string
+        }
+        Insert: {
+          archived_at?: string | null
+          joined_at?: string
+          last_read_at?: string | null
+          muted_at?: string | null
+          organization_id: string
+          thread_id: string
+          user_id: string
+        }
+        Update: {
+          archived_at?: string | null
+          joined_at?: string
+          last_read_at?: string | null
+          muted_at?: string | null
+          organization_id?: string
+          thread_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "message_thread_participants_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "message_thread_participants_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: false
+            referencedRelation: "message_threads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      message_threads: {
+        Row: {
+          created_at: string
+          created_by: string
+          id: string
+          organization_id: string
+          subject: string | null
+          thread_type: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          id?: string
+          organization_id: string
+          subject?: string | null
+          thread_type: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          id?: string
+          organization_id?: string
+          subject?: string | null
+          thread_type?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "message_threads_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      messages: {
+        Row: {
+          body: string
+          created_at: string
+          id: string
+          sender_id: string
+          thread_id: string
+        }
+        Insert: {
+          body: string
+          created_at?: string
+          id?: string
+          sender_id: string
+          thread_id: string
+        }
+        Update: {
+          body?: string
+          created_at?: string
+          id?: string
+          sender_id?: string
+          thread_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "messages_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: false
+            referencedRelation: "message_threads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       conversations: {
         Row: {
           created_at: string | null
@@ -5916,6 +6031,14 @@ export type Database = {
       assign_admin_role: {
         Args: { organization_id: string; reason?: string; user_email: string }
         Returns: undefined
+      }
+      create_staff_message_thread: {
+        Args: {
+          p_participant_user_ids: string[]
+          p_subject?: string
+          p_thread_type: string
+        }
+        Returns: string
       }
       assign_therapist_role:
         | { Args: { p_email: string; p_user_id: string }; Returns: undefined }

--- a/src/lib/messages/__tests__/fetchers.test.ts
+++ b/src/lib/messages/__tests__/fetchers.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { listEligibleStaff, listInboxThreads } from '../fetchers';
+
+const {
+  fromMock,
+  participantsSelectMock,
+  participantsEqMock,
+  participantsIsMock,
+  messagesSelectMock,
+  messagesInMock,
+  messagesOrderMock,
+  profilesSelectMock,
+  profilesEqMock,
+  profilesSecondEqMock,
+  rolesSelectMock,
+  rolesInMock,
+} = vi.hoisted(() => {
+  const participantsIsMock = vi.fn();
+  const participantsEqMock = vi.fn();
+  const participantsSelectMock = vi.fn();
+  const messagesOrderMock = vi.fn();
+  const messagesInMock = vi.fn();
+  const messagesSelectMock = vi.fn();
+  const profilesEqMock = vi.fn();
+  const profilesSecondEqMock = vi.fn();
+  const profilesSelectMock = vi.fn();
+  const rolesInMock = vi.fn();
+  const rolesSelectMock = vi.fn();
+
+  participantsEqMock.mockReturnValue({ is: participantsIsMock });
+  participantsSelectMock.mockReturnValue({ eq: participantsEqMock });
+  messagesInMock.mockReturnValue({ order: messagesOrderMock });
+  messagesSelectMock.mockReturnValue({ in: messagesInMock });
+  profilesEqMock.mockReturnValue({ eq: profilesSecondEqMock });
+  profilesSelectMock.mockReturnValue({ eq: profilesEqMock });
+  rolesSelectMock.mockReturnValue({ in: rolesInMock });
+
+  const fromMock = vi.fn((table: string) => {
+    if (table === 'message_thread_participants') {
+      return { select: participantsSelectMock };
+    }
+    if (table === 'messages') {
+      return { select: messagesSelectMock };
+    }
+    if (table === 'profiles') {
+      return { select: profilesSelectMock };
+    }
+    if (table === 'user_roles') {
+      return { select: rolesSelectMock };
+    }
+    throw new Error(`Unexpected table ${table}`);
+  });
+
+  return {
+    fromMock,
+    participantsSelectMock,
+    participantsEqMock,
+    participantsIsMock,
+    messagesSelectMock,
+    messagesInMock,
+    messagesOrderMock,
+    profilesSelectMock,
+    profilesEqMock,
+    profilesSecondEqMock,
+    rolesSelectMock,
+    rolesInMock,
+  };
+});
+
+vi.mock('../../supabase', () => ({
+  supabase: { from: fromMock },
+}));
+
+describe('staff messaging fetchers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    participantsIsMock.mockResolvedValue({
+      data: [
+        {
+          thread_id: 'thread-1',
+          last_read_at: null,
+          thread: {
+            id: 'thread-1',
+            subject: 'Ops sync',
+            thread_type: 'direct',
+            updated_at: '2026-05-20T12:00:00.000Z',
+          },
+        },
+      ],
+      error: null,
+    });
+    messagesOrderMock.mockResolvedValue({
+      data: [
+        {
+          id: 'msg-1',
+          thread_id: 'thread-1',
+          body: 'Synthetic update',
+          created_at: '2026-05-20T12:01:00.000Z',
+          sender_id: 'user-a',
+        },
+      ],
+      error: null,
+    });
+    profilesSecondEqMock.mockResolvedValue({
+      data: [
+        {
+          id: 'user-a',
+          full_name: 'Staff A',
+          email: 'staff-a@example.com',
+          organization_id: 'org-1',
+          is_active: true,
+        },
+      ],
+      error: null,
+    });
+    rolesInMock.mockResolvedValue({
+      data: [
+        {
+          user_id: 'user-a',
+          is_active: true,
+          expires_at: null,
+          roles: { name: 'therapist' },
+        },
+      ],
+      error: null,
+    });
+  });
+
+  it('maps inbox participant rows into thread list items', async () => {
+    const items = await listInboxThreads('user-a');
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      threadId: 'thread-1',
+      subject: 'Ops sync',
+      threadType: 'direct',
+      latestMessageBody: 'Synthetic update',
+    });
+    expect(participantsEqMock).toHaveBeenCalledWith('user_id', 'user-a');
+    expect(participantsIsMock).toHaveBeenCalledWith('archived_at', null);
+  });
+
+  it('filters eligible staff by active junction roles in org', async () => {
+    const staff = await listEligibleStaff('org-1');
+
+    expect(staff).toEqual([
+      {
+        id: 'user-a',
+        fullName: 'Staff A',
+        email: 'staff-a@example.com',
+      },
+    ]);
+    expect(profilesEqMock).toHaveBeenCalled();
+  });
+});

--- a/src/lib/messages/__tests__/hooks.test.ts
+++ b/src/lib/messages/__tests__/hooks.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { buildParticipantIdsForCreate, canCreateGroupThread } from '../hooks';
+
+describe('staff messaging hooks helpers', () => {
+  it('allows group thread creation for admins only', () => {
+    expect(canCreateGroupThread('admin')).toBe(true);
+    expect(canCreateGroupThread('super_admin')).toBe(true);
+    expect(canCreateGroupThread('therapist')).toBe(false);
+  });
+
+  it('builds participant ids including creator for direct threads', () => {
+    const ids = buildParticipantIdsForCreate('creator-id', ['other-id'], 'direct');
+    expect(ids).toEqual(expect.arrayContaining(['creator-id', 'other-id']));
+    expect(ids).toHaveLength(2);
+  });
+
+  it('rejects direct threads without exactly one other participant', () => {
+    expect(() => buildParticipantIdsForCreate('creator-id', [], 'direct')).toThrow(/exactly one other/i);
+  });
+});

--- a/src/lib/messages/__tests__/mutations.test.ts
+++ b/src/lib/messages/__tests__/mutations.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createThread, markThreadRead, sendMessage } from '../mutations';
+
+const { rpcMock, fromMock, insertMock, updateMock, eqMock, participantsTableMock } = vi.hoisted(() => {
+  const insertMock = vi.fn();
+  const updateMock = vi.fn();
+  const eqMock = vi.fn();
+  const rpcMock = vi.fn();
+  const participantsTableMock = {
+    update: updateMock.mockReturnValue({ eq: eqMock }),
+  };
+  const fromMock = vi.fn((table: string) => {
+    if (table === 'messages') {
+      return { insert: insertMock };
+    }
+    if (table === 'message_thread_participants') {
+      return participantsTableMock;
+    }
+    throw new Error(`Unexpected table ${table}`);
+  });
+  return { rpcMock, fromMock, insertMock, updateMock, eqMock, participantsTableMock };
+});
+
+vi.mock('../../supabase', () => ({
+  supabase: {
+    rpc: rpcMock,
+    from: fromMock,
+  },
+}));
+
+describe('staff messaging mutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eqMock.mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    insertMock.mockResolvedValue({ error: null });
+    rpcMock.mockResolvedValue({ data: 'thread-uuid-1', error: null });
+  });
+
+  it('calls create_staff_message_thread RPC for direct threads', async () => {
+    const threadId = await createThread({
+      subject: 'Coordination',
+      threadType: 'direct',
+      participantUserIds: ['user-a', 'user-b'],
+    });
+
+    expect(threadId).toBe('thread-uuid-1');
+    expect(rpcMock).toHaveBeenCalledWith('create_staff_message_thread', {
+      p_subject: 'Coordination',
+      p_thread_type: 'direct',
+      p_participant_user_ids: ['user-a', 'user-b'],
+    });
+  });
+
+  it('inserts messages with trimmed body', async () => {
+    await sendMessage({
+      threadId: 'thread-1',
+      senderId: 'user-a',
+      body: '  Synthetic staff note  ',
+    });
+
+    expect(insertMock).toHaveBeenCalledWith({
+      thread_id: 'thread-1',
+      sender_id: 'user-a',
+      body: 'Synthetic staff note',
+    });
+  });
+
+  it('rejects empty message bodies', async () => {
+    await expect(
+      sendMessage({
+        threadId: 'thread-1',
+        senderId: 'user-a',
+        body: '   ',
+      }),
+    ).rejects.toThrow(/empty/i);
+  });
+
+  it('updates participant last_read_at for markThreadRead', async () => {
+    await markThreadRead('thread-1', 'user-a');
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        last_read_at: expect.any(String),
+      }),
+    );
+    expect(eqMock).toHaveBeenCalledWith('thread_id', 'thread-1');
+  });
+});

--- a/src/lib/messages/constants.ts
+++ b/src/lib/messages/constants.ts
@@ -1,0 +1,24 @@
+export const MESSAGE_BODY_MAX_LENGTH = 8000;
+
+export const PHI_POLICY_BANNER =
+  'Staff messaging must not include PHI, client names, clinical details, or other client-sensitive content.';
+
+export const PHI_POLICY_COMPOSER_HINT =
+  'Do not include client names, clinical details, or identifiers in messages.';
+
+export const STAFF_MESSAGING_REFETCH_MS = 30_000;
+
+export const STAFF_ROLE_NAMES = [
+  'therapist',
+  'org_member',
+  'admin',
+  'org_admin',
+  'super_admin',
+  'org_super_admin',
+] as const;
+
+export const MESSAGES_ROUTES = {
+  inbox: '/messages',
+  new: '/messages/new',
+  thread: (threadId: string) => `/messages/${threadId}`,
+} as const;

--- a/src/lib/messages/fetchers.ts
+++ b/src/lib/messages/fetchers.ts
@@ -1,0 +1,236 @@
+import { supabase } from '../supabase';
+import { STAFF_ROLE_NAMES } from './constants';
+import type {
+  MessageThreadType,
+  StaffMember,
+  StaffMessage,
+  ThreadDetail,
+  ThreadListItem,
+  ThreadParticipantProfile,
+} from './types';
+
+const isStaffRoleName = (name: string): boolean =>
+  (STAFF_ROLE_NAMES as readonly string[]).includes(name);
+
+const roleRowIsActive = (isActive: boolean | null, expiresAt: string | null): boolean => {
+  if (isActive === false) {
+    return false;
+  }
+  if (!expiresAt) {
+    return true;
+  }
+  const parsed = new Date(expiresAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return true;
+  }
+  return parsed.getTime() > Date.now();
+};
+
+const toThreadType = (value: string): MessageThreadType =>
+  value === 'group' ? 'group' : 'direct';
+
+type InboxParticipantRow = {
+  thread_id: string;
+  last_read_at: string | null;
+  thread: {
+    id: string;
+    subject: string | null;
+    thread_type: string;
+    updated_at: string;
+  } | null;
+};
+
+export async function listInboxThreads(userId: string): Promise<ThreadListItem[]> {
+  const { data, error } = await supabase
+    .from('message_thread_participants')
+    .select(
+      `
+      thread_id,
+      last_read_at,
+      thread:message_threads (
+        id,
+        subject,
+        thread_type,
+        updated_at
+      )
+    `,
+    )
+    .eq('user_id', userId)
+    .is('archived_at', null);
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = (data ?? []) as InboxParticipantRow[];
+  const threadIds = rows
+    .map((row) => row.thread?.id ?? row.thread_id)
+    .filter((id): id is string => Boolean(id));
+
+  const latestByThread = new Map<
+    string,
+    { body: string; created_at: string; sender_id: string }
+  >();
+
+  if (threadIds.length > 0) {
+    const { data: messageRows, error: messagesError } = await supabase
+      .from('messages')
+      .select('id, thread_id, body, created_at, sender_id')
+      .in('thread_id', threadIds)
+      .order('created_at', { ascending: false });
+
+    if (messagesError) {
+      throw messagesError;
+    }
+
+    for (const message of messageRows ?? []) {
+      if (!latestByThread.has(message.thread_id)) {
+        latestByThread.set(message.thread_id, message);
+      }
+    }
+  }
+
+  const items: ThreadListItem[] = [];
+
+  for (const row of rows) {
+    const thread = row.thread;
+    if (!thread) {
+      continue;
+    }
+    const latest = latestByThread.get(thread.id);
+    items.push({
+      threadId: thread.id,
+      subject: thread.subject,
+      threadType: toThreadType(thread.thread_type),
+      updatedAt: thread.updated_at,
+      lastReadAt: row.last_read_at,
+      latestMessageBody: latest?.body ?? null,
+      latestMessageAt: latest?.created_at ?? null,
+      latestMessageSenderId: latest?.sender_id ?? null,
+    });
+  }
+
+  items.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+  return items;
+}
+
+export async function getThreadDetail(threadId: string): Promise<ThreadDetail | null> {
+  const { data: thread, error: threadError } = await supabase
+    .from('message_threads')
+    .select('id, subject, thread_type, updated_at, created_at')
+    .eq('id', threadId)
+    .maybeSingle();
+
+  if (threadError) {
+    throw threadError;
+  }
+  if (!thread) {
+    return null;
+  }
+
+  const { data: participantRows, error: participantsError } = await supabase
+    .from('message_thread_participants')
+    .select('user_id')
+    .eq('thread_id', threadId);
+
+  if (participantsError) {
+    throw participantsError;
+  }
+
+  const userIds = (participantRows ?? []).map((row) => row.user_id);
+  let participants: ThreadParticipantProfile[] = [];
+
+  if (userIds.length > 0) {
+    const { data: profiles, error: profilesError } = await supabase
+      .from('profiles')
+      .select('id, full_name, email')
+      .in('id', userIds);
+
+    if (profilesError) {
+      throw profilesError;
+    }
+
+    participants = (profiles ?? []).map((profile) => ({
+      userId: profile.id,
+      fullName: profile.full_name?.trim() || profile.email,
+      email: profile.email,
+    }));
+  }
+
+  return {
+    id: thread.id,
+    subject: thread.subject,
+    threadType: toThreadType(thread.thread_type),
+    updatedAt: thread.updated_at,
+    createdAt: thread.created_at,
+    participants,
+  };
+}
+
+export async function listThreadMessages(threadId: string): Promise<StaffMessage[]> {
+  const { data, error } = await supabase
+    .from('messages')
+    .select('id, thread_id, sender_id, body, created_at')
+    .eq('thread_id', threadId)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    threadId: row.thread_id,
+    senderId: row.sender_id,
+    body: row.body,
+    createdAt: row.created_at,
+  }));
+}
+
+export async function listEligibleStaff(organizationId: string): Promise<StaffMember[]> {
+  const { data: profiles, error: profilesError } = await supabase
+    .from('profiles')
+    .select('id, full_name, email, organization_id, is_active')
+    .eq('organization_id', organizationId)
+    .eq('is_active', true);
+
+  if (profilesError) {
+    throw profilesError;
+  }
+
+  const profileRows = profiles ?? [];
+  if (profileRows.length === 0) {
+    return [];
+  }
+
+  const userIds = profileRows.map((profile) => profile.id);
+  const { data: roleRows, error: rolesError } = await supabase
+    .from('user_roles')
+    .select('user_id, is_active, expires_at, roles!inner(name)')
+    .in('user_id', userIds);
+
+  if (rolesError) {
+    throw rolesError;
+  }
+
+  const staffUserIds = new Set<string>();
+  for (const row of roleRows ?? []) {
+    const roleName = row.roles?.name;
+    if (!roleName || !isStaffRoleName(roleName)) {
+      continue;
+    }
+    if (!roleRowIsActive(row.is_active, row.expires_at)) {
+      continue;
+    }
+    staffUserIds.add(row.user_id);
+  }
+
+  return profileRows
+    .filter((profile) => staffUserIds.has(profile.id))
+    .map((profile) => ({
+      id: profile.id,
+      fullName: profile.full_name?.trim() || profile.email,
+      email: profile.email,
+    }))
+    .sort((a, b) => a.fullName.localeCompare(b.fullName));
+}

--- a/src/lib/messages/hooks.ts
+++ b/src/lib/messages/hooks.ts
@@ -1,0 +1,151 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '../authContext';
+import { useActiveOrganizationId } from '../organization';
+import { STAFF_MESSAGING_REFETCH_MS } from './constants';
+import { createThread, markThreadRead, sendMessage } from './mutations';
+import { getThreadDetail, listEligibleStaff, listInboxThreads, listThreadMessages } from './fetchers';
+import { staffMessagesQueryKeys } from './queryKeys';
+import type { CreateThreadInput, MessageThreadType, SendMessageInput } from './types';
+
+export function useInboxThreads() {
+  const { user } = useAuth();
+  const userId = user?.id;
+
+  return useQuery({
+    queryKey: staffMessagesQueryKeys.threads(userId ?? 'anonymous'),
+    queryFn: () => {
+      if (!userId) {
+        throw new Error('User is required to load inbox threads');
+      }
+      return listInboxThreads(userId);
+    },
+    enabled: Boolean(userId),
+    refetchInterval: STAFF_MESSAGING_REFETCH_MS,
+  });
+}
+
+export function useThreadDetail(threadId: string | undefined) {
+  return useQuery({
+    queryKey: staffMessagesQueryKeys.thread(threadId ?? 'unknown'),
+    queryFn: () => {
+      if (!threadId) {
+        throw new Error('Thread id is required');
+      }
+      return getThreadDetail(threadId);
+    },
+    enabled: Boolean(threadId),
+  });
+}
+
+export function useThreadMessages(threadId: string | undefined) {
+  return useQuery({
+    queryKey: staffMessagesQueryKeys.messages(threadId ?? 'unknown'),
+    queryFn: () => {
+      if (!threadId) {
+        throw new Error('Thread id is required');
+      }
+      return listThreadMessages(threadId);
+    },
+    enabled: Boolean(threadId),
+    refetchInterval: STAFF_MESSAGING_REFETCH_MS,
+  });
+}
+
+export function useEligibleStaff() {
+  const organizationId = useActiveOrganizationId();
+
+  return useQuery({
+    queryKey: staffMessagesQueryKeys.eligibleStaff(organizationId ?? 'none'),
+    queryFn: () => {
+      if (!organizationId) {
+        throw new Error('Organization is required to load staff recipients');
+      }
+      return listEligibleStaff(organizationId);
+    },
+    enabled: Boolean(organizationId),
+  });
+}
+
+export function useCreateThreadMutation() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  return useMutation({
+    mutationFn: (input: CreateThreadInput) => createThread(input),
+    onSuccess: async () => {
+      if (user?.id) {
+        await queryClient.invalidateQueries({ queryKey: staffMessagesQueryKeys.threads(user.id) });
+      }
+    },
+  });
+}
+
+export function useSendMessageMutation(threadId: string | undefined) {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  return useMutation({
+    mutationFn: (input: Omit<SendMessageInput, 'threadId' | 'senderId'> & { body: string }) => {
+      if (!threadId || !user?.id) {
+        throw new Error('Thread and user are required to send a message');
+      }
+      return sendMessage({
+        threadId,
+        senderId: user.id,
+        body: input.body,
+      });
+    },
+    onSuccess: async () => {
+      if (!threadId) {
+        return;
+      }
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: staffMessagesQueryKeys.messages(threadId) }),
+        queryClient.invalidateQueries({ queryKey: staffMessagesQueryKeys.thread(threadId) }),
+        user?.id
+          ? queryClient.invalidateQueries({ queryKey: staffMessagesQueryKeys.threads(user.id) })
+          : Promise.resolve(),
+      ]);
+    },
+  });
+}
+
+export function useMarkThreadReadMutation(threadId: string | undefined) {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  return useMutation({
+    mutationFn: () => {
+      if (!threadId || !user?.id) {
+        throw new Error('Thread and user are required to mark read');
+      }
+      return markThreadRead(threadId, user.id);
+    },
+    onSuccess: async () => {
+      if (!user?.id) {
+        return;
+      }
+      await queryClient.invalidateQueries({ queryKey: staffMessagesQueryKeys.threads(user.id) });
+    },
+  });
+}
+
+export function canCreateGroupThread(effectiveRole: string | null | undefined): boolean {
+  return effectiveRole === 'admin' || effectiveRole === 'super_admin';
+}
+
+export function buildParticipantIdsForCreate(
+  currentUserId: string,
+  selectedRecipientIds: string[],
+  threadType: MessageThreadType,
+): string[] {
+  const unique = new Set<string>([currentUserId, ...selectedRecipientIds]);
+  const ids = Array.from(unique);
+  if (threadType === 'direct' && ids.length !== 2) {
+    throw new Error('Direct threads require exactly one other participant');
+  }
+  if (threadType === 'group' && ids.length < 2) {
+    throw new Error('Group threads require at least one other participant');
+  }
+  return ids;
+}

--- a/src/lib/messages/mutations.ts
+++ b/src/lib/messages/mutations.ts
@@ -1,0 +1,55 @@
+import { supabase } from '../supabase';
+import { MESSAGE_BODY_MAX_LENGTH } from './constants';
+import type { CreateThreadInput, SendMessageInput } from './types';
+
+const normalizeBody = (body: string): string => {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    throw new Error('Message body cannot be empty');
+  }
+  if (trimmed.length > MESSAGE_BODY_MAX_LENGTH) {
+    throw new Error(`Message body must be at most ${MESSAGE_BODY_MAX_LENGTH} characters`);
+  }
+  return trimmed;
+};
+
+export async function createThread(input: CreateThreadInput): Promise<string> {
+  const { data, error } = await supabase.rpc('create_staff_message_thread', {
+    p_subject: input.subject?.trim() || null,
+    p_thread_type: input.threadType,
+    p_participant_user_ids: input.participantUserIds,
+  });
+
+  if (error) {
+    throw error;
+  }
+  if (typeof data !== 'string' || !data) {
+    throw new Error('create_staff_message_thread returned an unexpected payload');
+  }
+  return data;
+}
+
+export async function sendMessage(input: SendMessageInput): Promise<void> {
+  const body = normalizeBody(input.body);
+  const { error } = await supabase.from('messages').insert({
+    thread_id: input.threadId,
+    sender_id: input.senderId,
+    body,
+  });
+
+  if (error) {
+    throw error;
+  }
+}
+
+export async function markThreadRead(threadId: string, userId: string): Promise<void> {
+  const { error } = await supabase
+    .from('message_thread_participants')
+    .update({ last_read_at: new Date().toISOString() })
+    .eq('thread_id', threadId)
+    .eq('user_id', userId);
+
+  if (error) {
+    throw error;
+  }
+}

--- a/src/lib/messages/queryKeys.ts
+++ b/src/lib/messages/queryKeys.ts
@@ -1,0 +1,8 @@
+export const staffMessagesQueryKeys = {
+  all: ['staff-messages'] as const,
+  threads: (userId: string) => [...staffMessagesQueryKeys.all, 'threads', userId] as const,
+  thread: (threadId: string) => [...staffMessagesQueryKeys.all, 'thread', threadId] as const,
+  messages: (threadId: string) => [...staffMessagesQueryKeys.all, 'messages', threadId] as const,
+  eligibleStaff: (organizationId: string) =>
+    [...staffMessagesQueryKeys.all, 'eligible-staff', organizationId] as const,
+};

--- a/src/lib/messages/types.ts
+++ b/src/lib/messages/types.ts
@@ -1,0 +1,53 @@
+export type MessageThreadType = 'direct' | 'group';
+
+export interface ThreadListItem {
+  threadId: string;
+  subject: string | null;
+  threadType: MessageThreadType;
+  updatedAt: string;
+  lastReadAt: string | null;
+  latestMessageBody: string | null;
+  latestMessageAt: string | null;
+  latestMessageSenderId: string | null;
+}
+
+export interface StaffMessage {
+  id: string;
+  threadId: string;
+  senderId: string;
+  body: string;
+  createdAt: string;
+}
+
+export interface ThreadParticipantProfile {
+  userId: string;
+  fullName: string;
+  email: string;
+}
+
+export interface ThreadDetail {
+  id: string;
+  subject: string | null;
+  threadType: MessageThreadType;
+  updatedAt: string;
+  createdAt: string;
+  participants: ThreadParticipantProfile[];
+}
+
+export interface StaffMember {
+  id: string;
+  fullName: string;
+  email: string;
+}
+
+export interface CreateThreadInput {
+  subject?: string | null;
+  threadType: MessageThreadType;
+  participantUserIds: string[];
+}
+
+export interface SendMessageInput {
+  threadId: string;
+  senderId: string;
+  body: string;
+}

--- a/src/pages/messages/MessagesInboxPage.tsx
+++ b/src/pages/messages/MessagesInboxPage.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Plus, RefreshCw } from 'lucide-react';
+import { StaffMessagingPolicyBanner } from '../../components/messages/StaffMessagingPolicyBanner';
+import { ThreadList } from '../../components/messages/ThreadList';
+import { RouteLoadingSkeleton } from '../../components/RouteLoadingSkeleton';
+import { MESSAGES_ROUTES } from '../../lib/messages/constants';
+import { useInboxThreads } from '../../lib/messages/hooks';
+import { showError } from '../../lib/toast';
+
+export function MessagesInboxPage() {
+  const navigate = useNavigate();
+  const [searchQuery, setSearchQuery] = useState('');
+  const { data: threads = [], isLoading, isError, error, refetch, isFetching } = useInboxThreads();
+
+  useEffect(() => {
+    if (isError) {
+      showError(error instanceof Error ? error.message : 'Failed to load messages');
+    }
+  }, [isError, error]);
+
+  if (isLoading) {
+    return <RouteLoadingSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <StaffMessagingPolicyBanner />
+        <p className="text-sm text-red-600">Unable to load conversations.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Staff messages</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Coordinate with staff in your organization.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600"
+          >
+            <RefreshCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} aria-hidden="true" />
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate(MESSAGES_ROUTES.new)}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            New message
+          </button>
+        </div>
+      </div>
+
+      <StaffMessagingPolicyBanner />
+
+      <ThreadList
+        threads={threads}
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
+        onSelectThread={(threadId) => navigate(MESSAGES_ROUTES.thread(threadId))}
+      />
+    </div>
+  );
+}

--- a/src/pages/messages/NewMessagePage.tsx
+++ b/src/pages/messages/NewMessagePage.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { StaffMessagingPolicyBanner } from '../../components/messages/StaffMessagingPolicyBanner';
+import { StaffRecipientPicker } from '../../components/messages/StaffRecipientPicker';
+import { MESSAGES_ROUTES } from '../../lib/messages/constants';
+import {
+  buildParticipantIdsForCreate,
+  canCreateGroupThread,
+  useCreateThreadMutation,
+  useEligibleStaff,
+} from '../../lib/messages/hooks';
+import type { MessageThreadType } from '../../lib/messages/types';
+import { useAuth } from '../../lib/authContext';
+import { showError, showSuccess } from '../../lib/toast';
+
+export function NewMessagePage() {
+  const navigate = useNavigate();
+  const { user, effectiveRole } = useAuth();
+  const [subject, setSubject] = useState('');
+  const [threadType, setThreadType] = useState<MessageThreadType>('direct');
+  const [selectedRecipientIds, setSelectedRecipientIds] = useState<string[]>([]);
+  const { data: staff = [], isLoading: isStaffLoading } = useEligibleStaff();
+  const createThreadMutation = useCreateThreadMutation();
+
+  const allowGroup = canCreateGroupThread(effectiveRole);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!user?.id) {
+      showError('You must be signed in to create a conversation');
+      return;
+    }
+
+    try {
+      const participantUserIds = buildParticipantIdsForCreate(
+        user.id,
+        selectedRecipientIds,
+        threadType,
+      );
+      const threadId = await createThreadMutation.mutateAsync({
+        subject: subject.trim() || null,
+        threadType,
+        participantUserIds,
+      });
+      showSuccess('Conversation created');
+      navigate(MESSAGES_ROUTES.thread(threadId));
+    } catch (submitError) {
+      showError(submitError instanceof Error ? submitError.message : 'Failed to create conversation');
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <button
+        type="button"
+        onClick={() => navigate(MESSAGES_ROUTES.inbox)}
+        className="mb-4 text-sm text-blue-600 hover:underline"
+      >
+        Back to inbox
+      </button>
+
+      <h1 className="mb-2 text-2xl font-semibold text-gray-900 dark:text-gray-100">New message</h1>
+      <StaffMessagingPolicyBanner />
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div>
+          <label htmlFor="message-subject" className="mb-1 block text-sm font-medium">
+            Subject (optional)
+          </label>
+          <input
+            id="message-subject"
+            type="text"
+            value={subject}
+            onChange={(event) => setSubject(event.target.value)}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-dark-lighter"
+            placeholder="e.g. Schedule handoff"
+          />
+        </div>
+
+        {allowGroup ? (
+          <div>
+            <span className="mb-2 block text-sm font-medium">Conversation type</span>
+            <div className="flex gap-4">
+              <label className="inline-flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="thread-type"
+                  checked={threadType === 'direct'}
+                  onChange={() => setThreadType('direct')}
+                />
+                Direct (1:1)
+              </label>
+              <label className="inline-flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="thread-type"
+                  checked={threadType === 'group'}
+                  onChange={() => setThreadType('group')}
+                />
+                Group
+              </label>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500">Therapists can start direct (1:1) conversations only.</p>
+        )}
+
+        <div>
+          <span className="mb-2 block text-sm font-medium">Recipients</span>
+          <StaffRecipientPicker
+            threadType={threadType}
+            staff={staff}
+            selectedIds={selectedRecipientIds}
+            currentUserId={user?.id ?? ''}
+            onChange={setSelectedRecipientIds}
+            isLoading={isStaffLoading}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={createThreadMutation.isPending || selectedRecipientIds.length === 0}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {createThreadMutation.isPending ? 'Creating…' : 'Create conversation'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/messages/ThreadDetailPage.tsx
+++ b/src/pages/messages/ThreadDetailPage.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { StaffMessagingPolicyBanner } from '../../components/messages/StaffMessagingPolicyBanner';
+import { MessageComposer } from '../../components/messages/MessageComposer';
+import { MessageList } from '../../components/messages/MessageList';
+import { RouteLoadingSkeleton } from '../../components/RouteLoadingSkeleton';
+import { MESSAGES_ROUTES } from '../../lib/messages/constants';
+import {
+  useMarkThreadReadMutation,
+  useSendMessageMutation,
+  useThreadDetail,
+  useThreadMessages,
+} from '../../lib/messages/hooks';
+import { useAuth } from '../../lib/authContext';
+import { showError } from '../../lib/toast';
+
+export function ThreadDetailPage() {
+  const navigate = useNavigate();
+  const { threadId } = useParams<{ threadId: string }>();
+  const { user } = useAuth();
+  const { data: thread, isLoading: isThreadLoading, isError: isThreadError } = useThreadDetail(threadId);
+  const { data: messages = [], isLoading: isMessagesLoading } = useThreadMessages(threadId);
+  const sendMessageMutation = useSendMessageMutation(threadId);
+  const markReadMutation = useMarkThreadReadMutation(threadId);
+
+  useEffect(() => {
+    if (!threadId || !thread) {
+      return;
+    }
+    markReadMutation.mutate();
+  }, [threadId, thread?.id]);
+
+  if (isThreadLoading || isMessagesLoading) {
+    return <RouteLoadingSkeleton />;
+  }
+
+  if (isThreadError || !thread) {
+    return (
+      <div className="p-6">
+        <StaffMessagingPolicyBanner />
+        <p className="text-sm text-red-600">Conversation not found or access denied.</p>
+        <button
+          type="button"
+          onClick={() => navigate(MESSAGES_ROUTES.inbox)}
+          className="mt-4 text-sm text-blue-600 hover:underline"
+        >
+          Back to inbox
+        </button>
+      </div>
+    );
+  }
+
+  const title = thread.subject?.trim() || (thread.threadType === 'group' ? 'Group conversation' : 'Direct message');
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <button
+        type="button"
+        onClick={() => navigate(MESSAGES_ROUTES.inbox)}
+        className="mb-4 text-sm text-blue-600 hover:underline"
+      >
+        Back to inbox
+      </button>
+
+      <h1 className="mb-2 text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
+      <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        {thread.threadType === 'group' ? 'Group' : 'Direct'} · {thread.participants.length} participants
+      </p>
+
+      <StaffMessagingPolicyBanner />
+
+      <MessageList
+        messages={messages}
+        participants={thread.participants}
+        currentUserId={user?.id ?? ''}
+      />
+
+      <MessageComposer
+        isSending={sendMessageMutation.isPending}
+        onSend={async (body) => {
+          try {
+            await sendMessageMutation.mutateAsync({ body });
+          } catch (sendError) {
+            showError(sendError instanceof Error ? sendError.message : 'Failed to send message');
+            throw sendError;
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/pages/messages/__tests__/MessagesInboxPage.test.tsx
+++ b/src/pages/messages/__tests__/MessagesInboxPage.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Routes, Route } from 'react-router-dom';
+import { renderWithProviders, screen } from '../../../test/utils';
+import { MessagesInboxPage } from '../MessagesInboxPage';
+import { PHI_POLICY_BANNER } from '../../../lib/messages/constants';
+
+const useInboxThreadsMock = vi.fn();
+
+vi.mock('../../../lib/messages/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/messages/hooks')>();
+  return {
+    ...actual,
+    useInboxThreads: () => useInboxThreadsMock(),
+  };
+});
+
+describe('MessagesInboxPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders inbox threads and PHI banner', () => {
+    useInboxThreadsMock.mockReturnValue({
+      data: [
+        {
+          threadId: 'thread-1',
+          subject: 'Handoff',
+          threadType: 'direct',
+          updatedAt: '2026-05-20T12:00:00.000Z',
+          lastReadAt: null,
+          latestMessageBody: 'See you at 3pm',
+          latestMessageAt: '2026-05-20T12:00:00.000Z',
+          latestMessageSenderId: 'user-a',
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/messages" element={<MessagesInboxPage />} />
+      </Routes>,
+      { router: { initialEntries: ['/messages'] }, auth: { role: 'admin', userId: 'admin-user-id' } },
+    );
+
+    expect(screen.getByText(PHI_POLICY_BANNER)).toBeInTheDocument();
+    expect(screen.getByText('Handoff')).toBeInTheDocument();
+    expect(screen.getByText(/See you at 3pm/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/messages/__tests__/NewMessagePage.test.tsx
+++ b/src/pages/messages/__tests__/NewMessagePage.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Routes, Route } from 'react-router-dom';
+import { renderWithProviders, screen } from '../../../test/utils';
+import { NewMessagePage } from '../NewMessagePage';
+import { PHI_POLICY_BANNER } from '../../../lib/messages/constants';
+
+const { useAuthMock, useEligibleStaffMock, useCreateThreadMutationMock } = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+  useEligibleStaffMock: vi.fn(),
+  useCreateThreadMutationMock: vi.fn(),
+}));
+
+vi.mock('../../../lib/authContext', () => ({
+  useAuth: () => useAuthMock(),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../../lib/messages/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/messages/hooks')>();
+  return {
+    ...actual,
+    useEligibleStaff: () => useEligibleStaffMock(),
+    useCreateThreadMutation: () => useCreateThreadMutationMock(),
+  };
+});
+
+const staff = [
+  { id: 'admin-user-id', fullName: 'Admin User', email: 'admin@example.com' },
+  { id: 'staff-b', fullName: 'Staff B', email: 'b@example.com' },
+];
+
+describe('NewMessagePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useEligibleStaffMock.mockReturnValue({ data: staff, isLoading: false });
+    useCreateThreadMutationMock.mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue('new-thread-id'),
+      isPending: false,
+    });
+  });
+
+  it('shows PHI banner and hides group option for therapists', () => {
+    useAuthMock.mockReturnValue({
+      user: { id: 'therapist-user-id' },
+      effectiveRole: 'therapist',
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/messages/new" element={<NewMessagePage />} />
+      </Routes>,
+      { router: { initialEntries: ['/messages/new'] } },
+    );
+
+    expect(screen.getByText(PHI_POLICY_BANNER)).toBeInTheDocument();
+    expect(screen.getByText(/direct \(1:1\) conversations only/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Group/i)).not.toBeInTheDocument();
+  });
+
+  it('shows group option for admins', () => {
+    useAuthMock.mockReturnValue({
+      user: { id: 'admin-user-id' },
+      effectiveRole: 'admin',
+    });
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/messages/new" element={<NewMessagePage />} />
+      </Routes>,
+      { router: { initialEntries: ['/messages/new'] } },
+    );
+
+    expect(screen.getByLabelText(/Group/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/messages/__tests__/ThreadDetailPage.test.tsx
+++ b/src/pages/messages/__tests__/ThreadDetailPage.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Routes, Route } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, screen, waitFor } from '../../../test/utils';
+import { ThreadDetailPage } from '../ThreadDetailPage';
+import { PHI_POLICY_BANNER } from '../../../lib/messages/constants';
+
+const {
+  useThreadDetailMock,
+  useThreadMessagesMock,
+  useSendMessageMutationMock,
+  useMarkThreadReadMutationMock,
+} = vi.hoisted(() => ({
+  useThreadDetailMock: vi.fn(),
+  useThreadMessagesMock: vi.fn(),
+  useSendMessageMutationMock: vi.fn(),
+  useMarkThreadReadMutationMock: vi.fn(),
+}));
+
+vi.mock('../../../lib/authContext', () => ({
+  useAuth: () => ({
+    user: { id: 'admin-user-id' },
+    effectiveRole: 'admin',
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../../lib/messages/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/messages/hooks')>();
+  return {
+    ...actual,
+    useThreadDetail: (threadId: string | undefined) => useThreadDetailMock(threadId),
+    useThreadMessages: (threadId: string | undefined) => useThreadMessagesMock(threadId),
+    useSendMessageMutation: (threadId: string | undefined) => useSendMessageMutationMock(threadId),
+    useMarkThreadReadMutation: (threadId: string | undefined) => useMarkThreadReadMutationMock(threadId),
+  };
+});
+
+const threadDetail = {
+  id: 'thread-1',
+  subject: 'Ops sync',
+  threadType: 'direct' as const,
+  updatedAt: '2026-05-20T12:00:00.000Z',
+  createdAt: '2026-05-20T10:00:00.000Z',
+  participants: [
+    { userId: 'admin-user-id', fullName: 'Admin', email: 'admin@example.com' },
+    { userId: 'staff-b', fullName: 'Staff B', email: 'b@example.com' },
+  ],
+};
+
+describe('ThreadDetailPage', () => {
+  const mutateAsync = vi.fn().mockResolvedValue(undefined);
+  const markReadMutate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useThreadDetailMock.mockReturnValue({
+      data: threadDetail,
+      isLoading: false,
+      isError: false,
+    });
+    useThreadMessagesMock.mockReturnValue({
+      data: [
+        {
+          id: 'msg-1',
+          threadId: 'thread-1',
+          senderId: 'staff-b',
+          body: 'Ready for handoff',
+          createdAt: '2026-05-20T11:00:00.000Z',
+        },
+      ],
+      isLoading: false,
+    });
+    useSendMessageMutationMock.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    });
+    useMarkThreadReadMutationMock.mockReturnValue({
+      mutate: markReadMutate,
+    });
+  });
+
+  it('renders thread messages, PHI banner, and marks read on load', async () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/messages/:threadId" element={<ThreadDetailPage />} />
+      </Routes>,
+      { router: { initialEntries: ['/messages/thread-1'] } },
+    );
+
+    expect(screen.getByText(PHI_POLICY_BANNER)).toBeInTheDocument();
+    expect(screen.getByText('Ops sync')).toBeInTheDocument();
+    expect(screen.getByText('Ready for handoff')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(markReadMutate).toHaveBeenCalled();
+    });
+  });
+
+  it('sends a message from the composer', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/messages/:threadId" element={<ThreadDetailPage />} />
+      </Routes>,
+      { router: { initialEntries: ['/messages/thread-1'] } },
+    );
+
+    await user.type(screen.getByLabelText(/message body/i), 'Thanks, noted.');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({ body: 'Thanks, noted.' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add staff messaging data layer (fetchers, mutations, React Query hooks) against Supabase RLS + create_staff_message_thread RPC
- Add inbox, compose, and thread detail UI with PHI policy banner on all surfaces
- Add Vitest coverage (lib, components, pages with MemoryRouter); **no App routes, Sidebar nav, guards, or Cypress** until Slice 4

## Test plan

- [x] npm run lint
- [x] npm run typecheck
- [x] npm test -- src/lib/messages src/components/messages src/pages/messages
- [x] npm run build
- [ ] Manual browser QA blocked until Slice 4 wires /messages routes

Made with [Cursor](https://cursor.com)