### PR TITLE
WIN-157 prefill IEHP assessor phone from primary therapist

### DIFF
--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -2525,6 +2525,138 @@ describe("assessmentDocumentsHandler", () => {
     expect(String((extractionPatch?.[1] as RequestInit).body)).toContain('"mode":"ASSISTED"');
   });
 
+  it("passes client primary therapist phone into IEHP extraction snapshot for assessor phone prefill", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([
+      {
+        section: "identification_admin",
+        label: "Assessor's phone number",
+        placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+        required: true,
+        mode: "ASSISTED",
+        source: "therapists.phone || company_settings.phone",
+        extraction_method: "assisted_draft_plus_review",
+        validation_rule: "phone_us_or_e164_or_na",
+        extraction_owner: "ClinicalAuthor",
+        review_owner: "BCBAReviewer",
+      },
+    ]);
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "11111111-1111-1111-1111-111111111111" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name,first_name,last_name")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            first_name: "Kim",
+            last_name: "Le",
+            therapist_id: "primary-therapist-1",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_versions?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "template-version-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_fields?select=")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            section_key: "identification_admin",
+            field_key: "IEHP_FBA_ASSESSOR_PHONE",
+            label: "Assessor's phone number",
+            field_type: "text",
+            mode: "ASSISTED",
+            required: true,
+            source: "therapists.phone || company_settings.phone",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/therapists?select=phone")) {
+        expect(url).toContain("id=eq.primary-therapist-1");
+        expect(url).toContain("organization_id=eq.org-1");
+        return { ok: true, status: 200, data: [{ phone: "(951) 555-0101" }] };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
+        return {
+          ok: true,
+          status: 201,
+          data: [{
+            id: "doc-iehp-assessor-phone",
+            organization_id: "org-1",
+            client_id: "11111111-1111-1111-1111-111111111111",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return {
+          ok: true,
+          status: 200,
+          data: {
+            fields: [],
+            structured_sections: [],
+            unresolved_keys: [],
+            extracted_count: 0,
+            unresolved_count: 0,
+          },
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) return { ok: true, status: 200, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) return { ok: true, status: 201, data: null };
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "iehp-fba.docx",
+          mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/iehp-fba.docx",
+          template_type: "iehp_fba",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const extractionCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" &&
+      url.includes("/functions/v1/extract-assessment-fields") &&
+      (init?.method ?? "").toUpperCase() === "POST"
+    );
+    expect(extractionCall).toBeDefined();
+    const payload = JSON.parse(String((extractionCall?.[1] as RequestInit).body)) as {
+      client_snapshot?: Record<string, unknown>;
+    };
+    expect(payload.client_snapshot).toMatchObject({
+      first_name: "Kim",
+      last_name: "Le",
+      primary_therapist_phone: "(951) 555-0101",
+    });
+  });
+
   it("records extraction_failed audit event when extraction API returns non-ok", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -2526,6 +2526,7 @@ describe("assessmentDocumentsHandler", () => {
   });
 
   it("passes client primary therapist phone into IEHP extraction snapshot for assessor phone prefill", async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
@@ -2590,6 +2591,10 @@ describe("assessmentDocumentsHandler", () => {
       if (method === "GET" && url.includes("/rest/v1/therapists?select=phone")) {
         expect(url).toContain("id=eq.primary-therapist-1");
         expect(url).toContain("organization_id=eq.org-1");
+        expect(init?.headers).toMatchObject({
+          apikey: "service-role",
+          Authorization: "Bearer service-role",
+        });
         return { ok: true, status: 200, data: [{ phone: "(951) 555-0101" }] };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -8,6 +8,7 @@ import {
   jsonForRequest,
   resolveOrgAndRole,
 } from "./shared";
+import { getOptionalServerEnv } from "../env";
 import {
   loadChecklistTemplateRows,
   type AssessmentChecklistSeedRow,
@@ -110,7 +111,6 @@ const compactNullableRecord = <T extends Record<string, unknown>>(value: T): Par
 
 const loadPrimaryTherapistPhone = async (args: {
   supabaseUrl: string;
-  headers: Record<string, string>;
   organizationId: string;
   therapistId: string | null | undefined;
   signal?: AbortSignal;
@@ -119,12 +119,24 @@ const loadPrimaryTherapistPhone = async (args: {
   if (!therapistId) {
     return null;
   }
+  const serviceRoleKey = getOptionalServerEnv("SUPABASE_SERVICE_ROLE_KEY")?.trim();
+  if (!serviceRoleKey) {
+    return null;
+  }
 
   const result = await fetchJson<Array<{ phone?: string | null }>>(
     `${args.supabaseUrl}/rest/v1/therapists?select=phone&id=eq.${encodeURIComponent(
       therapistId,
     )}&organization_id=eq.${encodeURIComponent(args.organizationId)}&limit=1`,
-    { method: "GET", headers: args.headers, signal: args.signal },
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        apikey: serviceRoleKey,
+        Authorization: `Bearer ${serviceRoleKey}`,
+      },
+      signal: args.signal,
+    },
   );
   if (!result.ok || !Array.isArray(result.data)) {
     return null;
@@ -657,7 +669,6 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
     const primaryTherapistPhone = clientSnapshotRow && templateType === "iehp_fba"
       ? await loadPrimaryTherapistPhone({
         supabaseUrl,
-        headers,
         organizationId,
         therapistId: clientSnapshotRow.therapist_id,
         signal,

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -91,6 +91,8 @@ interface ClientSnapshotRow {
   city?: string | null;
   state?: string | null;
   zip_code?: string | null;
+  therapist_id?: string | null;
+  primary_therapist_phone?: string | null;
 }
 
 interface AssessmentTemplateFieldRow {
@@ -105,6 +107,31 @@ interface AssessmentTemplateFieldRow {
 
 const compactNullableRecord = <T extends Record<string, unknown>>(value: T): Partial<T> =>
   Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== null && entry !== undefined)) as Partial<T>;
+
+const loadPrimaryTherapistPhone = async (args: {
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  organizationId: string;
+  therapistId: string | null | undefined;
+  signal?: AbortSignal;
+}): Promise<string | null> => {
+  const therapistId = typeof args.therapistId === "string" ? args.therapistId.trim() : "";
+  if (!therapistId) {
+    return null;
+  }
+
+  const result = await fetchJson<Array<{ phone?: string | null }>>(
+    `${args.supabaseUrl}/rest/v1/therapists?select=phone&id=eq.${encodeURIComponent(
+      therapistId,
+    )}&organization_id=eq.${encodeURIComponent(args.organizationId)}&limit=1`,
+    { method: "GET", headers: args.headers, signal: args.signal },
+  );
+  if (!result.ok || !Array.isArray(result.data)) {
+    return null;
+  }
+  const phone = result.data[0]?.phone;
+  return typeof phone === "string" && phone.trim().length > 0 ? phone.trim() : null;
+};
 
 const isExtractionFailurePendingStatus = (status: string): boolean =>
   PENDING_EXTRACTION_STATUSES.has(status as AssessmentDocumentExtractionRow["status"]);
@@ -616,7 +643,7 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
   try {
     assertExtractionNotAborted(signal);
     const clientSnapshotResult = await fetchJson<ClientSnapshotRow[]>(
-      `${supabaseUrl}/rest/v1/clients?select=full_name,first_name,last_name,date_of_birth,cin_number,client_id,phone,parent1_phone,parent1_first_name,parent1_last_name,parent1_relationship,preferred_language,address_line1,address_line2,city,state,zip_code&id=eq.${encodeURIComponent(
+      `${supabaseUrl}/rest/v1/clients?select=full_name,first_name,last_name,date_of_birth,cin_number,client_id,phone,parent1_phone,parent1_first_name,parent1_last_name,parent1_relationship,preferred_language,address_line1,address_line2,city,state,zip_code,therapist_id&id=eq.${encodeURIComponent(
         clientId,
       )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
       { method: "GET", headers, signal },
@@ -627,7 +654,23 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
       clientSnapshotResult.ok && Array.isArray(clientSnapshotResult.data) && clientSnapshotResult.data[0]
         ? clientSnapshotResult.data[0]
         : null;
-    const clientSnapshot = clientSnapshotRow ? compactNullableRecord(clientSnapshotRow) : undefined;
+    const primaryTherapistPhone = clientSnapshotRow && templateType === "iehp_fba"
+      ? await loadPrimaryTherapistPhone({
+        supabaseUrl,
+        headers,
+        organizationId,
+        therapistId: clientSnapshotRow.therapist_id,
+        signal,
+      })
+      : null;
+    assertExtractionNotAborted(signal);
+    const clientSnapshot = clientSnapshotRow
+      ? compactNullableRecord({
+        ...clientSnapshotRow,
+        therapist_id: undefined,
+        primary_therapist_phone: primaryTherapistPhone,
+      })
+      : undefined;
 
     const extractionResult = await fetchJson<ExtractionFunctionResponse>(`${supabaseUrl}/functions/v1/extract-assessment-fields`, {
         method: "POST",

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -783,3 +783,27 @@ Deno.test("deterministicValueForRow keeps manual and assisted IEHP rows honest w
   expect(assessorPhone.status).toBe("not_started");
   expect(assessorPhone.review_notes).toContain("reliable provider or organization source");
 });
+
+Deno.test("deterministicValueForRow prefills IEHP assessor phone from primary therapist snapshot", () => {
+  const assessorPhone = __TESTING__.deterministicValueForRow(
+    {
+      section: "identification_admin",
+      label: "Assessor's phone number",
+      placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+      required: true,
+      mode: "ASSISTED",
+    },
+    "",
+    { primary_therapist_phone: "(951) 555-0101" },
+  );
+
+  expect(assessorPhone.value_text).toBe("(951) 555-0101");
+  expect(assessorPhone.mode).toBe("ASSISTED");
+  expect(assessorPhone.status).toBe("drafted");
+  expect(assessorPhone.confidence).toBeLessThan(0.8);
+  expect(assessorPhone.source_span).toMatchObject({
+    method: "client_snapshot",
+    field: "primary_therapist_phone",
+  });
+  expect(assessorPhone.review_notes).toContain("primary therapist");
+});

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -53,6 +53,7 @@ const requestSchema = z.object({
       city: z.string().nullish(),
       state: z.string().nullish(),
       zip_code: z.string().nullish(),
+      primary_therapist_phone: z.string().nullish(),
     })
     .optional(),
 });
@@ -1477,6 +1478,18 @@ const deterministicValueForRow = (
     }
   }
   if (/ASSESSOR_PHONE/u.test(key)) {
+    if (client.primary_therapist_phone) {
+      return {
+        placeholder_key: key,
+        value_text: client.primary_therapist_phone,
+        value_json: null,
+        confidence: 0.74,
+        mode: row.mode ?? "ASSISTED",
+        status: "drafted",
+        source_span: { method: "client_snapshot", field: "primary_therapist_phone" },
+        review_notes: "Assisted fill from client primary therapist phone; clinician review required.",
+      };
+    }
     return {
       placeholder_key: key,
       value_text: null,


### PR DESCRIPTION
## Summary
- pass the client primary therapist phone into IEHP extraction snapshots when a client has a primary therapist
- prefill IEHP assessor phone as ASSISTED with clinician review required, not confident AUTO
- add server and Edge Function regression coverage for the snapshot handoff and deterministic prefill

## Verification
- deno test --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts --filter "primary therapist snapshot"
- npm test -- src/server/__tests__/assessmentDocumentsHandler.test.ts --runInBand -t "primary therapist phone"
- deno test --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts
- npm test -- src/server/__tests__/assessmentDocumentsHandler.test.ts --runInBand
- npm run ci:check-focused
- npm run validate:tenant
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
- npm run verify:local

## Risk / Rollout
- Critical protected-path change: server upload extraction snapshot and Supabase Edge extraction behavior.
- No migration required.
- After merge, redeploy Supabase Edge Function extract-assessment-fields before reprocessing/reuploading IEHP documents that need IEHP_FBA_ASSESSOR_PHONE populated.

## Notes
- Unrelated untracked file left untouched: docs/ai/post-merge-staff-message-sender-names.md