### PR TITLE
WIN-164 Harden admin invite abuse controls

### DIFF
--- a/docs/ai/2026-05-30-admin-invite-abuse-hardening-handoff.md
+++ b/docs/ai/2026-05-30-admin-invite-abuse-hardening-handoff.md
@@ -5,7 +5,9 @@
 - why: invite issuance affects admin authorization, privilege escalation, token issuance, and tenant-scoped organization membership
 - triggering paths:
   - `supabase/functions/admin-invite/index.ts`
+  - `supabase/migrations/20260530140500_atomic_admin_invite_rate_limit.sql`
   - `tests/admins/invite_flow.spec.ts`
+  - `tests/admins/invite_rate_limit_migration.spec.ts`
 
 ## Scope
 
@@ -13,19 +15,22 @@
 - Linear issue: `WIN-164`
 - files touched:
   - `supabase/functions/admin-invite/index.ts`
+  - `supabase/migrations/20260530140500_atomic_admin_invite_rate_limit.sql`
   - `tests/admins/invite_flow.spec.ts`
+  - `tests/admins/invite_rate_limit_migration.spec.ts`
   - `docs/ai/2026-05-30-admin-invite-abuse-hardening-handoff.md`
 - non-goals:
-  - no schema or RLS changes
+  - no table schema or RLS policy changes
   - no hosted data backfill
   - no new join-request feature or endpoint
   - no invite redemption implementation because no in-repo accept-invite server path was found
 
 ## Abuse Paths Reviewed
 
-- rate limits: added a per-admin hourly cap before token creation and email dispatch
-- replay protection: existing active invite conflict path remains covered by focused tests
-- expired token handling: existing expired invite replacement path remains covered by focused tests
+- rate limits: per-admin hourly cap is enforced inside `public.create_admin_invite_token_rate_limited`, with the one-hour window and limit defined in the RPC instead of caller-supplied parameters
+- concurrent burst protection: RPC takes a per-admin advisory transaction lock before duplicate-active checks, expired pruning, rate-limit count, and insert
+- replay protection: active invite conflict handling now runs in the same RPC critical section
+- expired token handling: expired invite pruning now runs in the same RPC critical section
 - revoked token handling: no revoked-token column or redemption endpoint exists in repo scope
 - privilege escalation: standard admins remain blocked from inviting `super_admin` users; focused test added
 - join requests: no in-repo join-request endpoint, table, or workflow was found
@@ -33,6 +38,7 @@
 ## Tenant Boundary
 
 - invite creation remains restricted to protected admin route handling
+- the atomic RPC independently verifies `auth.uid() = p_created_by`
 - standard admins can invite only into their own organization context
 - super-admin invite role elevation remains restricted to current super admins
 - no cross-tenant read/write broadening was introduced
@@ -53,7 +59,7 @@
 ## Verification Card
 
 - required checks:
-  - `npx vitest run tests/admins/invite_flow.spec.ts`
+  - `npx vitest run tests/admins/invite_flow.spec.ts tests/admins/invite_rate_limit_migration.spec.ts`
   - `npm run ci:check-focused`
   - `npm run lint`
   - `npm run typecheck`
@@ -62,11 +68,10 @@
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - `npx vitest run tests/admins/invite_flow.spec.ts`: pass
+  - `npx vitest run tests/admins/invite_flow.spec.ts tests/admins/invite_rate_limit_migration.spec.ts`: pass
   - `npm run ci:check-focused`: pass
   - `npm run lint`: pass
   - `npm run typecheck`: pass
-  - `npm run test:ci`: pass
   - `npm run validate:tenant`: pass
   - `npm run build`: pass
   - `npm run verify:local`: pass
@@ -79,7 +84,7 @@
 
 - branch-ready: yes
 - linear-ready: yes (`WIN-164`)
-- protected-path drift: expected `supabase/functions/admin-invite/**`
+- protected-path drift: expected `supabase/functions/admin-invite/**` and `supabase/migrations/**`
 - unrelated changes: none
 - generated artifact drift: none
 - verification summary: required local checks passed

--- a/docs/ai/2026-05-30-admin-invite-abuse-hardening-handoff.md
+++ b/docs/ai/2026-05-30-admin-invite-abuse-hardening-handoff.md
@@ -1,0 +1,94 @@
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: invite issuance affects admin authorization, privilege escalation, token issuance, and tenant-scoped organization membership
+- triggering paths:
+  - `supabase/functions/admin-invite/index.ts`
+  - `tests/admins/invite_flow.spec.ts`
+
+## Scope
+
+- task intent: harden the existing in-repo admin invite creation path against abuse
+- Linear issue: `WIN-164`
+- files touched:
+  - `supabase/functions/admin-invite/index.ts`
+  - `tests/admins/invite_flow.spec.ts`
+  - `docs/ai/2026-05-30-admin-invite-abuse-hardening-handoff.md`
+- non-goals:
+  - no schema or RLS changes
+  - no hosted data backfill
+  - no new join-request feature or endpoint
+  - no invite redemption implementation because no in-repo accept-invite server path was found
+
+## Abuse Paths Reviewed
+
+- rate limits: added a per-admin hourly cap before token creation and email dispatch
+- replay protection: existing active invite conflict path remains covered by focused tests
+- expired token handling: existing expired invite replacement path remains covered by focused tests
+- revoked token handling: no revoked-token column or redemption endpoint exists in repo scope
+- privilege escalation: standard admins remain blocked from inviting `super_admin` users; focused test added
+- join requests: no in-repo join-request endpoint, table, or workflow was found
+
+## Tenant Boundary
+
+- invite creation remains restricted to protected admin route handling
+- standard admins can invite only into their own organization context
+- super-admin invite role elevation remains restricted to current super admins
+- no cross-tenant read/write broadening was introduced
+
+## Required Agents
+
+- required sequence:
+  - `specification-engineer`
+  - `software-architect`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+  - `security-engineer`
+- agents used:
+  - Codex performed routing, implementation, focused testing, and security review directly
+- reviewer: completed locally; human review remains required before merge
+
+## Verification Card
+
+- required checks:
+  - `npx vitest run tests/admins/invite_flow.spec.ts`
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - `npx vitest run tests/admins/invite_flow.spec.ts`: pass
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run test:ci`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+  - `npm run verify:local`: pass
+- blocked checks:
+  - none
+- result: pass
+- residual risk: invite redemption and revoked-token handling cannot be fully verified because this repo currently contains only invite creation, not an accept-invite server flow
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes (`WIN-164`)
+- protected-path drift: expected `supabase/functions/admin-invite/**`
+- unrelated changes: none
+- generated artifact drift: none
+- verification summary: required local checks passed
+- pr-ready: yes
+- required follow-up:
+  - open PR for human review
+
+## Recommended Next Slice
+
+- define whether product needs a user-initiated join-request workflow
+- if yes, add an explicit backend endpoint/table with tenant-scoped RLS, rate limits, duplicate request handling, approval authority, audit logging, and denial/revocation semantics
+- if invite redemption exists outside this repo, map that system and add token replay, expiry, revocation, and privilege-boundary tests there

--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -13,6 +13,8 @@ const DEFAULT_EXPIRATION_HOURS = 72;
 const MIN_EXPIRATION_HOURS = 1;
 const MAX_EXPIRATION_HOURS = 24 * 7;
 const ADMIN_INVITE_PATH = "/admin/invite";
+const INVITE_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const MAX_INVITES_PER_ADMIN_PER_WINDOW = 10;
 
 const InviteRequestSchema = z.object({
   email: z.string().email(),
@@ -43,10 +45,15 @@ type InsertInviteResult = {
   error: { message?: string } | null;
 };
 
-const jsonResponse = (status: number, body: Record<string, unknown>) =>
+type CountResult = {
+  count: number | null;
+  error: { message?: string } | null;
+};
+
+const jsonResponse = (status: number, body: Record<string, unknown>, headers: Record<string, string> = {}) =>
   new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
+    headers: { ...corsHeaders, ...headers, "Content-Type": "application/json" },
   });
 
 const extractOrganizationId = (metadata: Record<string, unknown> | null | undefined): string | null => {
@@ -80,6 +87,18 @@ const ensureEmailServiceConfig = () => {
 const buildInviteUrl = (baseUrl: string, token: string) => {
   const trimmed = baseUrl.replace(/\/$/, "");
   return `${trimmed}/accept-invite?token=${token}`;
+};
+
+const getAdminInviteCountSince = async (
+  adminClient: ReturnType<typeof createRequestClient>,
+  createdBy: string,
+  sinceIso: string,
+): Promise<CountResult> => {
+  return await adminClient
+    .from("admin_invite_tokens")
+    .select("id", { count: "exact", head: true })
+    .eq("created_by", createdBy)
+    .gte("created_at", sinceIso) as CountResult;
 };
 
 async function sendInviteEmail(
@@ -172,6 +191,26 @@ async function handleInvite(req: Request, userContext: UserContext) {
     const now = new Date();
     const expiresInHours = payload.expiresInHours ?? DEFAULT_EXPIRATION_HOURS;
     const expiresAt = new Date(now.getTime() + expiresInHours * 60 * 60 * 1000);
+    const rateLimitWindowStart = new Date(now.getTime() - INVITE_RATE_LIMIT_WINDOW_MS).toISOString();
+
+    const inviteCount = await getAdminInviteCountSince(adminClient, userContext.user.id, rateLimitWindowStart);
+    if (inviteCount.error) {
+      console.error("Failed to check invite rate limit", { code: 'invite_rate_limit_lookup_failed' });
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
+      return jsonResponse(500, { error: "invite_rate_limit_lookup_failed" });
+    }
+
+    if ((inviteCount.count ?? 0) >= MAX_INVITES_PER_ADMIN_PER_WINDOW) {
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 429);
+      return jsonResponse(
+        429,
+        {
+          error: "invite_rate_limit_exceeded",
+          retry_after_seconds: Math.ceil(INVITE_RATE_LIMIT_WINDOW_MS / 1000),
+        },
+        { "Retry-After": String(Math.ceil(INVITE_RATE_LIMIT_WINDOW_MS / 1000)) },
+      );
+    }
 
     const existingInvite = (await adminClient
       .from("admin_invite_tokens")

--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -31,22 +31,13 @@ const InviteRequestSchema = z.object({
 type InviteRequest = z.infer<typeof InviteRequestSchema>;
 
 type InviteTokenRecord = {
-  id: string;
+  id: string | null;
   expires_at: string | null;
-};
-
-type InviteLookupResult = {
-  data: InviteTokenRecord | null;
-  error: { message?: string } | null;
+  status: "active_invite_exists" | "created" | "rate_limited" | string;
 };
 
 type InsertInviteResult = {
-  data: InviteTokenRecord | null;
-  error: { message?: string } | null;
-};
-
-type CountResult = {
-  count: number | null;
+  data: InviteTokenRecord[] | null;
   error: { message?: string } | null;
 };
 
@@ -87,18 +78,6 @@ const ensureEmailServiceConfig = () => {
 const buildInviteUrl = (baseUrl: string, token: string) => {
   const trimmed = baseUrl.replace(/\/$/, "");
   return `${trimmed}/accept-invite?token=${token}`;
-};
-
-const getAdminInviteCountSince = async (
-  adminClient: ReturnType<typeof createRequestClient>,
-  createdBy: string,
-  sinceIso: string,
-): Promise<CountResult> => {
-  return await adminClient
-    .from("admin_invite_tokens")
-    .select("id", { count: "exact", head: true })
-    .eq("created_by", createdBy)
-    .gte("created_at", sinceIso) as CountResult;
 };
 
 async function sendInviteEmail(
@@ -191,16 +170,31 @@ async function handleInvite(req: Request, userContext: UserContext) {
     const now = new Date();
     const expiresInHours = payload.expiresInHours ?? DEFAULT_EXPIRATION_HOURS;
     const expiresAt = new Date(now.getTime() + expiresInHours * 60 * 60 * 1000);
-    const rateLimitWindowStart = new Date(now.getTime() - INVITE_RATE_LIMIT_WINDOW_MS).toISOString();
+    const rawToken = crypto.randomUUID().replace(/-/g, "");
+    const tokenHash = await hashToken(rawToken);
 
-    const inviteCount = await getAdminInviteCountSince(adminClient, userContext.user.id, rateLimitWindowStart);
-    if (inviteCount.error) {
-      console.error("Failed to check invite rate limit", { code: 'invite_rate_limit_lookup_failed' });
+    const insertedInvite = (await adminClient.rpc("create_admin_invite_token_rate_limited", {
+      p_email: normalizedEmail,
+      p_token_hash: tokenHash,
+      p_organization_id: targetOrganizationId,
+      p_expires_at: expiresAt.toISOString(),
+      p_created_by: userContext.user.id,
+      p_role: desiredRole,
+    })) as InsertInviteResult;
+
+    if (insertedInvite.error || !insertedInvite.data?.[0]) {
+      console.error("Failed to insert invite token", { code: 'invite_insert_failed' });
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-      return jsonResponse(500, { error: "invite_rate_limit_lookup_failed" });
+      return jsonResponse(500, { error: "invite_creation_failed" });
     }
 
-    if ((inviteCount.count ?? 0) >= MAX_INVITES_PER_ADMIN_PER_WINDOW) {
+    const inviteResult = insertedInvite.data[0];
+    if (inviteResult.status === "active_invite_exists") {
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
+      return jsonResponse(409, { error: "active_invite_exists" });
+    }
+
+    if (inviteResult.status === "rate_limited") {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 429);
       return jsonResponse(
         429,
@@ -212,59 +206,8 @@ async function handleInvite(req: Request, userContext: UserContext) {
       );
     }
 
-    const existingInvite = (await adminClient
-      .from("admin_invite_tokens")
-      .select("id, expires_at")
-      .eq("email", normalizedEmail)
-      .eq("organization_id", targetOrganizationId)
-      .order("created_at", { ascending: false })
-      .limit(1)
-      .maybeSingle()) as InviteLookupResult;
-
-    if (existingInvite.error) {
-      console.error("Failed to lookup existing invite", { code: 'invite_lookup_failed' });
-      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-      return jsonResponse(500, { error: "invite_lookup_failed" });
-    }
-
-    const activeInvite = existingInvite.data;
-    if (activeInvite?.expires_at) {
-      const expiresAtDate = new Date(activeInvite.expires_at);
-      if (!Number.isNaN(expiresAtDate.getTime()) && expiresAtDate.getTime() > now.getTime()) {
-        logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
-        return jsonResponse(409, { error: "active_invite_exists" });
-      }
-    }
-
-    if (activeInvite?.id) {
-      const { error: deleteError } = await adminClient
-        .from("admin_invite_tokens")
-        .delete()
-        .eq("id", activeInvite.id);
-
-      if (deleteError) {
-        console.error("Failed to prune expired invite", { code: 'invite_prune_failed' });
-      }
-    }
-
-    const rawToken = crypto.randomUUID().replace(/-/g, "");
-    const tokenHash = await hashToken(rawToken);
-
-    const insertedInvite = (await adminClient
-      .from("admin_invite_tokens")
-      .insert({
-        email: normalizedEmail,
-        token_hash: tokenHash,
-        organization_id: targetOrganizationId,
-        expires_at: expiresAt.toISOString(),
-        created_by: userContext.user.id,
-        role: desiredRole,
-      })
-      .select("id, expires_at")
-      .single()) as InsertInviteResult;
-
-    if (insertedInvite.error || !insertedInvite.data) {
-      console.error("Failed to insert invite token", { code: 'invite_insert_failed' });
+    if (inviteResult.status !== "created" || !inviteResult.id || !inviteResult.expires_at) {
+      console.error("Unexpected invite RPC result", { code: 'invite_rpc_unexpected_status' });
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
       return jsonResponse(500, { error: "invite_creation_failed" });
     }
@@ -300,7 +243,7 @@ async function handleInvite(req: Request, userContext: UserContext) {
       action_details: {
         email: normalizedEmail,
         expires_at: expiresAt.toISOString(),
-        invite_id: insertedInvite.data.id,
+        invite_id: inviteResult.id,
         role: desiredRole,
         email_delivery_status: emailResult.status,
         ...(emailResult.error ? { email_error: emailResult.error } : {}),
@@ -318,8 +261,8 @@ async function handleInvite(req: Request, userContext: UserContext) {
 
     logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 201);
     return jsonResponse(201, {
-      inviteId: insertedInvite.data.id,
-      expiresAt: expiresAt.toISOString(),
+      inviteId: inviteResult.id,
+      expiresAt: inviteResult.expires_at,
     });
   } catch (error) {
     console.error("Unexpected admin invite error", { code: 'unexpected_invite_error' });

--- a/supabase/migrations/20260530140500_atomic_admin_invite_rate_limit.sql
+++ b/supabase/migrations/20260530140500_atomic_admin_invite_rate_limit.sql
@@ -1,0 +1,124 @@
+-- @migration-intent: Move admin invite rate-limit enforcement into one DB-side critical section.
+-- @migration-dependencies: 20251224120000_metadata_constraints_and_impersonation_queue.sql
+-- @migration-rollback: Drop public.create_admin_invite_token_rate_limited and restore edge-side insert path if needed.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.create_admin_invite_token_rate_limited(
+  p_email text,
+  p_token_hash text,
+  p_organization_id uuid,
+  p_expires_at timestamptz,
+  p_created_by uuid,
+  p_role public.role_type
+)
+RETURNS TABLE(id uuid, expires_at timestamptz, status text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+DECLARE
+  v_normalized_email text;
+  v_now timestamptz := timezone('utc', now());
+  v_window_start timestamptz := v_now - interval '1 hour';
+  v_invite_limit integer := 10;
+  v_existing_id uuid;
+  v_existing_expires_at timestamptz;
+  v_recent_invite_count integer;
+  v_inserted public.admin_invite_tokens%ROWTYPE;
+BEGIN
+  IF auth.uid() IS NULL OR auth.uid() <> p_created_by THEN
+    RAISE EXCEPTION USING ERRCODE = '28000', MESSAGE = 'Authentication required';
+  END IF;
+
+  v_normalized_email := lower(trim(COALESCE(p_email, '')));
+  IF v_normalized_email = '' THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Invite email is required';
+  END IF;
+
+  IF p_organization_id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Organization ID is required';
+  END IF;
+
+  IF p_token_hash IS NULL OR length(trim(p_token_hash)) = 0 THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Token hash is required';
+  END IF;
+
+  IF p_expires_at IS NULL OR p_expires_at <= v_now THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Invite expiration must be in the future';
+  END IF;
+
+  IF p_role = 'super_admin'::public.role_type AND NOT app.current_user_is_super_admin() THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Only super admins can create super admin invites';
+  END IF;
+
+  IF NOT app.current_user_is_super_admin() THEN
+    IF NOT app.is_admin() THEN
+      RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Admin role required';
+    END IF;
+
+    IF app.current_user_organization_id() IS DISTINCT FROM p_organization_id THEN
+      RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Caller organization mismatch';
+    END IF;
+  END IF;
+
+  -- Serialize the full check/prune/count/insert sequence per inviter so bursts cannot share a stale count.
+  PERFORM pg_advisory_xact_lock(hashtextextended('admin-invite:' || p_created_by::text, 0));
+
+  SELECT t.id, t.expires_at
+  INTO v_existing_id, v_existing_expires_at
+  FROM public.admin_invite_tokens t
+  WHERE t.email = v_normalized_email
+    AND t.organization_id = p_organization_id
+  ORDER BY t.created_at DESC
+  LIMIT 1;
+
+  IF v_existing_id IS NOT NULL AND v_existing_expires_at > v_now THEN
+    RETURN QUERY SELECT v_existing_id, v_existing_expires_at, 'active_invite_exists'::text;
+    RETURN;
+  END IF;
+
+  DELETE FROM public.admin_invite_tokens t
+  WHERE t.email = v_normalized_email
+    AND t.organization_id = p_organization_id
+    AND t.expires_at <= v_now;
+
+  SELECT COUNT(*)::integer
+  INTO v_recent_invite_count
+  FROM public.admin_invite_tokens t
+  WHERE t.created_by = p_created_by
+    AND t.created_at >= v_window_start;
+
+  IF COALESCE(v_recent_invite_count, 0) >= v_invite_limit THEN
+    RETURN QUERY SELECT NULL::uuid, NULL::timestamptz, 'rate_limited'::text;
+    RETURN;
+  END IF;
+
+  INSERT INTO public.admin_invite_tokens (
+    email,
+    token_hash,
+    organization_id,
+    expires_at,
+    created_by,
+    role
+  )
+  VALUES (
+    v_normalized_email,
+    p_token_hash,
+    p_organization_id,
+    p_expires_at,
+    p_created_by,
+    p_role
+  )
+  RETURNING *
+  INTO v_inserted;
+
+  RETURN QUERY SELECT v_inserted.id, v_inserted.expires_at, 'created'::text;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type) FROM anon;
+GRANT EXECUTE ON FUNCTION public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type) TO authenticated;
+
+COMMIT;

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -60,12 +60,20 @@ const inviteTokens: StoredInviteToken[] = [];
 const adminActionRows: Array<Record<string, unknown>> = [];
 
 const createInviteTableClient = () => {
-  const state: { email?: string; organizationId?: string } = {};
+  const state: { email?: string; organizationId?: string; createdBy?: string; createdAtGte?: string; countOnly?: boolean } = {};
   const builder: any = {
-    select: vi.fn(() => builder),
+    select: vi.fn((_columns?: string, options?: { count?: string; head?: boolean }) => {
+      state.countOnly = options?.count === 'exact' && options?.head === true;
+      return builder;
+    }),
     eq: vi.fn((column: string, value: string) => {
       if (column === 'email') state.email = value;
       if (column === 'organization_id') state.organizationId = value;
+      if (column === 'created_by') state.createdBy = value;
+      return builder;
+    }),
+    gte: vi.fn((column: string, value: string) => {
+      if (column === 'created_at') state.createdAtGte = value;
       return builder;
     }),
     order: vi.fn(() => builder),
@@ -80,6 +88,19 @@ const createInviteTableClient = () => {
       const record = filtered[0];
       return { data: record ? { id: record.id, expires_at: record.expires_at } : null, error: null };
     }),
+    then: (resolve: (value: unknown) => unknown, reject: (reason?: unknown) => unknown) => {
+      const filtered = inviteTokens.filter(token =>
+        (state.email ? token.email === state.email : true)
+        && (state.organizationId ? token.organization_id === state.organizationId : true)
+        && (state.createdBy ? token.created_by === state.createdBy : true)
+        && (state.createdAtGte ? token.created_at >= state.createdAtGte : true),
+      );
+      return Promise.resolve({
+        count: state.countOnly ? filtered.length : null,
+        data: state.countOnly ? null : filtered,
+        error: null,
+      }).then(resolve, reject);
+    },
     insert: (value: Record<string, unknown>) => {
       const record = Array.isArray(value) ? value[0] : value;
       const id = (record.id as string) ?? crypto.randomUUID();
@@ -263,5 +284,88 @@ describe('admin invite edge function', () => {
       email: expiredEmail,
       email_delivery_status: 'sent',
     });
+  }, 20_000);
+
+  it('rejects replay while an active invite token already exists for the email and organization', async () => {
+    inviteTokens.push({
+      id: 'invite-active',
+      email: 'activeadmin@example.com',
+      organization_id: 'org-123',
+      token_hash: 'deadbeef',
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      created_by: 'admin-1',
+      created_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      role: 'admin',
+    });
+
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'activeadmin@example.com' }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: 'active_invite_exists' });
+    expect(inviteTokens).toHaveLength(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adminActionRows).toHaveLength(0);
+  }, 20_000);
+
+  it('rate limits excessive invite creation by the same admin', async () => {
+    const now = Date.now();
+    for (let index = 0; index < 10; index += 1) {
+      inviteTokens.push({
+        id: `invite-${index}`,
+        email: `candidate-${index}@example.com`,
+        organization_id: 'org-123',
+        token_hash: `hash-${index}`,
+        expires_at: new Date(now + 60 * 60 * 1000).toISOString(),
+        created_by: 'admin-1',
+        created_at: new Date(now - index * 60 * 1000).toISOString(),
+        role: 'admin',
+      });
+    }
+
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'overflow@example.com' }),
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('3600');
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'invite_rate_limit_exceeded',
+      retry_after_seconds: 3600,
+    });
+    expect(inviteTokens).toHaveLength(10);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adminActionRows).toHaveLength(0);
+  }, 20_000);
+
+  it('prevents standard admins from inviting super admins', async () => {
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'super@example.com', role: 'super_admin' }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: 'insufficient_role_for_target' });
+    expect(inviteTokens).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adminActionRows).toHaveLength(0);
   }, 20_000);
 });

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -59,82 +59,6 @@ let currentUserMetadata: Record<string, unknown> = { organization_id: 'org-123' 
 const inviteTokens: StoredInviteToken[] = [];
 const adminActionRows: Array<Record<string, unknown>> = [];
 
-const createInviteTableClient = () => {
-  const state: { email?: string; organizationId?: string; createdBy?: string; createdAtGte?: string; countOnly?: boolean } = {};
-  const builder: any = {
-    select: vi.fn((_columns?: string, options?: { count?: string; head?: boolean }) => {
-      state.countOnly = options?.count === 'exact' && options?.head === true;
-      return builder;
-    }),
-    eq: vi.fn((column: string, value: string) => {
-      if (column === 'email') state.email = value;
-      if (column === 'organization_id') state.organizationId = value;
-      if (column === 'created_by') state.createdBy = value;
-      return builder;
-    }),
-    gte: vi.fn((column: string, value: string) => {
-      if (column === 'created_at') state.createdAtGte = value;
-      return builder;
-    }),
-    order: vi.fn(() => builder),
-    limit: vi.fn(() => builder),
-    maybeSingle: vi.fn(async () => {
-      const filtered = inviteTokens
-        .filter(token =>
-          (state.email ? token.email === state.email : true)
-          && (state.organizationId ? token.organization_id === state.organizationId : true),
-        )
-        .sort((a, b) => b.created_at.localeCompare(a.created_at));
-      const record = filtered[0];
-      return { data: record ? { id: record.id, expires_at: record.expires_at } : null, error: null };
-    }),
-    then: (resolve: (value: unknown) => unknown, reject: (reason?: unknown) => unknown) => {
-      const filtered = inviteTokens.filter(token =>
-        (state.email ? token.email === state.email : true)
-        && (state.organizationId ? token.organization_id === state.organizationId : true)
-        && (state.createdBy ? token.created_by === state.createdBy : true)
-        && (state.createdAtGte ? token.created_at >= state.createdAtGte : true),
-      );
-      return Promise.resolve({
-        count: state.countOnly ? filtered.length : null,
-        data: state.countOnly ? null : filtered,
-        error: null,
-      }).then(resolve, reject);
-    },
-    insert: (value: Record<string, unknown>) => {
-      const record = Array.isArray(value) ? value[0] : value;
-      const id = (record.id as string) ?? crypto.randomUUID();
-      const stored: StoredInviteToken = {
-        id,
-        email: record.email as string,
-        organization_id: record.organization_id as string,
-        token_hash: record.token_hash as string,
-        expires_at: record.expires_at as string,
-        created_by: record.created_by as string,
-        created_at: new Date().toISOString(),
-        role: (record.role as string) ?? 'admin',
-      };
-      inviteTokens.push(stored);
-      return {
-        select: () => ({
-          single: async () => ({ data: { id: stored.id, expires_at: stored.expires_at }, error: null }),
-        }),
-      };
-    },
-    delete: () => ({
-      eq: (column: string, value: string) => {
-        if (column !== 'id') throw new Error(`Unexpected delete column ${column}`);
-        const index = inviteTokens.findIndex(token => token.id === value);
-        if (index >= 0) {
-          inviteTokens.splice(index, 1);
-        }
-        return { error: null };
-      },
-    }),
-  };
-  return builder;
-};
-
 const createMockClient = () => ({
   auth: {
     getUser: vi.fn(async () => ({
@@ -142,10 +66,65 @@ const createMockClient = () => ({
       error: null,
     })),
   },
-  from: (table: string) => {
-    if (table === 'admin_invite_tokens') {
-      return createInviteTableClient();
+  rpc: vi.fn(async (functionName: string, params: Record<string, unknown>) => {
+    if (functionName !== 'create_admin_invite_token_rate_limited') {
+      throw new Error(`Unexpected RPC ${functionName}`);
     }
+
+    const email = String(params.p_email);
+    const organizationId = String(params.p_organization_id);
+    const createdBy = String(params.p_created_by);
+    const now = Date.now();
+    const activeToken = inviteTokens
+      .filter(token => token.email === email && token.organization_id === organizationId)
+      .sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
+
+    if (activeToken && new Date(activeToken.expires_at).getTime() > now) {
+      return {
+        data: [{ id: activeToken.id, expires_at: activeToken.expires_at, status: 'active_invite_exists' }],
+        error: null,
+      };
+    }
+
+    for (let index = inviteTokens.length - 1; index >= 0; index -= 1) {
+      const token = inviteTokens[index];
+      if (
+        token.email === email
+        && token.organization_id === organizationId
+        && new Date(token.expires_at).getTime() <= now
+      ) {
+        inviteTokens.splice(index, 1);
+      }
+    }
+
+    const windowStart = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const limit = 10;
+    const recentInviteCount = inviteTokens.filter(token =>
+      token.created_by === createdBy && token.created_at >= windowStart,
+    ).length;
+
+    if (recentInviteCount >= limit) {
+      return { data: [{ id: null, expires_at: null, status: 'rate_limited' }], error: null };
+    }
+
+    const stored: StoredInviteToken = {
+      id: crypto.randomUUID(),
+      email,
+      organization_id: organizationId,
+      token_hash: String(params.p_token_hash),
+      expires_at: String(params.p_expires_at),
+      created_by: createdBy,
+      created_at: new Date().toISOString(),
+      role: String(params.p_role ?? 'admin'),
+    };
+    inviteTokens.push(stored);
+
+    return {
+      data: [{ id: stored.id, expires_at: stored.expires_at, status: 'created' }],
+      error: null,
+    };
+  }),
+  from: (table: string) => {
     if (table === 'admin_actions') {
       return {
         insert: vi.fn(async (payload: Record<string, unknown>) => {

--- a/tests/admins/invite_rate_limit_migration.spec.ts
+++ b/tests/admins/invite_rate_limit_migration.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const migrationSql = readFileSync(
+  join(process.cwd(), 'supabase/migrations/20260530140500_atomic_admin_invite_rate_limit.sql'),
+  'utf-8',
+).replace(/\r\n/g, '\n');
+
+const functionSql = migrationSql.match(
+  /create or replace function public\.create_admin_invite_token_rate_limited[\s\S]+?\n\$\$;/i,
+)?.[0] ?? '';
+
+describe('admin invite atomic rate-limit migration', () => {
+  it('serializes check and insert through a per-admin advisory transaction lock', () => {
+    expect(functionSql, 'create_admin_invite_token_rate_limited function should exist').toBeTruthy();
+
+    const lockIndex = functionSql.indexOf('pg_advisory_xact_lock');
+    const countIndex = functionSql.indexOf('SELECT COUNT(*)::integer');
+    const insertIndex = functionSql.indexOf('INSERT INTO public.admin_invite_tokens');
+
+    expect(lockIndex).toBeGreaterThanOrEqual(0);
+    expect(countIndex).toBeGreaterThan(lockIndex);
+    expect(insertIndex).toBeGreaterThan(countIndex);
+  });
+
+  it('keeps duplicate-active, expired-prune, rate-limit, and insert logic inside one RPC', () => {
+    expect(functionSql).toMatch(/active_invite_exists/i);
+    expect(functionSql).toMatch(/DELETE FROM public\.admin_invite_tokens/i);
+    expect(functionSql).toMatch(/created_by = p_created_by/i);
+    expect(functionSql).toMatch(/v_window_start timestamptz := v_now - interval '1 hour'/i);
+    expect(functionSql).toMatch(/v_invite_limit integer := 10/i);
+    expect(functionSql).toMatch(/created_at >= v_window_start/i);
+    expect(functionSql).toMatch(/rate_limited/i);
+    expect(functionSql).toMatch(/RETURN QUERY SELECT v_inserted\.id, v_inserted\.expires_at, 'created'::text/i);
+  });
+
+  it('defends auth, org scope, and super-admin invite escalation in the RPC', () => {
+    expect(functionSql).not.toMatch(/p_window_start/i);
+    expect(functionSql).not.toMatch(/p_limit/i);
+    expect(functionSql).toMatch(/auth\.uid\(\) <> p_created_by/i);
+    expect(functionSql).toMatch(/app\.current_user_is_super_admin\(\)/i);
+    expect(functionSql).toMatch(/app\.is_admin\(\)/i);
+    expect(functionSql).toMatch(/app\.current_user_organization_id\(\) IS DISTINCT FROM p_organization_id/i);
+    expect(functionSql).toMatch(/Only super admins can create super admin invites/i);
+  });
+
+  it('does not expose the RPC to public or anonymous callers', () => {
+    expect(migrationSql).toMatch(/REVOKE ALL ON FUNCTION public\.create_admin_invite_token_rate_limited/i);
+    expect(migrationSql).toMatch(/REVOKE EXECUTE ON FUNCTION public\.create_admin_invite_token_rate_limited[\s\S]+FROM anon;/i);
+    expect(migrationSql).toMatch(/GRANT EXECUTE ON FUNCTION public\.create_admin_invite_token_rate_limited[\s\S]+TO authenticated;/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Move admin invite rate-limit enforcement into a DB-side RPC that serializes duplicate-active checks, expired-token pruning, hourly count, and insert under a per-admin advisory transaction lock.
- Keep the rate window and limit hard-coded inside the RPC, not caller-supplied, so direct RPC callers cannot choose a permissive window or limit.
- Update the edge function to call the atomic RPC and only send email/log success after the RPC returns a created token.
- Add migration contract coverage for the advisory-lock ordering, grants, and auth/org/role guardrails.

## Security Notes
- Existing active invite conflict handling remains the replay protection for duplicate email + organization invites, now inside the same DB critical section as insert.
- Expired invite replacement remains intact, now inside the same DB critical section.
- The RPC independently verifies `auth.uid() = p_created_by`, admin/super-admin authority, org scope for standard admins, and super-admin invite escalation.
- No in-repo join-request endpoint/table/workflow was found; the handoff documents this as a separate recommended slice if product wants user-initiated join requests.

## Verification
- `npx vitest run tests/admins/invite_flow.spec.ts tests/admins/invite_rate_limit_migration.spec.ts`
- `npm run ci:check-focused`
- `npm run validate:tenant`
- `npm run verify:local`

Notes: one `verify:local` run initially hit an unrelated flaky `Schedule.event.test.tsx` timeout; the isolated test passed immediately, and the full `verify:local` rerun passed.

## Residual Risk
- Invite redemption and revoked-token handling cannot be fully verified in this repo because only invite creation exists here; no accept-invite server flow was found.
- Local DB-connected policy checks that require `SUPABASE_DB_URL` were skipped by the repo policy runner, but static policy, tenant validation, and full local verification passed.

Linear: WIN-164