### PR TITLE
Fix IEHP placeholder transfer approval gates

### DIFF
--- a/src/server/__tests__/assessmentChecklistHandler.test.ts
+++ b/src/server/__tests__/assessmentChecklistHandler.test.ts
@@ -185,6 +185,56 @@ describe("assessmentChecklistHandler", () => {
     );
   });
 
+  it("blocks approving blank required checklist placeholders", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [
+        {
+          id: "item-1",
+          assessment_document_id: "doc-1",
+          organization_id: "org-1",
+          client_id: "client-1",
+          status: "drafted",
+          required: true,
+          placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+          label: "Assessor's phone number",
+          value_text: "",
+          value_json: null,
+        },
+      ],
+    });
+
+    const response = await assessmentChecklistHandler(
+      new Request("http://localhost/api/assessment-checklist", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          item_id: "11111111-1111-1111-1111-111111111111",
+          status: "approved",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Required checklist item Assessor's phone number cannot be approved while blank.",
+    });
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+  });
+
   it("returns checklist rows with structured sections", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -271,6 +321,123 @@ describe("assessmentChecklistHandler", () => {
       expect.objectContaining({
         method: "POST",
         body: expect.stringContaining("\"item_type\":\"structured_section\""),
+      }),
+    );
+  });
+
+  it("blocks approving blank required structured template placeholders", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [
+        {
+          id: "section-1",
+          assessment_document_id: "doc-1",
+          organization_id: "org-1",
+          client_id: "client-1",
+          status: "drafted",
+          required: true,
+          field_key: "IEHP_FBA_REFERRING_PROVIDER",
+          payload: {
+            field_key: "IEHP_FBA_REFERRING_PROVIDER",
+            label: "Name of Referring Provider, Credentials",
+            template_placeholder: true,
+            entered_value_present: false,
+            clinical_value: null,
+            raw_text: "",
+          },
+        },
+      ],
+    });
+
+    const response = await assessmentChecklistHandler(
+      new Request("http://localhost/api/assessment-checklist", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          structured_section_id: "11111111-1111-1111-1111-111111111111",
+          status: "approved",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Required structured section IEHP_FBA_REFERRING_PROVIDER cannot be approved while blank.",
+    });
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows approving filled structured placeholders even when extraction flags are stale", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "section-1",
+            assessment_document_id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "drafted",
+            required: true,
+            field_key: "IEHP_FBA_REFERRING_PROVIDER",
+            payload: {
+              field_key: "IEHP_FBA_REFERRING_PROVIDER",
+              label: "Name of Referring Provider, Credentials",
+              template_placeholder: true,
+              entered_value_present: false,
+              clinical_value: "",
+              raw_text: "Dr. Jane Referrer, MD",
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [{ id: "section-1", status: "approved" }] })
+      .mockResolvedValueOnce({ ok: true, status: 201, data: null });
+
+    const response = await assessmentChecklistHandler(
+      new Request("http://localhost/api/assessment-checklist", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          structured_section_id: "11111111-1111-1111-1111-111111111111",
+          status: "approved",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: "section-1", status: "approved" });
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_structured_sections?id=eq.section-1"),
+      expect.objectContaining({
+        method: "PATCH",
+        body: expect.stringContaining("\"status\":\"approved\""),
       }),
     );
   });

--- a/src/server/__tests__/assessmentChecklistHandler.test.ts
+++ b/src/server/__tests__/assessmentChecklistHandler.test.ts
@@ -235,6 +235,57 @@ describe("assessmentChecklistHandler", () => {
     expect(fetchJson).toHaveBeenCalledTimes(1);
   });
 
+  it("blocks blanking an already approved required checklist row when status is omitted", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [
+        {
+          id: "item-1",
+          assessment_document_id: "doc-1",
+          organization_id: "org-1",
+          client_id: "client-1",
+          status: "approved",
+          required: true,
+          placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+          label: "Assessor's phone number",
+          value_text: "951-555-0101",
+          value_json: null,
+        },
+      ],
+    });
+
+    const response = await assessmentChecklistHandler(
+      new Request("http://localhost/api/assessment-checklist", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          item_id: "11111111-1111-1111-1111-111111111111",
+          value_text: "",
+          value_json: null,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Required checklist item Assessor's phone number cannot be approved while blank.",
+    });
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+  });
+
   it("returns checklist rows with structured sections", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({

--- a/src/server/api/assessment-checklist.ts
+++ b/src/server/api/assessment-checklist.ts
@@ -297,7 +297,8 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
     }
     const finalValueText = parsed.data.value_text ?? existing.value_text;
     const finalValueJson = parsed.data.value_json === undefined ? existing.value_json : parsed.data.value_json;
-    if (nextStatus === "approved" && existing.required === true && !hasMeaningfulChecklistValue(finalValueText, finalValueJson)) {
+    const finalStatus = nextStatus ?? existing.status;
+    if (finalStatus === "approved" && existing.required === true && !hasMeaningfulChecklistValue(finalValueText, finalValueJson)) {
       return json(
         { error: `Required checklist item ${existing.label ?? existing.placeholder_key ?? existing.id} cannot be approved while blank.` },
         400,

--- a/src/server/api/assessment-checklist.ts
+++ b/src/server/api/assessment-checklist.ts
@@ -31,6 +31,13 @@ interface ChecklistRow {
   organization_id: string;
   client_id: string;
   status: ReviewStatus;
+  required?: boolean | null;
+  label?: string | null;
+  placeholder_key?: string | null;
+  field_key?: string | null;
+  value_text?: string | null;
+  value_json?: Record<string, unknown> | unknown[] | null;
+  payload?: Record<string, unknown> | null;
 }
 
 type ReviewStatus = z.infer<typeof reviewStatusSchema>;
@@ -51,6 +58,60 @@ const canTransitionStatus = (current: ReviewStatus, next: ReviewStatus): boolean
   }
   return statusOrder[next] >= statusOrder[current];
 };
+
+const structuredPayloadMetadataKeys = new Set([
+  "field_key",
+  "label",
+  "page_number",
+  "section_key",
+  "field_type",
+  "mode",
+  "required",
+  "source",
+  "layout_json",
+  "template_placeholder",
+  "entered_value_present",
+  "options",
+]);
+
+const hasMeaningfulReviewValue = (value: unknown, parentKey?: string): boolean => {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    return normalized.length > 0 && normalized.toLowerCase() !== "unknown";
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasMeaningfulReviewValue(entry, parentKey));
+  }
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).some(([key, child]) => {
+      if (structuredPayloadMetadataKeys.has(key)) {
+        return false;
+      }
+      if (parentKey === "options" && key === "label") {
+        return false;
+      }
+      return hasMeaningfulReviewValue(child, key);
+    });
+  }
+  return false;
+};
+
+const hasMeaningfulChecklistValue = (
+  valueText: string | null | undefined,
+  valueJson: Record<string, unknown> | unknown[] | null | undefined,
+): boolean => hasMeaningfulReviewValue(valueText) || hasMeaningfulReviewValue(valueJson);
+
+const hasMeaningfulStructuredPayload = (payload: Record<string, unknown> | null | undefined): boolean =>
+  Boolean(payload && hasMeaningfulReviewValue(payload));
 
 export async function assessmentChecklistHandler(request: Request): Promise<Response> {
   if (request.method === "OPTIONS") {
@@ -126,7 +187,7 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
     }
 
     if (parsed.data.structured_section_id) {
-      const lookupUrl = `${supabaseUrl}/rest/v1/assessment_structured_sections?select=id,assessment_document_id,organization_id,client_id,status&id=eq.${encodeURIComponent(
+      const lookupUrl = `${supabaseUrl}/rest/v1/assessment_structured_sections?select=id,assessment_document_id,organization_id,client_id,status,required,field_key,payload&id=eq.${encodeURIComponent(
         parsed.data.structured_section_id,
       )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`;
       const lookup = await fetchJson<ChecklistRow[]>(lookupUrl, { method: "GET", headers });
@@ -150,6 +211,13 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
       if (existing.status === "approved" && parsed.data.payload !== undefined) {
         return json(
           { error: "Approved structured section payloads are locked. Reject and recreate a reviewed section before changing clinical content." },
+          400,
+        );
+      }
+      const finalStructuredPayload = parsed.data.payload ?? existing.payload;
+      if (nextStatus === "approved" && existing.required === true && !hasMeaningfulStructuredPayload(finalStructuredPayload)) {
+        return json(
+          { error: `Required structured section ${existing.field_key ?? existing.id} cannot be approved while blank.` },
           400,
         );
       }
@@ -203,7 +271,7 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
       return json(updateResult.data[0]);
     }
 
-    const lookupUrl = `${supabaseUrl}/rest/v1/assessment_checklist_items?select=id,assessment_document_id,organization_id,client_id,status&id=eq.${encodeURIComponent(
+    const lookupUrl = `${supabaseUrl}/rest/v1/assessment_checklist_items?select=id,assessment_document_id,organization_id,client_id,status,required,label,placeholder_key,value_text,value_json&id=eq.${encodeURIComponent(
       parsed.data.item_id ?? "",
     )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`;
     const lookup = await fetchJson<ChecklistRow[]>(lookupUrl, { method: "GET", headers });
@@ -224,6 +292,14 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
               ? "Approved checklist rows cannot be downgraded. Edit notes or field value without lowering status."
               : `Invalid checklist status transition: ${existing.status} -> ${nextStatus}`,
         },
+        400,
+      );
+    }
+    const finalValueText = parsed.data.value_text ?? existing.value_text;
+    const finalValueJson = parsed.data.value_json === undefined ? existing.value_json : parsed.data.value_json;
+    if (nextStatus === "approved" && existing.required === true && !hasMeaningfulChecklistValue(finalValueText, finalValueJson)) {
+      return json(
+        { error: `Required checklist item ${existing.label ?? existing.placeholder_key ?? existing.id} cannot be approved while blank.` },
         400,
       );
     }

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -1421,6 +1421,58 @@ Deno.test("deterministicValueForRow maps IEHP PRESENTING CONCERNS heading into r
   expect(manual.value_text).not.toContain("Functional Communication");
 });
 
+Deno.test("hydrateIeHpTemplatePlaceholdersFromFields transfers presenting concerns into reason structured payload", () => {
+  const hydrated = __TESTING__.hydrateIeHpTemplatePlaceholdersFromFields(
+    [{
+      section_key: "identification_admin",
+      field_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+      section_index: 0,
+      payload: {
+        field_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+        template_placeholder: true,
+        entered_value_present: false,
+        clinical_value: null,
+        raw_text: "",
+      },
+      source_span: {
+        method: "iehp_template_layout_placeholder",
+        page_number: 2,
+        field_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+      },
+      status: "drafted",
+      required: true,
+      review_notes: "Template field preserved as an empty placeholder.",
+    }],
+    [{
+      placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+      value_text:
+        "Kim presents with significant communication deficits and primarily relies on hand-leading to express preferences.",
+      value_json: null,
+      confidence: 0.55,
+      mode: "MANUAL",
+      status: "drafted",
+      source_span: { method: "iehp_presenting_concerns_anchor" },
+      review_notes: "Presenting concerns narrative mapped into reason for referral.",
+    }],
+  );
+
+  const reason = hydrated.find((section) => section.field_key === "IEHP_FBA_REASON_FOR_REFERRAL");
+  expect(reason?.payload).toMatchObject({
+    field_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+    template_placeholder: false,
+    entered_value_present: true,
+    clinical_value:
+      "Kim presents with significant communication deficits and primarily relies on hand-leading to express preferences.",
+    raw_text:
+      "Kim presents with significant communication deficits and primarily relies on hand-leading to express preferences.",
+  });
+  expect(reason?.source_span).toMatchObject({
+    method: "iehp_template_layout_placeholder",
+    hydrated_from: "deterministic_checklist_field",
+    field_source_method: "iehp_presenting_concerns_anchor",
+  });
+});
+
 Deno.test("deterministicValueForRow ignores inline presenting concerns prose before heading", () => {
   const manual = __TESTING__.deterministicValueForRow(
     {

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -2529,6 +2529,48 @@ const isEmptyIeHpTemplatePlaceholderPayload = (payload: Record<string, unknown>)
 const hasExistingDeterministicValue = (field: ExtractedFieldResult): boolean =>
   Boolean(field.value_text) || field.value_json !== null;
 
+const hydrateIeHpTemplatePlaceholdersFromFields = (
+  sections: StructuredSectionResult[],
+  fields: ExtractedFieldResult[],
+): StructuredSectionResult[] => {
+  const fieldByKey = new Map(
+    fields
+      .filter(hasExistingDeterministicValue)
+      .map((field) => [field.placeholder_key, field]),
+  );
+
+  return sections.map((section) => {
+    if (!isEmptyIeHpTemplatePlaceholderPayload(section.payload)) {
+      return section;
+    }
+    const field = fieldByKey.get(section.field_key);
+    if (!field) {
+      return section;
+    }
+    const transferredValue = field.value_text ?? field.value_json;
+    if (transferredValue === null || transferredValue === undefined) {
+      return section;
+    }
+    return {
+      ...section,
+      payload: {
+        ...section.payload,
+        template_placeholder: false,
+        entered_value_present: true,
+        clinical_value: transferredValue,
+        raw_text: typeof transferredValue === "string" ? transferredValue : JSON.stringify(transferredValue),
+      },
+      source_span: {
+        ...(section.source_span ?? {}),
+        hydrated_from: "deterministic_checklist_field",
+        field_source_method: field.source_span?.method ?? null,
+      },
+      review_notes:
+        `${section.review_notes ?? "Template placeholder retained."} Populated from matching deterministic checklist extraction for data transfer review.`,
+    };
+  });
+};
+
 const mergeDeterministicFieldWithStructuredSummary = (
   field: ExtractedFieldResult,
   structuredSummary: { count: number; firstPayload: Record<string, unknown> },
@@ -2581,6 +2623,7 @@ export const __TESTING__ = {
   deterministicValueForRow,
   extractStructuredSections,
   hasExistingDeterministicValue,
+  hydrateIeHpTemplatePlaceholdersFromFields,
   mergeDeterministicFieldWithStructuredSummary,
   isAllowedAssessmentDocumentStorageTarget,
 };
@@ -2659,9 +2702,10 @@ const handler = async (req: Request): Promise<Response> => {
     const deterministic = data.checklist_rows.map((row) =>
       deterministicValueForRow(row, documentText, data.client_snapshot, data.checklist_rows)
     );
-    const structuredSections = extractStructuredSections(documentText, data.template_type, docxStructure).map((section) =>
-      withExtractionProviderSource(section, extractionProvider)
-    );
+    const structuredSections = hydrateIeHpTemplatePlaceholdersFromFields(
+      extractStructuredSections(documentText, data.template_type, docxStructure),
+      deterministic,
+    ).map((section) => withExtractionProviderSource(section, extractionProvider));
     const structuredGoalSummary = summarizeStructuredGoalSections(structuredSections);
     const coverageReport = buildStructuredExtractionCoverageReport(structuredSections, data.template_type);
     const structuredSummaryByKey = new Map<string, { count: number; firstPayload: Record<string, unknown> }>();


### PR DESCRIPTION
## Summary
- Hydrate empty IEHP template structured placeholders from matching deterministic checklist values so PRESENTING CONCERNS transfers into Reason for Referral structured payloads.
- Block approval of blank required checklist rows and blank required structured payloads in the assessment checklist API.
- Preserve the filled-placeholder path: meaningful raw_text/clinical_value can approve even if stale template_placeholder/entered_value_present flags remain.

## Verification
- `deno test --allow-env --allow-read supabase/functions/extract-assessment-fields/index.test.ts`
- `npm test -- src/server/__tests__/assessmentChecklistHandler.test.ts --runInBand`
- `npm run verify:local`
- `npm run validate:tenant`

## Routing / Risk
- classification: high-risk human-reviewed
- lane: critical
- protected paths: `supabase/functions/**`, `src/server/**`

## Known Local Skips / Blockers
- `npm run verify:local` passed, with existing local policy skips for missing `SUPABASE_DB_URL` / disabled auth parity, and branch-protection checks skipped outside CI.
- Reviewer subagent delegation was blocked by thread agent limit, so this PR still needs human review.
- Linear issue creation/linking was blocked because the available Linear tool surface in this thread did not expose issue search/create.