### PR TITLE
Add section evidence to clinical parity findings

### DIFF
--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -46,7 +46,9 @@ The runner rejects placeholder passwords, API routes, admin-only routes, and fix
     {
       "key": "target_behaviors",
       "label": "Target behaviors",
+      "sourceSection": "FBA target behavior summary",
       "expectedTerms": ["elopement", "property destruction"],
+      "observedSectionTerms": ["Programs", "Goals"],
       "severity": "high",
       "humanReviewBlocker": true
     }
@@ -54,7 +56,12 @@ The runner rejects placeholder passwords, API routes, admin-only routes, and fix
 }
 ```
 
-The browser runner compares each `expectedTerms` entry against the visible browser text and emits `dataParityFindings` plus `humanReviewBlockers` in the JSON payload.
+The browser runner compares each `expectedTerms` entry against the visible browser text and emits `dataParityFindings` plus `humanReviewBlockers` in the JSON payload. Findings include:
+
+- `sourceSection`: the redacted source section the expectation came from, or `null`.
+- `observedSectionTerms`: visible UI terms expected near the reviewed surface.
+- `mismatchType`: `match`, `partial`, or `missing`.
+- `observedTextSnippet`: a compact browser-text excerpt around matched evidence when available.
 
 ## Non-Goals
 

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -28,15 +28,21 @@ export type ClinicalQaParitySeverity = "low" | "medium" | "high";
 export type ClinicalQaParityExpectation = {
   key: string;
   label: string;
+  sourceSection: string | null;
   expectedTerms: string[];
+  observedSectionTerms: string[];
   severity: ClinicalQaParitySeverity;
   humanReviewBlocker: boolean;
 };
 
 export type ClinicalQaParityFinding = ClinicalQaParityExpectation & {
   status: "pass" | "fail";
+  mismatchType: "match" | "partial" | "missing";
   matchedTerms: string[];
   missingTerms: string[];
+  observedSectionMatchedTerms: string[];
+  observedSectionMissingTerms: string[];
+  observedTextSnippet: string | null;
 };
 
 const REDACTED_PASSWORD_PLACEHOLDER = "****";
@@ -150,6 +156,63 @@ const normalizeSeverity = (value: unknown): ClinicalQaParitySeverity => {
   return "medium";
 };
 
+const normalizeOptionalString = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const normalizeOptionalStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+};
+
+const sanitizeEvidenceText = (value: string): string =>
+  value.replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, "[redacted-email]");
+
+const buildObservedTextSnippet = (pageText: string, matchedTerms: string[]): string | null => {
+  const compactText = sanitizeEvidenceText(pageText.replace(/\s+/g, " ").trim());
+  if (!compactText) {
+    return null;
+  }
+  if (matchedTerms.length === 0) {
+    return compactText.slice(0, 240);
+  }
+
+  const normalizedText = compactText.toLowerCase();
+  const firstMatchIndex = matchedTerms
+    .map((term) => normalizedText.indexOf(term.toLowerCase()))
+    .filter((index) => index >= 0)
+    .sort((left, right) => left - right)[0];
+
+  if (firstMatchIndex === undefined) {
+    return compactText.slice(0, 240);
+  }
+
+  const start = Math.max(0, firstMatchIndex - 80);
+  return compactText.slice(start, start + 240);
+};
+
+const classifyMismatch = (
+  expectedTermCount: number,
+  missingTermCount: number,
+): ClinicalQaParityFinding["mismatchType"] => {
+  if (missingTermCount === 0) {
+    return "match";
+  }
+  if (missingTermCount === expectedTermCount) {
+    return "missing";
+  }
+  return "partial";
+};
+
 export const parseClinicalQaExpectations = (
   rawJson: string,
   fixturePath: string,
@@ -177,7 +240,9 @@ export const parseClinicalQaExpectations = (
     return {
       key,
       label,
+      sourceSection: normalizeOptionalString(expectation.sourceSection),
       expectedTerms: expectation.expectedTerms.map((term) => term.trim()),
+      observedSectionTerms: normalizeOptionalStringArray(expectation.observedSectionTerms),
       severity: normalizeSeverity(expectation.severity),
       humanReviewBlocker: expectation.humanReviewBlocker === true,
     };
@@ -196,12 +261,22 @@ export const evaluateClinicalDataParity = (
     const missingTerms = expectation.expectedTerms.filter(
       (term) => !normalizedText.includes(term.toLowerCase()),
     );
+    const observedSectionMatchedTerms = expectation.observedSectionTerms.filter((term) =>
+      normalizedText.includes(term.toLowerCase()),
+    );
+    const observedSectionMissingTerms = expectation.observedSectionTerms.filter(
+      (term) => !normalizedText.includes(term.toLowerCase()),
+    );
 
     return {
       ...expectation,
       status: missingTerms.length === 0 ? "pass" : "fail",
+      mismatchType: classifyMismatch(expectation.expectedTerms.length, missingTerms.length),
       matchedTerms,
       missingTerms,
+      observedSectionMatchedTerms,
+      observedSectionMissingTerms,
+      observedTextSnippet: buildObservedTextSnippet(pageText, [...matchedTerms, ...observedSectionMatchedTerms]),
     };
   });
 };

--- a/tests/fixtures/redacted-iehp-expectations.example.json
+++ b/tests/fixtures/redacted-iehp-expectations.example.json
@@ -3,21 +3,27 @@
     {
       "key": "target_behaviors",
       "label": "Target behaviors",
+      "sourceSection": "FBA target behavior summary",
       "expectedTerms": ["elopement", "property destruction"],
+      "observedSectionTerms": ["Programs", "Goals"],
       "severity": "high",
       "humanReviewBlocker": true
     },
     {
       "key": "replacement_behavior",
       "label": "Replacement behavior",
+      "sourceSection": "Replacement behavior plan",
       "expectedTerms": ["functional communication"],
+      "observedSectionTerms": ["Programs", "Goals"],
       "severity": "medium",
       "humanReviewBlocker": false
     },
     {
       "key": "program_goal_measurement",
       "label": "Program goal measurement",
+      "sourceSection": "Goals and measurement criteria",
       "expectedTerms": ["baseline", "mastery", "maintenance", "generalization"],
+      "observedSectionTerms": ["Programs", "Goals"],
       "severity": "medium",
       "humanReviewBlocker": false
     }

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -101,7 +101,9 @@ describe("clinical data parity agent helpers", () => {
           {
             key: "target_behaviors",
             label: "Target behaviors",
+            sourceSection: "Behavioral Observations",
             expectedTerms: ["elopement", "property destruction"],
+            observedSectionTerms: ["Programs and Goals"],
             severity: "high",
             humanReviewBlocker: true,
           },
@@ -116,7 +118,7 @@ describe("clinical data parity agent helpers", () => {
     );
 
     const findings = evaluateClinicalDataParity(
-      "Programs and goals include elopement and functional communication.",
+      "Programs and goals include elopement and functional communication. Logged in as qa@example.com.",
       expectations,
     );
 
@@ -125,20 +127,34 @@ describe("clinical data parity agent helpers", () => {
         key: "target_behaviors",
         label: "Target behaviors",
         status: "fail",
+        mismatchType: "partial",
+        sourceSection: "Behavioral Observations",
         severity: "high",
         expectedTerms: ["elopement", "property destruction"],
         matchedTerms: ["elopement"],
         missingTerms: ["property destruction"],
+        observedSectionTerms: ["Programs and Goals"],
+        observedSectionMatchedTerms: ["Programs and Goals"],
+        observedSectionMissingTerms: [],
+        observedTextSnippet:
+          "Programs and goals include elopement and functional communication. Logged in as [redacted-email].",
         humanReviewBlocker: true,
       },
       {
         key: "replacement_behavior",
         label: "Replacement behavior",
         status: "pass",
+        mismatchType: "match",
+        sourceSection: null,
         severity: "medium",
         expectedTerms: ["functional communication"],
         matchedTerms: ["functional communication"],
         missingTerms: [],
+        observedSectionTerms: [],
+        observedSectionMatchedTerms: [],
+        observedSectionMissingTerms: [],
+        observedTextSnippet:
+          "Programs and goals include elopement and functional communication. Logged in as [redacted-email].",
         humanReviewBlocker: false,
       },
     ]);


### PR DESCRIPTION
## Summary
- Adds section-aware evidence metadata to clinical parity expectations and findings.
- Classifies findings as `match`, `partial`, or `missing` and reports observed UI section term coverage.
- Sanitizes observed evidence snippets so browser-visible emails are redacted before JSON output.

## Route Task
- classification: low-risk autonomous
- lane: standard
- triggering paths: `scripts/lib/clinical-data-parity-agent.ts`, `tests/scripts/clinical-data-parity-agent.test.ts`, `tests/fixtures/**`, `docs/ai/**`
- protected paths touched: none

## Verification Card
- classification: low-risk autonomous
- lane: standard
- change type: QA tooling, script helper, docs, test fixture
- required checks: `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`, `npm run ci:check-focused`, `npm run typecheck`, `npm run lint`, `npm run build`, `npm run test:ci`, browser runner smoke when credentials are configured
- executed checks:
  - `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`: pass, 9 tests
  - `npm run ci:check-focused`: pass, DB/env-backed checks skipped where local secrets are absent
  - `npm run typecheck`: pass
  - `npm run lint`: pass
  - `npm run build`: pass
  - `npm run test:ci`: pass, 317 files / 1874 tests
  - `$env:PW_CLINICAL_QA_EXPECTATIONS_FILE='tests/fixtures/redacted-iehp-expectations.example.json'; npm run playwright:clinical-data-parity-agent`: pass, emitted section-aware findings and redacted observed snippets
- blocked checks: reviewer subagent not run because the active tool policy only permits subagent spawning when explicitly requested by the user
- result: pass-with-blocked-checks
- residual risk: The agent still evaluates redacted expectation terms against browser-visible text. It does not parse DOCX/PDF source files directly or provide clinical sign-off.

## PR Hygiene
- pr-ready: no under strict repo policy because reviewer is blocked by tool-use policy; otherwise branch is isolated, single-purpose, and verified.
- linear-ready: not linked; this is non-critical QA tooling and no Linear issue was provided.
- protected-path drift: none.