### PR TITLE
Add unread notifications for staff messages

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { NavLink, useNavigate, Link } from 'react-router-dom';
 import { 
   Calendar, Users, FileText, CreditCard, LayoutDashboard,
@@ -7,6 +8,9 @@ import {
   UserCircle2
 } from 'lucide-react';
 import { useAuth } from '../lib/authContext';
+import { useActiveOrganizationId } from '../lib/organization';
+import { MESSAGES_QUERY_KEY } from '../lib/messages/constants';
+import { fetchMessageThreads } from '../lib/messages/fetchers';
 import { useTheme } from '../lib/theme';
 import { preloadRouteModule } from '../lib/routeModulePrefetch';
 // Theme is toggled directly via context; no hidden proxy button
@@ -28,6 +32,7 @@ const ChatAssistantFallback = () => (
 
 export function Sidebar() {
   const { signOut, hasRole, hasAnyRole, user, profile, isGuardian, effectiveRole } = useAuth();
+  const organizationId = useActiveOrganizationId();
   const { isDark, toggleTheme } = useTheme();
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -210,6 +215,14 @@ export function Sidebar() {
     'admin',
     'super_admin'
   ]);
+  const canAccessMessages = hasAnyRole(['therapist', 'admin', 'super_admin']);
+
+  const { data: unreadMessagesData } = useQuery({
+    queryKey: [MESSAGES_QUERY_KEY, 'inbox', organizationId, profile?.id],
+    queryFn: () => fetchMessageThreads(organizationId!, profile!.id),
+    enabled: canAccessMessages && Boolean(organizationId && profile?.id),
+    refetchInterval: 30_000,
+  });
 
   const openChatAssistant = () => {
     setHasLoadedChatAssistant(true);
@@ -332,7 +345,17 @@ export function Sidebar() {
                         }
                       `}
                     />
-                    {label}
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="truncate">{label}</span>
+                      {path === '/messages' && (unreadMessagesData?.unreadThreadCount ?? 0) > 0 ? (
+                        <span
+                          className="inline-flex min-w-5 items-center justify-center rounded-full bg-blue-600 px-1.5 py-0.5 text-[11px] font-semibold text-white dark:bg-blue-500"
+                          data-testid="sidebar-messages-unread-badge"
+                        >
+                          {unreadMessagesData?.unreadThreadCount}
+                        </span>
+                      ) : null}
+                    </span>
                   </>
                 )}
               </NavLink>

--- a/src/components/__tests__/SidebarNavigation.test.tsx
+++ b/src/components/__tests__/SidebarNavigation.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Sidebar } from "../Sidebar";
@@ -9,6 +10,7 @@ import { Sidebar } from "../Sidebar";
 const mockUseAuth = vi.fn();
 const mockUseTheme = vi.fn();
 const mockPreloadRouteModule = vi.fn();
+const mockFetchMessageThreads = vi.fn();
 
 vi.mock("../../lib/authContext", () => ({
   useAuth: () => mockUseAuth(),
@@ -22,6 +24,14 @@ vi.mock("../../lib/routeModulePrefetch", () => ({
   preloadRouteModule: (...args: unknown[]) => mockPreloadRouteModule(...args),
 }));
 
+vi.mock("../../lib/organization", () => ({
+  useActiveOrganizationId: () => "org-1",
+}));
+
+vi.mock("../../lib/messages/fetchers", () => ({
+  fetchMessageThreads: (...args: unknown[]) => mockFetchMessageThreads(...args),
+}));
+
 vi.mock("../ChatBot", () => ({
   ChatBot: ({ isOpen }: { isOpen?: boolean }) =>
     isOpen ? <div data-testid="chatbot-mock" /> : null,
@@ -32,10 +42,22 @@ vi.mock("../ThemeToggle", () => ({
 }));
 
 describe("Sidebar navigation active styling", () => {
+  const renderSidebar = (initialEntries: string[] = ["/"]) => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <Sidebar />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+
   beforeEach(() => {
     mockUseAuth.mockReset();
     mockUseTheme.mockReset();
     mockPreloadRouteModule.mockReset();
+    mockFetchMessageThreads.mockReset();
     mockUseAuth.mockReturnValue({
       signOut: vi.fn(),
       hasRole: vi.fn(() => true),
@@ -46,24 +68,27 @@ describe("Sidebar navigation active styling", () => {
         },
       },
       profile: {
+        id: "user-1",
         role: "therapist",
       },
       isGuardian: false,
       hasAnyRole: vi.fn(() => true),
+      effectiveRole: "therapist",
     });
 
     mockUseTheme.mockReturnValue({
       isDark: false,
       toggleTheme: vi.fn(),
     });
+    mockFetchMessageThreads.mockResolvedValue({
+      threads: [],
+      schemaUnavailable: false,
+      unreadThreadCount: 0,
+    });
   });
 
   it("keeps the clients link icon highlighted for nested routes", () => {
-    render(
-      <MemoryRouter initialEntries={["/clients/123"]}>
-        <Sidebar />
-      </MemoryRouter>
-    );
+    renderSidebar(["/clients/123"]);
 
     const clientsLink = screen.getByRole("link", { name: /clients/i });
     expect(clientsLink).toHaveClass("border-blue-500");
@@ -90,6 +115,7 @@ describe("Sidebar navigation active styling", () => {
         },
       },
       profile: {
+        id: "user-1",
         role: "therapist",
       },
       isGuardian: false,
@@ -98,11 +124,7 @@ describe("Sidebar navigation active styling", () => {
       ),
     });
 
-    render(
-      <MemoryRouter initialEntries={["/schedule"]}>
-        <Sidebar />
-      </MemoryRouter>
-    );
+    renderSidebar(["/schedule"]);
 
     expect(screen.queryByRole("link", { name: /authorizations/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /documentation/i })).not.toBeInTheDocument();
@@ -126,6 +148,7 @@ describe("Sidebar navigation active styling", () => {
         user_metadata: {},
       },
       profile: {
+        id: "user-1",
         role: "super_admin",
       },
       isGuardian: false,
@@ -134,11 +157,7 @@ describe("Sidebar navigation active styling", () => {
       ),
     });
 
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Sidebar />
-      </MemoryRouter>
-    );
+    renderSidebar(["/"]);
 
     expect(screen.getByRole("link", { name: /therapists/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /billing/i })).toBeInTheDocument();
@@ -160,6 +179,7 @@ describe("Sidebar navigation active styling", () => {
         user_metadata: {},
       },
       profile: {
+        id: "user-1",
         role: "client",
       },
       isGuardian: true,
@@ -168,11 +188,7 @@ describe("Sidebar navigation active styling", () => {
       ),
     });
 
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Sidebar />
-      </MemoryRouter>
-    );
+    renderSidebar(["/"]);
 
     expect(screen.queryByRole("button", { name: /chat assistant/i })).not.toBeInTheDocument();
     expect(screen.queryByTestId("chatbot-mock")).not.toBeInTheDocument();
@@ -180,11 +196,7 @@ describe("Sidebar navigation active styling", () => {
   });
 
   it("lazily loads the chat assistant only when opened", async () => {
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Sidebar />
-      </MemoryRouter>
-    );
+    renderSidebar(["/"]);
 
     expect(screen.getByRole("button", { name: /chat assistant/i })).toBeInTheDocument();
     expect(screen.queryByTestId("chatbot-mock")).not.toBeInTheDocument();
@@ -194,11 +206,7 @@ describe("Sidebar navigation active styling", () => {
   });
 
   it("prefetches a route module on hover intent without preloading on initial render", async () => {
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Sidebar />
-      </MemoryRouter>
-    );
+    renderSidebar(["/"]);
 
     expect(mockPreloadRouteModule).not.toHaveBeenCalled();
 
@@ -209,11 +217,7 @@ describe("Sidebar navigation active styling", () => {
   });
 
   it("prefetches a route module on keyboard focus intent", async () => {
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Sidebar />
-      </MemoryRouter>
-    );
+    renderSidebar(["/"]);
 
     fireEvent.focus(screen.getByRole("link", { name: /schedule/i }));
 
@@ -221,11 +225,7 @@ describe("Sidebar navigation active styling", () => {
   });
 
   it("prefetches messages route module on hover intent", async () => {
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Sidebar />
-      </MemoryRouter>
-    );
+    renderSidebar(["/"]);
 
     await userEvent.hover(screen.getByRole("link", { name: /messages/i }));
 
@@ -245,6 +245,7 @@ describe("Sidebar navigation active styling", () => {
         user_metadata: {},
       },
       profile: {
+        id: "user-1",
         role: "client",
       },
       isGuardian: false,
@@ -253,21 +254,13 @@ describe("Sidebar navigation active styling", () => {
       ),
     });
 
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Sidebar />
-      </MemoryRouter>
-    );
+    renderSidebar(["/"]);
 
     expect(screen.queryByRole("link", { name: /family/i })).not.toBeInTheDocument();
   });
 
   it("keeps mobile sidebar sections scrollable so footer actions stay reachable", () => {
-    const { container } = render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Sidebar />
-      </MemoryRouter>
-    );
+    const { container } = renderSidebar(["/"]);
 
     const sidebar = container.querySelector("#app-sidebar");
     expect(sidebar).not.toBeNull();
@@ -277,5 +270,17 @@ describe("Sidebar navigation active styling", () => {
     expect(nav).not.toBeNull();
     expect(nav).toHaveClass("min-h-0");
     expect(nav).toHaveClass("overflow-y-auto");
+  });
+
+  it("shows an unread badge on the messages nav item when unread threads exist", async () => {
+    mockFetchMessageThreads.mockResolvedValueOnce({
+      threads: [],
+      schemaUnavailable: false,
+      unreadThreadCount: 3,
+    });
+
+    renderSidebar(["/"]);
+
+    expect(await screen.findByTestId("sidebar-messages-unread-badge")).toHaveTextContent("3");
   });
 });

--- a/src/components/messages/ThreadRow.tsx
+++ b/src/components/messages/ThreadRow.tsx
@@ -21,15 +21,43 @@ export function ThreadRow({ thread }: ThreadRowProps) {
   return (
     <Link
       to={`/messages/${thread.id}`}
-      className="block rounded-lg border border-gray-200 px-4 py-3 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+      className={`block rounded-lg border px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 ${
+        thread.isUnread
+          ? 'border-blue-200 bg-blue-50/70 dark:border-blue-900 dark:bg-blue-950/30'
+          : 'border-gray-200 dark:border-gray-700'
+      }`}
       data-testid={`message-thread-row-${thread.id}`}
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
-          <p className="truncate font-medium text-gray-900 dark:text-gray-100">{label}</p>
-          <p className="mt-1 truncate text-sm text-gray-500 dark:text-gray-400">{preview}</p>
+          <div className="flex items-center gap-2">
+            {thread.isUnread ? (
+              <span
+                className="h-2.5 w-2.5 shrink-0 rounded-full bg-blue-600 dark:bg-blue-400"
+                data-testid={`message-thread-unread-${thread.id}`}
+              />
+            ) : null}
+            <p
+              className={`truncate font-medium ${
+                thread.isUnread ? 'text-gray-950 dark:text-white' : 'text-gray-900 dark:text-gray-100'
+              }`}
+            >
+              {label}
+            </p>
+          </div>
+          <p
+            className={`mt-1 truncate text-sm ${
+              thread.isUnread ? 'text-gray-700 dark:text-gray-200' : 'text-gray-500 dark:text-gray-400'
+            }`}
+          >
+            {preview}
+          </p>
         </div>
-        <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+        <span
+          className={`shrink-0 text-xs ${
+            thread.isUnread ? 'text-blue-700 dark:text-blue-300' : 'text-gray-400 dark:text-gray-500'
+          }`}
+        >
           {format(parseISO(timestamp), 'MMM d, h:mm a')}
         </span>
       </div>

--- a/src/lib/messages/__tests__/fetchMessageThreads.test.ts
+++ b/src/lib/messages/__tests__/fetchMessageThreads.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fromMock = vi.fn();
+const rpcMock = vi.fn();
+
+vi.mock('../../supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => fromMock(...args),
+    rpc: (...args: unknown[]) => rpcMock(...args),
+  },
+}));
+
+import { fetchMessageThreads } from '../fetchers';
+
+describe('fetchMessageThreads', () => {
+  beforeEach(() => {
+    fromMock.mockReset();
+    rpcMock.mockReset();
+  });
+
+  it('marks threads unread when latest activity is newer than last_read_at and excludes muted threads from the count', async () => {
+    const participantSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          is: vi.fn().mockResolvedValue({
+            data: [
+              {
+                thread_id: 'thread-unread',
+                last_read_at: '2026-05-22T11:59:00.000Z',
+                archived_at: null,
+                muted_at: null,
+                joined_at: '2026-05-22T11:00:00.000Z',
+                organization_id: 'org-1',
+                user_id: 'user-1',
+              },
+              {
+                thread_id: 'thread-muted',
+                last_read_at: null,
+                archived_at: null,
+                muted_at: '2026-05-22T11:58:00.000Z',
+                joined_at: '2026-05-22T11:00:00.000Z',
+                organization_id: 'org-1',
+                user_id: 'user-1',
+              },
+              {
+                thread_id: 'thread-read',
+                last_read_at: '2026-05-22T12:02:00.000Z',
+                archived_at: null,
+                muted_at: null,
+                joined_at: '2026-05-22T11:00:00.000Z',
+                organization_id: 'org-1',
+                user_id: 'user-1',
+              },
+              {
+                thread_id: 'thread-empty',
+                last_read_at: null,
+                archived_at: null,
+                muted_at: null,
+                joined_at: '2026-05-22T11:00:00.000Z',
+                organization_id: 'org-1',
+                user_id: 'user-1',
+              },
+            ],
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const threadSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        in: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({
+            data: [
+              {
+                id: 'thread-unread',
+                organization_id: 'org-1',
+                created_by: 'user-2',
+                subject: 'Unread',
+                thread_type: 'direct',
+                created_at: '2026-05-22T11:00:00.000Z',
+                updated_at: '2026-05-22T12:01:00.000Z',
+              },
+              {
+                id: 'thread-muted',
+                organization_id: 'org-1',
+                created_by: 'user-2',
+                subject: 'Muted',
+                thread_type: 'direct',
+                created_at: '2026-05-22T11:00:00.000Z',
+                updated_at: '2026-05-22T12:01:00.000Z',
+              },
+              {
+                id: 'thread-read',
+                organization_id: 'org-1',
+                created_by: 'user-2',
+                subject: 'Read',
+                thread_type: 'direct',
+                created_at: '2026-05-22T11:00:00.000Z',
+                updated_at: '2026-05-22T12:01:00.000Z',
+              },
+              {
+                id: 'thread-empty',
+                organization_id: 'org-1',
+                created_by: 'user-2',
+                subject: 'Empty',
+                thread_type: 'direct',
+                created_at: '2026-05-22T11:00:00.000Z',
+                updated_at: '2026-05-22T11:00:00.000Z',
+              },
+            ],
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const messageSelect = vi.fn().mockReturnValue({
+      in: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({
+          data: [
+            {
+              thread_id: 'thread-unread',
+              body: 'Unread latest',
+              created_at: '2026-05-22T12:01:00.000Z',
+            },
+            {
+              thread_id: 'thread-muted',
+              body: 'Muted latest',
+              created_at: '2026-05-22T12:01:00.000Z',
+            },
+            {
+              thread_id: 'thread-read',
+              body: 'Read latest',
+              created_at: '2026-05-22T12:01:00.000Z',
+            },
+          ],
+          error: null,
+        }),
+      }),
+    });
+
+    fromMock.mockImplementation((table: string) => {
+      if (table === 'message_thread_participants') {
+        return { select: participantSelect };
+      }
+      if (table === 'message_threads') {
+        return { select: threadSelect };
+      }
+      if (table === 'messages') {
+        return { select: messageSelect };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    rpcMock.mockResolvedValue({ data: [], error: null });
+
+    const result = await fetchMessageThreads('org-1', 'user-1');
+
+    expect(result.schemaUnavailable).toBe(false);
+    expect(result.unreadThreadCount).toBe(1);
+    expect(result.threads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'thread-unread', isUnread: true }),
+        expect.objectContaining({ id: 'thread-muted', isUnread: false }),
+        expect.objectContaining({ id: 'thread-read', isUnread: false }),
+        expect.objectContaining({ id: 'thread-empty', isUnread: false }),
+      ]),
+    );
+  });
+});

--- a/src/lib/messages/fetchers.ts
+++ b/src/lib/messages/fetchers.ts
@@ -4,10 +4,26 @@ import { fetchThreadParticipantNames } from './fetchThreadParticipantNames';
 import { isMessagingSchemaUnavailable } from './errors';
 import type {
   Message,
+  MessageThreadParticipant,
   MessageThreadListItem,
 } from './types';
 
 export { fetchStaffRecipients };
+
+const isThreadUnread = (
+  participant: Pick<MessageThreadParticipant, 'last_read_at' | 'muted_at' | 'archived_at'> | undefined,
+  latestMessageAt: string | null | undefined,
+): boolean => {
+  if (!participant || participant.archived_at || participant.muted_at || !latestMessageAt) {
+    return false;
+  }
+
+  if (!participant.last_read_at) {
+    return true;
+  }
+
+  return new Date(latestMessageAt).getTime() > new Date(participant.last_read_at).getTime();
+};
 
 const fetchParticipantNamesByThread = async (
   threadIds: string[],
@@ -29,7 +45,7 @@ const fetchParticipantNamesByThread = async (
 export const fetchMessageThreads = async (
   organizationId: string,
   userId: string,
-): Promise<{ threads: MessageThreadListItem[]; schemaUnavailable: boolean }> => {
+): Promise<{ threads: MessageThreadListItem[]; schemaUnavailable: boolean; unreadThreadCount: number }> => {
   try {
     const { data: participants, error: participantError } = await supabase
       .from('message_thread_participants')
@@ -40,14 +56,14 @@ export const fetchMessageThreads = async (
 
     if (participantError) {
       if (isMessagingSchemaUnavailable(participantError)) {
-        return { threads: [], schemaUnavailable: true };
+        return { threads: [], schemaUnavailable: true, unreadThreadCount: 0 };
       }
       throw participantError;
     }
 
     const threadIds = (participants ?? []).map((row) => row.thread_id);
     if (threadIds.length === 0) {
-      return { threads: [], schemaUnavailable: false };
+      return { threads: [], schemaUnavailable: false, unreadThreadCount: 0 };
     }
 
     const { data: threads, error: threadError } = await supabase
@@ -59,7 +75,7 @@ export const fetchMessageThreads = async (
 
     if (threadError) {
       if (isMessagingSchemaUnavailable(threadError)) {
-        return { threads: [], schemaUnavailable: true };
+        return { threads: [], schemaUnavailable: true, unreadThreadCount: 0 };
       }
       throw threadError;
     }
@@ -105,6 +121,7 @@ export const fetchMessageThreads = async (
     const list: MessageThreadListItem[] = (threads ?? []).map((thread) => {
       const participant = participantByThread.get(thread.id);
       const latest = latestByThread.get(thread.id);
+      const isUnread = isThreadUnread(participant, latest?.created_at ?? null);
       return {
         ...thread,
         participant_names: participantNamesByThread.get(thread.id) ?? [],
@@ -121,13 +138,18 @@ export const fetchMessageThreads = async (
           : undefined,
         last_message_preview: latest?.body ?? null,
         last_message_at: latest?.created_at ?? null,
+        isUnread,
       };
     });
 
-    return { threads: list, schemaUnavailable: false };
+    return {
+      threads: list,
+      schemaUnavailable: false,
+      unreadThreadCount: list.filter((thread) => thread.isUnread).length,
+    };
   } catch (error) {
     if (isMessagingSchemaUnavailable(error)) {
-      return { threads: [], schemaUnavailable: true };
+      return { threads: [], schemaUnavailable: true, unreadThreadCount: 0 };
     }
     throw error;
   }

--- a/src/lib/messages/types.ts
+++ b/src/lib/messages/types.ts
@@ -34,6 +34,7 @@ export type MessageThreadListItem = MessageThread & {
   participant?: MessageThreadParticipant;
   last_message_preview?: string | null;
   last_message_at?: string | null;
+  isUnread: boolean;
 };
 
 export type StaffRecipient = {

--- a/src/pages/messages/MessageThread.tsx
+++ b/src/pages/messages/MessageThread.tsx
@@ -33,8 +33,11 @@ export function MessageThread() {
     if (!threadId || !profile?.id) {
       return;
     }
-    void markThreadRead(threadId, profile.id);
-  }, [threadId, profile?.id, messages.length]);
+    void (async () => {
+      await markThreadRead(threadId, profile.id);
+      await queryClient.invalidateQueries({ queryKey: [MESSAGES_QUERY_KEY] });
+    })();
+  }, [threadId, profile?.id, messages.length, queryClient]);
 
   const sendMutation = useMutation({
     mutationFn: (body: string) => sendThreadMessage(threadId!, body, profile!.id),

--- a/src/pages/messages/MessagesInbox.tsx
+++ b/src/pages/messages/MessagesInbox.tsx
@@ -13,6 +13,7 @@ export function MessagesInbox() {
   const { profile } = useAuth();
   const organizationId = useActiveOrganizationId();
   const [searchQuery, setSearchQuery] = useState('');
+  const [showUnreadOnly, setShowUnreadOnly] = useState(false);
 
   const { data, isLoading, isFetching, refetch, error } = useQuery({
     queryKey: [MESSAGES_QUERY_KEY, 'inbox', organizationId, profile?.id],
@@ -24,10 +25,15 @@ export function MessagesInbox() {
   const filteredThreads = useMemo(() => {
     const threads = data?.threads ?? [];
     const query = searchQuery.trim().toLowerCase();
-    if (!query) {
-      return threads;
-    }
     return threads.filter((thread) => {
+      if (showUnreadOnly && !thread.isUnread) {
+        return false;
+      }
+
+      if (!query) {
+        return true;
+      }
+
       const subject = (thread.subject ?? '').toLowerCase();
       const preview = (thread.last_message_preview ?? '').toLowerCase();
       const participantNames = (thread.participant_names ?? []).join(' ').toLowerCase();
@@ -37,7 +43,7 @@ export function MessagesInbox() {
         || participantNames.includes(query)
       );
     });
-  }, [data?.threads, searchQuery]);
+  }, [data?.threads, searchQuery, showUnreadOnly]);
 
   return (
     <div className="mx-auto max-w-4xl p-4 md:p-6" data-testid="messages-inbox-page">
@@ -92,6 +98,28 @@ export function MessagesInbox() {
           className="w-full rounded-lg border border-gray-300 py-2 pl-10 pr-3 text-sm dark:border-gray-600 dark:bg-dark-lighter dark:text-gray-100"
           data-testid="messages-inbox-search"
         />
+      </div>
+
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={() => setShowUnreadOnly((current) => !current)}
+          className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+            showUnreadOnly
+              ? 'border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-950/40 dark:text-blue-200'
+              : 'border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800'
+          }`}
+          data-testid="messages-unread-filter"
+        >
+          Unread only
+          {typeof data?.unreadThreadCount === 'number' ? ` (${data.unreadThreadCount})` : ''}
+        </button>
+
+        {showUnreadOnly && filteredThreads.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400" data-testid="messages-unread-empty-state">
+            No unread threads right now.
+          </p>
+        ) : null}
       </div>
 
       <ThreadList threads={filteredThreads} isLoading={isLoading} />

--- a/src/pages/messages/__tests__/MessageThread.test.tsx
+++ b/src/pages/messages/__tests__/MessageThread.test.tsx
@@ -5,7 +5,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { PHI_COMPOSER_PLACEHOLDER, PHI_POLICY_BANNER } from '../../../lib/messages/constants';
+import { MESSAGES_QUERY_KEY } from '../../../lib/messages/constants';
 import { fetchMessageThread } from '../../../lib/messages/fetchers';
+import { markThreadRead } from '../../../lib/messages/mutations';
 import { MessageThread } from '../MessageThread';
 
 vi.mock('../../../lib/authContext', () => ({
@@ -51,7 +53,9 @@ vi.mock('../../../lib/messages/mutations', () => ({
 
 const renderPage = () => {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  return {
+    client,
+    ...render(
     <QueryClientProvider client={client}>
       <MemoryRouter initialEntries={['/messages/thread-1']}>
         <Routes>
@@ -59,7 +63,8 @@ const renderPage = () => {
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
-  );
+    ),
+  };
 };
 
 describe('MessageThread', () => {
@@ -96,5 +101,15 @@ describe('MessageThread', () => {
 
     expect(await screen.findByRole('heading', { name: 'Alex Admin' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Conversation' })).not.toBeInTheDocument();
+  });
+
+  it('marks the thread read and invalidates shared messaging queries on open', async () => {
+    const { client } = renderPage();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    await screen.findByText(PHI_POLICY_BANNER);
+
+    expect(markThreadRead).toHaveBeenCalledWith('thread-1', 'user-1');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: [MESSAGES_QUERY_KEY] });
   });
 });

--- a/src/pages/messages/__tests__/MessagesInbox.test.tsx
+++ b/src/pages/messages/__tests__/MessagesInbox.test.tsx
@@ -31,9 +31,24 @@ vi.mock('../../../lib/messages/fetchers', () => ({
         last_message_preview: 'Latest note',
         last_message_at: '2026-05-22T12:01:00.000Z',
         participant_names: ['Alex Admin'],
+        isUnread: true,
+      },
+      {
+        id: 'thread-2',
+        organization_id: 'org-1',
+        created_by: 'user-2',
+        subject: 'Read thread',
+        thread_type: 'group',
+        created_at: '2026-05-22T11:00:00.000Z',
+        updated_at: '2026-05-22T11:01:00.000Z',
+        last_message_preview: 'Already read',
+        last_message_at: '2026-05-22T11:01:00.000Z',
+        participant_names: ['Jordan Admin'],
+        isUnread: false,
       },
     ],
     schemaUnavailable: false,
+    unreadThreadCount: 1,
   })),
 }));
 
@@ -72,5 +87,18 @@ describe('MessagesInbox', () => {
     fireEvent.change(search, { target: { value: 'alex' } });
 
     expect(screen.getByTestId('message-thread-row-thread-1')).toBeInTheDocument();
+  });
+
+  it('shows unread row treatment and supports unread-only filtering', async () => {
+    renderPage();
+
+    expect(await screen.findByTestId('message-thread-row-thread-1')).toBeInTheDocument();
+    expect(screen.getByTestId('message-thread-unread-thread-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('message-thread-unread-thread-2')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('messages-unread-filter'));
+
+    expect(screen.getByTestId('message-thread-row-thread-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('message-thread-row-thread-2')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add unread-thread derivation to the staff messaging fetcher and shared query payload
- show unread-only filtering and unread row treatment in the existing `/messages` inbox
- surface the unread thread count on the sidebar Messages nav item and invalidate shared messaging queries after thread reads

## Verification
- `npx vitest run src/lib/messages/__tests__/fetchMessageThreads.test.ts src/pages/messages/__tests__/MessagesInbox.test.tsx src/pages/messages/__tests__/MessageThread.test.tsx src/components/__tests__/SidebarNavigation.test.tsx`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Known blockers
- `npm run test:ci` still fails in the aggregate repo suite outside this diff; the reported timeout in `tests/edge/initiate-client-onboarding.utils.test.ts` does not reproduce in isolation.
- `npm run verify:local` remains blocked because it rolls up the same aggregate `test:ci` failure and then hits the existing `coverage/.tmp/*.json` write issue documented in `docs/ai/WIN-95-protected-bootstrap-shell-handoff.md`.
