### PR TITLE
WIN-169 Add IEHP browser import smoke

### DIFF
--- a/docs/ai/WIN-169-iehp-browser-import-smoke-handoff.md
+++ b/docs/ai/WIN-169-iehp-browser-import-smoke-handoff.md
@@ -1,0 +1,30 @@
+# WIN-169 IEHP Browser Import Smoke Handoff
+
+## Scope
+
+- Added an on-demand IEHP browser import smoke that selects the IEHP FBA upload template in the UI, uploads an explicitly configured IEHP DOCX fixture, waits for extraction, asserts zero draft programs/goals, captures a screenshot, and auto-cleans created assessment artifacts.
+- Added helper coverage for safe sample-file resolution, synthetic upload naming, redacted cleanup manifests, and existing assessment-import cleanup behavior.
+- Kept the smoke out of GitHub Actions workflows for this slice.
+
+## Route Classification
+
+- classification: low-risk autonomous
+- lane: standard
+- triggering paths: `scripts/**`, `tests/**`, `package.json`, `docs/ai/**`
+- protected paths touched: none
+
+## Verification Card
+
+- `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts tests/scripts/assessment-import-cleanup.test.ts` -> pass
+- `npm run playwright:iehp-assessment-import-smoke` with an explicit authorized IEHP sample fixture -> pass; final status `extracted`, draft programs `0`, draft goals `0`
+- `npm run ci:check-focused` -> pass; DB-backed checks skipped locally because database URLs were not configured
+- `npm run lint` -> pass
+- `npm run typecheck` -> pass
+- `npm run build` -> pass
+- `npm run verify:local` -> pass
+
+## Residual Risk
+
+- The IEHP smoke remains on-demand and credentialed; it is not part of CI.
+- The smoke requires `PW_ASSESSMENT_SAMPLE_FILE` unless a root sample filename is clearly marked redacted, synthetic, smoke, or test.
+- If cleanup fails after a hosted write, the local manifest is intentionally redacted; manual cleanup may require rerunning with terminal context or inspecting hosted smoke records.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "playwright:therapist-authorization": "tsx scripts/playwright-therapist-authorization.ts",
     "playwright:authorizations-read-scope": "tsx scripts/playwright-authorizations-read-scope-smoke.ts",
     "playwright:assessment-import-smoke": "tsx scripts/playwright-assessment-import-smoke.ts",
+    "playwright:iehp-assessment-import-smoke": "tsx scripts/playwright-iehp-assessment-import-smoke.ts",
     "playwright:assessment-upload-promote-smoke": "tsx scripts/playwright-assessment-upload-promote-smoke.ts",
     "playwright:assessment-pdf-smoke": "tsx scripts/playwright-assessment-pdf-smoke.ts",
     "playwright:mobile-role-smoke": "tsx scripts/playwright-mobile-role-smoke.ts",

--- a/scripts/lib/iehp-assessment-import-smoke.ts
+++ b/scripts/lib/iehp-assessment-import-smoke.ts
@@ -1,0 +1,79 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+
+type ResolveIehpSmokeSampleFileArgs = {
+  cwd: string;
+  env?: Pick<NodeJS.ProcessEnv, 'PW_ASSESSMENT_SAMPLE_FILE'>;
+  candidateFileNames?: string[];
+};
+
+const isRootIehpFbaSample = (fileName: string): boolean => {
+  const lowerName = fileName.toLowerCase();
+  return (
+    lowerName.endsWith('.docx') &&
+    lowerName.includes('iehp') &&
+    lowerName.includes('fba') &&
+    ['redacted', 'synthetic', 'smoke', 'test'].some((marker) => lowerName.includes(marker)) &&
+    !lowerName.startsWith('updated fba')
+  );
+};
+
+export const resolveIehpSmokeSampleFile = ({
+  cwd,
+  env = process.env,
+  candidateFileNames,
+}: ResolveIehpSmokeSampleFileArgs): string => {
+  const configuredSampleFile = env.PW_ASSESSMENT_SAMPLE_FILE?.trim();
+  if (configuredSampleFile) {
+    return path.resolve(cwd, configuredSampleFile);
+  }
+
+  const rootFileNames =
+    candidateFileNames ??
+    readdirSync(cwd, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name);
+  const matches = rootFileNames.filter(isRootIehpFbaSample);
+
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one safe root IEHP FBA DOCX sample when PW_ASSESSMENT_SAMPLE_FILE is not set; found ${matches.length}. Set PW_ASSESSMENT_SAMPLE_FILE for an explicit smoke fixture.`,
+    );
+  }
+
+  return path.resolve(cwd, matches[0]);
+};
+
+export const buildIehpSmokeUploadFileName = (timestamp = Date.now()): string => `iehp-fba-smoke-${timestamp}.docx`;
+
+export const buildIehpSmokeCleanupFailureManifestPayload = (args: {
+  cleanupError: Error;
+  cleanupTargetKnown: boolean;
+  createdAt?: string;
+  runError?: Error | null;
+}): {
+  createdAt: string;
+  cleanupTargetKnown: boolean;
+  cleanupError: string;
+  runError: string | null;
+} => ({
+  createdAt: args.createdAt ?? new Date().toISOString(),
+  cleanupTargetKnown: args.cleanupTargetKnown,
+  cleanupError: 'Cleanup failed; inspect local terminal context or hosted smoke records for manual cleanup.',
+  runError: args.runError ? 'IEHP smoke run failed before cleanup completed.' : null,
+});
+
+export const buildIehpSmokeCleanupFailureMessage = (args: {
+  cleanupFailed: boolean;
+  cleanupManifestPath?: string | null;
+  cleanupManifestWriteFailed?: boolean;
+  runFailed: boolean;
+}): string => {
+  const base = args.runFailed
+    ? 'IEHP assessment import smoke failed and cleanup did not complete.'
+    : 'IEHP assessment import smoke cleanup did not complete.';
+  const manifest = args.cleanupManifestPath ? ` Cleanup manifest: ${args.cleanupManifestPath}.` : '';
+  const manifestWrite = args.cleanupManifestWriteFailed ? ' Cleanup manifest write failed.' : '';
+  const cleanup = args.cleanupFailed ? ' Manual cleanup may be required.' : '';
+  return `${base}${cleanup}${manifest}${manifestWrite}`;
+};

--- a/scripts/playwright-iehp-assessment-import-smoke.ts
+++ b/scripts/playwright-iehp-assessment-import-smoke.ts
@@ -1,0 +1,310 @@
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { chromium } from 'playwright';
+
+import { cleanupAssessmentImportArtifacts } from './lib/assessment-import-cleanup';
+import {
+  buildIehpSmokeCleanupFailureMessage,
+  buildIehpSmokeCleanupFailureManifestPayload,
+  buildIehpSmokeUploadFileName,
+  resolveIehpSmokeSampleFile,
+} from './lib/iehp-assessment-import-smoke';
+import { loadPlaywrightEnv } from './lib/load-playwright-env';
+import {
+  captureFailureScreenshot,
+  ensureArtifactsDir,
+  loginAndAssertSession,
+  preflightCredentials,
+} from './lib/playwright-smoke';
+
+type AssessmentDocumentRecord = {
+  id: string;
+  file_name: string;
+  bucket_id?: string | null;
+  object_path: string;
+  status: 'uploaded' | 'extracting' | 'extraction_running' | 'extracted' | 'drafted' | 'approved' | 'rejected' | 'extraction_failed';
+  extraction_error?: string | null;
+  template_type?: string | null;
+};
+
+type AssessmentDraftsResponse = {
+  programs?: unknown[];
+  goals?: unknown[];
+};
+
+const DEFAULT_BASE_URL = 'https://app.allincompassing.ai';
+const EXTRACTION_TIMEOUT_MS = 120_000;
+
+const getRequiredEnv = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required for IEHP assessment import smoke.`);
+  }
+  return value;
+};
+
+const resolveSupabaseUrl = (): string => process.env.VITE_SUPABASE_URL?.trim() || getRequiredEnv('SUPABASE_URL');
+const resolveSupabaseAnonKey = (): string =>
+  process.env.VITE_SUPABASE_ANON_KEY?.trim() || getRequiredEnv('SUPABASE_ANON_KEY');
+
+const pause = async (ms: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const writeCleanupFailureManifest = (args: {
+  latestDir: string;
+  cleanupError: Error;
+  cleanupTargetKnown: boolean;
+  runError?: Error | null;
+}): string => {
+  const manifestPath = path.join(args.latestDir, `iehp-assessment-import-cleanup-failure-${Date.now()}.json`);
+  writeFileSync(
+    manifestPath,
+    JSON.stringify(buildIehpSmokeCleanupFailureManifestPayload(args), null, 2),
+  );
+  return manifestPath;
+};
+
+const fetchAssessmentDocuments = async (
+  baseUrl: string,
+  accessToken: string,
+  clientId: string,
+): Promise<AssessmentDocumentRecord[]> => {
+  const response = await fetch(`${baseUrl}/api/assessment-documents?client_id=${encodeURIComponent(clientId)}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Assessment document query failed with status ${response.status}.`);
+  }
+
+  return (await response.json()) as AssessmentDocumentRecord[];
+};
+
+const fetchAssessmentDraftCounts = async (
+  baseUrl: string,
+  accessToken: string,
+  assessmentDocumentId: string,
+): Promise<{ programCount: number; goalCount: number }> => {
+  const response = await fetch(
+    `${baseUrl}/api/assessment-drafts?assessment_document_id=${encodeURIComponent(assessmentDocumentId)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Assessment draft query failed with status ${response.status}.`);
+  }
+
+  const drafts = (await response.json()) as AssessmentDraftsResponse;
+  return {
+    programCount: drafts.programs?.length ?? 0,
+    goalCount: drafts.goals?.length ?? 0,
+  };
+};
+
+const selectConfiguredSmokeClient = async (
+  supabaseUrl: string,
+  supabaseAnonKey: string,
+  email: string,
+  password: string,
+): Promise<{ accessToken: string; clientId: string }> => {
+  const configuredClientId = getRequiredEnv('PW_ASSESSMENT_CLIENT_ID');
+  const supabase = createClient(supabaseUrl, supabaseAnonKey);
+  const { data: authData, error: authError } = await supabase.auth.signInWithPassword({ email, password });
+  if (authError || !authData.session || !authData.user) {
+    throw authError ?? new Error('Could not authenticate IEHP assessment import smoke user.');
+  }
+
+  const { data: client, error } = await supabase.from('clients').select('id').eq('id', configuredClientId).maybeSingle();
+  if (error || !client) {
+    throw error ?? new Error('Configured PW_ASSESSMENT_CLIENT_ID is not accessible.');
+  }
+
+  return {
+    accessToken: authData.session.access_token,
+    clientId: client.id,
+  };
+};
+
+async function run() {
+  loadPlaywrightEnv();
+
+  const baseUrl = (process.env.PW_BASE_URL?.trim() || DEFAULT_BASE_URL).replace(/\/$/, '');
+  const supabaseUrl = resolveSupabaseUrl();
+  const supabaseAnonKey = resolveSupabaseAnonKey();
+  const sampleFilePath = resolveIehpSmokeSampleFile({ cwd: process.cwd() });
+  const sourceFileBuffer = readFileSync(sampleFilePath);
+  const uploadFileName = buildIehpSmokeUploadFileName();
+  const credentials = preflightCredentials([
+    {
+      email: process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL,
+      password: process.env.PW_ADMIN_PASSWORD ?? process.env.PLAYWRIGHT_ADMIN_PASSWORD,
+      label: 'PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD',
+    },
+  ]);
+  const { accessToken, clientId } = await selectConfiguredSmokeClient(
+    supabaseUrl,
+    supabaseAnonKey,
+    credentials.email,
+    credentials.password,
+  );
+
+  const browser = await chromium.launch({ headless: process.env.HEADLESS !== 'false' });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const latestDir = ensureArtifactsDir();
+
+  let createdAssessment: AssessmentDocumentRecord | null = null;
+  let cleanupFailure: Error | null = null;
+  let runFailure: Error | null = null;
+  let cleanupFailureManifestPath: string | null = null;
+  let cleanupFailureManifestError: Error | null = null;
+
+  try {
+    await loginAndAssertSession(page, baseUrl, credentials.email, credentials.password);
+    await page.goto(`${baseUrl}/clients/${clientId}?tab=programs-goals`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+    await page.waitForLoadState('networkidle').catch(() => undefined);
+
+    await page.locator('#programs-goals-fba-template').selectOption('iehp_fba');
+    await page.getByText('IEHP FBA Upload Workflow').waitFor({ timeout: 20_000 });
+    await page.locator('#programs-goals-fba-file-upload').setInputFiles({
+      name: uploadFileName,
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      buffer: sourceFileBuffer,
+    });
+    await page.getByRole('button', { name: /Upload IEHP FBA/i }).click();
+    await page.getByText('Uploading and processing your FBA. This can take a moment.').waitFor({ timeout: 20_000 });
+
+    const deadline = Date.now() + EXTRACTION_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const documents = await fetchAssessmentDocuments(baseUrl, accessToken, clientId);
+      createdAssessment =
+        documents.find((document) => document.file_name === uploadFileName && document.template_type === 'iehp_fba') ??
+        null;
+      if (createdAssessment && !['uploaded', 'extracting', 'extraction_running'].includes(createdAssessment.status)) {
+        break;
+      }
+      await pause(2_000);
+    }
+
+    if (!createdAssessment) {
+      cleanupFailure = new Error('IEHP smoke could not rediscover the uploaded assessment for cleanup.');
+      throw new Error('Uploaded IEHP assessment document was not found in the queue.');
+    }
+    if (createdAssessment.status === 'drafted') {
+      throw new Error('IEHP import smoke unexpectedly created draft records and moved to drafted status.');
+    }
+    if (createdAssessment.status !== 'extracted') {
+      throw new Error(
+        `IEHP import smoke ended with ${createdAssessment.status}${
+          createdAssessment.extraction_error ? `: ${createdAssessment.extraction_error}` : ''
+        }`,
+      );
+    }
+
+    const { programCount, goalCount } = await fetchAssessmentDraftCounts(baseUrl, accessToken, createdAssessment.id);
+    if (programCount !== 0 || goalCount !== 0) {
+      throw new Error(`IEHP import smoke expected zero drafts but found ${programCount} program(s) and ${goalCount} goal(s).`);
+    }
+
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
+    await page.waitForLoadState('networkidle').catch(() => undefined);
+    await page.getByRole('button', { name: new RegExp(uploadFileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') })
+      .first()
+      .waitFor({ timeout: 20_000 });
+
+    const screenshotPath = path.join(latestDir, `iehp-assessment-import-smoke-${Date.now()}.png`);
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          templateType: 'iehp_fba',
+          status: createdAssessment.status,
+          draftPrograms: programCount,
+          draftGoals: goalCount,
+          screenshot: screenshotPath,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    const screenshot = await captureFailureScreenshot(page, 'playwright-iehp-assessment-import-smoke-failure');
+    console.error(`IEHP assessment import smoke failed. Screenshot: ${screenshot}`);
+    runFailure = error instanceof Error ? error : new Error(String(error));
+  } finally {
+    if (createdAssessment) {
+      await cleanupAssessmentImportArtifacts({
+        accessToken,
+        baseUrl,
+        supabaseAnonKey,
+        supabaseUrl,
+        target: {
+          assessmentDocumentId: createdAssessment.id,
+          bucketId: createdAssessment.bucket_id?.trim() || 'client-documents',
+          objectPath: createdAssessment.object_path,
+        },
+      }).catch((cleanupError) => {
+        cleanupFailure = cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError));
+        console.error('IEHP assessment import smoke cleanup failed.');
+      });
+    }
+    await context.close();
+    await browser.close();
+    if (cleanupFailure) {
+      try {
+        cleanupFailureManifestPath = writeCleanupFailureManifest({
+          latestDir,
+          cleanupError: cleanupFailure,
+          cleanupTargetKnown: Boolean(createdAssessment),
+          runError: runFailure,
+        });
+        console.error(`IEHP assessment import smoke cleanup manifest written to ${cleanupFailureManifestPath}`);
+      } catch (manifestError) {
+        cleanupFailureManifestError =
+          manifestError instanceof Error ? manifestError : new Error(String(manifestError));
+        console.error('IEHP assessment import smoke could not write cleanup manifest', cleanupFailureManifestError);
+      }
+    }
+    if (runFailure && cleanupFailure) {
+      throw new Error(
+        buildIehpSmokeCleanupFailureMessage({
+          cleanupFailed: true,
+          cleanupManifestPath: cleanupFailureManifestPath,
+          cleanupManifestWriteFailed: Boolean(cleanupFailureManifestError),
+          runFailed: true,
+        }),
+      );
+    }
+    if (runFailure) {
+      throw runFailure;
+    }
+    if (cleanupFailure) {
+      throw new Error(
+        buildIehpSmokeCleanupFailureMessage({
+          cleanupFailed: true,
+          cleanupManifestPath: cleanupFailureManifestPath,
+          cleanupManifestWriteFailed: Boolean(cleanupFailureManifestError),
+          runFailed: false,
+        }),
+      );
+    }
+  }
+}
+
+run().catch((error) => {
+  console.error('Playwright IEHP assessment import smoke failed', error);
+  process.exit(1);
+});

--- a/tests/scripts/iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/iehp-assessment-import-smoke.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildIehpSmokeUploadFileName,
+  buildIehpSmokeCleanupFailureMessage,
+  buildIehpSmokeCleanupFailureManifestPayload,
+  resolveIehpSmokeSampleFile,
+} from '../../scripts/lib/iehp-assessment-import-smoke';
+
+describe('IEHP assessment import smoke helpers', () => {
+  const normalizePath = (value: string): string => value.replace(/\\/g, '/');
+
+  it('uses an explicitly configured sample file when provided', () => {
+    const resolved = resolveIehpSmokeSampleFile({
+      cwd: 'C:/repo',
+      env: { PW_ASSESSMENT_SAMPLE_FILE: 'fixtures/custom-iehp.docx' },
+      candidateFileNames: ['root IEHP FBA.docx'],
+    });
+
+    expect(normalizePath(resolved)).toMatch(/\/repo\/fixtures\/custom-iehp\.docx$/);
+  });
+
+  it('discovers a single safe root IEHP FBA DOCX without hard-coding the real file name', () => {
+    const resolved = resolveIehpSmokeSampleFile({
+      cwd: 'C:/repo',
+      env: {},
+      candidateFileNames: ['Updated FBA -IEHP (2).docx', 'Synthetic IEHP FBA sample.docx', 'CO-FBA-Template (1).docx'],
+    });
+
+    expect(normalizePath(resolved)).toMatch(/\/repo\/Synthetic IEHP FBA sample\.docx$/);
+  });
+
+  it('does not silently select a client-like IEHP FBA file by default', () => {
+    expect(() =>
+      resolveIehpSmokeSampleFile({
+        cwd: 'C:/repo',
+        env: {},
+        candidateFileNames: ['Client Name IEHP FBA December 2025.docx'],
+      }),
+    ).toThrow('Set PW_ASSESSMENT_SAMPLE_FILE');
+  });
+
+  it('fails when the default IEHP sample cannot be selected deterministically', () => {
+    expect(() =>
+      resolveIehpSmokeSampleFile({
+        cwd: 'C:/repo',
+        env: {},
+        candidateFileNames: ['first IEHP FBA.docx', 'second IEHP FBA.docx'],
+      }),
+    ).toThrow('Expected exactly one safe root IEHP FBA DOCX sample');
+  });
+
+  it('uses a synthetic upload file name instead of the source file name', () => {
+    expect(buildIehpSmokeUploadFileName(12345)).toBe('iehp-fba-smoke-12345.docx');
+  });
+
+  it('redacts cleanup failure manifests', () => {
+    const payload = buildIehpSmokeCleanupFailureManifestPayload({
+      cleanupError: new Error('Storage cleanup failed for client-documents/clients/client-1/assessments/file.docx'),
+      cleanupTargetKnown: true,
+      createdAt: '2026-06-02T00:00:00.000Z',
+      runError: new Error('run failed for doc-1'),
+    });
+
+    expect(JSON.stringify(payload)).not.toContain('client-1');
+    expect(JSON.stringify(payload)).not.toContain('doc-1');
+    expect(payload).toEqual({
+      createdAt: '2026-06-02T00:00:00.000Z',
+      cleanupTargetKnown: true,
+      cleanupError: 'Cleanup failed; inspect local terminal context or hosted smoke records for manual cleanup.',
+      runError: 'IEHP smoke run failed before cleanup completed.',
+    });
+  });
+
+  it('redacts cleanup failure error messages', () => {
+    const message = buildIehpSmokeCleanupFailureMessage({
+      cleanupFailed: true,
+      cleanupManifestPath: 'artifacts/latest/manifest.json',
+      cleanupManifestWriteFailed: false,
+      runFailed: true,
+    });
+
+    expect(message).toContain('IEHP assessment import smoke failed and cleanup did not complete.');
+    expect(message).toContain('Manual cleanup may be required.');
+    expect(message).toContain('artifacts/latest/manifest.json');
+    expect(message).not.toContain('client-documents');
+    expect(message).not.toContain('doc-1');
+  });
+});


### PR DESCRIPTION
## Summary
- Add an on-demand IEHP browser import smoke that selects IEHP FBA in the UI, uploads an explicitly configured IEHP DOCX fixture, waits for extraction, asserts zero draft programs/goals, captures evidence, and auto-cleans artifacts.
- Add helper coverage for safe sample resolution, synthetic upload naming, redacted cleanup failure manifests/messages, and cleanup behavior.
- Keep the smoke out of GitHub Actions workflows for this slice.

Linear: WIN-169

## Verification
- `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts tests/scripts/assessment-import-cleanup.test.ts`
- `npm run playwright:iehp-assessment-import-smoke` with explicit authorized IEHP sample fixture: extracted, draft programs 0, draft goals 0
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run verify:local`

## Route
classification: low-risk autonomous
lane: standard
protected paths touched: none