### PR TITLE
WIN-134 Expose week-forward scheduling API

### DIFF
--- a/docs/api/netlify-function-allowlist.json
+++ b/docs/api/netlify-function-allowlist.json
@@ -18,6 +18,7 @@
   "boundaryExceptions": [
     "assessment-documents-extract-background.ts",
     "sessions-complete.ts",
+    "sessions-week-forward.ts",
     "session-notes-upsert.ts"
   ]
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -45,6 +45,16 @@
   status = 200
 
 [[redirects]]
+  from = "/api/sessions-week-forward"
+  to = "/.netlify/functions/sessions-week-forward"
+  status = 200
+
+[[redirects]]
+  from = "/api/sessions/week-forward"
+  to = "/.netlify/functions/sessions-week-forward"
+  status = 200
+
+[[redirects]]
   from = "/api/session-notes/upsert"
   to = "/.netlify/functions/session-notes-upsert"
   status = 200

--- a/netlify/functions/sessions-week-forward.ts
+++ b/netlify/functions/sessions-week-forward.ts
@@ -1,0 +1,43 @@
+import { Handler } from "@netlify/functions";
+import { sessionsWeekForwardHandler } from "../../src/server/api/sessions-week-forward";
+
+const toNetlifyResponse = async (response: Response) => {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  return {
+    statusCode: response.status,
+    headers,
+    body: await response.text(),
+    isBase64Encoded: false,
+  };
+};
+
+export const handler: Handler = async (event) => {
+  try {
+    const bodyNeeded = event.httpMethod !== "GET" && event.httpMethod !== "HEAD";
+    const body =
+      bodyNeeded && event.body
+        ? event.isBase64Encoded
+          ? Buffer.from(event.body, "base64")
+          : event.body
+        : undefined;
+
+    const request = new Request(event.rawUrl || `https://${event.headers.host}${event.path}`, {
+      method: event.httpMethod,
+      headers: event.headers as HeadersInit,
+      body,
+    });
+
+    const response = await sessionsWeekForwardHandler(request);
+    return toNetlifyResponse(response);
+  } catch {
+    return {
+      statusCode: 500,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ error: "Internal Server Error" }),
+    };
+  }
+};

--- a/scripts/ci/check-api-adapter-boundary.mjs
+++ b/scripts/ci/check-api-adapter-boundary.mjs
@@ -56,6 +56,11 @@ const run = () => {
     "fetch(",
     "in-function business logic (sessions-start should remain a transport adapter)",
   );
+  assertNotContains(
+    "netlify/functions/sessions-week-forward.ts",
+    "fetch(",
+    "in-function business logic (sessions-week-forward should remain a transport adapter)",
+  );
 
   console.log("API adapter boundary check passed.");
 };

--- a/scripts/ci/check-api-contract-smoke.mjs
+++ b/scripts/ci/check-api-contract-smoke.mjs
@@ -44,6 +44,15 @@ const CRITICAL_ENDPOINTS = [
     expectedMethod: "POST",
     expectedContentType: "application/json",
   },
+  {
+    route: "/api/sessions-week-forward",
+    aliases: ["/api/sessions/week-forward"],
+    netlifyFunction: "sessions-week-forward.ts",
+    sourceFile: "src/server/api/sessions-week-forward.ts",
+    handlerSymbol: "sessionsWeekForwardHandler",
+    expectedMethod: "POST",
+    expectedContentType: "application/json",
+  },
 ];
 
 const readText = async (relativePath) => {
@@ -75,8 +84,30 @@ const parseBoolean = (value, fallback) => {
   return /^(1|true|yes)$/i.test(value);
 };
 
+const parseRedirects = (content) => {
+  const redirects = [];
+  const lines = content.split(/\r?\n/);
+  let current = null;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === "[[redirects]]") {
+      if (current) redirects.push(current);
+      current = {};
+      continue;
+    }
+    if (!current) continue;
+    const fromMatch = trimmed.match(/^from\s*=\s*"([^"]+)"$/);
+    if (fromMatch) current.from = fromMatch[1];
+    const toMatch = trimmed.match(/^to\s*=\s*"([^"]+)"$/);
+    if (toMatch) current.to = toMatch[1];
+  }
+  if (current) redirects.push(current);
+  return redirects.filter((redirect) => typeof redirect.from === "string" && typeof redirect.to === "string");
+};
+
 const run = async () => {
   const failures = [];
+  const redirects = parseRedirects(await readText("netlify.toml"));
   const edgeParityRequired = parseBoolean(
     process.env.CI_EDGE_ROUTE_PARITY_REQUIRED,
     parseBoolean(process.env.CI_SUPABASE_AUTH_PARITY_REQUIRED, process.env.CI === "true"),
@@ -85,6 +116,15 @@ const run = async () => {
   for (const endpoint of CRITICAL_ENDPOINTS) {
     const netlifyPath = `netlify/functions/${endpoint.netlifyFunction}`;
     const netlifyText = await readText(netlifyPath);
+    const expectedTarget = `/.netlify/functions/${endpoint.netlifyFunction.replace(/\.ts$/, "")}`;
+    for (const route of [endpoint.route, ...(endpoint.aliases ?? [])]) {
+      const redirect = redirects.find((candidate) => candidate.from === route);
+      if (!redirect) {
+        failures.push(`${route}: missing Netlify redirect.`);
+      } else if (redirect.to !== expectedTarget) {
+        failures.push(`${route}: Netlify redirect points to ${redirect.to}, expected ${expectedTarget}.`);
+      }
+    }
     if (endpoint.sourceFile) {
       const sourceText = await readText(endpoint.sourceFile);
       const sourceImportStem = endpoint.sourceFile.replace(/\\/g, "/").replace(/^src\//, "../../src/").replace(/\.ts$/, "");


### PR DESCRIPTION
## Summary
- expose the existing `sessionsWeekForwardHandler` through a Netlify function adapter
- add Netlify redirects for both `/api/sessions-week-forward` and the slash-form `/api/sessions/week-forward` observed returning 404 in the browser
- extend API policy smoke checks so the week-forward function adapter and redirects are covered going forward

## Route task
- classification: high-risk human-reviewed
- lane: critical
- triggering paths: `netlify.toml`, `netlify/functions/**`, `scripts/ci/**`, API/deploy routing
- issue: WIN-134

## Verification
- `npm run ci:check-focused` passed
- `npm run typecheck` passed
- `npm test -- src/server/__tests__/sessionsWeekForwardHandler.test.ts src/pages/__tests__/Schedule.test.tsx` passed
- `npm run lint` passed
- `npm run build` passed
- `npm run test:ci` passed
- `npm run verify:local` passed
- `git diff --check` passed

## Notes
- Root cause: the server handler existed, but the deployed Netlify route did not. The SPA screenshot showed `/api/sessions/week-forward` returning 404; this PR also keeps the current client path `/api/sessions-week-forward` routable.
- This is a protected deploy/API routing change and requires human review before merge.