### PR TITLE
WIN-168 Disable IEHP AI draft flow

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -630,7 +630,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   ).length;
   const pendingDraftProgramCount = (assessmentDrafts?.programs ?? []).filter((program) => program.accept_state === "pending").length;
   const pendingDraftGoalCount = (assessmentDrafts?.goals ?? []).filter((goal) => goal.accept_state === "pending").length;
-  const showDraftReviewPanel = (ENABLE_PROGRAMS_GOALS_AI_PROPOSALS || selectedAssessmentIsIehp) && !selectedAssessmentAlreadyPublished;
+  const showDraftReviewPanel = ENABLE_PROGRAMS_GOALS_AI_PROPOSALS && !selectedAssessmentAlreadyPublished;
   const extractedChecklistValueCount = checklistItems.filter((item) => item.value_text?.trim()).length;
   const structuredChildGoalCount = structuredSections.filter(isStructuredChildGoalSection).length;
   const structuredParentGoalCount = structuredSections.filter(isStructuredParentGoalSection).length;

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -3666,7 +3666,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(screen.queryByText("Accepted draft goals: 2 child / 1 parent")).not.toBeInTheDocument();
   });
 
-  it("shows IEHP publish controls with explicit blockers when required rows remain unresolved", async () => {
+  it("does not show IEHP publish controls when required rows remain unresolved", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -3744,12 +3744,11 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
 
     await screen.findByText("synthetic-iehp.docx");
-    const publishButton = await screen.findByRole("button", { name: /Publish to Live Programs \+ Goals/i });
-    expect(publishButton).toBeDisabled();
-    expect(screen.getByText("1 required checklist or structured row must be approved before publishing.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("1 required checklist or structured row must be approved before publishing.")).not.toBeInTheDocument();
   });
 
-  it("publishes accepted IEHP drafts through the promotion API", async () => {
+  it("does not promote IEHP drafts through the live Programs and Goals API", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -3815,20 +3814,8 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
           { status: 200 },
         );
       }
-      if (method === "POST" && path === "/api/assessment-promote") {
-        return new Response(
-          JSON.stringify({
-            created_program_count: 1,
-            created_goal_count: 1,
-            promoted_program_count: 1,
-            promoted_goal_count: 1,
-          }),
-          { status: 200 },
-        );
-      }
       return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
 
     renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
       auth: {
@@ -3839,21 +3826,11 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
 
     await screen.findByText("synthetic-iehp.docx");
-    const publishButton = await screen.findByRole("button", { name: /Publish to Live Programs \+ Goals/i });
-    expect(publishButton).toBeEnabled();
-    await user.click(publishButton);
-
-    await waitFor(() => {
-      expect(callApi).toHaveBeenCalledWith(
-        "/api/assessment-promote",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({ assessment_document_id: ASSESSMENT_ID }),
-        }),
-      );
-    });
-    expect(showSuccess).toHaveBeenCalledWith("Published to live records. Created 1 production program and 1 goal.");
-    confirmSpy.mockRestore();
+    expect(screen.queryByRole("button", { name: /Publish to Live Programs \+ Goals/i })).not.toBeInTheDocument();
+    expect(callApi).not.toHaveBeenCalledWith(
+      "/api/assessment-promote",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
   it("does not render IEHP draft editors for already published assessments", async () => {

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -2927,6 +2927,24 @@ describe("assessmentDocumentsHandler", () => {
     expect(structuredBody).toContain("The behaviors and functional skills to be addressed");
     expect(structuredBody).toContain("Arlington High School");
     expect(structuredBody).not.toContain("Kim presents with communication deficits");
+
+    const draftWriteCalls = vi.mocked(fetchJson).mock.calls.filter(([url, init]) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (typeof url !== "string" || method !== "POST") return false;
+      return url.includes("/rest/v1/assessment_draft_programs") || url.includes("/rest/v1/assessment_draft_goals");
+    });
+    expect(draftWriteCalls).toHaveLength(0);
+    const extractedStatusPatchCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      const body = typeof init?.body === "string" ? init.body : "";
+      return (
+        typeof url === "string" &&
+        method === "PATCH" &&
+        url.includes("/rest/v1/assessment_documents?id=eq.doc-iehp-reason") &&
+        body.includes("\"status\":\"extracted\"")
+      );
+    });
+    expect(extractedStatusPatchCall).toBeDefined();
   });
 
   it("records extraction_failed audit event when extraction API returns non-ok", async () => {

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -388,7 +388,7 @@ describe("assessmentDraftsHandler", () => {
     expect(liveGoalWrite).toBeUndefined();
   });
 
-  it("auto-generates deterministic drafts from IEHP structured goal sections with child semantics", async () => {
+  it("blocks IEHP deterministic draft auto-generation at the drafts API", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -402,71 +402,14 @@ describe("assessmentDraftsHandler", () => {
       anonKey: "anon",
     });
 
-    const structuredGoals = [
-      {
-        id: "iehp-structured-child-1",
-        section_key: "treatment_goals",
-        field_key: "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
-        section_index: 0,
-        payload: {
-          title: "IEHP Target behavior",
-          raw_text: "IEHP intervention block with measurable criteria.",
-          goal_type: "child",
-          program_name: "Behavior Treatment",
-        },
-        status: "approved" as const,
-        required: true,
-      },
-      {
-        id: "iehp-structured-child-2",
-        section_key: "treatment_goals",
-        field_key: "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
-        section_index: 1,
-        payload: {
-          title: "IEHP Skill goal",
-          raw_text: "IEHP school/skill block with measurable criteria.",
-          goal_type: "child",
-          program_name: "Skill Acquisition",
-        },
-        status: "approved" as const,
-        required: true,
-      },
-    ];
-
     vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
       if (method === "GET" && url.includes("/rest/v1/assessment_documents?")) {
         return {
           ok: true,
           status: 200,
-          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
+          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted", template_type: "iehp_fba" }],
         };
-      }
-      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?select=id")) {
-        return { ok: true, status: 200, data: [] };
-      }
-      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?select=id")) {
-        return { ok: true, status: 200, data: [] };
-      }
-      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?")) {
-        return { ok: true, status: 200, data: structuredGoals };
-      }
-      if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
-        const body = JSON.parse(String(init?.body)) as Array<{ name: string }>;
-        return {
-          ok: true,
-          status: 201,
-          data: body.map((goal) => ({ id: `draft-program-${goal.name}`, name: goal.name })),
-        };
-      }
-      if (method === "POST" && url.includes("/rest/v1/assessment_draft_goals")) {
-        return { ok: true, status: 201, data: null };
-      }
-      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents")) {
-        return { ok: true, status: 200, data: null };
-      }
-      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
-        return { ok: true, status: 201, data: null };
       }
       return { ok: true, status: 200, data: null };
     });
@@ -479,20 +422,22 @@ describe("assessmentDraftsHandler", () => {
       }),
     );
 
-    expect(response.status).toBe(201);
-    const goalCreateCall = vi
-      .mocked(fetchJson)
-      .mock.calls.find(
-        ([path, init]) =>
-          typeof path === "string" &&
-          path.includes("/rest/v1/assessment_draft_goals") &&
-          (init?.method ?? "").toUpperCase() === "POST",
-      );
-    expect(goalCreateCall).toBeTruthy();
-    const goalPayload = JSON.parse((goalCreateCall?.[1] as RequestInit).body as string) as Array<Record<string, unknown>>;
-    expect(goalPayload).toHaveLength(2);
-    expect(goalPayload.every((goal) => goal.goal_type === "child")).toBe(true);
-    expect(goalPayload.map((goal) => goal.program_name)).toEqual(["Behavior Treatment", "Skill Acquisition"]);
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "IEHP assessments use structured review data for document generation; draft auto-generation is disabled.",
+    });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_structured_sections"),
+      expect.anything(),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_draft_programs"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_draft_goals"),
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
   it("deterministically persists every approved structured program and goal beyond the legacy caps", async () => {

--- a/src/server/__tests__/assessmentPlanPdfHandler.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfHandler.test.ts
@@ -562,6 +562,10 @@ describe("assessmentPlanPdfHandler", () => {
     expect(buildIehpDocxPayload).toHaveBeenCalledWith(
       expect.objectContaining({
         authorizationMemberId: "AUTH-MEMBER-999",
+        acceptedPrograms: [],
+        acceptedGoals: [],
+        pendingDraftProgramCount: 0,
+        pendingDraftGoalCount: 0,
       }),
     );
     expect(fetchJson).toHaveBeenLastCalledWith(
@@ -649,6 +653,10 @@ describe("assessmentPlanPdfHandler", () => {
     expect(buildIehpDocxPayload).toHaveBeenCalledWith(
       expect.objectContaining({
         authorizationMemberId: "OTHER-MEMBER-222",
+        acceptedPrograms: [],
+        acceptedGoals: [],
+        pendingDraftProgramCount: 0,
+        pendingDraftGoalCount: 0,
       }),
     );
   });

--- a/src/server/__tests__/iehpAssessmentDocx.test.ts
+++ b/src/server/__tests__/iehpAssessmentDocx.test.ts
@@ -156,7 +156,7 @@ describe("buildIehpDocxPayload", () => {
     );
   });
 
-  it("blocks pending draft goals and missing required output values", () => {
+  it("ignores staged draft review state and blocks only unresolved required output values", () => {
     const result = buildIehpDocxPayload({
       ...baseArgs,
       client: {
@@ -169,8 +169,8 @@ describe("buildIehpDocxPayload", () => {
     });
 
     expect(result.preflight.ready).toBe(false);
-    expect(result.preflight.blockers).toContainEqual(expect.objectContaining({ code: "pending_draft_goals", count: 2 }));
-    expect(result.preflight.blockers).toContainEqual(expect.objectContaining({ code: "missing_parent_goal" }));
+    expect(result.preflight.blockers).not.toContainEqual(expect.objectContaining({ code: "pending_draft_goals" }));
+    expect(result.preflight.blockers).not.toContainEqual(expect.objectContaining({ code: "missing_parent_goal" }));
     expect(result.preflight.blockers).toContainEqual(
       expect.objectContaining({ code: "missing_required_output", key: "IEHP_FBA_LANGUAGE" }),
     );

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -814,18 +814,21 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
         assertFetchOk(structuredInsertResult, "structured_section_persistence_failed");
       }
 
-      const deterministicDraftPayload = buildDeterministicDraftPayload(
-        structuredSections.map((section) => ({
-          id: `${createdDocumentId}:${section.field_key}:${section.section_index}`,
-          section_key: section.section_key,
-          field_key: section.field_key,
-          section_index: section.section_index,
-          payload: section.payload,
-          status: section.status,
-          required: section.required,
-        })),
-        AUTO_DRAFT_STRUCTURED_SECTION_STATUSES,
-      );
+      const deterministicDraftPayload =
+        templateType === "iehp_fba"
+          ? null
+          : buildDeterministicDraftPayload(
+              structuredSections.map((section) => ({
+                id: `${createdDocumentId}:${section.field_key}:${section.section_index}`,
+                section_key: section.section_key,
+                field_key: section.field_key,
+                section_index: section.section_index,
+                payload: section.payload,
+                status: section.status,
+                required: section.required,
+              })),
+              AUTO_DRAFT_STRUCTURED_SECTION_STATUSES,
+            );
       let finalStatus: "extracted" | "drafted" = "extracted";
       const extractionCompletedAt = new Date().toISOString();
 

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -97,6 +97,7 @@ interface AssessmentDocumentScopeRow {
   organization_id: string;
   client_id: string;
   status: string;
+  template_type?: string | null;
 }
 
 const AUTO_GENERATE_READY_DOCUMENT_STATUSES = new Set(["extracted", "extraction_failed"]);
@@ -105,20 +106,12 @@ const DRAFT_GOAL_FIELD_KEYS = new Set([
   "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
   "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
   "CALOPTIMA_FBA_PARENT_GOALS",
-  "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
-  "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
 ]);
 const DRAFT_PARENT_GOAL_FIELD_KEYS = new Set([
   "CALOPTIMA_FBA_PARENT_GOALS",
 ]);
 
 const resolveProgramNameFromGoalSection = (fieldKey: string, payload: Record<string, unknown>, isParentGoal: boolean): string => {
-  if (fieldKey === "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS") {
-    return getPayloadString(payload, ["program_name", "program", "domain"], "Skill Acquisition");
-  }
-  if (fieldKey === "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS") {
-    return getPayloadString(payload, ["program_name", "program", "domain"], "Behavior Treatment");
-  }
   return getPayloadString(payload, ["program_name", "program", "domain"], isParentGoal ? "Parent Training" : "Behavior Treatment");
 };
 
@@ -366,7 +359,7 @@ const getAssessmentDocument = async (
   organizationId: string,
   assessmentDocumentId: string,
 ): Promise<AssessmentDocumentScopeRow | null> => {
-  const lookupUrl = `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status&id=eq.${encodeURIComponent(
+  const lookupUrl = `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type&id=eq.${encodeURIComponent(
     assessmentDocumentId,
   )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`;
   const lookup = await fetchJson<AssessmentDocumentScopeRow[]>(lookupUrl, { method: "GET", headers });
@@ -693,6 +686,10 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
         return json({ error: result.error }, result.status);
       }
       return json({ draft_program_id: result.draftProgramId }, 201);
+    }
+
+    if (document.template_type === "iehp_fba") {
+      return json({ error: "IEHP assessments use structured review data for document generation; draft auto-generation is disabled." }, 409);
     }
 
     const hasExistingDrafts = await draftsAlreadyExistForDocument({

--- a/src/server/api/assessment-plan-pdf.ts
+++ b/src/server/api/assessment-plan-pdf.ts
@@ -335,15 +335,6 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
       activeAuthorizations[0]?.member_id?.trim() ??
       null;
 
-    const acceptedPrograms = (draftProgramsResult.data ?? []).filter(
-      (program) => program.accept_state === "accepted" || program.accept_state === "edited",
-    );
-    const acceptedGoals = (draftGoalsResult.data ?? []).filter(
-      (goal) => goal.accept_state === "accepted" || goal.accept_state === "edited",
-    );
-    const pendingDraftProgramCount = (draftProgramsResult.data ?? []).filter((program) => program.accept_state === "pending").length;
-    const pendingDraftGoalCount = (draftGoalsResult.data ?? []).filter((goal) => goal.accept_state === "pending").length;
-
     const payloadResult = buildIehpDocxPayload({
       templateFields: templateFieldsResult.data ?? [],
       checklistItems,
@@ -351,10 +342,10 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
       client,
       authorizationMemberId,
       writer,
-      acceptedPrograms,
-      acceptedGoals,
-      pendingDraftProgramCount,
-      pendingDraftGoalCount,
+      acceptedPrograms: [],
+      acceptedGoals: [],
+      pendingDraftProgramCount: 0,
+      pendingDraftGoalCount: 0,
     });
 
     const generationSecret = process.env.ASSESSMENT_GENERATION_SECRET?.trim();

--- a/src/server/iehpAssessmentDocx.ts
+++ b/src/server/iehpAssessmentDocx.ts
@@ -247,28 +247,6 @@ export function buildIehpDocxPayload(args: BuildIehpDocxPayloadArgs): BuiltIehpD
       });
     });
 
-  if ((args.pendingDraftProgramCount ?? 0) > 0) {
-    blockers.push({
-      code: "pending_draft_programs",
-      count: args.pendingDraftProgramCount,
-      message: "Draft programs are still pending review.",
-    });
-  }
-  if ((args.pendingDraftGoalCount ?? 0) > 0) {
-    blockers.push({
-      code: "pending_draft_goals",
-      count: args.pendingDraftGoalCount,
-      message: "Draft goals are still pending review.",
-    });
-  }
-
-  if (!args.acceptedGoals.some((goal) => goal.goal_type !== "parent")) {
-    blockers.push({ code: "missing_child_goal", message: "At least one accepted or edited child goal is required." });
-  }
-  if (!args.acceptedGoals.some((goal) => goal.goal_type === "parent")) {
-    blockers.push({ code: "missing_parent_goal", message: "At least one accepted or edited parent goal is required." });
-  }
-
   (args.structuredSections ?? [])
     .filter((section) => section.field_key === "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES" && hasManualReviewAdaptiveGap(section.payload))
     .forEach((section) => {


### PR DESCRIPTION
## Summary
- Disable IEHP-specific exposure of the draft Programs & Goals review/publish panel while the global AI proposal flag is off.
- Keep new IEHP extraction as structured review/data transfer only: IEHP uploads no longer auto-persist deterministic draft programs/goals.
- Generate IEHP DOCX payloads from approved checklist/structured review data only; staged draft programs/goals are ignored for IEHP preflight and mapping.

## Route
- classification: high-risk human-reviewed
- lane: critical
- issue: WIN-168
- reason: touches protected `src/server/**` assessment generation/extraction paths plus Programs & Goals UI behavior.

## Verification Card
- required checks: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run validate:tenant`, `npm run build`, `npm run verify:local`, targeted Vitest for IEHP DOCX payload, assessment-plan-pdf handler, assessment-documents handler, and ProgramsGoalsTab.
- executed checks: pass
- targeted: `npx vitest run src/server/__tests__/iehpAssessmentDocx.test.ts --reporter=verbose`; `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx --reporter=verbose`; `npx vitest run src/server/__tests__/assessmentPlanPdfHandler.test.ts --reporter=verbose`; `npx vitest run src/server/__tests__/assessmentDocumentsHandler.test.ts --reporter=verbose`.
- full: `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run validate:tenant`; `npm run build`; `npm run verify:local`.
- blocked checks: none.
- result: pass.

## Residual Risk
- Legacy IEHP rows may still have retained draft records from earlier uploads, but this change stops new IEHP deterministic draft persistence and stops current IEHP DOCX generation/UI from depending on those drafts.
- CalOptima draft/publish behavior is intentionally preserved.