### PR TITLE
Fix IEHP assessment procedures extraction completeness

### DIFF
--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -722,7 +722,13 @@ Deno.test("extractStructuredSections recognizes blank-template IEHP heading alia
   const byKey = new Map(sections.map((section) => [section.field_key, section]));
   expect(byKey.has("IEHP_FBA_BHT_AVAILABILITY_GRID")).toBe(true);
   expect((byKey.get("IEHP_FBA_ENVIRONMENTAL_ANALYSIS")?.payload.rows as unknown[]).length).toBeGreaterThanOrEqual(4);
-  expect((byKey.get("IEHP_FBA_ASSESSMENT_PROCEDURES_TABLE")?.payload.rows as unknown[]).length).toBeGreaterThanOrEqual(3);
+  const procedures = (byKey.get("IEHP_FBA_ASSESSMENT_PROCEDURES_TABLE")?.payload.rows as Array<Record<string, string>>).map(
+    (row) => row.procedure,
+  );
+  expect(procedures.length).toBeGreaterThanOrEqual(3);
+  expect(procedures).toContain("Record s Reviewed");
+  expect(procedures).toContain("1 st Member Observation");
+  expect(procedures).toContain("Brief Functional Analysis");
   expect(byKey.get("IEHP_FBA_CRISIS_PLAN")?.payload.raw_text).toContain("Safety Procedure");
   expect(byKey.get("IEHP_FBA_DISCHARGE_TRANSITION_EXIT_PLAN")?.payload.raw_text).toContain("Transition Planning");
   expect((byKey.get("IEHP_FBA_RECOMMENDATIONS_HCPCS_ROWS")?.payload.rows as unknown[]).length).toBe(1);

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -1485,7 +1485,7 @@ const extractIeHpGoalSections = (
       field_key: "IEHP_FBA_ASSESSMENT_PROCEDURES_TABLE",
       section_key: "assessment_procedures",
       start: [/\bDESCRIPTION OF ASSESSMENT PROCEDURES\b/i],
-      end: [/Records\s+reviewed\s+included/i, /Clinical Interview/i],
+      end: [/Records\s+reviewed\s+included/i],
     },
     {
       field_key: "IEHP_FBA_CLINICAL_INTERVIEW_NARRATIVE",


### PR DESCRIPTION
## Summary
- stop IEHP assessment procedures section extraction at `Records reviewed included` only
- remove premature `Clinical Interview` boundary that truncated checkbox/procedure rows
- strengthen extractor test assertions to require expected assessment procedure rows

## Why
Page 4 "DESCRIPTION OF ASSESSMENT PROCEDURES" was being truncated after the first row when documents include additional checkbox/procedure lines. This left the extracted assessment procedures incomplete.

## Verification
- deno test --allow-env --allow-read supabase/functions/extract-assessment-fields/index.test.ts --filter "next-slice IEHP narratives, checkboxes, reinforcers"
- deno test --allow-env --allow-read supabase/functions/extract-assessment-fields/index.test.ts
- npm run ci:check-focused
- npm run lint
- npm run typecheck

## Risk
- Critical lane (high-risk path): supabase/functions/** extraction logic
- Scope is narrowly bounded to one section boundary and targeted tests
