### PR TITLE
Fix IEHP assessment publish completion

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -270,6 +270,7 @@ interface AssessmentPromoteResponse {
   created_goal_count: number;
   promoted_program_count?: number;
   promoted_goal_count?: number;
+  completion_mode?: "assessment_only";
 }
 
 export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
@@ -630,7 +631,8 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   ).length;
   const pendingDraftProgramCount = (assessmentDrafts?.programs ?? []).filter((program) => program.accept_state === "pending").length;
   const pendingDraftGoalCount = (assessmentDrafts?.goals ?? []).filter((goal) => goal.accept_state === "pending").length;
-  const showDraftReviewPanel = ENABLE_PROGRAMS_GOALS_AI_PROPOSALS && !selectedAssessmentAlreadyPublished;
+  const showDraftReviewPanel =
+    ENABLE_PROGRAMS_GOALS_AI_PROPOSALS && !selectedAssessmentAlreadyPublished && !selectedAssessmentIsIehp;
   const extractedChecklistValueCount = checklistItems.filter((item) => item.value_text?.trim()).length;
   const structuredChildGoalCount = structuredSections.filter(isStructuredChildGoalSection).length;
   const structuredParentGoalCount = structuredSections.filter(isStructuredParentGoalSection).length;
@@ -654,6 +656,13 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
           : acceptedDraftGoalCount === 0
             ? "At least one draft goal must be accepted or edited before publishing."
             : null;
+  const iehpPublishDisabledReason = !selectedAssessmentId
+    ? "Select an assessment before publishing."
+    : selectedAssessmentAlreadyPublished
+      ? "This assessment has already been approved and published."
+      : hasPendingRequiredChecklistItems
+        ? `${unresolvedRequiredCount} required checklist or structured row${unresolvedRequiredCount === 1 ? "" : "s"} must be approved before publishing.`
+        : null;
 
   useEffect(() => {
     const firstAssessmentId = assessmentDocuments[0]?.id ?? null;
@@ -1012,6 +1021,14 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       return parseJson<AssessmentPromoteResponse>(response);
     },
     onSuccess: (result) => {
+      if (result.completion_mode === "assessment_only") {
+        queryClient.invalidateQueries({ queryKey: assessmentDocumentsQueryKey });
+        queryClient.invalidateQueries({
+          queryKey: ["assessment-checklist", selectedAssessmentId, organizationId ?? "MISSING_ORG"],
+        });
+        showSuccess("Published reviewed assessment.");
+        return;
+      }
       const programCount = result.promoted_program_count ?? result.created_program_count;
       const goalCount = result.promoted_goal_count ?? result.created_goal_count;
       queryClient.invalidateQueries({ queryKey: clientProgramsQueryKey });
@@ -1685,10 +1702,43 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                   Checklist review failed to load. Publishing stays blocked until checklist rows can be reviewed.
                 </p>
               ) : selectedAssessmentIsIehp && selectedAssessmentDocument ? (
-                <IehpFbaLayoutReview
-                  assessmentDocument={selectedAssessmentDocument}
-                  organizationId={organizationId}
-                />
+                <div className="space-y-4">
+                  <IehpFbaLayoutReview
+                    assessmentDocument={selectedAssessmentDocument}
+                    organizationId={organizationId}
+                  />
+                  <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm dark:border-emerald-900/60 dark:bg-emerald-950/20">
+                    <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                      <div className="space-y-1">
+                        <p className="font-semibold text-emerald-900 dark:text-emerald-100">Publish reviewed IEHP assessment</p>
+                        <p className="text-xs text-emerald-800 dark:text-emerald-200">
+                          This completes the review workflow and locks the approved extraction as the published assessment record.
+                        </p>
+                        {iehpPublishDisabledReason && (
+                          <p className="text-xs text-amber-700 dark:text-amber-200">{iehpPublishDisabledReason}</p>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (typeof window !== "undefined") {
+                            const confirmed = window.confirm(
+                              "Publish this reviewed IEHP assessment and complete the workflow?",
+                            );
+                            if (!confirmed) {
+                              return;
+                            }
+                          }
+                          promoteAssessment.mutate();
+                        }}
+                        disabled={Boolean(iehpPublishDisabledReason) || promoteAssessment.isLoading}
+                        className="rounded-md bg-emerald-700 px-3 py-2 text-xs font-semibold text-white hover:bg-emerald-800 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {promoteAssessment.isLoading ? "Publishing..." : "Publish Reviewed Assessment"}
+                      </button>
+                    </div>
+                  </div>
+                </div>
               ) : checklistBySection.length === 0 && structuredSectionsBySection.length === 0 ? (
                 <p className="text-sm text-gray-500">Checklist not available yet for this assessment.</p>
               ) : (

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -3833,6 +3833,99 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     );
   });
 
+  it("shows a publish button for fully approved IEHP assessments without staged drafts", async () => {
+    const invalidateQueriesSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "iehp_fba",
+              file_name: "approved-iehp.docx",
+              mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/approved-iehp.docx",
+              status: "extracted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "required-row-1",
+                section_key: "recommendations",
+                label: "Recommendation",
+                placeholder_key: "IEHP_FBA_RECOMMENDATION",
+                required: true,
+                mode: "ASSISTED",
+                status: "approved",
+                review_notes: null,
+                value_text: "Synthetic recommendation",
+              },
+            ],
+            structured_sections: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      if (method === "POST" && path === "/api/assessment-promote") {
+        return new Response(
+          JSON.stringify({
+            assessment_document_id: ASSESSMENT_ID,
+            completion_mode: "assessment_only",
+            created_program_count: 0,
+            created_goal_count: 0,
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("approved-iehp.docx");
+    const publishButton = await screen.findByRole("button", { name: /Publish Reviewed Assessment/i });
+    expect(publishButton).toBeEnabled();
+
+    await user.click(publishButton);
+
+    await waitFor(() => {
+      expect(callApi).toHaveBeenCalledWith(
+        "/api/assessment-promote",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    expect(showSuccess).toHaveBeenCalledWith("Published reviewed assessment.");
+    expect(invalidateQueriesSpy).toHaveBeenCalled();
+    invalidateQueriesSpy.mockRestore();
+    confirmSpy.mockRestore();
+  });
+
   it("does not render IEHP draft editors for already published assessments", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -188,6 +188,59 @@ describe("assessmentPromoteHandler", () => {
     ).toBe(false);
   });
 
+  it("blocks IEHP assessment publish before extraction completes", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "uploaded",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining("extraction must complete before publishing"),
+    });
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_checklist_items")),
+    ).toBe(false);
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_structured_sections")),
+    ).toBe(false);
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url, init]) => typeof url === "string" && init?.method === "PATCH"),
+    ).toBe(false);
+  });
+
   it("promotes all accepted draft programs and preserves goal-to-program links", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -45,6 +45,149 @@ describe("assessmentPromoteHandler", () => {
     vi.resetAllMocks();
   });
 
+  it("publishes a fully reviewed IEHP assessment without promoting draft programs or goals", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "approved",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      assessment_document_id: "doc-1",
+      completion_mode: "assessment_only",
+      created_program_count: 0,
+      created_goal_count: 0,
+    });
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_draft_programs")),
+    ).toBe(false);
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url]) => typeof url === "string" && url.includes("/rest/v1/programs")),
+    ).toBe(false);
+    const reviewEventCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(([url, init]) => typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && init?.method === "POST");
+    expect(reviewEventCall).toBeTruthy();
+    expect(JSON.parse(String((reviewEventCall?.[1] as RequestInit | undefined)?.body ?? "{}"))).toMatchObject({
+      action: "reviewed_assessment_published",
+      from_status: "extracted",
+      to_status: "approved",
+      event_payload: {
+        completion_mode: "assessment_only",
+        created_program_count: 0,
+        created_goal_count: 0,
+      },
+    });
+  });
+
+  it("blocks IEHP assessment publish until all required review rows are approved", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "required-row-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      unresolved_required_count: 1,
+    });
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url]) => typeof url === "string" && url.includes("/rest/v1/programs")),
+    ).toBe(false);
+  });
+
   it("promotes all accepted draft programs and preserves goal-to-program links", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -18,6 +18,7 @@ interface AssessmentDocumentRow {
   organization_id: string;
   client_id: string;
   status: string;
+  template_type?: string | null;
 }
 
 interface DraftProgramRow {
@@ -72,6 +73,30 @@ const normalizeGoalDataPoint = (point: Record<string, unknown> | string): Record
 const PROMOTED_ASSESSMENT_STATUSES = new Set(["approved", "promoted"]);
 const PROMOTION_READY_STATUS = "drafted";
 const PROMOTION_LOCK_STATUS = "extracted";
+const IEHP_ASSESSMENT_TEMPLATE_TYPE = "iehp_fba";
+
+const buildAssessmentRequiredApprovalLookups = (args: {
+  supabaseUrl: string;
+  organizationId: string;
+  assessmentDocumentId: string;
+  headers: Record<string, string>;
+}) => {
+  const { supabaseUrl, organizationId, assessmentDocumentId, headers } = args;
+  return Promise.all([
+    fetchJson<Array<{ id: string }>>(
+      `${supabaseUrl}/rest/v1/assessment_checklist_items?select=id&organization_id=eq.${encodeURIComponent(
+        organizationId,
+      )}&assessment_document_id=eq.${encodeURIComponent(assessmentDocumentId)}&required=is.true&status=neq.approved`,
+      { method: "GET", headers },
+    ),
+    fetchJson<Array<{ id: string }>>(
+      `${supabaseUrl}/rest/v1/assessment_structured_sections?select=id&organization_id=eq.${encodeURIComponent(
+        organizationId,
+      )}&assessment_document_id=eq.${encodeURIComponent(assessmentDocumentId)}&required=is.true&status=neq.approved`,
+      { method: "GET", headers },
+    ),
+  ]);
+};
 
 export async function assessmentPromoteHandler(request: Request): Promise<Response> {
   if (request.method === "OPTIONS") {
@@ -112,7 +137,7 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   };
 
   const docLookup = await fetchJson<AssessmentDocumentRow[]>(
-    `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status&id=eq.${encodeURIComponent(
+    `${supabaseUrl}/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type&id=eq.${encodeURIComponent(
       parsed.data.assessment_document_id,
     )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
     { method: "GET", headers },
@@ -123,6 +148,101 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   }
   if (PROMOTED_ASSESSMENT_STATUSES.has(document.status)) {
     return json({ error: "Assessment has already been approved and promoted to live records." }, 409);
+  }
+  if (document.template_type === IEHP_ASSESSMENT_TEMPLATE_TYPE) {
+    const [unapprovedChecklistResult, unapprovedStructuredResult] = await buildAssessmentRequiredApprovalLookups({
+      supabaseUrl,
+      organizationId,
+      assessmentDocumentId: parsed.data.assessment_document_id,
+      headers,
+    });
+    if (!unapprovedChecklistResult.ok || !unapprovedStructuredResult.ok) {
+      return json({ error: "Failed to evaluate IEHP review completion preconditions" }, 500);
+    }
+
+    const unapprovedChecklistCount = Array.isArray(unapprovedChecklistResult.data) ? unapprovedChecklistResult.data.length : 0;
+    const unapprovedStructuredCount = Array.isArray(unapprovedStructuredResult.data) ? unapprovedStructuredResult.data.length : 0;
+    const unresolvedRequiredCount = unapprovedChecklistCount + unapprovedStructuredCount;
+    if (unresolvedRequiredCount > 0) {
+      return json(
+        {
+          error: `Required checklist and structured review rows must be approved before publishing this IEHP assessment.`,
+          unresolved_required_count: unresolvedRequiredCount,
+        },
+        409,
+      );
+    }
+
+    const now = new Date().toISOString();
+    const actorId = getAccessTokenSubject(accessToken);
+    const finalizeReviewedAssessmentResult = await fetchJson<AssessmentDocumentRow[]>(
+      `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}&status=eq.${encodeURIComponent(document.status)}`,
+      {
+        method: "PATCH",
+        headers: { ...headers, Prefer: "return=representation" },
+        body: JSON.stringify({
+          status: "approved",
+          approved_at: now,
+          updated_at: now,
+        }),
+      },
+    );
+    const finalizedDocument = Array.isArray(finalizeReviewedAssessmentResult.data)
+      ? finalizeReviewedAssessmentResult.data[0]
+      : null;
+    if (!finalizeReviewedAssessmentResult.ok) {
+      return json({ error: "Failed to finalize reviewed assessment." }, finalizeReviewedAssessmentResult.status || 500);
+    }
+    if (!finalizedDocument) {
+      return json({ error: "Assessment review state changed before publish completed. Refresh and retry." }, 409);
+    }
+
+    const createReviewedEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        assessment_document_id: document.id,
+        organization_id: organizationId,
+        client_id: document.client_id,
+        item_type: "document",
+        item_id: document.id,
+        action: "reviewed_assessment_published",
+        from_status: document.status,
+        to_status: "approved",
+        actor_id: actorId,
+        event_payload: {
+          completion_mode: "assessment_only",
+          created_program_count: 0,
+          created_goal_count: 0,
+          promoted_program_count: 0,
+          promoted_goal_count: 0,
+        },
+      }),
+    });
+    if (!createReviewedEventResult.ok) {
+      await fetchJson(
+        `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}`,
+        {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({
+            status: document.status,
+            approved_at: null,
+            updated_at: new Date().toISOString(),
+          }),
+        },
+      );
+      return json({ error: "Failed to record reviewed assessment publish event." }, createReviewedEventResult.status || 500);
+    }
+
+    return json({
+      assessment_document_id: document.id,
+      completion_mode: "assessment_only",
+      created_program_count: 0,
+      created_goal_count: 0,
+      promoted_program_count: 0,
+      promoted_goal_count: 0,
+    });
   }
   if (document.status !== PROMOTION_READY_STATUS) {
     return json({ error: "Assessment drafts must be ready before promotion. Refresh and retry after draft generation completes." }, 409);

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -150,6 +150,13 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     return json({ error: "Assessment has already been approved and promoted to live records." }, 409);
   }
   if (document.template_type === IEHP_ASSESSMENT_TEMPLATE_TYPE) {
+    if (document.status !== PROMOTION_LOCK_STATUS) {
+      return json(
+        { error: "IEHP assessment extraction must complete before publishing. Refresh and retry once extraction finishes." },
+        409,
+      );
+    }
+
     const [unapprovedChecklistResult, unapprovedStructuredResult] = await buildAssessmentRequiredApprovalLookups({
       supabaseUrl,
       organizationId,


### PR DESCRIPTION
## Summary
- add an IEHP assessment-only completion path to `assessment-promote` when all required review rows are approved
- show a dedicated `Publish Reviewed Assessment` action in `ProgramsGoalsTab` for fully reviewed IEHP assessments with no draft programs/goals
- cover the server and UI regression with targeted tests

## Verification
- npm test -- src/server/__tests__/assessmentPromoteHandler.test.ts
- npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx
- npx vitest run src/lib/__tests__/idempotencyService.test.ts
- npm run typecheck
- npm run ci:check-focused
- npm run lint
- npm run build
- npm run test:routes:tier0

## Blocked / follow-up
- `npm run test:ci` still times out in the aggregate run on `src/lib/__tests__/idempotencyService.test.ts`, although the isolated test passes
- `npm run verify:local` inherits the same aggregate test failure and hit a coverage temp-file `ENOENT`
- `npm run ci:playwright` timed out locally

## Live production note
- completed the stuck IEHP assessment `428cd6fe-0997-4075-9ee4-7428c525249d` directly in Supabase after verifying it had zero unresolved required rows and no draft programs/goals; status is now `approved` with a `reviewed_assessment_published` event
