### PR TITLE
Make absent IEHP output fields optional

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -105,6 +105,11 @@ const IEHP_REQUIRED_PAYLOAD_FIELDS: Record<string, string[]> = {
   IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES: ["measure_name", "date_administered", "interviewer", "respondent"],
   IEHP_FBA_SIGNATURE_BLOCK: ["completed_by", "report_completed_date", "credentials", "agency"],
 };
+const IEHP_OPTIONAL_FINAL_OUTPUT_KEYS = new Set([
+  "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+  "IEHP_FBA_ASSESSOR_PHONE",
+  "IEHP_FBA_REFERRING_PROVIDER",
+]);
 const IEHP_REQUIRED_GOAL_FIELDS = [
   "program_name",
   "target_criteria",
@@ -231,6 +236,9 @@ const countIehpStructuredDataQualityIssues = (sections: AssessmentStructuredSect
       );
     });
   }).length;
+
+const isRequiredForAssessmentExport = (fieldKey: string, required: boolean, isIehp: boolean): boolean =>
+  required && !(isIehp && IEHP_OPTIONAL_FINAL_OUTPUT_KEYS.has(fieldKey));
 
 const buildStructuredPayloadPreview = (payload: Record<string, unknown>): string[] => {
   const rows = Array.isArray(payload.rows) ? payload.rows : [];
@@ -753,6 +761,17 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     (checklistReviewUnavailable ||
       checklistItems.some((item) => item.required && item.status !== "approved") ||
       structuredSections.some((section) => section.required && section.status !== "approved"));
+  const hasPendingRequiredExportItems =
+    ENABLE_CHECKLIST_MAPPING_UI &&
+    (checklistReviewUnavailable ||
+      checklistItems.some((item) =>
+        isRequiredForAssessmentExport(item.placeholder_key, item.required, selectedAssessmentIsIehp) &&
+        item.status !== "approved"
+      ) ||
+      structuredSections.some((section) =>
+        isRequiredForAssessmentExport(section.field_key, section.required, selectedAssessmentIsIehp) &&
+        section.status !== "approved"
+      ));
   const hasExistingDrafts = (assessmentDrafts?.programs?.length ?? 0) > 0 || (assessmentDrafts?.goals?.length ?? 0) > 0;
   const acceptedDraftProgramCount = (assessmentDrafts?.programs ?? []).filter(
     (program) => program.accept_state === "accepted" || program.accept_state === "edited",
@@ -1690,9 +1709,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
               <button
                 type="button"
                 onClick={() => generateAssessmentPlanPdf.mutate()}
-                disabled={!canQuerySelectedAssessment || hasPendingRequiredChecklistItems || generateAssessmentPlanPdf.isLoading}
+                disabled={!canQuerySelectedAssessment || hasPendingRequiredExportItems || generateAssessmentPlanPdf.isLoading}
                 title={
-                  hasPendingRequiredChecklistItems
+                  hasPendingRequiredExportItems
                       ? "Approve all required checklist and structured fields before export."
                       : undefined
                 }

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -2515,7 +2515,80 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
       if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
       if (method === "GET" && path.startsWith("/api/assessment-checklist?")) {
-        return new Response(JSON.stringify({ items: [], structured_sections: [] }), { status: 200 });
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                id: "optional-referring-provider",
+                assessment_document_id: ASSESSMENT_ID,
+                placeholder_key: "IEHP_FBA_REFERRING_PROVIDER",
+                label: "Name of Referring Provider",
+                value_text: null,
+                value_json: null,
+                status: "not_started",
+                required: true,
+              },
+              {
+                id: "optional-assessor-phone",
+                assessment_document_id: ASSESSMENT_ID,
+                placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+                label: "Assessor phone",
+                value_text: "N/a",
+                value_json: null,
+                status: "approved",
+                required: true,
+              },
+              {
+                id: "optional-adaptive-summary",
+                assessment_document_id: ASSESSMENT_ID,
+                placeholder_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+                label: "Adaptive measure summaries",
+                value_text: "1 structured section extracted",
+                value_json: null,
+                status: "approved",
+                required: true,
+              },
+            ],
+            structured_sections: [
+              {
+                id: "optional-assessor-phone-section",
+                assessment_document_id: ASSESSMENT_ID,
+                field_key: "IEHP_FBA_ASSESSOR_PHONE",
+                section_key: "identification_admin",
+                section_index: 0,
+                payload: null,
+                status: "drafted",
+                required: true,
+              },
+              {
+                id: "optional-referring-provider-section",
+                assessment_document_id: ASSESSMENT_ID,
+                field_key: "IEHP_FBA_REFERRING_PROVIDER",
+                section_key: "identification_admin",
+                section_index: 0,
+                payload: null,
+                status: "not_started",
+                required: true,
+              },
+              {
+                id: "optional-adaptive-summary-section",
+                assessment_document_id: ASSESSMENT_ID,
+                field_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+                section_key: "assessment_procedures_testing",
+                section_index: 0,
+                payload: {
+                  assessment_blocks: [
+                    { label: "VB-MAPP", raw_text: null, manual_review_required: true },
+                    { label: "Vineland", raw_text: "Vineland summary" },
+                  ],
+                },
+                status: "approved",
+                required: true,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
       }
       if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
         return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });

--- a/src/server/__tests__/iehpAssessmentDocx.test.ts
+++ b/src/server/__tests__/iehpAssessmentDocx.test.ts
@@ -190,31 +190,105 @@ describe("buildIehpDocxPayload", () => {
     const result = buildIehpDocxPayload({
       ...baseArgs,
       checklistItems: approvedChecklist.map((item) =>
-        item.placeholder_key === "IEHP_FBA_ASSESSOR_PHONE"
+        item.placeholder_key === "IEHP_FBA_LANGUAGE"
           ? { ...item, status: "not_started" as const, value_text: "N/A" }
           : item,
       ),
+      client: {
+        ...baseArgs.client,
+        preferred_language: null,
+      },
+    });
+
+    expect(result.preflight.ready).toBe(false);
+    expect(result.values.IEHP_FBA_LANGUAGE).toBe("");
+    expect(result.preflight.blockers).toContainEqual(
+      expect.objectContaining({
+        code: "unapproved_required_checklist",
+        key: "IEHP_FBA_LANGUAGE",
+      }),
+    );
+    expect(result.preflight.blockers).toContainEqual(
+      expect.objectContaining({
+        code: "missing_required_output",
+        key: "IEHP_FBA_LANGUAGE",
+        message: expect.stringContaining("missing from approved review data/source"),
+      }),
+    );
+  });
+
+  it("treats absent IEHP source fields as optional for final DOCX generation", () => {
+    const result = buildIehpDocxPayload({
+      ...baseArgs,
+      templateFields: [
+        { field_key: "IEHP_FBA_REFERRING_PROVIDER", required: true },
+        { field_key: "IEHP_FBA_ASSESSOR_PHONE", required: true },
+        { field_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES", required: true },
+      ],
+      checklistItems: [
+        {
+          placeholder_key: "IEHP_FBA_REFERRING_PROVIDER",
+          required: true,
+          status: "not_started",
+          value_text: null,
+          value_json: null,
+        },
+        {
+          placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+          required: true,
+          status: "approved",
+          value_text: "N/a",
+          value_json: null,
+        },
+        {
+          placeholder_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+          required: true,
+          status: "approved",
+          value_text: "1 structured section extracted",
+          value_json: null,
+        },
+      ],
+      structuredSections: [
+        {
+          field_key: "IEHP_FBA_ASSESSOR_PHONE",
+          section_key: "identification_admin",
+          section_index: 0,
+          payload: null,
+          status: "drafted",
+          required: true,
+        },
+        {
+          field_key: "IEHP_FBA_REFERRING_PROVIDER",
+          section_key: "identification_admin",
+          section_index: 0,
+          payload: null,
+          status: "not_started",
+          required: true,
+        },
+        {
+          field_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+          section_key: "assessment_procedures_testing",
+          section_index: 0,
+          payload: {
+            assessment_blocks: [
+              { label: "VB-MAPP", raw_text: null, manual_review_required: true },
+              { label: "Vineland", raw_text: "Vineland summary" },
+            ],
+          },
+          status: "approved",
+          required: true,
+        },
+      ],
       writer: {
         ...baseArgs.writer,
         phone: null,
       },
     });
 
-    expect(result.preflight.ready).toBe(false);
-    expect(result.values.IEHP_FBA_ASSESSOR_PHONE).toBe("");
-    expect(result.preflight.blockers).toContainEqual(
-      expect.objectContaining({
-        code: "unapproved_required_checklist",
-        key: "IEHP_FBA_ASSESSOR_PHONE",
-      }),
-    );
-    expect(result.preflight.blockers).toContainEqual(
-      expect.objectContaining({
-        code: "missing_required_output",
-        key: "IEHP_FBA_ASSESSOR_PHONE",
-        message: expect.stringContaining("missing from approved review data/source"),
-      }),
-    );
+    expect(result.preflight.ready).toBe(true);
+    expect(result.values.IEHP_FBA_REFERRING_PROVIDER).toBe("");
+    expect(result.values.IEHP_FBA_ASSESSOR_PHONE).toBe("N/a");
+    expect(result.preflight.blockers).toEqual([]);
   });
 
   it("allows optional approved N/A values without making them blockers", () => {
@@ -231,7 +305,7 @@ describe("buildIehpDocxPayload", () => {
     expect(result.values.IEHP_FBA_ADDITIONAL_NOTES).toBe("N/A");
   });
 
-  it("blocks unresolved manual-review adaptive blocks instead of inventing clinical content", () => {
+  it("does not block final generation on unresolved optional adaptive blocks", () => {
     const result = buildIehpDocxPayload({
       ...baseArgs,
       structuredSections: [
@@ -251,8 +325,8 @@ describe("buildIehpDocxPayload", () => {
       ],
     });
 
-    expect(result.preflight.ready).toBe(false);
-    expect(result.preflight.blockers).toContainEqual(
+    expect(result.preflight.ready).toBe(true);
+    expect(result.preflight.blockers).not.toContainEqual(
       expect.objectContaining({
         code: "manual_review_required",
         key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
@@ -327,10 +401,10 @@ describe("buildIehpDocxPayload", () => {
       structuredSections: [],
     });
 
-    expect(missingAssessorPhoneResult.preflight.blockers).toContainEqual(
+    expect(missingAssessorPhoneResult.preflight.blockers).not.toContainEqual(
       expect.objectContaining({ key: "IEHP_FBA_ASSESSOR_PHONE" }),
     );
-    expect(missingAssessorPhoneResult.preflight.blockers).toContainEqual(
+    expect(missingAssessorPhoneResult.preflight.blockers).not.toContainEqual(
       expect.objectContaining({ key: "IEHP_FBA_REFERRING_PROVIDER" }),
     );
   });

--- a/src/server/iehpAssessmentDocx.ts
+++ b/src/server/iehpAssessmentDocx.ts
@@ -96,6 +96,15 @@ const compactWhitespace = (value: string): string => value.replace(/\s+/g, " ").
 
 const collapseWhitespace = (value: string): string => value.replace(/\s+/g, "").trim();
 
+const IEHP_OPTIONAL_FINAL_OUTPUT_KEYS = new Set([
+  "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+  "IEHP_FBA_ASSESSOR_PHONE",
+  "IEHP_FBA_REFERRING_PROVIDER",
+]);
+
+const isRequiredForFinalOutput = (fieldKey: string, required: boolean): boolean =>
+  required && !IEHP_OPTIONAL_FINAL_OUTPUT_KEYS.has(fieldKey);
+
 const normalizeDateText = (value: string | null | undefined): string => {
   const compacted = compactWhitespace(value ?? "").replace(/\s*\/\s*/g, "/");
   if (!compacted) return "";
@@ -273,7 +282,7 @@ export function buildIehpDocxPayload(args: BuildIehpDocxPayloadArgs): BuiltIehpD
   }
 
   args.checklistItems
-    .filter((item) => item.required && item.status !== "approved")
+    .filter((item) => isRequiredForFinalOutput(item.placeholder_key, item.required) && item.status !== "approved")
     .forEach((item) => {
       blockers.push({
         code: "unapproved_required_checklist",
@@ -283,7 +292,7 @@ export function buildIehpDocxPayload(args: BuildIehpDocxPayloadArgs): BuiltIehpD
     });
 
   (args.structuredSections ?? [])
-    .filter((section) => section.required && section.status !== "approved")
+    .filter((section) => isRequiredForFinalOutput(section.field_key, section.required) && section.status !== "approved")
     .forEach((section) => {
       blockers.push({
         code: "unapproved_required_structured_section",
@@ -293,7 +302,11 @@ export function buildIehpDocxPayload(args: BuildIehpDocxPayloadArgs): BuiltIehpD
     });
 
   (args.structuredSections ?? [])
-    .filter((section) => section.field_key === "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES" && hasManualReviewAdaptiveGap(section.payload))
+    .filter((section) =>
+      isRequiredForFinalOutput(section.field_key, section.required) &&
+      section.field_key === "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES" &&
+      hasManualReviewAdaptiveGap(section.payload)
+    )
     .forEach((section) => {
       blockers.push({
         code: "manual_review_required",
@@ -306,7 +319,7 @@ export function buildIehpDocxPayload(args: BuildIehpDocxPayloadArgs): BuiltIehpD
   args.templateFields.forEach((field) => {
     const checklistValue = checklistByKey.get(field.field_key);
     values[field.field_key] = derivedValue(field.field_key, args, checklistValue);
-    if (field.required && !values[field.field_key]?.trim()) {
+    if (isRequiredForFinalOutput(field.field_key, field.required) && !values[field.field_key]?.trim()) {
       blockers.push({
         code: "missing_required_output",
         key: field.field_key,


### PR DESCRIPTION
## Summary
- Treat `IEHP_FBA_REFERRING_PROVIDER`, `IEHP_FBA_ASSESSOR_PHONE`, and `IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES` as optional for final IEHP DOCX generation preflight.
- Preserve existing required-field behavior for all other IEHP output fields.
- Add focused coverage for absent source fields, unresolved optional adaptive placeholders, and required-field N/A rejection on another required key.

## Route / Risk
- classification: high-risk human-reviewed
- lane: critical
- reason: touches `src/server/**` IEHP generation/preflight behavior.
- Linear: connector session did not expose issue search/create; please attach the appropriate IEHP issue before merge if required by process.

## Verification
- `npm test -- src/server/__tests__/iehpAssessmentDocx.test.ts` passed: 11 tests.
- `npm test -- src/server/__tests__/assessmentPlanPdfHandler.test.ts src/server/__tests__/iehpAssessmentDocx.test.ts` passed: 20 tests.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run ci:check-focused` passed.
- `npm run test:ci` passed: 311 files, 1821 tests.
- `npm run build` passed.
- `npm run verify:local` passed, including policy checks, lint, typecheck, test:ci, coverage verification, build, and tier-0 route tests.

## Residual Risk
- Hosted generation still requires deployment before the latest approved synthetic IEHP assessment can generate.
- This intentionally allows the three listed fields to render blank or approved N/A in final DOCX output when the uploaded source lacks them.