### PR TITLE
Deduplicate message participant-name RPC calls

### DIFF
--- a/src/lib/messages/__tests__/fetchThreadParticipantNames.test.ts
+++ b/src/lib/messages/__tests__/fetchThreadParticipantNames.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rpcMock = vi.fn();
+
+vi.mock('../../supabase', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => rpcMock(...args),
+  },
+}));
+
+import { fetchThreadParticipantNames } from '../fetchThreadParticipantNames';
+
+describe('fetchThreadParticipantNames', () => {
+  beforeEach(() => {
+    rpcMock.mockReset();
+  });
+
+  it('dedupes concurrent requests for the same thread id', async () => {
+    let resolveRpc: ((value: { data: unknown; error: null }) => void) | undefined;
+    rpcMock.mockImplementation(() => new Promise((resolve) => {
+      resolveRpc = resolve;
+    }));
+
+    const first = fetchThreadParticipantNames('thread-1');
+    const second = fetchThreadParticipantNames('thread-1');
+
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+
+    resolveRpc?.({
+      data: [{ user_id: 'user-a', full_name: 'Alex Admin' }],
+      error: null,
+    });
+
+    await expect(first).resolves.toEqual(new Map([['user-a', 'Alex Admin']]));
+    await expect(second).resolves.toEqual(new Map([['user-a', 'Alex Admin']]));
+  });
+
+  it('issues a new request after the previous one settles', async () => {
+    rpcMock.mockResolvedValue({
+      data: [{ user_id: 'user-a', full_name: 'Alex Admin' }],
+      error: null,
+    });
+
+    await fetchThreadParticipantNames('thread-1');
+    await fetchThreadParticipantNames('thread-1');
+
+    expect(rpcMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/messages/fetchThreadParticipantNames.ts
+++ b/src/lib/messages/fetchThreadParticipantNames.ts
@@ -5,6 +5,8 @@ type RpcParticipantNameRow = {
   full_name: string | null;
 };
 
+const inFlightParticipantNameRequests = new Map<string, Promise<Map<string, string>>>();
+
 /**
  * Thread-scoped display names for message senders.
  * Uses SECURITY DEFINER RPC so participants can resolve co-participant names
@@ -16,18 +18,32 @@ type RpcParticipantNameRow = {
 export const fetchThreadParticipantNames = async (
   threadId: string,
 ): Promise<Map<string, string>> => {
-  const { data, error } = await supabase.rpc('list_staff_message_thread_participant_names', {
-    p_thread_id: threadId,
-  });
-
-  if (error) {
-    throw error;
+  const existing = inFlightParticipantNameRequests.get(threadId);
+  if (existing) {
+    return existing;
   }
 
-  const map = new Map<string, string>();
-  for (const row of (data ?? []) as RpcParticipantNameRow[]) {
-    const name = row.full_name?.trim() || 'Staff member';
-    map.set(row.user_id, name);
+  const request = (async () => {
+    const { data, error } = await supabase.rpc('list_staff_message_thread_participant_names', {
+      p_thread_id: threadId,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    const map = new Map<string, string>();
+    for (const row of (data ?? []) as RpcParticipantNameRow[]) {
+      const name = row.full_name?.trim() || 'Staff member';
+      map.set(row.user_id, name);
+    }
+    return map;
+  })();
+
+  inFlightParticipantNameRequests.set(threadId, request);
+  try {
+    return await request;
+  } finally {
+    inFlightParticipantNameRequests.delete(threadId);
   }
-  return map;
 };

--- a/src/lib/messages/fetchers.ts
+++ b/src/lib/messages/fetchers.ts
@@ -29,7 +29,8 @@ const fetchParticipantNamesByThread = async (
   threadIds: string[],
   currentUserId: string,
 ): Promise<Map<string, string[]>> => {
-  const participantNames = await Promise.all(threadIds.map(async (threadId) => {
+  const uniqueThreadIds = Array.from(new Set(threadIds));
+  const participantNames = await Promise.all(uniqueThreadIds.map(async (threadId) => {
     const names = await fetchThreadParticipantNames(threadId);
     return [
       threadId,


### PR DESCRIPTION
## Summary\n- dedupe concurrent list_staff_message_thread_participant_names calls per thread id using an in-flight request map\n- dedupe thread ids per inbox load before resolving participant names\n- add targeted unit coverage proving one RPC call for concurrent same-thread requests\n\n## Verification\n- npx vitest run src/lib/messages/__tests__/fetchThreadParticipantNames.test.ts src/lib/messages/__tests__/fetchMessageThreads.test.ts src/lib/messages/__tests__/fetchThreadMessages.test.ts\n- npm run ci:check-focused\n- npm run lint\n- npm run typecheck\n- npm run test:ci\n- npm run build\n- npm run verify:local\n\n## Risk\nLow: scoped to messaging participant-name fetch path; unread logic remains unchanged and covered by existing tests.