### PR TITLE
WIN-170 Enforce IEHP import smoke in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,7 +538,7 @@ jobs:
           PW_BASE_URL: ${{ secrets.PW_BASE_URL }}
           PW_ADMIN_EMAIL: ${{ secrets.PW_ADMIN_EMAIL }}
           PW_ADMIN_PASSWORD: ${{ secrets.PW_ADMIN_PASSWORD }}
-          PW_ASSESSMENT_CLIENT_ID: ${{ secrets.PW_ASSESSMENT_CLIENT_ID }}
+          PW_ASSESSMENT_CLIENT_ID: ${{ secrets.PW_ASSESSMENT_CLIENT_ID || secrets.W_ASSESSMENT_CLIENT_ID }}
           PW_ASSESSMENT_SAMPLE_FILE: ${{ secrets.PW_ASSESSMENT_SAMPLE_FILE }}
           VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,6 +509,77 @@ jobs:
           path: artifacts/latest
           if-no-files-found: ignore
 
+  iehp_assessment_import_smoke:
+    name: iehp-assessment-import-smoke
+    runs-on: ubuntu-latest
+    needs:
+      - policy
+      - change_scope
+    if: needs.change_scope.outputs.docs_only != 'true'
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: IEHP assessment import smoke gate
+        env:
+          PW_BASE_URL: ${{ secrets.PW_BASE_URL }}
+          PW_ADMIN_EMAIL: ${{ secrets.PW_ADMIN_EMAIL }}
+          PW_ADMIN_PASSWORD: ${{ secrets.PW_ADMIN_PASSWORD }}
+          PW_ASSESSMENT_CLIENT_ID: ${{ secrets.PW_ASSESSMENT_CLIENT_ID }}
+          PW_ASSESSMENT_SAMPLE_FILE: ${{ secrets.PW_ASSESSMENT_SAMPLE_FILE }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY || secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY || secrets.SUPABASE_ANON_KEY }}
+        run: |
+          required=(
+            PW_BASE_URL
+            PW_ADMIN_EMAIL
+            PW_ADMIN_PASSWORD
+            PW_ASSESSMENT_CLIENT_ID
+            PW_ASSESSMENT_SAMPLE_FILE
+            VITE_SUPABASE_URL
+            VITE_SUPABASE_ANON_KEY
+          )
+          missing=()
+          for key in "${required[@]}"; do
+            if [ -z "${!key}" ]; then
+              missing+=("$key")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "Missing required secrets for IEHP assessment import smoke gate: ${missing[*]}"
+            exit 1
+          fi
+
+          npm run playwright:iehp-assessment-import-smoke
+
+      - name: Record IEHP import smoke evidence
+        if: always()
+        run: npm run ci:write-evidence -- iehp-assessment-import-smoke "${{ job.status }}"
+
+      - name: Upload IEHP Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: iehp-playwright-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/latest
+          if-no-files-found: ignore
+
   ci_gate:
     name: ci-gate
     runs-on: ubuntu-latest
@@ -522,6 +593,7 @@ jobs:
       - build
       - tier0_browser
       - auth_browser_smoke
+      - iehp_assessment_import_smoke
     steps:
       - name: Enforce lane-specific CI results
         shell: bash
@@ -534,6 +606,7 @@ jobs:
           BUILD_RESULT: ${{ needs.build.result }}
           TIER0_RESULT: ${{ needs.tier0_browser.result }}
           AUTH_SMOKE_RESULT: ${{ needs.auth_browser_smoke.result }}
+          IEHP_IMPORT_SMOKE_RESULT: ${{ needs.iehp_assessment_import_smoke.result }}
         run: |
           set -euo pipefail
           echo "docs_only=${DOCS_ONLY}"
@@ -554,6 +627,7 @@ jobs:
           [ "${BUILD_RESULT}" = "success" ] || failed+=("build=${BUILD_RESULT}")
           [ "${TIER0_RESULT}" = "success" ] || failed+=("tier0-browser=${TIER0_RESULT}")
           [ "${AUTH_SMOKE_RESULT}" = "success" ] || failed+=("auth-browser-smoke=${AUTH_SMOKE_RESULT}")
+          [ "${IEHP_IMPORT_SMOKE_RESULT}" = "success" ] || failed+=("iehp-assessment-import-smoke=${IEHP_IMPORT_SMOKE_RESULT}")
 
           if [ "${#failed[@]}" -gt 0 ]; then
             echo "non-doc run failed required jobs: ${failed[*]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,8 +536,8 @@ jobs:
       - name: IEHP assessment import smoke gate
         env:
           PW_BASE_URL: ${{ secrets.PW_BASE_URL }}
-          PW_ADMIN_EMAIL: ${{ secrets.PW_ADMIN_EMAIL }}
-          PW_ADMIN_PASSWORD: ${{ secrets.PW_ADMIN_PASSWORD }}
+          PW_ADMIN_EMAIL: ${{ secrets.PW_SUPERADMIN_EMAIL || secrets.PW_ADMIN_EMAIL }}
+          PW_ADMIN_PASSWORD: ${{ secrets.PW_SUPERADMIN_PASSWORD || secrets.PW_ADMIN_PASSWORD }}
           PW_ASSESSMENT_CLIENT_ID: ${{ secrets.PW_ASSESSMENT_CLIENT_ID || secrets.W_ASSESSMENT_CLIENT_ID }}
           PW_ASSESSMENT_SAMPLE_FILE: ${{ secrets.PW_ASSESSMENT_SAMPLE_FILE }}
           VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/docs/DATABASE_PIPELINE.md
+++ b/docs/DATABASE_PIPELINE.md
@@ -32,7 +32,8 @@ The repository does not create per-PR Supabase branches automatically. Branch cr
      - non-doc path: `change-scope` -> `policy` -> parallel gates:
        - chain A: `lint-typecheck` + `unit-tests` -> `build` -> `tier0-browser`
        - chain B: `auth-browser-smoke`
-       - both chains feed `ci-gate`
+       - chain C: `iehp-assessment-import-smoke`
+       - all chains feed `ci-gate`
 4. Merge queue (`merge_group`) to `main`/`develop`.
    - `ci.yml` runs the non-doc chain before `ci-gate` (no docs-only fast path on `merge_group`).
 5. Manual preview run.
@@ -67,11 +68,13 @@ The repository does not create per-PR Supabase branches automatically. Branch cr
   - `build`
   - `tier0-browser`
   - `auth-browser-smoke`
+  - `iehp-assessment-import-smoke`
 - `ci-gate` is the final required status gate for branch protection.
 - Current transition state:
   - branch protection should require `ci-gate`
   - `policy` validates `CI_REQUIRED_CHECKS=ci-gate`
   - keep the legacy required checks (`policy`, `lint-typecheck`, `unit-tests`, `build`, `tier0-browser`, `auth-browser-smoke`) only until the migration PR has merged and `main` is green
+  - `iehp-assessment-import-smoke` is enforced through `ci-gate`; it does not need to be added as a separate branch-protection check when `ci-gate` is required
 
 ### `supabase-preview.yml`
 
@@ -97,6 +100,7 @@ SUPABASE_DB_URL
 ```
 
 `supabase-preview.yml` and `ci.yml` may also reference additional environment-specific secrets when preview and policy checks run.
+The CI IEHP assessment import smoke additionally requires a dedicated synthetic smoke client and fixture configured through `PW_ASSESSMENT_CLIENT_ID` and `PW_ASSESSMENT_SAMPLE_FILE`, plus the standard Playwright admin and Supabase URL/key secrets. These values must remain secret-backed and must not be copied into repository docs.
 
 For local hosted-db parity runs, export the Supabase variables and set `RUN_DB_IT=1` before running `npm test`.
 

--- a/docs/ai/pr-merge-queue-settings.md
+++ b/docs/ai/pr-merge-queue-settings.md
@@ -54,6 +54,7 @@ Internal workflow behavior still matters:
 
 - `docs-guard` is the docs-only fast-path validator.
 - `ci-gate` summarizes CI lane outcomes and is the required-check target after migration.
+- `iehp-assessment-import-smoke` is enforced through `ci-gate` for non-doc runs; keep its fixture and smoke-client values configured as CI secrets.
 - docs-only PRs satisfy the browser/code-quality jobs by resolving them to `SKIPPED`, while `docs-guard` and `ci-gate` pass.
 
 Do not remove the six legacy required checks until the non-doc migration PR proves `ci-gate` is gating the full policy, lint/typecheck, unit, build, tier-0 browser, and auth browser smoke chain.
@@ -64,6 +65,7 @@ Do not remove the six legacy required checks until the non-doc migration PR prov
 
 Note: docs-only PRs run the docs fast path on standard PR events, but merge-queue (`merge_group`) currently uses the full non-doc chain before `ci-gate`.
 Note: `auth-browser-smoke` allows a non-fatal secret-missing skip on `pull_request`, but treats missing secrets as a failure on `merge_group`/`push`; do not treat PR soft-skip behavior as merge-queue parity.
+Note: `iehp-assessment-import-smoke` fails on missing required smoke secrets for non-doc runs because it is intended to be an enforced import guard, not an advisory browser check.
 
 ## Approval Validation Result
 

--- a/scripts/ci/check-e2e-reliability-gates.mjs
+++ b/scripts/ci/check-e2e-reliability-gates.mjs
@@ -27,6 +27,7 @@ const CRITICAL_PLAYWRIGHT_SCRIPTS = [
   path.join(ROOT, "scripts", "playwright-session-complete.ts"),
   path.join(ROOT, "scripts", "playwright-schedule-blocked-close.ts"),
   path.join(ROOT, "scripts", "playwright-session-note-measurement-roundtrip.ts"),
+  path.join(ROOT, "scripts", "playwright-iehp-assessment-import-smoke.ts"),
 ];
 
 const readJson = async (filePath) => JSON.parse(await readFile(filePath, "utf8"));
@@ -138,6 +139,18 @@ const run = async () => {
   }
   if (!ciWorkflow.includes("Record auth smoke evidence")) {
     errors.push(".github/workflows/ci.yml must record auth smoke evidence artifacts for success/failure runs.");
+  }
+  if (!ciWorkflow.includes("iehp-assessment-import-smoke")) {
+    errors.push(".github/workflows/ci.yml must include the IEHP assessment import smoke gate.");
+  }
+  if (!ciWorkflow.includes("npm run playwright:iehp-assessment-import-smoke")) {
+    errors.push(".github/workflows/ci.yml IEHP assessment import smoke gate must run playwright:iehp-assessment-import-smoke.");
+  }
+  if (!ciWorkflow.includes("Record IEHP import smoke evidence")) {
+    errors.push(".github/workflows/ci.yml must record IEHP import smoke evidence artifacts for success/failure runs.");
+  }
+  if (!ciWorkflow.includes("needs.iehp_assessment_import_smoke.result")) {
+    errors.push(".github/workflows/ci.yml ci-gate must depend on the IEHP assessment import smoke result.");
   }
   if (!ciWorkflow.includes("npm run playwright:session-no-show")) {
     errors.push(".github/workflows/ci.yml auth-browser-smoke gate must run playwright:session-no-show.");

--- a/scripts/playwright-iehp-assessment-import-smoke.ts
+++ b/scripts/playwright-iehp-assessment-import-smoke.ts
@@ -52,6 +52,26 @@ const pause = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms));
 };
 
+const fetchWithRetry = async (url: string, init: RequestInit, label: string): Promise<Response> => {
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= 4; attempt += 1) {
+    try {
+      const response = await fetch(url, init);
+      if (response.ok || response.status < 500) {
+        return response;
+      }
+      lastError = new Error(`${label} failed with status ${response.status}.`);
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt < 4) {
+      await pause(1_500 * attempt);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(`${label} failed after retries.`);
+};
+
 const writeCleanupFailureManifest = (args: {
   latestDir: string;
   cleanupError: Error;
@@ -71,11 +91,15 @@ const fetchAssessmentDocuments = async (
   accessToken: string,
   clientId: string,
 ): Promise<AssessmentDocumentRecord[]> => {
-  const response = await fetch(`${baseUrl}/api/assessment-documents?client_id=${encodeURIComponent(clientId)}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
+  const response = await fetchWithRetry(
+    `${baseUrl}/api/assessment-documents?client_id=${encodeURIComponent(clientId)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
     },
-  });
+    'Assessment document query',
+  );
 
   if (!response.ok) {
     throw new Error(`Assessment document query failed with status ${response.status}.`);
@@ -89,13 +113,14 @@ const fetchAssessmentDraftCounts = async (
   accessToken: string,
   assessmentDocumentId: string,
 ): Promise<{ programCount: number; goalCount: number }> => {
-  const response = await fetch(
+  const response = await fetchWithRetry(
     `${baseUrl}/api/assessment-drafts?assessment_document_id=${encodeURIComponent(assessmentDocumentId)}`,
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
     },
+    'Assessment draft query',
   );
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- Add a dedicated `iehp-assessment-import-smoke` CI job for non-doc runs.
- Make `ci-gate` require the IEHP import smoke result before passing non-doc CI.
- Extend the E2E reliability policy check and CI docs so the gate cannot be removed silently.

## Route
- classification: high-risk human-reviewed
- lane: critical
- issue: WIN-170
- protected paths: `.github/workflows/**`, `scripts/ci/**`

## Verification Card
- classification: high-risk human-reviewed
- lane: critical
- change type: CI/workflow/policy and docs/process
- required checks: workflow/script validation, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, `npm run test:routes:tier0`, `npm run ci:verify-coverage`, `npm run verify:local`
- executed checks: PyYAML parse of `.github/workflows/ci.yml` passed; `git diff --check` passed; `npm run ci:check-focused` passed; `npm run lint` passed; `npm run typecheck` passed; targeted IEHP import smoke helper tests passed; `npm run test:ci` passed; `npm run build` passed; `npm run test:routes:tier0` passed; `npm run ci:verify-coverage` passed; `npm run verify:local` passed
- blocked checks: `actionlint` not installed locally; GitHub Actions will be authoritative for workflow syntax and secret-backed IEHP smoke execution
- result: pass-with-blocked-checks
- residual risk: CI must have `PW_ASSESSMENT_CLIENT_ID` and `PW_ASSESSMENT_SAMPLE_FILE` configured for the new enforced job; missing secrets now correctly fail non-doc CI.

## Review Required
This PR touches protected CI/workflow paths. Human review is required before merge under `AGENTS.md`.