### PR TITLE
Add session capture target field

### DIFF
--- a/src/components/AddSessionNoteModal.tsx
+++ b/src/components/AddSessionNoteModal.tsx
@@ -586,6 +586,25 @@ export function AddSessionNoteModal({
                         >
                           {remaining.toLocaleString()} characters remaining
                         </p>
+                        <label
+                          htmlFor={`goal-target-${goal.id}`}
+                          className="mb-1 mt-3 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                        >
+                          Target
+                        </label>
+                        <textarea
+                          id={`goal-target-${goal.id}`}
+                          value={measurementEntry?.data.target ?? ''}
+                          onChange={(e) => updateGoalMeasurement(goal, { target: toOptionalString(e.target.value) })}
+                          rows={2}
+                          placeholder={goal.target_criteria?.trim() || `Record the target for "${goal.title}"…`}
+                          className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                        />
+                        {goal.target_criteria?.trim() ? (
+                          <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+                            Current plan target: {goal.target_criteria}
+                          </p>
+                        ) : null}
                         <div className="mt-3 rounded-md border border-indigo-100 bg-indigo-50/70 p-3 dark:border-indigo-900/40 dark:bg-indigo-900/10">
                           <div className="flex items-start justify-between gap-2">
                             <div>
@@ -745,6 +764,25 @@ export function AddSessionNoteModal({
                       >
                         {remaining.toLocaleString()} characters remaining
                       </p>
+                      <label
+                        htmlFor={`goal-target-${goal.id}`}
+                        className="mb-1 mt-3 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                      >
+                        Target
+                      </label>
+                      <textarea
+                        id={`goal-target-${goal.id}`}
+                        value={measurementEntry?.data.target ?? ''}
+                        onChange={(e) => updateGoalMeasurement(goal, { target: toOptionalString(e.target.value) })}
+                        rows={2}
+                        placeholder={goal.target_criteria?.trim() || `Record the target for "${goal.title}"…`}
+                        className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                      />
+                      {goal.target_criteria?.trim() ? (
+                        <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+                          Current plan target: {goal.target_criteria}
+                        </p>
+                      ) : null}
                       <div className="mt-3 rounded-md border border-indigo-100 bg-indigo-50/70 p-3 dark:border-indigo-900/40 dark:bg-indigo-900/10">
                         <div className="flex items-start justify-between gap-2">
                           <div>

--- a/src/components/ClientDetails/SessionNotesTab.tsx
+++ b/src/components/ClientDetails/SessionNotesTab.tsx
@@ -77,6 +77,13 @@ const buildMeasurementSummary = (
     });
   }
 
+  if (data.target?.trim()) {
+    summary.push({
+      label: 'Target',
+      value: data.target,
+    });
+  }
+
   if (data.note?.trim()) {
     summary.push({
       label: 'Measurement note',

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -2477,6 +2477,8 @@ export function SessionModal({
                             `session_note_goal_measurements.${selectedGoalId}.data.prompt_level` as const;
                           const noteFieldKey =
                             `session_note_goal_measurements.${selectedGoalId}.data.note` as const;
+                          const targetFieldKey =
+                            `session_note_goal_measurements.${selectedGoalId}.data.target` as const;
                           const correctWatch = watch(metricValueFieldKey);
                           const incorrectWatch = watch(incorrectTrialsFieldKey);
                           const correctDisplay =
@@ -2604,6 +2606,24 @@ export function SessionModal({
                                 className="mt-1 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                                 placeholder="Add progress notes for this goal..."
                               />
+                              <label
+                                htmlFor={`goal-target-${selectedGoalId}`}
+                                className="mt-3 block text-xs font-medium text-gray-600 dark:text-gray-300"
+                              >
+                                Target
+                              </label>
+                              <textarea
+                                id={`goal-target-${selectedGoalId}`}
+                                {...register(targetFieldKey)}
+                                rows={2}
+                                className="mt-1 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                placeholder={selectedGoal?.target_criteria?.trim() || 'Record the target for this session...'}
+                              />
+                              {selectedGoal?.target_criteria?.trim() ? (
+                                <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+                                  Current plan target: {selectedGoal.target_criteria}
+                                </p>
+                              ) : null}
                               <input
                                 type="hidden"
                                 {...register(metricLabelFieldKey)}

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -406,6 +406,9 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
     fireEvent.change(screen.getByLabelText(/note for this goal/i), {
       target: { value: 'Observed steady progress' },
     });
+    fireEvent.change(screen.getByLabelText(/^target$/i), {
+      target: { value: 'Match peer greeting in 4/5 trials' },
+    });
     fireEvent.change(screen.getByLabelText(/count \(responses\)/i), {
       target: { value: '4' },
     });
@@ -439,6 +442,7 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
               opportunities: 5,
               prompt_level: 'Gestural',
               note: 'Needed one reminder at the start',
+              target: 'Match peer greeting in 4/5 trials',
               trial_prompt_note: null,
             },
           },
@@ -475,6 +479,7 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
                 opportunities: 5,
                 prompt_level: 'Gestural',
                 note: 'Existing measurement note',
+                target: 'Existing target text',
               },
             },
           },
@@ -492,6 +497,7 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
     expect(screen.getByDisplayValue('5')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Gestural')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Existing measurement note')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Existing target text')).toBeInTheDocument();
   });
 
   it('preserves an unlinked existing note without auto-attaching a session', async () => {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1662,6 +1662,9 @@ describe('SessionModal', () => {
     fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
       target: { value: 'Observed steady progress' },
     });
+    fireEvent.change(screen.getByLabelText(/^Target$/i), {
+      target: { value: 'Match peer greeting in 4/5 trials' },
+    });
     for (let i = 0; i < 4; i += 1) {
       await userEvent.click(screen.getByRole('button', { name: /Increase correct trials/i }));
     }
@@ -1683,6 +1686,7 @@ describe('SessionModal', () => {
               metric_label: 'Count',
               metric_unit: 'responses',
               metric_value: 4,
+              target: 'Match peer greeting in 4/5 trials',
               trial_prompt_note: 'Needed one reminder at the start',
             }),
           },

--- a/src/components/__tests__/SessionNotesTab.test.tsx
+++ b/src/components/__tests__/SessionNotesTab.test.tsx
@@ -70,6 +70,7 @@ const noteWithGoalMeasurements: SessionNote = {
         opportunities: 5,
         prompt_level: 'Gestural',
         note: 'Needed one reminder at the start',
+        target: 'Match peer greeting in 4/5 trials',
       },
     },
   },
@@ -254,6 +255,8 @@ describe('SessionNotesTab — goal notes display', () => {
       expect(screen.getByText('5')).toBeInTheDocument();
       expect(screen.getByText('Prompt level')).toBeInTheDocument();
       expect(screen.getByText('Gestural')).toBeInTheDocument();
+      expect(screen.getByText('Target')).toBeInTheDocument();
+      expect(screen.getByText('Match peer greeting in 4/5 trials')).toBeInTheDocument();
       expect(screen.getByText('Measurement note')).toBeInTheDocument();
       expect(screen.getByText('Needed one reminder at the start')).toBeInTheDocument();
     });

--- a/src/lib/__tests__/goal-measurements.test.ts
+++ b/src/lib/__tests__/goal-measurements.test.ts
@@ -25,6 +25,7 @@ describe('goal-measurements helpers', () => {
         trials: '5',
         promptLevel: 'Gestural',
         comment: 'Needed one reminder',
+        target: '  Match peer greeting in 4/5 trials  ',
       }),
     ).toEqual({
       version: 1,
@@ -37,6 +38,7 @@ describe('goal-measurements helpers', () => {
         opportunities: 5,
         prompt_level: 'Gestural',
         note: 'Needed one reminder',
+        target: 'Match peer greeting in 4/5 trials',
         trial_prompt_note: null,
       },
     });
@@ -59,6 +61,7 @@ describe('goal-measurements helpers', () => {
         opportunities: null,
         prompt_level: null,
         note: null,
+        target: null,
         trial_prompt_note: null,
       },
     });

--- a/src/lib/__tests__/session-notes.test.ts
+++ b/src/lib/__tests__/session-notes.test.ts
@@ -112,13 +112,14 @@ describe('fetchClientSessionNotes', () => {
           metric_unit: null,
           metric_value: 4,
           incorrect_trials: null,
-          opportunities: 5,
-          prompt_level: 'Gestural',
-          note: 'Legacy payload still loads',
-          trial_prompt_note: null,
-        },
+        opportunities: 5,
+        prompt_level: 'Gestural',
+        note: 'Legacy payload still loads',
+        target: null,
+        trial_prompt_note: null,
       },
-    });
+    },
+  });
   });
 
   it('retries without goal_measurements when select fails on missing column', async () => {

--- a/src/lib/goal-measurements.ts
+++ b/src/lib/goal-measurements.ts
@@ -103,6 +103,7 @@ export const hasMeaningfulGoalMeasurementEntry = (
     (data.opportunities !== null && data.opportunities !== undefined) ||
     (data.prompt_level?.trim().length ?? 0) > 0 ||
     (data.note?.trim().length ?? 0) > 0 ||
+    (data.target?.trim().length ?? 0) > 0 ||
     (data.trial_prompt_note?.trim().length ?? 0) > 0
   );
 };
@@ -149,6 +150,7 @@ export const normalizeGoalMeasurementEntry = (
         sourceData.prompt_level ?? sourceData.promptLevel,
       ),
       note: toOptionalString(sourceData.note ?? sourceData.comment),
+      target: toOptionalString(sourceData.target),
       trial_prompt_note: toOptionalString(
         sourceData.trial_prompt_note ?? sourceData.trialPromptNote,
       ),
@@ -175,6 +177,7 @@ export const buildGoalMeasurementEntry = (
       opportunities: normalizedExisting?.data.opportunities ?? null,
       prompt_level: normalizedExisting?.data.prompt_level ?? null,
       note: normalizedExisting?.data.note ?? null,
+      target: normalizedExisting?.data.target ?? null,
       trial_prompt_note: normalizedExisting?.data.trial_prompt_note ?? null,
     },
   };
@@ -210,6 +213,9 @@ export const mergeGoalMeasurementEntry = (
       note: updates.note !== undefined
         ? updates.note ?? null
         : existing?.data.note ?? null,
+      target: updates.target !== undefined
+        ? updates.target ?? null
+        : existing?.data.target ?? null,
       trial_prompt_note: updates.trial_prompt_note !== undefined
         ? updates.trial_prompt_note ?? null
         : existing?.data.trial_prompt_note ?? null,

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -38,7 +38,7 @@ const basePayload = {
   goalNotes: { "44444444-4444-4444-8444-444444444444": "  covered  " },
   goalMeasurements: {
     "44444444-4444-4444-8444-444444444444": {
-      data: { metric_value: 4, opportunities: 5, note: "  measured  " },
+      data: { metric_value: 4, opportunities: 5, note: "  measured  ", target: "  Match peer greeting in 4/5 trials  " },
     },
     "55555555-5555-4555-8555-555555555555": {
       data: { note: "   " },
@@ -66,6 +66,7 @@ const buildSessionNoteRow = (id: string) => ({
         opportunities: 5,
         prompt_level: null,
         note: "measured",
+        target: "Match peer greeting in 4/5 trials",
         trial_prompt_note: null,
       },
     },
@@ -148,6 +149,7 @@ describe("sessionNotesUpsertHandler", () => {
               opportunities: 5,
               prompt_level: null,
               note: "measured",
+              target: "Match peer greeting in 4/5 trials",
               trial_prompt_note: null,
             },
           },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -335,6 +335,7 @@ export interface SessionGoalMeasurementData {
   opportunities?: number | null;
   prompt_level?: string | null;
   note?: string | null;
+  target?: string | null;
   /** Verbal / physical prompts and reactions for trial data (therapist capture). */
   trial_prompt_note?: string | null;
 }


### PR DESCRIPTION
## Summary
- add a per-goal session capture target field to the schedule session modal and client session-note modal
- persist the session-specific target in goal_measurements.data without a schema migration
- surface saved target text in session note summaries and extend focused tests for normalization and upsert behavior

## Verification
- npm test -- src/lib/__tests__/goal-measurements.test.ts
- npm test -- src/lib/__tests__/session-notes.test.ts
- npm test -- src/components/__tests__/AddSessionNoteModal.test.tsx
- npx vitest run src/components/__tests__/SessionModal.test.tsx -t "submits normalized per-goal measurements with session capture"
- npm test -- src/components/__tests__/SessionNotesTab.test.tsx
- npm test -- src/server/__tests__/sessionNotesUpsertHandler.test.ts
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run build

## Notes
- no database migration is required because the new field is stored under goal_measurements.data.target
- repo-wide route/test gates remain noisy locally because of unrelated pre-existing Schedule changes left unstaged in the working tree