### PR TITLE
WIN-134 Recur only scheduled appointments

### DIFF
--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -103,6 +103,9 @@ const MISSING_NOTES_RETRY_HINT =
   "Before closing this in-progress session, persist per-goal note text for each worked goal on a linked session note. Save session capture from Schedule (Session capture), or add notes in Client Details > Session Notes. Narrative and signatures are completed in Client Details.";
 const AUTO_SCHEDULE_CONCURRENCY = 3;
 const _scheduleBoundedConcurrencyMarker = AUTO_SCHEDULE_CONCURRENCY;
+const isWeekForwardRecurrenceSourceSession = (
+  session: Pick<Session, "status">,
+): boolean => session.status === "scheduled";
 const LazySessionModal = React.lazy(() =>
   import("../components/SessionModal").then((module) => ({ default: module.SessionModal })),
 );
@@ -850,16 +853,12 @@ export const Schedule = React.memo(() => {
     scopedTherapistId,
     therapistLinkedClientIdsQuery.data,
   ]);
-  const weekForwardSourceSessions = displayData.sessions;
-  const weekForwardHasVisibleSessions = weekForwardSourceSessions.length > 0;
-  const weekForwardInvalidStatusSessions = useMemo(
-    () => weekForwardSourceSessions.filter((session) => session.status !== "scheduled"),
-    [weekForwardSourceSessions],
+  const weekForwardVisibleSessions = displayData.sessions;
+  const weekForwardSourceSessions = useMemo(
+    () => weekForwardVisibleSessions.filter(isWeekForwardRecurrenceSourceSession),
+    [weekForwardVisibleSessions],
   );
-  const weekForwardBlockedStatuses = useMemo(
-    () => Array.from(new Set(weekForwardInvalidStatusSessions.map((session) => session.status).filter(Boolean))),
-    [weekForwardInvalidStatusSessions],
-  );
+  const weekForwardHasScheduledSessions = weekForwardSourceSessions.length > 0;
   const weekForwardRequiresOrgContext = effectiveRole === "super_admin" && !activeOrganizationId;
   const weekForwardAvailableInCurrentView = view === "week";
   const weekForwardSourceSummary = `${format(weekStart, "MMM d")} - ${format(weekEnd, "MMM d, yyyy")}`;
@@ -868,8 +867,7 @@ export const Schedule = React.memo(() => {
     recurrenceEnabled &&
     weekForwardAvailableInCurrentView &&
     !weekForwardRequiresOrgContext &&
-    weekForwardHasVisibleSessions &&
-    weekForwardInvalidStatusSessions.length === 0 &&
+    weekForwardHasScheduledSessions &&
     weekForwardEndDate.trim().length > 0;
   const isScheduleShellNarrow = useSyncExternalStore(
     (onStoreChange) => {
@@ -2082,7 +2080,7 @@ export const Schedule = React.memo(() => {
                     <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Source week</div>
                     <div className="mt-1 text-sm font-medium text-gray-900 dark:text-gray-100">{weekForwardSourceSummary}</div>
                     <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                      {weekForwardSourceSessions.length} visible {weekForwardSourceSessions.length === 1 ? "session" : "sessions"} will be used.
+                      {weekForwardSourceSessions.length} scheduled {weekForwardSourceSessions.length === 1 ? "session" : "sessions"} will be used.
                     </div>
                   </div>
 
@@ -2114,18 +2112,9 @@ export const Schedule = React.memo(() => {
                   </div>
                 ) : null}
 
-                {!weekForwardHasVisibleSessions ? (
+                {!weekForwardHasScheduledSessions ? (
                   <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
-                    There are no visible sessions in this displayed week to reuse.
-                  </div>
-                ) : null}
-
-                {weekForwardInvalidStatusSessions.length > 0 ? (
-                  <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
-                    Every visible session must be scheduled before cloning this week forward.
-                    <div className="mt-1 text-xs">
-                      Blocking statuses: {weekForwardBlockedStatuses.join(", ")}.
-                    </div>
+                    There are no scheduled sessions in this displayed week to reuse.
                   </div>
                 ) : null}
 

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -450,7 +450,25 @@ describe("Schedule", () => {
     });
   }, 15000);
 
-  it("blocks week-forward when visible sessions are not all scheduled", async () => {
+  it("recurs only scheduled sessions when visible sessions include other statuses", async () => {
+    const capturedRequests: Array<Record<string, unknown>> = [];
+    server.use(
+      http.post("*/api/sessions-week-forward", async ({ request }) => {
+        const body = await request.json() as Record<string, unknown>;
+        capturedRequests.push(body);
+        return HttpResponse.json({
+          success: true,
+          data: {
+            sourceSessionCount: 1,
+            generatedSessionCount: 4,
+            generatedWeekCount: 4,
+            endDate: "2025-08-31",
+            conflicts: [],
+            ...(body.dryRun === true ? {} : { createdSessions: [] }),
+          },
+        });
+      }),
+    );
     mockUseScheduleDataBatch.mockReturnValue({
       data: {
         ...scheduleFixtures,
@@ -471,10 +489,65 @@ describe("Schedule", () => {
       name: /Apply this visible week forward/i,
     });
     await userEvent.click(recurrenceToggle);
+    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2025-08-31" } });
 
+    expect(screen.getByText(/1 scheduled session will be used/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/Every visible session must be scheduled before cloning this week forward/i),
-    ).toBeInTheDocument();
+      screen.queryByText(/Every visible session must be scheduled before cloning this week forward/i),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /Preview week-forward schedule/i }));
+
+    await waitFor(() => {
+      expect(capturedRequests).toHaveLength(1);
+    });
+
+    expect(capturedRequests[0]).toMatchObject({
+      sourceSessionIds: ["session-1"],
+      endDate: "2025-08-31",
+      dryRun: true,
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Apply this week forward/i }));
+
+    await waitFor(() => {
+      expect(capturedRequests).toHaveLength(2);
+    });
+
+    expect(capturedRequests[1]).toMatchObject({
+      sourceSessionIds: ["session-1"],
+      endDate: "2025-08-31",
+      dryRun: false,
+    });
+  }, 15000);
+
+  it("blocks week-forward when no visible sessions are scheduled", async () => {
+    mockUseScheduleDataBatch.mockReturnValue({
+      data: {
+        ...scheduleFixtures,
+        sessions: [
+          {
+            ...scheduleFixtures.sessions[0],
+            status: "completed",
+          },
+          {
+            ...scheduleFixtures.sessions[1],
+            status: "cancelled",
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    renderWithProviders(<Schedule />);
+
+    const recurrenceToggle = await screen.findByRole("checkbox", {
+      name: /Apply this visible week forward/i,
+    });
+    await userEvent.click(recurrenceToggle);
+
+    expect(screen.getByText(/0 scheduled sessions will be used/i)).toBeInTheDocument();
+    expect(screen.getByText(/There are no scheduled sessions in this displayed week to reuse/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Preview week-forward schedule/i })).toBeDisabled();
   }, 15000);
 


### PR DESCRIPTION
## Summary
- Filter week-forward recurrence sources to scheduled appointments only, matching the blue/scheduled appointment contract.
- Ignore completed/cancelled/non-scheduled appointments instead of blocking recurrence when scheduled appointments exist in the displayed week.
- Keep the recurrence guard disabled when the displayed week has zero scheduled appointments.
- Add focused coverage for preview/apply payloads and the zero-scheduled-source state.

Linear: WIN-134

## Route task
- classification: low-risk autonomous
- lane: standard
- triggering paths: src/pages/Schedule.tsx, src/pages/__tests__/Schedule.test.tsx
- protected-path drift: none

## Verification
- npm test -- src/pages/__tests__/Schedule.test.tsx -t "recurs only scheduled sessions" -> pass
- npm test -- src/pages/__tests__/Schedule.test.tsx -> pass
- npm run ci:check-focused -> pass
- npm run lint -> pass
- npm run typecheck -> pass
- npm run test:ci -> pass
- npm run build -> pass
- npm run verify:local -> pass
- PR CI rerun: change-scope, policy, lint-typecheck, unit-tests, build, tier0-browser, iehp-assessment-import-smoke, Netlify deploy preview -> pass

## Live CI blocker
- auth-browser-smoke fails repeatedly in `scripts/playwright-session-lifecycle.ts` at `book-session` after 300000ms.
- ci-gate fails because `AUTH_SMOKE_RESULT=failure`.
- Downloaded Playwright artifact screenshot shows the Schedule new-session modal blocked by `Scheduling Conflicts`: `Client Amaya Martinez is not available during this time`.
- The legacy lifecycle script clicks `Create Session` and waits for a `/api/book` response; with the conflict banner active, the modal blocks submission and no `/api/book` request is emitted before the step timeout.
- This PR does not touch auth, runtime config, booking submit logic, server/API, database, deploy configuration, or the Playwright lifecycle harness.

## Residual risk
- Low for the recurrence slice. The code change is limited to Schedule UI recurrence source selection and focused tests.
- Merge is blocked by the required hosted auth browser smoke failure above until the smoke data/harness issue is resolved or accepted by maintainers. A harness fix should be routed separately because it changes required auth/session CI behavior.