### PR TITLE
Gate IEHP publish on transferred data quality

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
+++ b/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
@@ -10,6 +10,7 @@ export interface AssessmentChecklistItem {
   status: "not_started" | "drafted" | "verified" | "approved";
   review_notes: string | null;
   value_text: string | null;
+  value_json?: unknown | null;
 }
 
 export interface AssessmentStructuredSection {
@@ -17,7 +18,7 @@ export interface AssessmentStructuredSection {
   section_key: string;
   field_key: string;
   section_index: number;
-  payload: Record<string, unknown>;
+  payload: Record<string, unknown> | null;
   source_span?: Record<string, unknown> | null;
   status: "not_started" | "drafted" | "verified" | "approved" | "rejected";
   required: boolean;

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -101,6 +101,98 @@ const formatPayloadValue = (value: unknown): string => {
   }
 };
 
+const IEHP_REQUIRED_PAYLOAD_FIELDS: Record<string, string[]> = {
+  IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES: ["measure_name", "date_administered", "interviewer", "respondent"],
+  IEHP_FBA_SIGNATURE_BLOCK: ["completed_by", "report_completed_date", "credentials", "agency"],
+};
+const IEHP_REQUIRED_GOAL_FIELDS = [
+  "program_name",
+  "target_criteria",
+  "baseline_data",
+  "mastery_criteria",
+  "measurement_type",
+];
+const IEHP_GOAL_SECTION_KEYS = new Set([
+  "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
+  "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
+]);
+
+const isBlankTransferredValue = (value: unknown): boolean => {
+  if (value == null) return true;
+  if (typeof value === "string") return value.trim().length === 0;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === "object") return Object.keys(value).length === 0;
+  return false;
+};
+
+const hasNonBlankPayloadValue = (payload: Record<string, unknown>, key: string): boolean =>
+  !isBlankTransferredValue(payload[key]);
+
+const hasMeaningfulRawText = (payload: Record<string, unknown>): boolean =>
+  typeof payload.raw_text === "string" && payload.raw_text.trim().length > 0;
+
+const hasMeaningfulAdaptiveBlocks = (payload: Record<string, unknown>): boolean => {
+  const blocks = Array.isArray(payload.assessment_blocks) ? payload.assessment_blocks : [];
+  return blocks.some((block) => {
+    const record = block && typeof block === "object" ? block as Record<string, unknown> : {};
+    return (
+      typeof record.raw_text === "string" &&
+      record.raw_text.trim().length > 0 &&
+      record.manual_review_required !== true
+    );
+  });
+};
+
+const hasLegacySignaturePayload = (payload: Record<string, unknown>): boolean => {
+  const hasTransferSignatureFields = ["report_completed_date", "credentials", "agency"].some((key) =>
+    Object.prototype.hasOwnProperty.call(payload, key)
+  );
+  return !hasTransferSignatureFields && hasNonBlankPayloadValue(payload, "completed_by");
+};
+
+const countIehpStructuredDataQualityIssues = (sections: AssessmentStructuredSection[]): number =>
+  sections.filter((section) => {
+    if (!section.required || section.status !== "approved") {
+      return false;
+    }
+    const payload = section.payload && typeof section.payload === "object" ? section.payload : null;
+    if (!payload) {
+      return true;
+    }
+    const requiredFields = IEHP_REQUIRED_PAYLOAD_FIELDS[section.field_key] ?? (
+      IEHP_GOAL_SECTION_KEYS.has(section.field_key) ? IEHP_REQUIRED_GOAL_FIELDS : []
+    );
+    const hasMissingRequiredFields = requiredFields.some((field) => !hasNonBlankPayloadValue(payload, field));
+    if (
+      section.field_key === "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES" &&
+      hasMissingRequiredFields &&
+      hasMeaningfulAdaptiveBlocks(payload)
+    ) {
+      return false;
+    }
+    if (IEHP_GOAL_SECTION_KEYS.has(section.field_key) && hasMissingRequiredFields && hasMeaningfulRawText(payload)) {
+      return false;
+    }
+    if (section.field_key === "IEHP_FBA_SIGNATURE_BLOCK" && hasMissingRequiredFields && hasLegacySignaturePayload(payload)) {
+      return false;
+    }
+    if (hasMissingRequiredFields) {
+      return true;
+    }
+    if (section.field_key !== "IEHP_FBA_RECOMMENDATIONS_HCPCS_ROWS") {
+      return false;
+    }
+    const rows = Array.isArray(payload.rows) ? payload.rows : [];
+    return rows.length === 0 || rows.some((entry) => {
+      const row = entry && typeof entry === "object" ? entry as Record<string, unknown> : {};
+      return (
+        isBlankTransferredValue(row.hcpcs_code ?? row.cpt) ||
+        isBlankTransferredValue(row.description) ||
+        isBlankTransferredValue(row.units_requested)
+      );
+    });
+  }).length;
+
 const buildStructuredPayloadPreview = (payload: Record<string, unknown>): string[] => {
   const rows = Array.isArray(payload.rows) ? payload.rows : [];
   if (rows.length > 0) {
@@ -645,6 +737,18 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     ? checklistItems.filter((item) => item.required && item.status !== "approved").length +
       structuredSections.filter((section) => section.required && section.status !== "approved").length
     : 0;
+  const blankApprovedIehpChecklistValueCount = selectedAssessmentIsIehp
+    ? checklistItems.filter((item) =>
+        item.required &&
+        item.status === "approved" &&
+        isBlankTransferredValue(item.value_text) &&
+        isBlankTransferredValue(item.value_json)
+      ).length
+    : 0;
+  const malformedApprovedIehpStructuredCount = selectedAssessmentIsIehp
+    ? countIehpStructuredDataQualityIssues(structuredSections)
+    : 0;
+  const iehpDataQualityIssueCount = blankApprovedIehpChecklistValueCount + malformedApprovedIehpStructuredCount;
   const promoteDisabledReason = !selectedAssessmentId
     ? "Select an assessment before publishing."
     : selectedAssessmentAlreadyPublished
@@ -662,6 +766,8 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       ? "This assessment has already been approved and published."
       : hasPendingRequiredChecklistItems
         ? `${unresolvedRequiredCount} required checklist or structured row${unresolvedRequiredCount === 1 ? "" : "s"} must be approved before publishing.`
+        : iehpDataQualityIssueCount > 0
+          ? `${iehpDataQualityIssueCount} approved IEHP data value${iehpDataQualityIssueCount === 1 ? "" : "s"} must be completed before publishing.`
         : null;
 
   useEffect(() => {

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -3926,6 +3926,74 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     confirmSpy.mockRestore();
   });
 
+  it("disables IEHP publish when approved required fields are blank", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "iehp_fba",
+              file_name: "blank-approved-iehp.docx",
+              mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/blank-approved-iehp.docx",
+              status: "extracted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "required-row-1",
+                section_key: "assessment_information",
+                label: "Assessor phone",
+                placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+                required: true,
+                mode: "ASSISTED",
+                status: "approved",
+                review_notes: null,
+                value_text: "   ",
+                value_json: null,
+              },
+            ],
+            structured_sections: [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("blank-approved-iehp.docx");
+    const publishButton = await screen.findByRole("button", { name: /Publish Reviewed Assessment/i });
+    expect(publishButton).toBeDisabled();
+    expect(screen.getByText("1 approved IEHP data value must be completed before publishing.")).toBeInTheDocument();
+  });
+
   it("does not render IEHP draft editors for already published assessments", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -188,6 +188,439 @@ describe("assessmentPromoteHandler", () => {
     ).toBe(false);
   });
 
+  it("blocks IEHP assessment publish when approved required checklist rows are blank", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "required-row-1",
+            placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+            label: "Assessor phone",
+            value_text: "   ",
+            value_json: null,
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key,section_index,payload")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "approved",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      blank_required_checklist_count: 1,
+      malformed_structured_count: 0,
+    });
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url, init]) =>
+        typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted") && init?.method === "PATCH"
+      ),
+    ).toBe(false);
+  });
+
+  it("blocks IEHP assessment publish when approved structured transfer payloads are incomplete", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key,section_index,payload")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "structured-1",
+            field_key: "IEHP_FBA_SIGNATURE_BLOCK",
+            section_index: 0,
+            payload: {
+              completed_by: "Hailey Huynh",
+              report_completed_date: "",
+              credentials: "Board Certified Behavior Analyst, 1-24-72584",
+              agency: "West Coast ABA",
+            },
+          }],
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "approved",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      blank_required_checklist_count: 0,
+      malformed_structured_count: 1,
+    });
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url, init]) =>
+        typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted") && init?.method === "PATCH"
+      ),
+    ).toBe(false);
+  });
+
+  it("publishes IEHP assessments when approved transferred values and structured payloads are complete", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "required-row-1",
+            placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+            label: "Assessor phone",
+            value_text: "(555) 010-1212",
+            value_json: null,
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key,section_index,payload")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "structured-adaptive",
+              field_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+              section_index: 0,
+              payload: {
+                measure_name: "Vineland Adaptive Behavior Scales, 3rd Edition",
+                date_administered: "12/01/2025",
+                interviewer: "Hailey Huynh, BCBA",
+                respondent: "Chau Luu (Mother)",
+              },
+            },
+            {
+              id: "structured-goal",
+              field_key: "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
+              section_index: 1,
+              payload: {
+                program_name: "Identifying daily objects/items",
+                target_criteria: "80% of opportunities",
+                baseline_data: "Accuracy in 0% of opportunities",
+                mastery_criteria: "80% across 3 consecutive sessions",
+                measurement_type: "Percentage of opportunities",
+              },
+            },
+            {
+              id: "structured-recommendations",
+              field_key: "IEHP_FBA_RECOMMENDATIONS_HCPCS_ROWS",
+              section_index: 0,
+              payload: {
+                rows: [{
+                  cpt: "H2019",
+                  description: "Therapeutic Behavioral Services, per 15 minutes",
+                  units_requested: "2080 units",
+                }],
+              },
+            },
+            {
+              id: "structured-signature",
+              field_key: "IEHP_FBA_SIGNATURE_BLOCK",
+              section_index: 0,
+              payload: {
+                completed_by: "Hailey Huynh",
+                report_completed_date: "12/12/2025",
+                credentials: "Board Certified Behavior Analyst, 1-24-72584",
+                agency: "West Coast ABA",
+              },
+            },
+          ],
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "approved",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      assessment_document_id: "doc-1",
+      completion_mode: "assessment_only",
+    });
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url, init]) =>
+        typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted") && init?.method === "PATCH"
+      ),
+    ).toBe(true);
+  });
+
+  it("publishes IEHP assessments with documented legacy structured payload shapes", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "required-row-1",
+            placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+            label: "Reason for referral",
+            value_text: "Member was referred for ABA assessment.",
+            value_json: null,
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key,section_index,payload")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "structured-adaptive",
+              field_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+              section_index: 0,
+              payload: {
+                assessment_blocks: [{
+                  assessment_type: "Vineland",
+                  raw_text: "Vineland Adaptive Behavior Scales summary text.",
+                  manual_review_required: false,
+                }],
+              },
+            },
+            {
+              id: "structured-goal",
+              field_key: "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
+              section_index: 0,
+              payload: { raw_text: "School goal narrative with transferred baseline and criteria." },
+            },
+            {
+              id: "structured-signature",
+              field_key: "IEHP_FBA_SIGNATURE_BLOCK",
+              section_index: 0,
+              payload: { completed_by: "Jane Clinician" },
+            },
+          ],
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "approved",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      assessment_document_id: "doc-1",
+      completion_mode: "assessment_only",
+    });
+  });
+
   it("blocks IEHP assessment publish before extraction completes", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -21,6 +21,29 @@ interface AssessmentDocumentRow {
   template_type?: string | null;
 }
 
+interface AssessmentRequiredChecklistReviewRow {
+  id: string;
+  placeholder_key: string | null;
+  label: string | null;
+  value_text: string | null;
+  value_json: unknown | null;
+}
+
+interface AssessmentRequiredStructuredReviewRow {
+  id: string;
+  field_key: string;
+  section_index: number | null;
+  payload: Record<string, unknown> | null;
+}
+
+interface IehpPublishDataQualityBlocker {
+  code: "blank_required_checklist" | "incomplete_structured_payload";
+  key: string;
+  message: string;
+  id: string;
+  section_index?: number | null;
+}
+
 interface DraftProgramRow {
   id: string;
   name: string;
@@ -74,6 +97,115 @@ const PROMOTED_ASSESSMENT_STATUSES = new Set(["approved", "promoted"]);
 const PROMOTION_READY_STATUS = "drafted";
 const PROMOTION_LOCK_STATUS = "extracted";
 const IEHP_ASSESSMENT_TEMPLATE_TYPE = "iehp_fba";
+const IEHP_REQUIRED_PAYLOAD_FIELDS: Record<string, string[]> = {
+  IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES: ["measure_name", "date_administered", "interviewer", "respondent"],
+  IEHP_FBA_SIGNATURE_BLOCK: ["completed_by", "report_completed_date", "credentials", "agency"],
+};
+const IEHP_REQUIRED_GOAL_FIELDS = [
+  "program_name",
+  "target_criteria",
+  "baseline_data",
+  "mastery_criteria",
+  "measurement_type",
+];
+const IEHP_GOAL_SECTION_KEYS = new Set([
+  "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
+  "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
+]);
+
+const isBlankTransferredValue = (value: unknown): boolean => {
+  if (value == null) return true;
+  if (typeof value === "string") return value.trim().length === 0;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === "object") return Object.keys(value).length === 0;
+  return false;
+};
+
+const hasNonBlankPayloadValue = (payload: Record<string, unknown>, key: string): boolean =>
+  !isBlankTransferredValue(payload[key]);
+
+const hasMeaningfulRawText = (payload: Record<string, unknown>): boolean =>
+  typeof payload.raw_text === "string" && payload.raw_text.trim().length > 0;
+
+const hasMeaningfulAdaptiveBlocks = (payload: Record<string, unknown>): boolean => {
+  const blocks = Array.isArray(payload.assessment_blocks) ? payload.assessment_blocks : [];
+  return blocks.some((block) => {
+    const record = block && typeof block === "object" ? block as Record<string, unknown> : {};
+    return (
+      typeof record.raw_text === "string" &&
+      record.raw_text.trim().length > 0 &&
+      record.manual_review_required !== true
+    );
+  });
+};
+
+const hasLegacySignaturePayload = (payload: Record<string, unknown>): boolean => {
+  const hasTransferSignatureFields = ["report_completed_date", "credentials", "agency"].some((key) =>
+    Object.prototype.hasOwnProperty.call(payload, key)
+  );
+  return !hasTransferSignatureFields && hasNonBlankPayloadValue(payload, "completed_by");
+};
+
+const buildIehpStructuredDataQualityBlockers = (
+  rows: AssessmentRequiredStructuredReviewRow[],
+): IehpPublishDataQualityBlocker[] =>
+  rows.flatMap((row) => {
+    const payload = row.payload && typeof row.payload === "object" ? row.payload : null;
+    if (!payload) {
+      return [{
+        code: "incomplete_structured_payload" as const,
+        key: row.field_key,
+        id: row.id,
+        section_index: row.section_index,
+        message: `${row.field_key} must include a structured payload before publishing.`,
+      }];
+    }
+
+    const requiredFields = IEHP_REQUIRED_PAYLOAD_FIELDS[row.field_key] ?? (
+      IEHP_GOAL_SECTION_KEYS.has(row.field_key) ? IEHP_REQUIRED_GOAL_FIELDS : []
+    );
+    const missingFields = requiredFields.filter((field) => !hasNonBlankPayloadValue(payload, field));
+    if (
+      row.field_key === "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES" &&
+      missingFields.length > 0 &&
+      hasMeaningfulAdaptiveBlocks(payload)
+    ) {
+      return [];
+    }
+    if (IEHP_GOAL_SECTION_KEYS.has(row.field_key) && missingFields.length > 0 && hasMeaningfulRawText(payload)) {
+      return [];
+    }
+    if (row.field_key === "IEHP_FBA_SIGNATURE_BLOCK" && missingFields.length > 0 && hasLegacySignaturePayload(payload)) {
+      return [];
+    }
+
+    if (row.field_key === "IEHP_FBA_RECOMMENDATIONS_HCPCS_ROWS") {
+      const rowsValue = Array.isArray(payload.rows) ? payload.rows : [];
+      const malformedRow = rowsValue.length === 0 || rowsValue.some((entry) => {
+        const record = entry && typeof entry === "object" ? entry as Record<string, unknown> : {};
+        return (
+          isBlankTransferredValue(record.hcpcs_code ?? record.cpt) ||
+          isBlankTransferredValue(record.description) ||
+          isBlankTransferredValue(record.units_requested)
+        );
+      });
+      if (malformedRow) {
+        missingFields.push("rows");
+      }
+    }
+
+    if (missingFields.length === 0) {
+      return [];
+    }
+
+    return [{
+      code: "incomplete_structured_payload" as const,
+      key: row.field_key,
+      id: row.id,
+      section_index: row.section_index,
+      message: `${row.field_key} is missing required transferred value(s): ${missingFields.join(", ")}.`,
+    }];
+  });
 
 const buildAssessmentRequiredApprovalLookups = (args: {
   supabaseUrl: string;
@@ -93,6 +225,18 @@ const buildAssessmentRequiredApprovalLookups = (args: {
       `${supabaseUrl}/rest/v1/assessment_structured_sections?select=id&organization_id=eq.${encodeURIComponent(
         organizationId,
       )}&assessment_document_id=eq.${encodeURIComponent(assessmentDocumentId)}&required=is.true&status=neq.approved`,
+      { method: "GET", headers },
+    ),
+    fetchJson<AssessmentRequiredChecklistReviewRow[]>(
+      `${supabaseUrl}/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json&organization_id=eq.${encodeURIComponent(
+        organizationId,
+      )}&assessment_document_id=eq.${encodeURIComponent(assessmentDocumentId)}&required=is.true&status=eq.approved`,
+      { method: "GET", headers },
+    ),
+    fetchJson<AssessmentRequiredStructuredReviewRow[]>(
+      `${supabaseUrl}/rest/v1/assessment_structured_sections?select=id,field_key,section_index,payload&organization_id=eq.${encodeURIComponent(
+        organizationId,
+      )}&assessment_document_id=eq.${encodeURIComponent(assessmentDocumentId)}&required=is.true&status=eq.approved`,
       { method: "GET", headers },
     ),
   ]);
@@ -157,7 +301,12 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
       );
     }
 
-    const [unapprovedChecklistResult, unapprovedStructuredResult] = await buildAssessmentRequiredApprovalLookups({
+    const [
+      unapprovedChecklistResult,
+      unapprovedStructuredResult,
+      approvedChecklistResult,
+      approvedStructuredResult,
+    ] = await buildAssessmentRequiredApprovalLookups({
       supabaseUrl,
       organizationId,
       assessmentDocumentId: parsed.data.assessment_document_id,
@@ -165,6 +314,9 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     });
     if (!unapprovedChecklistResult.ok || !unapprovedStructuredResult.ok) {
       return json({ error: "Failed to evaluate IEHP review completion preconditions" }, 500);
+    }
+    if (!approvedChecklistResult.ok || !approvedStructuredResult.ok) {
+      return json({ error: "Failed to evaluate IEHP publish data quality preconditions" }, 500);
     }
 
     const unapprovedChecklistCount = Array.isArray(unapprovedChecklistResult.data) ? unapprovedChecklistResult.data.length : 0;
@@ -175,6 +327,30 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
         {
           error: `Required checklist and structured review rows must be approved before publishing this IEHP assessment.`,
           unresolved_required_count: unresolvedRequiredCount,
+        },
+        409,
+      );
+    }
+
+    const approvedChecklistRows = Array.isArray(approvedChecklistResult.data) ? approvedChecklistResult.data : [];
+    const blankRequiredChecklistBlockers: IehpPublishDataQualityBlocker[] = approvedChecklistRows
+      .filter((row) => isBlankTransferredValue(row.value_text) && isBlankTransferredValue(row.value_json))
+      .map((row) => ({
+        code: "blank_required_checklist",
+        key: row.placeholder_key ?? row.label ?? row.id,
+        id: row.id,
+        message: `${row.label ?? row.placeholder_key ?? "Required checklist row"} must include transferred data before publishing.`,
+      }));
+    const approvedStructuredRows = Array.isArray(approvedStructuredResult.data) ? approvedStructuredResult.data : [];
+    const malformedStructuredBlockers = buildIehpStructuredDataQualityBlockers(approvedStructuredRows);
+    const dataQualityBlockers = [...blankRequiredChecklistBlockers, ...malformedStructuredBlockers];
+    if (dataQualityBlockers.length > 0) {
+      return json(
+        {
+          error: "IEHP publish data quality validation failed. Resolve blank required checklist values and malformed structured payloads before publishing.",
+          blank_required_checklist_count: blankRequiredChecklistBlockers.length,
+          malformed_structured_count: malformedStructuredBlockers.length,
+          data_quality_blockers: dataQualityBlockers,
         },
         409,
       );


### PR DESCRIPTION
## Summary
- Adds an IEHP-only publish-time data-quality gate after extraction completion and required-row approval checks.
- Blocks publish when approved required checklist rows are blank or known structured transfer payloads are malformed.
- Keeps documented IEHP payload compatibility for adaptive assessment_blocks, narrative goal raw_text, and legacy signature completed_by-only payloads while validating the richer Slice 1 transfer shape.
- Disables the IEHP publish button client-side when approved data-quality blockers are visible.

## Route Task
- classification: high-risk human-reviewed
- lane: critical
- triggering paths: src/server/api/assessment-promote.ts, src/components/ClientDetails/ProgramsGoalsTab.tsx
- required agents used: implementation-engineer, tester, reviewer, security/tenant review via supabase-tenant-safety
- Linear: required by policy, but no Linear tool/context is available in this session; PR remains draft pending linkage.

## Verification
- RED first: new server/UI tests failed before production changes.
- npm test -- src/server/__tests__/assessmentPromoteHandler.test.ts --runInBand: pass, 21/21
- npm test -- src/components/__tests__/ProgramsGoalsTab.test.tsx --runInBand: pass, 57/57
- npm run lint: pass
- npm run typecheck: pass
- npm run build: pass
- npm run ci:check-focused: pass
- npm run validate:tenant: pass
- npm run test:ci: pass, 311 files / 1803 tests
- npm run verify:local: pass, includes policy, lint, typecheck, test:ci, coverage verification, build, and tier-0 route browser coverage

## Reviewer / Tester Notes
- Tester confirmed the verification matrix was sufficient and requested a positive valid-payload server regression; added.
- Reviewer found false-positive risks for existing IEHP adaptive, goal, and signature payload shapes; addressed with compatibility helpers plus positive regressions.

## Residual Risk
- Client and server duplicate IEHP data-quality rules; future schema changes should update both paths together or extract a shared validator.
- CI-only checks that need SUPABASE_DB_URL were skipped locally by policy tooling.
