### PR TITLE
WIN-174: guard lifecycle fallback and target indexing

### DIFF
--- a/docs/ai/2026-06-15-lifecycle-fallback-target-index-guard.md
+++ b/docs/ai/2026-06-15-lifecycle-fallback-target-index-guard.md
@@ -1,0 +1,20 @@
+# Lifecycle Fallback And Target Index Guard
+
+## Scope
+
+- Accept `409 ALREADY_TERMINAL` from the authenticated lifecycle fallback when the requested terminal state was already reached by the UI path.
+- Preserve blank target slots while editing and saving later indexed goal-measurement targets in `AddSessionNoteModal`.
+
+## Verification
+
+- `npm run test -- src/scripts/__tests__/playwrightSessionLifecycleFallback.test.ts src/components/__tests__/AddSessionNoteModal.test.tsx src/lib/__tests__/goal-measurements.test.ts`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run ci:check-focused`
+- `npm run build`
+- `npm run test:ci` -> failed outside this slice because untargeted `src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts` now requires `VITE_SUPABASE_URL` from process env or `.env.codex` in this worktree.
+
+## Residual Risk
+
+- The authenticated fallback now treats any `409` response carrying `code: "ALREADY_TERMINAL"` as success and relies on the existing post-close session-status assertion to reject mismatched terminal states.
+- Full `test:ci` remains blocked by baseline env setup unrelated to the touched files.

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -5,6 +5,7 @@ import { chromium, type BrowserContext, type Page } from "playwright";
 import { createClient } from "@supabase/supabase-js";
 import { buildLifecycleTargetPairs, type LifecycleTargetPair } from "../src/scripts/playwrightSessionLifecycleTargets";
 import { assertLifecycleSessionArtifacts } from "../src/scripts/playwrightSessionLifecycleArtifacts";
+import { isAlreadyTerminalLifecycleFallbackResponse } from "../src/scripts/playwrightSessionLifecycleFallback";
 import { buildLifecycleSessionNoteSeedPayload } from "../src/scripts/playwrightSessionLifecycleNoteSeed";
 
 import { loadPlaywrightEnv } from "./lib/load-playwright-env";
@@ -1101,6 +1102,9 @@ const completeSessionViaApiFallback = async ({
   });
   const bodyText = await response.text();
   if (!response.ok) {
+    if (isAlreadyTerminalLifecycleFallbackResponse(response.status, bodyText)) {
+      return;
+    }
     throw new Error(`sessions-complete fallback failed (${response.status}): ${bodyText.slice(0, 800)}`);
   }
 };

--- a/src/components/AddSessionNoteModal.tsx
+++ b/src/components/AddSessionNoteModal.tsx
@@ -353,23 +353,39 @@ export function AddSessionNoteModal({
     });
   };
 
+  const getEditableGoalTargets = (goal: Goal, rawMeasurementEntry: unknown): string[] => {
+    const rawTargets =
+      rawMeasurementEntry &&
+      typeof rawMeasurementEntry === 'object' &&
+      'data' in rawMeasurementEntry &&
+      rawMeasurementEntry.data &&
+      typeof rawMeasurementEntry.data === 'object' &&
+      'targets' in rawMeasurementEntry.data
+        ? rawMeasurementEntry.data.targets
+        : null;
+    if (Array.isArray(rawTargets) && rawTargets.length > 0) {
+      return rawTargets.map((target) => (typeof target === 'string' ? target : ''));
+    }
+
+    const measurementEntry = buildGoalMeasurementEntry(goal, rawMeasurementEntry);
+    const normalizedTargets = getGoalMeasurementTargets(measurementEntry?.data);
+    return normalizedTargets.length > 0 ? normalizedTargets : [''];
+  };
+
   const addGoalTarget = (goal: Goal) => {
-    const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
-    const currentTargets = getGoalMeasurementTargets(measurementEntry?.data);
+    const currentTargets = getEditableGoalTargets(goal, goalMeasurements[goal.id]);
     updateGoalTargets(goal, [...currentTargets, '']);
   };
 
   const changeGoalTarget = (goal: Goal, targetIndex: number, nextValue: string) => {
-    const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
-    const currentTargets = getGoalMeasurementTargets(measurementEntry?.data);
-    const nextTargets = (currentTargets.length > 0 ? currentTargets : ['']).slice();
+    const currentTargets = getEditableGoalTargets(goal, goalMeasurements[goal.id]);
+    const nextTargets = currentTargets.slice();
     nextTargets[targetIndex] = nextValue;
     updateGoalTargets(goal, nextTargets);
   };
 
   const removeGoalTarget = (goal: Goal, targetIndex: number) => {
-    const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
-    const currentTargets = getGoalMeasurementTargets(measurementEntry?.data);
+    const currentTargets = getEditableGoalTargets(goal, goalMeasurements[goal.id]);
     const nextTargets = currentTargets.filter((_, index) => index !== targetIndex);
     updateGoalTargets(goal, nextTargets.length > 0 ? nextTargets : ['']);
   };
@@ -609,14 +625,7 @@ export function AddSessionNoteModal({
                 const isSelected = selectedGoalIds.includes(goal.id);
                 const noteText = goalNotes[goal.id] ?? '';
                 const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
-                const sessionTargets = (() => {
-                  const rawTargets = goalMeasurements[goal.id]?.data.targets;
-                  if (Array.isArray(rawTargets) && rawTargets.length > 0) {
-                    return rawTargets.map((target) => (typeof target === 'string' ? target : ''));
-                  }
-                  const normalizedTargets = getGoalMeasurementTargets(measurementEntry?.data);
-                  return normalizedTargets.length > 0 ? normalizedTargets : [''];
-                })();
+                const sessionTargets = getEditableGoalTargets(goal, goalMeasurements[goal.id]);
                 const measurementFieldMeta = getGoalMeasurementFieldMeta(goal);
                 const remaining = MAX_GOAL_NOTE_LENGTH - noteText.length;
                 return (
@@ -827,14 +836,7 @@ export function AddSessionNoteModal({
               const isSelected = selectedGoalIds.includes(goal.id);
               const noteText = goalNotes[goal.id] ?? '';
               const measurementEntry = buildGoalMeasurementEntry(goal, goalMeasurements[goal.id]);
-              const sessionTargets = (() => {
-                const rawTargets = goalMeasurements[goal.id]?.data.targets;
-                if (Array.isArray(rawTargets) && rawTargets.length > 0) {
-                  return rawTargets.map((target) => (typeof target === 'string' ? target : ''));
-                }
-                const normalizedTargets = getGoalMeasurementTargets(measurementEntry?.data);
-                return normalizedTargets.length > 0 ? normalizedTargets : [''];
-              })();
+              const sessionTargets = getEditableGoalTargets(goal, goalMeasurements[goal.id]);
               const measurementFieldMeta = getGoalMeasurementFieldMeta(goal);
               const remaining = MAX_GOAL_NOTE_LENGTH - noteText.length;
               return (

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -507,6 +507,138 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
     expect(screen.getByDisplayValue('Second existing target')).toBeInTheDocument();
   });
 
+  it('preserves blank earlier target slots when editing a later target', async () => {
+    const onSubmit = vi.fn();
+
+    renderWithProviders(
+      <AddSessionNoteModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        therapists={[mockTherapist] as any}
+        selectedAuth="auth-1"
+        existingNote={{
+          id: 'note-target-edit',
+          date: '2026-03-31',
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+          service_code: '97153',
+          therapist_id: 'therapist-1',
+          therapist_name: 'Test Therapist',
+          goals_addressed: ['Default Goal'],
+          goal_ids: ['goal-1'],
+          goal_notes: { 'goal-1': 'Existing goal note' },
+          goal_measurements: {
+            'goal-1': {
+              version: 1,
+              data: {
+                measurement_type: 'frequency',
+                metric_label: 'Count',
+                metric_unit: 'responses',
+                metric_value: 4,
+                opportunities: 5,
+                prompt_level: 'Gestural',
+                note: 'Existing measurement note',
+                targets: ['First target', 'Second target'],
+                target: 'First target',
+              },
+            },
+          },
+          session_id: null,
+          narrative: 'Existing narrative',
+          is_locked: false,
+          client_id: 'client-1',
+          authorization_id: 'auth-1',
+        }}
+      />
+    );
+
+    fireEvent.change(await screen.findByLabelText(/^target$/i), {
+      target: { value: '' },
+    });
+    fireEvent.change(screen.getByLabelText(/^target 2$/i), {
+      target: { value: 'Updated second target' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save note/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        goal_measurements: {
+          'goal-1': expect.objectContaining({
+            data: expect.objectContaining({
+              targets: ['', 'Updated second target'],
+              target: 'Updated second target',
+            }),
+          }),
+        },
+      }));
+    });
+  });
+
+  it('preserves blank earlier target slots when removing a later target', async () => {
+    const onSubmit = vi.fn();
+
+    renderWithProviders(
+      <AddSessionNoteModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        therapists={[mockTherapist] as any}
+        selectedAuth="auth-1"
+        existingNote={{
+          id: 'note-target-remove',
+          date: '2026-03-31',
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+          service_code: '97153',
+          therapist_id: 'therapist-1',
+          therapist_name: 'Test Therapist',
+          goals_addressed: ['Default Goal'],
+          goal_ids: ['goal-1'],
+          goal_notes: { 'goal-1': 'Existing goal note' },
+          goal_measurements: {
+            'goal-1': {
+              version: 1,
+              data: {
+                measurement_type: 'frequency',
+                metric_label: 'Count',
+                metric_unit: 'responses',
+                metric_value: 4,
+                opportunities: 5,
+                prompt_level: 'Gestural',
+                note: 'Existing measurement note',
+                targets: ['First target', 'Second target'],
+                target: 'First target',
+              },
+            },
+          },
+          session_id: null,
+          narrative: 'Existing narrative',
+          is_locked: false,
+          client_id: 'client-1',
+          authorization_id: 'auth-1',
+        }}
+      />
+    );
+
+    fireEvent.change(await screen.findByLabelText(/^target$/i), {
+      target: { value: '' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /remove target 2/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save note/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        goal_measurements: {
+          'goal-1': expect.objectContaining({
+            data: expect.objectContaining({
+              targets: [''],
+              target: null,
+            }),
+          }),
+        },
+      }));
+    });
+  });
+
   it('preserves an unlinked existing note without auto-attaching a session', async () => {
     const onSubmit = vi.fn();
 

--- a/src/lib/goal-measurements.ts
+++ b/src/lib/goal-measurements.ts
@@ -43,6 +43,17 @@ const normalizeStringList = (value: unknown): string[] => {
     .filter((entry): entry is string => Boolean(entry));
 };
 
+const normalizeEditableStringList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map((entry) => (typeof entry === 'string' ? entry : ''));
+};
+
+const getPrimaryNonEmptyTarget = (targets: readonly string[]): string | null =>
+  targets.map((target) => toOptionalString(target)).find((target): target is string => Boolean(target)) ?? null;
+
 export const getGoalMeasurementTargets = (
   data: SessionGoalMeasurementData | null | undefined,
 ): string[] => {
@@ -199,7 +210,14 @@ export const buildGoalMeasurementEntry = (
 ): SessionGoalMeasurementEntry | null => {
   const fieldMeta = getGoalMeasurementFieldMeta(goal);
   const normalizedExisting = normalizeGoalMeasurementEntry(rawValue, goal);
-  const existingTargets = getGoalMeasurementTargets(normalizedExisting?.data);
+  const sourceData =
+    rawValue && typeof rawValue === 'object' && 'data' in rawValue && rawValue.data && typeof rawValue.data === 'object'
+      ? rawValue.data
+      : rawValue;
+  const editableTargets = normalizeEditableStringList(
+    sourceData && typeof sourceData === 'object' && 'targets' in sourceData ? sourceData.targets : undefined,
+  );
+  const existingTargets = editableTargets.length > 0 ? editableTargets : getGoalMeasurementTargets(normalizedExisting?.data);
   const nextEntry: SessionGoalMeasurementEntry = {
     version: GOAL_MEASUREMENT_VERSION,
     data: {
@@ -212,7 +230,7 @@ export const buildGoalMeasurementEntry = (
       prompt_level: normalizedExisting?.data.prompt_level ?? null,
       note: normalizedExisting?.data.note ?? null,
       targets: existingTargets.length > 0 ? existingTargets : null,
-      target: existingTargets[0] ?? null,
+      target: getPrimaryNonEmptyTarget(existingTargets),
       trial_prompt_note: normalizedExisting?.data.trial_prompt_note ?? null,
     },
   };
@@ -228,8 +246,8 @@ export const mergeGoalMeasurementEntry = (
   const fieldMeta = getGoalMeasurementFieldMeta(goal);
   const existing = buildGoalMeasurementEntry(goal, rawValue);
   const nextTargets = updates.targets !== undefined
-    ? normalizeStringList(updates.targets)
-    : getGoalMeasurementTargets(existing?.data);
+    ? normalizeEditableStringList(updates.targets)
+    : normalizeEditableStringList(existing?.data.targets) ;
   const normalizedLegacyTarget = updates.target !== undefined
     ? toOptionalString(updates.target)
     : null;
@@ -258,7 +276,7 @@ export const mergeGoalMeasurementEntry = (
         ? updates.note ?? null
         : existing?.data.note ?? null,
       targets: resolvedTargets.length > 0 ? resolvedTargets : null,
-      target: resolvedTargets[0] ?? null,
+      target: getPrimaryNonEmptyTarget(resolvedTargets),
       trial_prompt_note: updates.trial_prompt_note !== undefined
         ? updates.trial_prompt_note ?? null
         : existing?.data.trial_prompt_note ?? null,

--- a/src/scripts/__tests__/playwrightSessionLifecycleFallback.test.ts
+++ b/src/scripts/__tests__/playwrightSessionLifecycleFallback.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { isAlreadyTerminalLifecycleFallbackResponse } from "../playwrightSessionLifecycleFallback";
+
+describe("playwrightSessionLifecycleFallback", () => {
+  it("accepts already-terminal conflicts from the authenticated fallback API", () => {
+    expect(isAlreadyTerminalLifecycleFallbackResponse(
+      409,
+      JSON.stringify({
+        success: false,
+        error: "Session is already in a terminal state: completed",
+        code: "ALREADY_TERMINAL",
+      }),
+    )).toBe(true);
+  });
+
+  it("does not accept unrelated fallback failures", () => {
+    expect(isAlreadyTerminalLifecycleFallbackResponse(
+      409,
+      JSON.stringify({
+        success: false,
+        error: "Session notes are required",
+        code: "SESSION_NOTES_REQUIRED",
+      }),
+    )).toBe(false);
+    expect(isAlreadyTerminalLifecycleFallbackResponse(500, "{\"code\":\"ALREADY_TERMINAL\"}")).toBe(false);
+  });
+});

--- a/src/scripts/playwrightSessionLifecycleFallback.ts
+++ b/src/scripts/playwrightSessionLifecycleFallback.ts
@@ -1,0 +1,10 @@
+export const isAlreadyTerminalLifecycleFallbackResponse = (
+  responseStatus: number,
+  bodyText: string,
+): boolean => {
+  if (responseStatus !== 409) {
+    return false;
+  }
+
+  return /"code"\s*:\s*"ALREADY_TERMINAL"/i.test(bodyText);
+};


### PR DESCRIPTION
## Summary
- accept `409 ALREADY_TERMINAL` from the authenticated lifecycle smoke fallback when the UI already reached the requested terminal state
- preserve blank indexed `data.targets` slots while editing and saving later goal-measurement targets in `AddSessionNoteModal`
- add focused tests plus a markdown handoff for the standard-lane follow-up slice

## Why
Two regressions remained after the lifecycle smoke shape guard:
1. a missed Playwright `sessions-complete` response could trigger the fallback after the UI had already completed or no-showed the session, and the API would correctly return `ALREADY_TERMINAL`; the harness still failed that run
2. clearing an earlier goal target collapsed indexed target arrays before later edits/removals were applied, corrupting the target list order

## Verification
- `npm run test -- src/scripts/__tests__/playwrightSessionLifecycleFallback.test.ts src/components/__tests__/AddSessionNoteModal.test.tsx src/lib/__tests__/goal-measurements.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run ci:check-focused`
- `npm run build`

## Blocked / not clean locally
- `npm run test:ci` currently fails outside this slice because untargeted `src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts` now requires `VITE_SUPABASE_URL` in process env or `.env.codex` for this worktree
- reviewer/tester subagent tools were not callable in this session, so human review is still required in PR
