### PR TITLE
WIN-172 Block stale scheduled session saves

### DIFF
--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -185,6 +185,7 @@ export function SessionModal({
     handleSubmit,
     watch,
     setValue,
+    setError,
     reset,
     getValues,
     formState: { errors, isSubmitting, isDirty, dirtyFields },
@@ -913,6 +914,24 @@ export function SessionModal({
         return;
       }
     }
+    const isSavingUnstartedScheduledSession =
+      Boolean(session?.id) &&
+      !hasStartedSession &&
+      data.status === 'scheduled';
+    if (isSavingUnstartedScheduledSession && !hasProgramOptionForValue) {
+      setError('program_id', {
+        type: 'validate',
+        message: 'Select an active program before saving this scheduled session.',
+      });
+      return;
+    }
+    if (isSavingUnstartedScheduledSession && !hasGoalOptionForValue) {
+      setError('goal_id', {
+        type: 'validate',
+        message: 'Select an active primary goal before saving this scheduled session.',
+      });
+      return;
+    }
     try {
       const pruned = pruneEmptyAdhocSessionTargets(
         {
@@ -1171,7 +1190,9 @@ export function SessionModal({
   const isInProgressSession =
     !hasTerminalSessionStatus &&
     (session?.status === 'in_progress' || hasStartedSession);
-  const isDependentDataLoading = (Boolean(clientId) && isProgramsFetching) || (Boolean(clientId) && isGoalsFetching);
+  const isDependentDataLoading =
+    Boolean(clientId) &&
+    (isProgramsFetching || isGoalsFetching || !isProgramsFetched || !isGoalsFetched);
   const canStartSession = Boolean(
     session?.id &&
       !hasStartedSession &&

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -450,10 +450,12 @@ export function SessionModal({
     () => selectedGoalsForSession.map((goal) => goal.title).join(', '),
     [selectedGoalsForSession],
   );
-  const hasProgramOptionForValue = typeof programId === 'string' && programId.length > 0
+  const hasProgramValue = typeof programId === 'string' && programId.length > 0;
+  const hasGoalValue = typeof goalId === 'string' && goalId.length > 0;
+  const hasProgramOptionForValue = hasProgramValue
     ? activePrograms.some((program) => program.id === programId)
     : false;
-  const hasGoalOptionForValue = typeof goalId === 'string' && goalId.length > 0
+  const hasGoalOptionForValue = hasGoalValue
     ? selectedProgramGoals.some((goal) => goal.id === goalId)
     : false;
   const hasDirtySessionCaptureFields = useMemo(
@@ -918,14 +920,14 @@ export function SessionModal({
       Boolean(session?.id) &&
       !hasStartedSession &&
       data.status === 'scheduled';
-    if (isSavingUnstartedScheduledSession && !hasProgramOptionForValue) {
+    if (isSavingUnstartedScheduledSession && hasProgramValue && !hasProgramOptionForValue) {
       setError('program_id', {
         type: 'validate',
         message: 'Select an active program before saving this scheduled session.',
       });
       return;
     }
-    if (isSavingUnstartedScheduledSession && !hasGoalOptionForValue) {
+    if (isSavingUnstartedScheduledSession && hasGoalValue && !hasGoalOptionForValue) {
       setError('goal_id', {
         type: 'validate',
         message: 'Select an active primary goal before saving this scheduled session.',

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1021,6 +1021,125 @@ describe('SessionModal', () => {
     });
   });
 
+  it('saves a legacy scheduled session with no stored program or primary goal', async () => {
+    const buildChain = (rows: unknown[]) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs' || table === 'goals') {
+        return buildChain([]);
+      }
+      return buildChain([]);
+    });
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-legacy-no-plan-save',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: null,
+          goal_id: null,
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'scheduled',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    const legacyNoPlanUpdateButton = await screen.findByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(legacyNoPlanUpdateButton).not.toBeDisabled());
+    await userEvent.click(legacyNoPlanUpdateButton);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        program_id: '',
+        goal_id: '',
+        status: 'scheduled',
+      }));
+    });
+    expect(screen.queryByText(/Select an active program before saving this scheduled session/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Select an active primary goal before saving this scheduled session/i)).not.toBeInTheDocument();
+  });
+
+  it('saves a legacy scheduled session with an active program and no stored primary goal', async () => {
+    const buildChain = (rows: unknown[]) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain([]);
+      }
+      return buildChain([]);
+    });
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-legacy-no-primary-goal-save',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: null,
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'scheduled',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    expect(await screen.findByRole('option', { name: 'Default Program' })).toBeInTheDocument();
+    const legacyNoGoalUpdateButton = screen.getByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(legacyNoGoalUpdateButton).not.toBeDisabled());
+    await userEvent.click(legacyNoGoalUpdateButton);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        program_id: 'program-1',
+        goal_id: '',
+        status: 'scheduled',
+      }));
+    });
+    expect(screen.queryByText(/Select an active primary goal before saving this scheduled session/i)).not.toBeInTheDocument();
+  });
+
   describe('status select — create mode (no session prop)', () => {
     it('disables in_progress option in create mode', () => {
       renderWithProviders(<SessionModal {...defaultProps} />);

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -635,6 +635,76 @@ describe('SessionModal', () => {
     });
   });
 
+  it('closes an in-progress historical session even when stored program and goal are no longer active', async () => {
+    const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain([
+          {
+            ...mockPrograms[0],
+            id: 'inactive-program-1',
+            name: 'Inactive Published Program',
+            status: 'inactive',
+          },
+        ]);
+      }
+      if (table === 'goals') {
+        return buildChain([
+          {
+            ...mockGoals[0],
+            id: 'paused-goal-1',
+            program_id: 'inactive-program-1',
+            title: 'Paused Published Goal',
+            status: 'paused',
+          },
+        ]);
+      }
+      return buildChain([]);
+    });
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-close-inactive-history',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'inactive-program-1',
+          goal_id: 'paused-goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: '2026-03-01T10:00:00.000Z',
+        } satisfies Session}
+      />
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: /^Close Session$/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'completed',
+      }));
+    });
+  });
+
   it('blocks Close Session when session capture needs billing defaults but none exist', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const buildChain = (rows: unknown[], singleRow: unknown = null) => {
@@ -812,6 +882,145 @@ describe('SessionModal', () => {
     expect(onSessionStarted).not.toHaveBeenCalled();
   });
 
+  it('does not save an unstarted scheduled session with unavailable live program and goal selections', async () => {
+    const buildChain = (rows: unknown[]) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain([
+          {
+            ...mockPrograms[0],
+            id: 'inactive-program-1',
+            name: 'Inactive Published Program',
+            status: 'inactive',
+          },
+        ]);
+      }
+      if (table === 'goals') {
+        return buildChain([
+          {
+            ...mockGoals[0],
+            id: 'paused-goal-1',
+            program_id: 'inactive-program-1',
+            title: 'Paused Published Goal',
+            status: 'paused',
+          },
+        ]);
+      }
+      return buildChain([]);
+    });
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-unavailable-save',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'inactive-program-1',
+          goal_id: 'paused-goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'scheduled',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    expect(await screen.findByText(/Current program \(unavailable in active list\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/Current goal \(unavailable in active list\)/i)).toBeInTheDocument();
+    const unavailableUpdateButton = screen.getByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(unavailableUpdateButton).not.toBeDisabled());
+    await userEvent.click(unavailableUpdateButton);
+
+    await waitFor(() => {
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByText(/Select an active program before saving this scheduled session/i)).toBeInTheDocument();
+    });
+  });
+
+  it('does not save an unstarted scheduled session when the program is active but the primary goal is unavailable', async () => {
+    const buildChain = (rows: unknown[]) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain([
+          {
+            ...mockGoals[0],
+            id: 'paused-goal-1',
+            program_id: 'program-1',
+            title: 'Paused Published Goal',
+            status: 'paused',
+          },
+        ]);
+      }
+      return buildChain([]);
+    });
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-unavailable-goal-save',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'paused-goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'scheduled',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    expect(await screen.findByRole('option', { name: 'Default Program' })).toBeInTheDocument();
+    expect(screen.getByText(/Current goal \(unavailable in active list\)/i)).toBeInTheDocument();
+    const unavailableGoalUpdateButton = screen.getByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(unavailableGoalUpdateButton).not.toBeDisabled());
+    await userEvent.click(unavailableGoalUpdateButton);
+
+    await waitFor(() => {
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByText(/Select an active primary goal before saving this scheduled session/i)).toBeInTheDocument();
+    });
+  });
+
   describe('status select — create mode (no session prop)', () => {
     it('disables in_progress option in create mode', () => {
       renderWithProviders(<SessionModal {...defaultProps} />);
@@ -980,7 +1189,9 @@ describe('SessionModal', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /Update Session/i }));
+    const saveSuccessButton = screen.getByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(saveSuccessButton).not.toBeDisabled());
+    await userEvent.click(saveSuccessButton);
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalled();
     });
@@ -1014,7 +1225,9 @@ describe('SessionModal', () => {
     };
     const { rerender } = renderWithProviders(<SessionModal {...props} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Update Session/i }));
+    const saveResetButton = screen.getByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(saveResetButton).not.toBeDisabled());
+    await userEvent.click(saveResetButton);
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalled();
     });
@@ -1051,7 +1264,9 @@ describe('SessionModal', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /Update Session/i }));
+    const saveFailureButton = screen.getByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(saveFailureButton).not.toBeDisabled());
+    await userEvent.click(saveFailureButton);
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalled();
     });
@@ -1096,7 +1311,9 @@ describe('SessionModal', () => {
     fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2026-03-02T10:00' } });
     fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2026-03-02T11:00' } });
 
-    await userEvent.click(screen.getByRole('button', { name: /Update Session/i }));
+    const noConflictUpdateButton = screen.getByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(noConflictUpdateButton).not.toBeDisabled());
+    await userEvent.click(noConflictUpdateButton);
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalled();
@@ -1164,7 +1381,9 @@ describe('SessionModal', () => {
     fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2026-03-01T11:00' } });
 
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
-    await userEvent.click(screen.getByRole('button', { name: /Update Session/i }));
+    const linkedNoteUpdateButton = screen.getByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(linkedNoteUpdateButton).not.toBeDisabled());
+    await userEvent.click(linkedNoteUpdateButton);
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Block unstarted scheduled session saves when the stored program or primary goal is no longer an active live option.
- Keep historical unavailable program/goal values visible for context instead of corrupting completed or in-progress records.
- Add regression coverage for unavailable program/goal saves, unavailable-goal-only saves, and historical in-progress close behavior.

## Linear
- WIN-172: https://linear.app/winningedgeai/issue/WIN-172/use-active-live-programs-and-goals-in-session-workflows

## Verification
Passed locally:
- npm test -- src/components/__tests__/AutoScheduleModalWarnings.test.tsx src/components/__tests__/SessionModal.test.tsx --run --reporter=verbose
- npm run lint
- npm run typecheck
- npm run build
- npm run ci:check-focused
- npm run validate:tenant
- git diff --check

Not rerun locally:
- npm run test:ci / npm run verify:local due prior local Vitest worker/temp-dir instability; PR CI should be authoritative for the broader gate.
- npm run ci:playwright timed out locally earlier; PR CI browser gates should be authoritative.

## Risk
Critical lane because this affects tenant-scoped session workflow behavior. No protected files touched; human review required before merge.
