### PR TITLE
IEHP extraction mapping + page 3/4 review copy/visibility

### DIFF
--- a/src/components/ClientDetails/IehpFbaLayoutReview.tsx
+++ b/src/components/ClientDetails/IehpFbaLayoutReview.tsx
@@ -108,6 +108,33 @@ const formatPayloadPreview = (value: unknown): string => {
   }
 };
 
+const behaviorTargetsFromPayload = (payload: Record<string, unknown> | undefined): string[] => {
+  const targets = payload?.targets;
+  if (!Array.isArray(targets)) return [];
+  return targets
+    .map((target) => (typeof target === "string" ? target.trim() : ""))
+    .filter((target) => target.length > 0);
+};
+
+const formatStructuredPreview = (section: StructuredValue): string => {
+  if (section.field_key === "IEHP_FBA_BEHAVIOR_SKILL_TARGETS") {
+    const targets = behaviorTargetsFromPayload(section.payload);
+    if (targets.length === 0) return "Selected targets: none";
+    return `Selected targets: ${targets.join(", ")}`;
+  }
+  return formatPayloadPreview(section.payload);
+};
+
+const formatStructuredCopyText = (section: StructuredValue): string => {
+  if (section.field_key === "IEHP_FBA_BEHAVIOR_SKILL_TARGETS") {
+    const targets = behaviorTargetsFromPayload(section.payload);
+    const heading = "Behaviors and Functional Skills to be Addressed";
+    if (targets.length === 0) return `${heading}\n- none selected`;
+    return `${heading}\n${targets.map((target) => `- ${target}`).join("\n")}`;
+  }
+  return formatPayloadPreview(section.payload);
+};
+
 const getFieldInputRows = (fieldType: string): number => {
   if (fieldType === "textarea" || fieldType === "goal_blocks" || fieldType === "recommendation_table") return 5;
   if (fieldType === "repeatable_table" || fieldType === "schedule_table" || fieldType === "checkbox_grid" || fieldType === "table") return 4;
@@ -272,6 +299,18 @@ export function IehpFbaLayoutReview({
     },
   });
 
+  const copyStructuredSection = async (section: StructuredValue) => {
+    try {
+      if (!navigator?.clipboard?.writeText) {
+        throw new Error("Clipboard is unavailable in this browser.");
+      }
+      await navigator.clipboard.writeText(formatStructuredCopyText(section));
+      showSuccess("Structured section copied.");
+    } catch (error) {
+      showError(error instanceof Error ? error.message : "Failed to copy structured section");
+    }
+  };
+
   if (isLoading) {
     return <p className="text-sm text-gray-500">Loading IEHP document-style review...</p>;
   }
@@ -414,10 +453,22 @@ export function IehpFbaLayoutReview({
                                   <span className="font-semibold">
                                     Section {section.section_index + 1} • {section.status} • required: {String(section.required)}
                                   </span>
-                                  {structuredLocked && (
-                                    <span className="rounded bg-slate-100 px-2 py-1 text-[11px] text-slate-600">locked after approval</span>
-                                  )}
+                                  <div className="flex items-center gap-2">
+                                    <button
+                                      type="button"
+                                      onClick={() => void copyStructuredSection(section)}
+                                      className="rounded border border-slate-300 px-2 py-1 text-[11px] font-semibold text-slate-700 hover:bg-slate-50"
+                                    >
+                                      Copy extracted
+                                    </button>
+                                    {structuredLocked && (
+                                      <span className="rounded bg-slate-100 px-2 py-1 text-[11px] text-slate-600">locked after approval</span>
+                                    )}
+                                  </div>
                                 </div>
+                                <p className="mb-2 rounded border border-slate-200 bg-slate-50 px-2 py-1 text-[11px] text-slate-700">
+                                  {formatStructuredPreview(section)}
+                                </p>
                                 <textarea
                                   value={structuredEdit.payloadText}
                                   rows={4}
@@ -564,10 +615,22 @@ export function IehpFbaLayoutReview({
                               <span className="font-semibold">
                                 {section.field_key} section {section.section_index + 1} • {section.status}
                               </span>
-                              {structuredLocked && (
-                                <span className="rounded bg-slate-100 px-2 py-1 text-[11px] text-slate-600">locked after approval</span>
-                              )}
+                              <div className="flex items-center gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => void copyStructuredSection(section)}
+                                  className="rounded border border-slate-300 px-2 py-1 text-[11px] font-semibold text-slate-700 hover:bg-slate-50"
+                                >
+                                  Copy extracted
+                                </button>
+                                {structuredLocked && (
+                                  <span className="rounded bg-slate-100 px-2 py-1 text-[11px] text-slate-600">locked after approval</span>
+                                )}
+                              </div>
                             </div>
+                            <p className="mb-2 rounded border border-slate-200 bg-slate-50 px-2 py-1 text-[11px] text-slate-700">
+                              {formatStructuredPreview(section)}
+                            </p>
                             <textarea
                               value={structuredEdit.payloadText}
                               rows={4}

--- a/src/components/__tests__/IehpFbaLayoutReview.test.tsx
+++ b/src/components/__tests__/IehpFbaLayoutReview.test.tsx
@@ -31,6 +31,11 @@ const assessmentDocument: AssessmentDocumentRecord = {
 describe("IehpFbaLayoutReview", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
   });
 
   it("renders IEHP page layout metadata without CalOptima copy and saves checklist values", async () => {
@@ -405,7 +410,7 @@ describe("IehpFbaLayoutReview", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /Page 16/i }));
     expect(await screen.findByText("Page 16: School Goals")).toBeInTheDocument();
-    expect(screen.getByText(/School goal narrative/)).toBeInTheDocument();
+    expect(screen.getAllByText(/School goal narrative/).length).toBeGreaterThan(0);
     fireEvent.change(screen.getByLabelText("IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS structured section 1 status"), {
       target: { value: "verified" },
     });
@@ -429,7 +434,7 @@ describe("IehpFbaLayoutReview", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Page 17/i }));
     expect(await screen.findByText("Page 17: Parent Education Goals")).toBeInTheDocument();
-    expect(screen.getByText(/Parent education goal narrative/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Parent education goal narrative/).length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole("button", { name: /Page 24/i }));
     expect(await screen.findByLabelText("Recommendation Notes")).toBeInTheDocument();
@@ -570,5 +575,81 @@ describe("IehpFbaLayoutReview", () => {
     expect(screen.getByLabelText("Missing Manual Field")).toBeDisabled();
     expect(screen.getByText("missing row")).toBeInTheDocument();
     expect(screen.getAllByText("manual required")).toHaveLength(1);
+  });
+
+  it("renders behavior target preview and copies extracted checkbox targets", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string) => {
+      if (path.startsWith("/api/assessment-template-layout?")) {
+        return new Response(JSON.stringify({
+          template_version: {
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+          },
+          pages: [{ page_number: 3, title: "Behaviors", layout_json: {} }],
+          fields: [
+            {
+              page_number: 3,
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_BEHAVIOR_SKILL_TARGETS",
+              label: "Behaviors and Functional Skills to be Addressed",
+              field_type: "checkbox_grid",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+              layout_json: {},
+            },
+          ],
+          values: {
+            checklist_items: [
+              {
+                id: "item-behavior",
+                placeholder_key: "IEHP_FBA_BEHAVIOR_SKILL_TARGETS",
+                section_key: "behavior_background_services",
+                label: "Behaviors and Functional Skills to be Addressed",
+                mode: "ASSISTED",
+                required: true,
+                status: "drafted",
+                value_text: null,
+                value_json: null,
+                review_notes: null,
+              },
+            ],
+            structured_sections: [
+              {
+                id: "behavior-structured-1",
+                field_key: "IEHP_FBA_BEHAVIOR_SKILL_TARGETS",
+                section_index: 0,
+                payload: {
+                  raw_text: "The behaviors and functional skills to be addressed are: Physical Aggression, Self-Injury",
+                  targets: ["Physical Aggression", "Self-Injury"],
+                },
+                source_span: { page_number: 3, method: "iehp_section_anchor" },
+                status: "drafted",
+                required: true,
+                review_notes: null,
+              },
+            ],
+          },
+          unresolved_required_count: 1,
+          extracted_value_count: 1,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <IehpFbaLayoutReview assessmentDocument={assessmentDocument} organizationId="org-1" />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Page 3/i }));
+    expect(await screen.findByText("Selected targets: Physical Aggression, Self-Injury")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy extracted" }));
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "Behaviors and Functional Skills to be Addressed\n- Physical Aggression\n- Self-Injury",
+      );
+    });
   });
 });

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -2662,6 +2662,273 @@ describe("assessmentDocumentsHandler", () => {
     });
   });
 
+  it("persists reason-for-referral narrative and behavior-only structured payload from IEHP extraction response", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([
+      {
+        section: "identification_admin",
+        label: "Reason for Referral",
+        placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+        required: true,
+        mode: "MANUAL",
+        source: "clinician_manual_entry",
+        extraction_method: "assisted_draft_plus_review",
+        validation_rule: "non_empty_text",
+        extraction_owner: "ClinicalAuthor",
+        review_owner: "BCBAReviewer",
+      },
+      {
+        section: "behavior_background_services",
+        label: "Behaviors and Functional Skills to be Addressed",
+        placeholder_key: "IEHP_FBA_BEHAVIOR_SKILL_TARGETS",
+        required: true,
+        mode: "ASSISTED",
+        source: "uploaded_assessment_document",
+        extraction_method: "deterministic_docx_or_pdf_structured_extract",
+        validation_rule: "structured_payload_required",
+        extraction_owner: "ClinicalAuthor",
+        review_owner: "BCBAReviewer",
+      },
+      {
+        section: "behavior_background_services",
+        label: "Living Situation",
+        placeholder_key: "IEHP_FBA_HOUSEHOLD_MEMBERS",
+        required: true,
+        mode: "ASSISTED",
+        source: "uploaded_assessment_document",
+        extraction_method: "deterministic_docx_or_pdf_structured_extract",
+        validation_rule: "structured_payload_required",
+        extraction_owner: "ClinicalAuthor",
+        review_owner: "BCBAReviewer",
+      },
+      {
+        section: "behavior_background_services",
+        label: "School Information",
+        placeholder_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+        required: true,
+        mode: "ASSISTED",
+        source: "uploaded_assessment_document",
+        extraction_method: "deterministic_docx_or_pdf_structured_extract",
+        validation_rule: "structured_payload_required",
+        extraction_owner: "ClinicalAuthor",
+        review_owner: "BCBAReviewer",
+      },
+      {
+        section: "behavior_background_services",
+        label: "Health and Medical",
+        placeholder_key: "IEHP_FBA_HEALTH_MEDICAL_SUMMARY",
+        required: true,
+        mode: "ASSISTED",
+        source: "uploaded_assessment_document",
+        extraction_method: "deterministic_docx_or_pdf_structured_extract",
+        validation_rule: "structured_payload_required",
+        extraction_owner: "ClinicalAuthor",
+        review_owner: "BCBAReviewer",
+      },
+    ]);
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "11111111-1111-1111-1111-111111111111" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name,first_name,last_name")) {
+        return { ok: true, status: 200, data: [{ first_name: "Kim", last_name: "Le" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_versions?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "template-version-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_fields?select=")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              section_key: "identification_admin",
+              field_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+              label: "Reason for Referral",
+              field_type: "textarea",
+              mode: "MANUAL",
+              required: true,
+              source: "clinician_manual_entry",
+            },
+            {
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_BEHAVIOR_SKILL_TARGETS",
+              label: "Behaviors and Functional Skills to be Addressed",
+              field_type: "checkbox_grid",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+            },
+            {
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_HOUSEHOLD_MEMBERS",
+              label: "Living Situation",
+              field_type: "textarea",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+            },
+            {
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+              label: "School Information",
+              field_type: "textarea",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+            },
+            {
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_HEALTH_MEDICAL_SUMMARY",
+              label: "Health and Medical",
+              field_type: "textarea",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+            },
+          ],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
+        return {
+          ok: true,
+          status: 201,
+          data: [{ id: "doc-iehp-reason", organization_id: "org-1", client_id: "11111111-1111-1111-1111-111111111111" }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return {
+          ok: true,
+          status: 200,
+          data: {
+            fields: [{
+              placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+              value_text: "Kim presents with communication deficits and maladaptive behavior.",
+              value_json: null,
+              confidence: 0.55,
+              mode: "MANUAL",
+              status: "drafted",
+              source_span: { method: "iehp_presenting_concerns_anchor" },
+              review_notes: "Deterministic extraction from presenting concerns section.",
+            }],
+            structured_sections: [{
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_BEHAVIOR_SKILL_TARGETS",
+              section_index: 0,
+              payload: {
+                raw_text: "BEHAVIORS The behaviors and functional skills to be addressed are: Physical Aggression",
+                targets: ["Physical Aggression"],
+              },
+              source_span: { method: "iehp_section_anchor", page_number: 2 },
+              status: "drafted",
+              required: true,
+              review_notes: "Deterministic IEHP section extraction.",
+            },
+            {
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_HOUSEHOLD_MEMBERS",
+              section_index: 0,
+              payload: {
+                raw_text: "Kim lives in a single-family home and requires close supervision.",
+              },
+              source_span: { method: "iehp_section_anchor", page_number: 3 },
+              status: "drafted",
+              required: true,
+              review_notes: "Deterministic IEHP section extraction.",
+            },
+            {
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+              section_index: 0,
+              payload: {
+                raw_text: "Kim attends Arlington High School in Riverside.",
+              },
+              source_span: { method: "iehp_section_anchor", page_number: 3 },
+              status: "drafted",
+              required: true,
+              review_notes: "Deterministic IEHP section extraction.",
+            },
+            {
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_HEALTH_MEDICAL_SUMMARY",
+              section_index: 0,
+              payload: {
+                raw_text: "Family reports medical and developmental history concerns.",
+              },
+              source_span: { method: "iehp_section_anchor", page_number: 3 },
+              status: "drafted",
+              required: true,
+              review_notes: "Deterministic IEHP section extraction.",
+            }],
+            unresolved_keys: [],
+            extracted_count: 5,
+            unresolved_count: 0,
+          },
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_checklist_items")) return { ok: true, status: 200, data: null };
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_extractions")) return { ok: true, status: 200, data: null };
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) return { ok: true, status: 200, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_structured_sections")) return { ok: true, status: 201, data: null };
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) return { ok: true, status: 201, data: null };
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "iehp-presenting-concerns.docx",
+          mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/iehp-presenting-concerns.docx",
+          template_type: "iehp_fba",
+        }),
+      }),
+    );
+    expect(response.status).toBe(201);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const extractionPatch = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" &&
+      url.includes("/rest/v1/assessment_extractions") &&
+      (init?.method ?? "").toUpperCase() === "PATCH"
+    );
+    const extractionPatchBody = String((extractionPatch?.[1] as RequestInit).body ?? "");
+    expect(extractionPatchBody).toContain("Kim presents with communication deficits and maladaptive behavior.");
+
+    const structuredInsert = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" &&
+      url.includes("/rest/v1/assessment_structured_sections") &&
+      (init?.method ?? "").toUpperCase() === "POST"
+    );
+    const structuredBody = String((structuredInsert?.[1] as RequestInit).body ?? "");
+    expect(structuredBody).toContain("\"IEHP_FBA_BEHAVIOR_SKILL_TARGETS\"");
+    expect(structuredBody).toContain("\"IEHP_FBA_HOUSEHOLD_MEMBERS\"");
+    expect(structuredBody).toContain("\"IEHP_FBA_SCHOOL_INFORMATION_BLOCK\"");
+    expect(structuredBody).toContain("\"IEHP_FBA_HEALTH_MEDICAL_SUMMARY\"");
+    expect(structuredBody).toContain("The behaviors and functional skills to be addressed");
+    expect(structuredBody).toContain("Arlington High School");
+    expect(structuredBody).not.toContain("Kim presents with communication deficits");
+  });
+
   it("records extraction_failed audit event when extraction API returns non-ok", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -1162,6 +1162,32 @@ Deno.test("deterministicValueForRow maps IEHP presenting concerns narrative into
   expect(manual.value_text).not.toContain("The behaviors and functional skills to be addressed");
 });
 
+Deno.test("deterministicValueForRow stops presenting concerns extraction at colonless BEHAVIORS heading", () => {
+  const manual = __TESTING__.deterministicValueForRow(
+    {
+      section: "identification_admin",
+      label: "Reason for Referral",
+      placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+      required: true,
+      mode: "MANUAL",
+    },
+    `
+      II. REASON FOR REFERRAL AND PRESENTING CONCERNS
+      Kim presents with significant communication deficits and frequent maladaptive behaviors that disrupt family routines.
+      BEHAVIORS
+      The behaviors and functional skills to be addressed are:
+      Physical Aggression
+      Functional Communication
+    `,
+  );
+
+  expect(manual.mode).toBe("MANUAL");
+  expect(manual.status).toBe("drafted");
+  expect(manual.value_text).toContain("Kim presents with significant communication deficits");
+  expect(manual.value_text).not.toContain("The behaviors and functional skills to be addressed");
+  expect(manual.value_text).not.toContain("Physical Aggression");
+});
+
 Deno.test("extractStructuredSections keeps presenting concerns out of IEHP behavior skill targets", () => {
   const sections = asSections(
     "iehp_fba",

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -630,6 +630,8 @@ Deno.test("extractStructuredSections maps LE-style IEHP headings into normalized
   const byKey = new Map(sections.map((section) => [section.field_key, section]));
   [
     "IEHP_FBA_BEHAVIOR_SKILL_TARGETS",
+    "IEHP_FBA_HOUSEHOLD_MEMBERS",
+    "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
     "IEHP_FBA_BHT_SCHOOL_HOURS_MATRIX",
     "IEHP_FBA_HEALTH_MEDICAL_SUMMARY",
     "IEHP_FBA_CURRENT_SERVICES_ACTIVITIES",
@@ -655,6 +657,10 @@ Deno.test("extractStructuredSections maps LE-style IEHP headings into normalized
     "Physical Aggression",
     "Functional Communication",
   ]);
+  expect(byKey.get("IEHP_FBA_HOUSEHOLD_MEMBERS")?.payload.raw_text).toContain("Member lives with two caregivers");
+  expect(byKey.get("IEHP_FBA_HOUSEHOLD_MEMBERS")?.payload.raw_text).not.toContain("The behaviors and functional skills to be addressed");
+  expect(byKey.get("IEHP_FBA_SCHOOL_INFORMATION_BLOCK")?.payload.raw_text).toContain("Member attends a local high school");
+  expect(byKey.get("IEHP_FBA_SCHOOL_INFORMATION_BLOCK")?.payload.raw_text).not.toContain("Medical summary narrative");
   expect((byKey.get("IEHP_FBA_RECOMMENDATIONS_HCPCS_ROWS")?.payload.rows as unknown[]).length).toBeGreaterThan(2);
   expect(byKey.get("IEHP_FBA_SIGNATURE_BLOCK")?.payload.report_completed_date).toBe("12/12/2025");
   expect(byKey.get("IEHP_FBA_DISCHARGE_TRANSITION_EXIT_PLAN")?.payload.transition_of_care).toContain("Transition");
@@ -1126,6 +1132,58 @@ Deno.test("deterministicValueForRow keeps manual and assisted IEHP rows honest w
   expect(assessorPhone.value_text).toBeNull();
   expect(assessorPhone.status).toBe("not_started");
   expect(assessorPhone.review_notes).toContain("reliable provider or organization source");
+});
+
+Deno.test("deterministicValueForRow maps IEHP presenting concerns narrative into reason for referral", () => {
+  const manual = __TESTING__.deterministicValueForRow(
+    {
+      section: "identification_admin",
+      label: "Reason for Referral",
+      placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+      required: true,
+      mode: "MANUAL",
+    },
+    `
+      II. REASON FOR REFERRAL AND PRESENTING CONCERNS:
+      Write a brief description regarding the presenting concerns and why the Member is seeking services from your agency.
+      Kim presents with significant communication deficits and frequent maladaptive behaviors that disrupt family routines.
+      Name of Referring Provider, Credentials (if applicable):
+      Date Referred:
+      BEHAVIORS:
+      The behaviors and functional skills to be addressed are:
+      Physical Aggression
+    `,
+  );
+
+  expect(manual.mode).toBe("MANUAL");
+  expect(manual.status).toBe("drafted");
+  expect(manual.source_span).toMatchObject({ method: "iehp_presenting_concerns_anchor" });
+  expect(manual.value_text).toContain("Kim presents with significant communication deficits");
+  expect(manual.value_text).not.toContain("The behaviors and functional skills to be addressed");
+});
+
+Deno.test("extractStructuredSections keeps presenting concerns out of IEHP behavior skill targets", () => {
+  const sections = asSections(
+    "iehp_fba",
+    `
+      II. REASON FOR REFERRAL AND PRESENTING CONCERNS:
+      Kim presents with significant communication deficits and maladaptive behavior patterns.
+      Name of Referring Provider, Credentials (if applicable):
+      Date Referred:
+      Reason for Referral:
+      III. BEHAVIORS:
+      The behaviors and functional skills to be addressed are:
+      Physical Aggression
+      Functional Communication
+      IV. BACKGROUND INFORMATION:
+    `,
+  );
+  const behaviorSection = sections.find((section) => section.field_key === "IEHP_FBA_BEHAVIOR_SKILL_TARGETS");
+  const behaviorRawText = String(behaviorSection?.payload.raw_text ?? "");
+
+  expect(behaviorSection).toBeDefined();
+  expect(behaviorRawText).toContain("The behaviors and functional skills to be addressed");
+  expect(behaviorRawText).not.toContain("Kim presents with significant communication deficits");
 });
 
 Deno.test("deterministicValueForRow prefills IEHP assessor phone from primary therapist snapshot", () => {

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -1887,7 +1887,7 @@ const extractIehpPresentingConcernsNarrative = (text: string): string | null => 
   const narrative = extractSectionText(
     text,
     [/\bREASON\s+FOR\s+REFERRAL\s+AND\s+PRESENTING\s+CONCERNS\b/i],
-    [/\bName\s+of\s+Referring\s+Provider\b/i, /\bBEHAVIORS\s*:/i],
+    [/\bName\s+of\s+Referring\s+Provider\b/i, /\bBEHAVIORS\s*:?\b/i],
   );
   if (!narrative) {
     return null;

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -1407,7 +1407,10 @@ const extractIeHpGoalSections = (
     {
       field_key: "IEHP_FBA_BEHAVIOR_SKILL_TARGETS",
       section_key: "behavior_background_services",
-      start: [/BEHAVIORS\s*:?\s*?/i, /Behaviors\s+and\s+Functional\s+Skills\s+to\s+be\s+Addressed/i],
+      start: [
+        /(?:^|\n)\s*(?:[IVX]+\.\s*)?BEHAVIORS\s*:\s*(?:The\s+behaviors\s+and\s+functional\s+skills\s+to\s+be\s+addressed\b)?/i,
+        /(?:^|\n)\s*The\s+behaviors\s+and\s+functional\s+skills\s+to\s+be\s+addressed\b/i,
+      ],
       end: [/\bBACKGROUND INFORMATION\b/i, /\bPersons\s+in\s+Household\b/i],
     },
     {
@@ -1880,6 +1883,23 @@ const extractLineNearLabels = (
   return null;
 };
 
+const extractIehpPresentingConcernsNarrative = (text: string): string | null => {
+  const narrative = extractSectionText(
+    text,
+    [/\bREASON\s+FOR\s+REFERRAL\s+AND\s+PRESENTING\s+CONCERNS\b/i],
+    [/\bName\s+of\s+Referring\s+Provider\b/i, /\bBEHAVIORS\s*:/i],
+  );
+  if (!narrative) {
+    return null;
+  }
+
+  const compact = compactDocumentText(narrative)
+    .replace(/^\s*REASON\s+FOR\s+REFERRAL\s+AND\s+PRESENTING\s+CONCERNS\s*:?\s*/i, "")
+    .replace(/^Write a brief description[^.]*\.\s*/i, "")
+    .trim();
+  return compact.length > 0 ? compact : null;
+};
+
 const deterministicValueForRow = (
   row: z.infer<typeof checklistRowSchema>,
   text: string,
@@ -1903,6 +1923,21 @@ const deterministicValueForRow = (
       review_notes: null,
     };
   }
+  if (key === "IEHP_FBA_REASON_FOR_REFERRAL") {
+    const presentingConcerns = extractIehpPresentingConcernsNarrative(text);
+    if (presentingConcerns) {
+      return {
+        placeholder_key: key,
+        value_text: presentingConcerns,
+        value_json: null,
+        confidence: 0.55,
+        mode: row.mode ?? "MANUAL",
+        status: "drafted",
+        source_span: { method: "iehp_presenting_concerns_anchor" },
+        review_notes: "Deterministic extraction from IEHP presenting concerns narrative block.",
+      };
+    }
+  }
   const labels = [row.label, ...(row.extraction_aliases ?? [])];
   const fromLabel = extractLineNearLabels(text, labels, collectStopLabels(labels, allRows));
   if (fromLabel) {
@@ -1918,7 +1953,6 @@ const deterministicValueForRow = (
       review_notes: `Deterministic extraction from document label match. (Calibrated confidence ${confidence.toFixed(2)})`,
     };
   }
-
   const client = clientSnapshot ?? {};
   if (/MEMBER_NAME|CLIENT_NAME/u.test(key) && client.full_name) {
     return {


### PR DESCRIPTION
## Summary
- map IEHP presenting concerns narrative into IEHP_FBA_REASON_FOR_REFERRAL deterministically while keeping manual review mode
- keep presenting-concerns prose out of IEHP_FBA_BEHAVIOR_SKILL_TARGETS by tightening section boundaries
- add Copy extracted actions in IEHP layout review structured sections
- add behavior-target preview formatting so selected checkbox targets are explicit in UI
- harden extractor and handler tests for page 3/4 behavior + background sections

## Verification
- deno test --allow-env --allow-read supabase/functions/extract-assessment-fields/index.test.ts
- npx vitest run src/components/__tests__/IehpFbaLayoutReview.test.tsx --reporter=verbose
- npx vitest run src/server/__tests__/assessmentDocumentsHandler.test.ts --reporter=verbose
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
- npm run verify:local

## Notes
- Critical lane / high-risk-human-reviewed scope due to extraction-related coverage in supabase/functions/**.
- Unrelated local changes remain uncommitted (eports/test-reliability-latest.json, docs/ai/post-merge-staff-message-sender-names.md).