### PR TITLE
Show optional IEHP review fields as optional

### DIFF
--- a/src/components/ClientDetails/IehpFbaLayoutReview.tsx
+++ b/src/components/ClientDetails/IehpFbaLayoutReview.tsx
@@ -453,8 +453,27 @@ const emptyPageMessage = (pageNumber: number, title: string | undefined): string
   return "This template page is represented for layout parity. No mapped checklist field lands on this page yet.";
 };
 
+const IEHP_OPTIONAL_FINAL_OUTPUT_KEYS = new Set([
+  "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+  "IEHP_FBA_ASSESSOR_PHONE",
+  "IEHP_FBA_REFERRING_PROVIDER",
+]);
+
+const isOptionalFinalOutputField = (fieldKey: string): boolean => IEHP_OPTIONAL_FINAL_OUTPUT_KEYS.has(fieldKey);
+
+const isRequiredForIehpReview = (fieldKey: string, required: boolean): boolean =>
+  required && !isOptionalFinalOutputField(fieldKey);
+
+const displayRequiredLabel = (fieldKey: string, required: boolean): string =>
+  isRequiredForIehpReview(fieldKey, required) ? "Required" : "Optional";
+
+const displayRequiredDetails = (fieldKey: string, required: boolean): string =>
+  isOptionalFinalOutputField(fieldKey) && required
+    ? "required for final DOCX: false (template metadata: true)"
+    : `required: ${String(required)}`;
+
 const isManualRequiredReviewItem = (field: TemplateField, item: ChecklistValue | undefined): boolean =>
-  field.required && field.mode === "MANUAL" && (!item || item.status === "not_started");
+  isRequiredForIehpReview(field.field_key, field.required) && field.mode === "MANUAL" && (!item || item.status === "not_started");
 
 const emptyPageReviewSummary = (): PageReviewSummary => ({
   needsAttention: 0,
@@ -570,13 +589,22 @@ export function IehpFbaLayoutReview({
     data.fields.forEach((field) => {
       const pageNumber = PAGE_FIELD_KEY_OVERRIDES[field.field_key] ?? field.page_number;
       const item = checklistByKey.get(field.field_key);
-      const status = isManualRequiredReviewItem(field, item) ? "not_started" : item?.status ?? "missing";
+      const status = !isRequiredForIehpReview(field.field_key, field.required) && (!item || isAttentionReviewStatus(item.status))
+        ? "approved"
+        : isManualRequiredReviewItem(field, item)
+          ? "not_started"
+          : item?.status ?? "missing";
       addStatusToPageReviewSummary(ensureSummary(pageNumber), status);
     });
     data.values.structured_sections.forEach((section) => {
       const pageNumber = getStructuredSectionPageNumber(section) ?? fieldPageByKey.get(section.field_key);
       if (pageNumber === undefined) return;
-      addStatusToPageReviewSummary(ensureSummary(pageNumber), section.status);
+      addStatusToPageReviewSummary(
+        ensureSummary(pageNumber),
+        !isRequiredForIehpReview(section.field_key, section.required) && isAttentionReviewStatus(section.status)
+          ? "approved"
+          : section.status,
+      );
     });
 
     return summaries;
@@ -599,17 +627,28 @@ export function IehpFbaLayoutReview({
   const activePageAttentionTargetKey = useMemo(() => {
     for (const field of activePageFields) {
       const item = checklistByKey.get(field.field_key);
-      const fieldStatus = isManualRequiredReviewItem(field, item) ? "not_started" : item?.status ?? "missing";
+      const fieldStatus = !isRequiredForIehpReview(field.field_key, field.required) && (!item || isAttentionReviewStatus(item.status))
+        ? "approved"
+        : isManualRequiredReviewItem(field, item)
+          ? "not_started"
+          : item?.status ?? "missing";
       const structuredSections = (structuredByKey.get(field.field_key) ?? []).filter((section) => {
         const pageNumber = getStructuredSectionPageNumber(section);
         return pageNumber === null || pageNumber === activePage;
       });
-      if (isAttentionReviewStatus(fieldStatus) || structuredSections.some((section) => isAttentionReviewStatus(section.status))) {
+      if (
+        isAttentionReviewStatus(fieldStatus) ||
+        structuredSections.some((section) =>
+          isRequiredForIehpReview(section.field_key, section.required) && isAttentionReviewStatus(section.status)
+        )
+      ) {
         return `field-${field.field_key}`;
       }
     }
 
-    const looseSection = activePageLooseStructuredSections.find((section) => isAttentionReviewStatus(section.status));
+    const looseSection = activePageLooseStructuredSections.find((section) =>
+      isRequiredForIehpReview(section.field_key, section.required) && isAttentionReviewStatus(section.status)
+    );
     return looseSection ? `structured-${looseSection.id}` : null;
   }, [activePage, activePageFields, activePageLooseStructuredSections, checklistByKey, structuredByKey]);
 
@@ -932,9 +971,19 @@ export function IehpFbaLayoutReview({
                   });
                   const locked = item?.status === "approved";
                   const manualRequired = isManualRequiredReviewItem(field, item);
-                  const fieldStatus = manualRequired ? "not_started" : item?.status ?? "missing";
+                  const reviewRequired = isRequiredForIehpReview(field.field_key, field.required);
+                  const optionalFinalOutput = isOptionalFinalOutputField(field.field_key);
+                  const fieldStatus = !reviewRequired && (!item || isAttentionReviewStatus(item.status))
+                    ? "approved"
+                    : manualRequired
+                      ? "not_started"
+                      : item?.status ?? "missing";
                   const fieldAttentionTargetKey = `field-${field.field_key}`;
-                  const fieldNeedsAttention = isAttentionReviewStatus(fieldStatus) || structuredSections.some((section) => isAttentionReviewStatus(section.status));
+                  const fieldNeedsAttention =
+                    isAttentionReviewStatus(fieldStatus) ||
+                    structuredSections.some((section) =>
+                      isRequiredForIehpReview(section.field_key, section.required) && isAttentionReviewStatus(section.status)
+                    );
                   const highlightAttentionTarget = activePageAttentionTargetKey === fieldAttentionTargetKey && fieldNeedsAttention;
                   const expanded = Boolean(expandedFieldByKey[field.field_key]);
                   const fieldValuePreview = edit.valueText.trim();
@@ -961,9 +1010,9 @@ export function IehpFbaLayoutReview({
                           )}
                         </div>
                         <div className="flex flex-wrap items-center justify-end gap-2">
-                          {field.required && (
-                            <span className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-300">Required</span>
-                          )}
+                          <span className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-300">
+                            {displayRequiredLabel(field.field_key, field.required)}
+                          </span>
                           <span className={`rounded px-2 py-1 text-[11px] font-semibold ${statusChipClass(manualRequired ? "not_started" : item?.status ?? "not_started")}`}>
                             {manualRequired ? "Manual review required" : formatStatusLabel(item?.status ?? "not_started")}
                           </span>
@@ -973,6 +1022,11 @@ export function IehpFbaLayoutReview({
                       {manualRequired && (
                         <p className="mt-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900">
                           This required IEHP field is intentionally manual unless reliable document evidence is present.
+                        </p>
+                      )}
+                      {optionalFinalOutput && (
+                        <p className="mt-2 rounded border border-sky-500/40 bg-sky-950/40 p-2 text-xs text-sky-100">
+                          Optional for final IEHP DOCX export; leave blank when no source value exists.
                         </p>
                       )}
 
@@ -1039,7 +1093,7 @@ export function IehpFbaLayoutReview({
                       {expanded && (
                         <div className="mt-3 space-y-3">
                           <p className="text-[11px] text-slate-400">
-                            {field.field_key} • {field.mode} • {field.field_type} • required: {String(field.required)}
+                            {field.field_key} • {field.mode} • {field.field_type} • {displayRequiredDetails(field.field_key, field.required)}
                           </p>
                           <textarea
                             id={`iehp-${field.field_key}`}
@@ -1074,7 +1128,7 @@ export function IehpFbaLayoutReview({
                                   <div key={section.id} className="rounded border border-slate-600 bg-slate-800 p-2">
                                     <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
                                       <span className="font-semibold text-slate-100">
-                                        Section {section.section_index + 1} • required: {String(section.required)}
+                                        Section {section.section_index + 1} • {displayRequiredDetails(section.field_key, section.required)}
                                       </span>
                                       <div className="flex items-center gap-2">
                                         <span className={`rounded px-2 py-1 text-[11px] font-semibold ${statusChipClass(section.status)}`}>{formatStatusLabel(section.status)}</span>
@@ -1262,7 +1316,10 @@ export function IehpFbaLayoutReview({
                         };
                         const structuredLocked = section.status === "approved";
                         const structuredAttentionTargetKey = `structured-${section.id}`;
-                        const highlightAttentionTarget = activePageAttentionTargetKey === structuredAttentionTargetKey && isAttentionReviewStatus(section.status);
+                        const highlightAttentionTarget =
+                          activePageAttentionTargetKey === structuredAttentionTargetKey &&
+                          isRequiredForIehpReview(section.field_key, section.required) &&
+                          isAttentionReviewStatus(section.status);
                         const expanded = Boolean(expandedStructuredSectionById[section.id]);
                         const sectionTitle = structuredSectionDisplayTitle(section);
                         return (

--- a/src/components/__tests__/IehpFbaLayoutReview.test.tsx
+++ b/src/components/__tests__/IehpFbaLayoutReview.test.tsx
@@ -154,6 +154,91 @@ describe("IehpFbaLayoutReview", () => {
     });
   });
 
+  it("shows final-output optional IEHP fields as optional even when template metadata is required", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string) => {
+      if (path.startsWith("/api/assessment-template-layout?")) {
+        return new Response(JSON.stringify({
+          template_version: {
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+          },
+          pages: [{ page_number: 1, title: "General Information", layout_json: {} }],
+          fields: [
+            {
+              page_number: 1,
+              section_key: "identification_admin",
+              field_key: "IEHP_FBA_ASSESSOR_PHONE",
+              label: "Assessor's phone number",
+              field_type: "text",
+              mode: "ASSISTED",
+              required: true,
+              source: "therapists.phone || company_settings.phone",
+              layout_json: {},
+            },
+          ],
+          values: {
+            checklist_items: [
+              {
+                id: "assessor-phone-item",
+                placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+                section_key: "identification_admin",
+                label: "Assessor's phone number",
+                mode: "ASSISTED",
+                required: true,
+                status: "verified",
+                value_text: "",
+                value_json: null,
+                review_notes: "No extracted field value was found in the source document.",
+              },
+            ],
+            structured_sections: [
+              {
+                id: "assessor-phone-section",
+                field_key: "IEHP_FBA_ASSESSOR_PHONE",
+                section_index: 0,
+                payload: {
+                  label: "Assessor's phone number",
+                  raw_text: "No extracted field value was found in the source document.",
+                },
+                status: "drafted",
+                required: true,
+                review_notes: "Template field preserved as optional for final export.",
+              },
+            ],
+          },
+          unresolved_required_count: 0,
+          extracted_value_count: 0,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <IehpFbaLayoutReview assessmentDocument={assessmentDocument} organizationId="org-1" />,
+    );
+
+    const card = await screen.findByTestId("review-attention-target-field-IEHP_FBA_ASSESSOR_PHONE");
+    expect(within(card).getByText("Optional")).toBeInTheDocument();
+    expect(within(card).queryByText("Required")).not.toBeInTheDocument();
+    expect(within(card).getByText(/Optional for final IEHP DOCX export/)).toBeInTheDocument();
+    expect(within(card).queryByText("Manual review required")).not.toBeInTheDocument();
+    expect(screen.getByText("No fields need attention")).toBeInTheDocument();
+
+    fireEvent.click(within(card).getByRole("button", { name: "Expand Assessor's phone number" }));
+
+    await waitFor(() => {
+      expect(
+        within(card).getAllByText(/required for final DOCX: false \(template metadata: true\)/),
+      ).toHaveLength(2);
+    });
+    expect(
+      within(card).getByText((content) =>
+        content.includes("Section 1") && content.includes("required for final DOCX: false")
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("saves required IEHP structured sections so reviewers can clear publish blockers", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       if (path.startsWith("/api/assessment-template-layout?")) {
@@ -626,29 +711,27 @@ describe("IehpFbaLayoutReview", () => {
     const pageSummary = screen.getByText("Page 2 review summary").closest("div")?.parentElement?.parentElement;
     expect(pageSummary).not.toBeNull();
     expect(within(pageSummary as HTMLElement).getByText("Needs attention")).toBeInTheDocument();
-    expect(within(pageSummary as HTMLElement).getByText("3")).toBeInTheDocument();
+    expect(within(pageSummary as HTMLElement).getByText("2")).toBeInTheDocument();
     expect(within(pageSummary as HTMLElement).getByText(/4 rows on this page/)).toBeInTheDocument();
     expect(within(pageSummary as HTMLElement).getByText("In draft / review")).toBeInTheDocument();
-    const attentionTarget = await screen.findByTestId("review-attention-target-field-IEHP_FBA_REFERRING_PROVIDER");
+    const attentionTarget = await screen.findByTestId("review-attention-target-field-IEHP_FBA_MISSING_MANUAL_FIELD");
     await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: "center", behavior: "smooth" }));
     expect(document.activeElement).toBe(attentionTarget);
     expect(attentionTarget).toHaveClass("ring-2");
-    expect(await screen.findByText("Name of Referring Provider, Credentials")).toBeInTheDocument();
+    expect(await screen.findByText("Missing Manual Field")).toBeInTheDocument();
     expect(screen.getAllByText("Manual review required").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/This required IEHP field is intentionally manual/).length).toBeGreaterThan(0);
-    expect(screen.queryByRole("button", { name: "Approve Name of Referring Provider, Credentials" })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Review Name of Referring Provider, Credentials" }));
-    expect(await screen.findByLabelText("Name of Referring Provider, Credentials")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve Missing Manual Field" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Review Missing Manual Field" }));
+    expect(await screen.findByLabelText("Missing Manual Field")).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: /Page 1/i }));
     expect(await screen.findByText("Reason for Referral")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Expand Reason for Referral" }));
     expect(await screen.findByLabelText("Reason for Referral")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Reviewed referral reason")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Page 2/i }));
-    fireEvent.click(screen.getByRole("button", { name: "Review Missing Manual Field" }));
-    expect(screen.getByLabelText("Missing Manual Field")).toBeDisabled();
     expect(screen.getAllByText("Not started").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Manual review required")).toHaveLength(2);
+    expect(screen.getAllByText("Manual review required")).toHaveLength(1);
   });
 
   it("renders mapped fields as collapsed triage cards and quick-approves the field with attached structured sections", async () => {


### PR DESCRIPTION
## Summary
- Align the IEHP document-style review panel with the final DOCX optional-field policy for assessor phone, referring provider, and adaptive measure summaries.
- Show those rows as Optional even when manifest metadata still says required, exclude unresolved optional rows from page attention/highlight targeting, and clarify technical details as final-DOCX optional.
- Add focused component coverage for optional IEHP rows and update manual-required expectations so truly required rows remain blockers.

## Verification
- npm test -- src/components/__tests__/IehpFbaLayoutReview.test.tsx --runInBand
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
- git diff --check

## Notes
- npm run verify:local was attempted but hit the local 5-minute command timeout after underlying checks had already been run independently.
- No server, Supabase, migration, or generation-path files changed.