### PR TITLE
WIN-157 close IEHP upload lifecycle gaps

### DIFF
--- a/src/components/ClientDetails/IehpFbaLayoutReview.tsx
+++ b/src/components/ClientDetails/IehpFbaLayoutReview.tsx
@@ -119,6 +119,16 @@ const getStructuredSectionPageNumber = (section: StructuredValue): number | null
   return typeof pageNumber === "number" ? pageNumber : null;
 };
 
+const emptyPageMessage = (pageNumber: number, title: string | undefined): string => {
+  if (pageNumber === 16 || /school goals/i.test(title ?? "")) {
+    return "No school-specific goals were extracted for this IEHP document.";
+  }
+  return "This template page is represented for layout parity. No mapped checklist field lands on this page yet.";
+};
+
+const isManualRequiredReviewItem = (field: TemplateField, item: ChecklistValue | undefined): boolean =>
+  Boolean(item) && field.required && field.mode === "MANUAL" && item?.status === "not_started";
+
 export function IehpFbaLayoutReview({
   assessmentDocument,
   organizationId,
@@ -331,7 +341,7 @@ export function IehpFbaLayoutReview({
 
             {activePageFields.length === 0 && activePageLooseStructuredSections.length === 0 ? (
               <div className="rounded border border-dashed border-slate-300 p-4 text-sm text-slate-600">
-                This template page is represented for layout parity. No mapped checklist field lands on this page yet.
+                {emptyPageMessage(activePage, activePageMeta?.title)}
               </div>
             ) : (
               <div className="space-y-4">
@@ -347,6 +357,7 @@ export function IehpFbaLayoutReview({
                     return pageNumber === null || pageNumber === activePage;
                   });
                   const locked = item?.status === "approved";
+                  const manualRequired = isManualRequiredReviewItem(field, item);
                   return (
                     <div key={field.field_key} className="rounded-md border border-slate-300 p-3">
                       <div className="mb-2 flex flex-wrap items-start justify-between gap-2">
@@ -359,9 +370,15 @@ export function IehpFbaLayoutReview({
                           </p>
                         </div>
                         <span className="rounded bg-slate-100 px-2 py-1 text-[11px] font-semibold text-slate-700">
-                          {item?.status ?? "missing row"}
+                          {manualRequired ? "manual required" : item?.status ?? "missing row"}
                         </span>
                       </div>
+
+                      {manualRequired && (
+                        <p className="mb-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900">
+                          This required IEHP field is intentionally manual unless reliable document evidence is present.
+                        </p>
+                      )}
 
                       <textarea
                         id={`iehp-${field.field_key}`}

--- a/src/components/__tests__/IehpFbaLayoutReview.test.tsx
+++ b/src/components/__tests__/IehpFbaLayoutReview.test.tsx
@@ -443,4 +443,132 @@ describe("IehpFbaLayoutReview", () => {
     expect(await screen.findByLabelText("Appendix and Supporting Information")).toBeInTheDocument();
     expect(screen.queryByText(/CalOptima/i)).not.toBeInTheDocument();
   });
+
+  it("renders a school-goals empty state on page 16 when no school goal sections were extracted", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string) => {
+      if (path.startsWith("/api/assessment-template-layout?")) {
+        return new Response(JSON.stringify({
+          template_version: {
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+          },
+          pages: [{ page_number: 16, title: "School Goals", layout_json: {} }],
+          fields: [],
+          values: {
+            checklist_items: [],
+            structured_sections: [],
+          },
+          unresolved_required_count: 0,
+          extracted_value_count: 0,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <IehpFbaLayoutReview assessmentDocument={assessmentDocument} organizationId="org-1" />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Page 16/i }));
+    expect(await screen.findByText("Page 16: School Goals")).toBeInTheDocument();
+    expect(screen.getByText("No school-specific goals were extracted for this IEHP document.")).toBeInTheDocument();
+    expect(screen.queryByText(/CalOptima/i)).not.toBeInTheDocument();
+  });
+
+  it("labels unresolved required manual IEHP rows as manual-required review items", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string) => {
+      if (path.startsWith("/api/assessment-template-layout?")) {
+        return new Response(JSON.stringify({
+          template_version: {
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+          },
+          pages: [{ page_number: 2, title: "Referral Information", layout_json: {} }],
+          fields: [
+            {
+              page_number: 2,
+              section_key: "identification_admin",
+              field_key: "IEHP_FBA_REFERRING_PROVIDER",
+              label: "Name of Referring Provider, Credentials",
+              field_type: "textarea",
+              mode: "MANUAL",
+              required: true,
+              source: "clinician_manual_entry unless present in uploaded document",
+              layout_json: {},
+            },
+            {
+              page_number: 2,
+              section_key: "identification_admin",
+              field_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+              label: "Reason for Referral",
+              field_type: "textarea",
+              mode: "MANUAL",
+              required: true,
+              source: "clinician_manual_entry unless present in uploaded document",
+              layout_json: {},
+            },
+            {
+              page_number: 2,
+              section_key: "identification_admin",
+              field_key: "IEHP_FBA_MISSING_MANUAL_FIELD",
+              label: "Missing Manual Field",
+              field_type: "textarea",
+              mode: "MANUAL",
+              required: true,
+              source: "clinician_manual_entry",
+              layout_json: {},
+            },
+          ],
+          values: {
+            checklist_items: [
+              {
+                id: "item-referring-provider",
+                placeholder_key: "IEHP_FBA_REFERRING_PROVIDER",
+                section_key: "identification_admin",
+                label: "Name of Referring Provider, Credentials",
+                mode: "MANUAL",
+                required: true,
+                status: "not_started",
+                value_text: null,
+                value_json: null,
+                review_notes: null,
+              },
+              {
+                id: "item-reason",
+                placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+                section_key: "identification_admin",
+                label: "Reason for Referral",
+                mode: "MANUAL",
+                required: true,
+                status: "verified",
+                value_text: "Reviewed referral reason",
+                value_json: null,
+                review_notes: null,
+              },
+            ],
+            structured_sections: [],
+          },
+          unresolved_required_count: 1,
+          extracted_value_count: 0,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <IehpFbaLayoutReview assessmentDocument={assessmentDocument} organizationId="org-1" />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Page 2/i }));
+    expect(await screen.findByLabelText("Name of Referring Provider, Credentials")).toBeInTheDocument();
+    expect(screen.getByText("manual required")).toBeInTheDocument();
+    expect(screen.getByText(/This required IEHP field is intentionally manual/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Reason for Referral")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Reviewed referral reason")).toBeInTheDocument();
+    expect(screen.getByLabelText("Missing Manual Field")).toBeDisabled();
+    expect(screen.getByText("missing row")).toBeInTheDocument();
+    expect(screen.getAllByText("manual required")).toHaveLength(1);
+  });
 });

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -108,6 +108,7 @@ describe("assessmentDocumentsHandler", () => {
     expect(payload).toMatchObject({
       status: "extraction_failed",
       extraction_error: expectedError,
+      extracted_at: null,
     });
     expect(payload.updated_at).toEqual(expect.any(String));
   };
@@ -3324,6 +3325,13 @@ describe("assessmentDocumentsHandler", () => {
       return typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-full-workflow") && body.includes('"status":"drafted"');
     });
     expect(draftedStatusPatchCall).toBeDefined();
+    const draftedStatusPatchPayload = JSON.parse(String((draftedStatusPatchCall?.[1] as RequestInit).body)) as Record<string, unknown>;
+    expect(draftedStatusPatchPayload).toMatchObject({
+      status: "drafted",
+      extraction_error: null,
+    });
+    expect(draftedStatusPatchPayload.extracted_at).toEqual(expect.any(String));
+    expect(Date.parse(String(draftedStatusPatchPayload.extracted_at))).not.toBeNaN();
 
     const draftGeneratedEventCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
       const body = typeof init?.body === "string" ? init.body : "";
@@ -3430,6 +3438,20 @@ describe("assessmentDocumentsHandler", () => {
       .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-event-fail"))
       .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
     expect(documentStatusBodies.some((body) => body.includes('"status":"drafted"'))).toBe(true);
+    const draftedStatusPayload = documentStatusBodies
+      .map((body) => {
+        try {
+          return JSON.parse(body) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      })
+      .find((payload) => payload?.status === "drafted");
+    expect(draftedStatusPayload).toMatchObject({
+      status: "drafted",
+      extraction_error: null,
+    });
+    expect(draftedStatusPayload?.extracted_at).toEqual(expect.any(String));
     expect(documentStatusBodies.some((body) => body.includes('"status":"extraction_failed"'))).toBe(false);
 
     const extractionCompletedEventCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -264,6 +264,13 @@ const asExtractionWorkflowError = (error: unknown, signal?: AbortSignal): Extrac
   return new ExtractionWorkflowError("extraction_workflow_failed", "Field extraction failed. Review checklist manually.");
 };
 
+const buildExtractionSuccessDocumentPatch = (status: "extracted" | "drafted", timestamp = new Date().toISOString()) => ({
+  status,
+  extracted_at: timestamp,
+  extraction_error: null,
+  updated_at: timestamp,
+});
+
 const assertFetchOk = (result: { ok: boolean; status?: number }, reasonCode: string): void => {
   if (!result.ok) {
     throw new ExtractionWorkflowError(reasonCode, reasonCode, result.status);
@@ -545,6 +552,7 @@ const persistExtractionFailure = async (args: {
       headers,
       body: JSON.stringify({
         status: "extraction_failed",
+        extracted_at: null,
         extraction_error: extractionError,
         updated_at: updatedAt,
       }),
@@ -750,6 +758,7 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
         AUTO_DRAFT_STRUCTURED_SECTION_STATUSES,
       );
       let finalStatus: "extracted" | "drafted" = "extracted";
+      const extractionCompletedAt = new Date().toISOString();
 
       if (deterministicDraftPayload) {
         const draftResult = await persistDraftRows({
@@ -760,6 +769,7 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
           document: { id: createdDocumentId, organization_id: organizationId, client_id: clientId, status: fromStatus },
           assessmentDocumentId: createdDocumentId,
           payload: deterministicDraftPayload,
+          extractedAt: extractionCompletedAt,
           signal,
         });
         assertExtractionNotAborted(signal);
@@ -777,12 +787,7 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
           method: "PATCH",
           headers,
           signal,
-          body: JSON.stringify({
-            status: "extracted",
-            extracted_at: new Date().toISOString(),
-            extraction_error: null,
-            updated_at: new Date().toISOString(),
-          }),
+          body: JSON.stringify(buildExtractionSuccessDocumentPatch("extracted", extractionCompletedAt)),
         });
         assertExtractionNotAborted(signal);
         assertFetchOk(documentExtractedResult, "assessment_status_update_failed");

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -388,9 +388,10 @@ export const persistDraftRows = async (args: {
   document: AssessmentDocumentScopeRow;
   assessmentDocumentId: string;
   payload: GeneratedDraftPayload;
+  extractedAt?: string;
   signal?: AbortSignal;
 }) => {
-  const { supabaseUrl, headers, organizationId, actorId, document, assessmentDocumentId, payload, signal } = args;
+  const { supabaseUrl, headers, organizationId, actorId, document, assessmentDocumentId, payload, extractedAt, signal } = args;
   const createProgramPayload = payload.programs.map((program) => ({
     assessment_document_id: assessmentDocumentId,
     organization_id: organizationId,
@@ -508,8 +509,9 @@ export const persistDraftRows = async (args: {
       signal,
       body: JSON.stringify({
         status: "drafted",
+        ...(extractedAt ? { extracted_at: extractedAt } : {}),
         extraction_error: null,
-        updated_at: new Date().toISOString(),
+        updated_at: extractedAt ?? new Date().toISOString(),
       }),
     },
   );
@@ -546,6 +548,7 @@ export const persistDraftRows = async (args: {
         signal,
         body: JSON.stringify({
           status: document.status,
+          ...(extractedAt ? { extracted_at: null } : {}),
           updated_at: new Date().toISOString(),
         }),
       },

--- a/supabase/migrations/20260522143000_backfill_iehp_extracted_at.sql
+++ b/supabase/migrations/20260522143000_backfill_iehp_extracted_at.sql
@@ -1,0 +1,61 @@
+-- @migration-intent: Backfill extracted_at for IEHP assessment documents that were successfully drafted before
+-- the draft persistence path wrote extraction completion timestamps.
+-- @migration-dependencies: 20260520131400_add_iehp_template_layout_metadata.sql, 20260521132512_backfill_iehp_template_metadata_rows.sql
+-- @migration-rollback: Set extracted_at back to null only for IEHP drafted assessment_documents that were updated by this backfill and have not been reprocessed.
+
+begin;
+
+update public.assessment_documents documents
+set extracted_at = (
+  select coalesce(max(events.created_at), documents.created_at)
+  from public.assessment_review_events events
+  where events.assessment_document_id = documents.id
+    and events.organization_id = documents.organization_id
+    and events.action = 'extraction_completed'
+    and events.to_status in ('drafted', 'extracted')
+)
+where documents.template_type = 'iehp_fba'
+  and documents.status in ('extracted', 'drafted', 'approved', 'rejected')
+  and documents.extracted_at is null
+  and documents.extraction_error is null
+  and exists (
+    select 1
+    from public.assessment_review_events events
+    where events.assessment_document_id = documents.id
+      and events.organization_id = documents.organization_id
+      and events.action = 'extraction_completed'
+      and events.to_status in ('drafted', 'extracted')
+  )
+  and (
+    exists (
+      select 1
+      from public.assessment_extractions extractions
+      where extractions.assessment_document_id = documents.id
+        and extractions.organization_id = documents.organization_id
+        and (
+          extractions.status = 'drafted'
+          or extractions.value_text is not null
+          or extractions.value_json is not null
+        )
+    )
+    or exists (
+      select 1
+      from public.assessment_checklist_items checklist
+      where checklist.assessment_document_id = documents.id
+        and checklist.organization_id = documents.organization_id
+        and (
+          checklist.status = 'drafted'
+          or checklist.value_text is not null
+          or checklist.value_json is not null
+        )
+    )
+    or exists (
+      select 1
+      from public.assessment_structured_sections sections
+      where sections.assessment_document_id = documents.id
+        and sections.organization_id = documents.organization_id
+        and sections.status in ('drafted', 'verified', 'approved')
+    )
+  );
+
+commit;


### PR DESCRIPTION
## Summary
- Set `extracted_at` and clear `extraction_error` on successful extraction paths that end in `drafted` or `extracted`.
- Clear `extracted_at` on extraction failure and rollback the draft timestamp if draft event recording fails.
- Add IEHP page-16 school-goal empty state and manual-required labeling for intentionally unresolved required manual rows.
- Add an idempotent IEHP data backfill migration for successfully extracted/drafted documents missing `extracted_at`.

## Verification
- `npm test -- src/server/__tests__/assessmentDocumentsHandler.test.ts --runInBand`
- `npm test -- src/components/__tests__/IehpFbaLayoutReview.test.tsx --runInBand`
- `deno test --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts`
- `npm run ci:check-focused`
- `npm run validate:tenant`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`
- `npm run verify:local`

## Notes
- Draft PR because this touches protected paths: `src/server/**`, `supabase/migrations/**`, and IEHP review UI behavior.
- Do not apply the hosted Supabase migration until after merge and explicit production rollout approval.
- No Supabase Edge Function deployment is needed for this slice because `supabase/functions/**` was not changed.