### PR TITLE
fix: align ProgramsGoalsTab with live IEHP promote mode

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -409,7 +409,7 @@ interface AssessmentPromoteResponse {
   created_goal_count: number;
   promoted_program_count?: number;
   promoted_goal_count?: number;
-  completion_mode?: "assessment_only";
+  completion_mode?: "assessment_only" | "live_program_goals";
 }
 
 export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -3906,7 +3906,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     );
   });
 
-  it("shows a publish button for fully approved IEHP assessments without staged drafts", async () => {
+  it("publishes fully approved IEHP assessments to live programs and goals when the server reports live completion", async () => {
     const invalidateQueriesSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();
@@ -3961,9 +3961,9 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
         return new Response(
           JSON.stringify({
             assessment_document_id: ASSESSMENT_ID,
-            completion_mode: "assessment_only",
-            created_program_count: 0,
-            created_goal_count: 0,
+            completion_mode: "live_program_goals",
+            created_program_count: 1,
+            created_goal_count: 2,
           }),
           { status: 200 },
         );
@@ -3993,7 +3993,9 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
         expect.objectContaining({ method: "POST" }),
       );
     });
-    expect(showSuccess).toHaveBeenCalledWith("Published reviewed assessment.");
+    expect(showSuccess).toHaveBeenCalledWith(
+      "Published to live records. Created 1 production program and 2 goals.",
+    );
     expect(invalidateQueriesSpy).toHaveBeenCalled();
     invalidateQueriesSpy.mockRestore();
     confirmSpy.mockRestore();


### PR DESCRIPTION
## Summary
- align `ProgramsGoalsTab`'s local `AssessmentPromoteResponse` typing with the current IEHP promote API by accepting `completion_mode: "live_program_goals"`
- update the focused IEHP publish component test to cover the live-program-goals success branch and assert the live records toast

## Routing
- classification: `low-risk autonomous`
- lane: `fast`

## Verification
- `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx -t "publishes fully approved IEHP assessments to live programs and goals when the server reports live completion" --reporter=verbose`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

## Notes
- `npm test -- --run src/components/__tests__/ProgramsGoalsTab.test.tsx` hit the repo Vitest watchdog timeout after 45s without surfacing a specific failing spec; the direct focused `vitest` invocation above passed.
- reviewer sub-agent was not invoked because this session's tool policy allows sub-agent spawning only on explicit user delegation.