### PR TITLE
WIN-163 Mark missing IEHP adaptive blocks for review

### DIFF
--- a/docs/ai/2026-05-29-iehp-adaptive-measure-review-blocks-handoff.md
+++ b/docs/ai/2026-05-29-iehp-adaptive-measure-review-blocks-handoff.md
@@ -43,7 +43,7 @@
 - blocked checks:
   - `none`
 - result: pass
-- residual risk: the hosted document `86cdd0ce-dba3-44a9-b431-0653f3a2fafa` currently persists only one populated `Vineland` block in `assessment_blocks`, so the UI will now show explicit empty states for the other named measures rather than invent content
+- residual risk: the `WIN-163 target assessment document` currently persists only one populated `Vineland` block in `assessment_blocks`, so the UI will now show explicit empty states for the other named measures rather than invent content
 
 ## PR Hygiene
 

--- a/docs/ai/2026-05-30-iehp-adaptive-block-extraction-fix-handoff.md
+++ b/docs/ai/2026-05-30-iehp-adaptive-block-extraction-fix-handoff.md
@@ -16,7 +16,7 @@
   - `supabase/functions/extract-assessment-fields/index.test.ts`
   - `docs/ai/2026-05-30-iehp-adaptive-block-extraction-fix-handoff.md`
 - hosted document updated:
-  - `assessment_documents.id = 86cdd0ce-dba3-44a9-b431-0653f3a2fafa`
+  - assessment document: `WIN-163 target assessment document`
   - updated one `assessment_structured_sections` row and one `assessment_extractions` row for `IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES`
 - single-purpose diff: yes
 
@@ -62,7 +62,7 @@
 - blocked checks:
   - none
 - result: pass
-- residual risk: hosted source structure for document `86cdd0ce-dba3-44a9-b431-0653f3a2fafa` still contains only populated Vineland source text; VB-MAPP, AFLS, and ABAS-3 are represented as explicit null block slots until source decoding/content is investigated
+- residual risk: hosted source structure for the `WIN-163 target assessment document` still contains only populated Vineland source text; VB-MAPP, AFLS, and ABAS-3 are represented as explicit null block slots until source decoding/content is investigated
 
 ## PR Hygiene
 
@@ -79,7 +79,7 @@
 ## Recommended Next Slice
 
 - Linear issue: `WIN-163`
-- inspect the original uploaded DOCX/source conversion path for `Le, Ki IEHP FBA December 2025 (1).docx`
+- inspect the original uploaded DOCX/source conversion path for the `WIN-163 target IEHP FBA DOCX`
 - determine whether VB-MAPP, AFLS, and ABAS-3 content exists in the uploaded source but was dropped during DOCX decoding or normalization
 - if source text exists, fix the decoder or section extraction path and re-run extraction for the document
 - if source text does not exist, keep the review UI empty states and mark those blocks as requiring manual clinician review

--- a/docs/ai/2026-05-30-iehp-source-conversion-investigation-handoff.md
+++ b/docs/ai/2026-05-30-iehp-source-conversion-investigation-handoff.md
@@ -1,0 +1,91 @@
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: changes `supabase/functions/extract-assessment-fields/**`, IEHP review UI behavior, and a hosted assessment payload for one target document
+- triggering paths:
+  - `supabase/functions/extract-assessment-fields/index.ts`
+  - `supabase/functions/extract-assessment-fields/index.test.ts`
+  - `src/components/ClientDetails/IehpFbaLayoutReview.tsx`
+  - `src/components/__tests__/IehpFbaLayoutReview.test.tsx`
+
+## Scope
+
+- task intent: execute `WIN-163` by determining whether missing VB-MAPP, AFLS, and ABAS-3 source content exists in the WIN-163 uploaded IEHP FBA DOCX, then mark true source absence for clinician review without inventing content
+- Linear issue: `WIN-163`
+- target document:
+  - assessment document: `WIN-163 target assessment document`
+  - file name: `WIN-163 target IEHP FBA DOCX`
+- hosted rows updated:
+  - one `assessment_structured_sections` row for `IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES`
+  - one `assessment_extractions` row for `IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES`
+- non-goal: no synthetic VB-MAPP, AFLS, or ABAS-3 clinical narrative
+
+## Source Conversion Evidence
+
+- local original DOCX was found at repository root as the `WIN-163 target IEHP FBA DOCX`
+- OpenXML inspection covered all `word/*.xml` parts, not only `word/document.xml`
+- result:
+  - `word/document.xml` length: `88461`
+  - all `word/*.xml` combined text length: `99194`
+  - `Vineland`: present
+  - adaptive-measure heading: present
+  - `VB-MAPP`: absent
+  - `AFLS`: absent
+  - `ABAS-3`: absent
+- conclusion: the missing VB-MAPP, AFLS, and ABAS-3 blocks are absent from the text-bearing DOCX source parts inspected here; this is not explained by the current `word/document.xml` decoder dropping separate Word XML text parts
+
+## Tenant Boundary
+
+- only the existing target assessment document rows were backfilled
+- no schema, RLS, grant, auth, or cross-organization query behavior changed
+- cross-tenant access must remain impossible through existing Supabase policies and server-side organization filters
+
+## Implementation
+
+- extractor now annotates missing adaptive-measure blocks with:
+  - `manual_review_required: true`
+  - `review_note: "<measure> content was not found in the source document text; clinician review is required."`
+- review UI renders the note for missing blocks, infers the same note for legacy known block slots with no raw text, and includes it in copied staff-readable text
+- hosted target rows now carry manual-review markers for VB-MAPP, AFLS, and ABAS-3; Vineland remains the only populated source block
+
+## Verification Card
+
+- required checks:
+  - `deno test --allow-read --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts`
+  - `npx vitest run src/components/__tests__/IehpFbaLayoutReview.test.tsx`
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - local OpenXML inspection of the `WIN-163 target IEHP FBA DOCX`: pass, found Vineland only among target adaptive-measure names
+  - hosted Supabase diagnostic query for target adaptive blocks: pass
+  - hosted Supabase targeted backfill for `manual_review_required` markers: pass, updated one structured row and one extraction row
+  - `deno test --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts --filter "adaptive measure block slots"`: pass
+  - `npx vitest run src/components/__tests__/IehpFbaLayoutReview.test.tsx`: pass
+  - `deno test --allow-read --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts --filter "decodeDocxStructured parses the committed IEHP FBA DOCX fixture"`: pass
+  - `deno test --allow-read --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts`: pass
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run test:ci`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+  - `npm run verify:local`: pass
+- blocked checks:
+  - none currently
+- result: pass
+- residual risk: source evidence is based on text-bearing OpenXML parts; if the missing content exists only in embedded images, screenshots, or non-text binary objects, it would require OCR/manual source review rather than DOCX text decoding changes
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes (`WIN-163`)
+- protected-path drift: expected `supabase/functions/extract-assessment-fields/**`
+- unrelated changes: none expected
+- generated artifact drift: none expected
+- pr-ready: yes

--- a/src/components/ClientDetails/IehpFbaLayoutReview.tsx
+++ b/src/components/ClientDetails/IehpFbaLayoutReview.tsx
@@ -90,6 +90,8 @@ interface AdaptiveMeasureBlockPreview {
   assessment_type: string;
   raw_text: string;
   extracted: boolean;
+  manual_review_required: boolean;
+  review_note: string;
 }
 
 const EMPTY_LAYOUT: TemplateLayoutResponse = {
@@ -114,6 +116,8 @@ const PAGE_FIELD_KEY_OVERRIDES: Record<string, number> = {
   IEHP_FBA_REASON_FOR_REFERRAL: 1,
 };
 const IEHP_ADAPTIVE_MEASURE_TYPES = ["VB-MAPP", "Vineland", "AFLS", "ABAS-3"] as const;
+const adaptiveMeasureReviewNote = (assessmentType: string): string =>
+  `${assessmentType} content was not found in the source document text; clinician review is required.`;
 
 const formatPayloadPreview = (value: unknown): string => {
   if (value == null) return "";
@@ -181,11 +185,17 @@ const adaptiveMeasureBlocksFromPayload = (payload: Record<string, unknown> | und
               : "";
           const rawText =
             typeof (block as { raw_text?: unknown }).raw_text === "string" ? (block as { raw_text: string }).raw_text.trim() : "";
+          const manualReviewRequired = (block as { manual_review_required?: unknown }).manual_review_required === true;
+          const reviewNote =
+            typeof (block as { review_note?: unknown }).review_note === "string" ? (block as { review_note: string }).review_note.trim() : "";
+          const isKnownEmptyBlock = IEHP_ADAPTIVE_MEASURE_TYPES.some((type) => type.toLowerCase() === assessmentType.toLowerCase()) && rawText.length === 0;
           if (!assessmentType) return null;
           return {
             assessment_type: assessmentType,
             raw_text: rawText,
             extracted: rawText.length > 0,
+            manual_review_required: manualReviewRequired || isKnownEmptyBlock,
+            review_note: reviewNote || (isKnownEmptyBlock ? adaptiveMeasureReviewNote(assessmentType) : ""),
           };
         })
         .filter((block): block is AdaptiveMeasureBlockPreview => block !== null)
@@ -194,7 +204,13 @@ const adaptiveMeasureBlocksFromPayload = (payload: Record<string, unknown> | und
   const knownTypeSet = new Set(IEHP_ADAPTIVE_MEASURE_TYPES.map((type) => type.toLowerCase()));
   const orderedKnownBlocks = IEHP_ADAPTIVE_MEASURE_TYPES.map((assessmentType) => {
     const existing = parsedBlocks.find((block) => block.assessment_type.toLowerCase() === assessmentType.toLowerCase());
-    return existing ?? { assessment_type: assessmentType, raw_text: "", extracted: false };
+    return existing ?? {
+      assessment_type: assessmentType,
+      raw_text: "",
+      extracted: false,
+      manual_review_required: true,
+      review_note: adaptiveMeasureReviewNote(assessmentType),
+    };
   });
   const extraBlocks = parsedBlocks.filter((block) => !knownTypeSet.has(block.assessment_type.toLowerCase()));
   return [...orderedKnownBlocks, ...extraBlocks];
@@ -247,7 +263,7 @@ const formatStructuredReadableText = (section: StructuredValue): string => {
   if (section.field_key === "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES") {
     const blocks = adaptiveMeasureBlocksFromPayload(section.payload);
     return `Adaptive Measure Summaries\n${blocks
-      .map((block) => `- ${block.assessment_type}: ${block.raw_text || "No extracted block found."}`)
+      .map((block) => `- ${block.assessment_type}: ${block.raw_text || block.review_note || "No extracted block found."}`)
       .join("\n")}`;
   }
   const narrative = readableNarrativeFromPayload(section.payload);
@@ -320,7 +336,9 @@ const renderStructuredReadablePreview = (section: StructuredValue): JSX.Element 
               className={`rounded border px-2 py-2 ${block.extracted ? "border-slate-600/60 bg-slate-900/50" : "border-dashed border-slate-700 bg-slate-900/20"}`}
             >
               <p className="text-xs font-semibold text-slate-100">{block.assessment_type}</p>
-              <p className="text-xs leading-relaxed whitespace-pre-wrap text-slate-300">{block.raw_text || "No extracted block found."}</p>
+              <p className="text-xs leading-relaxed whitespace-pre-wrap text-slate-300">
+                {block.raw_text || block.review_note || "No extracted block found."}
+              </p>
             </div>
           ))}
         </div>

--- a/src/components/__tests__/IehpFbaLayoutReview.test.tsx
+++ b/src/components/__tests__/IehpFbaLayoutReview.test.tsx
@@ -1091,7 +1091,7 @@ describe("IehpFbaLayoutReview", () => {
                     { assessment_type: "VB-MAPP", raw_text: "VB-MAPP Assessment Summary: Preserve as assessment block." },
                     { assessment_type: "Vineland", raw_text: "Vineland Assessment Summary: Preserve as assessment block." },
                     { assessment_type: "AFLS", raw_text: "AFLS Assessment Summary: Preserve as assessment block." },
-                    { assessment_type: "ABAS-3", raw_text: "" },
+                    { assessment_type: "ABAS-3", raw_text: null },
                   ],
                 },
                 source_span: { page_number: 10, method: "iehp_section_anchor" },
@@ -1118,13 +1118,13 @@ describe("IehpFbaLayoutReview", () => {
     expect(screen.getByText("Vineland")).toBeInTheDocument();
     expect(screen.getByText("AFLS")).toBeInTheDocument();
     expect(screen.getByText("ABAS-3")).toBeInTheDocument();
-    expect(screen.getAllByText("No extracted block found.").length).toBeGreaterThan(0);
+    expect(screen.getByText("ABAS-3 content was not found in the source document text; clinician review is required.")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Expand Adaptive and Functional Measure Summaries" }));
     fireEvent.click(screen.getByRole("button", { name: "Copy extracted" }));
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        "Adaptive Measure Summaries\n- VB-MAPP: VB-MAPP Assessment Summary: Preserve as assessment block.\n- Vineland: Vineland Assessment Summary: Preserve as assessment block.\n- AFLS: AFLS Assessment Summary: Preserve as assessment block.\n- ABAS-3: No extracted block found.",
+        "Adaptive Measure Summaries\n- VB-MAPP: VB-MAPP Assessment Summary: Preserve as assessment block.\n- Vineland: Vineland Assessment Summary: Preserve as assessment block.\n- AFLS: AFLS Assessment Summary: Preserve as assessment block.\n- ABAS-3: ABAS-3 content was not found in the source document text; clinician review is required.",
       );
     });
   });

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -701,13 +701,28 @@ Deno.test("extractStructuredSections preserves IEHP adaptive measure block slots
 
   const adaptivePayload = sections.find((section) => section.field_key === "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES")?.payload;
   expect(adaptivePayload?.assessment_blocks).toEqual([
-    { assessment_type: "VB-MAPP", raw_text: null },
+    {
+      assessment_type: "VB-MAPP",
+      raw_text: null,
+      manual_review_required: true,
+      review_note: "VB-MAPP content was not found in the source document text; clinician review is required.",
+    },
     expect.objectContaining({
       assessment_type: "Vineland",
       raw_text: expect.stringContaining("Vineland Adaptive Behavior Scales"),
     }),
-    { assessment_type: "AFLS", raw_text: null },
-    { assessment_type: "ABAS-3", raw_text: null },
+    {
+      assessment_type: "AFLS",
+      raw_text: null,
+      manual_review_required: true,
+      review_note: "AFLS content was not found in the source document text; clinician review is required.",
+    },
+    {
+      assessment_type: "ABAS-3",
+      raw_text: null,
+      manual_review_required: true,
+      review_note: "ABAS-3 content was not found in the source document text; clinician review is required.",
+    },
   ]);
 });
 

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -1183,14 +1183,21 @@ const normalizeIeHpSectionPayload = (fieldKey: string, rawText: string): Record<
     return { raw_text: compact, rows: preferenceRows };
   }
   if (fieldKey === "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES") {
+    const adaptiveBlocks = [
+      { assessment_type: "VB-MAPP", raw_text: compact.match(/VB-MAPP[\s\S]*?(?=Vineland|AFLS|ABAS-3|$)/i)?.[0] ?? null },
+      { assessment_type: "Vineland", raw_text: compact.match(/Vineland[\s\S]*?(?=VB-MAPP|AFLS|ABAS-3|$)/i)?.[0] ?? null },
+      { assessment_type: "AFLS", raw_text: compact.match(/AFLS[\s\S]*?(?=VB-MAPP|Vineland|ABAS-3|$)/i)?.[0] ?? null },
+      { assessment_type: "ABAS-3", raw_text: compact.match(/ABAS-3[\s\S]*?(?=VB-MAPP|Vineland|AFLS|$)/i)?.[0] ?? null },
+    ].map((block) => block.raw_text
+      ? block
+      : {
+        ...block,
+        manual_review_required: true,
+        review_note: `${block.assessment_type} content was not found in the source document text; clinician review is required.`,
+      });
     return {
       raw_text: compact,
-      assessment_blocks: [
-        { assessment_type: "VB-MAPP", raw_text: compact.match(/VB-MAPP[\s\S]*?(?=Vineland|AFLS|ABAS-3|$)/i)?.[0] ?? null },
-        { assessment_type: "Vineland", raw_text: compact.match(/Vineland[\s\S]*?(?=VB-MAPP|AFLS|ABAS-3|$)/i)?.[0] ?? null },
-        { assessment_type: "AFLS", raw_text: compact.match(/AFLS[\s\S]*?(?=VB-MAPP|Vineland|ABAS-3|$)/i)?.[0] ?? null },
-        { assessment_type: "ABAS-3", raw_text: compact.match(/ABAS-3[\s\S]*?(?=VB-MAPP|Vineland|AFLS|$)/i)?.[0] ?? null },
-      ],
+      assessment_blocks: adaptiveBlocks,
       measure_name: compact.match(/(Vineland Adaptive Behavior Scales,\s*3rd Edition)/i)?.[1] ?? null,
       date_administered: compact.match(/Date Administered\s*:?\s*([0-9/]+)/i)?.[1] ?? null,
       interviewer: normalizeExtractedValue(compact.match(/Name of Interviewer\s*:?\s*(.+?)(?=Name of Respondent|Assessment Summary|$)/i)?.[1] ?? ""),


### PR DESCRIPTION
## Summary
- Investigated WIN-163 source conversion for the WIN-163 target assessment document / WIN-163 target IEHP FBA DOCX.
- Confirmed text-bearing DOCX OpenXML parts contain Vineland but not VB-MAPP, AFLS, or ABAS-3, so the missing blocks are not explained by the current document XML decoder dropping separate Word XML text parts.
- Annotated missing IEHP adaptive-measure block slots with `manual_review_required` and a clinician-review note, and rendered/inferred those notes in the review UI/copy output for both new and legacy empty known block slots.
- Backfilled the target hosted extraction/structured adaptive rows with manual-review markers for VB-MAPP, AFLS, and ABAS-3 only.

## Verification
- Local OpenXML source inspection for the WIN-163 target IEHP FBA DOCX: pass; found Vineland only among target adaptive measure names.
- Hosted Supabase diagnostic query/backfill verification for the WIN-163 target assessment document: pass.
- `deno test --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts --filter "adaptive measure block slots"`: pass.
- `npx vitest run src/components/__tests__/IehpFbaLayoutReview.test.tsx`: pass.
- `deno test --allow-read --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts`: pass.
- `npm run ci:check-focused`: pass; branch protection, privileged DB grant, Supabase auth parity, and preview drift checks skipped locally due CI/env configuration.
- `npm run lint`: pass.
- `npm run typecheck`: pass.
- `npm run test:ci`: pass.
- `npm run validate:tenant`: pass.
- `npm run build`: pass.
- `npm run verify:local`: pass.
- Review patch verification: `npx vitest run src/components/__tests__/IehpFbaLayoutReview.test.tsx`, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, and `npm run build`: pass.

## Risk
- Critical lane because this touches `supabase/functions/extract-assessment-fields/**` and hosted assessment payload data.
- This does not synthesize missing clinical content. If VB-MAPP, AFLS, or ABAS-3 exist only as embedded images/non-text binary objects, OCR or manual clinician review remains required.

## Tracking
- Linear: WIN-163