### PR TITLE
[codex] Fix IEHP presenting concerns extraction

### DIFF
--- a/src/components/ClientDetails/IehpFbaLayoutReview.tsx
+++ b/src/components/ClientDetails/IehpFbaLayoutReview.tsx
@@ -97,6 +97,9 @@ const EMPTY_LAYOUT: TemplateLayoutResponse = {
 
 const STATUS_OPTIONS: ReviewStatus[] = ["not_started", "drafted", "verified", "approved"];
 const STRUCTURED_STATUS_OPTIONS: StructuredReviewStatus[] = ["not_started", "drafted", "verified", "approved", "rejected"];
+const PAGE_FIELD_KEY_OVERRIDES: Record<string, number> = {
+  IEHP_FBA_REASON_FOR_REFERRAL: 1,
+};
 
 const formatPayloadPreview = (value: unknown): string => {
   if (value == null) return "";
@@ -201,8 +204,9 @@ export function IehpFbaLayoutReview({
   const fieldsByPage = useMemo(() => {
     const map = new Map<number, TemplateField[]>();
     data.fields.forEach((field) => {
-      const existing = map.get(field.page_number) ?? [];
-      map.set(field.page_number, [...existing, field]);
+      const effectivePageNumber = PAGE_FIELD_KEY_OVERRIDES[field.field_key] ?? field.page_number;
+      const existing = map.get(effectivePageNumber) ?? [];
+      map.set(effectivePageNumber, [...existing, field]);
     });
     return map;
   }, [data.fields]);

--- a/src/components/__tests__/IehpFbaLayoutReview.test.tsx
+++ b/src/components/__tests__/IehpFbaLayoutReview.test.tsx
@@ -490,7 +490,10 @@ describe("IehpFbaLayoutReview", () => {
             source_document_name: "Updated FBA -IEHP (11).docx",
             page_count: 30,
           },
-          pages: [{ page_number: 2, title: "Referral Information", layout_json: {} }],
+          pages: [
+            { page_number: 1, title: "General Information", layout_json: {} },
+            { page_number: 2, title: "Referral Information", layout_json: {} },
+          ],
           fields: [
             {
               page_number: 2,
@@ -570,8 +573,10 @@ describe("IehpFbaLayoutReview", () => {
     expect(await screen.findByLabelText("Name of Referring Provider, Credentials")).toBeInTheDocument();
     expect(screen.getByText("manual required")).toBeInTheDocument();
     expect(screen.getByText(/This required IEHP field is intentionally manual/)).toBeInTheDocument();
-    expect(screen.getByLabelText("Reason for Referral")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Page 1/i }));
+    expect(await screen.findByLabelText("Reason for Referral")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Reviewed referral reason")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Page 2/i }));
     expect(screen.getByLabelText("Missing Manual Field")).toBeDisabled();
     expect(screen.getByText("missing row")).toBeInTheDocument();
     expect(screen.getAllByText("manual required")).toHaveLength(1);

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -1188,6 +1188,33 @@ Deno.test("deterministicValueForRow stops presenting concerns extraction at colo
   expect(manual.value_text).not.toContain("Physical Aggression");
 });
 
+Deno.test("deterministicValueForRow maps IEHP PRESENTING CONCERNS heading into reason for referral", () => {
+  const manual = __TESTING__.deterministicValueForRow(
+    {
+      section: "identification_admin",
+      label: "Reason for Referral",
+      placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+      required: true,
+      mode: "MANUAL",
+    },
+    `
+      II. PRESENTING CONCERNS
+      Kim presents with significant communication deficits and primarily relies on hand-leading to express preferences.
+      Additional concerns include recent sleep difficulties and caregiver safety concerns in the community.
+      III. BEHAVIORS
+      The behaviors and functional skills to be addressed are:
+      Tantrums
+      Functional Communication
+    `,
+  );
+
+  expect(manual.mode).toBe("MANUAL");
+  expect(manual.status).toBe("drafted");
+  expect(manual.value_text).toContain("Kim presents with significant communication deficits");
+  expect(manual.value_text).not.toContain("The behaviors and functional skills to be addressed");
+  expect(manual.value_text).not.toContain("Functional Communication");
+});
+
 Deno.test("extractStructuredSections keeps presenting concerns out of IEHP behavior skill targets", () => {
   const sections = asSections(
     "iehp_fba",

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -1215,6 +1215,34 @@ Deno.test("deterministicValueForRow maps IEHP PRESENTING CONCERNS heading into r
   expect(manual.value_text).not.toContain("Functional Communication");
 });
 
+Deno.test("deterministicValueForRow ignores inline presenting concerns prose before heading", () => {
+  const manual = __TESTING__.deterministicValueForRow(
+    {
+      section: "identification_admin",
+      label: "Reason for Referral",
+      placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+      required: true,
+      mode: "MANUAL",
+    },
+    `
+      General instructions mention presenting concerns and background content before section headers.
+      Caregiver stated these presenting concerns should be discussed with the clinician.
+      II. PRESENTING CONCERNS
+      Kim presents with significant communication deficits and requires close supervision in public settings.
+      III. BEHAVIORS
+      The behaviors and functional skills to be addressed are:
+      Tantrums
+      Functional Communication
+    `,
+  );
+
+  expect(manual.mode).toBe("MANUAL");
+  expect(manual.status).toBe("drafted");
+  expect(manual.value_text).toContain("Kim presents with significant communication deficits");
+  expect(manual.value_text).not.toContain("General instructions mention presenting concerns");
+  expect(manual.value_text).not.toContain("The behaviors and functional skills to be addressed");
+});
+
 Deno.test("extractStructuredSections keeps presenting concerns out of IEHP behavior skill targets", () => {
   const sections = asSections(
     "iehp_fba",

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -1886,7 +1886,10 @@ const extractLineNearLabels = (
 const extractIehpPresentingConcernsNarrative = (text: string): string | null => {
   const narrative = extractSectionText(
     text,
-    [/\bREASON\s+FOR\s+REFERRAL\s+AND\s+PRESENTING\s+CONCERNS\b/i],
+    [
+      /\bREASON\s+FOR\s+REFERRAL\s+AND\s+PRESENTING\s+CONCERNS\b/i,
+      /\bPRESENTING\s+CONCERNS\b/i,
+    ],
     [/\bName\s+of\s+Referring\s+Provider\b/i, /\bBEHAVIORS\s*:?\b/i],
   );
   if (!narrative) {
@@ -1894,7 +1897,7 @@ const extractIehpPresentingConcernsNarrative = (text: string): string | null => 
   }
 
   const compact = compactDocumentText(narrative)
-    .replace(/^\s*REASON\s+FOR\s+REFERRAL\s+AND\s+PRESENTING\s+CONCERNS\s*:?\s*/i, "")
+    .replace(/^\s*(?:REASON\s+FOR\s+REFERRAL\s+AND\s+PRESENTING\s+CONCERNS|PRESENTING\s+CONCERNS)\s*:?\s*/i, "")
     .replace(/^Write a brief description[^.]*\.\s*/i, "")
     .trim();
   return compact.length > 0 ? compact : null;

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -1888,7 +1888,7 @@ const extractIehpPresentingConcernsNarrative = (text: string): string | null => 
     text,
     [
       /\bREASON\s+FOR\s+REFERRAL\s+AND\s+PRESENTING\s+CONCERNS\b/i,
-      /\bPRESENTING\s+CONCERNS\b/i,
+      /(?:^|\n)\s*(?:[IVX]+[.)]\s*)?PRESENTING\s+CONCERNS\s*:?(?=\s*(?:\n|$))/i,
     ],
     [/\bName\s+of\s+Referring\s+Provider\b/i, /\bBEHAVIORS\s*:?\b/i],
   );


### PR DESCRIPTION
## Summary
- accept IEHP documents whose narrative heading is `PRESENTING CONCERNS` without the longer `REASON FOR REFERRAL AND PRESENTING CONCERNS` label
- keep the captured narrative mapped into `IEHP_FBA_REASON_FOR_REFERRAL` without absorbing the following behaviors section
- render `IEHP_FBA_REASON_FOR_REFERRAL` under Page 1 / General Information in the IEHP review UI

## Root Cause
The latest uploaded IEHP document uses `II. PRESENTING CONCERNS`, but the deterministic extractor only started on `REASON FOR REFERRAL AND PRESENTING CONCERNS`. Hosted Supabase showed the latest IEHP upload had behavior/background sections drafted while `IEHP_FBA_REASON_FOR_REFERRAL` remained `not_started` with empty-template notes.

## Verification
- `deno test --allow-env --allow-read supabase/functions/extract-assessment-fields/index.test.ts`
- `npx vitest run src/components/__tests__/IehpFbaLayoutReview.test.tsx --reporter=verbose`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`
- `npm run verify:local`

## Risk
Critical lane because this touches `supabase/functions/**`. Existing uploaded documents need re-extraction/re-upload after deployment to backfill the newly recognized narrative.