### PR TITLE
Show sender names on staff message threads.

### DIFF
--- a/cypress/support/routeScenarios.ts
+++ b/cypress/support/routeScenarios.ts
@@ -132,6 +132,13 @@ export const installRouteDataStubs = (): void => {
     ],
     headers: { "content-type": "application/json" },
   });
+  cy.intercept("POST", "**/__supabase/rest/v1/rpc/list_staff_message_thread_participant_names**", {
+    statusCode: 200,
+    body: [
+      { user_id: "staff-2", full_name: "Staff Two" },
+    ],
+    headers: { "content-type": "application/json" },
+  });
 };
 
 export const assertVisibleRoute = (path: string): void => {

--- a/src/components/messages/MessageList.tsx
+++ b/src/components/messages/MessageList.tsx
@@ -20,12 +20,21 @@ export function MessageList({ messages, currentUserId }: MessageListProps) {
     <ul className="space-y-3" data-testid="messages-list">
       {messages.map((message) => {
         const isOwn = message.sender_id === currentUserId;
+        const senderLabel = message.sender_name ?? 'Staff member';
         return (
           <li
             key={message.id}
-            className={`flex ${isOwn ? 'justify-end' : 'justify-start'}`}
+            className={`flex flex-col ${isOwn ? 'items-end' : 'items-start'}`}
             data-testid={`message-item-${message.id}`}
           >
+            {!isOwn ? (
+              <p
+                className="mb-1 px-1 text-xs font-semibold text-gray-600 dark:text-gray-300"
+                data-testid={`message-sender-${message.id}`}
+              >
+                {senderLabel}
+              </p>
+            ) : null}
             <div
               className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
                 isOwn

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -6040,6 +6040,13 @@ export type Database = {
         }
         Returns: string
       }
+      list_staff_message_thread_participant_names: {
+        Args: { p_thread_id: string }
+        Returns: {
+          full_name: string
+          user_id: string
+        }[]
+      }
       assign_therapist_role:
         | { Args: { p_email: string; p_user_id: string }; Returns: undefined }
         | { Args: { p_therapist_id: string }; Returns: undefined }

--- a/src/lib/messages/__tests__/errors.test.ts
+++ b/src/lib/messages/__tests__/errors.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isMessagingRpcUnavailable, isMessagingSchemaUnavailable } from '../errors';
+
+describe('messaging error guards', () => {
+  it('detects missing RPC via PostgREST code metadata', () => {
+    const error = {
+      code: 'PGRST202',
+      message: 'Could not find the function public.list_staff_message_thread_participant_names',
+    };
+
+    expect(isMessagingRpcUnavailable(error)).toBe(true);
+    expect(isMessagingSchemaUnavailable(error)).toBe(true);
+  });
+
+  it('does not treat unrelated errors as schema-unavailable', () => {
+    const error = { code: '42501', message: 'permission denied' };
+
+    expect(isMessagingRpcUnavailable(error)).toBe(false);
+    expect(isMessagingSchemaUnavailable(error)).toBe(false);
+  });
+});

--- a/src/lib/messages/__tests__/fetchThreadMessages.test.ts
+++ b/src/lib/messages/__tests__/fetchThreadMessages.test.ts
@@ -70,6 +70,38 @@ describe('fetchThreadMessages', () => {
     ]);
   });
 
+  it('still loads messages when participant names RPC is unavailable (PGRST202)', async () => {
+    const orderMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'msg-1',
+          thread_id: 'thread-1',
+          sender_id: 'user-b',
+          body: 'Hello',
+          created_at: '2026-05-22T12:00:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    const eqMock = vi.fn().mockReturnValue({ order: orderMock });
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+    fromMock.mockReturnValue({ select: selectMock });
+
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: {
+        code: 'PGRST202',
+        message: 'Could not find the function public.list_staff_message_thread_participant_names',
+      },
+    });
+
+    const messages = await fetchThreadMessages('thread-1');
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.body).toBe('Hello');
+    expect(messages[0]?.sender_name).toBe('Staff member');
+  });
+
   it('falls back to Staff member when sender is missing from RPC map', async () => {
     const orderMock = vi.fn().mockResolvedValue({
       data: [

--- a/src/lib/messages/__tests__/fetchThreadMessages.test.ts
+++ b/src/lib/messages/__tests__/fetchThreadMessages.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fromMock = vi.fn();
+const rpcMock = vi.fn();
+
+vi.mock('../../supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => fromMock(...args),
+    rpc: (...args: unknown[]) => rpcMock(...args),
+  },
+}));
+
+import { fetchThreadMessages } from '../fetchers';
+
+describe('fetchThreadMessages', () => {
+  beforeEach(() => {
+    fromMock.mockReset();
+    rpcMock.mockReset();
+  });
+
+  it('enriches messages with sender_name from participant names RPC', async () => {
+    const orderMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'msg-1',
+          thread_id: 'thread-1',
+          sender_id: 'user-a',
+          body: 'Hello',
+          created_at: '2026-05-22T12:00:00.000Z',
+        },
+        {
+          id: 'msg-2',
+          thread_id: 'thread-1',
+          sender_id: 'user-b',
+          body: 'Reply',
+          created_at: '2026-05-22T12:01:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    const eqMock = vi.fn().mockReturnValue({ order: orderMock });
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+    fromMock.mockReturnValue({ select: selectMock });
+
+    rpcMock.mockResolvedValue({
+      data: [
+        { user_id: 'user-a', full_name: 'Alex Admin' },
+        { user_id: 'user-b', full_name: 'Taylor Therapist' },
+      ],
+      error: null,
+    });
+
+    const messages = await fetchThreadMessages('thread-1');
+
+    expect(fromMock).toHaveBeenCalledWith('messages');
+    expect(rpcMock).toHaveBeenCalledWith('list_staff_message_thread_participant_names', {
+      p_thread_id: 'thread-1',
+    });
+    expect(messages).toEqual([
+      expect.objectContaining({
+        id: 'msg-1',
+        sender_id: 'user-a',
+        sender_name: 'Alex Admin',
+      }),
+      expect.objectContaining({
+        id: 'msg-2',
+        sender_id: 'user-b',
+        sender_name: 'Taylor Therapist',
+      }),
+    ]);
+  });
+
+  it('falls back to Staff member when sender is missing from RPC map', async () => {
+    const orderMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'msg-1',
+          thread_id: 'thread-1',
+          sender_id: 'unknown-user',
+          body: 'Hello',
+          created_at: '2026-05-22T12:00:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    const eqMock = vi.fn().mockReturnValue({ order: orderMock });
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+    fromMock.mockReturnValue({ select: selectMock });
+
+    rpcMock.mockResolvedValue({
+      data: [{ user_id: 'user-a', full_name: 'Alex Admin' }],
+      error: null,
+    });
+
+    const messages = await fetchThreadMessages('thread-1');
+
+    expect(messages[0]?.sender_name).toBe('Staff member');
+  });
+});

--- a/src/lib/messages/errors.ts
+++ b/src/lib/messages/errors.ts
@@ -1,6 +1,39 @@
 import { toError } from '../logger/normalizeError';
 
+const readPostgrestCode = (error: unknown): string | undefined => {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === 'string' && code.trim().length > 0) {
+      return code.trim();
+    }
+  }
+
+  const normalized = toError(error);
+  if (normalized.name.startsWith('SupabaseError:')) {
+    return normalized.name.slice('SupabaseError:'.length);
+  }
+
+  return undefined;
+};
+
+/** Missing RPC or stale PostgREST schema cache for staff messaging helpers. */
+export const isMessagingRpcUnavailable = (error: unknown): boolean => {
+  const code = readPostgrestCode(error);
+  const message = toError(error).message.toLowerCase();
+
+  return (
+    code === 'PGRST202'
+    || message.includes('pgrst202')
+    || message.includes('list_staff_message_thread_participant_names')
+    || message.includes('list_eligible_staff_for_messaging')
+  );
+};
+
 export const isMessagingSchemaUnavailable = (error: unknown): boolean => {
+  if (isMessagingRpcUnavailable(error)) {
+    return true;
+  }
+
   const normalized = toError(error);
   const message = normalized.message.toLowerCase();
   return (
@@ -8,6 +41,6 @@ export const isMessagingSchemaUnavailable = (error: unknown): boolean => {
     || message.includes('message_thread_participants')
     || message.includes('does not exist')
     || message.includes('schema cache')
-    || normalized.message.includes('PGRST205')
+    || message.includes('pgrst205')
   );
 };

--- a/src/lib/messages/fetchThreadParticipantNames.ts
+++ b/src/lib/messages/fetchThreadParticipantNames.ts
@@ -5,15 +5,13 @@ type RpcParticipantNameRow = {
   full_name: string | null;
 };
 
-const isMissingRpc = (error: { code?: string; message?: string }): boolean => {
-  const message = (error.message ?? '').toLowerCase();
-  return error.code === 'PGRST202' || message.includes('list_staff_message_thread_participant_names');
-};
-
 /**
  * Thread-scoped display names for message senders.
  * Uses SECURITY DEFINER RPC so participants can resolve co-participant names
  * without profiles_select_self RLS blocking cross-user reads.
+ *
+ * Re-throws PostgREST errors as-is so callers can detect PGRST202 / schema-cache
+ * failures via isMessagingSchemaUnavailable without losing error metadata.
  */
 export const fetchThreadParticipantNames = async (
   threadId: string,
@@ -23,11 +21,6 @@ export const fetchThreadParticipantNames = async (
   });
 
   if (error) {
-    if (isMissingRpc(error)) {
-      throw new Error(
-        'Thread participant names are not available until the list_staff_message_thread_participant_names migration is applied.',
-      );
-    }
     throw error;
   }
 

--- a/src/lib/messages/fetchThreadParticipantNames.ts
+++ b/src/lib/messages/fetchThreadParticipantNames.ts
@@ -1,0 +1,40 @@
+import { supabase } from '../supabase';
+
+type RpcParticipantNameRow = {
+  user_id: string;
+  full_name: string | null;
+};
+
+const isMissingRpc = (error: { code?: string; message?: string }): boolean => {
+  const message = (error.message ?? '').toLowerCase();
+  return error.code === 'PGRST202' || message.includes('list_staff_message_thread_participant_names');
+};
+
+/**
+ * Thread-scoped display names for message senders.
+ * Uses SECURITY DEFINER RPC so participants can resolve co-participant names
+ * without profiles_select_self RLS blocking cross-user reads.
+ */
+export const fetchThreadParticipantNames = async (
+  threadId: string,
+): Promise<Map<string, string>> => {
+  const { data, error } = await supabase.rpc('list_staff_message_thread_participant_names', {
+    p_thread_id: threadId,
+  });
+
+  if (error) {
+    if (isMissingRpc(error)) {
+      throw new Error(
+        'Thread participant names are not available until the list_staff_message_thread_participant_names migration is applied.',
+      );
+    }
+    throw error;
+  }
+
+  const map = new Map<string, string>();
+  for (const row of (data ?? []) as RpcParticipantNameRow[]) {
+    const name = row.full_name?.trim() || 'Staff member';
+    map.set(row.user_id, name);
+  }
+  return map;
+};

--- a/src/lib/messages/fetchers.ts
+++ b/src/lib/messages/fetchers.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../supabase';
 import { fetchStaffRecipients } from './fetchStaffRecipients';
+import { fetchThreadParticipantNames } from './fetchThreadParticipantNames';
 import { isMessagingSchemaUnavailable } from './errors';
 import type {
   Message,
@@ -101,11 +102,21 @@ export const fetchMessageThreads = async (
 };
 
 export const fetchThreadMessages = async (threadId: string): Promise<Message[]> => {
-  const { data, error } = await supabase
-    .from('messages')
-    .select('*')
-    .eq('thread_id', threadId)
-    .order('created_at', { ascending: true });
+  const [messagesResult, participantNames] = await Promise.all([
+    supabase
+      .from('messages')
+      .select('*')
+      .eq('thread_id', threadId)
+      .order('created_at', { ascending: true }),
+    fetchThreadParticipantNames(threadId).catch((nameError) => {
+      if (isMessagingSchemaUnavailable(nameError)) {
+        return new Map<string, string>();
+      }
+      throw nameError;
+    }),
+  ]);
+
+  const { data, error } = messagesResult;
 
   if (error) {
     if (isMessagingSchemaUnavailable(error)) {
@@ -114,7 +125,10 @@ export const fetchThreadMessages = async (threadId: string): Promise<Message[]> 
     throw error;
   }
 
-  return (data ?? []) as Message[];
+  return ((data ?? []) as Message[]).map((message) => ({
+    ...message,
+    sender_name: participantNames.get(message.sender_id) ?? 'Staff member',
+  }));
 };
 
 export const fetchMessageThread = async (threadId: string) => {

--- a/src/lib/messages/types.ts
+++ b/src/lib/messages/types.ts
@@ -26,6 +26,7 @@ export type Message = {
   sender_id: string;
   body: string;
   created_at: string;
+  sender_name?: string;
 };
 
 export type MessageThreadListItem = MessageThread & {

--- a/supabase/migrations/20260522143000_list_staff_message_thread_participant_names.sql
+++ b/supabase/migrations/20260522143000_list_staff_message_thread_participant_names.sql
@@ -1,0 +1,55 @@
+-- @migration-intent: Thread-scoped participant display names for staff messaging without widening profiles SELECT RLS.
+-- @migration-dependencies: 20260520143000_staff_messaging_tables_and_rls.sql
+-- @migration-rollback: DROP FUNCTION IF EXISTS public.list_staff_message_thread_participant_names(uuid);
+
+BEGIN;
+
+SET LOCAL search_path = public, app, auth;
+SET LOCAL check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.list_staff_message_thread_participant_names(
+  p_thread_id uuid
+)
+RETURNS TABLE (
+  user_id uuid,
+  full_name text
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth, app
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '28000', MESSAGE = 'Authentication required';
+  END IF;
+
+  IF p_thread_id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Thread context required';
+  END IF;
+
+  IF NOT app.is_staff_message_thread_participant(p_thread_id) THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Not a participant in this thread';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    mtp.user_id,
+    COALESCE(
+      NULLIF(BTRIM(p.full_name), ''),
+      NULLIF(BTRIM(p.email), ''),
+      'Staff member'
+    ) AS full_name
+  FROM public.message_thread_participants mtp
+  INNER JOIN public.profiles p ON p.id = mtp.user_id
+  WHERE mtp.thread_id = p_thread_id
+  ORDER BY full_name, mtp.user_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.list_staff_message_thread_participant_names(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.list_staff_message_thread_participant_names(uuid) TO authenticated, service_role;
+
+COMMIT;

--- a/tests/integration/rls.message-threads.access.test.ts
+++ b/tests/integration/rls.message-threads.access.test.ts
@@ -267,6 +267,62 @@ describe("RLS staff messaging (live Supabase)", () => {
     createdThreadIds.push(data as string);
   });
 
+  it("allows participants to resolve thread participant display names via RPC", async () => {
+    if (!harness.enabled) {
+      if (harness.required) {
+        throw new Error(harness.skipReason);
+      }
+      return;
+    }
+
+    const therapistClient = await harness.signInTherapistA();
+    const threadId = await createDirectThread(therapistClient, [
+      harness.orgATherapistUserId,
+      harness.orgAAdminUserId,
+    ]);
+
+    const therapistNames = await therapistClient.rpc("list_staff_message_thread_participant_names", {
+      p_thread_id: threadId,
+    });
+    expect(therapistNames.error).toBeNull();
+    const therapistRows = therapistNames.data ?? [];
+    expect(therapistRows.length).toBeGreaterThanOrEqual(2);
+    expect(therapistRows.some((row) => row.user_id === harness.orgATherapistUserId)).toBe(true);
+    expect(therapistRows.some((row) => row.user_id === harness.orgAAdminUserId)).toBe(true);
+    expect(therapistRows.every((row) => typeof row.full_name === "string" && row.full_name.length > 0)).toBe(
+      true,
+    );
+
+    if (!orgAObserverAdmin) {
+      return;
+    }
+
+    const env = await resolveSupabaseTestEnv({
+      isCiEnvironment: Boolean(process.env.CI),
+      runDatabaseIntegrationTests: true,
+    });
+    if (!env.shouldRun || !env.supabaseAnonKey) {
+      throw new Error(computeEnvironmentGuidance(env.missing));
+    }
+
+    const observerClient = createClient<Database>(env.supabaseUrl as string, env.supabaseAnonKey as string, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const signIn = await observerClient.auth.signInWithPassword({
+      email: orgAObserverAdmin.email,
+      password: orgAObserverAdmin.password,
+    });
+    expect(signIn.error).toBeNull();
+
+    const deniedNames = await observerClient.rpc("list_staff_message_thread_participant_names", {
+      p_thread_id: threadId,
+    });
+    expect(deniedNames.error).not.toBeNull();
+    expect((deniedNames.error?.message ?? "").toLowerCase()).toMatch(
+      /not a participant|permission|42501|28000/,
+    );
+  });
+
   it("limits participant-local archive updates to the owning participant", async () => {
     if (!harness.enabled) {
       if (harness.required) {


### PR DESCRIPTION
Add a participant-gated RPC to resolve co-participant display names without widening profiles RLS, enrich thread message fetches, and label incoming bubbles.