### PR TITLE
WIN-161 Render IEHP adaptive measure review blocks distinctly

### DIFF
--- a/docs/ai/2026-05-29-iehp-adaptive-measure-review-blocks-handoff.md
+++ b/docs/ai/2026-05-29-iehp-adaptive-measure-review-blocks-handoff.md
@@ -1,0 +1,64 @@
+## Routing
+
+- classification: `low-risk autonomous`
+- lane: `fast`
+- why: bounded UI-only review rendering fix in `src/components/**` plus focused component coverage; no auth, server, Supabase schema, or protected-path edits
+- triggering paths:
+  - `src/components/ClientDetails/IehpFbaLayoutReview.tsx`
+  - `src/components/__tests__/IehpFbaLayoutReview.test.tsx`
+
+## Scope
+
+- task intent: render `IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES` as named adaptive-measure blocks instead of a single narrative blob in the IEHP review UI
+- files touched:
+  - `src/components/ClientDetails/IehpFbaLayoutReview.tsx`
+  - `src/components/__tests__/IehpFbaLayoutReview.test.tsx`
+  - `docs/ai/2026-05-29-iehp-adaptive-measure-review-blocks-handoff.md`
+- single-purpose diff: yes
+
+## Required Agents
+
+- required sequence:
+  - `specification-engineer`
+  - `implementation-engineer`
+  - `code-review-engineer`
+- agents used:
+  - Codex performed routing, implementation, verification, and review directly for this fast-lane slice
+- reviewer: completed
+
+## Verification Card
+
+- required checks:
+  - `npm run lint`
+  - `npm run typecheck`
+  - targeted tests when available, otherwise `npm test`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - `npm test -- src/components/__tests__/IehpFbaLayoutReview.test.tsx`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+  - `npm run verify:local`: pass
+- blocked checks:
+  - `none`
+- result: pass
+- residual risk: the hosted document `86cdd0ce-dba3-44a9-b431-0653f3a2fafa` currently persists only one populated `Vineland` block in `assessment_blocks`, so the UI will now show explicit empty states for the other named measures rather than invent content
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes (`WIN-161`)
+- protected-path drift: none
+- unrelated changes: none
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: yes
+- required follow-up:
+  - push branch
+  - open PR
+  - move `WIN-161` to `In Review` once PR exists
+
+## Handoff Summary
+
+This slice updates the IEHP review renderer to treat adaptive measure summaries as named assessment cards in VB-MAPP, Vineland, AFLS, and ABAS-3 order instead of a single narrative block. Missing named blocks now stay visible as explicit empty states, which matches the hosted payload more honestly for today’s document while still rendering multi-block payloads distinctly. Focused component coverage was added, and `lint`, `typecheck`, `build`, and full `verify:local` all passed.

--- a/src/components/ClientDetails/IehpFbaLayoutReview.tsx
+++ b/src/components/ClientDetails/IehpFbaLayoutReview.tsx
@@ -175,8 +175,6 @@ const formatGenericStructuredReadableText = (payload: Record<string, unknown> | 
   const label = stringifyReadablePayloadValue(payload.label);
   const rawText = stringifyReadablePayloadValue(payload.raw_text);
   const clinicalValue = stringifyReadablePayloadValue(payload.clinical_value);
-  const source = stringifyReadablePayloadValue(payload.source);
-  const fieldType = stringifyReadablePayloadValue(payload.field_type);
   const enteredValuePresent = payload.entered_value_present;
   const templatePlaceholder = payload.template_placeholder;
 
@@ -188,8 +186,6 @@ const formatGenericStructuredReadableText = (payload: Record<string, unknown> | 
   else if (templatePlaceholder === true) lines.push("Template field placeholder preserved for staff review.");
   else lines.push("No extracted staff-readable content available.");
 
-  if (fieldType) lines.push(`Field type: ${fieldType}`);
-  if (source) lines.push(`Source guidance: ${source}`);
   return lines.join("\n");
 };
 
@@ -292,6 +288,13 @@ const getStructuredSectionPageNumber = (section: StructuredValue): number | null
   return typeof pageNumber === "number" ? pageNumber : null;
 };
 
+const pluralizeExtractedSectionCount = (count: number): string => `${count} extracted section${count === 1 ? "" : "s"}`;
+
+const structuredSectionDisplayTitle = (section: StructuredValue): string => {
+  const label = stringifyReadablePayloadValue(section.payload?.label);
+  return label || `${section.field_key} section ${section.section_index + 1}`;
+};
+
 const emptyPageMessage = (pageNumber: number, title: string | undefined): string => {
   if (pageNumber === 16 || /school goals/i.test(title ?? "")) {
     return "No school-specific goals were extracted for this IEHP document.";
@@ -300,7 +303,7 @@ const emptyPageMessage = (pageNumber: number, title: string | undefined): string
 };
 
 const isManualRequiredReviewItem = (field: TemplateField, item: ChecklistValue | undefined): boolean =>
-  Boolean(item) && field.required && field.mode === "MANUAL" && item?.status === "not_started";
+  field.required && field.mode === "MANUAL" && (!item || item.status === "not_started");
 
 const emptyPageReviewSummary = (): PageReviewSummary => ({
   needsAttention: 0,
@@ -339,6 +342,8 @@ export function IehpFbaLayoutReview({
   const [edits, setEdits] = useState<Record<string, FieldEdit>>({});
   const [structuredEdits, setStructuredEdits] = useState<Record<string, StructuredEdit>>({});
   const [rawPreviewBySectionId, setRawPreviewBySectionId] = useState<Record<string, boolean>>({});
+  const [expandedFieldByKey, setExpandedFieldByKey] = useState<Record<string, boolean>>({});
+  const [expandedStructuredSectionById, setExpandedStructuredSectionById] = useState<Record<string, boolean>>({});
 
   const queryKey = ["assessment-template-layout", assessmentDocument.id, organizationId ?? "MISSING_ORG"] as const;
   const { data = EMPTY_LAYOUT, isLoading, isError } = useQuery({
@@ -458,6 +463,11 @@ export function IehpFbaLayoutReview({
   }, [activePage, activePageFields, activePageLooseStructuredSections, checklistByKey, structuredByKey]);
 
   useEffect(() => {
+    if (data.pages.length === 0 || data.pages.some((page) => page.page_number === activePage)) return;
+    setActivePage(data.pages[0].page_number);
+  }, [activePage, data.pages]);
+
+  useEffect(() => {
     if (pendingAttentionFocusPage !== activePage || !activePageAttentionTargetKey) return;
     const target = attentionTargetRefs.current[activePageAttentionTargetKey];
     if (!target) return;
@@ -543,6 +553,97 @@ export function IehpFbaLayoutReview({
     },
     onError: (error) => {
       showError(error instanceof Error ? error.message : "Failed to save IEHP structured section");
+    },
+  });
+
+  const setFieldDisposition = useMutation({
+    mutationFn: async ({
+      field,
+      status,
+      structuredSections,
+    }: {
+      field: TemplateField;
+      status: ReviewStatus;
+      structuredSections: StructuredValue[];
+    }) => {
+      const item = checklistByKey.get(field.field_key);
+      if (!item) {
+        throw new Error("No checklist row exists for this IEHP field.");
+      }
+      const edit = edits[field.field_key] ?? {
+        valueText: item.value_text ?? "",
+        reviewNotes: item.review_notes ?? "",
+        status: item.status,
+      };
+      const responses = await Promise.all([
+        callApi("/api/assessment-checklist", {
+          method: "PATCH",
+          body: JSON.stringify({
+            item_id: item.id,
+            status,
+            review_notes: edit.reviewNotes,
+            value_text: edit.valueText,
+          }),
+        }),
+        ...(status === "approved"
+          ? structuredSections
+              .filter((section) => section.status !== "approved")
+              .map((section) =>
+                callApi("/api/assessment-checklist", {
+                  method: "PATCH",
+                  body: JSON.stringify({
+                    structured_section_id: section.id,
+                    status: "approved",
+                    review_notes: section.review_notes ?? "",
+                    payload: section.payload,
+                  }),
+                }),
+              )
+          : []),
+      ]);
+      const failedResponse = responses.find((response) => !response.ok);
+      if (failedResponse) {
+        throw new Error(await parseApiErrorMessage(failedResponse, "Failed to update IEHP review status"));
+      }
+      return Promise.all(responses.map((response) => response.json()));
+    },
+    onSuccess: async (_result, { field, status }) => {
+      showSuccess(`${field.label} marked ${formatStatusLabel(status).toLowerCase()}.`);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey }),
+        queryClient.invalidateQueries({ queryKey: ["assessment-checklist", assessmentDocument.id, organizationId ?? "MISSING_ORG"] }),
+      ]);
+    },
+    onError: (error) => {
+      showError(error instanceof Error ? error.message : "Failed to update IEHP review status");
+    },
+  });
+
+  const setLooseStructuredSectionDisposition = useMutation({
+    mutationFn: async ({ section, status }: { section: StructuredValue; status: StructuredReviewStatus }) => {
+      const response = await callApi("/api/assessment-checklist", {
+        method: "PATCH",
+        body: JSON.stringify({
+          structured_section_id: section.id,
+          status,
+          review_notes: section.review_notes ?? "",
+          payload: section.payload,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(await parseApiErrorMessage(response, "Failed to update IEHP structured section"));
+      }
+      return response.json();
+    },
+    onSuccess: async () => {
+      showSuccess("IEHP structured section updated.");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey }),
+        queryClient.invalidateQueries({ queryKey: ["assessment-checklist", assessmentDocument.id, organizationId ?? "MISSING_ORG"] }),
+      ]);
+    },
+    onError: (error) => {
+      showError(error instanceof Error ? error.message : "Failed to update IEHP structured section");
     },
   });
 
@@ -684,6 +785,9 @@ export function IehpFbaLayoutReview({
                   const fieldAttentionTargetKey = `field-${field.field_key}`;
                   const fieldNeedsAttention = isAttentionReviewStatus(fieldStatus) || structuredSections.some((section) => isAttentionReviewStatus(section.status));
                   const highlightAttentionTarget = activePageAttentionTargetKey === fieldAttentionTargetKey && fieldNeedsAttention;
+                  const expanded = Boolean(expandedFieldByKey[field.field_key]);
+                  const fieldValuePreview = edit.valueText.trim();
+                  const dispositionDisabled = setFieldDisposition.isLoading || locked || !item;
                   return (
                     <div
                       key={field.field_key}
@@ -696,91 +800,401 @@ export function IehpFbaLayoutReview({
                         highlightAttentionTarget ? "border-amber-300 ring-2 ring-amber-300/70" : "border-slate-600"
                       }`}
                     >
-                      <div className="mb-2 flex flex-wrap items-start justify-between gap-2">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
                         <div>
-                          <label htmlFor={`iehp-${field.field_key}`} className="text-sm font-semibold text-slate-100">
+                          <p className="text-sm font-semibold text-slate-100">
                             {field.label}
-                          </label>
-                          <p className="text-[11px] text-slate-400">
-                            {field.field_key} • {field.mode} • {field.field_type} • required: {String(field.required)}
                           </p>
+                          {structuredSections.length > 0 && (
+                            <p className="mt-1 text-[11px] font-semibold text-slate-300">{pluralizeExtractedSectionCount(structuredSections.length)}</p>
+                          )}
                         </div>
-                        <span className={`rounded px-2 py-1 text-[11px] font-semibold ${statusChipClass(manualRequired ? "not_started" : item?.status ?? "not_started")}`}>
-                          {manualRequired ? "Manual review required" : formatStatusLabel(item?.status ?? "not_started")}
-                        </span>
+                        <div className="flex flex-wrap items-center justify-end gap-2">
+                          {field.required && (
+                            <span className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-300">Required</span>
+                          )}
+                          <span className={`rounded px-2 py-1 text-[11px] font-semibold ${statusChipClass(manualRequired ? "not_started" : item?.status ?? "not_started")}`}>
+                            {manualRequired ? "Manual review required" : formatStatusLabel(item?.status ?? "not_started")}
+                          </span>
+                        </div>
                       </div>
 
                       {manualRequired && (
-                        <p className="mb-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900">
+                        <p className="mt-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900">
                           This required IEHP field is intentionally manual unless reliable document evidence is present.
                         </p>
                       )}
 
-                      <textarea
-                        id={`iehp-${field.field_key}`}
-                        value={edit.valueText}
-                        rows={getFieldInputRows(field.field_type)}
-                        disabled={locked || !item}
-                        onChange={(event) =>
-                          setEdits((current) => ({
-                            ...current,
-                            [field.field_key]: {
-                              ...edit,
-                              valueText: event.target.value,
-                            },
-                          }))
-                        }
-                        className="w-full rounded border border-slate-600 bg-slate-950 p-2 text-sm text-slate-100 disabled:bg-slate-800"
-                        placeholder={field.field_type.includes("table") ? "Enter table rows or structured summary for reviewer confirmation." : "Field value"}
-                      />
+                      <div className="mt-3 space-y-2 rounded border border-slate-700 bg-slate-900/50 p-2 text-xs text-slate-100">
+                        {fieldValuePreview ? (
+                          <p className="max-h-24 overflow-hidden whitespace-pre-wrap leading-relaxed">{fieldValuePreview}</p>
+                        ) : structuredSections.length === 0 ? (
+                          <p className="text-slate-400">No extracted wording is available yet.</p>
+                        ) : null}
+                        {structuredSections.slice(0, 2).map((section) => (
+                          <div key={`preview-${section.id}`} className="rounded border border-slate-700 bg-slate-950/40 px-2 py-2">
+                            {renderStructuredReadablePreview(section)}
+                          </div>
+                        ))}
+                        {structuredSections.length > 2 && (
+                          <p className="text-[11px] text-slate-400">{structuredSections.length - 2} more extracted sections hidden until expanded.</p>
+                        )}
+                      </div>
 
-                      {structuredSections.length > 0 && (
-                        <div className="mt-2 space-y-2 rounded bg-slate-900/80 p-2 text-xs text-slate-200">
-                          <p className="font-semibold">Structured extracted sections</p>
-                          {structuredSections.map((section) => {
-                            const structuredEdit = structuredEdits[section.id] ?? {
-                              payloadText: formatPayloadPreview(section.payload),
-                              reviewNotes: section.review_notes ?? "",
-                              status: section.status,
-                            };
-                            const structuredLocked = section.status === "approved";
-                            return (
-                              <div key={section.id} className="rounded border border-slate-600 bg-slate-800 p-2">
-                                <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-                                  <span className="font-semibold text-slate-100">
-                                    Section {section.section_index + 1} • required: {String(section.required)}
-                                  </span>
-                                  <div className="flex items-center gap-2">
-                                    <span className={`rounded px-2 py-1 text-[11px] font-semibold ${statusChipClass(section.status)}`}>{formatStatusLabel(section.status)}</span>
-                                    <button
-                                      type="button"
-                                      onClick={() => void copyStructuredSection(section)}
-                                      className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-200 hover:bg-slate-700"
-                                    >
-                                      Copy extracted
-                                    </button>
-                                    <button
-                                      type="button"
-                                      onClick={() =>
-                                        setRawPreviewBySectionId((current) => ({
-                                          ...current,
-                                          [section.id]: !current[section.id],
-                                        }))
-                                      }
-                                      className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-200 hover:bg-slate-700"
-                                    >
-                                      {rawPreviewBySectionId[section.id] ? "Hide technical details" : "Show technical details"}
-                                    </button>
-                                    {structuredLocked && (
-                                      <span className="rounded bg-slate-700 px-2 py-1 text-[11px] text-slate-200">locked after approval</span>
+                      <div className="mt-3 flex flex-wrap items-center gap-2">
+                        {!manualRequired && !locked && (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => setFieldDisposition.mutate({ field, status: "approved", structuredSections })}
+                              disabled={dispositionDisabled}
+                              className="rounded bg-emerald-700 px-3 py-2 text-xs font-semibold text-white hover:bg-emerald-600 disabled:opacity-50"
+                            >
+                              Approve {field.label}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setFieldDisposition.mutate({ field, status: item?.status ?? "not_started", structuredSections: [] })}
+                              disabled={dispositionDisabled}
+                              className="rounded border border-amber-400/50 px-3 py-2 text-xs font-semibold text-amber-100 hover:bg-amber-500/10 disabled:opacity-50"
+                            >
+                              Needs review {field.label}
+                            </button>
+                          </>
+                        )}
+                        {manualRequired && (
+                          <button
+                            type="button"
+                            onClick={() => setExpandedFieldByKey((current) => ({ ...current, [field.field_key]: true }))}
+                            className="rounded border border-amber-400/50 px-3 py-2 text-xs font-semibold text-amber-100 hover:bg-amber-500/10"
+                          >
+                            Review {field.label}
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExpandedFieldByKey((current) => ({
+                              ...current,
+                              [field.field_key]: !current[field.field_key],
+                            }))
+                          }
+                          className="rounded border border-slate-500 px-3 py-2 text-xs font-semibold text-slate-100 hover:bg-slate-700"
+                        >
+                          {expanded ? `Collapse ${field.label}` : `Expand ${field.label}`}
+                        </button>
+                      </div>
+
+                      {expanded && (
+                        <div className="mt-3 space-y-3">
+                          <p className="text-[11px] text-slate-400">
+                            {field.field_key} • {field.mode} • {field.field_type} • required: {String(field.required)}
+                          </p>
+                          <textarea
+                            id={`iehp-${field.field_key}`}
+                            aria-label={field.label}
+                            value={edit.valueText}
+                            rows={getFieldInputRows(field.field_type)}
+                            disabled={locked || !item}
+                            onChange={(event) =>
+                              setEdits((current) => ({
+                                ...current,
+                                [field.field_key]: {
+                                  ...edit,
+                                  valueText: event.target.value,
+                                },
+                              }))
+                            }
+                            className="w-full rounded border border-slate-600 bg-slate-950 p-2 text-sm text-slate-100 disabled:bg-slate-800"
+                            placeholder={field.field_type.includes("table") ? "Enter table rows or structured summary for reviewer confirmation." : "Field value"}
+                          />
+
+                          {structuredSections.length > 0 && (
+                            <div className="mt-2 space-y-2 rounded bg-slate-900/80 p-2 text-xs text-slate-200">
+                              <p className="font-semibold">Structured extracted sections</p>
+                              {structuredSections.map((section) => {
+                                const structuredEdit = structuredEdits[section.id] ?? {
+                                  payloadText: formatPayloadPreview(section.payload),
+                                  reviewNotes: section.review_notes ?? "",
+                                  status: section.status,
+                                };
+                                const structuredLocked = section.status === "approved";
+                                return (
+                                  <div key={section.id} className="rounded border border-slate-600 bg-slate-800 p-2">
+                                    <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                                      <span className="font-semibold text-slate-100">
+                                        Section {section.section_index + 1} • required: {String(section.required)}
+                                      </span>
+                                      <div className="flex items-center gap-2">
+                                        <span className={`rounded px-2 py-1 text-[11px] font-semibold ${statusChipClass(section.status)}`}>{formatStatusLabel(section.status)}</span>
+                                        <button
+                                          type="button"
+                                          onClick={() => void copyStructuredSection(section)}
+                                          className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-200 hover:bg-slate-700"
+                                        >
+                                          Copy extracted
+                                        </button>
+                                        <button
+                                          type="button"
+                                          onClick={() =>
+                                            setRawPreviewBySectionId((current) => ({
+                                              ...current,
+                                              [section.id]: !current[section.id],
+                                            }))
+                                          }
+                                          className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-200 hover:bg-slate-700"
+                                        >
+                                          {rawPreviewBySectionId[section.id] ? "Hide technical details" : "Show technical details"}
+                                        </button>
+                                        {structuredLocked && (
+                                          <span className="rounded bg-slate-700 px-2 py-1 text-[11px] text-slate-200">locked after approval</span>
+                                        )}
+                                      </div>
+                                    </div>
+                                    <div className="mb-2 rounded border border-slate-600 bg-slate-900/60 px-2 py-2 text-[11px] text-slate-100">
+                                      {renderStructuredReadablePreview(section)}
+                                    </div>
+                                    {rawPreviewBySectionId[section.id] && (
+                                      <div className="mb-2 space-y-2 rounded border border-slate-600 bg-slate-900/80 p-2">
+                                        <div>
+                                          <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Technical details</p>
+                                          <p className="text-[11px] text-slate-400">Raw JSON is hidden by default so staff can focus on the readable extracted content above.</p>
+                                        </div>
+                                        <pre
+                                          data-testid={`raw-json-${section.id}`}
+                                          className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded border border-slate-700 bg-slate-950 p-2 text-[11px] text-slate-300"
+                                        >
+                                          {formatPayloadPreview(section.payload)}
+                                        </pre>
+                                        <label className="block text-[11px] font-semibold text-slate-300" htmlFor={`structured-payload-${section.id}`}>
+                                          Editable JSON payload
+                                        </label>
+                                        <textarea
+                                          id={`structured-payload-${section.id}`}
+                                          value={structuredEdit.payloadText}
+                                          rows={4}
+                                          disabled={structuredLocked}
+                                          onChange={(event) =>
+                                            setStructuredEdits((current) => ({
+                                              ...current,
+                                              [section.id]: {
+                                                ...structuredEdit,
+                                                payloadText: event.target.value,
+                                              },
+                                            }))
+                                          }
+                                          className="w-full rounded border border-slate-600 bg-slate-950 p-2 font-mono text-xs text-slate-100 disabled:bg-slate-800"
+                                          aria-label={`${field.label} structured section ${section.section_index + 1} payload`}
+                                        />
+                                      </div>
                                     )}
+                                    <div className="mt-2 grid gap-2 md:grid-cols-[10rem_1fr_auto]">
+                                      <select
+                                        value={structuredEdit.status}
+                                        disabled={structuredLocked}
+                                        onChange={(event) =>
+                                          setStructuredEdits((current) => ({
+                                            ...current,
+                                            [section.id]: {
+                                              ...structuredEdit,
+                                              status: event.target.value as StructuredReviewStatus,
+                                            },
+                                          }))
+                                        }
+                                        className="rounded border border-slate-600 bg-slate-950 p-2 text-sm disabled:bg-slate-800"
+                                        aria-label={`${field.label} structured section ${section.section_index + 1} status`}
+                                      >
+                                        {STRUCTURED_STATUS_OPTIONS.map((status) => (
+                                          <option key={status} value={status}>
+                                            {formatStatusLabel(status)}
+                                          </option>
+                                        ))}
+                                      </select>
+                                      <input
+                                        value={structuredEdit.reviewNotes}
+                                        disabled={structuredLocked}
+                                        onChange={(event) =>
+                                          setStructuredEdits((current) => ({
+                                            ...current,
+                                            [section.id]: {
+                                              ...structuredEdit,
+                                              reviewNotes: event.target.value,
+                                            },
+                                          }))
+                                        }
+                                        className="rounded border border-slate-600 bg-slate-950 p-2 text-sm disabled:bg-slate-800"
+                                        placeholder="Structured section review notes"
+                                        aria-label={`${field.label} structured section ${section.section_index + 1} review notes`}
+                                      />
+                                      <button
+                                        type="button"
+                                        onClick={() => saveStructuredSection.mutate(section)}
+                                        disabled={saveStructuredSection.isLoading || structuredLocked}
+                                        className="rounded bg-indigo-700 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-600 disabled:opacity-50"
+                                      >
+                                        Save extracted section
+                                      </button>
+                                    </div>
                                   </div>
-                                </div>
-                                <div className="mb-2 rounded border border-slate-600 bg-slate-900/60 px-2 py-2 text-[11px] text-slate-100">
-                                  {renderStructuredReadablePreview(section)}
+                                );
+                              })}
+                            </div>
+                          )}
+
+                          <div className="mt-2 grid gap-2 md:grid-cols-[10rem_1fr_auto]">
+                            <select
+                              value={edit.status}
+                              disabled={locked || !item}
+                              onChange={(event) =>
+                                setEdits((current) => ({
+                                  ...current,
+                                  [field.field_key]: {
+                                    ...edit,
+                                    status: event.target.value as ReviewStatus,
+                                  },
+                                }))
+                              }
+                              className="rounded border border-slate-600 bg-slate-950 p-2 text-sm disabled:bg-slate-800"
+                              aria-label={`${field.label} review status`}
+                            >
+                              {STATUS_OPTIONS.map((status) => (
+                                <option key={status} value={status}>
+                                  {formatStatusLabel(status)}
+                                </option>
+                              ))}
+                            </select>
+                            <input
+                              value={edit.reviewNotes}
+                              disabled={locked || !item}
+                              onChange={(event) =>
+                                setEdits((current) => ({
+                                  ...current,
+                                  [field.field_key]: {
+                                    ...edit,
+                                    reviewNotes: event.target.value,
+                                  },
+                                }))
+                              }
+                              className="rounded border border-slate-600 bg-slate-950 p-2 text-sm disabled:bg-slate-800"
+                              placeholder="Review notes"
+                              aria-label={`${field.label} review notes`}
+                            />
+                            <button
+                              type="button"
+                              onClick={() => saveField.mutate(field)}
+                              disabled={saveField.isLoading || locked || !item}
+                              className="rounded bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-600 disabled:opacity-50"
+                            >
+                              Save field
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                      {locked && <p className="mt-2 text-[11px] text-slate-400">Approved IEHP rows stay locked for clinical review integrity.</p>}
+                    </div>
+                  );
+                })}
+                {activePageLooseStructuredSections.length > 0 && (
+                  <div className="rounded-md border border-slate-600 bg-slate-800/70 p-3">
+                    <div className="mb-2">
+                      <p className="text-sm font-semibold text-slate-100">Page-specific structured sections</p>
+                      <p className="text-[11px] text-slate-400">
+                        Extracted content placed on this IEHP page by document source metadata.
+                      </p>
+                    </div>
+                    <div className="space-y-2 rounded bg-slate-900/80 p-2 text-xs text-slate-200">
+                      {activePageLooseStructuredSections.map((section) => {
+                        const structuredEdit = structuredEdits[section.id] ?? {
+                          payloadText: formatPayloadPreview(section.payload),
+                          reviewNotes: section.review_notes ?? "",
+                          status: section.status,
+                        };
+                        const structuredLocked = section.status === "approved";
+                        const structuredAttentionTargetKey = `structured-${section.id}`;
+                        const highlightAttentionTarget = activePageAttentionTargetKey === structuredAttentionTargetKey && isAttentionReviewStatus(section.status);
+                        const expanded = Boolean(expandedStructuredSectionById[section.id]);
+                        const sectionTitle = structuredSectionDisplayTitle(section);
+                        return (
+                          <div
+                            key={section.id}
+                            ref={(node) => {
+                              attentionTargetRefs.current[structuredAttentionTargetKey] = node;
+                            }}
+                            tabIndex={-1}
+                            data-testid={`review-attention-target-${structuredAttentionTargetKey}`}
+                            className={`rounded border bg-slate-800 p-2 focus:outline-none ${
+                              highlightAttentionTarget ? "border-amber-300 ring-2 ring-amber-300/70" : "border-slate-600"
+                            }`}
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <span className="font-semibold text-slate-100">{sectionTitle}</span>
+                              <div className="flex flex-wrap items-center gap-2">
+                                <span className={`rounded px-2 py-1 text-[11px] font-semibold ${statusChipClass(section.status)}`}>{formatStatusLabel(section.status)}</span>
+                                {!structuredLocked && (
+                                  <>
+                                    <button
+                                      type="button"
+                                      onClick={() => setLooseStructuredSectionDisposition.mutate({ section, status: "approved" })}
+                                      disabled={setLooseStructuredSectionDisposition.isLoading}
+                                      className="rounded bg-emerald-700 px-2 py-1 text-[11px] font-semibold text-white hover:bg-emerald-600 disabled:opacity-50"
+                                    >
+                                      Approve {sectionTitle}
+                                    </button>
+                                    <button
+                                      type="button"
+                                      onClick={() => setLooseStructuredSectionDisposition.mutate({ section, status: "rejected" })}
+                                      disabled={setLooseStructuredSectionDisposition.isLoading}
+                                      className="rounded border border-amber-400/50 px-2 py-1 text-[11px] font-semibold text-amber-100 hover:bg-amber-500/10 disabled:opacity-50"
+                                    >
+                                      Needs review {sectionTitle}
+                                    </button>
+                                  </>
+                                )}
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setExpandedStructuredSectionById((current) => ({
+                                      ...current,
+                                      [section.id]: !current[section.id],
+                                    }))
+                                  }
+                                  className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-200 hover:bg-slate-700"
+                                >
+                                  {expanded ? `Collapse ${sectionTitle}` : `Expand ${sectionTitle}`}
+                                </button>
+                                {structuredLocked && (
+                                  <span className="rounded bg-slate-700 px-2 py-1 text-[11px] text-slate-200">locked after approval</span>
+                                )}
+                              </div>
+                            </div>
+                            <div className="mt-2 rounded border border-slate-600 bg-slate-900/60 px-2 py-2 text-[11px] text-slate-100">
+                              {renderStructuredReadablePreview(section)}
+                            </div>
+                            {expanded && (
+                              <div className="mt-2 space-y-2">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <button
+                                    type="button"
+                                    onClick={() => void copyStructuredSection(section)}
+                                    className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-200 hover:bg-slate-700"
+                                  >
+                                    Copy extracted
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      setRawPreviewBySectionId((current) => ({
+                                        ...current,
+                                        [section.id]: !current[section.id],
+                                      }))
+                                    }
+                                    className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-200 hover:bg-slate-700"
+                                  >
+                                    {rawPreviewBySectionId[section.id] ? "Hide technical details" : "Show technical details"}
+                                  </button>
                                 </div>
                                 {rawPreviewBySectionId[section.id] && (
-                                  <div className="mb-2 space-y-2 rounded border border-slate-600 bg-slate-900/80 p-2">
+                                  <div className="space-y-2 rounded border border-slate-600 bg-slate-900/80 p-2">
                                     <div>
                                       <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Technical details</p>
                                       <p className="text-[11px] text-slate-400">Raw JSON is hidden by default so staff can focus on the readable extracted content above.</p>
@@ -809,11 +1223,11 @@ export function IehpFbaLayoutReview({
                                         }))
                                       }
                                       className="w-full rounded border border-slate-600 bg-slate-950 p-2 font-mono text-xs text-slate-100 disabled:bg-slate-800"
-                                      aria-label={`${field.label} structured section ${section.section_index + 1} payload`}
+                                      aria-label={`${section.field_key} structured section ${section.section_index + 1} payload`}
                                     />
                                   </div>
                                 )}
-                                <div className="mt-2 grid gap-2 md:grid-cols-[10rem_1fr_auto]">
+                                <div className="grid gap-2 md:grid-cols-[10rem_1fr_auto]">
                                   <select
                                     value={structuredEdit.status}
                                     disabled={structuredLocked}
@@ -827,7 +1241,7 @@ export function IehpFbaLayoutReview({
                                       }))
                                     }
                                     className="rounded border border-slate-600 bg-slate-950 p-2 text-sm disabled:bg-slate-800"
-                                    aria-label={`${field.label} structured section ${section.section_index + 1} status`}
+                                    aria-label={`${section.field_key} structured section ${section.section_index + 1} status`}
                                   >
                                     {STRUCTURED_STATUS_OPTIONS.map((status) => (
                                       <option key={status} value={status}>
@@ -849,7 +1263,7 @@ export function IehpFbaLayoutReview({
                                     }
                                     className="rounded border border-slate-600 bg-slate-950 p-2 text-sm disabled:bg-slate-800"
                                     placeholder="Structured section review notes"
-                                    aria-label={`${field.label} structured section ${section.section_index + 1} review notes`}
+                                    aria-label={`${section.field_key} structured section ${section.section_index + 1} review notes`}
                                   />
                                   <button
                                     type="button"
@@ -861,210 +1275,7 @@ export function IehpFbaLayoutReview({
                                   </button>
                                 </div>
                               </div>
-                            );
-                          })}
-                        </div>
-                      )}
-
-                      <div className="mt-2 grid gap-2 md:grid-cols-[10rem_1fr_auto]">
-                        <select
-                          value={edit.status}
-                          disabled={locked || !item}
-                          onChange={(event) =>
-                            setEdits((current) => ({
-                              ...current,
-                              [field.field_key]: {
-                                ...edit,
-                                status: event.target.value as ReviewStatus,
-                              },
-                            }))
-                          }
-                          className="rounded border border-slate-600 bg-slate-950 p-2 text-sm disabled:bg-slate-800"
-                          aria-label={`${field.label} review status`}
-                        >
-                          {STATUS_OPTIONS.map((status) => (
-                            <option key={status} value={status}>
-                              {formatStatusLabel(status)}
-                            </option>
-                          ))}
-                        </select>
-                        <input
-                          value={edit.reviewNotes}
-                          disabled={locked || !item}
-                          onChange={(event) =>
-                            setEdits((current) => ({
-                              ...current,
-                              [field.field_key]: {
-                                ...edit,
-                                reviewNotes: event.target.value,
-                              },
-                            }))
-                          }
-                          className="rounded border border-slate-600 bg-slate-950 p-2 text-sm disabled:bg-slate-800"
-                          placeholder="Review notes"
-                          aria-label={`${field.label} review notes`}
-                        />
-                        <button
-                          type="button"
-                          onClick={() => saveField.mutate(field)}
-                          disabled={saveField.isLoading || locked || !item}
-                          className="rounded bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-600 disabled:opacity-50"
-                        >
-                          Save field
-                        </button>
-                      </div>
-                      {locked && (
-                        <p className="mt-1 text-[11px] text-slate-400">
-                          Approved IEHP rows stay locked for clinical review integrity.
-                        </p>
-                      )}
-                    </div>
-                  );
-                })}
-                {activePageLooseStructuredSections.length > 0 && (
-                  <div className="rounded-md border border-slate-600 bg-slate-800/70 p-3">
-                    <div className="mb-2">
-                      <p className="text-sm font-semibold text-slate-100">Page-specific structured sections</p>
-                      <p className="text-[11px] text-slate-400">
-                        Extracted content placed on this IEHP page by document source metadata.
-                      </p>
-                    </div>
-                    <div className="space-y-2 rounded bg-slate-900/80 p-2 text-xs text-slate-200">
-                      {activePageLooseStructuredSections.map((section) => {
-                        const structuredEdit = structuredEdits[section.id] ?? {
-                          payloadText: formatPayloadPreview(section.payload),
-                          reviewNotes: section.review_notes ?? "",
-                          status: section.status,
-                        };
-                        const structuredLocked = section.status === "approved";
-                        const structuredAttentionTargetKey = `structured-${section.id}`;
-                        const highlightAttentionTarget = activePageAttentionTargetKey === structuredAttentionTargetKey && isAttentionReviewStatus(section.status);
-                        return (
-                          <div
-                            key={section.id}
-                            ref={(node) => {
-                              attentionTargetRefs.current[structuredAttentionTargetKey] = node;
-                            }}
-                            tabIndex={-1}
-                            data-testid={`review-attention-target-${structuredAttentionTargetKey}`}
-                            className={`rounded border bg-slate-800 p-2 focus:outline-none ${
-                              highlightAttentionTarget ? "border-amber-300 ring-2 ring-amber-300/70" : "border-slate-600"
-                            }`}
-                          >
-                            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-                              <span className="font-semibold text-slate-100">
-                                {section.field_key} section {section.section_index + 1}
-                              </span>
-                              <div className="flex items-center gap-2">
-                                <span className={`rounded px-2 py-1 text-[11px] font-semibold ${statusChipClass(section.status)}`}>{formatStatusLabel(section.status)}</span>
-                                <button
-                                  type="button"
-                                  onClick={() => void copyStructuredSection(section)}
-                                  className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-200 hover:bg-slate-700"
-                                >
-                                  Copy extracted
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    setRawPreviewBySectionId((current) => ({
-                                      ...current,
-                                      [section.id]: !current[section.id],
-                                    }))
-                                  }
-                                  className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-200 hover:bg-slate-700"
-                                >
-                                  {rawPreviewBySectionId[section.id] ? "Hide technical details" : "Show technical details"}
-                                </button>
-                                {structuredLocked && (
-                                  <span className="rounded bg-slate-700 px-2 py-1 text-[11px] text-slate-200">locked after approval</span>
-                                )}
-                              </div>
-                            </div>
-                            <div className="mb-2 rounded border border-slate-600 bg-slate-900/60 px-2 py-2 text-[11px] text-slate-100">
-                              {renderStructuredReadablePreview(section)}
-                            </div>
-                            {rawPreviewBySectionId[section.id] && (
-                              <div className="mb-2 space-y-2 rounded border border-slate-600 bg-slate-900/80 p-2">
-                                <div>
-                                  <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Technical details</p>
-                                  <p className="text-[11px] text-slate-400">Raw JSON is hidden by default so staff can focus on the readable extracted content above.</p>
-                                </div>
-                                <pre
-                                  data-testid={`raw-json-${section.id}`}
-                                  className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded border border-slate-700 bg-slate-950 p-2 text-[11px] text-slate-300"
-                                >
-                                  {formatPayloadPreview(section.payload)}
-                                </pre>
-                                <label className="block text-[11px] font-semibold text-slate-300" htmlFor={`structured-payload-${section.id}`}>
-                                  Editable JSON payload
-                                </label>
-                                <textarea
-                                  id={`structured-payload-${section.id}`}
-                                  value={structuredEdit.payloadText}
-                                  rows={4}
-                                  disabled={structuredLocked}
-                                  onChange={(event) =>
-                                    setStructuredEdits((current) => ({
-                                      ...current,
-                                      [section.id]: {
-                                        ...structuredEdit,
-                                        payloadText: event.target.value,
-                                      },
-                                    }))
-                                  }
-                                  className="w-full rounded border border-slate-600 bg-slate-950 p-2 font-mono text-xs text-slate-100 disabled:bg-slate-800"
-                                  aria-label={`${section.field_key} structured section ${section.section_index + 1} payload`}
-                                />
-                              </div>
                             )}
-                            <div className="mt-2 grid gap-2 md:grid-cols-[10rem_1fr_auto]">
-                              <select
-                                value={structuredEdit.status}
-                                disabled={structuredLocked}
-                                onChange={(event) =>
-                                  setStructuredEdits((current) => ({
-                                    ...current,
-                                    [section.id]: {
-                                      ...structuredEdit,
-                                      status: event.target.value as StructuredReviewStatus,
-                                    },
-                                  }))
-                                }
-                                className="rounded border border-slate-600 bg-slate-950 p-2 text-sm disabled:bg-slate-800"
-                                aria-label={`${section.field_key} structured section ${section.section_index + 1} status`}
-                              >
-                                {STRUCTURED_STATUS_OPTIONS.map((status) => (
-                                  <option key={status} value={status}>
-                                    {formatStatusLabel(status)}
-                                  </option>
-                                ))}
-                              </select>
-                              <input
-                                value={structuredEdit.reviewNotes}
-                                disabled={structuredLocked}
-                                onChange={(event) =>
-                                  setStructuredEdits((current) => ({
-                                    ...current,
-                                    [section.id]: {
-                                      ...structuredEdit,
-                                      reviewNotes: event.target.value,
-                                    },
-                                  }))
-                                }
-                                className="rounded border border-slate-600 bg-slate-950 p-2 text-sm disabled:bg-slate-800"
-                                placeholder="Structured section review notes"
-                                aria-label={`${section.field_key} structured section ${section.section_index + 1} review notes`}
-                              />
-                              <button
-                                type="button"
-                                onClick={() => saveStructuredSection.mutate(section)}
-                                disabled={saveStructuredSection.isLoading || structuredLocked}
-                                className="rounded bg-indigo-700 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-600 disabled:opacity-50"
-                              >
-                                Save extracted section
-                              </button>
-                            </div>
                           </div>
                         );
                       })}

--- a/src/components/ClientDetails/IehpFbaLayoutReview.tsx
+++ b/src/components/ClientDetails/IehpFbaLayoutReview.tsx
@@ -86,6 +86,12 @@ interface PageReviewSummary {
   total: number;
 }
 
+interface AdaptiveMeasureBlockPreview {
+  assessment_type: string;
+  raw_text: string;
+  extracted: boolean;
+}
+
 const EMPTY_LAYOUT: TemplateLayoutResponse = {
   template_version: {
     version_key: "",
@@ -107,6 +113,7 @@ const STRUCTURED_STATUS_OPTIONS: StructuredReviewStatus[] = ["not_started", "dra
 const PAGE_FIELD_KEY_OVERRIDES: Record<string, number> = {
   IEHP_FBA_REASON_FOR_REFERRAL: 1,
 };
+const IEHP_ADAPTIVE_MEASURE_TYPES = ["VB-MAPP", "Vineland", "AFLS", "ABAS-3"] as const;
 
 const formatPayloadPreview = (value: unknown): string => {
   if (value == null) return "";
@@ -162,6 +169,37 @@ const readableNarrativeFromPayload = (payload: Record<string, unknown> | undefin
   return "";
 };
 
+const adaptiveMeasureBlocksFromPayload = (payload: Record<string, unknown> | undefined): AdaptiveMeasureBlockPreview[] => {
+  const rawBlocks = payload?.assessment_blocks;
+  const parsedBlocks = Array.isArray(rawBlocks)
+    ? rawBlocks
+        .map((block) => {
+          if (!block || typeof block !== "object") return null;
+          const assessmentType =
+            typeof (block as { assessment_type?: unknown }).assessment_type === "string"
+              ? (block as { assessment_type: string }).assessment_type.trim()
+              : "";
+          const rawText =
+            typeof (block as { raw_text?: unknown }).raw_text === "string" ? (block as { raw_text: string }).raw_text.trim() : "";
+          if (!assessmentType) return null;
+          return {
+            assessment_type: assessmentType,
+            raw_text: rawText,
+            extracted: rawText.length > 0,
+          };
+        })
+        .filter((block): block is AdaptiveMeasureBlockPreview => block !== null)
+    : [];
+
+  const knownTypeSet = new Set(IEHP_ADAPTIVE_MEASURE_TYPES.map((type) => type.toLowerCase()));
+  const orderedKnownBlocks = IEHP_ADAPTIVE_MEASURE_TYPES.map((assessmentType) => {
+    const existing = parsedBlocks.find((block) => block.assessment_type.toLowerCase() === assessmentType.toLowerCase());
+    return existing ?? { assessment_type: assessmentType, raw_text: "", extracted: false };
+  });
+  const extraBlocks = parsedBlocks.filter((block) => !knownTypeSet.has(block.assessment_type.toLowerCase()));
+  return [...orderedKnownBlocks, ...extraBlocks];
+};
+
 const stringifyReadablePayloadValue = (value: unknown): string => {
   if (value == null) return "";
   if (typeof value === "string") return value.trim();
@@ -205,6 +243,12 @@ const formatStructuredReadableText = (section: StructuredValue): string => {
       return `${heading}\n- none extracted`;
     }
     return `${heading}\n${rows.map((row) => `- ${row.procedure}: ${row.raw_text || "not provided"}`).join("\n")}`;
+  }
+  if (section.field_key === "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES") {
+    const blocks = adaptiveMeasureBlocksFromPayload(section.payload);
+    return `Adaptive Measure Summaries\n${blocks
+      .map((block) => `- ${block.assessment_type}: ${block.raw_text || "No extracted block found."}`)
+      .join("\n")}`;
   }
   const narrative = readableNarrativeFromPayload(section.payload);
   if (narrative.length > 0) return narrative;
@@ -260,6 +304,26 @@ const renderStructuredReadablePreview = (section: StructuredValue): JSX.Element 
             ))}
           </div>
         )}
+      </div>
+    );
+  }
+
+  if (section.field_key === "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES") {
+    const blocks = adaptiveMeasureBlocksFromPayload(section.payload);
+    return (
+      <div className="space-y-2">
+        <p className="text-[11px] font-semibold uppercase tracking-wide text-indigo-200">Adaptive Measure Blocks</p>
+        <div className="grid gap-2">
+          {blocks.map((block) => (
+            <div
+              key={block.assessment_type}
+              className={`rounded border px-2 py-2 ${block.extracted ? "border-slate-600/60 bg-slate-900/50" : "border-dashed border-slate-700 bg-slate-900/20"}`}
+            >
+              <p className="text-xs font-semibold text-slate-100">{block.assessment_type}</p>
+              <p className="text-xs leading-relaxed whitespace-pre-wrap text-slate-300">{block.raw_text || "No extracted block found."}</p>
+            </div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -364,6 +364,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     enabled: Boolean(client.id && organizationId),
     retry: false,
     staleTime: TAB_QUERY_STALE_TIME_MS,
+    refetchOnReconnect: false,
   });
 
   const livePrograms = useMemo(
@@ -438,6 +439,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     enabled: Boolean(resolvedProgramId),
     retry: false,
     staleTime: TAB_QUERY_STALE_TIME_MS,
+    refetchOnReconnect: false,
   });
 
   const liveGoals = useMemo(
@@ -474,6 +476,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     enabled: Boolean(resolvedProgramId),
     retry: false,
     staleTime: TAB_QUERY_STALE_TIME_MS,
+    refetchOnReconnect: false,
   });
 
   const {

--- a/src/components/__tests__/IehpFbaLayoutReview.test.tsx
+++ b/src/components/__tests__/IehpFbaLayoutReview.test.tsx
@@ -28,6 +28,11 @@ const assessmentDocument: AssessmentDocumentRecord = {
   created_at: "2026-05-20T00:00:00.000Z",
 };
 
+const assessmentChecklistPatchBodies = () =>
+  vi.mocked(callApi).mock.calls
+    .filter(([path, init]) => path === "/api/assessment-checklist" && ((init as RequestInit | undefined)?.method ?? "").toUpperCase() === "PATCH")
+    .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
+
 describe("IehpFbaLayoutReview", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -132,6 +137,9 @@ describe("IehpFbaLayoutReview", () => {
     expect(screen.getByText("Page 1: General Information")).toBeInTheDocument();
     expect(screen.queryByText(/CalOptima/i)).not.toBeInTheDocument();
 
+    await screen.findByText("First Name");
+    expect(screen.queryByLabelText("First Name")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Expand First Name" }));
     await screen.findByLabelText("First Name");
     screen.getByRole("button", { name: "Save field" }).click();
 
@@ -211,6 +219,7 @@ describe("IehpFbaLayoutReview", () => {
     );
 
     fireEvent.click(await screen.findByRole("button", { name: /Page 30/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "Expand Signature Block" }));
     const status = await screen.findByLabelText("Signature Block structured section 1 status");
     fireEvent.change(status, { target: { value: "approved" } });
     screen.getByRole("button", { name: "Save extracted section" }).click();
@@ -411,6 +420,7 @@ describe("IehpFbaLayoutReview", () => {
     fireEvent.click(await screen.findByRole("button", { name: /Page 16/i }));
     expect(await screen.findByText("Page 16: School Goals")).toBeInTheDocument();
     expect(screen.getAllByText(/School goal narrative/).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: "Expand IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS section 1" }));
     fireEvent.change(screen.getByLabelText("IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS structured section 1 status"), {
       target: { value: "verified" },
     });
@@ -437,15 +447,17 @@ describe("IehpFbaLayoutReview", () => {
     expect(screen.getAllByText(/Parent education goal narrative/).length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole("button", { name: /Page 24/i }));
+    expect((await screen.findAllByText("Recommendation Notes")).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: "Expand Recommendation Notes" }));
     expect(await screen.findByLabelText("Recommendation Notes")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Page 25/i }));
-    expect(await screen.findByLabelText("Caregiver Participation")).toBeInTheDocument();
+    expect((await screen.findAllByText("Caregiver Participation")).length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: /Page 26/i }));
-    expect(await screen.findByLabelText("Treatment Plan Review")).toBeInTheDocument();
+    expect((await screen.findAllByText("Treatment Plan Review")).length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: /Page 27/i }));
-    expect(await screen.findByLabelText("Additional Notes")).toBeInTheDocument();
+    expect((await screen.findAllByText("Additional Notes")).length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: /Page 28/i }));
-    expect(await screen.findByLabelText("Appendix and Supporting Information")).toBeInTheDocument();
+    expect((await screen.findAllByText("Appendix and Supporting Information")).length).toBeGreaterThan(0);
     expect(screen.queryByText(/CalOptima/i)).not.toBeInTheDocument();
   });
 
@@ -621,16 +633,244 @@ describe("IehpFbaLayoutReview", () => {
     await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: "center", behavior: "smooth" }));
     expect(document.activeElement).toBe(attentionTarget);
     expect(attentionTarget).toHaveClass("ring-2");
+    expect(await screen.findByText("Name of Referring Provider, Credentials")).toBeInTheDocument();
+    expect(screen.getAllByText("Manual review required").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/This required IEHP field is intentionally manual/).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Approve Name of Referring Provider, Credentials" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Review Name of Referring Provider, Credentials" }));
     expect(await screen.findByLabelText("Name of Referring Provider, Credentials")).toBeInTheDocument();
-    expect(screen.getByText("Manual review required")).toBeInTheDocument();
-    expect(screen.getByText(/This required IEHP field is intentionally manual/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Page 1/i }));
+    expect(await screen.findByText("Reason for Referral")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Expand Reason for Referral" }));
     expect(await screen.findByLabelText("Reason for Referral")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Reviewed referral reason")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Page 2/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Review Missing Manual Field" }));
     expect(screen.getByLabelText("Missing Manual Field")).toBeDisabled();
     expect(screen.getAllByText("Not started").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Manual review required")).toHaveLength(1);
+    expect(screen.getAllByText("Manual review required")).toHaveLength(2);
+  });
+
+  it("renders mapped fields as collapsed triage cards and quick-approves the field with attached structured sections", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      if (path.startsWith("/api/assessment-template-layout?")) {
+        return new Response(JSON.stringify({
+          template_version: {
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+          },
+          pages: [{ page_number: 30, title: "Signature Block", layout_json: {} }],
+          fields: [
+            {
+              page_number: 30,
+              section_key: "treatment_coordination_recommendations",
+              field_key: "IEHP_FBA_SIGNATURE_BLOCK",
+              label: "Signature Block",
+              field_type: "signature",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+              layout_json: {},
+            },
+          ],
+          values: {
+            checklist_items: [
+              {
+                id: "item-signature",
+                placeholder_key: "IEHP_FBA_SIGNATURE_BLOCK",
+                section_key: "treatment_coordination_recommendations",
+                label: "Signature Block",
+                mode: "ASSISTED",
+                required: true,
+                status: "drafted",
+                value_text: "Signature summary",
+                value_json: null,
+                review_notes: null,
+              },
+            ],
+            structured_sections: [
+              {
+                id: "signature-structured-1",
+                field_key: "IEHP_FBA_SIGNATURE_BLOCK",
+                section_index: 0,
+                payload: { completed_by: "Jane Clinician" },
+                status: "drafted",
+                required: true,
+                review_notes: "review note",
+              },
+            ],
+          },
+          unresolved_required_count: 1,
+          extracted_value_count: 1,
+        }), { status: 200 });
+      }
+      if (path === "/api/assessment-checklist" && (init?.method ?? "").toUpperCase() === "PATCH") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <IehpFbaLayoutReview assessmentDocument={assessmentDocument} organizationId="org-1" />,
+    );
+
+    expect((await screen.findAllByText("Signature Block")).length).toBeGreaterThan(0);
+    expect(screen.getByText("Signature summary")).toBeInTheDocument();
+    expect(screen.getByText("1 extracted section")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Signature Block")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Signature Block structured section 1 payload")).not.toBeInTheDocument();
+    expect(screen.queryByText(/IEHP_FBA_SIGNATURE_BLOCK/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve Signature Block" }));
+
+    await waitFor(() => {
+      const patchBodies = assessmentChecklistPatchBodies();
+      expect(patchBodies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ item_id: "item-signature", status: "approved", value_text: "Signature summary" }),
+          expect.objectContaining({
+            structured_section_id: "signature-structured-1",
+            status: "approved",
+            review_notes: "review note",
+            payload: { completed_by: "Jane Clinician" },
+          }),
+        ]),
+      );
+    });
+  });
+
+  it("lets reviewers mark extracted fields as needing review from the collapsed triage card", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      if (path.startsWith("/api/assessment-template-layout?")) {
+        return new Response(JSON.stringify({
+          template_version: {
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+          },
+          pages: [{ page_number: 5, title: "Current Services", layout_json: {} }],
+          fields: [
+            {
+              page_number: 5,
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_CURRENT_SERVICES_ACTIVITIES",
+              label: "Current Services and Activities",
+              field_type: "repeatable_table",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+              layout_json: {},
+            },
+          ],
+          values: {
+            checklist_items: [
+              {
+                id: "item-current-services",
+                placeholder_key: "IEHP_FBA_CURRENT_SERVICES_ACTIVITIES",
+                section_key: "behavior_background_services",
+                label: "Current Services and Activities",
+                mode: "ASSISTED",
+                required: true,
+                status: "verified",
+                value_text: "Current services extracted wording.",
+                value_json: null,
+                review_notes: null,
+              },
+            ],
+            structured_sections: [],
+          },
+          unresolved_required_count: 0,
+          extracted_value_count: 1,
+        }), { status: 200 });
+      }
+      if (path === "/api/assessment-checklist" && (init?.method ?? "").toUpperCase() === "PATCH") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <IehpFbaLayoutReview assessmentDocument={assessmentDocument} organizationId="org-1" />,
+    );
+
+    expect((await screen.findAllByText("Current Services and Activities")).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: "Needs review Current Services and Activities" }));
+
+    await waitFor(() => {
+      expect(assessmentChecklistPatchBodies()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            item_id: "item-current-services",
+            status: "verified",
+            value_text: "Current services extracted wording.",
+          }),
+        ]),
+      );
+    });
+  });
+
+  it("marks loose structured sections as rejected when reviewers flag them for review", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      if (path.startsWith("/api/assessment-template-layout?")) {
+        return new Response(JSON.stringify({
+          template_version: {
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+          },
+          pages: [{ page_number: 5, title: "Current Services", layout_json: {} }],
+          fields: [],
+          values: {
+            checklist_items: [],
+            structured_sections: [
+              {
+                id: "current-services-structured-1",
+                field_key: "IEHP_FBA_CURRENT_SERVICES_ACTIVITIES",
+                section_index: 0,
+                payload: {
+                  label: "Current Services and Activities",
+                  raw_text: "Current services extracted wording.",
+                },
+                source_span: { page_number: 5, method: "iehp_section_anchor" },
+                status: "verified",
+                required: true,
+                review_notes: "keep this note",
+              },
+            ],
+          },
+          unresolved_required_count: 0,
+          extracted_value_count: 1,
+        }), { status: 200 });
+      }
+      if (path === "/api/assessment-checklist" && (init?.method ?? "").toUpperCase() === "PATCH") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <IehpFbaLayoutReview assessmentDocument={assessmentDocument} organizationId="org-1" />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Page 5/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "Needs review Current Services and Activities" }));
+
+    await waitFor(() => {
+      expect(assessmentChecklistPatchBodies()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            structured_section_id: "current-services-structured-1",
+            status: "rejected",
+            review_notes: "keep this note",
+            payload: {
+              label: "Current Services and Activities",
+              raw_text: "Current services extracted wording.",
+            },
+          }),
+        ]),
+      );
+    });
   });
 
   it("renders behavior target preview and copies extracted checkbox targets", async () => {
@@ -703,6 +943,7 @@ describe("IehpFbaLayoutReview", () => {
     expect(screen.getByText("Physical Aggression")).toBeInTheDocument();
     expect(screen.getByText("Self-Injury")).toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("button", { name: "Expand Behaviors and Functional Skills to be Addressed" }));
     fireEvent.click(screen.getByRole("button", { name: "Copy extracted" }));
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
@@ -786,6 +1027,8 @@ describe("IehpFbaLayoutReview", () => {
 
     expect(screen.queryByTestId("raw-json-procedures-structured-1")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Description of Assessment Procedures structured section 1 payload")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Expand Description of Assessment Procedures" }));
+    expect(screen.queryByTestId("raw-json-procedures-structured-1")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Show technical details" }));
     expect(await screen.findByTestId("raw-json-procedures-structured-1")).toBeInTheDocument();
     expect(screen.getByLabelText("Description of Assessment Procedures structured section 1 payload")).toBeInTheDocument();
@@ -849,9 +1092,9 @@ describe("IehpFbaLayoutReview", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /Page 2/i }));
     expect(await screen.findByText("Page-specific structured sections")).toBeInTheDocument();
-    expect(screen.getByText(/Reason for Referral/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Reason for Referral/).length).toBeGreaterThan(0);
     expect(screen.getByText(/No extracted field value was found in the source document\./)).toBeInTheDocument();
-    expect(screen.getByText(/Field type: textarea/)).toBeInTheDocument();
+    expect(screen.queryByText(/Field type: textarea/)).not.toBeInTheDocument();
     expect(screen.queryByText(/"mode"/)).not.toBeInTheDocument();
     expect(screen.queryByTestId("raw-json-referral-placeholder-structured")).not.toBeInTheDocument();
   });
@@ -924,6 +1167,7 @@ describe("IehpFbaLayoutReview", () => {
     fireEvent.click(await screen.findByRole("button", { name: /Page 7/i }));
     expect(await screen.findByText("Procedures completed in narrative format without labeled row markers.")).toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("button", { name: "Expand Description of Assessment Procedures" }));
     fireEvent.click(screen.getByRole("button", { name: "Copy extracted" }));
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(

--- a/src/components/__tests__/IehpFbaLayoutReview.test.tsx
+++ b/src/components/__tests__/IehpFbaLayoutReview.test.tsx
@@ -1042,6 +1042,93 @@ describe("IehpFbaLayoutReview", () => {
     });
   });
 
+  it("renders adaptive measure assessment blocks separately and preserves missing block slots", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string) => {
+      if (path.startsWith("/api/assessment-template-layout?")) {
+        return new Response(JSON.stringify({
+          template_version: {
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+          },
+          pages: [{ page_number: 10, title: "Adaptive Measures", layout_json: {} }],
+          fields: [
+            {
+              page_number: 10,
+              section_key: "assessment_procedures_testing",
+              field_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+              label: "Adaptive and Functional Measure Summaries",
+              field_type: "textarea",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+              layout_json: {},
+            },
+          ],
+          values: {
+            checklist_items: [
+              {
+                id: "item-adaptive-measures",
+                placeholder_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+                section_key: "assessment_procedures_testing",
+                label: "Adaptive and Functional Measure Summaries",
+                mode: "ASSISTED",
+                required: true,
+                status: "drafted",
+                value_text: "1 structured section extracted",
+                value_json: null,
+                review_notes: null,
+              },
+            ],
+            structured_sections: [
+              {
+                id: "adaptive-measures-structured-1",
+                field_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+                section_index: 0,
+                payload: {
+                  raw_text: "Combined adaptive measure narrative.",
+                  assessment_blocks: [
+                    { assessment_type: "VB-MAPP", raw_text: "VB-MAPP Assessment Summary: Preserve as assessment block." },
+                    { assessment_type: "Vineland", raw_text: "Vineland Assessment Summary: Preserve as assessment block." },
+                    { assessment_type: "AFLS", raw_text: "AFLS Assessment Summary: Preserve as assessment block." },
+                    { assessment_type: "ABAS-3", raw_text: "" },
+                  ],
+                },
+                source_span: { page_number: 10, method: "iehp_section_anchor" },
+                status: "drafted",
+                required: true,
+                review_notes: null,
+              },
+            ],
+          },
+          unresolved_required_count: 1,
+          extracted_value_count: 1,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <IehpFbaLayoutReview assessmentDocument={assessmentDocument} organizationId="org-1" />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Page 10/i }));
+    expect(await screen.findByText("Adaptive Measure Blocks")).toBeInTheDocument();
+    expect(screen.getByText("VB-MAPP")).toBeInTheDocument();
+    expect(screen.getByText("Vineland")).toBeInTheDocument();
+    expect(screen.getByText("AFLS")).toBeInTheDocument();
+    expect(screen.getByText("ABAS-3")).toBeInTheDocument();
+    expect(screen.getAllByText("No extracted block found.").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand Adaptive and Functional Measure Summaries" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy extracted" }));
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "Adaptive Measure Summaries\n- VB-MAPP: VB-MAPP Assessment Summary: Preserve as assessment block.\n- Vineland: Vineland Assessment Summary: Preserve as assessment block.\n- AFLS: AFLS Assessment Summary: Preserve as assessment block.\n- ABAS-3: No extracted block found.",
+      );
+    });
+  });
+
   it("renders generic structured placeholders as staff-readable copy instead of raw JSON", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string) => {
       if (path.startsWith("/api/assessment-template-layout?")) {

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1,15 +1,52 @@
+import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { QueryClient } from "@tanstack/react-query";
-import { fireEvent, renderWithProviders, screen, userEvent, waitFor, within } from "../../test/utils";
+import { QueryClient, QueryClientProvider, onlineManager } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { fireEvent, render, renderWithProviders, screen, userEvent, waitFor, within } from "../../test/utils";
 import { ProgramsGoalsTab } from "../ClientDetails/ProgramsGoalsTab";
 import { generateProgramGoalDraft } from "../../lib/ai";
 import { showError, showInfo, showSuccess } from "../../lib/toast";
 import { callApi, callEdgeFunctionHttp } from "../../lib/api";
 import { supabase } from "../../lib/supabase";
+import { AuthProvider } from "../../lib/authContext";
+import { STUB_AUTH_STORAGE_KEY } from "../../lib/authStubSession";
 
 const ORG_ID = "5238e88b-6198-4862-80a2-dbe15bbeabdd";
 const ASSESSMENT_ID = "11111111-1111-4111-8111-111111111111";
 type ProgramsGoalsTabClient = React.ComponentProps<typeof ProgramsGoalsTab>["client"];
+
+const seedStubAuthState = () => {
+  const now = new Date();
+  const nowIso = now.toISOString();
+
+  window.localStorage.setItem(
+    STUB_AUTH_STORAGE_KEY,
+    JSON.stringify({
+      user: {
+        id: "therapist-user-id",
+        email: "therapist@example.com",
+        role: "therapist",
+        full_name: "Test User",
+        first_name: "Test",
+        last_name: "User",
+      },
+      role: "therapist",
+      accessToken: "test-access-token",
+      refreshToken: "test-refresh-token",
+      expiresAt: now.getTime() + 60 * 60 * 1000,
+      profile: {
+        id: "therapist-user-id",
+        email: "therapist@example.com",
+        role: "therapist",
+        organization_id: ORG_ID,
+        full_name: "Test User",
+        is_active: true,
+        created_at: nowIso,
+        updated_at: nowIso,
+      },
+    }),
+  );
+};
 
 const buildClient = (overrides: Partial<ProgramsGoalsTabClient> = {}): ProgramsGoalsTabClient => ({
   id: "client-1",
@@ -855,6 +892,156 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
         ),
     ).toHaveLength(noteFetchCountBeforeCreate);
     expect(await screen.findByText("Progress note")).toBeInTheDocument();
+  });
+
+  it("does not repeat initial programs, goals, and notes fetches under StrictMode", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "program-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              name: "Communication Program",
+              description: "Live program",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goals?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/program-notes?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <React.StrictMode>
+        <ProgramsGoalsTab client={buildClient()} />
+      </React.StrictMode>,
+      {
+        auth: {
+          role: "therapist",
+          organizationId: ORG_ID,
+          accessToken: "test-access-token",
+        },
+      },
+    );
+
+    await screen.findByText("Communication Program");
+
+    const getCalls = vi
+      .mocked(callEdgeFunctionHttp)
+      .mock.calls.filter(([, init]) => (init?.method ?? "GET").toUpperCase() === "GET")
+      .map(([path]) => String(path));
+
+    expect(getCalls.filter((path) => path.startsWith("programs?"))).toHaveLength(1);
+    expect(getCalls.filter((path) => path.startsWith("goals?"))).toHaveLength(1);
+    expect(getCalls.filter((path) => path.startsWith("program-notes?"))).toHaveLength(1);
+  });
+
+  it("does not reconnect active Programs & Goals queries while their data is still fresh", async () => {
+    seedStubAuthState();
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+          staleTime: 60_000,
+          refetchOnReconnect: "always",
+        },
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "program-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              name: "Communication Program",
+              description: "Live program",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goals?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/program-notes?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AuthProvider>
+            <ProgramsGoalsTab client={buildClient()} />
+          </AuthProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Communication Program");
+
+    const countEdgeGets = () =>
+      vi
+        .mocked(callEdgeFunctionHttp)
+        .mock.calls.filter(([, init]) => (init?.method ?? "GET").toUpperCase() === "GET")
+        .map(([path]) => String(path));
+
+    expect(countEdgeGets().filter((path) => path.startsWith("programs?"))).toHaveLength(1);
+    expect(countEdgeGets().filter((path) => path.startsWith("goals?"))).toHaveLength(1);
+    expect(countEdgeGets().filter((path) => path.startsWith("program-notes?"))).toHaveLength(1);
+
+    onlineManager.setOnline(false);
+    onlineManager.setOnline(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const edgeGetCalls = countEdgeGets();
+    expect(edgeGetCalls.filter((path) => path.startsWith("programs?"))).toHaveLength(1);
+    expect(edgeGetCalls.filter((path) => path.startsWith("goals?"))).toHaveLength(1);
+    expect(edgeGetCalls.filter((path) => path.startsWith("program-notes?"))).toHaveLength(1);
   });
 
   it("polls assessment documents only while extraction work is active", async () => {


### PR DESCRIPTION
## Summary
- render IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES as named adaptive-measure blocks in VB-MAPP / Vineland / AFLS / ABAS-3 order
- preserve explicit empty-state cards when a named adaptive-measure block is missing from the payload
- add focused component coverage for the adaptive-measure review renderer

## Verification
- npm test -- src/components/__tests__/IehpFbaLayoutReview.test.tsx
- npm run lint
- npm run typecheck
- npm run build
- npm run verify:local

## Linear
- WIN-161