### PR TITLE
Show sender names on outbound messages

### DIFF
--- a/docs/ai/2026-05-22-message-sender-names-handoff.md
+++ b/docs/ai/2026-05-22-message-sender-names-handoff.md
@@ -12,7 +12,15 @@
 ## Scope
 
 - task intent: show sender names for messages in the messaging thread route, including outbound messages from the current user
+- follow-up slice: add participant names to inbox rows and direct-message thread titles, and keep direct-message participant fetching bounded to threads that actually render those names
 - files touched:
+  - `src/components/messages/ThreadRow.tsx`
+  - `src/lib/messages/fetchers.ts`
+  - `src/lib/messages/types.ts`
+  - `src/lib/messages/__tests__/fetchMessageThread.test.ts`
+  - `src/pages/messages/MessageThread.tsx`
+  - `src/pages/messages/MessagesInbox.tsx`
+  - `src/pages/messages/__tests__/MessagesInbox.test.tsx`
   - `src/components/messages/MessageList.tsx`
   - `src/pages/messages/__tests__/MessageThread.test.tsx`
   - `docs/ai/2026-05-22-message-sender-names-handoff.md`
@@ -40,6 +48,7 @@
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
+  - `npx vitest run src/lib/messages/__tests__/fetchMessageThread.test.ts src/pages/messages/__tests__/MessagesInbox.test.tsx src/pages/messages/__tests__/MessageThread.test.tsx`: pass
   - `npx vitest run src/pages/messages/__tests__/MessageThread.test.tsx`: pass
   - `npm run ci:check-focused`: pass
   - `npm run lint`: pass
@@ -50,7 +59,7 @@
 - blocked checks:
   - none
 - result: pass
-- residual risk: the change is intentionally narrow and only affects sender-label rendering inside the thread view; inbox/thread-title participant naming remains unchanged.
+- residual risk: the change is still UI-bounded, but participant names for direct-message chrome now depend on the existing participant-name RPC. Group-thread naming remains subject-driven, and the branch still inherits pre-existing non-fatal test warnings from unrelated suites.
 
 ## PR Hygiene
 
@@ -58,7 +67,7 @@
 - linear-ready: yes (`WIN-158`)
 - protected-path drift: none
 - unrelated changes: none
-- generated artifact drift: none
+- generated artifact drift: none after restoring `reports/test-reliability-latest.json`
 - verification summary: present
 - pr-ready: yes
 - required follow-up:
@@ -67,4 +76,4 @@
 
 ## Handoff Summary
 
-The messaging thread UI now renders a sender label for every message, including the current user's outbound messages, so conversations clearly show who said what. The change is limited to `MessageList` and a route-level regression test in `MessageThread.test.tsx`, and it passed policy checks, lint, typecheck, full Vitest coverage, build, and `verify:local`. Remaining risk is low and limited to adjacent message-list presentation that was intentionally left unchanged.
+The messaging UI now shows names in the three places needed to answer “who is messaging who”: outbound sender labels inside the thread, inbox rows for subjectless direct messages, and direct-message thread titles. The fetcher work preserves the `fetchMessageThread()` null contract, limits participant-name lookups to direct threads that need the names, and extends inbox search to match participant names. The slice passed focused messaging tests, policy checks, lint, typecheck, full Vitest coverage, build, and `verify:local`.

--- a/docs/ai/2026-05-22-message-sender-names-handoff.md
+++ b/docs/ai/2026-05-22-message-sender-names-handoff.md
@@ -1,0 +1,70 @@
+# Message Sender Names Handoff
+
+## Routing
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- why: bounded messaging UI behavior change across existing client message components and tests, with no auth, server, CI, deploy, or schema edits
+- triggering paths:
+  - `src/components/messages/**`
+  - `src/pages/messages/**`
+
+## Scope
+
+- task intent: show sender names for messages in the messaging thread route, including outbound messages from the current user
+- files touched:
+  - `src/components/messages/MessageList.tsx`
+  - `src/pages/messages/__tests__/MessageThread.test.tsx`
+  - `docs/ai/2026-05-22-message-sender-names-handoff.md`
+- single-purpose diff: yes
+
+## Required Agents
+
+- required sequence:
+  - `specification-engineer`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+- agents used:
+  - `reviewer`
+  - `tester`
+- reviewer: completed
+
+## Verification Card
+
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - `npx vitest run src/pages/messages/__tests__/MessageThread.test.tsx`: pass
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run test:ci`: pass with local dummy env values for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
+  - `npm run build`: pass
+  - `npm run verify:local`: pass with local dummy env values for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
+- blocked checks:
+  - none
+- result: pass
+- residual risk: the change is intentionally narrow and only affects sender-label rendering inside the thread view; inbox/thread-title participant naming remains unchanged.
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes (`WIN-158`)
+- protected-path drift: none
+- unrelated changes: none
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: yes
+- required follow-up:
+  - push branch
+  - open PR for human review
+
+## Handoff Summary
+
+The messaging thread UI now renders a sender label for every message, including the current user's outbound messages, so conversations clearly show who said what. The change is limited to `MessageList` and a route-level regression test in `MessageThread.test.tsx`, and it passed policy checks, lint, typecheck, full Vitest coverage, build, and `verify:local`. Remaining risk is low and limited to adjacent message-list presentation that was intentionally left unchanged.

--- a/src/components/messages/MessageList.tsx
+++ b/src/components/messages/MessageList.tsx
@@ -27,14 +27,14 @@ export function MessageList({ messages, currentUserId }: MessageListProps) {
             className={`flex flex-col ${isOwn ? 'items-end' : 'items-start'}`}
             data-testid={`message-item-${message.id}`}
           >
-            {!isOwn ? (
-              <p
-                className="mb-1 px-1 text-xs font-semibold text-gray-600 dark:text-gray-300"
-                data-testid={`message-sender-${message.id}`}
-              >
-                {senderLabel}
-              </p>
-            ) : null}
+            <p
+              className={`mb-1 px-1 text-xs font-semibold ${
+                isOwn ? 'text-blue-700 dark:text-blue-300' : 'text-gray-600 dark:text-gray-300'
+              }`}
+              data-testid={`message-sender-${message.id}`}
+            >
+              {senderLabel}
+            </p>
             <div
               className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
                 isOwn

--- a/src/components/messages/ThreadRow.tsx
+++ b/src/components/messages/ThreadRow.tsx
@@ -8,7 +8,13 @@ type ThreadRowProps = {
 };
 
 export function ThreadRow({ thread }: ThreadRowProps) {
-  const label = thread.subject?.trim() || (thread.thread_type === 'group' ? 'Group conversation' : 'Direct message');
+  const participantLabel = thread.participant_names?.join(', ').trim();
+  const label = thread.subject?.trim()
+    || (thread.thread_type === 'direct' && participantLabel
+      ? participantLabel
+      : thread.thread_type === 'group'
+        ? 'Group conversation'
+        : 'Direct message');
   const preview = thread.last_message_preview?.trim() || 'No messages yet';
   const timestamp = thread.last_message_at ?? thread.updated_at;
 

--- a/src/lib/messages/__tests__/fetchMessageThread.test.ts
+++ b/src/lib/messages/__tests__/fetchMessageThread.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fromMock = vi.fn();
+const rpcMock = vi.fn();
+
+vi.mock('../../supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => fromMock(...args),
+    rpc: (...args: unknown[]) => rpcMock(...args),
+  },
+}));
+
+import { fetchMessageThread } from '../fetchers';
+
+describe('fetchMessageThread', () => {
+  beforeEach(() => {
+    fromMock.mockReset();
+    rpcMock.mockReset();
+  });
+
+  it('returns null when the thread row is missing', async () => {
+    const maybeSingleMock = vi.fn().mockResolvedValue({
+      data: null,
+      error: null,
+    });
+    const eqMock = vi.fn().mockReturnValue({ maybeSingle: maybeSingleMock });
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+    fromMock.mockReturnValue({ select: selectMock });
+
+    const result = await fetchMessageThread('thread-missing', 'user-1');
+
+    expect(result).toBeNull();
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/messages/fetchers.ts
+++ b/src/lib/messages/fetchers.ts
@@ -9,6 +9,23 @@ import type {
 
 export { fetchStaffRecipients };
 
+const fetchParticipantNamesByThread = async (
+  threadIds: string[],
+  currentUserId: string,
+): Promise<Map<string, string[]>> => {
+  const participantNames = await Promise.all(threadIds.map(async (threadId) => {
+    const names = await fetchThreadParticipantNames(threadId);
+    return [
+      threadId,
+      Array.from(names.entries())
+        .filter(([userId]) => userId !== currentUserId)
+        .map(([, name]) => name),
+    ] as const;
+  }));
+
+  return new Map(participantNames);
+};
+
 export const fetchMessageThreads = async (
   organizationId: string,
   userId: string,
@@ -71,11 +88,26 @@ export const fetchMessageThreads = async (
       }
     }
 
+    const threadIdsNeedingParticipantNames = (threads ?? [])
+      .filter((thread) => thread.thread_type === 'direct' && !(thread.subject ?? '').trim())
+      .map((thread) => thread.id);
+
+    const participantNamesByThread = await fetchParticipantNamesByThread(
+      threadIdsNeedingParticipantNames,
+      userId,
+    ).catch((nameError) => {
+      if (isMessagingSchemaUnavailable(nameError)) {
+        return new Map<string, string[]>();
+      }
+      throw nameError;
+    });
+
     const list: MessageThreadListItem[] = (threads ?? []).map((thread) => {
       const participant = participantByThread.get(thread.id);
       const latest = latestByThread.get(thread.id);
       return {
         ...thread,
+        participant_names: participantNamesByThread.get(thread.id) ?? [],
         participant: participant
           ? {
               thread_id: thread.id,
@@ -131,7 +163,7 @@ export const fetchThreadMessages = async (threadId: string): Promise<Message[]> 
   }));
 };
 
-export const fetchMessageThread = async (threadId: string) => {
+export const fetchMessageThread = async (threadId: string, currentUserId: string) => {
   const { data, error } = await supabase
     .from('message_threads')
     .select('*')
@@ -145,6 +177,22 @@ export const fetchMessageThread = async (threadId: string) => {
     throw error;
   }
 
-  return data;
+  if (!data) {
+    return null;
+  }
+
+  const participantNames = await fetchThreadParticipantNames(threadId).catch((nameError) => {
+    if (isMessagingSchemaUnavailable(nameError)) {
+      return new Map<string, string>();
+    }
+    throw nameError;
+  });
+
+  return {
+    ...data,
+    participant_names: Array.from(participantNames.entries())
+      .filter(([userId]) => userId !== currentUserId)
+      .map(([, name]) => name),
+  };
 };
 

--- a/src/lib/messages/types.ts
+++ b/src/lib/messages/types.ts
@@ -8,6 +8,7 @@ export type MessageThread = {
   thread_type: MessageThreadType;
   created_at: string;
   updated_at: string;
+  participant_names?: string[];
 };
 
 export type MessageThreadParticipant = {

--- a/src/pages/messages/MessageThread.tsx
+++ b/src/pages/messages/MessageThread.tsx
@@ -18,8 +18,8 @@ export function MessageThread() {
 
   const { data: thread, isLoading: threadLoading } = useQuery({
     queryKey: [MESSAGES_QUERY_KEY, 'thread', threadId],
-    queryFn: () => fetchMessageThread(threadId!),
-    enabled: Boolean(threadId),
+    queryFn: () => fetchMessageThread(threadId!, profile!.id),
+    enabled: Boolean(threadId && profile?.id),
   });
 
   const { data: messages = [], isLoading: messagesLoading, refetch } = useQuery({
@@ -51,7 +51,13 @@ export function MessageThread() {
     return null;
   }
 
-  const title = thread?.subject?.trim() || (thread?.thread_type === 'group' ? 'Group conversation' : 'Conversation');
+  const participantLabel = thread?.participant_names?.join(', ').trim();
+  const title = thread?.subject?.trim()
+    || (thread?.thread_type === 'direct' && participantLabel
+      ? participantLabel
+      : thread?.thread_type === 'group'
+        ? 'Group conversation'
+        : 'Conversation');
 
   return (
     <div className="mx-auto flex max-w-3xl flex-col p-4 md:p-6" data-testid="messages-thread-page">

--- a/src/pages/messages/MessagesInbox.tsx
+++ b/src/pages/messages/MessagesInbox.tsx
@@ -30,7 +30,12 @@ export function MessagesInbox() {
     return threads.filter((thread) => {
       const subject = (thread.subject ?? '').toLowerCase();
       const preview = (thread.last_message_preview ?? '').toLowerCase();
-      return subject.includes(query) || preview.includes(query);
+      const participantNames = (thread.participant_names ?? []).join(' ').toLowerCase();
+      return (
+        subject.includes(query)
+        || preview.includes(query)
+        || participantNames.includes(query)
+      );
     });
   }, [data?.threads, searchQuery]);
 

--- a/src/pages/messages/__tests__/MessageThread.test.tsx
+++ b/src/pages/messages/__tests__/MessageThread.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { PHI_COMPOSER_PLACEHOLDER, PHI_POLICY_BANNER } from '../../../lib/messages/constants';
+import { fetchMessageThread } from '../../../lib/messages/fetchers';
 import { MessageThread } from '../MessageThread';
 
 vi.mock('../../../lib/authContext', () => ({
@@ -77,5 +78,23 @@ describe('MessageThread', () => {
 
     expect(await screen.findByTestId('message-sender-message-1')).toHaveTextContent('Alex Admin');
     expect(screen.getByTestId('message-sender-message-2')).toHaveTextContent('Taylor Therapist');
+  });
+
+  it('uses participant names for direct-message thread titles when no subject is set', async () => {
+    vi.mocked(fetchMessageThread).mockResolvedValueOnce({
+      id: 'thread-1',
+      organization_id: 'org-1',
+      created_by: 'user-1',
+      subject: null,
+      thread_type: 'direct',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      participant_names: ['Alex Admin'],
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'Alex Admin' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Conversation' })).not.toBeInTheDocument();
   });
 });

--- a/src/pages/messages/__tests__/MessageThread.test.tsx
+++ b/src/pages/messages/__tests__/MessageThread.test.tsx
@@ -23,7 +23,24 @@ vi.mock('../../../lib/messages/fetchers', () => ({
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   })),
-  fetchThreadMessages: vi.fn(async () => []),
+  fetchThreadMessages: vi.fn(async () => ([
+    {
+      id: 'message-1',
+      thread_id: 'thread-1',
+      sender_id: 'user-2',
+      sender_name: 'Alex Admin',
+      body: 'Hello from Alex',
+      created_at: '2026-05-22T12:00:00.000Z',
+    },
+    {
+      id: 'message-2',
+      thread_id: 'thread-1',
+      sender_id: 'user-1',
+      sender_name: 'Taylor Therapist',
+      body: 'Reply from Taylor',
+      created_at: '2026-05-22T12:01:00.000Z',
+    },
+  ])),
 }));
 
 vi.mock('../../../lib/messages/mutations', () => ({
@@ -53,5 +70,12 @@ describe('MessageThread', () => {
     renderPage();
     expect(await screen.findByText(PHI_POLICY_BANNER)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(PHI_COMPOSER_PLACEHOLDER)).toBeInTheDocument();
+  });
+
+  it('shows sender names for both incoming and outgoing messages', async () => {
+    renderPage();
+
+    expect(await screen.findByTestId('message-sender-message-1')).toHaveTextContent('Alex Admin');
+    expect(screen.getByTestId('message-sender-message-2')).toHaveTextContent('Taylor Therapist');
   });
 });

--- a/src/pages/messages/__tests__/MessagesInbox.test.tsx
+++ b/src/pages/messages/__tests__/MessagesInbox.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -18,7 +18,23 @@ vi.mock('../../../lib/organization', () => ({
 }));
 
 vi.mock('../../../lib/messages/fetchers', () => ({
-  fetchMessageThreads: vi.fn(async () => ({ threads: [], schemaUnavailable: false })),
+  fetchMessageThreads: vi.fn(async () => ({
+    threads: [
+      {
+        id: 'thread-1',
+        organization_id: 'org-1',
+        created_by: 'user-1',
+        subject: null,
+        thread_type: 'direct',
+        created_at: '2026-05-22T12:00:00.000Z',
+        updated_at: '2026-05-22T12:01:00.000Z',
+        last_message_preview: 'Latest note',
+        last_message_at: '2026-05-22T12:01:00.000Z',
+        participant_names: ['Alex Admin'],
+      },
+    ],
+    schemaUnavailable: false,
+  })),
 }));
 
 const renderPage = () => {
@@ -40,5 +56,21 @@ describe('MessagesInbox', () => {
   it('shows PHI policy banner', async () => {
     renderPage();
     expect(await screen.findByText(PHI_POLICY_BANNER)).toBeInTheDocument();
+  });
+
+  it('shows participant names for direct-message inbox rows without subjects', async () => {
+    renderPage();
+
+    expect(await screen.findByText('Alex Admin')).toBeInTheDocument();
+    expect(screen.queryByText('Direct message')).not.toBeInTheDocument();
+  });
+
+  it('searches inbox threads by participant name', async () => {
+    renderPage();
+
+    const search = await screen.findByTestId('messages-inbox-search');
+    fireEvent.change(search, { target: { value: 'alex' } });
+
+    expect(screen.getByTestId('message-thread-row-thread-1')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- render sender labels for outbound messages in the message thread view
- add a route-level regression test proving both inbound and outbound sender names render
- record the standard-lane handoff in docs/ai/2026-05-22-message-sender-names-handoff.md

## Verification
- npx vitest run src/pages/messages/__tests__/MessageThread.test.tsx
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run test:ci (with local dummy env values for VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY)
- npm run build
- npm run verify:local (with the same local dummy env values)
