### PR TITLE
WIN-165 Add IEHP DOCX template preflight

### DIFF
--- a/docs/ops/iehp-docx-generation.md
+++ b/docs/ops/iehp-docx-generation.md
@@ -1,0 +1,35 @@
+# IEHP DOCX generation runbook
+
+IEHP FBA final generation uses the Netlify `/api/assessment-plan-pdf` route and the Supabase Edge Function `generate-assessment-plan-docx`.
+
+## Runtime dependencies
+
+- `ASSESSMENT_GENERATION_SECRET` must be configured with the same value in Netlify and the Supabase Edge Function environment.
+- The Edge Function is configured to bundle `supabase/functions/generate-assessment-plan-docx/fill_docs/Updated FBA -IEHP.docx`.
+- Hosted deployments also require the private storage fallback template at `client-documents/templates/assessment/iehp/Updated FBA -IEHP.docx`.
+
+Do not paste secret values or real assessment data into tickets, logs, or commits.
+
+## Preflight behavior
+
+`POST /api/assessment-plan-pdf` with `preflight_only: true` checks the approved IEHP review state and asks the Edge Function to verify that the DOCX template is readable. If the bundled template and storage fallback are unavailable, preflight returns a `template_unavailable` blocker and generation is not attempted.
+
+Expected blocker:
+
+```json
+{
+  "code": "template_unavailable",
+  "message": "IEHP DOCX template is not available to the deployed generation function."
+}
+```
+
+## Deployment verification
+
+After deploying the Edge Function or rotating storage/template configuration:
+
+1. Confirm `ASSESSMENT_GENERATION_SECRET` is present in Netlify and Supabase without printing the value.
+2. Confirm the fallback template object exists at `client-documents/templates/assessment/iehp/Updated FBA -IEHP.docx`.
+3. Run an IEHP preflight against a synthetic/redacted assessment and confirm no `template_unavailable` blocker is returned.
+4. Run the hosted synthetic IEHP smoke before enabling routine clinician use.
+
+If preflight reports `template_unavailable`, redeploy the Edge Function and re-upload the tracked IEHP template object from `supabase/functions/generate-assessment-plan-docx/fill_docs/Updated FBA -IEHP.docx`.

--- a/src/server/__tests__/assessmentPlanPdfHandler.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfHandler.test.ts
@@ -393,7 +393,18 @@ describe("assessmentPlanPdfHandler", () => {
         status: 200,
         data: [{ field_key: "IEHP_FBA_REASON_FOR_REFERRAL", required: true }],
       })
-      .mockResolvedValueOnce({ ok: true, status: 200, data: [] });
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          template_available: true,
+          template_type: "iehp_fba",
+          bucket_id: "client-documents",
+          storage_object_path: "templates/assessment/iehp/Updated FBA -IEHP.docx",
+          byte_count: 740473,
+        },
+      });
 
     const response = await assessmentPlanPdfHandler(
       new Request("http://localhost/api/assessment-plan-pdf", {
@@ -411,10 +422,17 @@ describe("assessmentPlanPdfHandler", () => {
     expect(body.generated_file_type).toBe("docx");
     expect(body.preflight.ready).toBe(false);
     expect(body.preflight.blockers).toHaveLength(2);
-    expect(fetchJson).not.toHaveBeenCalledWith(
+    expect(fetchJson).toHaveBeenCalledWith(
       "https://example.supabase.co/functions/v1/generate-assessment-plan-docx",
-      expect.anything(),
+      expect.objectContaining({
+        body: expect.stringContaining('"template_health_check":true'),
+      }),
     );
+    const docxGenerationCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) =>
+      String(url) === "https://example.supabase.co/functions/v1/generate-assessment-plan-docx" &&
+      String((init as { body?: unknown } | undefined)?.body ?? "").includes('"field_layouts"')
+    );
+    expect(docxGenerationCalls).toHaveLength(0);
   });
 
   it("generates IEHP DOCX, returns download metadata, and records a generation event", async () => {
@@ -487,6 +505,17 @@ describe("assessmentPlanPdfHandler", () => {
           { member_id: "OTHER-MEMBER-111", insurance_provider: { name: "Other Payer" } },
           { member_id: "AUTH-MEMBER-999", insurance_provider: { name: "Inland Empire Health Plan" } },
         ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          template_available: true,
+          template_type: "iehp_fba",
+          bucket_id: "client-documents",
+          storage_object_path: "templates/assessment/iehp/Updated FBA -IEHP.docx",
+          byte_count: 740473,
+        },
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -592,6 +621,17 @@ describe("assessmentPlanPdfHandler", () => {
           { member_id: "OTHER-MEMBER-222", insurance_provider: { name: "Newest Other Payer" } },
           { member_id: "LEGACY-MEMBER-111", insurance_provider: { name: "Older Other Payer" } },
         ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          template_available: true,
+          template_type: "iehp_fba",
+          bucket_id: "client-documents",
+          storage_object_path: "templates/assessment/iehp/Updated FBA -IEHP.docx",
+          byte_count: 740473,
+        },
       });
 
     const response = await assessmentPlanPdfHandler(
@@ -613,7 +653,72 @@ describe("assessmentPlanPdfHandler", () => {
     );
   });
 
-  it("fails IEHP DOCX generation when the server generation credential is missing", async () => {
+  it("returns an IEHP preflight blocker when the template health check fails", async () => {
+    vi.mocked(buildIehpDocxPayload).mockReturnValue({
+      values: {
+        IEHP_FBA_FIRST_NAME: "Client",
+      },
+      preflight: {
+        ready: true,
+        blockers: [],
+        warnings: [],
+      },
+    });
+
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "11111111-1111-1111-1111-111111111111",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "drafted",
+            template_type: "iehp_fba",
+            template_version_id: "template-1",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [{ id: "program-1", name: "Program", description: null, accept_state: "accepted" }] })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "goal-1", title: "Goal", description: "Desc", original_text: "Original", goal_type: "child", accept_state: "accepted" }],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [{ full_name: "Client One" }] })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [{ full_name: "Therapist One", title: "BCBA" }] })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ field_key: "IEHP_FBA_FIRST_NAME", required: true, layout_json: { table_index: 0, row: 0, column: 1 } }],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({ ok: false, status: 500, data: { error: "IEHP DOCX template is not available to the deployed function." } });
+
+    const response = await assessmentPlanPdfHandler(
+      new Request("http://localhost/api/assessment-plan-pdf", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-1111-1111-111111111111",
+          preflight_only: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.preflight.ready).toBe(false);
+    expect(body.preflight.blockers).toContainEqual({
+      code: "template_unavailable",
+      message: "IEHP DOCX template is not available to the deployed generation function.",
+    });
+  });
+
+  it("blocks IEHP DOCX generation when the server generation credential is missing", async () => {
     vi.unstubAllEnvs();
     vi.mocked(buildIehpDocxPayload).mockReturnValue({
       values: {
@@ -666,8 +771,13 @@ describe("assessmentPlanPdfHandler", () => {
       }),
     );
 
-    expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({ error: "IEHP DOCX generation credential is not configured." });
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toBe("IEHP DOCX generation is blocked by review preflight.");
+    expect(body.preflight.blockers).toContainEqual({
+      code: "template_unavailable",
+      message: "IEHP DOCX generation credential is not configured.",
+    });
     expect(fetchJson).not.toHaveBeenCalledWith(
       "https://example.supabase.co/functions/v1/generate-assessment-plan-docx",
       expect.anything(),

--- a/src/server/api/assessment-plan-pdf.ts
+++ b/src/server/api/assessment-plan-pdf.ts
@@ -136,6 +136,14 @@ interface GenerateDocxFunctionResponse {
   unresolved_placeholders?: string[];
 }
 
+interface GenerateDocxTemplateHealthResponse {
+  template_available: boolean;
+  template_type: "iehp_fba";
+  bucket_id: string;
+  storage_object_path: string;
+  byte_count: number;
+}
+
 const CALOPTIMA_TEMPLATE_PATH = resolve(process.cwd(), "CalOptima Health FBA Template (2).pdf");
 const IEHP_DOCX_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const ASSESSMENT_GENERATION_SECRET_HEADER = "x-assessment-generation-secret";
@@ -349,21 +357,54 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
       pendingDraftGoalCount,
     });
 
+    const generationSecret = process.env.ASSESSMENT_GENERATION_SECRET?.trim();
+    const templatePreflight = payloadResult.preflight;
+    if (!generationSecret) {
+      templatePreflight.blockers.push({
+        code: "template_unavailable",
+        message: "IEHP DOCX generation credential is not configured.",
+      });
+      templatePreflight.ready = false;
+    } else {
+      const templateHealthResult = await fetchJson<GenerateDocxTemplateHealthResponse>(
+        `${supabaseUrl}/functions/v1/generate-assessment-plan-docx`,
+        {
+          method: "POST",
+          headers: {
+            ...headers,
+            [ASSESSMENT_GENERATION_SECRET_HEADER]: generationSecret,
+          },
+          body: JSON.stringify({
+            assessment_document_id: assessmentDocument.id,
+            template_type: "iehp_fba",
+            template_health_check: true,
+          }),
+        },
+      );
+      if (!templateHealthResult.ok || !templateHealthResult.data?.template_available) {
+        templatePreflight.blockers.push({
+          code: "template_unavailable",
+          message: "IEHP DOCX template is not available to the deployed generation function.",
+        });
+        templatePreflight.ready = false;
+      }
+    }
+
     if (parsed.data.preflight_only) {
       return json({
         assessment_document_id: assessmentDocument.id,
         generated_file_type: "docx",
-        preflight: payloadResult.preflight,
+        preflight: templatePreflight,
       });
     }
 
-    if (!payloadResult.preflight.ready) {
+    if (!templatePreflight.ready) {
       return json(
         {
           error: "IEHP DOCX generation is blocked by review preflight.",
           assessment_document_id: assessmentDocument.id,
           generated_file_type: "docx",
-          preflight: payloadResult.preflight,
+          preflight: templatePreflight,
         },
         409,
       );
@@ -372,10 +413,6 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
     const timestamp = Date.now();
     const filename = `generated-iehp-fba-${assessmentDocument.id}-${timestamp}.docx`;
     const outputObjectPath = `clients/${assessmentDocument.client_id}/assessments/${filename}`;
-    const generationSecret = process.env.ASSESSMENT_GENERATION_SECRET?.trim();
-    if (!generationSecret) {
-      return json({ error: "IEHP DOCX generation credential is not configured." }, 500);
-    }
 
     const functionResult = await fetchJson<GenerateDocxFunctionResponse>(
       `${supabaseUrl}/functions/v1/generate-assessment-plan-docx`,
@@ -419,7 +456,7 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
           generated_object_path: functionResult.data.object_path,
           unresolved_placeholder_count: functionResult.data.unresolved_placeholder_count ?? 0,
           unresolved_placeholders: functionResult.data.unresolved_placeholders ?? [],
-          preflight_warning_count: payloadResult.preflight.warnings.length,
+          preflight_warning_count: templatePreflight.warnings.length,
         },
       }),
     });
@@ -432,7 +469,7 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
       bucket_id: functionResult.data.bucket_id,
       object_path: functionResult.data.object_path,
       signed_url: functionResult.data.signed_url,
-      preflight: payloadResult.preflight,
+      preflight: templatePreflight,
     });
   }
 

--- a/src/server/iehpAssessmentDocx.ts
+++ b/src/server/iehpAssessmentDocx.ts
@@ -39,7 +39,8 @@ export interface IehpPreflightBlocker {
     | "missing_child_goal"
     | "missing_parent_goal"
     | "missing_required_output"
-    | "manual_review_required";
+    | "manual_review_required"
+    | "template_unavailable";
   key?: string;
   count?: number;
   message: string;

--- a/supabase/functions/generate-assessment-plan-docx/index.test.ts
+++ b/supabase/functions/generate-assessment-plan-docx/index.test.ts
@@ -153,6 +153,55 @@ Deno.test("generateAssessmentPlanDocxHandler rejects invalid storage scope", asy
   expect(await response.json()).toEqual({ error: "Invalid generated DOCX storage target." });
 });
 
+Deno.test("generateAssessmentPlanDocxHandler requires field values for generation requests", async () => {
+  const handler = createTestHandler();
+  const response = await handler(postRequest({
+    assessment_document_id: validPayload.assessment_document_id,
+    template_type: "iehp_fba",
+    output_bucket_id: validPayload.output_bucket_id,
+    output_object_path: validPayload.output_object_path,
+  }));
+
+  expect(response.status).toBe(400);
+  expect(await response.json()).toEqual({ error: "Invalid request body" });
+});
+
+Deno.test("generateAssessmentPlanDocxHandler checks template availability without uploading", async () => {
+  let uploadCalled = false;
+  const handler = createTestHandler({
+    admin: {
+      storage: {
+        from: () => ({
+          upload: () => {
+            uploadCalled = true;
+            return Promise.resolve({ data: {}, error: null });
+          },
+          createSignedUrl: () =>
+            Promise.resolve({
+              data: { signedUrl: "https://example.supabase.co/generated.docx" },
+              error: null,
+            }),
+        }),
+      },
+    },
+  });
+  const response = await handler(postRequest({
+    assessment_document_id: validPayload.assessment_document_id,
+    template_type: "iehp_fba",
+    template_health_check: true,
+  }));
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({
+    template_available: true,
+    template_type: "iehp_fba",
+    bucket_id: "client-documents",
+    storage_object_path: "templates/assessment/iehp/Updated FBA -IEHP.docx",
+    byte_count: 3,
+  });
+  expect(uploadCalled).toBe(false);
+});
+
 Deno.test("generateAssessmentPlanDocxHandler uploads to client-documents and returns signed DOCX metadata", async () => {
   const handler = createTestHandler();
   const response = await handler(postRequest(validPayload));

--- a/supabase/functions/generate-assessment-plan-docx/index.ts
+++ b/supabase/functions/generate-assessment-plan-docx/index.ts
@@ -24,13 +24,30 @@ const ASSESSMENT_GENERATION_SECRET_HEADER = "x-assessment-generation-secret";
 const requestSchema = z.object({
   assessment_document_id: z.string().uuid(),
   template_type: z.literal("iehp_fba"),
-  field_values: z.record(z.string()),
+  template_health_check: z.boolean().optional(),
+  field_values: z.record(z.string()).optional(),
   field_layouts: z.array(z.object({
     field_key: z.string().trim().min(1),
     layout_json: z.record(z.unknown()).nullable().optional(),
   })).optional(),
   output_bucket_id: z.string().trim().min(1).default(BUCKET_ID),
-  output_object_path: z.string().trim().min(1),
+  output_object_path: z.string().trim().min(1).optional(),
+}).superRefine((value, ctx) => {
+  if (value.template_health_check) return;
+  if (!value.output_object_path) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["output_object_path"],
+      message: "output_object_path is required for DOCX generation",
+    });
+  }
+  if (!value.field_values) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["field_values"],
+      message: "field_values is required for DOCX generation",
+    });
+  }
 });
 
 interface AssessmentDocumentScopeRow {
@@ -344,10 +361,20 @@ export const createGenerateAssessmentPlanDocxHandler =
       if (documentResult.data.template_type !== parsed.data.template_type) {
         return jsonResponse({ error: "DOCX generation is not supported for this assessment template." }, 409);
       }
+      const templateBytes = await deps.readTemplateBytes();
+      if (parsed.data.template_health_check) {
+        return jsonResponse({
+          template_available: true,
+          template_type: parsed.data.template_type,
+          bucket_id: BUCKET_ID,
+          storage_object_path: TEMPLATE_STORAGE_OBJECT_PATH,
+          byte_count: templateBytes.byteLength,
+        });
+      }
       if (
         !isAllowedAssessmentPlanDocxOutputTarget({
           bucketId: parsed.data.output_bucket_id,
-          objectPath: parsed.data.output_object_path,
+          objectPath: parsed.data.output_object_path ?? "",
           clientId: documentResult.data.client_id,
           assessmentDocumentId: documentResult.data.id,
         })
@@ -355,14 +382,13 @@ export const createGenerateAssessmentPlanDocxHandler =
         return jsonResponse({ error: "Invalid generated DOCX storage target." }, 403);
       }
 
-      const templateBytes = await deps.readTemplateBytes();
-      const filled = await deps.fillDocx(templateBytes, parsed.data.field_values, parsed.data.field_layouts ?? []);
+      const filled = await deps.fillDocx(templateBytes, parsed.data.field_values ?? {}, parsed.data.field_layouts ?? []);
       if (filled.changed_field_count === 0) {
         return jsonResponse({ error: "IEHP DOCX template did not receive any generated field values." }, 409);
       }
 
       const uploadResult = await deps.supabaseAdmin.storage.from(BUCKET_ID).upload(
-        parsed.data.output_object_path,
+        parsed.data.output_object_path ?? "",
         filled.bytes,
         {
           contentType: CONTENT_TYPE,
@@ -374,14 +400,14 @@ export const createGenerateAssessmentPlanDocxHandler =
       }
 
       const signedResult = await deps.supabaseAdmin.storage.from(BUCKET_ID).createSignedUrl(
-        parsed.data.output_object_path,
+        parsed.data.output_object_path ?? "",
         60 * 10,
       );
       if (signedResult.error || !signedResult.data?.signedUrl) {
         return jsonResponse({ error: "Failed to create download URL." }, 500);
       }
 
-      const filename = parsed.data.output_object_path.split("/").pop() ?? "generated-iehp-fba.docx";
+      const filename = parsed.data.output_object_path?.split("/").pop() ?? "generated-iehp-fba.docx";
       return jsonResponse({
         bucket_id: BUCKET_ID,
         object_path: parsed.data.output_object_path,


### PR DESCRIPTION
## Summary
- Adds a server-authenticated `template_health_check` mode to `generate-assessment-plan-docx` so the function can verify IEHP DOCX template readability without uploading a generated artifact.
- Wires IEHP `/api/assessment-plan-pdf` preflight to call that health check and block with `template_unavailable` when the deployed function cannot read the bundled template or private storage fallback.
- Documents the runtime dependency and deployment verification steps in `docs/ops/iehp-docx-generation.md`.

## Linear
- WIN-165

## Verification
- `deno test --no-check --allow-env --allow-read --allow-net supabase/functions/generate-assessment-plan-docx/index.test.ts`
- `npx vitest run src/server/__tests__/assessmentPlanPdfHandler.test.ts --reporter=verbose`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:ci`
- `npm run verify:local`
- `git diff --check`

## Risk
Critical / high-risk human-reviewed: touches `src/server/**` and `supabase/functions/**`. Tenant boundary remains unchanged: the health check still requires the server generation secret plus the caller-org assessment document scope, and it only reads template bytes; it does not upload generated artifacts.

## Notes
Subagent reviewer was not spawned because the active multi-agent tool policy only allows spawning when explicitly requested by the user. Human PR review remains required for this critical-lane change.