### PR TITLE
Add multi-target session capture support

### DIFF
--- a/src/components/AddSessionNoteModal.tsx
+++ b/src/components/AddSessionNoteModal.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { X, Calendar, Clock, FileText, CheckCircle } from 'lucide-react';
+import { X, Calendar, Clock, FileText, CheckCircle, Plus, Trash2 } from 'lucide-react';
 import type { Goal, Program, SessionGoalMeasurementEntry, SessionNote, Therapist } from '../types';
 import {
   buildGoalMeasurementEntry,
+  getGoalMeasurementTargets,
   getGoalMeasurementFieldMeta,
   mergeGoalMeasurementEntry,
   mergeUniqueGoalIds,
@@ -312,6 +313,67 @@ export function AddSessionNoteModal({
     });
   };
 
+  const createDraftGoalMeasurementEntry = (
+    goal: Goal,
+    existingEntry: SessionGoalMeasurementEntry | undefined,
+  ): SessionGoalMeasurementEntry => {
+    const measurementFieldMeta = getGoalMeasurementFieldMeta(goal);
+    return existingEntry ?? {
+      version: 1,
+      data: {
+        measurement_type: goal.measurement_type ?? null,
+        metric_label: measurementFieldMeta.primaryLabel,
+        metric_unit: measurementFieldMeta.primaryUnit,
+        metric_value: null,
+        incorrect_trials: null,
+        opportunities: null,
+        prompt_level: null,
+        note: null,
+        targets: null,
+        target: null,
+        trial_prompt_note: null,
+      },
+    };
+  };
+
+  const updateGoalTargets = (goal: Goal, nextTargets: string[]) => {
+    setGoalMeasurements((prev) => {
+      const draftEntry = createDraftGoalMeasurementEntry(goal, prev[goal.id]);
+      return {
+        ...prev,
+        [goal.id]: {
+          ...draftEntry,
+          data: {
+            ...draftEntry.data,
+            targets: nextTargets,
+            target: nextTargets.map((target) => toOptionalString(target)).find((target) => Boolean(target)) ?? null,
+          },
+        },
+      };
+    });
+  };
+
+  const addGoalTarget = (goal: Goal) => {
+    const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
+    const currentTargets = getGoalMeasurementTargets(measurementEntry?.data);
+    updateGoalTargets(goal, [...currentTargets, '']);
+  };
+
+  const changeGoalTarget = (goal: Goal, targetIndex: number, nextValue: string) => {
+    const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
+    const currentTargets = getGoalMeasurementTargets(measurementEntry?.data);
+    const nextTargets = (currentTargets.length > 0 ? currentTargets : ['']).slice();
+    nextTargets[targetIndex] = nextValue;
+    updateGoalTargets(goal, nextTargets);
+  };
+
+  const removeGoalTarget = (goal: Goal, targetIndex: number) => {
+    const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
+    const currentTargets = getGoalMeasurementTargets(measurementEntry?.data);
+    const nextTargets = currentTargets.filter((_, index) => index !== targetIndex);
+    updateGoalTargets(goal, nextTargets.length > 0 ? nextTargets : ['']);
+  };
+
   useEffect(() => {
     if (!hasSessions || selectedSessionId || isEditingUnlinkedNote) {
       return;
@@ -547,6 +609,14 @@ export function AddSessionNoteModal({
                 const isSelected = selectedGoalIds.includes(goal.id);
                 const noteText = goalNotes[goal.id] ?? '';
                 const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
+                const sessionTargets = (() => {
+                  const rawTargets = goalMeasurements[goal.id]?.data.targets;
+                  if (Array.isArray(rawTargets) && rawTargets.length > 0) {
+                    return rawTargets.map((target) => (typeof target === 'string' ? target : ''));
+                  }
+                  const normalizedTargets = getGoalMeasurementTargets(measurementEntry?.data);
+                  return normalizedTargets.length > 0 ? normalizedTargets : [''];
+                })();
                 const measurementFieldMeta = getGoalMeasurementFieldMeta(goal);
                 const remaining = MAX_GOAL_NOTE_LENGTH - noteText.length;
                 return (
@@ -586,20 +656,49 @@ export function AddSessionNoteModal({
                         >
                           {remaining.toLocaleString()} characters remaining
                         </p>
-                        <label
-                          htmlFor={`goal-target-${goal.id}`}
-                          className="mb-1 mt-3 block text-xs font-medium text-gray-600 dark:text-gray-400"
-                        >
-                          Target
-                        </label>
-                        <textarea
-                          id={`goal-target-${goal.id}`}
-                          value={measurementEntry?.data.target ?? ''}
-                          onChange={(e) => updateGoalMeasurement(goal, { target: toOptionalString(e.target.value) })}
-                          rows={2}
-                          placeholder={goal.target_criteria?.trim() || `Record the target for "${goal.title}"…`}
-                          className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
-                        />
+                        <div className="mt-3">
+                          <div className="mb-1 flex items-center justify-between gap-2">
+                            <label
+                              htmlFor={`goal-target-${goal.id}-0`}
+                              className="block text-xs font-medium text-gray-600 dark:text-gray-400"
+                            >
+                              Targets
+                            </label>
+                            <button
+                              type="button"
+                              onClick={() => addGoalTarget(goal)}
+                              className="inline-flex items-center gap-1 rounded-md border border-indigo-200 bg-white px-2 py-1 text-[11px] font-semibold text-indigo-700 shadow-sm hover:bg-indigo-50 dark:border-indigo-800 dark:bg-dark dark:text-indigo-200 dark:hover:bg-indigo-950/40"
+                            >
+                              <Plus className="h-3.5 w-3.5" />
+                              Add target
+                            </button>
+                          </div>
+                          <div className="space-y-2">
+                            {sessionTargets.map((targetValue, targetIndex) => (
+                              <div key={`${goal.id}-target-${targetIndex}`} className="flex items-start gap-2">
+                                <textarea
+                                  id={`goal-target-${goal.id}-${targetIndex}`}
+                                  aria-label={targetIndex === 0 ? 'Target' : `Target ${targetIndex + 1}`}
+                                  value={targetValue}
+                                  onChange={(e) => changeGoalTarget(goal, targetIndex, e.target.value)}
+                                  rows={2}
+                                  placeholder={goal.target_criteria?.trim() || `Record the target for "${goal.title}"…`}
+                                  className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                />
+                                {sessionTargets.length > 1 ? (
+                                  <button
+                                    type="button"
+                                    onClick={() => removeGoalTarget(goal, targetIndex)}
+                                    aria-label={`Remove target ${targetIndex + 1}`}
+                                    className="mt-1 shrink-0 rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-rose-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-rose-300"
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </button>
+                                ) : null}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
                         {goal.target_criteria?.trim() ? (
                           <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
                             Current plan target: {goal.target_criteria}
@@ -728,6 +827,14 @@ export function AddSessionNoteModal({
               const isSelected = selectedGoalIds.includes(goal.id);
               const noteText = goalNotes[goal.id] ?? '';
               const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
+              const sessionTargets = (() => {
+                const rawTargets = goalMeasurements[goal.id]?.data.targets;
+                if (Array.isArray(rawTargets) && rawTargets.length > 0) {
+                  return rawTargets.map((target) => (typeof target === 'string' ? target : ''));
+                }
+                const normalizedTargets = getGoalMeasurementTargets(measurementEntry?.data);
+                return normalizedTargets.length > 0 ? normalizedTargets : [''];
+              })();
               const measurementFieldMeta = getGoalMeasurementFieldMeta(goal);
               const remaining = MAX_GOAL_NOTE_LENGTH - noteText.length;
               return (
@@ -764,20 +871,49 @@ export function AddSessionNoteModal({
                       >
                         {remaining.toLocaleString()} characters remaining
                       </p>
-                      <label
-                        htmlFor={`goal-target-${goal.id}`}
-                        className="mb-1 mt-3 block text-xs font-medium text-gray-600 dark:text-gray-400"
-                      >
-                        Target
-                      </label>
-                      <textarea
-                        id={`goal-target-${goal.id}`}
-                        value={measurementEntry?.data.target ?? ''}
-                        onChange={(e) => updateGoalMeasurement(goal, { target: toOptionalString(e.target.value) })}
-                        rows={2}
-                        placeholder={goal.target_criteria?.trim() || `Record the target for "${goal.title}"…`}
-                        className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
-                      />
+                      <div className="mt-3">
+                        <div className="mb-1 flex items-center justify-between gap-2">
+                          <label
+                            htmlFor={`goal-target-${goal.id}-0`}
+                            className="block text-xs font-medium text-gray-600 dark:text-gray-400"
+                          >
+                            Targets
+                          </label>
+                          <button
+                            type="button"
+                            onClick={() => addGoalTarget(goal)}
+                            className="inline-flex items-center gap-1 rounded-md border border-indigo-200 bg-white px-2 py-1 text-[11px] font-semibold text-indigo-700 shadow-sm hover:bg-indigo-50 dark:border-indigo-800 dark:bg-dark dark:text-indigo-200 dark:hover:bg-indigo-950/40"
+                          >
+                            <Plus className="h-3.5 w-3.5" />
+                            Add target
+                          </button>
+                        </div>
+                        <div className="space-y-2">
+                          {sessionTargets.map((targetValue, targetIndex) => (
+                            <div key={`${goal.id}-target-${targetIndex}`} className="flex items-start gap-2">
+                              <textarea
+                                id={`goal-target-${goal.id}-${targetIndex}`}
+                                aria-label={targetIndex === 0 ? 'Target' : `Target ${targetIndex + 1}`}
+                                value={targetValue}
+                                onChange={(e) => changeGoalTarget(goal, targetIndex, e.target.value)}
+                                rows={2}
+                                placeholder={goal.target_criteria?.trim() || `Record the target for "${goal.title}"…`}
+                                className="w-full rounded-md border border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                              />
+                              {sessionTargets.length > 1 ? (
+                                <button
+                                  type="button"
+                                  onClick={() => removeGoalTarget(goal, targetIndex)}
+                                  aria-label={`Remove target ${targetIndex + 1}`}
+                                  className="mt-1 shrink-0 rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-rose-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-rose-300"
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                </button>
+                              ) : null}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
                       {goal.target_criteria?.trim() ? (
                         <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
                           Current plan target: {goal.target_criteria}

--- a/src/components/ClientDetails/SessionNotesTab.tsx
+++ b/src/components/ClientDetails/SessionNotesTab.tsx
@@ -21,6 +21,7 @@ import { AddSessionNoteModal, type SessionNoteFormValues  } from '../AddSessionN
 import { useAuth } from '../../lib/authContext';
 import { useActiveOrganizationId } from '../../lib/organization';
 import { showError, showSuccess } from '../../lib/toast';
+import { getGoalMeasurementTargets } from '../../lib/goal-measurements';
 import {
   calculateSessionDurationMinutes,
   createClientSessionNote,
@@ -77,12 +78,13 @@ const buildMeasurementSummary = (
     });
   }
 
-  if (data.target?.trim()) {
+  const targets = getGoalMeasurementTargets(data);
+  targets.forEach((target, index) => {
     summary.push({
-      label: 'Target',
-      value: data.target,
+      label: targets.length > 1 ? `Target ${index + 1}` : 'Target',
+      value: target,
     });
-  }
+  });
 
   if (data.note?.trim()) {
     summary.push({

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -41,6 +41,7 @@ import {
 } from "../features/scheduling/domain/time";
 import { startSessionFromModal } from "../features/scheduling/domain/sessionStart";
 import {
+  getGoalMeasurementTargets,
   getGoalMeasurementFieldMeta,
   hasMeaningfulGoalMeasurementEntry,
   mergeUniqueGoalIds,
@@ -1286,6 +1287,37 @@ export function SessionModal({
     [getValues, setValue],
   );
 
+  const updateGoalTargets = useCallback(
+    (goalId: string, nextTargets: string[]) => {
+      const targetsPath = `session_note_goal_measurements.${goalId}.data.targets` as const;
+      const targetPath = `session_note_goal_measurements.${goalId}.data.target` as const;
+      setValue(targetsPath, nextTargets, { shouldDirty: true, shouldTouch: true });
+      setValue(
+        targetPath,
+        nextTargets
+          .map((target) => (typeof target === 'string' ? target.trim() : ''))
+          .find((target) => target.length > 0) ?? '',
+        { shouldDirty: true, shouldTouch: true },
+      );
+    },
+    [setValue],
+  );
+
+  const addGoalTarget = useCallback(
+    (goalId: string, existingTargets: string[]) => {
+      updateGoalTargets(goalId, [...existingTargets, '']);
+    },
+    [updateGoalTargets],
+  );
+
+  const removeGoalTarget = useCallback(
+    (goalId: string, targetIndex: number, existingTargets: string[]) => {
+      const nextTargets = existingTargets.filter((_, index) => index !== targetIndex);
+      updateGoalTargets(goalId, nextTargets.length > 0 ? nextTargets : ['']);
+    },
+    [updateGoalTargets],
+  );
+
   const addAdhocSessionTarget = useCallback(
     (kind: 'skill' | 'bx') => {
       const id = createAdhocSessionTargetId(kind);
@@ -2477,10 +2509,24 @@ export function SessionModal({
                             `session_note_goal_measurements.${selectedGoalId}.data.prompt_level` as const;
                           const noteFieldKey =
                             `session_note_goal_measurements.${selectedGoalId}.data.note` as const;
+                          const targetsFieldBaseKey =
+                            `session_note_goal_measurements.${selectedGoalId}.data.targets` as const;
                           const targetFieldKey =
                             `session_note_goal_measurements.${selectedGoalId}.data.target` as const;
                           const correctWatch = watch(metricValueFieldKey);
                           const incorrectWatch = watch(incorrectTrialsFieldKey);
+                          const watchedTargets = watch(targetsFieldBaseKey) as unknown;
+                          const sessionTargets = (() => {
+                            if (Array.isArray(watchedTargets)) {
+                              const normalizedWatchedTargets = watchedTargets
+                                .map((target) => (typeof target === 'string' ? target : ''));
+                              if (normalizedWatchedTargets.length > 0) {
+                                return normalizedWatchedTargets;
+                              }
+                            }
+                            const normalizedExistingTargets = getGoalMeasurementTargets(existingMeasurementEntry?.data);
+                            return normalizedExistingTargets.length > 0 ? normalizedExistingTargets : [''];
+                          })();
                           const correctDisplay =
                             typeof correctWatch === 'number' && Number.isFinite(correctWatch)
                               ? correctWatch
@@ -2606,24 +2652,73 @@ export function SessionModal({
                                 className="mt-1 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                                 placeholder="Add progress notes for this goal..."
                               />
-                              <label
-                                htmlFor={`goal-target-${selectedGoalId}`}
-                                className="mt-3 block text-xs font-medium text-gray-600 dark:text-gray-300"
-                              >
-                                Target
-                              </label>
-                              <textarea
-                                id={`goal-target-${selectedGoalId}`}
-                                {...register(targetFieldKey)}
-                                rows={2}
-                                className="mt-1 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
-                                placeholder={selectedGoal?.target_criteria?.trim() || 'Record the target for this session...'}
-                              />
+                              <div className="mt-3">
+                                <div className="flex items-center justify-between gap-2">
+                                  <label
+                                    htmlFor={`goal-target-${selectedGoalId}-0`}
+                                    className="block text-xs font-medium text-gray-600 dark:text-gray-300"
+                                  >
+                                    Targets
+                                  </label>
+                                  <button
+                                    type="button"
+                                    onClick={() => addGoalTarget(selectedGoalId, sessionTargets)}
+                                    className="inline-flex items-center gap-1 rounded-md border border-indigo-200 bg-white px-2 py-1 text-[11px] font-semibold text-indigo-700 shadow-sm hover:bg-indigo-50 dark:border-indigo-800 dark:bg-dark dark:text-indigo-200 dark:hover:bg-indigo-950/40"
+                                  >
+                                    <Plus className="h-3.5 w-3.5" />
+                                    Add target
+                                  </button>
+                                </div>
+                                <div className="mt-1 space-y-2">
+                                  {sessionTargets.map((targetValue, targetIndex) => {
+                                    const indexedTargetFieldKey =
+                                      `${targetsFieldBaseKey}.${targetIndex}` as const;
+                                    const indexedTargetRegistration = register(indexedTargetFieldKey, {
+                                      onChange: (event) => {
+                                        const nextTargets = sessionTargets.slice();
+                                        nextTargets[targetIndex] = String(event.target.value ?? '');
+                                        updateGoalTargets(selectedGoalId, nextTargets);
+                                      },
+                                    });
+                                    return (
+                                      <div
+                                        key={`${selectedGoalId}-target-${targetIndex}`}
+                                        className="flex items-start gap-2"
+                                      >
+                                        <textarea
+                                          id={`goal-target-${selectedGoalId}-${targetIndex}`}
+                                          aria-label={targetIndex === 0 ? 'Target' : `Target ${targetIndex + 1}`}
+                                          {...indexedTargetRegistration}
+                                          rows={2}
+                                          defaultValue={targetValue}
+                                          className="w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                          placeholder={selectedGoal?.target_criteria?.trim() || 'Record the target for this session...'}
+                                        />
+                                        {sessionTargets.length > 1 ? (
+                                          <button
+                                            type="button"
+                                            onClick={() => removeGoalTarget(selectedGoalId, targetIndex, sessionTargets)}
+                                            aria-label={`Remove target ${targetIndex + 1}`}
+                                            className="mt-1 shrink-0 rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-rose-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-rose-300"
+                                          >
+                                            <Trash2 className="h-4 w-4" />
+                                          </button>
+                                        ) : null}
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              </div>
                               {selectedGoal?.target_criteria?.trim() ? (
                                 <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
                                   Current plan target: {selectedGoal.target_criteria}
                                 </p>
                               ) : null}
+                              <input
+                                type="hidden"
+                                {...register(targetFieldKey)}
+                                defaultValue={existingMeasurementEntry?.data.target ?? ''}
+                              />
                               <input
                                 type="hidden"
                                 {...register(metricLabelFieldKey)}

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -409,6 +409,10 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
     fireEvent.change(screen.getByLabelText(/^target$/i), {
       target: { value: 'Match peer greeting in 4/5 trials' },
     });
+    fireEvent.click(screen.getByRole('button', { name: /add target/i }));
+    fireEvent.change(screen.getByLabelText(/^target 2$/i), {
+      target: { value: 'Wave to peer independently' },
+    });
     fireEvent.change(screen.getByLabelText(/count \(responses\)/i), {
       target: { value: '4' },
     });
@@ -442,6 +446,7 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
               opportunities: 5,
               prompt_level: 'Gestural',
               note: 'Needed one reminder at the start',
+              targets: ['Match peer greeting in 4/5 trials', 'Wave to peer independently'],
               target: 'Match peer greeting in 4/5 trials',
               trial_prompt_note: null,
             },
@@ -479,6 +484,7 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
                 opportunities: 5,
                 prompt_level: 'Gestural',
                 note: 'Existing measurement note',
+                targets: ['Existing target text', 'Second existing target'],
                 target: 'Existing target text',
               },
             },
@@ -498,6 +504,7 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
     expect(screen.getByDisplayValue('Gestural')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Existing measurement note')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Existing target text')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Second existing target')).toBeInTheDocument();
   });
 
   it('preserves an unlinked existing note without auto-attaching a session', async () => {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1665,6 +1665,10 @@ describe('SessionModal', () => {
     fireEvent.change(screen.getByLabelText(/^Target$/i), {
       target: { value: 'Match peer greeting in 4/5 trials' },
     });
+    await userEvent.click(screen.getByRole('button', { name: /add target/i }));
+    fireEvent.change(screen.getByLabelText(/^Target 2$/i), {
+      target: { value: 'Wave to peer independently' },
+    });
     for (let i = 0; i < 4; i += 1) {
       await userEvent.click(screen.getByRole('button', { name: /Increase correct trials/i }));
     }
@@ -1686,6 +1690,7 @@ describe('SessionModal', () => {
               metric_label: 'Count',
               metric_unit: 'responses',
               metric_value: 4,
+              targets: ['Match peer greeting in 4/5 trials', 'Wave to peer independently'],
               target: 'Match peer greeting in 4/5 trials',
               trial_prompt_note: 'Needed one reminder at the start',
             }),

--- a/src/components/__tests__/SessionNotesTab.test.tsx
+++ b/src/components/__tests__/SessionNotesTab.test.tsx
@@ -70,6 +70,7 @@ const noteWithGoalMeasurements: SessionNote = {
         opportunities: 5,
         prompt_level: 'Gestural',
         note: 'Needed one reminder at the start',
+        targets: ['Match peer greeting in 4/5 trials', 'Wave to peer independently'],
         target: 'Match peer greeting in 4/5 trials',
       },
     },
@@ -255,8 +256,10 @@ describe('SessionNotesTab — goal notes display', () => {
       expect(screen.getByText('5')).toBeInTheDocument();
       expect(screen.getByText('Prompt level')).toBeInTheDocument();
       expect(screen.getByText('Gestural')).toBeInTheDocument();
-      expect(screen.getByText('Target')).toBeInTheDocument();
+      expect(screen.getByText('Target 1')).toBeInTheDocument();
       expect(screen.getByText('Match peer greeting in 4/5 trials')).toBeInTheDocument();
+      expect(screen.getByText('Target 2')).toBeInTheDocument();
+      expect(screen.getByText('Wave to peer independently')).toBeInTheDocument();
       expect(screen.getByText('Measurement note')).toBeInTheDocument();
       expect(screen.getByText('Needed one reminder at the start')).toBeInTheDocument();
     });

--- a/src/lib/__tests__/goal-measurements.test.ts
+++ b/src/lib/__tests__/goal-measurements.test.ts
@@ -1,5 +1,6 @@
 import {
   buildGoalMeasurementEntry,
+  getGoalMeasurementTargets,
   getGoalMeasurementFieldMeta,
   mergeGoalMeasurementEntry,
   mergeUniqueGoalIds,
@@ -38,6 +39,7 @@ describe('goal-measurements helpers', () => {
         opportunities: 5,
         prompt_level: 'Gestural',
         note: 'Needed one reminder',
+        targets: ['Match peer greeting in 4/5 trials'],
         target: 'Match peer greeting in 4/5 trials',
         trial_prompt_note: null,
       },
@@ -61,6 +63,7 @@ describe('goal-measurements helpers', () => {
         opportunities: null,
         prompt_level: null,
         note: null,
+        targets: null,
         target: null,
         trial_prompt_note: null,
       },
@@ -75,6 +78,14 @@ describe('goal-measurements helpers', () => {
         { metric_value: null, opportunities: null, note: null, prompt_level: null },
       ),
     ).toBeNull();
+  });
+
+  it('prefers targets arrays and falls back to legacy target strings', () => {
+    expect(getGoalMeasurementTargets({ targets: [' First ', 'Second'], target: 'Legacy' } as any)).toEqual([
+      'First',
+      'Second',
+    ]);
+    expect(getGoalMeasurementTargets({ target: ' Legacy only ' } as any)).toEqual(['Legacy only']);
   });
 
   it('merges unique goal ids while trimming blanks', () => {

--- a/src/lib/__tests__/session-notes.test.ts
+++ b/src/lib/__tests__/session-notes.test.ts
@@ -112,14 +112,15 @@ describe('fetchClientSessionNotes', () => {
           metric_unit: null,
           metric_value: 4,
           incorrect_trials: null,
-        opportunities: 5,
-        prompt_level: 'Gestural',
-        note: 'Legacy payload still loads',
-        target: null,
-        trial_prompt_note: null,
+          opportunities: 5,
+          prompt_level: 'Gestural',
+          note: 'Legacy payload still loads',
+          targets: null,
+          target: null,
+          trial_prompt_note: null,
+        },
       },
-    },
-  });
+    });
   });
 
   it('retries without goal_measurements when select fails on missing column', async () => {

--- a/src/lib/goal-measurements.ts
+++ b/src/lib/goal-measurements.ts
@@ -1,4 +1,4 @@
-import type { Goal, SessionGoalMeasurementEntry } from '../types';
+import type { Goal, SessionGoalMeasurementData, SessionGoalMeasurementEntry } from '../types';
 
 export const GOAL_MEASUREMENT_VERSION = 1 as const;
 
@@ -31,6 +31,32 @@ const toOptionalString = (value: unknown): string | null => {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+};
+
+const normalizeStringList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => toOptionalString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+};
+
+export const getGoalMeasurementTargets = (
+  data: SessionGoalMeasurementData | null | undefined,
+): string[] => {
+  if (!data) {
+    return [];
+  }
+
+  const normalizedTargets = normalizeStringList(data.targets);
+  if (normalizedTargets.length > 0) {
+    return normalizedTargets;
+  }
+
+  const legacyTarget = toOptionalString(data.target);
+  return legacyTarget ? [legacyTarget] : [];
 };
 
 export const getGoalMeasurementFieldMeta = (goal: Goal | undefined): GoalMeasurementFieldMeta => {
@@ -103,7 +129,7 @@ export const hasMeaningfulGoalMeasurementEntry = (
     (data.opportunities !== null && data.opportunities !== undefined) ||
     (data.prompt_level?.trim().length ?? 0) > 0 ||
     (data.note?.trim().length ?? 0) > 0 ||
-    (data.target?.trim().length ?? 0) > 0 ||
+    getGoalMeasurementTargets(data).length > 0 ||
     (data.trial_prompt_note?.trim().length ?? 0) > 0
   );
 };
@@ -131,6 +157,12 @@ export const normalizeGoalMeasurementEntry = (
     options && 'fallbackMetricUnit' in options
       ? options.fallbackMetricUnit
       : fieldMeta.primaryUnit;
+  const normalizedTargets = normalizeStringList(sourceData.targets);
+  const fallbackLegacyTarget = toOptionalString(sourceData.target);
+  const resolvedTargets =
+    normalizedTargets.length > 0
+      ? normalizedTargets
+      : (fallbackLegacyTarget ? [fallbackLegacyTarget] : []);
   const normalizedEntry: SessionGoalMeasurementEntry = {
     version: GOAL_MEASUREMENT_VERSION,
     data: {
@@ -150,7 +182,8 @@ export const normalizeGoalMeasurementEntry = (
         sourceData.prompt_level ?? sourceData.promptLevel,
       ),
       note: toOptionalString(sourceData.note ?? sourceData.comment),
-      target: toOptionalString(sourceData.target),
+      targets: resolvedTargets.length > 0 ? resolvedTargets : null,
+      target: resolvedTargets[0] ?? null,
       trial_prompt_note: toOptionalString(
         sourceData.trial_prompt_note ?? sourceData.trialPromptNote,
       ),
@@ -166,6 +199,7 @@ export const buildGoalMeasurementEntry = (
 ): SessionGoalMeasurementEntry | null => {
   const fieldMeta = getGoalMeasurementFieldMeta(goal);
   const normalizedExisting = normalizeGoalMeasurementEntry(rawValue, goal);
+  const existingTargets = getGoalMeasurementTargets(normalizedExisting?.data);
   const nextEntry: SessionGoalMeasurementEntry = {
     version: GOAL_MEASUREMENT_VERSION,
     data: {
@@ -177,7 +211,8 @@ export const buildGoalMeasurementEntry = (
       opportunities: normalizedExisting?.data.opportunities ?? null,
       prompt_level: normalizedExisting?.data.prompt_level ?? null,
       note: normalizedExisting?.data.note ?? null,
-      target: normalizedExisting?.data.target ?? null,
+      targets: existingTargets.length > 0 ? existingTargets : null,
+      target: existingTargets[0] ?? null,
       trial_prompt_note: normalizedExisting?.data.trial_prompt_note ?? null,
     },
   };
@@ -192,6 +227,15 @@ export const mergeGoalMeasurementEntry = (
 ): SessionGoalMeasurementEntry | null => {
   const fieldMeta = getGoalMeasurementFieldMeta(goal);
   const existing = buildGoalMeasurementEntry(goal, rawValue);
+  const nextTargets = updates.targets !== undefined
+    ? normalizeStringList(updates.targets)
+    : getGoalMeasurementTargets(existing?.data);
+  const normalizedLegacyTarget = updates.target !== undefined
+    ? toOptionalString(updates.target)
+    : null;
+  const resolvedTargets = nextTargets.length > 0
+    ? nextTargets
+    : (normalizedLegacyTarget ? [normalizedLegacyTarget] : []);
   const nextEntry: SessionGoalMeasurementEntry = {
     version: GOAL_MEASUREMENT_VERSION,
     data: {
@@ -213,9 +257,8 @@ export const mergeGoalMeasurementEntry = (
       note: updates.note !== undefined
         ? updates.note ?? null
         : existing?.data.note ?? null,
-      target: updates.target !== undefined
-        ? updates.target ?? null
-        : existing?.data.target ?? null,
+      targets: resolvedTargets.length > 0 ? resolvedTargets : null,
+      target: resolvedTargets[0] ?? null,
       trial_prompt_note: updates.trial_prompt_note !== undefined
         ? updates.trial_prompt_note ?? null
         : existing?.data.trial_prompt_note ?? null,

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -149,6 +149,7 @@ describe("sessionNotesUpsertHandler", () => {
               opportunities: 5,
               prompt_level: null,
               note: "measured",
+              targets: ["Match peer greeting in 4/5 trials"],
               target: "Match peer greeting in 4/5 trials",
               trial_prompt_note: null,
             },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -335,6 +335,7 @@ export interface SessionGoalMeasurementData {
   opportunities?: number | null;
   prompt_level?: string | null;
   note?: string | null;
+  targets?: string[] | null;
   target?: string | null;
   /** Verbal / physical prompts and reactions for trial data (therapist capture). */
   trial_prompt_note?: string | null;


### PR DESCRIPTION
## Summary
- replace the single session target field with an ordered multi-target UI in SessionModal and AddSessionNoteModal
- persist normalized target arrays in goal_measurements.data.targets while keeping data.target synced to the first entry for backward compatibility
- render saved multi-target details in SessionNotesTab and extend focused normalization, UI, and upsert tests

## Verification
- npm test -- src/lib/__tests__/goal-measurements.test.ts
- npm test -- src/lib/__tests__/session-notes.test.ts
- npm test -- src/components/__tests__/AddSessionNoteModal.test.tsx
- npx vitest run src/components/__tests__/SessionModal.test.tsx -t "submits normalized per-goal measurements with session capture"
- npm test -- src/components/__tests__/SessionNotesTab.test.tsx
- npm test -- src/server/__tests__/sessionNotesUpsertHandler.test.ts
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run build

## Notes
- no migration is required; the new ordered values are stored in goal_measurements.data.targets
- legacy goal_measurements.data.target is still read and is kept in sync with the first target entry on save
- reviewer and Linear were not available in-tool for this run; no Linear issue is linked