### PR TITLE
Keep optional IEHP publish blockers visible

### DIFF
--- a/src/components/ClientDetails/IehpFbaLayoutReview.tsx
+++ b/src/components/ClientDetails/IehpFbaLayoutReview.tsx
@@ -453,8 +453,33 @@ const emptyPageMessage = (pageNumber: number, title: string | undefined): string
   return "This template page is represented for layout parity. No mapped checklist field lands on this page yet.";
 };
 
+const IEHP_OPTIONAL_FINAL_OUTPUT_KEYS = new Set([
+  "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+  "IEHP_FBA_ASSESSOR_PHONE",
+  "IEHP_FBA_REFERRING_PROVIDER",
+]);
+
+const isOptionalFinalOutputField = (fieldKey: string): boolean => IEHP_OPTIONAL_FINAL_OUTPUT_KEYS.has(fieldKey);
+
+const isRequiredForIehpReview = (fieldKey: string, required: boolean): boolean =>
+  required && !isOptionalFinalOutputField(fieldKey);
+
+const isOptionalRequiredPublishBlocker = (
+  fieldKey: string,
+  required: boolean,
+  status: ReviewStatus | StructuredReviewStatus | "missing",
+): boolean => isOptionalFinalOutputField(fieldKey) && required && status !== "approved";
+
+const displayRequiredLabel = (fieldKey: string, required: boolean): string =>
+  isRequiredForIehpReview(fieldKey, required) ? "Required" : "Optional";
+
+const displayRequiredDetails = (fieldKey: string, required: boolean): string =>
+  isOptionalFinalOutputField(fieldKey) && required
+    ? "required for final DOCX: false (template metadata: true)"
+    : `required: ${String(required)}`;
+
 const isManualRequiredReviewItem = (field: TemplateField, item: ChecklistValue | undefined): boolean =>
-  field.required && field.mode === "MANUAL" && (!item || item.status === "not_started");
+  isRequiredForIehpReview(field.field_key, field.required) && field.mode === "MANUAL" && (!item || item.status === "not_started");
 
 const emptyPageReviewSummary = (): PageReviewSummary => ({
   needsAttention: 0,
@@ -570,13 +595,23 @@ export function IehpFbaLayoutReview({
     data.fields.forEach((field) => {
       const pageNumber = PAGE_FIELD_KEY_OVERRIDES[field.field_key] ?? field.page_number;
       const item = checklistByKey.get(field.field_key);
-      const status = isManualRequiredReviewItem(field, item) ? "not_started" : item?.status ?? "missing";
+      const rawStatus = item?.status ?? "missing";
+      const status = isOptionalRequiredPublishBlocker(field.field_key, field.required, rawStatus)
+        ? "not_started"
+        : isManualRequiredReviewItem(field, item)
+          ? "not_started"
+          : rawStatus;
       addStatusToPageReviewSummary(ensureSummary(pageNumber), status);
     });
     data.values.structured_sections.forEach((section) => {
       const pageNumber = getStructuredSectionPageNumber(section) ?? fieldPageByKey.get(section.field_key);
       if (pageNumber === undefined) return;
-      addStatusToPageReviewSummary(ensureSummary(pageNumber), section.status);
+      addStatusToPageReviewSummary(
+        ensureSummary(pageNumber),
+        isOptionalRequiredPublishBlocker(section.field_key, section.required, section.status)
+          ? "not_started"
+          : section.status,
+      );
     });
 
     return summaries;
@@ -599,17 +634,31 @@ export function IehpFbaLayoutReview({
   const activePageAttentionTargetKey = useMemo(() => {
     for (const field of activePageFields) {
       const item = checklistByKey.get(field.field_key);
-      const fieldStatus = isManualRequiredReviewItem(field, item) ? "not_started" : item?.status ?? "missing";
+      const rawFieldStatus = item?.status ?? "missing";
+      const fieldStatus = isOptionalRequiredPublishBlocker(field.field_key, field.required, rawFieldStatus)
+        ? "not_started"
+        : isManualRequiredReviewItem(field, item)
+          ? "not_started"
+          : rawFieldStatus;
       const structuredSections = (structuredByKey.get(field.field_key) ?? []).filter((section) => {
         const pageNumber = getStructuredSectionPageNumber(section);
         return pageNumber === null || pageNumber === activePage;
       });
-      if (isAttentionReviewStatus(fieldStatus) || structuredSections.some((section) => isAttentionReviewStatus(section.status))) {
+      if (
+        isAttentionReviewStatus(fieldStatus) ||
+        structuredSections.some((section) =>
+          isOptionalRequiredPublishBlocker(section.field_key, section.required, section.status) ||
+          (isRequiredForIehpReview(section.field_key, section.required) && isAttentionReviewStatus(section.status))
+        )
+      ) {
         return `field-${field.field_key}`;
       }
     }
 
-    const looseSection = activePageLooseStructuredSections.find((section) => isAttentionReviewStatus(section.status));
+    const looseSection = activePageLooseStructuredSections.find((section) =>
+      isOptionalRequiredPublishBlocker(section.field_key, section.required, section.status) ||
+      (isRequiredForIehpReview(section.field_key, section.required) && isAttentionReviewStatus(section.status))
+    );
     return looseSection ? `structured-${looseSection.id}` : null;
   }, [activePage, activePageFields, activePageLooseStructuredSections, checklistByKey, structuredByKey]);
 
@@ -932,9 +981,20 @@ export function IehpFbaLayoutReview({
                   });
                   const locked = item?.status === "approved";
                   const manualRequired = isManualRequiredReviewItem(field, item);
-                  const fieldStatus = manualRequired ? "not_started" : item?.status ?? "missing";
+                  const optionalFinalOutput = isOptionalFinalOutputField(field.field_key);
+                  const rawFieldStatus = item?.status ?? "missing";
+                  const fieldStatus = isOptionalRequiredPublishBlocker(field.field_key, field.required, rawFieldStatus)
+                    ? "not_started"
+                    : manualRequired
+                      ? "not_started"
+                      : rawFieldStatus;
                   const fieldAttentionTargetKey = `field-${field.field_key}`;
-                  const fieldNeedsAttention = isAttentionReviewStatus(fieldStatus) || structuredSections.some((section) => isAttentionReviewStatus(section.status));
+                  const fieldNeedsAttention =
+                    isAttentionReviewStatus(fieldStatus) ||
+                    structuredSections.some((section) =>
+                      isOptionalRequiredPublishBlocker(section.field_key, section.required, section.status) ||
+                      (isRequiredForIehpReview(section.field_key, section.required) && isAttentionReviewStatus(section.status))
+                    );
                   const highlightAttentionTarget = activePageAttentionTargetKey === fieldAttentionTargetKey && fieldNeedsAttention;
                   const expanded = Boolean(expandedFieldByKey[field.field_key]);
                   const fieldValuePreview = edit.valueText.trim();
@@ -961,9 +1021,9 @@ export function IehpFbaLayoutReview({
                           )}
                         </div>
                         <div className="flex flex-wrap items-center justify-end gap-2">
-                          {field.required && (
-                            <span className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-300">Required</span>
-                          )}
+                          <span className="rounded border border-slate-500 px-2 py-1 text-[11px] font-semibold text-slate-300">
+                            {displayRequiredLabel(field.field_key, field.required)}
+                          </span>
                           <span className={`rounded px-2 py-1 text-[11px] font-semibold ${statusChipClass(manualRequired ? "not_started" : item?.status ?? "not_started")}`}>
                             {manualRequired ? "Manual review required" : formatStatusLabel(item?.status ?? "not_started")}
                           </span>
@@ -973,6 +1033,11 @@ export function IehpFbaLayoutReview({
                       {manualRequired && (
                         <p className="mt-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900">
                           This required IEHP field is intentionally manual unless reliable document evidence is present.
+                        </p>
+                      )}
+                      {optionalFinalOutput && (
+                        <p className="mt-2 rounded border border-sky-500/40 bg-sky-950/40 p-2 text-xs text-sky-100">
+                          Optional for final IEHP DOCX export; leave blank when no source value exists.
                         </p>
                       )}
 
@@ -1039,7 +1104,7 @@ export function IehpFbaLayoutReview({
                       {expanded && (
                         <div className="mt-3 space-y-3">
                           <p className="text-[11px] text-slate-400">
-                            {field.field_key} • {field.mode} • {field.field_type} • required: {String(field.required)}
+                            {field.field_key} • {field.mode} • {field.field_type} • {displayRequiredDetails(field.field_key, field.required)}
                           </p>
                           <textarea
                             id={`iehp-${field.field_key}`}
@@ -1074,7 +1139,7 @@ export function IehpFbaLayoutReview({
                                   <div key={section.id} className="rounded border border-slate-600 bg-slate-800 p-2">
                                     <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
                                       <span className="font-semibold text-slate-100">
-                                        Section {section.section_index + 1} • required: {String(section.required)}
+                                        Section {section.section_index + 1} • {displayRequiredDetails(section.field_key, section.required)}
                                       </span>
                                       <div className="flex items-center gap-2">
                                         <span className={`rounded px-2 py-1 text-[11px] font-semibold ${statusChipClass(section.status)}`}>{formatStatusLabel(section.status)}</span>
@@ -1262,7 +1327,12 @@ export function IehpFbaLayoutReview({
                         };
                         const structuredLocked = section.status === "approved";
                         const structuredAttentionTargetKey = `structured-${section.id}`;
-                        const highlightAttentionTarget = activePageAttentionTargetKey === structuredAttentionTargetKey && isAttentionReviewStatus(section.status);
+                        const highlightAttentionTarget =
+                          activePageAttentionTargetKey === structuredAttentionTargetKey &&
+                          (
+                            isOptionalRequiredPublishBlocker(section.field_key, section.required, section.status) ||
+                            (isRequiredForIehpReview(section.field_key, section.required) && isAttentionReviewStatus(section.status))
+                          );
                         const expanded = Boolean(expandedStructuredSectionById[section.id]);
                         const sectionTitle = structuredSectionDisplayTitle(section);
                         return (

--- a/src/components/__tests__/IehpFbaLayoutReview.test.tsx
+++ b/src/components/__tests__/IehpFbaLayoutReview.test.tsx
@@ -154,6 +154,93 @@ describe("IehpFbaLayoutReview", () => {
     });
   });
 
+  it("shows final-output optional IEHP fields as optional even when template metadata is required", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string) => {
+      if (path.startsWith("/api/assessment-template-layout?")) {
+        return new Response(JSON.stringify({
+          template_version: {
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+          },
+          pages: [{ page_number: 1, title: "General Information", layout_json: {} }],
+          fields: [
+            {
+              page_number: 1,
+              section_key: "identification_admin",
+              field_key: "IEHP_FBA_ASSESSOR_PHONE",
+              label: "Assessor's phone number",
+              field_type: "text",
+              mode: "ASSISTED",
+              required: true,
+              source: "therapists.phone || company_settings.phone",
+              layout_json: {},
+            },
+          ],
+          values: {
+            checklist_items: [
+              {
+                id: "assessor-phone-item",
+                placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+                section_key: "identification_admin",
+                label: "Assessor's phone number",
+                mode: "ASSISTED",
+                required: true,
+                status: "verified",
+                value_text: "",
+                value_json: null,
+                review_notes: "No extracted field value was found in the source document.",
+              },
+            ],
+            structured_sections: [
+              {
+                id: "assessor-phone-section",
+                field_key: "IEHP_FBA_ASSESSOR_PHONE",
+                section_index: 0,
+                payload: {
+                  label: "Assessor's phone number",
+                  raw_text: "No extracted field value was found in the source document.",
+                },
+                status: "drafted",
+                required: true,
+                review_notes: "Template field preserved as optional for final export.",
+              },
+            ],
+          },
+          unresolved_required_count: 0,
+          extracted_value_count: 0,
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 });
+    });
+
+    renderWithProviders(
+      <IehpFbaLayoutReview assessmentDocument={assessmentDocument} organizationId="org-1" />,
+    );
+
+    const card = await screen.findByTestId("review-attention-target-field-IEHP_FBA_ASSESSOR_PHONE");
+    expect(within(card).getByText("Optional")).toBeInTheDocument();
+    expect(within(card).queryByText("Required")).not.toBeInTheDocument();
+    expect(within(card).getByText(/Optional for final IEHP DOCX export/)).toBeInTheDocument();
+    expect(within(card).queryByText("Manual review required")).not.toBeInTheDocument();
+    expect(screen.queryByText("No fields need attention")).not.toBeInTheDocument();
+    expect(screen.getByText("Jump to page 1 needs attention")).toBeInTheDocument();
+    expect(card).toHaveClass("ring-2");
+
+    fireEvent.click(within(card).getByRole("button", { name: "Expand Assessor's phone number" }));
+
+    await waitFor(() => {
+      expect(
+        within(card).getAllByText(/required for final DOCX: false \(template metadata: true\)/),
+      ).toHaveLength(2);
+    });
+    expect(
+      within(card).getByText((content) =>
+        content.includes("Section 1") && content.includes("required for final DOCX: false")
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("saves required IEHP structured sections so reviewers can clear publish blockers", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       if (path.startsWith("/api/assessment-template-layout?")) {
@@ -634,10 +721,11 @@ describe("IehpFbaLayoutReview", () => {
     expect(document.activeElement).toBe(attentionTarget);
     expect(attentionTarget).toHaveClass("ring-2");
     expect(await screen.findByText("Name of Referring Provider, Credentials")).toBeInTheDocument();
+    expect(within(attentionTarget).getByText("Optional")).toBeInTheDocument();
     expect(screen.getAllByText("Manual review required").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/This required IEHP field is intentionally manual/).length).toBeGreaterThan(0);
-    expect(screen.queryByRole("button", { name: "Approve Name of Referring Provider, Credentials" })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Review Name of Referring Provider, Credentials" }));
+    expect(screen.getByRole("button", { name: "Approve Name of Referring Provider, Credentials" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Expand Name of Referring Provider, Credentials" }));
     expect(await screen.findByLabelText("Name of Referring Provider, Credentials")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Page 1/i }));
     expect(await screen.findByText("Reason for Referral")).toBeInTheDocument();
@@ -648,7 +736,7 @@ describe("IehpFbaLayoutReview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Review Missing Manual Field" }));
     expect(screen.getByLabelText("Missing Manual Field")).toBeDisabled();
     expect(screen.getAllByText("Not started").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Manual review required")).toHaveLength(2);
+    expect(screen.getAllByText("Manual review required")).toHaveLength(1);
   });
 
   it("renders mapped fields as collapsed triage cards and quick-approves the field with attached structured sections", async () => {


### PR DESCRIPTION
## Summary
- Keep IEHP final-output optional rows visually labeled as Optional.
- Do not hide persisted `required=true` optional rows from page attention/highlight logic while publish still requires approval.
- Add/update component coverage so optional required rows remain jump targets until approved.

## Verification
- npm test -- src/components/__tests__/IehpFbaLayoutReview.test.tsx --runInBand
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run build
- git diff --check

## Notes
- This is UI-only follow-up to #616; no server, Supabase, migration, or generation code changed.