### PR TITLE
Deploy IEHP DOCX function in CI bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Lighthouse CI currently runs in advisory mode (non-blocking) while preview URL a
 
 - Audit Supabase routes against expected edge and RPC functions: `npm run audit:routes`
 - Generate stubs for missing routes and functions when scaffolding new APIs: `npm run fix:routes`
-- CI deploy bundle (`npm run ci:deploy:session-edge-bundle`) pushes session lifecycle functions plus `programs`, `goals`, `program-notes`, and `emails` to the linked Supabase project when `SUPABASE_ACCESS_TOKEN` and project ref secrets are present.
+- CI deploy bundle (`npm run ci:deploy:session-edge-bundle`) pushes session lifecycle, care-plan, email, and assessment extraction/generation functions to the linked Supabase project when `SUPABASE_ACCESS_TOKEN` and project ref secrets are present.
 - Deploy updates with the Supabase CLI: `supabase functions deploy <name> --project-ref wnnjeqheqxxyrgsjmygy`
 - Optional `emails` edge proxy: set Supabase Edge secret `EMAILS_HTTP_PROXY_URL` (HTTPS URL) on the `emails` function; see `docs/api/EMAILS_EDGE_FUNCTION.md`.
 - Authentication utilities:

--- a/docs/OPS_READINESS.md
+++ b/docs/OPS_READINESS.md
@@ -36,7 +36,7 @@ Document the minimum monitoring, alerting, and incident response requirements fo
 - [ ] `API_AUTHORITY_MODE=edge` is enabled in production so `/api/*` remains transport-only for converged routes
 - [ ] Dual-layer throttling is configured (`RATE_LIMIT_MODE=distributed` with Upstash credentials or approved `waf_only` exception)
 - [ ] CORS allowlists are aligned across runtimes (`API_ALLOWED_ORIGINS`/`CORS_ALLOWED_ORIGINS`)
-- [ ] Session lifecycle edge functions enforce `verify_jwt=true` (validated by `npm run ci:deploy:session-edge-bundle`)
+- [ ] Session lifecycle and assessment edge functions enforce `verify_jwt=true` (validated by `npm run ci:deploy:session-edge-bundle`)
 - [ ] Pull-request CI deploy step (`npm run ci:deploy:session-edge-bundle`) can reach Supabase with valid secrets so policy no longer skips downstream quality gates
 - [ ] Dashboard authority path is healthy (`/api/dashboard` transport + `get-dashboard-data` edge envelope parity)
 - [ ] Lighthouse CI advisory reports are reviewed for each release candidate while strict preview URL gating is temporarily disabled

--- a/docs/STAGING_OPERATIONS.md
+++ b/docs/STAGING_OPERATIONS.md
@@ -74,8 +74,8 @@ CI policy checks currently validate branch protection for `main` via `CI_PROTECT
 For CI policy strict mode, ensure the `SUPABASE_DB_URL` secret is configured so RLS overlap checks do not get skipped.
 
 For API authority convergence checks, `scripts/ci/check-api-adapter-boundary.mjs` now enforces that converged routes remain adapter-only and point to canonical edge functions.
-For session lifecycle edge contracts, `scripts/ci/deploy-session-edge-bundle.mjs` deploys the full required bundle (session lifecycle routes, `programs`, `goals`, `program-notes`, `emails`, and related session-notes PDF functions) and enforces `verify_jwt=true` for every function in that list unless `CI_EXPECT_VERIFY_JWT` is overridden.
-The `policy` job now runs `npm run ci:deploy:session-edge-bundle` on push and pull-request events before policy checks so parity is verified against freshly deployed lifecycle functions.
+For session lifecycle edge contracts, `scripts/ci/deploy-session-edge-bundle.mjs` deploys the full required bundle (session lifecycle routes, `programs`, `goals`, `program-notes`, `emails`, assessment extraction/generation functions, and related session-notes PDF functions) and enforces `verify_jwt=true` for every function in that list unless `CI_EXPECT_VERIFY_JWT` is overridden.
+The `policy` job now runs `npm run ci:deploy:session-edge-bundle` on push and pull-request events before policy checks so parity is verified against freshly deployed lifecycle and assessment functions.
 `lighthouse-ci` currently runs as an advisory (non-blocking) signal while preview URL detection is stabilized; retain artifact review in release checklists even though it does not block merge.
 
 For Priority 3 rollout, review `docs/architecture/P3_SDK_MIGRATION_TRACKER.md` to confirm compatibility shims and removal targets before promoting staging changes to production.

--- a/docs/supabase_branching.md
+++ b/docs/supabase_branching.md
@@ -66,7 +66,7 @@ We currently run all environments (preview, staging, production) against the sam
    ```bash
    npm run ci:deploy:session-edge-bundle
    ```
-   That script deploys session lifecycle functions plus care-plan routes (`programs`, `goals`, `program-notes`) and the optional `emails` proxy; see `scripts/ci/deploy-session-edge-bundle.mjs` for the authoritative list.
+   That script deploys session lifecycle functions, care-plan routes (`programs`, `goals`, `program-notes`), the optional `emails` proxy, and assessment extraction/generation functions; see `scripts/ci/deploy-session-edge-bundle.mjs` for the authoritative list.
    Alternatively deploy each function manually with `supabase functions deploy <name> --project-ref <ref>`.
    For session lifecycle routes, ensure gateway JWT verification remains enabled (`verify_jwt=true`) for `sessions-book`, `sessions-hold`, `sessions-confirm`, `sessions-start`, `sessions-cancel`, `generate-session-notes-pdf`, `session-notes-pdf-status`, and `session-notes-pdf-download`.
 5. Monitor the Supabase dashboard deployment logs. If a migration fails, follow the rollback/forward-fix plan documented in the PR.

--- a/scripts/ci/deploy-session-edge-bundle.mjs
+++ b/scripts/ci/deploy-session-edge-bundle.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 
-/** Session lifecycle + care-plan edge routes deployed before policy checks in CI. Keep in sync with docs/supabase_branching.md and README. */
+/** Session lifecycle, care-plan, and assessment edge routes deployed before policy checks in CI. Keep in sync with docs/supabase_branching.md and README. */
 const REQUIRED_FUNCTIONS = [
   "sessions-book",
   "sessions-hold",
@@ -16,6 +16,7 @@ const REQUIRED_FUNCTIONS = [
   "program-notes",
   "emails",
   "extract-assessment-fields",
+  "generate-assessment-plan-docx",
 ];
 
 const EXPECT_VERIFY_JWT = String(process.env.CI_EXPECT_VERIFY_JWT ?? "true").toLowerCase() !== "false";


### PR DESCRIPTION
## Summary
- Add `generate-assessment-plan-docx` to the CI Supabase Edge Function deploy bundle.
- Update operations/readme docs so the documented bundle includes assessment extraction and generation functions.
- Preserve existing function auth/config behavior; no Edge Function code, schema, RLS, or secret changes.

## Risk
- Critical protected-path change because it touches `scripts/ci/**` deploy behavior.
- Human review required before merge.
- Linear: WIN-166

## Verification
- `node -c scripts/ci/deploy-session-edge-bundle.mjs`
- `git diff --check`
- `npm run ci:check-focused`
- `npm run validate:tenant`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run build`
- `npm run verify:local`
