### PR TITLE
Reject empty IEHP structured placeholders before publish

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -181,9 +181,6 @@ const hasMeaningfulStructuredValue = (value: unknown): boolean => {
 };
 
 const hasDefaultRequiredStructuredValue = (payload: Record<string, unknown>): boolean => {
-  if (payload.template_placeholder === true && payload.entered_value_present === false) {
-    return false;
-  }
   return Object.entries(payload).some(([key, value]) =>
     !IEHP_STRUCTURED_METADATA_KEYS.has(key) && hasMeaningfulStructuredValue(value)
   );

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -116,6 +116,19 @@ const IEHP_GOAL_SECTION_KEYS = new Set([
   "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
   "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
 ]);
+const IEHP_STRUCTURED_METADATA_KEYS = new Set([
+  "field_key",
+  "label",
+  "page_number",
+  "section_key",
+  "field_type",
+  "mode",
+  "required",
+  "source",
+  "layout_json",
+  "template_placeholder",
+  "entered_value_present",
+]);
 
 const isBlankTransferredValue = (value: unknown): boolean => {
   if (value == null) return true;
@@ -150,6 +163,32 @@ const hasLegacySignaturePayload = (payload: Record<string, unknown>): boolean =>
   return !hasTransferSignatureFields && hasNonBlankPayloadValue(payload, "completed_by");
 };
 
+const hasMeaningfulStructuredValue = (value: unknown): boolean => {
+  if (value == null) return false;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized.length > 0 && normalized !== "unknown";
+  }
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value === "boolean") return value === true;
+  if (Array.isArray(value)) return value.some(hasMeaningfulStructuredValue);
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).some(([key, nestedValue]) =>
+      !IEHP_STRUCTURED_METADATA_KEYS.has(key) && hasMeaningfulStructuredValue(nestedValue)
+    );
+  }
+  return false;
+};
+
+const hasDefaultRequiredStructuredValue = (payload: Record<string, unknown>): boolean => {
+  if (payload.template_placeholder === true && payload.entered_value_present === false) {
+    return false;
+  }
+  return Object.entries(payload).some(([key, value]) =>
+    !IEHP_STRUCTURED_METADATA_KEYS.has(key) && hasMeaningfulStructuredValue(value)
+  );
+};
+
 const countIehpStructuredDataQualityIssues = (sections: AssessmentStructuredSection[]): number =>
   sections.filter((section) => {
     if (!section.required || section.status !== "approved") {
@@ -175,6 +214,9 @@ const countIehpStructuredDataQualityIssues = (sections: AssessmentStructuredSect
     }
     if (section.field_key === "IEHP_FBA_SIGNATURE_BLOCK" && hasMissingRequiredFields && hasLegacySignaturePayload(payload)) {
       return false;
+    }
+    if (requiredFields.length === 0 && !hasDefaultRequiredStructuredValue(payload)) {
+      return true;
     }
     if (hasMissingRequiredFields) {
       return true;

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -3994,6 +3994,79 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(screen.getByText("1 approved IEHP data value must be completed before publishing.")).toBeInTheDocument();
   });
 
+  it("disables IEHP publish when approved required structured rows are empty template placeholders", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "iehp_fba",
+              file_name: "placeholder-iehp.docx",
+              mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/placeholder-iehp.docx",
+              status: "extracted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify({
+            items: [],
+            structured_sections: [
+              {
+                id: "structured-placeholder",
+                section_key: "behavior_background_services",
+                field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+                section_index: 0,
+                required: true,
+                status: "approved",
+                review_notes: null,
+                payload: {
+                  field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+                  label: "School Information Block",
+                  template_placeholder: true,
+                  entered_value_present: false,
+                  clinical_value: null,
+                  raw_text: "",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("placeholder-iehp.docx");
+    const publishButton = await screen.findByRole("button", { name: /Publish Reviewed Assessment/i });
+    expect(publishButton).toBeDisabled();
+    expect(screen.getByText("1 approved IEHP data value must be completed before publishing.")).toBeInTheDocument();
+  });
+
   it("does not render IEHP draft editors for already published assessments", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -4067,6 +4067,79 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(screen.getByText("1 approved IEHP data value must be completed before publishing.")).toBeInTheDocument();
   });
 
+  it("allows IEHP publish when a placeholder structured row has clinician-entered content", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: ASSESSMENT_ID,
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              template_type: "iehp_fba",
+              file_name: "filled-placeholder-iehp.docx",
+              mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              file_size: 1000,
+              bucket_id: "client-documents",
+              object_path: "clients/client-1/assessments/filled-placeholder-iehp.docx",
+              status: "extracted",
+              created_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
+        return new Response(
+          JSON.stringify({
+            items: [],
+            structured_sections: [
+              {
+                id: "structured-placeholder",
+                section_key: "behavior_background_services",
+                field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+                section_index: 0,
+                required: true,
+                status: "approved",
+                review_notes: null,
+                payload: {
+                  field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+                  label: "School Information Block",
+                  template_placeholder: true,
+                  entered_value_present: false,
+                  clinical_value: null,
+                  raw_text: "Student attends school with current IEP supports.",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await screen.findByText("filled-placeholder-iehp.docx");
+    const publishButton = await screen.findByRole("button", { name: /Publish Reviewed Assessment/i });
+    expect(publishButton).toBeEnabled();
+    expect(screen.queryByText("1 approved IEHP data value must be completed before publishing.")).not.toBeInTheDocument();
+  });
+
   it("does not render IEHP draft editors for already published assessments", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -462,6 +462,100 @@ describe("assessmentPromoteHandler", () => {
     ).toBe(false);
   });
 
+  it("publishes IEHP assessment when a placeholder structured row has clinician-entered content", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key,section_index,payload")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "structured-placeholder",
+            field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+            section_index: 0,
+            payload: {
+              field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+              label: "School Information Block",
+              template_placeholder: true,
+              entered_value_present: false,
+              clinical_value: null,
+              raw_text: "Student attends school with current IEP supports.",
+            },
+          }],
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "approved",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      assessment_document_id: "doc-1",
+      completion_mode: "assessment_only",
+    });
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url, init]) =>
+        typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted") && init?.method === "PATCH"
+      ),
+    ).toBe(true);
+  });
+
   it("publishes IEHP assessments when approved transferred values and structured payloads are complete", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -368,6 +368,100 @@ describe("assessmentPromoteHandler", () => {
     ).toBe(false);
   });
 
+  it("blocks IEHP assessment publish when approved required structured rows are empty template placeholders", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key,section_index,payload")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "structured-placeholder",
+            field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+            section_index: 0,
+            payload: {
+              field_key: "IEHP_FBA_SCHOOL_INFORMATION_BLOCK",
+              label: "School Information Block",
+              template_placeholder: true,
+              entered_value_present: false,
+              clinical_value: null,
+              raw_text: "",
+            },
+          }],
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "approved",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      blank_required_checklist_count: 0,
+      malformed_structured_count: 1,
+    });
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url, init]) =>
+        typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted") && init?.method === "PATCH"
+      ),
+    ).toBe(false);
+  });
+
   it("publishes IEHP assessments when approved transferred values and structured payloads are complete", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -177,9 +177,6 @@ const hasMeaningfulStructuredValue = (value: unknown): boolean => {
 };
 
 const hasDefaultRequiredStructuredValue = (payload: Record<string, unknown>): boolean => {
-  if (payload.template_placeholder === true && payload.entered_value_present === false) {
-    return false;
-  }
   return Object.entries(payload).some(([key, value]) =>
     !IEHP_STRUCTURED_METADATA_KEYS.has(key) && hasMeaningfulStructuredValue(value)
   );

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -112,6 +112,19 @@ const IEHP_GOAL_SECTION_KEYS = new Set([
   "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
   "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
 ]);
+const IEHP_STRUCTURED_METADATA_KEYS = new Set([
+  "field_key",
+  "label",
+  "page_number",
+  "section_key",
+  "field_type",
+  "mode",
+  "required",
+  "source",
+  "layout_json",
+  "template_placeholder",
+  "entered_value_present",
+]);
 
 const isBlankTransferredValue = (value: unknown): boolean => {
   if (value == null) return true;
@@ -146,6 +159,32 @@ const hasLegacySignaturePayload = (payload: Record<string, unknown>): boolean =>
   return !hasTransferSignatureFields && hasNonBlankPayloadValue(payload, "completed_by");
 };
 
+const hasMeaningfulStructuredValue = (value: unknown): boolean => {
+  if (value == null) return false;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized.length > 0 && normalized !== "unknown";
+  }
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value === "boolean") return value === true;
+  if (Array.isArray(value)) return value.some(hasMeaningfulStructuredValue);
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).some(([key, nestedValue]) =>
+      !IEHP_STRUCTURED_METADATA_KEYS.has(key) && hasMeaningfulStructuredValue(nestedValue)
+    );
+  }
+  return false;
+};
+
+const hasDefaultRequiredStructuredValue = (payload: Record<string, unknown>): boolean => {
+  if (payload.template_placeholder === true && payload.entered_value_present === false) {
+    return false;
+  }
+  return Object.entries(payload).some(([key, value]) =>
+    !IEHP_STRUCTURED_METADATA_KEYS.has(key) && hasMeaningfulStructuredValue(value)
+  );
+};
+
 const buildIehpStructuredDataQualityBlockers = (
   rows: AssessmentRequiredStructuredReviewRow[],
 ): IehpPublishDataQualityBlocker[] =>
@@ -177,6 +216,9 @@ const buildIehpStructuredDataQualityBlockers = (
     }
     if (row.field_key === "IEHP_FBA_SIGNATURE_BLOCK" && missingFields.length > 0 && hasLegacySignaturePayload(payload)) {
       return [];
+    }
+    if (requiredFields.length === 0 && !hasDefaultRequiredStructuredValue(payload)) {
+      missingFields.push("payload");
     }
 
     if (row.field_key === "IEHP_FBA_RECOMMENDATIONS_HCPCS_ROWS") {


### PR DESCRIPTION
## Summary
- block IEHP publish when an approved required structured row is only a template placeholder or otherwise has no meaningful non-metadata value
- mirror the same data-quality guard in the Programs & Goals publish UI so the button remains disabled before the server rejects it
- add regression coverage for server promotion and UI publish gating

## Route / risk
- route-task: high-risk human-reviewed, lane critical
- affected protected surface: server API publish precondition for IEHP assessment documents
- tenant boundary: existing org-scoped assessment document/read model only; no schema, RLS, grants, or migrations changed

## Verification
- PASS: npm test -- src/server/__tests__/assessmentPromoteHandler.test.ts --runInBand
- PASS: npm test -- src/components/__tests__/ProgramsGoalsTab.test.tsx --runInBand
- PASS: npm run typecheck
- PASS: npm run lint
- PASS: npm run build
- PASS: npm run ci:check-focused
- PASS: npm run validate:tenant
- verify:local: reached test:ci and failed from unrelated local Vitest worker/resource contention: Windows temp EBUSY and unrelated timeout suites. After terminating stale node workers, every failed subset passed serially:
  - PASS: npm test -- tests/vitest.env-isolation.test.ts --runInBand
  - PASS: npm test -- tests/admins/invite_flow.spec.ts --runInBand
  - PASS: npm test -- tests/edge/initiate-client-onboarding.utils.test.ts --runInBand
  - PASS: npm test -- src/lib/__tests__/idempotencyService.test.ts --runInBand

## Residual risk
- The generic meaningful-value heuristic is intentionally conservative. If extractor metadata-only payload keys expand later, the metadata allowlist should be updated with matching tests.