### PR TITLE
WIN-172 Require active live programs and goals for sessions

### DIFF
--- a/src/components/AutoScheduleModal.tsx
+++ b/src/components/AutoScheduleModal.tsx
@@ -87,20 +87,22 @@ export function AutoScheduleModal({
             throw new Error(`Failed to load programs for client ${clientId}`);
           }
           const programs = await programsResponse.json() as Array<{ id: string; status: string }>;
-          const program = programs.find((p) => p.status === 'active') ?? programs[0];
-          if (!program) {
-            throw new Error(`No program found for client ${clientId}`);
+          const activePrograms = programs.filter((p) => p.status === 'active');
+          if (activePrograms.length === 0) {
+            throw new Error(`No active program found for client ${clientId}`);
           }
-          const goalsResponse = await callEdgeFunctionHttp(`goals?program_id=${program.id}`);
-          if (!goalsResponse.ok) {
-            throw new Error(`Failed to load goals for client ${clientId}`);
+          for (const program of activePrograms) {
+            const goalsResponse = await callEdgeFunctionHttp(`goals?program_id=${program.id}`);
+            if (!goalsResponse.ok) {
+              throw new Error(`Failed to load goals for client ${clientId}`);
+            }
+            const goals = await goalsResponse.json() as Array<{ id: string; status: string }>;
+            const goal = goals.find((g) => g.status === 'active');
+            if (goal) {
+              return { clientId, programId: program.id, goalId: goal.id };
+            }
           }
-          const goals = await goalsResponse.json() as Array<{ id: string; status: string }>;
-          const goal = goals.find((g) => g.status === 'active') ?? goals[0];
-          if (!goal) {
-            throw new Error(`No goal found for client ${clientId}`);
-          }
-          return { clientId, programId: program.id, goalId: goal.id };
+          throw new Error(`No active goal found for client ${clientId}`);
         }),
       );
       const programGoalMap = new Map(programGoalPairs.map((entry) => [entry.clientId, entry]));

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -552,20 +552,24 @@ export function SessionModal({
       setSelectedProgramIds([]);
       return;
     }
-    const programIdsSet = new Set(programs.map((program) => program.id));
-    const nextProgram = programs.find((program) => program.status === 'active') ?? programs[0];
-    if (!programId || !programIdsSet.has(programId)) {
-      if (session?.id && programId && !programIdsSet.has(programId)) {
+    const activeProgramIdsSet = new Set(
+      programs.filter((program) => program.status === 'active').map((program) => program.id)
+    );
+    const nextProgram = programs.find((program) => program.status === 'active');
+    if (!programId || !activeProgramIdsSet.has(programId)) {
+      if (session?.id && programId && !activeProgramIdsSet.has(programId)) {
         return;
       }
       if (nextProgram?.id) {
         setValue('program_id', nextProgram.id);
+      } else if (programId) {
+        setValue('program_id', '');
       }
     }
 
     setSelectedProgramIds((current) => {
-      const filtered = current.filter((id) => programIdsSet.has(id));
-      const preferredPrimaryProgram = programIdsSet.has(programId ?? '') ? programId : nextProgram?.id ?? '';
+      const filtered = current.filter((id) => activeProgramIdsSet.has(id));
+      const preferredPrimaryProgram = activeProgramIdsSet.has(programId ?? '') ? programId : nextProgram?.id ?? '';
       const withPrimary =
         preferredPrimaryProgram && !filtered.includes(preferredPrimaryProgram)
           ? [preferredPrimaryProgram, ...filtered]
@@ -590,17 +594,19 @@ export function SessionModal({
       activeGoalsByProgram.get(primaryProgramId) ??
       activeGoalsByProgram.get(programId ?? '') ??
       activeGoals;
-    const goalIdsSet = new Set(availableGoals.map((goal) => goal.id));
-    if (session?.id && goalId && !goalIdsSet.has(goalId)) {
+    const activeGoalIdsSet = new Set(activeGoals.map((goal) => goal.id));
+    if (session?.id && goalId && !activeGoalIdsSet.has(goalId)) {
       return;
     }
-    if (!goalId || !goalIdsSet.has(goalId)) {
-      const nextGoal = primaryProgramGoals[0] ?? activeGoals[0] ?? availableGoals[0];
+    if (!goalId || !activeGoalIdsSet.has(goalId)) {
+      const nextGoal = primaryProgramGoals[0] ?? activeGoals[0];
       if (nextGoal?.id) {
         setValue('goal_id', nextGoal.id);
         if (nextGoal.program_id) {
           setValue('program_id', nextGoal.program_id);
         }
+      } else if (goalId) {
+        setValue('goal_id', '');
       }
     }
   }, [
@@ -680,12 +686,13 @@ export function SessionModal({
       }
 
       const currentPrimaryGoal = goalId ? goalsById.get(goalId) : undefined;
+      const canKeepCurrentPrimaryGoal =
+        Boolean(session?.id) || currentPrimaryGoal?.status === 'active';
       const fallbackGoal =
         uniqueProgramIds.flatMap((id) => activeGoalsByProgram.get(id) ?? [])[0] ??
-        activeGoals[0] ??
-        availableGoals[0];
+        activeGoals[0];
       const nextPrimaryGoal =
-        currentPrimaryGoal && uniqueProgramIds.includes(currentPrimaryGoal.program_id)
+        currentPrimaryGoal && canKeepCurrentPrimaryGoal && uniqueProgramIds.includes(currentPrimaryGoal.program_id)
           ? currentPrimaryGoal
           : fallbackGoal;
       if (nextPrimaryGoal?.id && nextPrimaryGoal.id !== goalId) {
@@ -700,7 +707,7 @@ export function SessionModal({
         setValue('program_id', nextPrimaryProgramId);
       }
     },
-    [activeGoals, activeGoalsByProgram, availableGoals, goalId, goalIds, goalsById, programId, programsById, setValue],
+    [activeGoals, activeGoalsByProgram, goalId, goalIds, goalsById, programId, programsById, session?.id, setValue],
   );
 
   const toggleProgramSelection = useCallback(
@@ -1170,7 +1177,9 @@ export function SessionModal({
       !hasStartedSession &&
       session?.status !== 'in_progress' &&
       programId &&
-      goalId,
+      goalId &&
+      hasProgramOptionForValue &&
+      hasGoalOptionForValue,
   );
   const sessionModalMode = useMemo(() => {
     if (!session) {
@@ -1873,7 +1882,7 @@ export function SessionModal({
                   className="min-h-11 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                 >
                   <option value="">Select a program</option>
-                  {programId && !hasProgramOptionForValue && (
+                  {session?.id && programId && !hasProgramOptionForValue && (
                     <option value={programId}>
                       Current program (unavailable in active list)
                     </option>
@@ -1920,7 +1929,7 @@ export function SessionModal({
                   className="min-h-11 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                 >
                   <option value="">Select a goal</option>
-                  {goalId && !hasGoalOptionForValue && (
+                  {session?.id && goalId && !hasGoalOptionForValue && (
                     <option value={goalId}>
                       Current goal (unavailable in active list)
                     </option>

--- a/src/components/__tests__/AutoScheduleModalWarnings.test.tsx
+++ b/src/components/__tests__/AutoScheduleModalWarnings.test.tsx
@@ -3,9 +3,25 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { AutoScheduleModal } from '../AutoScheduleModal';
 import type { Therapist, Client, Session } from '../../types';
 import { generateOptimalSchedule } from '../../lib/autoSchedule';
+import { callEdgeFunctionHttp } from '../../lib/api';
+import { showError } from '../../lib/toast';
 
 vi.mock('../../lib/autoSchedule', () => ({
   generateOptimalSchedule: vi.fn()
+}));
+
+vi.mock('../../lib/api', () => ({
+  callEdgeFunctionHttp: vi.fn(),
+}));
+
+vi.mock('../../lib/toast', () => ({
+  showError: vi.fn(),
+}));
+
+vi.mock('../../lib/logger/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
 }));
 
 const createTherapist = (overrides: Partial<Therapist> = {}): Therapist => ({
@@ -55,10 +71,14 @@ const createClient = (overrides: Partial<Client> = {}): Client => ({
 });
 
 const mockedGenerateOptimalSchedule = vi.mocked(generateOptimalSchedule);
+const mockedCallEdgeFunctionHttp = vi.mocked(callEdgeFunctionHttp);
+const mockedShowError = vi.mocked(showError);
 
 describe('AutoScheduleModal warnings', () => {
   beforeEach(() => {
     mockedGenerateOptimalSchedule.mockReset();
+    mockedCallEdgeFunctionHttp.mockReset();
+    mockedShowError.mockReset();
   });
 
   it('renders as an accessible dialog with labeled controls', () => {
@@ -153,5 +173,159 @@ describe('AutoScheduleModal warnings', () => {
     expect(
       screen.getByText('All eligible clients are already at their authorized limits for the selected range.')
     ).toBeInTheDocument();
+  });
+
+  it('does not schedule against inactive live programs or non-active goals', async () => {
+    const therapist = createTherapist();
+    const client = createClient();
+    const onSchedule = vi.fn();
+    mockedGenerateOptimalSchedule.mockReturnValue({
+      slots: [
+        {
+          therapist,
+          client,
+          startTime: new Date('2025-03-18T09:00:00.000Z').toISOString(),
+          endTime: new Date('2025-03-18T10:00:00.000Z').toISOString(),
+          score: 0.9,
+        },
+      ],
+      cappedClients: [],
+    });
+    mockedCallEdgeFunctionHttp.mockImplementation(async (path: string) => {
+      if (path.startsWith('programs?')) {
+        return new Response(JSON.stringify([{ id: 'program-inactive', status: 'inactive' }]), { status: 200 });
+      }
+      if (path.startsWith('goals?')) {
+        return new Response(JSON.stringify([{ id: 'goal-paused', status: 'paused' }]), { status: 200 });
+      }
+      return new Response(JSON.stringify([]), { status: 404 });
+    });
+
+    render(
+      <AutoScheduleModal
+        isOpen
+        onClose={() => {}}
+        onSchedule={onSchedule}
+        therapists={[therapist]}
+        clients={[client]}
+        existingSessions={[] as Session[]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /generate preview/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^schedule all sessions$/i }));
+
+    await screen.findByRole('button', { name: /^schedule all sessions$/i });
+    expect(onSchedule).not.toHaveBeenCalled();
+    expect(mockedShowError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('No active program found'),
+    }));
+  });
+
+  it('does not schedule when the selected live program has no active goals', async () => {
+    const therapist = createTherapist();
+    const client = createClient();
+    const onSchedule = vi.fn();
+    mockedGenerateOptimalSchedule.mockReturnValue({
+      slots: [
+        {
+          therapist,
+          client,
+          startTime: new Date('2025-03-18T09:00:00.000Z').toISOString(),
+          endTime: new Date('2025-03-18T10:00:00.000Z').toISOString(),
+          score: 0.9,
+        },
+      ],
+      cappedClients: [],
+    });
+    mockedCallEdgeFunctionHttp.mockImplementation(async (path: string) => {
+      if (path.startsWith('programs?')) {
+        return new Response(JSON.stringify([{ id: 'program-active', status: 'active' }]), { status: 200 });
+      }
+      if (path.startsWith('goals?')) {
+        return new Response(JSON.stringify([{ id: 'goal-paused', status: 'paused' }]), { status: 200 });
+      }
+      return new Response(JSON.stringify([]), { status: 404 });
+    });
+
+    render(
+      <AutoScheduleModal
+        isOpen
+        onClose={() => {}}
+        onSchedule={onSchedule}
+        therapists={[therapist]}
+        clients={[client]}
+        existingSessions={[] as Session[]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /generate preview/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^schedule all sessions$/i }));
+
+    await screen.findByRole('button', { name: /^schedule all sessions$/i });
+    expect(onSchedule).not.toHaveBeenCalled();
+    expect(mockedShowError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('No active goal found'),
+    }));
+  });
+
+  it('uses the first active live program that has an active goal', async () => {
+    const therapist = createTherapist();
+    const client = createClient();
+    const onSchedule = vi.fn();
+    mockedGenerateOptimalSchedule.mockReturnValue({
+      slots: [
+        {
+          therapist,
+          client,
+          startTime: new Date('2025-03-18T09:00:00.000Z').toISOString(),
+          endTime: new Date('2025-03-18T10:00:00.000Z').toISOString(),
+          score: 0.9,
+        },
+      ],
+      cappedClients: [],
+    });
+    mockedCallEdgeFunctionHttp.mockImplementation(async (path: string) => {
+      if (path.startsWith('programs?')) {
+        return new Response(
+          JSON.stringify([
+            { id: 'program-active-empty', status: 'active' },
+            { id: 'program-active-ready', status: 'active' },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (path === 'goals?program_id=program-active-empty') {
+        return new Response(JSON.stringify([{ id: 'goal-paused', status: 'paused' }]), { status: 200 });
+      }
+      if (path === 'goals?program_id=program-active-ready') {
+        return new Response(JSON.stringify([{ id: 'goal-active', status: 'active' }]), { status: 200 });
+      }
+      return new Response(JSON.stringify([]), { status: 404 });
+    });
+
+    render(
+      <AutoScheduleModal
+        isOpen
+        onClose={() => {}}
+        onSchedule={onSchedule}
+        therapists={[therapist]}
+        clients={[client]}
+        existingSessions={[] as Session[]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /generate preview/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^schedule all sessions$/i }));
+
+    await screen.findByRole('button', { name: /^schedule all sessions$/i });
+    expect(onSchedule).toHaveBeenCalledWith([
+      expect.objectContaining({
+        client_id: client.id,
+        program_id: 'program-active-ready',
+        goal_id: 'goal-active',
+      }),
+    ]);
+    expect(mockedShowError).not.toHaveBeenCalled();
   });
 });

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -743,6 +743,75 @@ describe('SessionModal', () => {
     });
   });
 
+  it('does not start a scheduled session with unavailable live program and goal selections', async () => {
+    const buildChain = (rows: unknown[]) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain([
+          {
+            ...mockPrograms[0],
+            id: 'inactive-program-1',
+            name: 'Inactive Published Program',
+            status: 'inactive',
+          },
+        ]);
+      }
+      if (table === 'goals') {
+        return buildChain([
+          {
+            ...mockGoals[0],
+            id: 'paused-goal-1',
+            program_id: 'inactive-program-1',
+            title: 'Paused Published Goal',
+            status: 'paused',
+          },
+        ]);
+      }
+      return buildChain([]);
+    });
+    const onSessionStarted = vi.fn();
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSessionStarted={onSessionStarted}
+        session={{
+          id: 'session-unavailable-start',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'inactive-program-1',
+          goal_id: 'paused-goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'scheduled',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    const startButton = await screen.findByRole('button', { name: /Start Session/i });
+    await waitFor(() => expect(startButton).toBeDisabled());
+    await userEvent.click(startButton);
+
+    expect(vi.mocked(startSessionFromModal)).not.toHaveBeenCalled();
+    expect(onSessionStarted).not.toHaveBeenCalled();
+  });
+
   describe('status select — create mode (no session prop)', () => {
     it('disables in_progress option in create mode', () => {
       renderWithProviders(<SessionModal {...defaultProps} />);
@@ -820,6 +889,69 @@ describe('SessionModal', () => {
       );
       const select = screen.getByRole('combobox', { name: /Status/i }) as HTMLSelectElement;
       expect(select.value).toBe('in_progress');
+    });
+  });
+
+  it('does not preselect inactive published programs or paused goals for a new session', async () => {
+    const buildChain = (rows: unknown[]) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain([
+          {
+            ...mockPrograms[0],
+            id: 'inactive-program-1',
+            name: 'Inactive Published Program',
+            status: 'inactive',
+          },
+        ]);
+      }
+      if (table === 'goals') {
+        return buildChain([
+          {
+            ...mockGoals[0],
+            id: 'paused-goal-1',
+            program_id: 'inactive-program-1',
+            title: 'Paused Published Goal',
+            status: 'paused',
+          },
+        ]);
+      }
+      return buildChain([]);
+    });
+
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(<SessionModal {...defaultProps} onSubmit={onSubmit} />);
+
+    const programSelect = await screen.findByRole('combobox', { name: /Program/i }) as HTMLSelectElement;
+    const goalSelect = screen.getByRole('combobox', { name: /Primary Goal/i }) as HTMLSelectElement;
+    await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
+    await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
+
+    await waitFor(() => {
+      expect(programSelect.value).toBe('');
+      expect(goalSelect.value).toBe('');
+    });
+    expect(screen.queryByRole('option', { name: 'Inactive Published Program' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Paused Published Goal' })).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2025-03-18T10:00' } });
+    fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2025-03-18T11:00' } });
+    await userEvent.click(screen.getByRole('button', { name: /Create Session/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByText(/Program is required/i)).toBeInTheDocument();
+      expect(screen.getByText(/Primary goal is required/i)).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- Require session creation/start to use active live programs and goals for the selected client/org.
- Block unstarted scheduled session saves when the stored program or primary goal is no longer an active live option, while keeping historical unavailable values visible for context.
- Update autoschedule to choose an active live program with an active live goal, without falling back to inactive/non-active records.

## Linear
- WIN-172: https://linear.app/winningedgeai/issue/WIN-172/use-active-live-programs-and-goals-in-session-workflows

## Verification
Passed locally:
- npm test -- src/components/__tests__/AutoScheduleModalWarnings.test.tsx src/components/__tests__/SessionModal.test.tsx --run --reporter=verbose
- npm run lint
- npm run typecheck
- npm run validate:tenant
- npm run build
- npm run ci:check-focused
- npm run test:routes:tier0
- git diff --check

CI previously passed on PR #620 before this follow-up commit; new checks are pending after ee6400f3.

Local-only instability observed earlier:
- npm run test:ci failed locally on unrelated Vitest timeout/temp-dir worker instability outside changed files, while CI unit-tests passed on the prior PR head.
- npm run verify:local failed locally at test:ci for the same local instability.
- npm run ci:playwright timed out locally earlier with no actionable output; CI auth-browser-smoke and tier0-browser passed on the prior PR head.

## Risk
Critical lane because this changes tenant-scoped session workflow behavior. No protected files were touched, but human review is required by repo policy.
