### PR TITLE
Fix week-forward preview state reset

### DIFF
--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1097,7 +1097,7 @@ export const Schedule = React.memo(() => {
         timeZone: recurrenceTimeZone,
       }),
     onSuccess: async (result) => {
-      setWeekForwardPreview(result);
+      setWeekForwardPreview(null);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["sessions"] }),
         queryClient.invalidateQueries({ queryKey: ["sessions-batch"] }),

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -858,6 +858,22 @@ export const Schedule = React.memo(() => {
     () => weekForwardVisibleSessions.filter(isWeekForwardRecurrenceSourceSession),
     [weekForwardVisibleSessions],
   );
+  const weekForwardSourceSessionSignature = useMemo(
+    () =>
+      weekForwardSourceSessions
+        .map((session) => [
+          session.id,
+          session.start_time,
+          session.end_time,
+          session.status,
+          session.therapist_id,
+          session.client_id,
+        ].join(":"))
+        .sort()
+        .join("|"),
+    [weekForwardSourceSessions],
+  );
+  const weekForwardDisplayedWeekSignature = `${weekStart.toISOString()}|${weekEnd.toISOString()}`;
   const weekForwardHasScheduledSessions = weekForwardSourceSessions.length > 0;
   const weekForwardRequiresOrgContext = effectiveRole === "super_admin" && !activeOrganizationId;
   const weekForwardAvailableInCurrentView = view === "week";
@@ -1106,7 +1122,8 @@ export const Schedule = React.memo(() => {
     recurrenceEnabled,
     recurrenceTimeZone,
     weekForwardEndDate,
-    weekForwardSourceSessions,
+    weekForwardDisplayedWeekSignature,
+    weekForwardSourceSessionSignature,
     weekForwardAvailableInCurrentView,
   ]);
 

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -112,6 +112,23 @@ const scheduleFixtures = {
   ],
 };
 
+const cloneScheduleFixtures = () => ({
+  ...scheduleFixtures,
+  sessions: scheduleFixtures.sessions.map((session) => ({
+    ...session,
+    therapist: session.therapist ? { ...session.therapist } : session.therapist,
+    client: session.client ? { ...session.client } : session.client,
+  })),
+  therapists: scheduleFixtures.therapists.map((therapist) => ({
+    ...therapist,
+    availability_hours: { ...therapist.availability_hours },
+  })),
+  clients: scheduleFixtures.clients.map((client) => ({
+    ...client,
+    availability_hours: { ...client.availability_hours },
+  })),
+});
+
 vi.mock("../../lib/optimizedQueries", () => ({
   useScheduleDataBatch: (...args: unknown[]) => mockUseScheduleDataBatch(...args),
   useSessionsOptimized: (...args: unknown[]) => mockUseSessionsOptimized(...args),
@@ -436,6 +453,57 @@ describe("Schedule", () => {
       endDate: "2025-08-31",
       timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       dryRun: true,
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Apply this week forward/i }));
+
+    await waitFor(() => {
+      expect(capturedRequests).toHaveLength(2);
+    });
+    expect(capturedRequests[1]).toMatchObject({
+      sourceSessionIds: ["session-1", "session-2"],
+      endDate: "2025-08-31",
+      dryRun: false,
+    });
+  }, 15000);
+
+  it("keeps the week-forward preview actionable when schedule data refreshes with unchanged sessions", async () => {
+    const capturedRequests: Array<Record<string, unknown>> = [];
+    server.use(
+      http.post("*/api/sessions-week-forward", async ({ request }) => {
+        const body = await request.json() as Record<string, unknown>;
+        capturedRequests.push(body);
+        return HttpResponse.json({
+          success: true,
+          data: {
+            sourceSessionCount: 2,
+            generatedSessionCount: 8,
+            generatedWeekCount: 4,
+            endDate: "2025-08-31",
+            conflicts: [],
+            ...(body.dryRun === true ? {} : { createdSessions: [] }),
+          },
+        });
+      }),
+    );
+    mockUseScheduleDataBatch.mockImplementation(() => ({
+      data: cloneScheduleFixtures(),
+      isLoading: false,
+    }));
+
+    renderWithProviders(<Schedule />);
+
+    const recurrenceToggle = await screen.findByRole("checkbox", {
+      name: /Apply this visible week forward/i,
+    });
+    await userEvent.click(recurrenceToggle);
+    fireEvent.change(screen.getByLabelText(/End date/i), { target: { value: "2025-08-31" } });
+
+    await userEvent.click(screen.getByRole("button", { name: /Preview week-forward schedule/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/^Preview$/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Apply this week forward/i })).toBeEnabled();
     });
 
     await userEvent.click(screen.getByRole("button", { name: /Apply this week forward/i }));

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -516,7 +516,13 @@ describe("Schedule", () => {
       endDate: "2025-08-31",
       dryRun: false,
     });
-  }, 15000);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Preview week-forward schedule/i })).toBeEnabled();
+    });
+    expect(screen.getByRole("button", { name: /Apply this week forward/i })).toBeDisabled();
+    expect(screen.queryByText(/^Preview$/i)).not.toBeInTheDocument();
+  }, 30000);
 
   it("recurs only scheduled sessions when visible sessions include other statuses", async () => {
     const capturedRequests: Array<Record<string, unknown>> = [];


### PR DESCRIPTION
## Summary
- Keep week-forward preview/apply state stable when schedule data refreshes with identical source sessions.
- Reset the preview only when the displayed week or actual source session signature changes.
- Add regression coverage proving Apply remains enabled after Preview when schedule hook data returns fresh object identities.

## Root cause
The preview reset effect depended on the `weekForwardSourceSessions` array reference. When schedule data refreshed or re-rendered with equivalent session objects, the array identity changed and cleared `weekForwardPreview`, so Apply stayed disabled after Preview.

## Verification
- `npm test -- src/pages/__tests__/Schedule.test.tsx -t "keeps the week-forward preview actionable"` failed before the fix and passed after.
- `npm test -- src/pages/__tests__/Schedule.test.tsx`
- `npm run verify:local`

## Notes
- Scope is limited to `src/pages/Schedule.tsx` and its focused test.
- No server/API, migration, auth, or tenant-boundary files changed.
- Repo-required sub-agent reviewer was not invoked because this session's tool contract only allows spawning sub-agents when explicitly requested; PR is ready for human review.