### PR TITLE
WIN-171 Normalize IEHP review output rendering

### DIFF
--- a/src/components/ClientDetails/IehpFbaLayoutReview.tsx
+++ b/src/components/ClientDetails/IehpFbaLayoutReview.tsx
@@ -94,6 +94,11 @@ interface AdaptiveMeasureBlockPreview {
   review_note: string;
 }
 
+interface CheckboxPreviewRow {
+  label: string;
+  state: "checked" | "unchecked" | "unknown";
+}
+
 const EMPTY_LAYOUT: TemplateLayoutResponse = {
   template_version: {
     version_key: "",
@@ -164,6 +169,33 @@ const assessmentProcedureRowsFromPayload = (payload: Record<string, unknown> | u
       return { procedure, raw_text: rawText };
     })
     .filter((row) => row.procedure.length > 0 || row.raw_text.length > 0);
+};
+
+const checkboxStateFromValue = (value: unknown): CheckboxPreviewRow["state"] => {
+  if (value === true) return "checked";
+  if (value === false) return "unchecked";
+  if (typeof value !== "string") return "unknown";
+  const normalized = value.trim().toLowerCase();
+  if (["checked", "selected", "true", "yes", "y", "x"].includes(normalized)) return "checked";
+  if (["unchecked", "unselected", "false", "no", "n", ""].includes(normalized)) return "unchecked";
+  return "unknown";
+};
+
+const checkboxRowsFromPayload = (payload: Record<string, unknown> | undefined): CheckboxPreviewRow[] => {
+  const rows = payload?.rows;
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .map((row) => {
+      if (!row || typeof row !== "object") return null;
+      const record = row as Record<string, unknown>;
+      const labelValue = record.label ?? record.name ?? record.question ?? record.item;
+      const label = typeof labelValue === "string" ? labelValue.trim() : "";
+      if (!label) return null;
+      const state = checkboxStateFromValue(record.checked ?? record.selected ?? record.value ?? record.present ?? record.enabled);
+      const hasCheckboxSignal = ["checked", "selected", "value", "present", "enabled"].some((key) => Object.prototype.hasOwnProperty.call(record, key));
+      return hasCheckboxSignal ? { label, state } : null;
+    })
+    .filter((row): row is CheckboxPreviewRow => row !== null);
 };
 
 const readableNarrativeFromPayload = (payload: Record<string, unknown> | undefined): string => {
@@ -339,6 +371,43 @@ const renderStructuredReadablePreview = (section: StructuredValue): JSX.Element 
               <p className="text-xs leading-relaxed whitespace-pre-wrap text-slate-300">
                 {block.raw_text || block.review_note || "No extracted block found."}
               </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const checkboxRows = checkboxRowsFromPayload(section.payload);
+  if (checkboxRows.length > 0) {
+    const tokenByState: Record<CheckboxPreviewRow["state"], string> = {
+      checked: "✓",
+      unchecked: "☐",
+      unknown: "-",
+    };
+    const labelByState: Record<CheckboxPreviewRow["state"], string> = {
+      checked: "selected",
+      unchecked: "not selected",
+      unknown: "unknown",
+    };
+    const classByState: Record<CheckboxPreviewRow["state"], string> = {
+      checked: "border-emerald-400/40 bg-emerald-500/15 text-emerald-200",
+      unchecked: "border-slate-500/50 bg-slate-800/50 text-slate-300",
+      unknown: "border-dashed border-amber-400/40 bg-amber-500/10 text-amber-200",
+    };
+    return (
+      <div className="space-y-2">
+        <p className="text-[11px] font-semibold uppercase tracking-wide text-indigo-200">Checkbox Review</p>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {checkboxRows.map((row) => (
+            <div key={row.label} className={`flex items-center gap-2 rounded border px-2 py-1 ${classByState[row.state]}`}>
+              <span
+                aria-label={`${row.label} ${labelByState[row.state]}`}
+                className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-current text-xs font-bold"
+              >
+                {tokenByState[row.state]}
+              </span>
+              <span className="text-xs font-medium">{row.label}</span>
             </div>
           ))}
         </div>

--- a/src/components/__tests__/IehpFbaLayoutReview.test.tsx
+++ b/src/components/__tests__/IehpFbaLayoutReview.test.tsx
@@ -952,6 +952,81 @@ describe("IehpFbaLayoutReview", () => {
     });
   });
 
+  it("renders checkbox-grid structured payloads with accessible checked and unchecked tokens", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string) => {
+      if (path.startsWith("/api/assessment-template-layout?")) {
+        return new Response(JSON.stringify({
+          template_version: {
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+          },
+          pages: [{ page_number: 7, title: "Environmental Analysis", layout_json: {} }],
+          fields: [
+            {
+              page_number: 7,
+              section_key: "behavior_background_services",
+              field_key: "IEHP_FBA_ENVIRONMENTAL_ANALYSIS",
+              label: "Member Environmental Analysis",
+              field_type: "checkbox_grid",
+              mode: "ASSISTED",
+              required: true,
+              source: "uploaded_assessment_document",
+              layout_json: {},
+            },
+          ],
+          values: {
+            checklist_items: [
+              {
+                id: "item-env",
+                placeholder_key: "IEHP_FBA_ENVIRONMENTAL_ANALYSIS",
+                section_key: "behavior_background_services",
+                label: "Member Environmental Analysis",
+                mode: "ASSISTED",
+                required: true,
+                status: "approved",
+                value_text: "1 structured section extracted",
+                value_json: null,
+                review_notes: null,
+              },
+            ],
+            structured_sections: [
+              {
+                id: "section-env",
+                field_key: "IEHP_FBA_ENVIRONMENTAL_ANALYSIS",
+                section_index: 0,
+                payload: {
+                  rows: [
+                    { label: "Unsafe items secured", checked: true },
+                    { label: "Pets present", checked: false },
+                    { label: "Community hazards reviewed", checked: null },
+                  ],
+                },
+                source_span: { page_number: 7, method: "iehp_section_anchor" },
+                status: "approved",
+                required: true,
+                review_notes: null,
+              },
+            ],
+          },
+          unresolved_required_count: 0,
+          extracted_value_count: 1,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <IehpFbaLayoutReview assessmentDocument={assessmentDocument} organizationId="org-1" />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Page 7/i }));
+    expect(await screen.findByText("Checkbox Review")).toBeInTheDocument();
+    expect(screen.getByLabelText("Unsafe items secured selected")).toHaveTextContent("✓");
+    expect(screen.getByLabelText("Pets present not selected")).toHaveTextContent("☐");
+    expect(screen.getByLabelText("Community hazards reviewed unknown")).toHaveTextContent("-");
+  });
+
   it("renders readable assessment procedures preview with optional technical details toggle and readable copy output", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string) => {
       if (path.startsWith("/api/assessment-template-layout?")) {

--- a/src/server/__tests__/iehpAssessmentDocx.test.ts
+++ b/src/server/__tests__/iehpAssessmentDocx.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { buildIehpDocxPayload } from "../iehpAssessmentDocx";
 
@@ -24,7 +26,7 @@ const approvedChecklist = templateFields.map((field) => ({
   placeholder_key: field.field_key,
   required: field.required,
   status: "approved" as const,
-  value_text: `${field.field_key} checklist value`,
+  value_text: field.field_key === "IEHP_FBA_REPORT_DATE" ? "06/01/2026" : `${field.field_key} checklist value`,
   value_json: null,
 }));
 
@@ -127,6 +129,83 @@ describe("buildIehpDocxPayload", () => {
     expect(result.values.IEHP_FBA_MEMBER_ID).toBe("AUTH-MEMBER-999");
   });
 
+  it("normalizes approved IEHP report date and member id before rendering", () => {
+    const result = buildIehpDocxPayload({
+      ...baseArgs,
+      authorizationMemberId: "201209 00973100",
+      checklistItems: approvedChecklist.map((item) =>
+        item.placeholder_key === "IEHP_FBA_REPORT_DATE"
+          ? { ...item, value_text: "12/ 09 /2025" }
+          : item,
+      ),
+    });
+
+    expect(result.values.IEHP_FBA_REPORT_DATE).toBe("12/09/2025");
+    expect(result.values.IEHP_FBA_MEMBER_ID).toBe("20120900973100");
+  });
+
+  it("uses client profile names over extracted names and warns when they differ", () => {
+    const result = buildIehpDocxPayload({
+      ...baseArgs,
+      checklistItems: approvedChecklist.map((item) => {
+        if (item.placeholder_key === "IEHP_FBA_FIRST_NAME") return { ...item, value_text: "Le" };
+        if (item.placeholder_key === "IEHP_FBA_LAST_NAME") return { ...item, value_text: "Kim" };
+        return item;
+      }),
+    });
+
+    expect(result.values.IEHP_FBA_FIRST_NAME).toBe("Synthetic");
+    expect(result.values.IEHP_FBA_LAST_NAME).toBe("Client");
+    expect(result.preflight.warnings).toContainEqual(
+      expect.stringContaining("extracted document name differs from client profile"),
+    );
+  });
+
+  it("does not render unapproved N/A values for required missing fields", () => {
+    const result = buildIehpDocxPayload({
+      ...baseArgs,
+      checklistItems: approvedChecklist.map((item) =>
+        item.placeholder_key === "IEHP_FBA_ASSESSOR_PHONE"
+          ? { ...item, status: "not_started" as const, value_text: "N/A" }
+          : item,
+      ),
+      writer: {
+        ...baseArgs.writer,
+        phone: null,
+      },
+    });
+
+    expect(result.preflight.ready).toBe(false);
+    expect(result.values.IEHP_FBA_ASSESSOR_PHONE).toBe("");
+    expect(result.preflight.blockers).toContainEqual(
+      expect.objectContaining({
+        code: "unapproved_required_checklist",
+        key: "IEHP_FBA_ASSESSOR_PHONE",
+      }),
+    );
+    expect(result.preflight.blockers).toContainEqual(
+      expect.objectContaining({
+        code: "missing_required_output",
+        key: "IEHP_FBA_ASSESSOR_PHONE",
+        message: expect.stringContaining("missing from approved review data/source"),
+      }),
+    );
+  });
+
+  it("allows optional approved N/A values without making them blockers", () => {
+    const result = buildIehpDocxPayload({
+      ...baseArgs,
+      checklistItems: approvedChecklist.map((item) =>
+        item.placeholder_key === "IEHP_FBA_ADDITIONAL_NOTES"
+          ? { ...item, required: false, status: "approved" as const, value_text: "N/A" }
+          : item,
+      ),
+    });
+
+    expect(result.preflight.ready).toBe(true);
+    expect(result.values.IEHP_FBA_ADDITIONAL_NOTES).toBe("N/A");
+  });
+
   it("blocks unresolved manual-review adaptive blocks instead of inventing clinical content", () => {
     const result = buildIehpDocxPayload({
       ...baseArgs,
@@ -173,6 +252,61 @@ describe("buildIehpDocxPayload", () => {
     expect(result.preflight.blockers).not.toContainEqual(expect.objectContaining({ code: "missing_parent_goal" }));
     expect(result.preflight.blockers).toContainEqual(
       expect.objectContaining({ code: "missing_required_output", key: "IEHP_FBA_LANGUAGE" }),
+    );
+  });
+
+  it("keeps IEHP manifest fields covered by checklist metadata and output preflight", () => {
+    const manifestPath = join(process.cwd(), "docs", "fill_docs", "iehp_fba_layout_manifest.json");
+    const checklistPath = join(process.cwd(), "docs", "fill_docs", "iehp_fba_field_extraction_checklist.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      fields: Array<{ field_key: string; required: boolean; mode: string; source: string }>;
+    };
+    const checklist = JSON.parse(readFileSync(checklistPath, "utf8")) as {
+      rows: Array<{ placeholder_key: string; required: boolean; mode: string; source: string }>;
+    };
+    const checklistByKey = new Map(checklist.rows.map((field) => [field.placeholder_key, field]));
+    const duplicateManifestKeys = manifest.fields
+      .map((field) => field.field_key)
+      .filter((key, index, keys) => keys.indexOf(key) !== index);
+
+    expect(duplicateManifestKeys).toEqual([]);
+    expect(manifest.fields.length).toBeGreaterThan(40);
+    for (const field of manifest.fields) {
+      const checklistField = checklistByKey.get(field.field_key);
+      expect(checklistField, `${field.field_key} is missing checklist metadata`).toBeDefined();
+      expect(checklistField?.required).toBe(field.required);
+      expect(checklistField?.mode).toBe(field.mode);
+      expect(checklistField?.source || field.source).toBeTruthy();
+    }
+
+    const manualRequired = manifest.fields
+      .filter((field) => field.required && field.mode === "MANUAL")
+      .map((field) => field.field_key);
+    expect(manualRequired).toEqual(expect.arrayContaining(["IEHP_FBA_REFERRING_PROVIDER"]));
+
+    const missingAssessorPhoneResult = buildIehpDocxPayload({
+      ...baseArgs,
+      templateFields: manifest.fields.map((field) => ({ field_key: field.field_key, required: field.required })),
+      checklistItems: manifest.fields.map((field) => ({
+        placeholder_key: field.field_key,
+        required: field.required,
+        status: field.required ? ("not_started" as const) : ("approved" as const),
+        value_text: "",
+        value_json: null,
+      })),
+      writer: {
+        ...baseArgs.writer,
+        phone: null,
+      },
+      acceptedGoals: [],
+      structuredSections: [],
+    });
+
+    expect(missingAssessorPhoneResult.preflight.blockers).toContainEqual(
+      expect.objectContaining({ key: "IEHP_FBA_ASSESSOR_PHONE" }),
+    );
+    expect(missingAssessorPhoneResult.preflight.blockers).toContainEqual(
+      expect.objectContaining({ key: "IEHP_FBA_REFERRING_PROVIDER" }),
     );
   });
 });

--- a/src/server/__tests__/iehpAssessmentDocx.test.ts
+++ b/src/server/__tests__/iehpAssessmentDocx.test.ts
@@ -144,6 +144,31 @@ describe("buildIehpDocxPayload", () => {
     expect(result.values.IEHP_FBA_MEMBER_ID).toBe("20120900973100");
   });
 
+  it("blocks approved slashed dates that are not real calendar dates", () => {
+    const result = buildIehpDocxPayload({
+      ...baseArgs,
+      client: {
+        ...baseArgs.client,
+        date_of_birth: null,
+      },
+      checklistItems: approvedChecklist.map((item) => {
+        if (item.placeholder_key === "IEHP_FBA_REPORT_DATE") return { ...item, value_text: "13/40/2025" };
+        if (item.placeholder_key === "IEHP_FBA_BIRTH_DATE") return { ...item, value_text: "02/30/2025" };
+        return item;
+      }),
+    });
+
+    expect(result.preflight.ready).toBe(false);
+    expect(result.values.IEHP_FBA_REPORT_DATE).toBe("");
+    expect(result.values.IEHP_FBA_BIRTH_DATE).toBe("");
+    expect(result.preflight.blockers).toContainEqual(
+      expect.objectContaining({ code: "missing_required_output", key: "IEHP_FBA_REPORT_DATE" }),
+    );
+    expect(result.preflight.blockers).toContainEqual(
+      expect.objectContaining({ code: "missing_required_output", key: "IEHP_FBA_BIRTH_DATE" }),
+    );
+  });
+
   it("uses client profile names over extracted names and warns when they differ", () => {
     const result = buildIehpDocxPayload({
       ...baseArgs,

--- a/src/server/iehpAssessmentDocx.ts
+++ b/src/server/iehpAssessmentDocx.ts
@@ -102,6 +102,18 @@ const normalizeDateText = (value: string | null | undefined): string => {
   const slashedDate = compacted.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
   if (slashedDate) {
     const [, month, day, year] = slashedDate;
+    const parsedMonth = Number(month);
+    const parsedDay = Number(day);
+    const parsedYear = Number(year);
+    const date = new Date(Date.UTC(parsedYear, parsedMonth - 1, parsedDay));
+    if (
+      Number.isNaN(date.getTime()) ||
+      date.getUTCFullYear() !== parsedYear ||
+      date.getUTCMonth() !== parsedMonth - 1 ||
+      date.getUTCDate() !== parsedDay
+    ) {
+      return "";
+    }
     return `${month.padStart(2, "0")}/${day.padStart(2, "0")}/${year}`;
   }
   return formatDate(compacted);

--- a/src/server/iehpAssessmentDocx.ts
+++ b/src/server/iehpAssessmentDocx.ts
@@ -92,6 +92,28 @@ const formatDate = (value: string | null | undefined): string => {
   return `${`${date.getUTCMonth() + 1}`.padStart(2, "0")}/${`${date.getUTCDate()}`.padStart(2, "0")}/${date.getUTCFullYear()}`;
 };
 
+const compactWhitespace = (value: string): string => value.replace(/\s+/g, " ").trim();
+
+const collapseWhitespace = (value: string): string => value.replace(/\s+/g, "").trim();
+
+const normalizeDateText = (value: string | null | undefined): string => {
+  const compacted = compactWhitespace(value ?? "").replace(/\s*\/\s*/g, "/");
+  if (!compacted) return "";
+  const slashedDate = compacted.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (slashedDate) {
+    const [, month, day, year] = slashedDate;
+    return `${month.padStart(2, "0")}/${day.padStart(2, "0")}/${year}`;
+  }
+  return formatDate(compacted);
+};
+
+const approvedChecklistText = (checklistValue: AssessmentChecklistValueRow | undefined): string => {
+  if (checklistValue?.status !== "approved") return "";
+  return toText(checklistValue.value_text ?? checklistValue.value_json);
+};
+
+const normalizedCompareText = (value: string): string => compactWhitespace(value).toLowerCase();
+
 const formatAddress = (client: AssessmentClientSnapshot): string =>
   [client.address_line1, client.address_line2, client.city, client.state, client.zip_code]
     .map((item) => (typeof item === "string" ? item.trim() : ""))
@@ -181,7 +203,7 @@ const derivedValue = (
   const structuredText = formatSectionsForKey(fieldKey, args.structuredSections);
   if (structuredText) return structuredText;
 
-  const checklistText = checklistValue ? toText(checklistValue.value_text ?? checklistValue.value_json) : "";
+  const checklistText = approvedChecklistText(checklistValue);
   const { client, writer, acceptedPrograms, acceptedGoals } = args;
   const childGoals = acceptedGoals.filter((goal) => goal.goal_type !== "parent");
   const parentGoals = acceptedGoals.filter((goal) => goal.goal_type === "parent");
@@ -192,9 +214,9 @@ const derivedValue = (
     case "IEHP_FBA_LAST_NAME":
       return client.last_name?.trim() || client.full_name?.trim().split(/\s+/).slice(1).join(" ") || checklistText;
     case "IEHP_FBA_BIRTH_DATE":
-      return formatDate(client.date_of_birth) || checklistText;
+      return formatDate(client.date_of_birth) || normalizeDateText(checklistText);
     case "IEHP_FBA_MEMBER_ID":
-      return `${args.authorizationMemberId ?? client.cin_number ?? client.client_id ?? ""}`.trim() || checklistText;
+      return collapseWhitespace(`${args.authorizationMemberId ?? client.cin_number ?? client.client_id ?? ""}`) || collapseWhitespace(checklistText);
     case "IEHP_FBA_PRESENT_ADDRESS":
       return formatAddress(client) || checklistText;
     case "IEHP_FBA_PARENT_GUARDIAN":
@@ -204,7 +226,7 @@ const derivedValue = (
     case "IEHP_FBA_LANGUAGE":
       return `${client.preferred_language ?? ""}`.trim() || checklistText;
     case "IEHP_FBA_REPORT_DATE":
-      return formatDate(new Date().toISOString()) || checklistText;
+      return normalizeDateText(checklistText);
     case "IEHP_FBA_ASSESSOR_CERTIFICATION":
       return [writer.full_name, formatWriterCredentials(writer)].filter(Boolean).join(", ") || checklistText;
     case "IEHP_FBA_ASSESSOR_PHONE":
@@ -226,6 +248,17 @@ export function buildIehpDocxPayload(args: BuildIehpDocxPayloadArgs): BuiltIehpD
   const checklistByKey = new Map(args.checklistItems.map((item) => [item.placeholder_key, item]));
   const blockers: IehpPreflightBlocker[] = [];
   const warnings: string[] = [];
+  const profileFirstName = args.client.first_name?.trim() || "";
+  const profileLastName = args.client.last_name?.trim() || "";
+  const extractedFirstName = approvedChecklistText(checklistByKey.get("IEHP_FBA_FIRST_NAME"));
+  const extractedLastName = approvedChecklistText(checklistByKey.get("IEHP_FBA_LAST_NAME"));
+
+  if (
+    (profileFirstName && extractedFirstName && normalizedCompareText(profileFirstName) !== normalizedCompareText(extractedFirstName)) ||
+    (profileLastName && extractedLastName && normalizedCompareText(profileLastName) !== normalizedCompareText(extractedLastName))
+  ) {
+    warnings.push("Approved extracted document name differs from client profile; final output uses the client profile name.");
+  }
 
   args.checklistItems
     .filter((item) => item.required && item.status !== "approved")
@@ -265,7 +298,7 @@ export function buildIehpDocxPayload(args: BuildIehpDocxPayloadArgs): BuiltIehpD
       blockers.push({
         code: "missing_required_output",
         key: field.field_key,
-        message: `Required IEHP output field ${field.field_key} resolved empty.`,
+        message: `Required IEHP output field ${field.field_key} is missing from approved review data/source.`,
       });
     }
   });


### PR DESCRIPTION
## Summary
- Normalize IEHP final DOCX values for report date and member ID from approved review data.
- Prefer client profile first/last names in final IEHP output and warn when approved extracted names differ.
- Keep required missing/unapproved fields as blockers and avoid implicit `N/A`/default output for required missing source data.
- Add accessible checkbox-grid review tokens and IEHP manifest/checklist mapping coverage.

## Route / Risk
- Classification: high-risk human-reviewed
- Lane: critical
- Reason: touches `src/server/**` IEHP output/preflight behavior and protected assessment output paths.
- Linear: WIN-171

## Verification
- `npm test -- src/server/__tests__/iehpAssessmentDocx.test.ts src/components/__tests__/IehpFbaLayoutReview.test.tsx` passed
- `npm run ci:check-focused` passed
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run test:ci` passed: 311 files, 1819 tests
- `npm run build` passed
- `npm run ci:verify-coverage` passed: line coverage 91.97% >= 86.00%
- `npm run test:routes:tier0` passed: 78/78 Cypress route tests

## Notes
- `npm run verify:local` was attempted but timed out while repeating the chained gates. All sub-gates from that script were run individually afterward and passed.
- Local policy checks skipped DB-backed grant/drift checks because `SUPABASE_DB_URL`/`DATABASE_URL` are not configured locally.