### PR TITLE
WIN-173: Publish IEHP goals to live sessions

### DIFF
--- a/docs/ai/2026-06-08-iehp-live-program-goals-repair-handoff.md
+++ b/docs/ai/2026-06-08-iehp-live-program-goals-repair-handoff.md
@@ -1,0 +1,64 @@
+# IEHP Live Program Goals Repair Handoff
+
+- Linear issue: `WIN-173`
+- Assessment document: `4f1cad9b-ba5e-4ba4-8898-f5b25048e2d7`
+- Route-task classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Triggering paths: `src/server/api/assessment-promote.ts`, tenant-scoped production `programs` and `goals` repair
+
+## Scope
+
+Fix the IEHP publish path so approved IEHP structured goal sections create active, session-visible `programs` and `goals`.
+
+Repair only the already-approved June 8, 2026 IEHP document above after proving it had approved goal sections but zero live session rows.
+
+## Tenant Boundary
+
+All repair rows are constrained to the assessment document's `organization_id` and `client_id`.
+
+The repair does not change schema, RLS, grants, RPC exposure, secrets, or cross-tenant access rules.
+
+## Live Repair Evidence
+
+Before repair:
+
+- document status: `approved`
+- template type: `iehp_fba`
+- approved IEHP goal-section candidates: `31`
+- invalid candidate count: `0`
+- live programs for document client/org: `0`
+- live goals for document client/org: `0`
+- latest publish payload: `completion_mode = assessment_only`
+
+Repair guardrails:
+
+- abort unless the document is `approved` and `iehp_fba`
+- abort unless candidates are exactly `31`
+- abort unless distinct program names are exactly `31`
+- abort unless invalid candidate count is `0`
+- abort unless existing live program and goal counts are both `0`
+
+After repair:
+
+- active programs for document client/org: `31`
+- active goals for document client/org: `31`
+- repair audit event: `reviewed_assessment_live_repair`
+- repair payload: `completion_mode = live_program_goals`, `created_program_count = 31`, `created_goal_count = 31`
+
+## Verification
+
+- `npx vitest run src/server/__tests__/assessmentPromoteHandler.test.ts --reporter=verbose -t "promotes approved IEHP structured goals"`: pass
+- `npx vitest run src/server/__tests__/assessmentPromoteHandler.test.ts --reporter=verbose`: pass, `25/25`
+- `npm run typecheck`: pass
+- `npm run lint`: pass
+- `npm run build`: pass
+- `npm run ci:check-focused`: pass
+- `npm run validate:tenant`: pass
+- `git diff --check`: pass, CRLF warnings only
+- `npm run test:ci`: timed out locally after about 302 seconds with unrelated existing test noise visible
+
+## Residual Risk
+
+This is a critical protected-path change and production data repair. Human review is still required before merging the publish-path code.
+
+The production document is now live for sessions, but the original publish event remains historically accurate as `assessment_only`; the later repair event records the live row creation.

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -809,6 +809,167 @@ describe("assessmentPromoteHandler", () => {
     ).toBe(true);
   });
 
+  it("promotes approved IEHP structured goals into live session programs and goals", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key,section_index,payload")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [
+            {
+              id: "structured-behavior-goal",
+              field_key: "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
+              section_index: 0,
+              payload: {
+                title: "Physical aggression",
+                program_name: "Physical aggression",
+                goal_type: "child",
+                description: "Reduce physical aggression from 3x per hour to 0x per hour.",
+                original_text: "Program Name: Physical aggression Instrumental Goal: Reduce physical aggression.",
+                target_behavior: "Physical aggression",
+                target_criteria: "0x per hour across 4 consecutive weeks",
+                baseline_data: "3x per hour",
+                mastery_criteria: "0x per hour across 4 consecutive weeks",
+                measurement_type: "Rate",
+                generalization_criteria: "Across home and school",
+              },
+            },
+            {
+              id: "structured-skill-goal",
+              field_key: "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
+              section_index: 1,
+              payload: {
+                title: "Manding for tangibles",
+                program_name: "Manding for tangibles",
+                goal_type: "child",
+                description: "Mand for tangibles with AAC across 10 targets.",
+                original_text: "Program Name: Manding for tangibles Instrumental Goal: Mand with AAC.",
+                target_behavior: "Manding for tangibles",
+                target_criteria: "80% of opportunities across 4 consecutive weeks",
+                baseline_data: "0% of opportunities",
+                mastery_criteria: "80% across 4 consecutive weeks",
+                measurement_type: "Percentage of opportunities",
+                generalization_criteria: "Across home and school",
+              },
+            },
+          ],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/programs")) {
+        const body = JSON.parse(String(init?.body)) as { name: string };
+        return {
+          ok: true,
+          status: 201,
+          data: [{ id: body.name === "Physical aggression" ? "prod-program-1" : "prod-program-2" }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/goals")) {
+        const body = JSON.parse(String(init?.body)) as Array<{ title: string }>;
+        return {
+          ok: true,
+          status: 201,
+          data: body.map((goal, index) => ({ id: `prod-goal-${index + 1}`, title: goal.title })),
+        };
+      }
+      if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.extracted")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "approved",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "POST" && url.includes("/rest/v1/assessment_review_events")) {
+        return { ok: true, status: 201, data: null };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      assessment_document_id: "doc-1",
+      completion_mode: "live_program_goals",
+      created_program_count: 2,
+      created_goal_count: 2,
+      promoted_program_count: 2,
+      promoted_goal_count: 2,
+    });
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/programs"),
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"status":"active"'),
+      }),
+    );
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goals"),
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"status":"active"'),
+      }),
+    );
+    const reviewEventCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(([url, init]) => typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && init?.method === "POST");
+    expect(reviewEventCall).toBeTruthy();
+    expect(JSON.parse(String((reviewEventCall?.[1] as RequestInit | undefined)?.body ?? "{}"))).toMatchObject({
+      action: "reviewed_assessment_published",
+      event_payload: {
+        completion_mode: "live_program_goals",
+        created_program_count: 2,
+        created_goal_count: 2,
+      },
+    });
+  });
+
   it("publishes IEHP assessments with documented legacy structured payload shapes", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -55,6 +55,22 @@ interface IehpPublishDataQualityBlocker {
   section_index?: number | null;
 }
 
+interface IehpLiveGoalCandidate {
+  programName: string;
+  title: string;
+  description: string;
+  originalText: string;
+  goalType: "child" | "parent";
+  targetBehavior: string | null;
+  measurementType: string | null;
+  baselineData: string | null;
+  targetCriteria: string | null;
+  masteryCriteria: string | null;
+  maintenanceCriteria: string | null;
+  generalizationCriteria: string | null;
+  objectiveDataPoints: Array<Record<string, unknown> | string>;
+}
+
 interface DraftProgramRow {
   id: string;
   name: string;
@@ -192,6 +208,46 @@ const hasDefaultRequiredStructuredValue = (payload: Record<string, unknown>): bo
     !IEHP_STRUCTURED_METADATA_KEYS.has(key) && hasMeaningfulStructuredValue(value)
   );
 };
+
+const normalizeIehpGoalType = (value: unknown): "child" | "parent" =>
+  typeof value === "string" && value.trim().toLowerCase() === "parent" ? "parent" : "child";
+
+const toIehpGoalCandidate = (row: AssessmentRequiredStructuredReviewRow): IehpLiveGoalCandidate | null => {
+  if (!IEHP_GOAL_SECTION_KEYS.has(row.field_key) || !row.payload || typeof row.payload !== "object") {
+    return null;
+  }
+  const payload = row.payload;
+  const programName = toStringOrNull(payload.program_name) ?? toStringOrNull(payload.program) ?? toStringOrNull(payload.title);
+  const title = toStringOrNull(payload.title) ?? programName ?? toStringOrNull(payload.target_behavior);
+  const rawText = toStringOrNull(payload.original_text) ?? toStringOrNull(payload.raw_text);
+  const description = toStringOrNull(payload.description) ?? toStringOrNull(payload.target_criteria) ?? rawText ?? title;
+  if (!programName || !title || !description || !rawText) {
+    return null;
+  }
+  return {
+    programName,
+    title,
+    description,
+    originalText: rawText,
+    goalType: normalizeIehpGoalType(payload.goal_type),
+    targetBehavior: toStringOrNull(payload.target_behavior),
+    measurementType: toStringOrNull(payload.measurement_type),
+    baselineData: toStringOrNull(payload.baseline_data),
+    targetCriteria: toStringOrNull(payload.target_criteria),
+    masteryCriteria: toStringOrNull(payload.mastery_criteria),
+    maintenanceCriteria: toStringOrNull(payload.maintenance_criteria),
+    generalizationCriteria: toStringOrNull(payload.generalization_criteria),
+    objectiveDataPoints: Array.isArray(payload.objective_data_points)
+      ? payload.objective_data_points.filter((point): point is Record<string, unknown> | string =>
+        (typeof point === "string" && point.trim().length > 0) ||
+        (!!point && typeof point === "object" && !Array.isArray(point)),
+      )
+      : [],
+  };
+};
+
+const buildIehpLiveGoalCandidates = (rows: AssessmentRequiredStructuredReviewRow[]): IehpLiveGoalCandidate[] =>
+  rows.map(toIehpGoalCandidate).filter((goal): goal is IehpLiveGoalCandidate => goal !== null);
 
 const buildIehpStructuredDataQualityBlockers = (
   rows: AssessmentRequiredStructuredReviewRow[],
@@ -411,6 +467,59 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
 
     const now = new Date().toISOString();
     const actorId = getAccessTokenSubject(accessToken);
+    const iehpLiveGoals = buildIehpLiveGoalCandidates(approvedStructuredRows);
+    const iehpProgramNames = Array.from(new Set(iehpLiveGoals.map((goal) => goal.programName)));
+    const createdIehpProgramIds: string[] = [];
+    const createdIehpProgramIdByName = new Map<string, string>();
+    let createdIehpGoals: Array<{ id: string; title: string }> = [];
+
+    const rollbackIehpLivePromotion = async (args: { restoreDocumentStatus: boolean }) => {
+      const failedSteps: string[] = [];
+      if (createdIehpProgramIds.length > 0) {
+        const programIdFilter = buildInFilter(createdIehpProgramIds);
+        const deleteGoalsResult = await fetchJson(
+          `${supabaseUrl}/rest/v1/goals?program_id=${programIdFilter}&organization_id=eq.${encodeURIComponent(
+            organizationId,
+          )}&client_id=eq.${encodeURIComponent(document.client_id)}`,
+          { method: "DELETE", headers },
+        );
+        if (!deleteGoalsResult.ok) {
+          failedSteps.push("delete_goals");
+        }
+
+        const deleteProgramsResult = await fetchJson(
+          `${supabaseUrl}/rest/v1/programs?id=${programIdFilter}&organization_id=eq.${encodeURIComponent(
+            organizationId,
+          )}&client_id=eq.${encodeURIComponent(document.client_id)}`,
+          { method: "DELETE", headers },
+        );
+        if (!deleteProgramsResult.ok) {
+          failedSteps.push("delete_programs");
+        }
+      }
+
+      const liveRollbackFailed = failedSteps.includes("delete_goals") || failedSteps.includes("delete_programs");
+      if (args.restoreDocumentStatus && !liveRollbackFailed) {
+        const restoreDocumentResult = await fetchJson(
+          `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}`,
+          {
+            method: "PATCH",
+            headers,
+            body: JSON.stringify({
+              status: document.status,
+              approved_at: null,
+              updated_at: new Date().toISOString(),
+            }),
+          },
+        );
+        if (!restoreDocumentResult.ok) {
+          failedSteps.push("restore_document_status");
+        }
+      }
+
+      return { ok: failedSteps.length === 0, failedSteps };
+    };
+
     const finalizeReviewedAssessmentResult = await fetchJson<AssessmentDocumentRow[]>(
       `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}&status=eq.${encodeURIComponent(document.status)}`,
       {
@@ -427,12 +536,115 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
       ? finalizeReviewedAssessmentResult.data[0]
       : null;
     if (!finalizeReviewedAssessmentResult.ok) {
+      const rollback = await rollbackIehpLivePromotion({ restoreDocumentStatus: false });
+      if (!rollback.ok) {
+        return json(
+          {
+            error: "Failed to finalize reviewed assessment, and rollback did not complete cleanly.",
+            rollback_failed_steps: rollback.failedSteps,
+          },
+          finalizeReviewedAssessmentResult.status || 500,
+        );
+      }
       return json({ error: "Failed to finalize reviewed assessment." }, finalizeReviewedAssessmentResult.status || 500);
     }
     if (!finalizedDocument) {
+      const rollback = await rollbackIehpLivePromotion({ restoreDocumentStatus: false });
+      if (!rollback.ok) {
+        return json(
+          {
+            error: "Assessment review state changed before publish completed, and rollback did not complete cleanly.",
+            rollback_failed_steps: rollback.failedSteps,
+          },
+          409,
+        );
+      }
       return json({ error: "Assessment review state changed before publish completed. Refresh and retry." }, 409);
     }
 
+    for (const programName of iehpProgramNames) {
+      const createProgramResult = await fetchJson<Array<{ id: string }>>(`${supabaseUrl}/rest/v1/programs`, {
+        method: "POST",
+        headers: { ...headers, Prefer: "return=representation" },
+        body: JSON.stringify({
+          organization_id: organizationId,
+          client_id: document.client_id,
+          name: programName,
+          description: `Program derived from approved IEHP structured goal section for ${programName}.`,
+          status: "active",
+        }),
+      });
+      if (!createProgramResult.ok || !Array.isArray(createProgramResult.data) || !createProgramResult.data[0]?.id) {
+        const rollback = await rollbackIehpLivePromotion({ restoreDocumentStatus: true });
+        return json(
+          {
+            error: rollback.ok
+              ? "Failed to create IEHP production programs. Promotion rolled back safely."
+              : "Failed to create IEHP production programs, and rollback did not complete cleanly.",
+            rollback_failed_steps: rollback.ok ? undefined : rollback.failedSteps,
+          },
+          createProgramResult.status || 500,
+        );
+      }
+      const createdProgramId = createProgramResult.data[0].id;
+      createdIehpProgramIds.push(createdProgramId);
+      createdIehpProgramIdByName.set(programName, createdProgramId);
+    }
+
+    const iehpGoalsPayload = iehpLiveGoals.map((goal) => ({
+      organization_id: organizationId,
+      client_id: document.client_id,
+      program_id: createdIehpProgramIdByName.get(goal.programName) ?? null,
+      title: goal.title,
+      description: goal.description,
+      original_text: goal.originalText,
+      goal_type: goal.goalType,
+      target_behavior: goal.targetBehavior,
+      measurement_type: goal.measurementType,
+      baseline_data: goal.baselineData,
+      target_criteria: goal.targetCriteria,
+      mastery_criteria: goal.masteryCriteria,
+      maintenance_criteria: goal.maintenanceCriteria,
+      generalization_criteria: goal.generalizationCriteria,
+      objective_data_points: goal.objectiveDataPoints,
+      status: "active",
+    }));
+
+    if (iehpGoalsPayload.some((goal) => !goal.program_id)) {
+      const rollback = await rollbackIehpLivePromotion({ restoreDocumentStatus: true });
+      return json(
+        {
+          error: rollback.ok
+            ? "Approved IEHP goals could not be matched to production programs. Promotion rolled back safely."
+            : "Approved IEHP goals could not be matched to production programs, and rollback did not complete cleanly.",
+          rollback_failed_steps: rollback.ok ? undefined : rollback.failedSteps,
+        },
+        409,
+      );
+    }
+
+    const createIehpGoalsResult = iehpGoalsPayload.length > 0
+      ? await fetchJson<Array<{ id: string; title: string }>>(`${supabaseUrl}/rest/v1/goals`, {
+        method: "POST",
+        headers: { ...headers, Prefer: "return=representation" },
+        body: JSON.stringify(iehpGoalsPayload),
+      })
+      : { ok: true, status: 200, data: [] };
+    if (!createIehpGoalsResult.ok) {
+      const rollback = await rollbackIehpLivePromotion({ restoreDocumentStatus: true });
+      return json(
+        {
+          error: rollback.ok
+            ? "Failed to create IEHP production goals. Promotion rolled back safely."
+            : "Failed to create IEHP production goals, and rollback did not complete cleanly.",
+          rollback_failed_steps: rollback.ok ? undefined : rollback.failedSteps,
+        },
+        createIehpGoalsResult.status || 500,
+      );
+    }
+    createdIehpGoals = Array.isArray(createIehpGoalsResult.data) ? createIehpGoalsResult.data : [];
+
+    const iehpCompletionMode = iehpLiveGoals.length > 0 ? "live_program_goals" : "assessment_only";
     const createReviewedEventResult = await fetchJson(`${supabaseUrl}/rest/v1/assessment_review_events`, {
       method: "POST",
       headers,
@@ -447,37 +659,36 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
         to_status: "approved",
         actor_id: actorId,
         event_payload: {
-          completion_mode: "assessment_only",
-          created_program_count: 0,
-          created_goal_count: 0,
-          promoted_program_count: 0,
-          promoted_goal_count: 0,
+          completion_mode: iehpCompletionMode,
+          created_program_count: createdIehpProgramIds.length,
+          created_program_ids: createdIehpProgramIds,
+          created_goal_count: createdIehpGoals.length || iehpLiveGoals.length,
+          promoted_program_count: iehpProgramNames.length,
+          promoted_goal_count: iehpLiveGoals.length,
         },
       }),
     });
     if (!createReviewedEventResult.ok) {
-      await fetchJson(
-        `${supabaseUrl}/rest/v1/assessment_documents?id=eq.${encodeURIComponent(document.id)}`,
-        {
-          method: "PATCH",
-          headers,
-          body: JSON.stringify({
-            status: document.status,
-            approved_at: null,
-            updated_at: new Date().toISOString(),
-          }),
-        },
-      );
+      const rollback = await rollbackIehpLivePromotion({ restoreDocumentStatus: true });
+      if (!rollback.ok) {
+        return json(
+          {
+            error: "Failed to record reviewed assessment publish event, and rollback did not complete cleanly.",
+            rollback_failed_steps: rollback.failedSteps,
+          },
+          createReviewedEventResult.status || 500,
+        );
+      }
       return json({ error: "Failed to record reviewed assessment publish event." }, createReviewedEventResult.status || 500);
     }
 
     return json({
       assessment_document_id: document.id,
-      completion_mode: "assessment_only",
-      created_program_count: 0,
-      created_goal_count: 0,
-      promoted_program_count: 0,
-      promoted_goal_count: 0,
+      completion_mode: iehpCompletionMode,
+      created_program_count: createdIehpProgramIds.length,
+      created_goal_count: createdIehpGoals.length || iehpLiveGoals.length,
+      promoted_program_count: iehpProgramNames.length,
+      promoted_goal_count: iehpLiveGoals.length,
     });
   }
   if (document.status !== PROMOTION_READY_STATUS) {


### PR DESCRIPTION
## Summary
- Promotes approved IEHP structured goal sections into active live `programs` and `goals` during IEHP assessment publish.
- Keeps the IEHP publish completion mode as `assessment_only` only when no approved IEHP live-goal candidates exist.
- Adds focused regression coverage and a critical-lane handoff artifact for the production repair.

## Live Repair Evidence
- Linear: WIN-173
- Document: `assessment_documents.id = 4f1cad9b-ba5e-4ba4-8898-f5b25048e2d7`
- Before repair: approved IEHP document with 31 valid structured goal candidates, 0 live programs, 0 live goals, latest publish payload `assessment_only`.
- Guarded repair executed for only that document/org/client after duplicate and candidate preconditions passed.
- After repair: 31 active programs and 31 active goals; audit event `reviewed_assessment_live_repair` records `completion_mode = live_program_goals` and created/promoted counts 31.

## Verification
- `npx vitest run src/server/__tests__/assessmentPromoteHandler.test.ts --reporter=verbose -t "promotes approved IEHP structured goals"` passed.
- `npx vitest run src/server/__tests__/assessmentPromoteHandler.test.ts --reporter=verbose` passed, 25/25.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run build` passed.
- `npm run ci:check-focused` passed; local DB-backed checks skipped because `SUPABASE_DB_URL` is not configured.
- `npm run validate:tenant` passed.
- `git diff --check` passed with CRLF warnings only.

## Known Blocker
- `npm run test:ci` timed out locally after about 302 seconds with unrelated existing test noise visible. This draft PR needs reviewer/CI follow-up before merge.

## Risk
Critical protected path: `src/server/api/assessment-promote.ts` performs tenant-scoped live writes to `programs` and `goals`. Human review is required before merge.