### PR TITLE
Add clinical parity expectations engine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,8 @@ PW_CLINICAL_QA_ROUTE=
 # Optional local redacted source/output fixtures for reviewer context.
 PW_CLINICAL_QA_SOURCE_FILE=fixtures/redacted-iehp-source.docx
 PW_CLINICAL_QA_OUTPUT_FILE=fixtures/redacted-iehp-output.pdf
+# Optional redacted JSON fixture with expected source terms to compare against the browser-visible output.
+PW_CLINICAL_QA_EXPECTATIONS_FILE=tests/fixtures/redacted-iehp-expectations.example.json
 
 # ---------------------------------------------------------------------------
 # Production health / verification script configuration

--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -32,8 +32,29 @@ Optional:
 - `PW_CLINICAL_QA_ROUTE`
 - `PW_CLINICAL_QA_SOURCE_FILE`
 - `PW_CLINICAL_QA_OUTPUT_FILE`
+- `PW_CLINICAL_QA_EXPECTATIONS_FILE`
 
 The runner rejects placeholder passwords, API routes, admin-only routes, and fixture paths that are not clearly redacted, synthetic, smoke, or test fixtures.
+
+## Expectations Fixture Contract
+
+`PW_CLINICAL_QA_EXPECTATIONS_FILE` points to a redacted, synthetic, smoke, or test JSON fixture. A safe example lives at `tests/fixtures/redacted-iehp-expectations.example.json`:
+
+```json
+{
+  "expectations": [
+    {
+      "key": "target_behaviors",
+      "label": "Target behaviors",
+      "expectedTerms": ["elopement", "property destruction"],
+      "severity": "high",
+      "humanReviewBlocker": true
+    }
+  ]
+}
+```
+
+The browser runner compares each `expectedTerms` entry against the visible browser text and emits `dataParityFindings` plus `humanReviewBlockers` in the JSON payload.
 
 ## Non-Goals
 
@@ -53,5 +74,5 @@ The runner rejects placeholder passwords, API routes, admin-only routes, and fix
 
 ## Residual Risk
 
-- Browser evidence proves access and visible surface checks only; source-to-output clinical parity still requires redacted fixture selection and human review of findings.
+- Browser evidence now supports source-to-output term parity when a redacted expectations JSON fixture is configured. It still requires fixture curation and human review of findings.
 - The agent can reduce reviewer workload but cannot replace BCBA sign-off.

--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -1,10 +1,13 @@
 import path from "node:path";
+import { readFile } from "node:fs/promises";
 import { chromium } from "playwright";
 
 import {
   assertRedactedQaFixture,
   buildClinicalQaRoute,
+  evaluateClinicalDataParity,
   evaluateClinicalQaChecklist,
+  parseClinicalQaExpectations,
   requireClinicalQaClientId,
   selectClinicalQaCredentials,
 } from "./lib/clinical-data-parity-agent";
@@ -45,6 +48,13 @@ const run = async (): Promise<void> => {
     process.env.PW_CLINICAL_QA_OUTPUT_FILE,
     "PW_CLINICAL_QA_OUTPUT_FILE",
   );
+  const expectationsFixture = assertRedactedQaFixture(
+    process.env.PW_CLINICAL_QA_EXPECTATIONS_FILE,
+    "PW_CLINICAL_QA_EXPECTATIONS_FILE",
+  );
+  const expectations = expectationsFixture
+    ? parseClinicalQaExpectations(await readFile(expectationsFixture, "utf8"), expectationsFixture)
+    : [];
 
   const browser = await chromium.launch({ headless: process.env.HEADLESS !== "false" });
   const context = await browser.newContext();
@@ -57,6 +67,7 @@ const run = async (): Promise<void> => {
 
     const pageText = await page.locator("body").innerText({ timeout: 10_000 });
     const checklist = evaluateClinicalQaChecklist(pageText);
+    const dataParityFindings = evaluateClinicalDataParity(pageText, expectations);
     const screenshotPath = path.join(latestDir, `clinical-data-parity-agent-${Date.now()}.png`);
     await page.screenshot({ path: screenshotPath, fullPage: true });
 
@@ -69,8 +80,13 @@ const run = async (): Promise<void> => {
       fixtures: {
         sourceConfigured: Boolean(sourceFixture),
         outputConfigured: Boolean(outputFixture),
+        expectationsConfigured: Boolean(expectationsFixture),
       },
       checklist,
+      dataParityFindings,
+      humanReviewBlockers: dataParityFindings.filter(
+        (finding) => finding.status === "fail" && finding.humanReviewBlocker,
+      ),
       screenshot: screenshotPath,
       disclaimer: "QA evidence only. This is not BCBA approval or clinical sign-off.",
     };

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -23,6 +23,22 @@ export type ClinicalQaChecklistResult = {
   missingTerms: string[];
 };
 
+export type ClinicalQaParitySeverity = "low" | "medium" | "high";
+
+export type ClinicalQaParityExpectation = {
+  key: string;
+  label: string;
+  expectedTerms: string[];
+  severity: ClinicalQaParitySeverity;
+  humanReviewBlocker: boolean;
+};
+
+export type ClinicalQaParityFinding = ClinicalQaParityExpectation & {
+  status: "pass" | "fail";
+  matchedTerms: string[];
+  missingTerms: string[];
+};
+
 const REDACTED_PASSWORD_PLACEHOLDER = "****";
 
 export const DEFAULT_CLINICAL_QA_ROUTE = "/";
@@ -119,6 +135,72 @@ export const evaluateClinicalQaChecklist = (
       key: item.key,
       label: item.label,
       status: missingTerms.length === 0 ? "pass" : "fail",
+      missingTerms,
+    };
+  });
+};
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string" && item.trim().length > 0);
+
+const normalizeSeverity = (value: unknown): ClinicalQaParitySeverity => {
+  if (value === "low" || value === "medium" || value === "high") {
+    return value;
+  }
+  return "medium";
+};
+
+export const parseClinicalQaExpectations = (
+  rawJson: string,
+  fixturePath: string,
+): ClinicalQaParityExpectation[] => {
+  assertRedactedQaFixture(fixturePath, "PW_CLINICAL_QA_EXPECTATIONS_FILE");
+
+  const parsed = JSON.parse(rawJson) as { expectations?: unknown };
+  if (!Array.isArray(parsed.expectations)) {
+    throw new Error("Clinical QA expectations fixture must contain an expectations array.");
+  }
+
+  return parsed.expectations.map((entry, index) => {
+    if (!entry || typeof entry !== "object") {
+      throw new Error(`Clinical QA expectation at index ${index} must be an object.`);
+    }
+    const expectation = entry as Record<string, unknown>;
+    const key = typeof expectation.key === "string" ? expectation.key.trim() : "";
+    const label = typeof expectation.label === "string" ? expectation.label.trim() : "";
+    if (!key || !label || !isStringArray(expectation.expectedTerms)) {
+      throw new Error(
+        `Clinical QA expectation at index ${index} requires key, label, and non-empty expectedTerms.`,
+      );
+    }
+
+    return {
+      key,
+      label,
+      expectedTerms: expectation.expectedTerms.map((term) => term.trim()),
+      severity: normalizeSeverity(expectation.severity),
+      humanReviewBlocker: expectation.humanReviewBlocker === true,
+    };
+  });
+};
+
+export const evaluateClinicalDataParity = (
+  pageText: string,
+  expectations: ClinicalQaParityExpectation[],
+): ClinicalQaParityFinding[] => {
+  const normalizedText = pageText.toLowerCase();
+  return expectations.map((expectation) => {
+    const matchedTerms = expectation.expectedTerms.filter((term) =>
+      normalizedText.includes(term.toLowerCase()),
+    );
+    const missingTerms = expectation.expectedTerms.filter(
+      (term) => !normalizedText.includes(term.toLowerCase()),
+    );
+
+    return {
+      ...expectation,
+      status: missingTerms.length === 0 ? "pass" : "fail",
+      matchedTerms,
       missingTerms,
     };
   });

--- a/tests/fixtures/redacted-iehp-expectations.example.json
+++ b/tests/fixtures/redacted-iehp-expectations.example.json
@@ -1,0 +1,25 @@
+{
+  "expectations": [
+    {
+      "key": "target_behaviors",
+      "label": "Target behaviors",
+      "expectedTerms": ["elopement", "property destruction"],
+      "severity": "high",
+      "humanReviewBlocker": true
+    },
+    {
+      "key": "replacement_behavior",
+      "label": "Replacement behavior",
+      "expectedTerms": ["functional communication"],
+      "severity": "medium",
+      "humanReviewBlocker": false
+    },
+    {
+      "key": "program_goal_measurement",
+      "label": "Program goal measurement",
+      "expectedTerms": ["baseline", "mastery", "maintenance", "generalization"],
+      "severity": "medium",
+      "humanReviewBlocker": false
+    }
+  ]
+}

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -5,6 +5,8 @@ import {
   assertRedactedQaFixture,
   buildClinicalQaRoute,
   evaluateClinicalQaChecklist,
+  evaluateClinicalDataParity,
+  parseClinicalQaExpectations,
   requireClinicalQaClientId,
   selectClinicalQaCredentials,
 } from "../../scripts/lib/clinical-data-parity-agent";
@@ -90,5 +92,55 @@ describe("clinical data parity agent helpers", () => {
 
     expect(results.every((result) => result.status === "pass")).toBe(true);
     expect(evaluateClinicalQaChecklist("Dashboard only").filter((result) => result.status === "fail")).toHaveLength(3);
+  });
+
+  it("parses redacted parity expectations and flags missing clinically important terms", () => {
+    const expectations = parseClinicalQaExpectations(
+      JSON.stringify({
+        expectations: [
+          {
+            key: "target_behaviors",
+            label: "Target behaviors",
+            expectedTerms: ["elopement", "property destruction"],
+            severity: "high",
+            humanReviewBlocker: true,
+          },
+          {
+            key: "replacement_behavior",
+            label: "Replacement behavior",
+            expectedTerms: ["functional communication"],
+          },
+        ],
+      }),
+      "fixtures/redacted-iehp-expectations.json",
+    );
+
+    const findings = evaluateClinicalDataParity(
+      "Programs and goals include elopement and functional communication.",
+      expectations,
+    );
+
+    expect(findings).toEqual([
+      {
+        key: "target_behaviors",
+        label: "Target behaviors",
+        status: "fail",
+        severity: "high",
+        expectedTerms: ["elopement", "property destruction"],
+        matchedTerms: ["elopement"],
+        missingTerms: ["property destruction"],
+        humanReviewBlocker: true,
+      },
+      {
+        key: "replacement_behavior",
+        label: "Replacement behavior",
+        status: "pass",
+        severity: "medium",
+        expectedTerms: ["functional communication"],
+        matchedTerms: ["functional communication"],
+        missingTerms: [],
+        humanReviewBlocker: false,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a redacted clinical QA expectations JSON contract for source-to-browser-output parity checks.
- Wires the clinical data parity browser runner to emit `dataParityFindings` and `humanReviewBlockers` from configured expectations.
- Adds focused parser/evaluator tests, a safe example expectations fixture, and updates the handoff/env documentation.

## Route Task
- classification: low-risk autonomous
- lane: standard
- triggering paths: `scripts/clinical-data-parity-agent.ts`, `scripts/lib/clinical-data-parity-agent.ts`, `tests/scripts/clinical-data-parity-agent.test.ts`, `tests/fixtures/**`, `.env.example`, `docs/ai/**`
- protected paths touched: none

## Verification Card
- classification: low-risk autonomous
- lane: standard
- change type: QA tooling, script helper, docs/env example, test fixture
- required checks: `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`, `npm run ci:check-focused`, `npm run typecheck`, `npm run lint`, `npm run build`, `npm run test:ci`, browser runner smoke when credentials are configured
- executed checks:
  - `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`: pass, 9 tests
  - `npm run ci:check-focused`: pass, DB/env-backed checks skipped where local secrets are absent
  - `npm run typecheck`: pass
  - `npm run lint`: pass
  - `npm run build`: pass
  - `npm run test:ci`: pass, 317 files / 1874 tests
  - `$env:PW_CLINICAL_QA_EXPECTATIONS_FILE='tests/fixtures/redacted-iehp-expectations.example.json'; npm run playwright:clinical-data-parity-agent`: pass, emitted `dataParityFindings` and `humanReviewBlockers`
- blocked checks: reviewer subagent not run because the active tool policy only permits subagent spawning when explicitly requested by the user
- result: pass-with-blocked-checks
- residual risk: The engine checks expected terms against visible browser text only. It still requires curated redacted expectations and human review; it is not clinical sign-off.

## PR Hygiene
- pr-ready: no under strict repo policy because reviewer is blocked by tool-use policy; otherwise branch is isolated, single-purpose, and verified.
- linear-ready: not linked; this is non-critical QA tooling and no Linear issue was provided.
- protected-path drift: none.