### PR TITLE
WIN-157 fix Supabase Validate post-merge gates

### DIFF
--- a/.github/workflows/supabase-validate.yml
+++ b/.github/workflows/supabase-validate.yml
@@ -62,8 +62,10 @@ jobs:
         run: npm test -- --run --reporter=verbose
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY || secrets.SUPABASE_PUBLISHABLE_KEY }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY || secrets.SUPABASE_PUBLISHABLE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || secrets.SUPABASE_SECRET_KEY }}
           RUN_DB_IT: '1'
       - name: Record Supabase validate evidence
         if: always()
@@ -86,6 +88,8 @@ jobs:
       MIGRATION_PARITY_HEAD_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- map Supabase Validate test env to the configured Supabase key secret names while preserving legacy aliases
- expose Vite Supabase URL/key aliases for server tests that load shared config
- fetch full git history in runtime migration parity so the base/head migration diff works on push reruns

## Verification
- npm run ci:check-focused
- YAML parse check for .github/workflows/supabase-validate.yml

## Risk
Critical workflow/protected-path change. No application runtime code or production data mutation in this PR.