### PR TITLE
WIN-174 guard session capture when goals are missing

### DIFF
--- a/src/components/AddSessionNoteModal.tsx
+++ b/src/components/AddSessionNoteModal.tsx
@@ -9,6 +9,7 @@ import {
   mergeUniqueGoalIds,
 } from '../lib/goal-measurements';
 import { useActiveOrganizationId } from '../lib/organization';
+import { resolveSessionCloseRequiredGoalIds } from '../lib/sessionCloseRequiredGoals';
 import { showError } from '../lib/toast';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../lib/authContext';
@@ -184,7 +185,7 @@ export function AddSessionNoteModal({
       }
       const { data, error } = await supabase
         .from('sessions')
-        .select('id, start_time, end_time, therapist_id, therapist:therapist_id(full_name)')
+        .select('id, start_time, end_time, therapist_id, goal_id, therapist:therapist_id(full_name)')
         .eq('client_id', clientId)
         .eq('organization_id', organizationId)
         .order('start_time', { ascending: false })
@@ -198,6 +199,7 @@ export function AddSessionNoteModal({
         start_time: string;
         end_time: string;
         therapist_id: string;
+        goal_id: string | null;
         therapist: { full_name: string | null } | null;
       }>;
     },
@@ -244,14 +246,18 @@ export function AddSessionNoteModal({
   // session ID so that any manual edits the therapist makes afterwards are
   // preserved.  The ref is reset in resetForm() when the modal closes.
   useEffect(() => {
-    if (!sessionGoalsData || sessionGoalsData.length === 0 || goals.length === 0) {
+    if (goals.length === 0) {
       return;
     }
     if (selectedSessionId && selectedSessionId === appliedForSession.current) {
       return;
     }
 
-    const goalIds = sessionGoalsData.map((sg) => sg.goal_id);
+    const selectedSession = sessions.find((entry) => entry.id === selectedSessionId);
+    const goalIds = resolveSessionCloseRequiredGoalIds({
+      sessionGoalIds: (sessionGoalsData ?? []).map((sg) => sg.goal_id),
+      primaryGoalId: selectedSession?.goal_id ?? null,
+    });
     const validIds = goals
       .filter((g) => g.status !== 'archived' && goalIds.includes(g.id))
       .map((g) => g.id);
@@ -260,7 +266,7 @@ export function AddSessionNoteModal({
       setSelectedGoalIds(validIds);
       appliedForSession.current = selectedSessionId;
     }
-  }, [sessionGoalsData, goals, selectedSessionId]);
+  }, [goals, selectedSessionId, sessionGoalsData, sessions]);
 
   const toggleGoalSelection = (goalId: string) => {
     setSelectedGoalIds((prev) => {

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -56,6 +56,7 @@ import {
   showGoalOnBxCaptureTab,
   showGoalOnSkillCaptureTab,
 } from '../lib/session-adhoc-targets';
+import { resolveSessionCloseRequiredGoalIds } from '../lib/sessionCloseRequiredGoals';
 import {
   firstServiceCodeOnAuthorization,
   isSessionCaptureBillingGateRelaxed,
@@ -523,16 +524,26 @@ export function SessionModal({
   }, [sessionDetails, setValue]);
 
   useEffect(() => {
-    if (!sessionGoalRows || sessionGoalRows.length === 0) {
+    if (!session?.id) {
       return;
     }
-    const uniqueGoals = Array.from(
-      new Set(sessionGoalRows.map((row) => row.goal_id).filter((id) => typeof id === 'string'))
-    );
+
+    const uniqueGoals = resolveSessionCloseRequiredGoalIds({
+      sessionGoalIds: sessionGoalRows.map((row) => row.goal_id),
+      primaryGoalId: sessionDetails?.goal_id ?? session?.goal_id ?? null,
+    });
+
     if (uniqueGoals.length > 0) {
+      const currentGoalIds = Array.isArray(getValues('goal_ids')) ? getValues('goal_ids') : [];
+      const isSameGoalSet =
+        currentGoalIds.length === uniqueGoals.length &&
+        currentGoalIds.every((goalId, index) => goalId === uniqueGoals[index]);
+      if (isSameGoalSet) {
+        return;
+      }
       setValue('goal_ids', uniqueGoals);
     }
-  }, [sessionGoalRows, setValue]);
+  }, [getValues, session?.goal_id, session?.id, sessionDetails?.goal_id, sessionGoalRows, setValue]);
 
   useEffect(() => {
     if (!isProgramsFetched) {

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -44,6 +44,7 @@ const mockSession = {
   end_time: '2026-03-31T11:00:00Z',
   therapist_id: 'therapist-1',
   therapist: { full_name: 'Test Therapist' },
+  goal_id: 'goal-1',
 };
 
 const mockTherapist = {
@@ -181,6 +182,16 @@ describe('AddSessionNoteModal — session_goals auto-population', () => {
 
     // Goal must NOT be pre-checked when there are no session_goals.
     expect(goalCheckbox).not.toBeChecked();
+  });
+
+  it('falls back to the linked session primary goal when session_goals are empty', async () => {
+    renderWithProviders(<AddSessionNoteModal {...defaultProps} />);
+
+    const goalCheckbox = await screen.findByRole('checkbox', { name: /default goal/i });
+
+    await waitFor(() => {
+      expect(goalCheckbox).toBeChecked();
+    });
   });
 
   it('allows the therapist to uncheck an auto-populated goal', async () => {

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -44,7 +44,7 @@ const mockSession = {
   end_time: '2026-03-31T11:00:00Z',
   therapist_id: 'therapist-1',
   therapist: { full_name: 'Test Therapist' },
-  goal_id: 'goal-1',
+  goal_id: null,
 };
 
 const mockTherapist = {
@@ -185,6 +185,16 @@ describe('AddSessionNoteModal — session_goals auto-population', () => {
   });
 
   it('falls back to the linked session primary goal when session_goals are empty', async () => {
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') return buildChain([mockProgram]) as any;
+      if (table === 'goals') return buildChain([mockGoal]) as any;
+      if (table === 'sessions') {
+        return buildChainWithLimit([{ ...mockSession, goal_id: 'goal-1' }]) as any;
+      }
+      if (table === 'session_goals') return buildChain([]) as any;
+      return buildChain([]) as any;
+    });
+
     renderWithProviders(<AddSessionNoteModal {...defaultProps} />);
 
     const goalCheckbox = await screen.findByRole('checkbox', { name: /default goal/i });

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -601,6 +601,63 @@ describe('SessionModal', () => {
     expect(screen.queryByRole('button', { name: /^Close Session$/i })).not.toBeInTheDocument();
   });
 
+  it('falls back to the primary session goal for live capture when session_goals are missing', async () => {
+    const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        return buildChain([], {
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          started_at: '2026-03-01T10:00:00.000Z',
+        });
+      }
+      if (table === 'session_goals') {
+        return buildChain([]);
+      }
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        session={{
+          id: 'session-missing-session-goals',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    expect(await screen.findByLabelText(/^Per-goal note$/i)).toBeInTheDocument();
+  });
+
   it('submits completed status when Close Session is clicked', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     renderWithProviders(


### PR DESCRIPTION
## Summary
- Align therapist-facing session capture with the WIN-174 close-time fallback by using `sessions.goal_id` when `session_goals` are unexpectedly empty.
- Keep `SessionModal` from repeatedly writing the same fallback `goal_ids` during pending query state.
- Add focused regression coverage for `SessionModal` live capture and `AddSessionNoteModal` linked-note goal preselection.

## Verification
- PASS `npm run ci:check-focused`
- PASS `npm run lint`
- PASS `npm run typecheck`
- PASS `npm run build`
- PASS `npx vitest run src/components/__tests__/SessionModal.test.tsx -t "falls back to the primary session goal for live capture when session_goals are missing" --testTimeout=10000 --hookTimeout=10000 --reporter=verbose`
- PASS `npx vitest run src/components/__tests__/AddSessionNoteModal.test.tsx -t "falls back to the linked session primary goal when session_goals are empty"`
- PASS `npm run test:routes:tier0` (78 Cypress route checks)
- FAIL `npm run test:ci`: broad-suite failures/timeouts outside this diff, including `src/pages/__tests__/authLogging.test.tsx`, `src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx`, multiple `src/pages/__tests__/Schedule.test.tsx` week-forward/recurrence tests, and `src/pages/messages/__tests__/MessageThread.test.tsx`.
- TIMEOUT `npm run ci:playwright`: local command did not complete within 20 minutes and did not return actionable wrapper output.

## Risk
- No server/API, Supabase, auth, routing, migration, CI, or deploy config files changed.
- Draft PR until the failing broad-suite and local Playwright gates are resolved or confirmed unrelated in CI.

Linear: WIN-174