### PR TITLE
WIN-167 Show IEHP publish controls

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -265,6 +265,13 @@ interface ProgramsGoalsTabProps {
   client: Client;
 }
 
+interface AssessmentPromoteResponse {
+  created_program_count: number;
+  created_goal_count: number;
+  promoted_program_count?: number;
+  promoted_goal_count?: number;
+}
+
 export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const queryClient = useQueryClient();
   const organizationId = useActiveOrganizationId();
@@ -615,6 +622,15 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       checklistItems.some((item) => item.required && item.status !== "approved") ||
       structuredSections.some((section) => section.required && section.status !== "approved"));
   const hasExistingDrafts = (assessmentDrafts?.programs?.length ?? 0) > 0 || (assessmentDrafts?.goals?.length ?? 0) > 0;
+  const acceptedDraftProgramCount = (assessmentDrafts?.programs ?? []).filter(
+    (program) => program.accept_state === "accepted" || program.accept_state === "edited",
+  ).length;
+  const acceptedDraftGoalCount = (assessmentDrafts?.goals ?? []).filter(
+    (goal) => goal.accept_state === "accepted" || goal.accept_state === "edited",
+  ).length;
+  const pendingDraftProgramCount = (assessmentDrafts?.programs ?? []).filter((program) => program.accept_state === "pending").length;
+  const pendingDraftGoalCount = (assessmentDrafts?.goals ?? []).filter((goal) => goal.accept_state === "pending").length;
+  const showDraftReviewPanel = ENABLE_PROGRAMS_GOALS_AI_PROPOSALS || selectedAssessmentIsIehp;
   const extractedChecklistValueCount = checklistItems.filter((item) => item.value_text?.trim()).length;
   const structuredChildGoalCount = structuredSections.filter(isStructuredChildGoalSection).length;
   const structuredParentGoalCount = structuredSections.filter(isStructuredParentGoalSection).length;
@@ -627,6 +643,17 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     ? checklistItems.filter((item) => item.required && item.status !== "approved").length +
       structuredSections.filter((section) => section.required && section.status !== "approved").length
     : 0;
+  const promoteDisabledReason = !selectedAssessmentId
+    ? "Select an assessment before publishing."
+    : selectedAssessmentAlreadyPublished
+      ? "This assessment has already been approved and published."
+      : hasPendingRequiredChecklistItems
+        ? `${unresolvedRequiredCount} required checklist or structured row${unresolvedRequiredCount === 1 ? "" : "s"} must be approved before publishing.`
+        : acceptedDraftProgramCount === 0
+          ? "At least one draft program must be accepted or edited before publishing."
+          : acceptedDraftGoalCount === 0
+            ? "At least one draft goal must be accepted or edited before publishing."
+            : null;
 
   useEffect(() => {
     const firstAssessmentId = assessmentDocuments[0]?.id ?? null;
@@ -966,6 +993,36 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         queryKey: ["assessment-drafts", selectedAssessmentId, organizationId ?? "MISSING_ORG"],
       });
       showSuccess("Goal draft saved. Not published yet.");
+    },
+    onError: showError,
+  });
+
+  const promoteAssessment = useMutation({
+    mutationFn: async () => {
+      if (!selectedAssessmentId) {
+        throw new Error("Select an assessment before publishing.");
+      }
+      const response = await callApi("/api/assessment-promote", {
+        method: "POST",
+        body: JSON.stringify({ assessment_document_id: selectedAssessmentId }),
+      });
+      if (!response.ok) {
+        throw new Error(await parseApiErrorMessage(response, "Failed to publish assessment drafts."));
+      }
+      return parseJson<AssessmentPromoteResponse>(response);
+    },
+    onSuccess: (result) => {
+      const programCount = result.promoted_program_count ?? result.created_program_count;
+      const goalCount = result.promoted_goal_count ?? result.created_goal_count;
+      queryClient.invalidateQueries({ queryKey: clientProgramsQueryKey });
+      queryClient.invalidateQueries({ queryKey: programGoalsQueryKey });
+      queryClient.invalidateQueries({ queryKey: assessmentDocumentsQueryKey });
+      queryClient.invalidateQueries({
+        queryKey: ["assessment-drafts", selectedAssessmentId, organizationId ?? "MISSING_ORG"],
+      });
+      showSuccess(
+        `Published to live records. Created ${programCount} production program${programCount === 1 ? "" : "s"} and ${goalCount} goal${goalCount === 1 ? "" : "s"}.`,
+      );
     },
     onError: showError,
   });
@@ -1321,7 +1378,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
             Live care plan: <span className="font-semibold">{livePrograms.length}</span> program(s) and{" "}
             <span className="font-semibold">{liveGoals.length}</span> active goal(s) in the selected program.
           </p>
-          {ENABLE_PROGRAMS_GOALS_AI_PROPOSALS && hasDraftsButNoLivePrograms && (
+          {showDraftReviewPanel && hasDraftsButNoLivePrograms && (
             <button
               type="button"
               onClick={() => publishSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })}
@@ -1331,7 +1388,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
             </button>
           )}
         </div>
-        {ENABLE_PROGRAMS_GOALS_AI_PROPOSALS && hasDraftsButNoLivePrograms && (
+        {showDraftReviewPanel && hasDraftsButNoLivePrograms && (
           <p className="mt-2 text-xs text-sky-800/90 dark:text-sky-100/90">
             Uploaded assessments and draft proposals stay in review until you publish them to live Programs & Goals.
           </p>
@@ -1845,7 +1902,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
             </div>
           )}
 
-          {ENABLE_PROGRAMS_GOALS_AI_PROPOSALS && (
+          {showDraftReviewPanel && (
             <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">
               Draft Review (Approve / Reject / Edit)
@@ -2193,6 +2250,40 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
 
                 {(assessmentDrafts?.programs?.length ?? 0) === 0 && (assessmentDrafts?.goals?.length ?? 0) === 0 && (
                   <p className="text-sm text-gray-500">No staged drafts yet. Generate then save drafts to assessment.</p>
+                )}
+                {selectedAssessmentId && hasExistingDrafts && (
+                  <div className="rounded-md border border-gray-200 bg-gray-50 p-3 text-sm dark:border-gray-700 dark:bg-gray-900/40">
+                    <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                      <div className="space-y-1">
+                        <p className="font-semibold text-gray-800 dark:text-gray-100">Publish accepted drafts to live Programs & Goals</p>
+                        <p className="text-xs text-gray-600 dark:text-gray-300">
+                          Accepted drafts: {acceptedDraftProgramCount} program(s), {acceptedDraftGoalCount} goal(s). Pending drafts:{" "}
+                          {pendingDraftProgramCount} program(s), {pendingDraftGoalCount} goal(s).
+                        </p>
+                        {promoteDisabledReason && (
+                          <p className="text-xs text-amber-700 dark:text-amber-200">{promoteDisabledReason}</p>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (typeof window !== "undefined") {
+                            const confirmed = window.confirm(
+                              "Publish accepted assessment drafts to this client's live Programs & Goals?",
+                            );
+                            if (!confirmed) {
+                              return;
+                            }
+                          }
+                          promoteAssessment.mutate();
+                        }}
+                        disabled={Boolean(promoteDisabledReason) || promoteAssessment.isLoading}
+                        className="rounded-md bg-emerald-700 px-3 py-2 text-xs font-semibold text-white hover:bg-emerald-800 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {promoteAssessment.isLoading ? "Publishing..." : "Publish to Live Programs + Goals"}
+                      </button>
+                    </div>
+                  </div>
                 )}
               </div>
             )}

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -630,7 +630,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   ).length;
   const pendingDraftProgramCount = (assessmentDrafts?.programs ?? []).filter((program) => program.accept_state === "pending").length;
   const pendingDraftGoalCount = (assessmentDrafts?.goals ?? []).filter((goal) => goal.accept_state === "pending").length;
-  const showDraftReviewPanel = ENABLE_PROGRAMS_GOALS_AI_PROPOSALS || selectedAssessmentIsIehp;
+  const showDraftReviewPanel = (ENABLE_PROGRAMS_GOALS_AI_PROPOSALS || selectedAssessmentIsIehp) && !selectedAssessmentAlreadyPublished;
   const extractedChecklistValueCount = checklistItems.filter((item) => item.value_text?.trim()).length;
   const structuredChildGoalCount = structuredSections.filter(isStructuredChildGoalSection).length;
   const structuredParentGoalCount = structuredSections.filter(isStructuredParentGoalSection).length;

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -3856,6 +3856,72 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     confirmSpy.mockRestore();
   });
 
+  it("does not render IEHP draft editors for already published assessments", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "iehp_fba",
+              file_name: "synthetic-published-iehp.docx",
+              mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/synthetic-published-iehp.docx",
+              status: "approved",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(JSON.stringify({ items: [], structured_sections: [] }), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [{ id: "p1", name: "Program A", description: null, accept_state: "accepted", review_notes: null }],
+            goals: [
+              {
+                id: "g1",
+                title: "Goal A",
+                description: "Goal description",
+                original_text: "Original wording",
+                goal_type: "child",
+                accept_state: "accepted",
+                review_notes: null,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findByText("synthetic-published-iehp.docx")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Save Program Draft/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Save Goal Draft/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Draft Review (Approve / Reject / Edit)")).not.toBeInTheDocument();
+  });
+
   it("shows add-goal prerequisites when create goal is disabled", async () => {
     renderWithProviders(
       <ProgramsGoalsTab client={buildClient()} />,

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -3666,6 +3666,196 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(screen.queryByText("Accepted draft goals: 2 child / 1 parent")).not.toBeInTheDocument();
   });
 
+  it("shows IEHP publish controls with explicit blockers when required rows remain unresolved", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "iehp_fba",
+              file_name: "synthetic-iehp.docx",
+              mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/synthetic-iehp.docx",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "required-row-1",
+                section_key: "recommendations",
+                label: "Recommendation",
+                placeholder_key: "IEHP_FBA_RECOMMENDATION",
+                required: true,
+                mode: "ASSISTED",
+                status: "drafted",
+                review_notes: null,
+                value_text: "Synthetic recommendation",
+              },
+            ],
+            structured_sections: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [{ id: "p1", name: "Program A", description: null, accept_state: "accepted", review_notes: null }],
+            goals: [
+              {
+                id: "g1",
+                title: "Goal A",
+                description: "Goal description",
+                original_text: "Original wording",
+                goal_type: "child",
+                accept_state: "accepted",
+                review_notes: null,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("synthetic-iehp.docx");
+    const publishButton = await screen.findByRole("button", { name: /Publish to Live Programs \+ Goals/i });
+    expect(publishButton).toBeDisabled();
+    expect(screen.getByText("1 required checklist or structured row must be approved before publishing.")).toBeInTheDocument();
+  });
+
+  it("publishes accepted IEHP drafts through the promotion API", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "iehp_fba",
+              file_name: "synthetic-iehp.docx",
+              mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/synthetic-iehp.docx",
+              status: "drafted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "required-row-1",
+                section_key: "recommendations",
+                label: "Recommendation",
+                placeholder_key: "IEHP_FBA_RECOMMENDATION",
+                required: true,
+                mode: "ASSISTED",
+                status: "approved",
+                review_notes: null,
+                value_text: "Synthetic recommendation",
+              },
+            ],
+            structured_sections: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(
+          JSON.stringify({
+            programs: [{ id: "p1", name: "Program A", description: null, accept_state: "accepted", review_notes: null }],
+            goals: [
+              {
+                id: "g1",
+                title: "Goal A",
+                description: "Goal description",
+                original_text: "Original wording",
+                goal_type: "child",
+                accept_state: "accepted",
+                review_notes: null,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "POST" && path === "/api/assessment-promote") {
+        return new Response(
+          JSON.stringify({
+            created_program_count: 1,
+            created_goal_count: 1,
+            promoted_program_count: 1,
+            promoted_goal_count: 1,
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("synthetic-iehp.docx");
+    const publishButton = await screen.findByRole("button", { name: /Publish to Live Programs \+ Goals/i });
+    expect(publishButton).toBeEnabled();
+    await user.click(publishButton);
+
+    await waitFor(() => {
+      expect(callApi).toHaveBeenCalledWith(
+        "/api/assessment-promote",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ assessment_document_id: ASSESSMENT_ID }),
+        }),
+      );
+    });
+    expect(showSuccess).toHaveBeenCalledWith("Published to live records. Created 1 production program and 1 goal.");
+    confirmSpy.mockRestore();
+  });
+
   it("shows add-goal prerequisites when create goal is disabled", async () => {
     renderWithProviders(
       <ProgramsGoalsTab client={buildClient()} />,

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -1192,6 +1192,126 @@ describe("assessmentDraftsHandler", () => {
     );
   });
 
+  it("blocks draft program updates when the parent assessment is already approved", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "draft-program-1",
+            assessment_document_id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            accept_state: "accepted",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "approved" }],
+      });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          draft_type: "program",
+          id: "11111111-1111-1111-1111-111111111111",
+          accept_state: "edited",
+          name: "Mutated Program",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Published assessment drafts are retained for audit and cannot be edited.",
+    });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_draft_programs?id=eq.draft-program-1"),
+      expect.objectContaining({ method: "PATCH" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_review_events"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("blocks draft goal updates when the parent assessment is already promoted", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "draft-goal-1",
+            assessment_document_id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            accept_state: "accepted",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "promoted" }],
+      });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          draft_type: "goal",
+          id: "11111111-1111-1111-1111-111111111111",
+          accept_state: "edited",
+          title: "Mutated Goal",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Published assessment drafts are retained for audit and cannot be edited.",
+    });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_draft_goals?id=eq.draft-goal-1"),
+      expect.objectContaining({ method: "PATCH" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_review_events"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("returns empty drafts when requested assessment is no longer in scope", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -100,6 +100,7 @@ interface AssessmentDocumentScopeRow {
 }
 
 const AUTO_GENERATE_READY_DOCUMENT_STATUSES = new Set(["extracted", "extraction_failed"]);
+const IMMUTABLE_DRAFT_ASSESSMENT_STATUSES = new Set(["approved", "promoted"]);
 const DRAFT_GOAL_FIELD_KEYS = new Set([
   "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
   "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
@@ -136,6 +137,28 @@ interface AssessmentDraftGoalRow {
   client_id: string;
   accept_state: "pending" | "accepted" | "rejected" | "edited";
 }
+
+const assertDraftAssessmentIsMutable = async (args: {
+  supabaseUrl: string;
+  headers: HeadersInit;
+  organizationId: string;
+  assessmentDocumentId: string;
+}): Promise<{ ok: true } | { ok: false; status: number; error: string }> => {
+  const lookup = await fetchJson<AssessmentDocumentScopeRow[]>(
+    `${args.supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status&id=eq.${encodeURIComponent(
+      args.assessmentDocumentId,
+    )}&organization_id=eq.${encodeURIComponent(args.organizationId)}&limit=1`,
+    { method: "GET", headers: args.headers },
+  );
+  const document = Array.isArray(lookup.data) ? lookup.data[0] : null;
+  if (!lookup.ok || !document) {
+    return { ok: false, status: lookup.status || 404, error: "Assessment document not found in organization scope" };
+  }
+  if (IMMUTABLE_DRAFT_ASSESSMENT_STATUSES.has(document.status)) {
+    return { ok: false, status: 409, error: "Published assessment drafts are retained for audit and cannot be edited." };
+  }
+  return { ok: true };
+};
 
 export interface GeneratedDraftPayload {
   programs: Array<{
@@ -745,6 +768,15 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
       if (!lookup.ok || !existing) {
         return json({ error: "Draft program not found in organization scope" }, 404);
       }
+      const mutableAssessment = await assertDraftAssessmentIsMutable({
+        supabaseUrl,
+        headers,
+        organizationId,
+        assessmentDocumentId: existing.assessment_document_id,
+      });
+      if (!mutableAssessment.ok) {
+        return json({ error: mutableAssessment.error }, mutableAssessment.status);
+      }
 
       const updatePayload: Record<string, unknown> = {
         updated_at: now,
@@ -814,6 +846,15 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
     const existing = Array.isArray(lookup.data) ? lookup.data[0] : null;
     if (!lookup.ok || !existing) {
       return json({ error: "Draft goal not found in organization scope" }, 404);
+    }
+    const mutableAssessment = await assertDraftAssessmentIsMutable({
+      supabaseUrl,
+      headers,
+      organizationId,
+      assessmentDocumentId: existing.assessment_document_id,
+    });
+    if (!mutableAssessment.ok) {
+      return json({ error: mutableAssessment.error }, mutableAssessment.status);
     }
 
     const updatePayload: Record<string, unknown> = {


### PR DESCRIPTION
## Summary
- Exposes the draft review panel for unpublished IEHP assessments even while the legacy AI proposals flag remains disabled.
- Adds a template-aware publish control that calls the existing `/api/assessment-promote` endpoint and invalidates assessment/live program queries after success.
- Shows explicit blockers for unresolved required checklist/structured rows and missing accepted draft programs/goals.
- Guards published assessment audit rows: approved/promoted parent assessments no longer render IEHP draft editors, and `/api/assessment-drafts` PATCH rejects retained draft mutations server-side.

## Verification
- `npx vitest run src/server/__tests__/assessmentDraftsHandler.test.ts` passed: 18 tests.
- `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx` passed: 55 tests.
- `npm run ci:check-focused` passed.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run validate:tenant` passed.
- `npm run test:ci` passed: 310 files, 1787 tests.
- `npm run build` passed.
- Prior route gate on this branch: `npm run test:routes:tier0` passed: 78 Cypress route tests.

## Hosted State Note
The latest hosted IEHP assessment checked during triage is still not promotion-ready: required rows and staged drafts remain incomplete. This PR makes the review/publish controls reachable for unpublished IEHP assessments and preserves retained draft rows as immutable after approval/promotion.

Linear: WIN-167