### PR TITLE
Repair missing session goals coverage

### DIFF
--- a/src/features/scheduling/domain/__tests__/sessionComplete.test.ts
+++ b/src/features/scheduling/domain/__tests__/sessionComplete.test.ts
@@ -191,7 +191,7 @@ describe("checkInProgressSessionCloseReadiness", () => {
     expect(result.missingGoalIds).toEqual([]);
   });
 
-  it("falls back to sessions.goal_id when session_goals is unexpectedly empty", async () => {
+  it("falls back to sessions.goal_id when session_goals are missing", async () => {
     supabaseFromMock.mockImplementation((table: string) => {
       if (table === "session_goals") {
         return createFromResponse({
@@ -200,22 +200,14 @@ describe("checkInProgressSessionCloseReadiness", () => {
         });
       }
       if (table === "sessions") {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                maybeSingle: vi.fn(() => Promise.resolve({
-                  data: { goal_id: "goal-fallback" },
-                  error: null,
-                })),
-              })),
-            })),
-          })),
-        };
+        return createFromResponse({
+          data: [{ goal_id: "goal-fallback" }],
+          error: null,
+        });
       }
       if (table === "client_session_notes") {
         return createFromResponse({
-          data: [{ goal_notes: { "goal-fallback": "Covered by fallback." } }],
+          data: [{ goal_notes: { "goal-fallback": "Covered from primary goal." } }],
           error: null,
         });
       }
@@ -224,7 +216,7 @@ describe("checkInProgressSessionCloseReadiness", () => {
 
     const { checkInProgressSessionCloseReadiness } = await import("../sessionComplete");
     const result = await checkInProgressSessionCloseReadiness({
-      sessionId: "session-fallback",
+      sessionId: "session-3",
       organizationId: "org-1",
     });
 

--- a/src/features/scheduling/domain/__tests__/sessionComplete.test.ts
+++ b/src/features/scheduling/domain/__tests__/sessionComplete.test.ts
@@ -190,4 +190,46 @@ describe("checkInProgressSessionCloseReadiness", () => {
     expect(result.ready).toBe(true);
     expect(result.missingGoalIds).toEqual([]);
   });
+
+  it("falls back to sessions.goal_id when session_goals is unexpectedly empty", async () => {
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === "session_goals") {
+        return createFromResponse({
+          data: [],
+          error: null,
+        });
+      }
+      if (table === "sessions") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn(() => Promise.resolve({
+                  data: { goal_id: "goal-fallback" },
+                  error: null,
+                })),
+              })),
+            })),
+          })),
+        };
+      }
+      if (table === "client_session_notes") {
+        return createFromResponse({
+          data: [{ goal_notes: { "goal-fallback": "Covered by fallback." } }],
+          error: null,
+        });
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    const { checkInProgressSessionCloseReadiness } = await import("../sessionComplete");
+    const result = await checkInProgressSessionCloseReadiness({
+      sessionId: "session-fallback",
+      organizationId: "org-1",
+    });
+
+    expect(result.ready).toBe(true);
+    expect(result.requiredGoalIds).toEqual(["goal-fallback"]);
+    expect(result.missingGoalIds).toEqual([]);
+  });
 });

--- a/src/features/scheduling/domain/sessionComplete.ts
+++ b/src/features/scheduling/domain/sessionComplete.ts
@@ -22,6 +22,13 @@ export type InProgressSessionCloseReadiness = {
 export const IN_PROGRESS_CLOSE_NOT_READY_MESSAGE =
   "You must complete the linked session documentation with per-goal notes before closing this in-progress session. Add per-goal text on a client_session_notes row linked to this session_id (for example by saving Session capture on Schedule or Session Notes under Client Details). Unsaved modal text alone does not satisfy this requirement.";
 
+const normalizeRequiredGoalIds = (goalIds: Array<string | null | undefined>): string[] =>
+  Array.from(
+    new Set(
+      goalIds.filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0),
+    ),
+  );
+
 export async function checkInProgressSessionCloseReadiness(
   input: InProgressSessionCloseReadinessInput,
 ): Promise<InProgressSessionCloseReadiness> {
@@ -39,13 +46,22 @@ export async function checkInProgressSessionCloseReadiness(
     throw sessionGoalsError;
   }
 
-  const requiredGoalIds = Array.from(
-    new Set(
-      (sessionGoals ?? [])
-        .map((row) => row.goal_id)
-        .filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0),
-    ),
-  );
+  let requiredGoalIds = normalizeRequiredGoalIds((sessionGoals ?? []).map((row) => row.goal_id));
+
+  if (requiredGoalIds.length === 0) {
+    const { data: sessionRow, error: sessionError } = await supabase
+      .from("sessions")
+      .select("goal_id")
+      .eq("id", input.sessionId)
+      .eq("organization_id", input.organizationId)
+      .maybeSingle();
+
+    if (sessionError) {
+      throw sessionError;
+    }
+
+    requiredGoalIds = normalizeRequiredGoalIds([sessionRow?.goal_id]);
+  }
 
   if (requiredGoalIds.length === 0) {
     return { ready: true, requiredGoalIds: [], missingGoalIds: [] };

--- a/src/features/scheduling/domain/sessionComplete.ts
+++ b/src/features/scheduling/domain/sessionComplete.ts
@@ -1,5 +1,6 @@
 import { callApi } from "../../../lib/api";
 import { toNormalizedApiError } from "../../../lib/sdk/errors";
+import { resolveSessionCloseRequiredGoalIds } from "../../../lib/sessionCloseRequiredGoals";
 import { supabase } from "../../../lib/supabase";
 
 export type CompleteSessionRequest = {
@@ -22,13 +23,6 @@ export type InProgressSessionCloseReadiness = {
 export const IN_PROGRESS_CLOSE_NOT_READY_MESSAGE =
   "You must complete the linked session documentation with per-goal notes before closing this in-progress session. Add per-goal text on a client_session_notes row linked to this session_id (for example by saving Session capture on Schedule or Session Notes under Client Details). Unsaved modal text alone does not satisfy this requirement.";
 
-const normalizeRequiredGoalIds = (goalIds: Array<string | null | undefined>): string[] =>
-  Array.from(
-    new Set(
-      goalIds.filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0),
-    ),
-  );
-
 export async function checkInProgressSessionCloseReadiness(
   input: InProgressSessionCloseReadinessInput,
 ): Promise<InProgressSessionCloseReadiness> {
@@ -46,22 +40,28 @@ export async function checkInProgressSessionCloseReadiness(
     throw sessionGoalsError;
   }
 
-  let requiredGoalIds = normalizeRequiredGoalIds((sessionGoals ?? []).map((row) => row.goal_id));
-
-  if (requiredGoalIds.length === 0) {
-    const { data: sessionRow, error: sessionError } = await supabase
+  let primaryGoalId: string | null = null;
+  if ((sessionGoals ?? []).length === 0) {
+    const { data: sessions, error: sessionError } = await supabase
       .from("sessions")
       .select("goal_id")
       .eq("id", input.sessionId)
-      .eq("organization_id", input.organizationId)
-      .maybeSingle();
+      .eq("organization_id", input.organizationId);
 
     if (sessionError) {
       throw sessionError;
     }
 
-    requiredGoalIds = normalizeRequiredGoalIds([sessionRow?.goal_id]);
+    primaryGoalId =
+      typeof sessions?.[0]?.goal_id === "string" && sessions[0].goal_id.length > 0
+        ? sessions[0].goal_id
+        : null;
   }
+
+  const requiredGoalIds = resolveSessionCloseRequiredGoalIds({
+    sessionGoalIds: (sessionGoals ?? []).map((row) => row.goal_id),
+    primaryGoalId,
+  });
 
   if (requiredGoalIds.length === 0) {
     return { ready: true, requiredGoalIds: [], missingGoalIds: [] };

--- a/src/lib/__tests__/sessionCloseRequiredGoals.test.ts
+++ b/src/lib/__tests__/sessionCloseRequiredGoals.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSessionCloseRequiredGoalIds } from "../sessionCloseRequiredGoals";
+
+describe("resolveSessionCloseRequiredGoalIds", () => {
+  it("prefers session_goals when they exist", () => {
+    expect(
+      resolveSessionCloseRequiredGoalIds({
+        sessionGoalIds: ["goal-1", "goal-2", "goal-1"],
+        primaryGoalId: "goal-primary",
+      }),
+    ).toEqual(["goal-1", "goal-2"]);
+  });
+
+  it("falls back to the primary session goal when session_goals are missing", () => {
+    expect(
+      resolveSessionCloseRequiredGoalIds({
+        sessionGoalIds: [],
+        primaryGoalId: "goal-primary",
+      }),
+    ).toEqual(["goal-primary"]);
+  });
+
+  it("returns an empty list when neither source has a usable goal id", () => {
+    expect(
+      resolveSessionCloseRequiredGoalIds({
+        sessionGoalIds: ["", "   ", null, undefined],
+        primaryGoalId: "   ",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/sessionCloseRequiredGoals.ts
+++ b/src/lib/sessionCloseRequiredGoals.ts
@@ -1,0 +1,19 @@
+export const resolveSessionCloseRequiredGoalIds = ({
+  sessionGoalIds,
+  primaryGoalId,
+}: {
+  sessionGoalIds: Array<string | null | undefined>;
+  primaryGoalId?: string | null;
+}): string[] => {
+  const normalizedSessionGoalIds = sessionGoalIds.filter(
+    (goalId): goalId is string => typeof goalId === "string" && goalId.trim().length > 0,
+  );
+
+  if (normalizedSessionGoalIds.length > 0) {
+    return Array.from(new Set(normalizedSessionGoalIds));
+  }
+
+  return typeof primaryGoalId === "string" && primaryGoalId.trim().length > 0
+    ? [primaryGoalId]
+    : [];
+};

--- a/src/server/__tests__/sessionsCompleteHandler.test.ts
+++ b/src/server/__tests__/sessionsCompleteHandler.test.ts
@@ -44,6 +44,8 @@ describe("sessionsCompleteHandler", () => {
     authStatus = 200,
     sessionStatus = 200,
     sessionRows,
+    sessionGoalFallbackRows,
+    sessionGoalFallbackStatus = 200,
     goalsStatus = 200,
     notesStatus = 200,
     auditStatus = 200,
@@ -75,6 +77,9 @@ describe("sessionsCompleteHandler", () => {
       return jsonResponse(noteRows, notesStatus);
     }
     if (url.includes("/rest/v1/sessions") && method === "GET") {
+      if (url.includes("select=goal_id")) {
+        return jsonResponse(sessionGoalFallbackRows ?? [{ goal_id: session.goal_id ?? null }], sessionGoalFallbackStatus);
+      }
       return jsonResponse(sessionRows ?? [session], sessionStatus);
     }
     if (url.includes("/rest/v1/sessions") && method === "PATCH") {
@@ -414,6 +419,32 @@ describe("sessionsCompleteHandler", () => {
     });
   });
 
+  it("runtime REST fallback uses sessions.goal_id when session_goals is unexpectedly empty", async () => {
+    makeFallbackFetchMock({
+      session: {
+        id: sessionId,
+        status: "in_progress",
+        therapist_id: "therapist-user",
+        start_time: "2026-03-31T09:00:00Z",
+        end_time: "2026-03-31T10:00:00Z",
+        goal_id: "goal-fallback",
+      },
+      goalRows: [],
+      noteRows: [],
+    });
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+    const body = await response.json() as { code: string };
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("SESSION_NOTES_REQUIRED");
+  });
+
   it("runtime REST fallback emits concurrent-modification metric", async () => {
     makeFallbackFetchMock({ updateRows: [] });
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -533,6 +564,32 @@ describe("sessionsCompleteHandler", () => {
 
     expect(response.status).toBe(502);
     expect(body.error).toBe("Failed to load session goals for notes check");
+  });
+
+  it("runtime REST fallback maps goal fallback fetch failures to upstream errors", async () => {
+    makeFallbackFetchMock({
+      session: {
+        id: sessionId,
+        status: "in_progress",
+        therapist_id: "therapist-user",
+        start_time: "2026-03-31T09:00:00Z",
+        end_time: "2026-03-31T10:00:00Z",
+        goal_id: "goal-fallback",
+      },
+      goalRows: [],
+      sessionGoalFallbackStatus: 500,
+    });
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+    const body = await response.json() as { error: string };
+
+    expect(response.status).toBe(502);
+    expect(body.error).toBe("Failed to load session goal fallback for notes check");
   });
 
   it("runtime REST fallback maps client_session_notes fetch failures to upstream errors", async () => {

--- a/src/server/__tests__/sessionsCompleteHandler.test.ts
+++ b/src/server/__tests__/sessionsCompleteHandler.test.ts
@@ -35,6 +35,7 @@ describe("sessionsCompleteHandler", () => {
       id: sessionId,
       status: "scheduled",
       therapist_id: "therapist-user",
+      goal_id: "goal-primary",
       start_time: "2026-03-31T09:00:00Z",
       end_time: "2026-03-31T10:00:00Z",
     },
@@ -395,6 +396,7 @@ describe("sessionsCompleteHandler", () => {
         id: sessionId,
         status: "in_progress",
         therapist_id: "therapist-user",
+        goal_id: "goal-1",
         start_time: "2026-03-31T09:00:00Z",
         end_time: "2026-03-31T10:00:00Z",
       },
@@ -548,6 +550,7 @@ describe("sessionsCompleteHandler", () => {
         id: sessionId,
         status: "in_progress",
         therapist_id: "therapist-user",
+        goal_id: "goal-1",
         start_time: "2026-03-31T09:00:00Z",
         end_time: "2026-03-31T10:00:00Z",
       },
@@ -598,6 +601,7 @@ describe("sessionsCompleteHandler", () => {
         id: sessionId,
         status: "in_progress",
         therapist_id: "therapist-user",
+        goal_id: "goal-1",
         start_time: "2026-03-31T09:00:00Z",
         end_time: "2026-03-31T10:00:00Z",
       },
@@ -615,5 +619,31 @@ describe("sessionsCompleteHandler", () => {
 
     expect(response.status).toBe(502);
     expect(body.error).toBe("Failed to load session notes for notes check");
+  });
+
+  it("runtime REST fallback uses sessions.goal_id when session_goals are missing", async () => {
+    makeFallbackFetchMock({
+      session: {
+        id: sessionId,
+        status: "in_progress",
+        therapist_id: "therapist-user",
+        goal_id: "goal-primary",
+        start_time: "2026-03-31T09:00:00Z",
+        end_time: "2026-03-31T10:00:00Z",
+      },
+      goalRows: [],
+      noteRows: [],
+    });
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+    const body = await response.json() as { code: string };
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("SESSION_NOTES_REQUIRED");
   });
 });

--- a/src/server/__tests__/sessionsCompleteHandler.test.ts
+++ b/src/server/__tests__/sessionsCompleteHandler.test.ts
@@ -45,8 +45,6 @@ describe("sessionsCompleteHandler", () => {
     authStatus = 200,
     sessionStatus = 200,
     sessionRows,
-    sessionGoalFallbackRows,
-    sessionGoalFallbackStatus = 200,
     goalsStatus = 200,
     notesStatus = 200,
     auditStatus = 200,
@@ -78,9 +76,6 @@ describe("sessionsCompleteHandler", () => {
       return jsonResponse(noteRows, notesStatus);
     }
     if (url.includes("/rest/v1/sessions") && method === "GET") {
-      if (url.includes("select=goal_id")) {
-        return jsonResponse(sessionGoalFallbackRows ?? [{ goal_id: session.goal_id ?? null }], sessionGoalFallbackStatus);
-      }
       return jsonResponse(sessionRows ?? [session], sessionStatus);
     }
     if (url.includes("/rest/v1/sessions") && method === "PATCH") {
@@ -567,32 +562,6 @@ describe("sessionsCompleteHandler", () => {
 
     expect(response.status).toBe(502);
     expect(body.error).toBe("Failed to load session goals for notes check");
-  });
-
-  it("runtime REST fallback maps goal fallback fetch failures to upstream errors", async () => {
-    makeFallbackFetchMock({
-      session: {
-        id: sessionId,
-        status: "in_progress",
-        therapist_id: "therapist-user",
-        start_time: "2026-03-31T09:00:00Z",
-        end_time: "2026-03-31T10:00:00Z",
-        goal_id: "goal-fallback",
-      },
-      goalRows: [],
-      sessionGoalFallbackStatus: 500,
-    });
-
-    const response = await __TESTING__.completeSessionViaRuntimeRest({
-      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
-      payload: { session_id: sessionId, outcome: "completed", notes: null },
-      accessToken: "token-123",
-      traceHeaders: {},
-    });
-    const body = await response.json() as { error: string };
-
-    expect(response.status).toBe(502);
-    expect(body.error).toBe("Failed to load session goal fallback for notes check");
   });
 
   it("runtime REST fallback maps client_session_notes fetch failures to upstream errors", async () => {

--- a/src/server/api/sessions-complete.ts
+++ b/src/server/api/sessions-complete.ts
@@ -178,13 +178,29 @@ const checkNotesCoverage = async ({
   if (!sessionGoalsResult.ok || !sessionGoalsResult.data) {
     return { upstreamError: true, message: "Failed to load session goals for notes check" };
   }
-  if (sessionGoalsResult.data.length === 0) {
+
+  let requiredGoalIds = sessionGoalsResult.data
+    .map((row) => row.goal_id)
+    .filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0);
+
+  if (requiredGoalIds.length === 0) {
+    const sessionResult = await fetchJson<Array<{ goal_id: string | null }>>(
+      `${supabaseUrl}/rest/v1/sessions?select=goal_id&organization_id=eq.${encodeURIComponent(organizationId)}&id=eq.${encodeURIComponent(sessionId)}`,
+      { method: "GET", headers },
+    );
+    if (!sessionResult.ok || !sessionResult.data) {
+      return { upstreamError: true, message: "Failed to load session goal fallback for notes check" };
+    }
+
+    requiredGoalIds = sessionResult.data
+      .map((row) => row.goal_id)
+      .filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0);
+  }
+
+  if (requiredGoalIds.length === 0) {
     return { ok: true };
   }
 
-  const requiredGoalIds = sessionGoalsResult.data
-    .map((row) => row.goal_id)
-    .filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0);
   const notesRowsResult = await fetchJson<Array<{ goal_notes: Record<string, unknown> | null }>>(
     `${supabaseUrl}/rest/v1/client_session_notes?select=goal_notes&organization_id=eq.${encodeURIComponent(organizationId)}&session_id=eq.${encodeURIComponent(sessionId)}`,
     { method: "GET", headers },

--- a/src/server/api/sessions-complete.ts
+++ b/src/server/api/sessions-complete.ts
@@ -9,6 +9,7 @@ import {
   jsonForRequest,
 } from "./shared";
 import { getRuntimeSupabaseConfig } from "../runtimeConfig";
+import { resolveSessionCloseRequiredGoalIds } from "../../lib/sessionCloseRequiredGoals";
 
 const completeSessionSchema = z.object({
   session_id: z.string().uuid(),
@@ -165,11 +166,13 @@ const checkNotesCoverage = async ({
   organizationId,
   supabaseUrl,
   headers,
+  primaryGoalId,
 }: {
   sessionId: string;
   organizationId: string;
   supabaseUrl: string;
   headers: Record<string, string>;
+  primaryGoalId?: string | null;
 }): Promise<{ ok: true } | { ok: false } | { upstreamError: true; message: string }> => {
   const sessionGoalsResult = await fetchJson<Array<{ goal_id: string }>>(
     `${supabaseUrl}/rest/v1/session_goals?select=goal_id&organization_id=eq.${encodeURIComponent(organizationId)}&session_id=eq.${encodeURIComponent(sessionId)}`,
@@ -178,29 +181,13 @@ const checkNotesCoverage = async ({
   if (!sessionGoalsResult.ok || !sessionGoalsResult.data) {
     return { upstreamError: true, message: "Failed to load session goals for notes check" };
   }
-
-  let requiredGoalIds = sessionGoalsResult.data
-    .map((row) => row.goal_id)
-    .filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0);
-
-  if (requiredGoalIds.length === 0) {
-    const sessionResult = await fetchJson<Array<{ goal_id: string | null }>>(
-      `${supabaseUrl}/rest/v1/sessions?select=goal_id&organization_id=eq.${encodeURIComponent(organizationId)}&id=eq.${encodeURIComponent(sessionId)}`,
-      { method: "GET", headers },
-    );
-    if (!sessionResult.ok || !sessionResult.data) {
-      return { upstreamError: true, message: "Failed to load session goal fallback for notes check" };
-    }
-
-    requiredGoalIds = sessionResult.data
-      .map((row) => row.goal_id)
-      .filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0);
-  }
-
+  const requiredGoalIds = resolveSessionCloseRequiredGoalIds({
+    sessionGoalIds: sessionGoalsResult.data.map((row) => row.goal_id),
+    primaryGoalId,
+  });
   if (requiredGoalIds.length === 0) {
     return { ok: true };
   }
-
   const notesRowsResult = await fetchJson<Array<{ goal_notes: Record<string, unknown> | null }>>(
     `${supabaseUrl}/rest/v1/client_session_notes?select=goal_notes&organization_id=eq.${encodeURIComponent(organizationId)}&session_id=eq.${encodeURIComponent(sessionId)}`,
     { method: "GET", headers },
@@ -337,10 +324,11 @@ const completeSessionViaRuntimeRest = async ({
     id: string;
     status: string;
     therapist_id: string | null;
+    goal_id: string | null;
     start_time: string;
     end_time: string;
   }>>(
-    `${supabaseUrl}/rest/v1/sessions?select=id,status,therapist_id,start_time,end_time&organization_id=eq.${encodeURIComponent(organizationId)}&id=eq.${encodeURIComponent(payload.session_id)}`,
+    `${supabaseUrl}/rest/v1/sessions?select=id,status,therapist_id,goal_id,start_time,end_time&organization_id=eq.${encodeURIComponent(organizationId)}&id=eq.${encodeURIComponent(payload.session_id)}`,
     { method: "GET", headers },
   );
   incrementRuntimeMetric("org_scoped_query_total", {
@@ -398,6 +386,7 @@ const completeSessionViaRuntimeRest = async ({
       organizationId,
       supabaseUrl,
       headers,
+      primaryGoalId: session.goal_id,
     });
     if ("upstreamError" in notesCoverage) {
       return errorResponse(request, "upstream_error", notesCoverage.message, {

--- a/supabase/functions/sessions-complete/index.ts
+++ b/supabase/functions/sessions-complete/index.ts
@@ -16,6 +16,7 @@ import { getLogger, type Logger } from "../_shared/logging.ts";
 import { increment } from "../_shared/metrics.ts";
 import { recordSessionAuditEvent } from "../_shared/audit.ts";
 import type { SupabaseClient } from "npm:@supabase/supabase-js@2.50.0";
+import { resolveSessionCloseRequiredGoalIds } from "../../../src/lib/sessionCloseRequiredGoals.ts";
 
 // Statuses from which a session may be moved to a terminal outcome.
 // Symmetric with CANCELLABLE_STATUSES in sessions-cancel.
@@ -37,6 +38,7 @@ interface SessionRecord {
   id: string;
   status: string;
   therapist_id: string | null;
+  goal_id: string | null;
   start_time: string;
   end_time: string;
 }
@@ -46,13 +48,6 @@ interface TraceMeta {
   correlationId: string | null;
   agentOperationId: string | null;
 }
-
-const normalizeRequiredGoalIds = (goalIds: Array<string | null | undefined>): string[] =>
-  Array.from(
-    new Set(
-      goalIds.filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0),
-    ),
-  );
 
 class BadRequestError extends Error {
   status = 400;
@@ -160,6 +155,7 @@ async function checkSessionNotesPresentForRequest(
   sessionId: string,
   orgId: string,
   logger: Logger,
+  primaryGoalId: string | null = null,
 ): Promise<Response | null> {
   // 1. Fetch session_goals for this session within the org.
   const { data: sessionGoals, error: sgError } = await supabaseAdmin
@@ -173,29 +169,11 @@ async function checkSessionNotesPresentForRequest(
     throw new Error(sgError.message ?? "Failed to load session goals for notes check");
   }
 
-  let requiredGoalIds = normalizeRequiredGoalIds(
-    ((sessionGoals ?? []) as Array<{ goal_id?: string | null }>).map((sg) => sg.goal_id),
-  );
-
+  const requiredGoalIds = resolveSessionCloseRequiredGoalIds({
+    sessionGoalIds: (sessionGoals ?? []).map((sg) => sg.goal_id),
+    primaryGoalId,
+  });
   if (requiredGoalIds.length === 0) {
-    const { data: sessionRows, error: sessionError } = await supabaseAdmin
-      .from("sessions")
-      .select("goal_id")
-      .eq("id", sessionId)
-      .eq("organization_id", orgId);
-
-    if (sessionError) {
-      logger.error("session.notes-check.goal-fallback-fetch-error", { error: sessionError.message ?? "unknown" });
-      throw new Error(sessionError.message ?? "Failed to load session goal fallback for notes check");
-    }
-
-    requiredGoalIds = normalizeRequiredGoalIds(
-      ((sessionRows ?? []) as Array<{ goal_id?: string | null }>).map((row) => row.goal_id),
-    );
-  }
-
-  if (requiredGoalIds.length === 0) {
-    // No goals were recorded for this session — notes guard does not apply.
     return null;
   }
 
@@ -255,8 +233,9 @@ export async function checkSessionNotesPresent(
   sessionId: string,
   orgId: string,
   logger: Logger,
+  primaryGoalId: string | null = null,
 ): Promise<Response | null> {
-  return checkSessionNotesPresentForRequest(buildFallbackRequest(), sessionId, orgId, logger);
+  return checkSessionNotesPresentForRequest(buildFallbackRequest(), sessionId, orgId, logger, primaryGoalId);
 }
 
 async function handleSessionCompletionForRequest(
@@ -273,7 +252,7 @@ async function handleSessionCompletionForRequest(
 
   // Fetch session scoped to the caller's org (uses request-auth client for RLS read)
   const { data: sessions, error: fetchError } = await orgScopedQuery(db, "sessions", orgId)
-    .select("id, status, therapist_id, start_time, end_time")
+    .select("id, status, therapist_id, goal_id, start_time, end_time")
     .eq("id", sessionId)
     .limit(1);
 
@@ -288,7 +267,7 @@ async function handleSessionCompletionForRequest(
     throw new Error(fetchError.message ?? "Failed to load session");
   }
 
-  const session = ((sessions ?? []) as SessionRecord[])[0] ?? null;
+  const session = ((sessions ?? []) as unknown as SessionRecord[])[0] ?? null;
 
   if (!session) {
     logger.warn("session.not-found", { sessionId, reason: "not-in-org-scope" });
@@ -353,7 +332,13 @@ async function handleSessionCompletionForRequest(
   // row with non-empty goal_notes covering every session_goal before the
   // session can be closed.
   if (session.status === "in_progress") {
-    const notesCheckFailure = await checkSessionNotesPresentForRequest(req, sessionId, orgId, logger);
+    const notesCheckFailure = await checkSessionNotesPresentForRequest(
+      req,
+      sessionId,
+      orgId,
+      logger,
+      session.goal_id,
+    );
     if (notesCheckFailure) {
       return notesCheckFailure;
     }

--- a/supabase/functions/sessions-complete/index.ts
+++ b/supabase/functions/sessions-complete/index.ts
@@ -47,6 +47,13 @@ interface TraceMeta {
   agentOperationId: string | null;
 }
 
+const normalizeRequiredGoalIds = (goalIds: Array<string | null | undefined>): string[] =>
+  Array.from(
+    new Set(
+      goalIds.filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0),
+    ),
+  );
+
 class BadRequestError extends Error {
   status = 400;
   constructor(message: string) {
@@ -166,12 +173,31 @@ async function checkSessionNotesPresentForRequest(
     throw new Error(sgError.message ?? "Failed to load session goals for notes check");
   }
 
-  if (!sessionGoals || sessionGoals.length === 0) {
+  let requiredGoalIds = normalizeRequiredGoalIds(
+    ((sessionGoals ?? []) as Array<{ goal_id?: string | null }>).map((sg) => sg.goal_id),
+  );
+
+  if (requiredGoalIds.length === 0) {
+    const { data: sessionRows, error: sessionError } = await supabaseAdmin
+      .from("sessions")
+      .select("goal_id")
+      .eq("id", sessionId)
+      .eq("organization_id", orgId);
+
+    if (sessionError) {
+      logger.error("session.notes-check.goal-fallback-fetch-error", { error: sessionError.message ?? "unknown" });
+      throw new Error(sessionError.message ?? "Failed to load session goal fallback for notes check");
+    }
+
+    requiredGoalIds = normalizeRequiredGoalIds(
+      ((sessionRows ?? []) as Array<{ goal_id?: string | null }>).map((row) => row.goal_id),
+    );
+  }
+
+  if (requiredGoalIds.length === 0) {
     // No goals were recorded for this session — notes guard does not apply.
     return null;
   }
-
-  const requiredGoalIds = (sessionGoals as Array<{ goal_id: string }>).map((sg) => sg.goal_id);
 
   // 2. Fetch all note rows linked to this session within the org.
   const { data: notes, error: notesError } = await supabaseAdmin

--- a/supabase/migrations/20260610021522_noop_probe_do_not_apply.sql
+++ b/supabase/migrations/20260610021522_noop_probe_do_not_apply.sql
@@ -1,0 +1,7 @@
+-- @migration-intent: Preserve hosted migration history after a no-op Supabase tool probe executed during the session_goals disappearance trace.
+-- @migration-dependencies: none
+-- @migration-rollback: No rollback required; this migration intentionally performs no schema or data changes.
+
+set search_path = public;
+
+select 1;

--- a/supabase/migrations/20260610021608_backfill_started_sessions_missing_session_goals.sql
+++ b/supabase/migrations/20260610021608_backfill_started_sessions_missing_session_goals.sql
@@ -1,0 +1,65 @@
+-- @migration-intent: Backfill the primary session_goals row for already-started sessions whose goal linkage disappeared after confirm/start persistence.
+-- @migration-dependencies: 20260402182221_repair_goal_notes_and_session_goals_close_notes.sql,20251111130500_session_audit_rpc_wrapper.sql
+-- @migration-rollback: Remove rows identified by the paired session_goals_backfilled audit events if rollback is required and no downstream note coverage depends on them.
+
+set search_path = public;
+
+with target_sessions as (
+  select
+    s.id as session_id,
+    s.organization_id,
+    s.client_id,
+    s.program_id,
+    s.goal_id
+  from public.sessions s
+  where s.goal_id is not null
+    and (
+      s.started_at is not null
+      or s.status in ('in_progress', 'completed', 'no-show')
+    )
+    and not exists (
+      select 1
+      from public.session_goals sg
+      where sg.session_id = s.id
+    )
+),
+inserted_session_goals as (
+  insert into public.session_goals (
+    session_id,
+    goal_id,
+    organization_id,
+    client_id,
+    program_id
+  )
+  select
+    ts.session_id,
+    ts.goal_id,
+    ts.organization_id,
+    ts.client_id,
+    ts.program_id
+  from target_sessions ts
+  on conflict (session_id, goal_id) do nothing
+  returning session_id, goal_id, organization_id
+)
+insert into public.session_audit_logs (
+  session_id,
+  organization_id,
+  therapist_id,
+  actor_id,
+  event_type,
+  event_payload
+)
+select
+  s.id,
+  s.organization_id,
+  s.therapist_id,
+  null,
+  'session_goals_backfilled',
+  jsonb_build_object(
+    'repair', '20260610021608_backfill_started_sessions_missing_session_goals',
+    'goalId', isg.goal_id,
+    'reason', 'missing_session_goals_for_started_session'
+  )
+from inserted_session_goals isg
+join public.sessions s
+  on s.id = isg.session_id;

--- a/supabase/migrations/20260610022354_probe_duplicate_will_fail.sql
+++ b/supabase/migrations/20260610022354_probe_duplicate_will_fail.sql
@@ -1,0 +1,7 @@
+-- @migration-intent: Preserve hosted migration history after a transactional no-op Supabase tool probe executed during the session_goals disappearance trace.
+-- @migration-dependencies: none
+-- @migration-rollback: No rollback required; this migration intentionally performs no schema or data changes.
+
+begin;
+select 1;
+rollback;

--- a/tests/edge/sessions-complete.test.ts
+++ b/tests/edge/sessions-complete.test.ts
@@ -65,12 +65,14 @@ const makeSession = (overrides: Partial<{
   id: string;
   status: string;
   therapist_id: string | null;
+  goal_id: string | null;
   start_time: string;
   end_time: string;
 }> = {}) => ({
   id: "session-1",
   status: "scheduled",
   therapist_id: "therapist-1",
+  goal_id: null,
   start_time: "2026-03-31T09:00:00Z",
   end_time: "2026-03-31T10:00:00Z",
   ...overrides,
@@ -390,17 +392,6 @@ describe("checkSessionNotesPresent", () => {
     return builder;
   };
 
-  const makeAdminSelectError = (message: string) => {
-    const builder: any = {};
-    const chain = () => builder;
-    builder.select = vi.fn(() => chain());
-    builder.eq = vi.fn(() => chain());
-    builder.then = (
-      resolve: (value: { data: unknown[]; error: { message: string } }) => unknown,
-    ) => resolve({ data: [], error: { message } });
-    return builder;
-  };
-
   it("returns null (passes) when there are no session_goals", async () => {
     (database.supabaseAdmin.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
       if (table === "session_goals") return makeAdminSelect([]);
@@ -429,12 +420,11 @@ describe("checkSessionNotesPresent", () => {
   it("falls back to sessions.goal_id when session_goals is unexpectedly empty", async () => {
     (database.supabaseAdmin.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
       if (table === "session_goals") return makeAdminSelect([]);
-      if (table === "sessions") return makeAdminSelect([{ goal_id: "goal-fallback" }]);
       if (table === "client_session_notes") return makeAdminSelect([]);
       return makeAdminSelect([]);
     });
 
-    const result = await checkSessionNotesPresent("session-1", "org-1", createStubLogger());
+    const result = await checkSessionNotesPresent("session-1", "org-1", createStubLogger(), "goal-fallback");
     expect(result).not.toBeNull();
     const body = await result!.json() as { success: boolean; code: string; missing_goal_count: number };
     expect(result!.status).toBe(409);
@@ -442,16 +432,13 @@ describe("checkSessionNotesPresent", () => {
     expect(body.missing_goal_count).toBe(1);
   });
 
-  it("throws when the fallback sessions.goal_id query fails", async () => {
+  it("returns null when session_goals are empty and no primaryGoalId is provided", async () => {
     (database.supabaseAdmin.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
       if (table === "session_goals") return makeAdminSelect([]);
-      if (table === "sessions") return makeAdminSelectError("fallback blew up");
       return makeAdminSelect([]);
     });
 
-    await expect(
-      checkSessionNotesPresent("session-1", "org-1", createStubLogger()),
-    ).rejects.toThrow("fallback blew up");
+    await expect(checkSessionNotesPresent("session-1", "org-1", createStubLogger())).resolves.toBeNull();
   });
 
   it("returns 409 SESSION_NOTES_REQUIRED when a note row exists but goal_notes is missing an entry for one goal", async () => {
@@ -608,14 +595,17 @@ describe("sessions-complete handler — SESSION_NOTES_REQUIRED guard", () => {
   });
 
   it("rejects an in_progress session when session_goals is empty but sessions.goal_id exists", async () => {
-    const session = makeSession({ id: "session-notes-fallback", status: "in_progress" });
+    const session = makeSession({
+      id: "session-notes-fallback",
+      status: "in_progress",
+      goal_id: "goal-fallback",
+    });
 
     vi.spyOn(orgHelpers, "orgScopedQuery").mockReturnValue(
       makeSelectBuilder([session]) as unknown as ReturnType<typeof orgHelpers.orgScopedQuery>,
     );
     (database.supabaseAdmin.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
       if (table === "session_goals") return makeAdminSelect([]);
-      if (table === "sessions") return makeAdminSelect([{ goal_id: "goal-fallback" }]);
       if (table === "client_session_notes") return makeAdminSelect([]);
       return makeAdminSelect([]);
     });

--- a/tests/edge/sessions-complete.test.ts
+++ b/tests/edge/sessions-complete.test.ts
@@ -390,6 +390,17 @@ describe("checkSessionNotesPresent", () => {
     return builder;
   };
 
+  const makeAdminSelectError = (message: string) => {
+    const builder: any = {};
+    const chain = () => builder;
+    builder.select = vi.fn(() => chain());
+    builder.eq = vi.fn(() => chain());
+    builder.then = (
+      resolve: (value: { data: unknown[]; error: { message: string } }) => unknown,
+    ) => resolve({ data: [], error: { message } });
+    return builder;
+  };
+
   it("returns null (passes) when there are no session_goals", async () => {
     (database.supabaseAdmin.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
       if (table === "session_goals") return makeAdminSelect([]);
@@ -413,6 +424,34 @@ describe("checkSessionNotesPresent", () => {
     expect(result!.status).toBe(409);
     expect(body.code).toBe("SESSION_NOTES_REQUIRED");
     expect(body.missing_goal_count).toBe(1);
+  });
+
+  it("falls back to sessions.goal_id when session_goals is unexpectedly empty", async () => {
+    (database.supabaseAdmin.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
+      if (table === "session_goals") return makeAdminSelect([]);
+      if (table === "sessions") return makeAdminSelect([{ goal_id: "goal-fallback" }]);
+      if (table === "client_session_notes") return makeAdminSelect([]);
+      return makeAdminSelect([]);
+    });
+
+    const result = await checkSessionNotesPresent("session-1", "org-1", createStubLogger());
+    expect(result).not.toBeNull();
+    const body = await result!.json() as { success: boolean; code: string; missing_goal_count: number };
+    expect(result!.status).toBe(409);
+    expect(body.code).toBe("SESSION_NOTES_REQUIRED");
+    expect(body.missing_goal_count).toBe(1);
+  });
+
+  it("throws when the fallback sessions.goal_id query fails", async () => {
+    (database.supabaseAdmin.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
+      if (table === "session_goals") return makeAdminSelect([]);
+      if (table === "sessions") return makeAdminSelectError("fallback blew up");
+      return makeAdminSelect([]);
+    });
+
+    await expect(
+      checkSessionNotesPresent("session-1", "org-1", createStubLogger()),
+    ).rejects.toThrow("fallback blew up");
   });
 
   it("returns 409 SESSION_NOTES_REQUIRED when a note row exists but goal_notes is missing an entry for one goal", async () => {
@@ -558,6 +597,33 @@ describe("sessions-complete handler — SESSION_NOTES_REQUIRED guard", () => {
       makeDb(),
       "org-1",
       { session_id: "session-notes-2", outcome: "completed", notes: null },
+      "admin-user",
+      "admin",
+      createStubLogger(),
+    );
+
+    const body = await response.json() as { success: boolean; code: string };
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("SESSION_NOTES_REQUIRED");
+  });
+
+  it("rejects an in_progress session when session_goals is empty but sessions.goal_id exists", async () => {
+    const session = makeSession({ id: "session-notes-fallback", status: "in_progress" });
+
+    vi.spyOn(orgHelpers, "orgScopedQuery").mockReturnValue(
+      makeSelectBuilder([session]) as unknown as ReturnType<typeof orgHelpers.orgScopedQuery>,
+    );
+    (database.supabaseAdmin.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
+      if (table === "session_goals") return makeAdminSelect([]);
+      if (table === "sessions") return makeAdminSelect([{ goal_id: "goal-fallback" }]);
+      if (table === "client_session_notes") return makeAdminSelect([]);
+      return makeAdminSelect([]);
+    });
+
+    const response = await handleSessionCompletion(
+      makeDb(),
+      "org-1",
+      { session_id: "session-notes-fallback", outcome: "completed", notes: null },
       "admin-user",
       "admin",
       createStubLogger(),


### PR DESCRIPTION
## Summary
- fall back to `sessions.goal_id` when close-time `session_goals` reads are unexpectedly empty so in-progress sessions still enforce per-goal notes coverage
- mirror that same fallback inside the primary `supabase/functions/sessions-complete` edge path so hosted `/functions/v1/sessions-complete` and the server proxy enforce the same guard
- add a hosted repair migration that backfills the primary `session_goals` row for already-started sessions with missing goal linkage and writes a `session_goals_backfilled` audit event
- preserve local migration history for the two no-op Supabase probe entries that were applied during hosted investigation

## Hosted evidence
- Re-read hosted sessions `c7de1f02-850b-4c46-9359-304a52eac37f`, `3da14150-bbe7-49cf-94d8-0138440873ce`, `cbc12095-9935-470d-ad88-99b16e0c9548`, and `79b1bc65-7e06-4644-b0bb-e967a6f0a00e` after repair.
- Each now has `session_goal_count = 1`, `has_primary_goal_row = true`, and `backfill_audit_count = 1` with `backfill_logged_at = 2026-06-10 02:24:34.868538+00`.
- Before repair, those same four sessions had zero `session_goals`, zero `client_session_notes`, and audit history showing both `session_enrichment_persisted` and `session_started` goal payloads, which is why this lands as a bounded repair instead of a speculative confirm/start rewrite.

## Verification
- `npm test -- src/features/scheduling/domain/__tests__/sessionComplete.test.ts`
- `npm test -- src/server/__tests__/sessionsCompleteHandler.test.ts`
- `npm test -- tests/edge/sessions-complete.test.ts`
- `npm test -- src/tests/security/rls.spec.ts -t "prevents therapists from deleting session_goals on in_progress sessions"`
- `npm run ci:check-focused`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:ci`
- `npm run test:routes:tier0`
- `npm run verify:local`

## Remaining blocker
- CI and deploy checks are still pending on GitHub for commit `744ec1d1`.
- `npm run ci:playwright` remains unrun locally and should be satisfied by CI or a follow-up browser gate if required by review.