### PR TITLE
Normalize optional IEHP final-output required flags

### DIFF
--- a/src/server/__tests__/assessmentChecklistHandler.test.ts
+++ b/src/server/__tests__/assessmentChecklistHandler.test.ts
@@ -209,8 +209,8 @@ describe("assessmentChecklistHandler", () => {
           client_id: "client-1",
           status: "drafted",
           required: true,
-          placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
-          label: "Assessor's phone number",
+          placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+          label: "Reason for Referral",
           value_text: "",
           value_json: null,
         },
@@ -230,7 +230,7 @@ describe("assessmentChecklistHandler", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: "Required checklist item Assessor's phone number cannot be approved while blank.",
+      error: "Required checklist item Reason for Referral cannot be approved while blank.",
     });
     expect(fetchJson).toHaveBeenCalledTimes(1);
   });
@@ -259,8 +259,8 @@ describe("assessmentChecklistHandler", () => {
           client_id: "client-1",
           status: "approved",
           required: true,
-          placeholder_key: "IEHP_FBA_ASSESSOR_PHONE",
-          label: "Assessor's phone number",
+          placeholder_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+          label: "Reason for Referral",
           value_text: "951-555-0101",
           value_json: null,
         },
@@ -281,9 +281,59 @@ describe("assessmentChecklistHandler", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: "Required checklist item Assessor's phone number cannot be approved while blank.",
+      error: "Required checklist item Reason for Referral cannot be approved while blank.",
     });
     expect(fetchJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows approving blank optional IEHP checklist rows even when stored required metadata is stale", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "item-1",
+            assessment_document_id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "drafted",
+            required: true,
+            placeholder_key: "IEHP_FBA_REFERRING_PROVIDER",
+            label: "Name of Referring Provider, Credentials",
+            value_text: "",
+            value_json: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [{ id: "item-1", status: "approved" }] })
+      .mockResolvedValueOnce({ ok: true, status: 201, data: null });
+
+    const response = await assessmentChecklistHandler(
+      new Request("http://localhost/api/assessment-checklist", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          item_id: "11111111-1111-1111-1111-111111111111",
+          status: "approved",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: "item-1", status: "approved" });
   });
 
   it("returns checklist rows with structured sections", async () => {
@@ -400,10 +450,10 @@ describe("assessmentChecklistHandler", () => {
           client_id: "client-1",
           status: "drafted",
           required: true,
-          field_key: "IEHP_FBA_REFERRING_PROVIDER",
+          field_key: "IEHP_FBA_REASON_FOR_REFERRAL",
           payload: {
-            field_key: "IEHP_FBA_REFERRING_PROVIDER",
-            label: "Name of Referring Provider, Credentials",
+            field_key: "IEHP_FBA_REASON_FOR_REFERRAL",
+            label: "Reason for Referral",
             template_placeholder: true,
             entered_value_present: false,
             clinical_value: null,
@@ -426,9 +476,64 @@ describe("assessmentChecklistHandler", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: "Required structured section IEHP_FBA_REFERRING_PROVIDER cannot be approved while blank.",
+      error: "Required structured section IEHP_FBA_REASON_FOR_REFERRAL cannot be approved while blank.",
     });
     expect(fetchJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows approving blank optional IEHP structured placeholders even when stored required metadata is stale", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "section-1",
+            assessment_document_id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "drafted",
+            required: true,
+            field_key: "IEHP_FBA_REFERRING_PROVIDER",
+            payload: {
+              field_key: "IEHP_FBA_REFERRING_PROVIDER",
+              label: "Name of Referring Provider, Credentials",
+              template_placeholder: true,
+              entered_value_present: false,
+              clinical_value: null,
+              raw_text: "",
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [{ id: "section-1", status: "approved" }] })
+      .mockResolvedValueOnce({ ok: true, status: 201, data: null });
+
+    const response = await assessmentChecklistHandler(
+      new Request("http://localhost/api/assessment-checklist", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          structured_section_id: "11111111-1111-1111-1111-111111111111",
+          status: "approved",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: "section-1", status: "approved" });
   });
 
   it("allows approving filled structured placeholders even when extraction flags are stale", async () => {

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -1797,6 +1797,164 @@ describe("assessmentDocumentsHandler", () => {
     await expect(response.json()).resolves.toMatchObject({ accepted: true });
   });
 
+  it("normalizes optional IEHP structured rows before persisting fresh extraction results", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type,template_version_id,bucket_id,object_path")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              organization_id: "org-1",
+              client_id: "22222222-2222-4222-8222-222222222222",
+              status: "extracting",
+              template_type: "iehp_fba",
+              template_version_id: "template-1",
+              bucket_id: "client-documents",
+              object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.docx",
+              updated_at: "2026-05-15T20:00:00.000Z",
+            },
+          ],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_fields?select=section_key,field_key,label,field_type,mode,required,source")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            section_key: "identification_admin",
+            field_key: "IEHP_FBA_REFERRING_PROVIDER",
+            label: "Name of Referring Provider, Credentials",
+            field_type: "textarea",
+            mode: "MANUAL",
+            required: true,
+            source: "clinician_manual_entry unless present in uploaded document",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/clients?select=full_name")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{ full_name: "Client One", date_of_birth: "2017-05-01" }],
+        };
+      }
+      if (
+        method === "GET" &&
+        url.includes(
+          "/rest/v1/assessment_documents?select=status&id=eq.11111111-1111-4111-8111-111111111111&organization_id=eq.org-1&limit=1",
+        )
+      ) {
+        return { ok: true, status: 200, data: [{ status: "extracting" }] };
+      }
+      if (
+        method === "GET" &&
+        url.includes("/rest/v1/assessment_documents?select=status&id=eq.11111111-1111-4111-8111-111111111111")
+      ) {
+        return { ok: true, status: 200, data: [{ status: "extracting" }] };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.11111111-1111-4111-8111-111111111111")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              organization_id: "org-1",
+              client_id: "22222222-2222-4222-8222-222222222222",
+              status: "extracting",
+              template_type: "iehp_fba",
+              template_version_id: "template-1",
+              bucket_id: "client-documents",
+              object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.docx",
+              updated_at: "2026-05-15T20:00:00.000Z",
+            },
+          ],
+        };
+      }
+      if (method === "POST" && url.includes("/functions/v1/extract-assessment-fields")) {
+        return {
+          ok: true,
+          status: 200,
+          data: {
+            assessment_document_id: "11111111-1111-4111-8111-111111111111",
+            template_type: "iehp_fba",
+            fields: [],
+            unresolved_keys: [],
+            extracted_count: 0,
+            unresolved_count: 0,
+            extraction_provider: "local_docx",
+            structured_sections: [{
+              section_key: "identification_admin",
+              field_key: "IEHP_FBA_REFERRING_PROVIDER",
+              section_index: 0,
+              payload: {
+                field_key: "IEHP_FBA_REFERRING_PROVIDER",
+                label: "Name of Referring Provider, Credentials",
+                template_placeholder: true,
+                entered_value_present: false,
+                clinical_value: null,
+                raw_text: "",
+              },
+              source_span: { method: "template_placeholder" },
+              status: "drafted",
+              required: true,
+              review_notes: null,
+            }],
+            structured_section_count: 1,
+            structured_child_goal_count: 0,
+            structured_parent_goal_count: 0,
+            adobe_element_count: null,
+            adobe_table_count: null,
+          },
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_structured_sections")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentDocumentsExtractionBackgroundHandler(
+      new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-4111-8111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    const structuredInsertCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" &&
+      url.includes("/rest/v1/assessment_structured_sections") &&
+      (init?.method ?? "").toUpperCase() === "POST"
+    );
+    expect(structuredInsertCall).toBeDefined();
+    expect(String(structuredInsertCall?.[1]?.body)).toContain("\"field_key\":\"IEHP_FBA_REFERRING_PROVIDER\"");
+    expect(String(structuredInsertCall?.[1]?.body)).toContain("\"required\":false");
+  });
+
   it("skips background extraction for documents no longer in extracting status", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
@@ -1880,6 +2038,103 @@ describe("assessmentDocumentsHandler", () => {
     });
     expect(json.extraction_error).toBeNull();
     expect(loadChecklistTemplateRows).not.toHaveBeenCalled();
+  });
+
+  it("normalizes optional IEHP checklist seed rows before persisting a fresh upload", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(loadChecklistTemplateRows).mockResolvedValue([]);
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_versions?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "template-version-1" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_template_fields?select=")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            section_key: "identification_admin",
+            field_key: "IEHP_FBA_REFERRING_PROVIDER",
+            label: "Name of Referring Provider, Credentials",
+            field_type: "textarea",
+            mode: "MANUAL",
+            required: true,
+            source: "clinician_manual_entry unless present in uploaded document",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_documents")) {
+        return {
+          ok: true,
+          status: 201,
+          data: [{ id: "doc-iehp-optional", organization_id: "org-1", client_id: "11111111-1111-1111-1111-111111111111" }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_checklist_items")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_extractions")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-iehp-optional")) {
+        return { ok: true, status: 200, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "iehp-fba.docx",
+          mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          file_size: 2200,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/iehp-fba.docx",
+          template_type: "iehp_fba",
+        }),
+      }),
+      {
+        scheduleCaloptimaExtraction: async () => ({ ok: true, status: 202 }),
+      },
+    );
+
+    expect(response.status).toBe(201);
+    const checklistInsertCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" &&
+      url.includes("/rest/v1/assessment_checklist_items") &&
+      (init?.method ?? "").toUpperCase() === "POST"
+    );
+    const extractionInsertCall = vi.mocked(fetchJson).mock.calls.find(([url, init]) =>
+      typeof url === "string" &&
+      url.includes("/rest/v1/assessment_extractions") &&
+      (init?.method ?? "").toUpperCase() === "POST"
+    );
+    expect(checklistInsertCall).toBeDefined();
+    expect(extractionInsertCall).toBeDefined();
+    expect(String(checklistInsertCall?.[1]?.body)).toContain("\"placeholder_key\":\"IEHP_FBA_REFERRING_PROVIDER\"");
+    expect(String(checklistInsertCall?.[1]?.body)).toContain("\"required\":false");
+    expect(String(extractionInsertCall?.[1]?.body)).toContain("\"field_key\":\"IEHP_FBA_REFERRING_PROVIDER\"");
+    expect(String(extractionInsertCall?.[1]?.body)).toContain("\"required\":false");
   });
 
   it("rejects unsupported template_type", async () => {

--- a/src/server/__tests__/assessmentTemplateLayoutHandler.test.ts
+++ b/src/server/__tests__/assessmentTemplateLayoutHandler.test.ts
@@ -137,6 +137,109 @@ describe("assessmentTemplateLayoutHandler", () => {
     expect(body.unresolved_required_count).toBe(0);
   });
 
+  it("excludes optional IEHP final-output rows from unresolved required counts", async () => {
+    vi.mocked(fetchJson).mockImplementation(async (url: string) => {
+      if (url.includes("/rest/v1/assessment_documents?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "11111111-1111-4111-8111-111111111111",
+            organization_id: "org-1",
+            client_id: "client-1",
+            template_type: "iehp_fba",
+            template_version_id: "template-1",
+            status: "drafted",
+            file_name: "synthetic-iehp.docx",
+          }],
+        };
+      }
+      if (url.includes("/rest/v1/assessment_checklist_items?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "item-1",
+            placeholder_key: "IEHP_FBA_REFERRING_PROVIDER",
+            section_key: "identification_admin",
+            label: "Name of Referring Provider, Credentials",
+            mode: "MANUAL",
+            required: true,
+            status: "not_started",
+            value_text: "",
+            value_json: null,
+            review_notes: null,
+          }],
+        };
+      }
+      if (url.includes("/rest/v1/assessment_structured_sections?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "section-1",
+            field_key: "IEHP_FBA_REFERRING_PROVIDER",
+            required: true,
+            status: "drafted",
+            payload: null,
+          }],
+        };
+      }
+      if (url.includes("/rest/v1/assessment_template_versions?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "template-1",
+            template_type: "iehp_fba",
+            version_key: "iehp_fba_updated_fba_11_2026_05",
+            source_document_name: "Updated FBA -IEHP (11).docx",
+            page_count: 30,
+            source_sha256: "hash",
+            status: "active",
+          }],
+        };
+      }
+      if (url.includes("/rest/v1/assessment_template_pages?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{ id: "page-1", template_version_id: "template-1", page_number: 1, title: "General Information", layout_json: {} }],
+        };
+      }
+      if (url.includes("/rest/v1/assessment_template_fields?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "field-1",
+            template_version_id: "template-1",
+            page_number: 1,
+            section_key: "identification_admin",
+            field_key: "IEHP_FBA_REFERRING_PROVIDER",
+            label: "Name of Referring Provider, Credentials",
+            field_type: "textarea",
+            mode: "MANUAL",
+            required: true,
+            source: "clinician_manual_entry unless present in uploaded document",
+            layout_json: {},
+          }],
+        };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentTemplateLayoutHandler(
+      new Request("http://localhost/api/assessment-template-layout?assessment_document_id=11111111-1111-4111-8111-111111111111", {
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.unresolved_required_count).toBe(0);
+  });
+
   it("rejects non-IEHP documents", async () => {
     vi.mocked(fetchJson).mockResolvedValueOnce({
       ok: true,

--- a/src/server/api/assessment-checklist.ts
+++ b/src/server/api/assessment-checklist.ts
@@ -8,6 +8,7 @@ import {
   json,
   resolveOrgAndRole,
 } from "./shared";
+import { normalizeIehpRequiredFlag } from "../iehpOptionalFinalOutput";
 
 const reviewStatusSchema = z.enum(["not_started", "drafted", "verified", "approved", "rejected"]);
 
@@ -215,7 +216,11 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
         );
       }
       const finalStructuredPayload = parsed.data.payload ?? existing.payload;
-      if (nextStatus === "approved" && existing.required === true && !hasMeaningfulStructuredPayload(finalStructuredPayload)) {
+      if (
+        nextStatus === "approved" &&
+        normalizeIehpRequiredFlag(existing.field_key, existing.required) &&
+        !hasMeaningfulStructuredPayload(finalStructuredPayload)
+      ) {
         return json(
           { error: `Required structured section ${existing.field_key ?? existing.id} cannot be approved while blank.` },
           400,
@@ -298,7 +303,11 @@ export async function assessmentChecklistHandler(request: Request): Promise<Resp
     const finalValueText = parsed.data.value_text ?? existing.value_text;
     const finalValueJson = parsed.data.value_json === undefined ? existing.value_json : parsed.data.value_json;
     const finalStatus = nextStatus ?? existing.status;
-    if (finalStatus === "approved" && existing.required === true && !hasMeaningfulChecklistValue(finalValueText, finalValueJson)) {
+    if (
+      finalStatus === "approved" &&
+      normalizeIehpRequiredFlag(existing.placeholder_key, existing.required) &&
+      !hasMeaningfulChecklistValue(finalValueText, finalValueJson)
+    ) {
       return json(
         { error: `Required checklist item ${existing.label ?? existing.placeholder_key ?? existing.id} cannot be approved while blank.` },
         400,

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -14,6 +14,7 @@ import {
   type AssessmentChecklistSeedRow,
   type AssessmentTemplateType,
 } from "../assessmentChecklistTemplate";
+import { normalizeIehpRequiredFlag } from "../iehpOptionalFinalOutput";
 import { buildDeterministicDraftPayload, persistDraftRows } from "./assessment-drafts";
 import { serverLogger } from "../../lib/logger/server";
 
@@ -477,7 +478,7 @@ const normalizeTemplateFieldRow = (row: AssessmentTemplateFieldRow): AssessmentC
   const mode = normalizeTemplateFieldMode(row.mode);
   const source = typeof row.source === "string" && row.source.trim().length > 0 ? row.source : "uploaded_assessment_document";
   const fieldType = typeof row.field_type === "string" && row.field_type.trim().length > 0 ? row.field_type : "text";
-  const required = row.required === true;
+  const required = normalizeIehpRequiredFlag(row.field_key, row.required === true);
   return {
     section: row.section_key,
     label: row.label,
@@ -805,7 +806,7 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
               payload: section.payload,
               source_span: section.source_span,
               status: section.status,
-              required: section.required,
+              required: normalizeIehpRequiredFlag(section.field_key, section.required),
               review_notes: section.review_notes,
             })),
           ),

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -8,6 +8,7 @@ import {
   json,
   resolveOrgAndRole,
 } from "./shared";
+import { isOptionalIehpFinalOutputKey } from "../iehpOptionalFinalOutput";
 
 const promoteSchema = z.object({
   assessment_document_id: z.string().uuid(),
@@ -122,11 +123,6 @@ const IEHP_GOAL_SECTION_KEYS = new Set([
   "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
   "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
 ]);
-const IEHP_OPTIONAL_FINAL_OUTPUT_KEYS = new Set([
-  "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
-  "IEHP_FBA_ASSESSOR_PHONE",
-  "IEHP_FBA_REFERRING_PROVIDER",
-]);
 const IEHP_STRUCTURED_METADATA_KEYS = new Set([
   "field_key",
   "label",
@@ -151,9 +147,6 @@ const isBlankTransferredValue = (value: unknown): boolean => {
 
 const hasNonBlankPayloadValue = (payload: Record<string, unknown>, key: string): boolean =>
   !isBlankTransferredValue(payload[key]);
-
-const isOptionalIehpFinalOutputKey = (fieldKey: string | null | undefined): boolean =>
-  typeof fieldKey === "string" && IEHP_OPTIONAL_FINAL_OUTPUT_KEYS.has(fieldKey);
 
 const hasMeaningfulRawText = (payload: Record<string, unknown>): boolean =>
   typeof payload.raw_text === "string" && payload.raw_text.trim().length > 0;

--- a/src/server/api/assessment-template-layout.ts
+++ b/src/server/api/assessment-template-layout.ts
@@ -12,6 +12,7 @@ import {
   type AssessmentTemplatePage,
   type AssessmentTemplateVersion,
 } from "../assessmentTemplateLayout";
+import { normalizeIehpRequiredFlag } from "../iehpOptionalFinalOutput";
 
 const uuidSchema = z.string().uuid();
 
@@ -248,8 +249,12 @@ export async function assessmentTemplateLayoutHandler(request: Request): Promise
 
   const checklistRows = Array.isArray(checklistResult.data) ? checklistResult.data : [];
   const structuredSections = Array.isArray(structuredResult.data) ? structuredResult.data : [];
-  const unresolvedRequiredCount = checklistRows.filter((row) => row.required && row.status !== "approved").length +
-    structuredSections.filter((section) => section.required && section.status !== "approved").length;
+  const unresolvedRequiredCount = checklistRows
+    .filter((row) => normalizeIehpRequiredFlag(row.placeholder_key, row.required) && row.status !== "approved")
+    .length +
+    structuredSections
+      .filter((section) => normalizeIehpRequiredFlag(section.field_key, section.required) && section.status !== "approved")
+      .length;
   const extractedValueCount = checklistRows.filter((row) => typeof row.value_text === "string" && row.value_text.trim().length > 0).length;
 
   return jsonForRequest(request, {

--- a/src/server/iehpAssessmentDocx.ts
+++ b/src/server/iehpAssessmentDocx.ts
@@ -4,6 +4,7 @@ import type {
   AssessmentStructuredSectionValueRow,
   AssessmentWriterSnapshot,
 } from "./assessmentPlanPdf";
+import { normalizeIehpRequiredFlag } from "./iehpOptionalFinalOutput";
 
 export interface IehpTemplateFieldRow {
   field_key: string;
@@ -96,14 +97,8 @@ const compactWhitespace = (value: string): string => value.replace(/\s+/g, " ").
 
 const collapseWhitespace = (value: string): string => value.replace(/\s+/g, "").trim();
 
-const IEHP_OPTIONAL_FINAL_OUTPUT_KEYS = new Set([
-  "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
-  "IEHP_FBA_ASSESSOR_PHONE",
-  "IEHP_FBA_REFERRING_PROVIDER",
-]);
-
 const isRequiredForFinalOutput = (fieldKey: string, required: boolean): boolean =>
-  required && !IEHP_OPTIONAL_FINAL_OUTPUT_KEYS.has(fieldKey);
+  normalizeIehpRequiredFlag(fieldKey, required);
 
 const normalizeDateText = (value: string | null | undefined): string => {
   const compacted = compactWhitespace(value ?? "").replace(/\s*\/\s*/g, "/");

--- a/src/server/iehpOptionalFinalOutput.ts
+++ b/src/server/iehpOptionalFinalOutput.ts
@@ -1,0 +1,13 @@
+const IEHP_OPTIONAL_FINAL_OUTPUT_KEYS = new Set([
+  "IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES",
+  "IEHP_FBA_ASSESSOR_PHONE",
+  "IEHP_FBA_REFERRING_PROVIDER",
+]);
+
+export const isOptionalIehpFinalOutputKey = (fieldKey: string | null | undefined): boolean =>
+  typeof fieldKey === "string" && IEHP_OPTIONAL_FINAL_OUTPUT_KEYS.has(fieldKey);
+
+export const normalizeIehpRequiredFlag = (
+  fieldKey: string | null | undefined,
+  required: boolean | null | undefined,
+): boolean => Boolean(required) && !isOptionalIehpFinalOutputKey(fieldKey);


### PR DESCRIPTION
## Summary
- add a shared server-side helper for IEHP optional final-output keys
- normalize fresh IEHP upload seeds and structured extraction rows so `IEHP_FBA_REFERRING_PROVIDER` is treated as optional
- align checklist approval, layout unresolved counts, publish gating, and export logic with the same effective-required rule

## Verification
- npm test -- src/server/__tests__/assessmentChecklistHandler.test.ts src/server/__tests__/assessmentTemplateLayoutHandler.test.ts src/server/__tests__/assessmentDocumentsHandler.test.ts
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run build

## Blocked / Follow-up
- `npm run test:ci` timed out twice after 10 minutes locally
- `npm run verify:local` timed out twice after 10 minutes locally because it includes the full `test:ci` chain
- critical-lane work still needs a Linear issue link before merge
- human review is still required before merge