### PR TITLE
Align IEHP optional rows with publish gate

### DIFF
--- a/src/components/__tests__/IehpFbaLayoutReview.test.tsx
+++ b/src/components/__tests__/IehpFbaLayoutReview.test.tsx
@@ -224,6 +224,7 @@ describe("IehpFbaLayoutReview", () => {
     expect(within(card).getByText(/Optional for final IEHP DOCX export/)).toBeInTheDocument();
     expect(within(card).queryByText("Manual review required")).not.toBeInTheDocument();
     expect(screen.getByText("No fields need attention")).toBeInTheDocument();
+    expect(card).not.toHaveClass("ring-2");
 
     fireEvent.click(within(card).getByRole("button", { name: "Expand Assessor's phone number" }));
 

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -188,6 +188,119 @@ describe("assessmentPromoteHandler", () => {
     ).toBe(false);
   });
 
+  it("publishes IEHP assessments when only optional final-output rows remain blank or unapproved", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key&")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            { id: "optional-assessor-phone", placeholder_key: "IEHP_FBA_ASSESSOR_PHONE" },
+            { id: "optional-referring-provider", placeholder_key: "IEHP_FBA_REFERRING_PROVIDER" },
+          ],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key&")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{ id: "optional-adaptive", field_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES" }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "optional-approved-phone",
+            placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
+            label: "Assessor phone",
+            value_text: "",
+            value_json: null,
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key,section_index,payload")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "optional-approved-adaptive",
+            field_key: "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+            section_index: 0,
+            payload: {
+              assessment_blocks: [
+                { label: "VB-MAPP", raw_text: null, manual_review_required: true },
+              ],
+            },
+          }],
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "approved",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      assessment_document_id: "doc-1",
+      completion_mode: "assessment_only",
+    });
+    expect(
+      vi.mocked(fetchJson).mock.calls.some(([url, init]) =>
+        typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted") && init?.method === "PATCH"
+      ),
+    ).toBe(true);
+  });
+
   it("blocks IEHP assessment publish when approved required checklist rows are blank", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -215,10 +328,10 @@ describe("assessmentPromoteHandler", () => {
           }],
         };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key&")) {
         return { ok: true, status: 200, data: [] };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key&")) {
         return { ok: true, status: 200, data: [] };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
@@ -227,8 +340,8 @@ describe("assessmentPromoteHandler", () => {
           status: 200,
           data: [{
             id: "required-row-1",
-            placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
-            label: "Assessor phone",
+            placeholder_key: "IEHP_FBA_REPORT_DATE",
+            label: "Report date",
             value_text: "   ",
             value_json: null,
           }],
@@ -303,10 +416,10 @@ describe("assessmentPromoteHandler", () => {
           }],
         };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key&")) {
         return { ok: true, status: 200, data: [] };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key&")) {
         return { ok: true, status: 200, data: [] };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
@@ -395,10 +508,10 @@ describe("assessmentPromoteHandler", () => {
           }],
         };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key&")) {
         return { ok: true, status: 200, data: [] };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key&")) {
         return { ok: true, status: 200, data: [] };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
@@ -489,10 +602,10 @@ describe("assessmentPromoteHandler", () => {
           }],
         };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key&")) {
         return { ok: true, status: 200, data: [] };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key&")) {
         return { ok: true, status: 200, data: [] };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
@@ -584,10 +697,10 @@ describe("assessmentPromoteHandler", () => {
           }],
         };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key&")) {
         return { ok: true, status: 200, data: [] };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key&")) {
         return { ok: true, status: 200, data: [] };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
@@ -724,10 +837,10 @@ describe("assessmentPromoteHandler", () => {
           }],
         };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key&")) {
         return { ok: true, status: 200, data: [] };
       }
-      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id&")) {
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key&")) {
         return { ok: true, status: 200, data: [] };
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -29,11 +29,21 @@ interface AssessmentRequiredChecklistReviewRow {
   value_json: unknown | null;
 }
 
+interface AssessmentRequiredChecklistStatusRow {
+  id: string;
+  placeholder_key: string | null;
+}
+
 interface AssessmentRequiredStructuredReviewRow {
   id: string;
   field_key: string;
   section_index: number | null;
   payload: Record<string, unknown> | null;
+}
+
+interface AssessmentRequiredStructuredStatusRow {
+  id: string;
+  field_key: string;
 }
 
 interface IehpPublishDataQualityBlocker {
@@ -112,6 +122,11 @@ const IEHP_GOAL_SECTION_KEYS = new Set([
   "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
   "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
 ]);
+const IEHP_OPTIONAL_FINAL_OUTPUT_KEYS = new Set([
+  "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+  "IEHP_FBA_ASSESSOR_PHONE",
+  "IEHP_FBA_REFERRING_PROVIDER",
+]);
 const IEHP_STRUCTURED_METADATA_KEYS = new Set([
   "field_key",
   "label",
@@ -136,6 +151,9 @@ const isBlankTransferredValue = (value: unknown): boolean => {
 
 const hasNonBlankPayloadValue = (payload: Record<string, unknown>, key: string): boolean =>
   !isBlankTransferredValue(payload[key]);
+
+const isOptionalIehpFinalOutputKey = (fieldKey: string | null | undefined): boolean =>
+  typeof fieldKey === "string" && IEHP_OPTIONAL_FINAL_OUTPUT_KEYS.has(fieldKey);
 
 const hasMeaningfulRawText = (payload: Record<string, unknown>): boolean =>
   typeof payload.raw_text === "string" && payload.raw_text.trim().length > 0;
@@ -185,7 +203,7 @@ const hasDefaultRequiredStructuredValue = (payload: Record<string, unknown>): bo
 const buildIehpStructuredDataQualityBlockers = (
   rows: AssessmentRequiredStructuredReviewRow[],
 ): IehpPublishDataQualityBlocker[] =>
-  rows.flatMap((row) => {
+  rows.filter((row) => !isOptionalIehpFinalOutputKey(row.field_key)).flatMap((row) => {
     const payload = row.payload && typeof row.payload === "object" ? row.payload : null;
     if (!payload) {
       return [{
@@ -254,14 +272,14 @@ const buildAssessmentRequiredApprovalLookups = (args: {
 }) => {
   const { supabaseUrl, organizationId, assessmentDocumentId, headers } = args;
   return Promise.all([
-    fetchJson<Array<{ id: string }>>(
-      `${supabaseUrl}/rest/v1/assessment_checklist_items?select=id&organization_id=eq.${encodeURIComponent(
+    fetchJson<AssessmentRequiredChecklistStatusRow[]>(
+      `${supabaseUrl}/rest/v1/assessment_checklist_items?select=id,placeholder_key&organization_id=eq.${encodeURIComponent(
         organizationId,
       )}&assessment_document_id=eq.${encodeURIComponent(assessmentDocumentId)}&required=is.true&status=neq.approved`,
       { method: "GET", headers },
     ),
-    fetchJson<Array<{ id: string }>>(
-      `${supabaseUrl}/rest/v1/assessment_structured_sections?select=id&organization_id=eq.${encodeURIComponent(
+    fetchJson<AssessmentRequiredStructuredStatusRow[]>(
+      `${supabaseUrl}/rest/v1/assessment_structured_sections?select=id,field_key&organization_id=eq.${encodeURIComponent(
         organizationId,
       )}&assessment_document_id=eq.${encodeURIComponent(assessmentDocumentId)}&required=is.true&status=neq.approved`,
       { method: "GET", headers },
@@ -358,8 +376,10 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
       return json({ error: "Failed to evaluate IEHP publish data quality preconditions" }, 500);
     }
 
-    const unapprovedChecklistCount = Array.isArray(unapprovedChecklistResult.data) ? unapprovedChecklistResult.data.length : 0;
-    const unapprovedStructuredCount = Array.isArray(unapprovedStructuredResult.data) ? unapprovedStructuredResult.data.length : 0;
+    const unapprovedChecklistRows = Array.isArray(unapprovedChecklistResult.data) ? unapprovedChecklistResult.data : [];
+    const unapprovedStructuredRows = Array.isArray(unapprovedStructuredResult.data) ? unapprovedStructuredResult.data : [];
+    const unapprovedChecklistCount = unapprovedChecklistRows.filter((row) => !isOptionalIehpFinalOutputKey(row.placeholder_key)).length;
+    const unapprovedStructuredCount = unapprovedStructuredRows.filter((row) => !isOptionalIehpFinalOutputKey(row.field_key)).length;
     const unresolvedRequiredCount = unapprovedChecklistCount + unapprovedStructuredCount;
     if (unresolvedRequiredCount > 0) {
       return json(
@@ -373,6 +393,7 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
 
     const approvedChecklistRows = Array.isArray(approvedChecklistResult.data) ? approvedChecklistResult.data : [];
     const blankRequiredChecklistBlockers: IehpPublishDataQualityBlocker[] = approvedChecklistRows
+      .filter((row) => !isOptionalIehpFinalOutputKey(row.placeholder_key))
       .filter((row) => isBlankTransferredValue(row.value_text) && isBlankTransferredValue(row.value_json))
       .map((row) => ({
         code: "blank_required_checklist",


### PR DESCRIPTION
## Summary
- Exclude IEHP final-output optional keys from assessment publish unresolved-row and data-quality blockers.
- Keep optional blank rows visually labeled Optional without turning them into uncleared page attention targets.
- Add regression coverage for blank/unapproved optional checklist and structured rows, while preserving blockers for non-optional required rows.

## Verification
- npm test -- src/server/__tests__/assessmentPromoteHandler.test.ts --runInBand
- npm test -- src/components/__tests__/IehpFbaLayoutReview.test.tsx --runInBand
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run validate:tenant
- npm run build
- git diff --check

## Notes
- Critical/high-risk human-reviewed: touches src/server/api/assessment-promote.ts.
- No migration or Supabase function changes.
