### PR TITLE
WIN-168 Reject IEHP draft mutations

### DIFF
--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -21,6 +21,9 @@ import {
   resolveOrgAndRole,
 } from "../api/shared";
 
+const IEHP_DRAFTS_DISABLED_ERROR =
+  "IEHP assessments use structured review data for document generation; draft creation and editing are disabled.";
+
 const buildTypedGoals = (
   counts: { childCount?: number; parentCount?: number; programName?: string } = {},
 ): Array<Record<string, unknown>> => [
@@ -265,6 +268,59 @@ describe("assessmentDraftsHandler", () => {
     expect(response.status).toBe(201);
   });
 
+  it("blocks IEHP manual draft creation at the drafts API", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted", template_type: "iehp_fba" }],
+    });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-1111-1111-111111111111",
+          programs: [
+            {
+              name: "Communication Program",
+              description: "Program description",
+              rationale: "Program rationale",
+              evidence_refs: [{ section_key: "assessment_summary", source_span: "Program evidence snippet" }],
+              review_flags: [],
+            },
+          ],
+          summary_rationale: "Summary rationale",
+          confidence: "medium",
+          goals: buildTypedGoals({ childCount: 2, parentCount: 1 }),
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: IEHP_DRAFTS_DISABLED_ERROR });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_draft_programs"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_draft_goals"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("deterministically creates staged drafts from approved structured sections", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
@@ -423,9 +479,7 @@ describe("assessmentDraftsHandler", () => {
     );
 
     expect(response.status).toBe(409);
-    await expect(response.json()).resolves.toEqual({
-      error: "IEHP assessments use structured review data for document generation; draft auto-generation is disabled.",
-    });
+    await expect(response.json()).resolves.toEqual({ error: IEHP_DRAFTS_DISABLED_ERROR });
     expect(fetchJson).not.toHaveBeenCalledWith(
       expect.stringContaining("/rest/v1/assessment_structured_sections"),
       expect.anything(),
@@ -1249,6 +1303,64 @@ describe("assessmentDraftsHandler", () => {
     });
     expect(fetchJson).not.toHaveBeenCalledWith(
       expect.stringContaining("/rest/v1/assessment_draft_goals?id=eq.draft-goal-1"),
+      expect.objectContaining({ method: "PATCH" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_review_events"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("blocks retained IEHP draft updates even when the parent assessment is not published", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "draft-program-1",
+            assessment_document_id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            accept_state: "pending",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted", template_type: "iehp_fba" }],
+      });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          draft_type: "program",
+          id: "11111111-1111-1111-1111-111111111111",
+          accept_state: "edited",
+          name: "Mutated IEHP Program",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: IEHP_DRAFTS_DISABLED_ERROR });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_draft_programs?id=eq.draft-program-1"),
       expect.objectContaining({ method: "PATCH" }),
     );
     expect(fetchJson).not.toHaveBeenCalledWith(

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -102,6 +102,7 @@ interface AssessmentDocumentScopeRow {
 
 const AUTO_GENERATE_READY_DOCUMENT_STATUSES = new Set(["extracted", "extraction_failed"]);
 const IMMUTABLE_DRAFT_ASSESSMENT_STATUSES = new Set(["approved", "promoted"]);
+const IEHP_DRAFTS_DISABLED_ERROR = "IEHP assessments use structured review data for document generation; draft creation and editing are disabled.";
 const DRAFT_GOAL_FIELD_KEYS = new Set([
   "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
   "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
@@ -138,7 +139,7 @@ const assertDraftAssessmentIsMutable = async (args: {
   assessmentDocumentId: string;
 }): Promise<{ ok: true } | { ok: false; status: number; error: string }> => {
   const lookup = await fetchJson<AssessmentDocumentScopeRow[]>(
-    `${args.supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status&id=eq.${encodeURIComponent(
+    `${args.supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type&id=eq.${encodeURIComponent(
       args.assessmentDocumentId,
     )}&organization_id=eq.${encodeURIComponent(args.organizationId)}&limit=1`,
     { method: "GET", headers: args.headers },
@@ -149,6 +150,9 @@ const assertDraftAssessmentIsMutable = async (args: {
   }
   if (IMMUTABLE_DRAFT_ASSESSMENT_STATUSES.has(document.status)) {
     return { ok: false, status: 409, error: "Published assessment drafts are retained for audit and cannot be edited." };
+  }
+  if (document.template_type === "iehp_fba") {
+    return { ok: false, status: 409, error: IEHP_DRAFTS_DISABLED_ERROR };
   }
   return { ok: true };
 };
@@ -665,6 +669,9 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
     if (!document) {
       return json({ error: "assessment_document_id is not in scope for this organization" }, 403);
     }
+    if (document.template_type === "iehp_fba") {
+      return json({ error: IEHP_DRAFTS_DISABLED_ERROR }, 409);
+    }
 
     const actorId = getAccessTokenSubject(accessToken);
     if (parsedManual.success) {
@@ -686,10 +693,6 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
         return json({ error: result.error }, result.status);
       }
       return json({ draft_program_id: result.draftProgramId }, 201);
-    }
-
-    if (document.template_type === "iehp_fba") {
-      return json({ error: "IEHP assessments use structured review data for document generation; draft auto-generation is disabled." }, 409);
     }
 
     const hasExistingDrafts = await draftsAlreadyExistForDocument({


### PR DESCRIPTION
## Summary
- Reject all IEHP draft mutations at `/api/assessment-drafts`, not just deterministic `auto_generate`.
- Block IEHP manual draft creation immediately after org-scoped document lookup, before any draft table writes.
- Block retained IEHP draft edits through the shared parent-assessment mutability check.
- Add focused regression coverage for IEHP manual create rejection and retained draft update rejection.

## Route / Risk
- classification: high-risk human-reviewed
- lane: critical
- issue: WIN-168
- protected paths: `src/server/**`

## Verification
- `npx vitest run src/server/__tests__/assessmentDraftsHandler.test.ts --reporter=verbose` passed, 20 tests.
- `npm run ci:check-focused` passed locally with expected local skips.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run validate:tenant` passed.
- `npm run build` passed.
- `npx vitest run src/pages/__tests__/Schedule.test.tsx --reporter=verbose` passed, 14 tests.
- `npm run test:ci` was run twice before isolating this branch and failed both times on the same unrelated Schedule timeout: `src/pages/__tests__/Schedule.test.tsx > previews and applies the visible week with the displayed week payload`. The Schedule file passed in isolation.

## Residual Risk
- Full local `test:ci` did not produce a clean pass due to the unrelated Schedule timeout noted above; CI should provide full-suite confirmation for this focused PR.
- Critical protected-path change still requires human review before merge.