### PR TITLE
WIN-157 Seed IEHP uploads from template metadata

### DIFF
--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -540,6 +540,15 @@ describe("assessmentDocumentsHandler", () => {
               required: true,
               source: "uploaded_assessment_document",
             },
+            {
+              section_key: "signature_block",
+              field_key: "IEHP_FBA_SIGNATURE_BLOCK",
+              label: "Report completed by / signature and date",
+              field_type: "signature_block",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+            },
           ],
         };
       }
@@ -566,7 +575,13 @@ describe("assessmentDocumentsHandler", () => {
           "IEHP_FBA_FIRST_NAME",
           "IEHP_FBA_CLINICAL_INTERVIEW_NARRATIVE",
           "IEHP_FBA_PREFERENCE_REINFORCERS_TABLE",
+          "IEHP_FBA_SIGNATURE_BLOCK",
         ]);
+        expect(body.find((row) => row.placeholder_key === "IEHP_FBA_FIRST_NAME")).toMatchObject({
+          mode: "AUTO",
+          extraction_owner: "IntakeCoordinator",
+          review_owner: "ClinicalReviewer",
+        });
         expect(body.find((row) => row.placeholder_key === "IEHP_FBA_CLINICAL_INTERVIEW_NARRATIVE")).toMatchObject({
           mode: "ASSISTED",
           extraction_method: "deterministic_docx_or_pdf_structured_extract",
@@ -576,6 +591,10 @@ describe("assessmentDocumentsHandler", () => {
           mode: "ASSISTED",
           validation_rule: "structured_payload_required",
         });
+        expect(body.find((row) => row.placeholder_key === "IEHP_FBA_SIGNATURE_BLOCK")).toMatchObject({
+          mode: "ASSISTED",
+          validation_rule: "signature_and_date_present",
+        });
         return { ok: true, status: 201, data: null };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) {
@@ -584,6 +603,7 @@ describe("assessmentDocumentsHandler", () => {
           "IEHP_FBA_FIRST_NAME",
           "IEHP_FBA_CLINICAL_INTERVIEW_NARRATIVE",
           "IEHP_FBA_PREFERENCE_REINFORCERS_TABLE",
+          "IEHP_FBA_SIGNATURE_BLOCK",
         ]);
         return { ok: true, status: 201, data: null };
       }
@@ -627,6 +647,7 @@ describe("assessmentDocumentsHandler", () => {
       "IEHP_FBA_FIRST_NAME",
       "IEHP_FBA_CLINICAL_INTERVIEW_NARRATIVE",
       "IEHP_FBA_PREFERENCE_REINFORCERS_TABLE",
+      "IEHP_FBA_SIGNATURE_BLOCK",
     ]);
     expect(loadChecklistTemplateRows).not.toHaveBeenCalled();
   });

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -130,6 +130,21 @@ describe("assessmentDocumentsHandler", () => {
       if (method === "GET" && url.includes("/rest/v1/assessment_template_versions?select=id")) {
         return { ok: true, status: 200, data: [{ id: "template-version-1" }] };
       }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_fields?select=")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            section_key: "behavior_background_services",
+            field_key: "IEHP_FBA_BHT_AVAILABILITY_GRID",
+            label: "BHT Availability Grid",
+            field_type: "checkbox_grid",
+            mode: "ASSISTED",
+            required: true,
+            source: "uploaded_assessment_document",
+          }],
+        };
+      }
       if (
         method === "GET" &&
         url.includes(
@@ -263,7 +278,7 @@ describe("assessmentDocumentsHandler", () => {
       }
       if (
         method === "GET" &&
-        url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path,updated_at")
+        url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,template_version_id,bucket_id,object_path,updated_at")
       ) {
         if (mode === "lookup-fails") {
           return { ok: false, status: 500, data: null };
@@ -483,19 +498,7 @@ describe("assessmentDocumentsHandler", () => {
       anonKey: "anon",
     });
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
-    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([
-      {
-        section: "identification_admin",
-        label: "First Name",
-        placeholder_key: "IEHP_FBA_FIRST_NAME",
-        mode: "AUTO",
-        source: "clients.first_name",
-        required: true,
-        extraction_method: "database_prefill",
-        validation_rule: "non_empty_text",
-        status: "not_started",
-      },
-    ]);
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
 
     vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
@@ -504,6 +507,41 @@ describe("assessmentDocumentsHandler", () => {
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_template_versions?select=id")) {
         return { ok: true, status: 200, data: [{ id: "template-version-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_fields?select=")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              section_key: "identification_admin",
+              field_key: "IEHP_FBA_FIRST_NAME",
+              label: "First Name",
+              field_type: "text",
+              mode: "AUTO",
+              required: true,
+              source: "clients.first_name",
+            },
+            {
+              section_key: "assessment_observations",
+              field_key: "IEHP_FBA_CLINICAL_INTERVIEW_NARRATIVE",
+              label: "Clinical Interview Narrative",
+              field_type: "textarea",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+            },
+            {
+              section_key: "preference_assessment",
+              field_key: "IEHP_FBA_PREFERENCE_REINFORCERS_TABLE",
+              label: "Preference Reinforcers Table",
+              field_type: "repeatable_table",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+            },
+          ],
+        };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
         const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
@@ -522,14 +560,40 @@ describe("assessmentDocumentsHandler", () => {
           }],
         };
       }
-      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) return { ok: true, status: 201, data: null };
-      if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) {
+        const body = JSON.parse(String(init?.body ?? "[]")) as Array<Record<string, unknown>>;
+        expect(body.map((row) => row.placeholder_key)).toEqual([
+          "IEHP_FBA_FIRST_NAME",
+          "IEHP_FBA_CLINICAL_INTERVIEW_NARRATIVE",
+          "IEHP_FBA_PREFERENCE_REINFORCERS_TABLE",
+        ]);
+        expect(body.find((row) => row.placeholder_key === "IEHP_FBA_CLINICAL_INTERVIEW_NARRATIVE")).toMatchObject({
+          mode: "ASSISTED",
+          extraction_method: "deterministic_docx_or_pdf_structured_extract",
+          validation_rule: "non_empty_text",
+        });
+        expect(body.find((row) => row.placeholder_key === "IEHP_FBA_PREFERENCE_REINFORCERS_TABLE")).toMatchObject({
+          mode: "ASSISTED",
+          validation_rule: "structured_payload_required",
+        });
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) {
+        const body = JSON.parse(String(init?.body ?? "[]")) as Array<Record<string, unknown>>;
+        expect(body.map((row) => row.field_key)).toEqual([
+          "IEHP_FBA_FIRST_NAME",
+          "IEHP_FBA_CLINICAL_INTERVIEW_NARRATIVE",
+          "IEHP_FBA_PREFERENCE_REINFORCERS_TABLE",
+        ]);
+        return { ok: true, status: 201, data: null };
+      }
       if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) return { ok: true, status: 201, data: null };
       if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) return { ok: true, status: 200, data: null };
       return { ok: false, status: 500, data: null };
     });
 
     const scheduled: string[] = [];
+    const scheduledChecklistFieldKeys: string[] = [];
     const response = await assessmentDocumentsHandler(
       new Request("http://localhost/api/assessment-documents", {
         method: "POST",
@@ -544,8 +608,9 @@ describe("assessmentDocumentsHandler", () => {
         }),
       }),
       {
-        scheduleCaloptimaExtraction: async ({ createdDocumentId }) => {
+        scheduleCaloptimaExtraction: async ({ createdDocumentId, checklistRows }) => {
           scheduled.push(createdDocumentId);
+          scheduledChecklistFieldKeys.push(...checklistRows.map((row) => row.placeholder_key));
           return { ok: true, status: 202 };
         },
       },
@@ -558,7 +623,64 @@ describe("assessmentDocumentsHandler", () => {
       template_version_id: "template-version-1",
     });
     expect(scheduled).toEqual(["doc-iehp-template"]);
-    expect(loadChecklistTemplateRows).toHaveBeenCalledWith("iehp_fba");
+    expect(scheduledChecklistFieldKeys).toEqual([
+      "IEHP_FBA_FIRST_NAME",
+      "IEHP_FBA_CLINICAL_INTERVIEW_NARRATIVE",
+      "IEHP_FBA_PREFERENCE_REINFORCERS_TABLE",
+    ]);
+    expect(loadChecklistTemplateRows).not.toHaveBeenCalled();
+  });
+
+  it("fails IEHP upload before document creation when template field metadata cannot be loaded", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_versions?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "template-version-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_fields?select=")) {
+        return { ok: false, status: 503, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
+        throw new Error("assessment document should not be created when IEHP template metadata fails");
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "iehp.docx",
+          mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/iehp.docx",
+          template_type: "iehp_fba",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: "Unable to load IEHP template field metadata." });
+    expect(loadChecklistTemplateRows).not.toHaveBeenCalled();
   });
 
   it("fails closed when scheduling CalOptima extraction throws after marking the document extracting", async () => {
@@ -959,7 +1081,7 @@ describe("assessmentDocumentsHandler", () => {
     ]);
     vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
-      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,template_version_id,bucket_id,object_path")) {
         return {
           ok: true,
           status: 200,
@@ -1084,7 +1206,7 @@ describe("assessmentDocumentsHandler", () => {
     });
     vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
-      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,template_version_id,bucket_id,object_path")) {
         return {
           ok: true,
           status: 200,
@@ -1141,7 +1263,7 @@ describe("assessmentDocumentsHandler", () => {
     let documentLoadCount = 0;
     vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
-      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,template_version_id,bucket_id,object_path")) {
         documentLoadCount += 1;
         return {
           ok: true,
@@ -1242,7 +1364,7 @@ describe("assessmentDocumentsHandler", () => {
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
-      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,template_version_id,bucket_id,object_path")) {
         return { ok: false, status: 503, data: null };
       }
       if (
@@ -1309,7 +1431,7 @@ describe("assessmentDocumentsHandler", () => {
     vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       const body = String(init?.body ?? "");
-      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,template_version_id,bucket_id,object_path")) {
         return {
           ok: true,
           status: 200,
@@ -1394,7 +1516,7 @@ describe("assessmentDocumentsHandler", () => {
     let claimAttempts = 0;
     vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
-      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,template_version_id,bucket_id,object_path")) {
         return {
           ok: true,
           status: 200,
@@ -1539,7 +1661,7 @@ describe("assessmentDocumentsHandler", () => {
     vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
     vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
-      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,template_version_id,bucket_id,object_path")) {
         return {
           ok: true,
           status: 200,
@@ -1719,7 +1841,7 @@ describe("assessmentDocumentsHandler", () => {
       status: "extracting",
     });
     expect(json.extraction_error).toBeNull();
-    expect(loadChecklistTemplateRows).toHaveBeenCalledWith("iehp_fba");
+    expect(loadChecklistTemplateRows).not.toHaveBeenCalled();
   });
 
   it("rejects unsupported template_type", async () => {
@@ -2235,19 +2357,7 @@ describe("assessmentDocumentsHandler", () => {
       anonKey: "anon",
     });
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
-    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([
-      {
-        section: "behavior_background_services",
-        label: "BHT Availability Grid",
-        placeholder_key: "IEHP_FBA_BHT_AVAILABILITY_GRID",
-        mode: "ASSISTED",
-        source: "uploaded_assessment_document",
-        required: true,
-        extraction_method: "deterministic_extract",
-        validation_rule: "structured_payload_required",
-        status: "not_started",
-      },
-    ]);
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
 
     vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
@@ -2273,6 +2383,21 @@ describe("assessmentDocumentsHandler", () => {
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_template_versions?select=id")) {
         return { ok: true, status: 200, data: [{ id: "template-version-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_fields?select=")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            section_key: "behavior_background_services",
+            field_key: "IEHP_FBA_BHT_AVAILABILITY_GRID",
+            label: "BHT Availability Grid",
+            field_type: "checkbox_grid",
+            mode: "ASSISTED",
+            required: true,
+            source: "uploaded_assessment_document",
+          }],
+        };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
         return {

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -385,8 +385,17 @@ const extractionMethodForTemplateField = (
   return "database_prefill";
 };
 
-const validationRuleForTemplateField = (fieldType: string, required: boolean): string => {
+const validationRuleForTemplateField = (fieldType: string, required: boolean, fieldKey: string, label: string): string => {
   const normalizedFieldType = fieldType.toLowerCase();
+  const normalizedFieldKey = fieldKey.toLowerCase();
+  const normalizedLabel = label.toLowerCase();
+  if (
+    normalizedFieldType.includes("signature") ||
+    normalizedFieldKey.includes("signature") ||
+    normalizedLabel.includes("signature")
+  ) {
+    return "signature_and_date_present";
+  }
   if (normalizedFieldType.includes("table") || normalizedFieldType.includes("grid")) {
     return required ? "structured_payload_required" : "optional_structured_payload";
   }
@@ -422,7 +431,7 @@ const normalizeTemplateFieldRow = (row: AssessmentTemplateFieldRow): AssessmentC
     source,
     required,
     extraction_method: extractionMethodForTemplateField(mode, source),
-    validation_rule: validationRuleForTemplateField(fieldType, required),
+    validation_rule: validationRuleForTemplateField(fieldType, required, row.field_key, row.label),
     status: "not_started",
     extraction_owner: mode === "AUTO" ? "IntakeCoordinator" : "ClinicalAuthor",
     review_owner: mode === "AUTO" ? "ClinicalReviewer" : "BCBAReviewer",

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -59,6 +59,7 @@ interface AssessmentDocumentExtractionRow {
   client_id: string;
   status: string;
   template_type: AssessmentTemplateType;
+  template_version_id?: string | null;
   bucket_id: string | null;
   object_path: string | null;
   updated_at: string | null;
@@ -90,6 +91,16 @@ interface ClientSnapshotRow {
   city?: string | null;
   state?: string | null;
   zip_code?: string | null;
+}
+
+interface AssessmentTemplateFieldRow {
+  section_key?: string | null;
+  field_key?: string | null;
+  label?: string | null;
+  field_type?: string | null;
+  mode?: string | null;
+  required?: boolean | null;
+  source?: string | null;
 }
 
 const compactNullableRecord = <T extends Record<string, unknown>>(value: T): Partial<T> =>
@@ -340,6 +351,132 @@ const resolveActiveTemplateVersionId = async (args: {
   }
   const row = Array.isArray(result.data) ? result.data[0] ?? null : null;
   return typeof row?.id === "string" ? row.id : null;
+};
+
+const normalizeTemplateFieldMode = (mode: string | null | undefined): AssessmentChecklistSeedRow["mode"] => {
+  if (mode === "AUTO" || mode === "ASSISTED" || mode === "MANUAL") {
+    return mode;
+  }
+  return "ASSISTED";
+};
+
+const extractionMethodForTemplateField = (
+  mode: AssessmentChecklistSeedRow["mode"],
+  source: string,
+): string => {
+  const normalizedSource = source.toLowerCase();
+  if (normalizedSource.includes("uploaded_assessment_document")) {
+    return "deterministic_docx_or_pdf_structured_extract";
+  }
+  if (mode === "MANUAL" || normalizedSource.includes("clinician_manual_entry")) {
+    return "clinician_manual_entry";
+  }
+  if (
+    normalizedSource.includes("clients.") ||
+    normalizedSource.includes("therapists.") ||
+    normalizedSource.includes("company_settings") ||
+    normalizedSource.includes("today")
+  ) {
+    return "database_prefill";
+  }
+  if (mode === "ASSISTED") {
+    return "assisted_draft_plus_review";
+  }
+  return "database_prefill";
+};
+
+const validationRuleForTemplateField = (fieldType: string, required: boolean): string => {
+  const normalizedFieldType = fieldType.toLowerCase();
+  if (normalizedFieldType.includes("table") || normalizedFieldType.includes("grid")) {
+    return required ? "structured_payload_required" : "optional_structured_payload";
+  }
+  if (normalizedFieldType.includes("date")) {
+    return required ? "date_mm_dd_yyyy_or_na" : "optional_date";
+  }
+  if (normalizedFieldType.includes("phone")) {
+    return required ? "phone_us_or_e164_or_na" : "optional_phone";
+  }
+  return required ? "non_empty_text" : "optional_text";
+};
+
+const normalizeTemplateFieldRow = (row: AssessmentTemplateFieldRow): AssessmentChecklistSeedRow | null => {
+  if (
+    typeof row.section_key !== "string" ||
+    row.section_key.trim().length === 0 ||
+    typeof row.field_key !== "string" ||
+    row.field_key.trim().length === 0 ||
+    typeof row.label !== "string" ||
+    row.label.trim().length === 0
+  ) {
+    return null;
+  }
+  const mode = normalizeTemplateFieldMode(row.mode);
+  const source = typeof row.source === "string" && row.source.trim().length > 0 ? row.source : "uploaded_assessment_document";
+  const fieldType = typeof row.field_type === "string" && row.field_type.trim().length > 0 ? row.field_type : "text";
+  const required = row.required === true;
+  return {
+    section: row.section_key,
+    label: row.label,
+    placeholder_key: row.field_key,
+    mode,
+    source,
+    required,
+    extraction_method: extractionMethodForTemplateField(mode, source),
+    validation_rule: validationRuleForTemplateField(fieldType, required),
+    status: "not_started",
+    extraction_owner: mode === "AUTO" ? "IntakeCoordinator" : "ClinicalAuthor",
+    review_owner: mode === "AUTO" ? "ClinicalReviewer" : "BCBAReviewer",
+  };
+};
+
+const loadIeHpChecklistTemplateRowsFromMetadata = async (args: {
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  templateVersionId: string;
+}): Promise<AssessmentChecklistSeedRow[]> => {
+  const result = await fetchJson<AssessmentTemplateFieldRow[]>(
+    `${args.supabaseUrl}/rest/v1/assessment_template_fields?select=section_key,field_key,label,field_type,mode,required,source&template_version_id=eq.${encodeURIComponent(
+      args.templateVersionId,
+    )}&order=page_number.asc,section_key.asc,field_key.asc`,
+    { method: "GET", headers: args.headers },
+  );
+  if (!result.ok) {
+    throw new ExtractionWorkflowError(
+      "iehp_template_fields_load_failed",
+      "iehp_template_fields_load_failed",
+      result.status,
+      "Unable to load IEHP template field metadata.",
+    );
+  }
+  const rows = Array.isArray(result.data) ? result.data.map(normalizeTemplateFieldRow).filter(Boolean) : [];
+  if (rows.length === 0) {
+    throw new ExtractionWorkflowError(
+      "iehp_template_fields_missing",
+      "iehp_template_fields_missing",
+      409,
+      "IEHP template field metadata is missing.",
+    );
+  }
+  return rows;
+};
+
+const loadChecklistRowsForAssessmentUpload = async (args: {
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  templateType: AssessmentTemplateType;
+  templateVersionId: string | null;
+}): Promise<AssessmentChecklistSeedRow[]> => {
+  if (args.templateType !== "iehp_fba") {
+    return loadChecklistTemplateRows(args.templateType);
+  }
+  if (!args.templateVersionId) {
+    return loadChecklistTemplateRows(args.templateType);
+  }
+  return loadIeHpChecklistTemplateRowsFromMetadata({
+    supabaseUrl: args.supabaseUrl,
+    headers: args.headers,
+    templateVersionId: args.templateVersionId,
+  });
 };
 
 const persistExtractionFailure = async (args: {
@@ -781,7 +918,7 @@ export async function assessmentDocumentsExtractionBackgroundHandler(request: Re
   };
 
   const documentResult = await fetchJson<AssessmentDocumentExtractionRow[]>(
-    `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,bucket_id,object_path,updated_at&id=eq.${encodeURIComponent(
+    `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,template_version_id,bucket_id,object_path,updated_at&id=eq.${encodeURIComponent(
       parsed.data.assessment_document_id,
     )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
     { method: "GET", headers },
@@ -857,7 +994,12 @@ export async function assessmentDocumentsExtractionBackgroundHandler(request: Re
   }
 
   try {
-    const checklistRows = await loadChecklistTemplateRows(claimedDocument.template_type);
+    const checklistRows = await loadChecklistRowsForAssessmentUpload({
+      supabaseUrl,
+      headers,
+      templateType: claimedDocument.template_type,
+      templateVersionId: claimedDocument.template_version_id ?? null,
+    });
     await runBoundedCaloptimaExtractionWorkflow({
       supabaseUrl,
       headers,
@@ -1005,6 +1147,23 @@ export async function assessmentDocumentsHandler(
     if (templateType === "iehp_fba" && !templateVersionId) {
       return jsonForRequest(request, { error: "Active IEHP FBA template layout version is not configured." }, 500);
     }
+
+    let checklistRows: AssessmentChecklistSeedRow[];
+    try {
+      checklistRows = await loadChecklistRowsForAssessmentUpload({
+        supabaseUrl,
+        headers,
+        templateType,
+        templateVersionId,
+      });
+    } catch (error) {
+      if (error instanceof ExtractionWorkflowError) {
+        return jsonForRequest(request, { error: error.publicMessage }, error.status || 500);
+      }
+      const message = error instanceof Error ? error.message : "Unable to load checklist template rows.";
+      return jsonForRequest(request, { error: message }, 500);
+    }
+
     const createPayload = {
       organization_id: organizationId,
       client_id: parsed.data.client_id,
@@ -1034,13 +1193,6 @@ export async function assessmentDocumentsHandler(
 
     const createdDocument = createResult.data[0];
 
-    let checklistRows: AssessmentChecklistSeedRow[];
-    try {
-      checklistRows = await loadChecklistTemplateRows(templateType);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Unable to load checklist template rows.";
-      return jsonForRequest(request, { error: message }, 500);
-    }
     const checklistInsertPayload = checklistRows.map((row) => ({
       assessment_document_id: createdDocument.id,
       organization_id: organizationId,

--- a/supabase/migrations/20260521132512_backfill_iehp_template_metadata_rows.sql
+++ b/supabase/migrations/20260521132512_backfill_iehp_template_metadata_rows.sql
@@ -25,6 +25,9 @@ with iehp_template_fields as (
       else 'database_prefill'
     end as extraction_method,
     case
+      when lower(fields.field_type) like '%signature%'
+        or lower(fields.field_key) like '%signature%'
+        or lower(fields.label) like '%signature%' then 'signature_and_date_present'
       when lower(fields.field_type) like '%table%' or lower(fields.field_type) like '%grid%' then
         case when fields.required then 'structured_payload_required' else 'optional_structured_payload' end
       when lower(fields.field_type) like '%date%' then
@@ -33,7 +36,9 @@ with iehp_template_fields as (
         case when fields.required then 'phone_us_or_e164_or_na' else 'optional_phone' end
       else
         case when fields.required then 'non_empty_text' else 'optional_text' end
-    end as validation_rule
+    end as validation_rule,
+    case when fields.mode = 'AUTO' then 'IntakeCoordinator' else 'ClinicalAuthor' end as extraction_owner,
+    case when fields.mode = 'AUTO' then 'ClinicalReviewer' else 'BCBAReviewer' end as review_owner
   from public.assessment_template_versions versions
   join public.assessment_template_fields fields
     on fields.template_version_id = versions.id
@@ -81,8 +86,8 @@ select
   fields.extraction_method,
   fields.validation_rule,
   'not_started',
-  'ClinicalAuthor',
-  'BCBAReviewer',
+  fields.extraction_owner,
+  fields.review_owner,
   'Backfilled empty IEHP review row from active template metadata.'
 from iehp_documents documents
 join iehp_template_fields fields

--- a/supabase/migrations/20260521132512_backfill_iehp_template_metadata_rows.sql
+++ b/supabase/migrations/20260521132512_backfill_iehp_template_metadata_rows.sql
@@ -1,0 +1,157 @@
+-- @migration-intent: Backfill missing IEHP assessment checklist and extraction rows from the active template metadata so already-uploaded documents match the DOCX-like review layout.
+-- @migration-dependencies: 20260520131400_add_iehp_template_layout_metadata.sql, 20260520193000_extend_iehp_template_mapping_fields.sql
+-- @migration-rollback: Delete only rows with review_notes = 'Backfilled empty IEHP review row from active template metadata.' for the affected IEHP documents if this metadata seeding approach is reverted before review use.
+
+begin;
+
+with iehp_template_fields as (
+  select
+    versions.id as template_version_id,
+    fields.section_key,
+    fields.field_key,
+    fields.label,
+    fields.field_type,
+    fields.mode,
+    fields.source,
+    fields.required,
+    case
+      when fields.source ilike '%uploaded_assessment_document%' then 'deterministic_docx_or_pdf_structured_extract'
+      when fields.mode = 'MANUAL' or fields.source ilike '%clinician_manual_entry%' then 'clinician_manual_entry'
+      when fields.source ilike '%clients.%'
+        or fields.source ilike '%therapists.%'
+        or fields.source ilike '%company_settings%'
+        or fields.source ilike '%today%' then 'database_prefill'
+      when fields.mode = 'ASSISTED' then 'assisted_draft_plus_review'
+      else 'database_prefill'
+    end as extraction_method,
+    case
+      when lower(fields.field_type) like '%table%' or lower(fields.field_type) like '%grid%' then
+        case when fields.required then 'structured_payload_required' else 'optional_structured_payload' end
+      when lower(fields.field_type) like '%date%' then
+        case when fields.required then 'date_mm_dd_yyyy_or_na' else 'optional_date' end
+      when lower(fields.field_type) like '%phone%' then
+        case when fields.required then 'phone_us_or_e164_or_na' else 'optional_phone' end
+      else
+        case when fields.required then 'non_empty_text' else 'optional_text' end
+    end as validation_rule
+  from public.assessment_template_versions versions
+  join public.assessment_template_fields fields
+    on fields.template_version_id = versions.id
+  where versions.version_key = 'iehp_fba_updated_fba_11_2026_05'
+),
+iehp_documents as (
+  select
+    documents.id,
+    documents.organization_id,
+    documents.client_id,
+    documents.template_version_id
+  from public.assessment_documents documents
+  join public.assessment_template_versions versions
+    on versions.id = documents.template_version_id
+  where documents.template_type = 'iehp_fba'
+    and versions.version_key = 'iehp_fba_updated_fba_11_2026_05'
+)
+insert into public.assessment_checklist_items (
+  assessment_document_id,
+  organization_id,
+  client_id,
+  section_key,
+  label,
+  placeholder_key,
+  mode,
+  source,
+  required,
+  extraction_method,
+  validation_rule,
+  status,
+  extraction_owner,
+  review_owner,
+  review_notes
+)
+select
+  documents.id,
+  documents.organization_id,
+  documents.client_id,
+  fields.section_key,
+  fields.label,
+  fields.field_key,
+  fields.mode,
+  fields.source,
+  fields.required,
+  fields.extraction_method,
+  fields.validation_rule,
+  'not_started',
+  'ClinicalAuthor',
+  'BCBAReviewer',
+  'Backfilled empty IEHP review row from active template metadata.'
+from iehp_documents documents
+join iehp_template_fields fields
+  on fields.template_version_id = documents.template_version_id
+where not exists (
+  select 1
+  from public.assessment_checklist_items existing
+  where existing.assessment_document_id = documents.id
+    and existing.organization_id = documents.organization_id
+    and existing.placeholder_key = fields.field_key
+);
+
+with iehp_template_fields as (
+  select
+    versions.id as template_version_id,
+    fields.section_key,
+    fields.field_key,
+    fields.label,
+    fields.mode,
+    fields.required
+  from public.assessment_template_versions versions
+  join public.assessment_template_fields fields
+    on fields.template_version_id = versions.id
+  where versions.version_key = 'iehp_fba_updated_fba_11_2026_05'
+),
+iehp_documents as (
+  select
+    documents.id,
+    documents.organization_id,
+    documents.client_id,
+    documents.template_version_id
+  from public.assessment_documents documents
+  join public.assessment_template_versions versions
+    on versions.id = documents.template_version_id
+  where documents.template_type = 'iehp_fba'
+    and versions.version_key = 'iehp_fba_updated_fba_11_2026_05'
+)
+insert into public.assessment_extractions (
+  assessment_document_id,
+  organization_id,
+  client_id,
+  section_key,
+  field_key,
+  label,
+  mode,
+  required,
+  status,
+  review_notes
+)
+select
+  documents.id,
+  documents.organization_id,
+  documents.client_id,
+  fields.section_key,
+  fields.field_key,
+  fields.label,
+  fields.mode,
+  fields.required,
+  'not_started',
+  'Backfilled empty IEHP review row from active template metadata.'
+from iehp_documents documents
+join iehp_template_fields fields
+  on fields.template_version_id = documents.template_version_id
+where not exists (
+  select 1
+  from public.assessment_extractions existing
+  where existing.assessment_document_id = documents.id
+    and existing.organization_id = documents.organization_id
+    and existing.field_key = fields.field_key
+);
+
+commit;


### PR DESCRIPTION
## Summary
- Seed IEHP upload checklist/extraction rows from active `assessment_template_fields` metadata after resolving `template_version_id`.
- Keep CalOptima on the static JSON checklist path and keep IEHP JSON fallback only when no linked template version exists.
- Add idempotent backfill migration for existing IEHP documents linked to `iehp_fba_updated_fba_11_2026_05`.

## Verification
- `npm test -- src/server/__tests__/assessmentDocumentsHandler.test.ts --runInBand`
- `npm run ci:check-focused`
- `npm run validate:tenant`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci` with `VITE_SUPABASE_URL=https://test.supabase.co` and `VITE_SUPABASE_ANON_KEY=anon-key`
- `npm run build`
- `npm run verify:local` with dummy local Supabase env values

## Notes
- No hosted Supabase mutation was performed in this PR. Migration application/backfill should happen after merge/deploy approval.
- PR targets `Messaging` because this slice depends on the IEHP next mapping metadata currently on that branch.