### PR TITLE
Write clinical parity report artifacts

### DIFF
--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -63,6 +63,16 @@ The browser runner compares each `expectedTerms` entry against the visible brows
 - `mismatchType`: `match`, `partial`, or `missing`.
 - `observedTextSnippet`: a compact browser-text excerpt around matched evidence when available.
 
+## Report Artifacts
+
+Each successful run writes durable artifacts under `artifacts/latest`:
+
+- screenshot: `clinical-data-parity-agent-<timestamp>.png`
+- JSON report: `clinical-data-parity-agent-<timestamp>.json`
+- markdown report: `clinical-data-parity-agent-<timestamp>.md`
+
+The JSON report matches the stdout payload. The markdown report is intended for reviewer handoff and redacts browser-visible email addresses from observed snippets.
+
 ## Non-Goals
 
 - No production account access.

--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -1,9 +1,10 @@
 import path from "node:path";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { chromium } from "playwright";
 
 import {
   assertRedactedQaFixture,
+  buildClinicalQaReportMarkdown,
   buildClinicalQaRoute,
   evaluateClinicalDataParity,
   evaluateClinicalQaChecklist,
@@ -68,8 +69,13 @@ const run = async (): Promise<void> => {
     const pageText = await page.locator("body").innerText({ timeout: 10_000 });
     const checklist = evaluateClinicalQaChecklist(pageText);
     const dataParityFindings = evaluateClinicalDataParity(pageText, expectations);
-    const screenshotPath = path.join(latestDir, `clinical-data-parity-agent-${Date.now()}.png`);
+    const runId = Date.now();
+    const screenshotPath = path.join(latestDir, `clinical-data-parity-agent-${runId}.png`);
     await page.screenshot({ path: screenshotPath, fullPage: true });
+    const reportJsonPath = path.join(latestDir, `clinical-data-parity-agent-${runId}.json`);
+    const reportMarkdownPath = path.join(latestDir, `clinical-data-parity-agent-${runId}.md`);
+    const generatedAt = new Date().toISOString();
+    const disclaimer = "QA evidence only. This is not BCBA approval or clinical sign-off.";
 
     const payload = {
       ok: true,
@@ -88,8 +94,24 @@ const run = async (): Promise<void> => {
         (finding) => finding.status === "fail" && finding.humanReviewBlocker,
       ),
       screenshot: screenshotPath,
-      disclaimer: "QA evidence only. This is not BCBA approval or clinical sign-off.",
+      reportJson: reportJsonPath,
+      reportMarkdown: reportMarkdownPath,
+      generatedAt,
+      disclaimer,
     };
+    const markdown = buildClinicalQaReportMarkdown({
+      generatedAt,
+      baseUrl,
+      routePath,
+      credentialLabel: credentials.label,
+      screenshotPath,
+      checklist,
+      dataParityFindings,
+      disclaimer,
+    });
+
+    await writeFile(reportJsonPath, JSON.stringify(payload, null, 2));
+    await writeFile(reportMarkdownPath, markdown);
 
     console.log(JSON.stringify(payload, null, 2));
   } catch (error) {

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -45,6 +45,17 @@ export type ClinicalQaParityFinding = ClinicalQaParityExpectation & {
   observedTextSnippet: string | null;
 };
 
+export type ClinicalQaReportInput = {
+  generatedAt: string;
+  baseUrl: string;
+  routePath: string;
+  credentialLabel: string;
+  screenshotPath: string;
+  checklist: ClinicalQaChecklistResult[];
+  dataParityFindings: ClinicalQaParityFinding[];
+  disclaimer: string;
+};
+
 const REDACTED_PASSWORD_PLACEHOLDER = "****";
 
 export const DEFAULT_CLINICAL_QA_ROUTE = "/";
@@ -279,4 +290,52 @@ export const evaluateClinicalDataParity = (
       observedTextSnippet: buildObservedTextSnippet(pageText, [...matchedTerms, ...observedSectionMatchedTerms]),
     };
   });
+};
+
+const formatTermList = (terms: string[]): string => (terms.length > 0 ? terms.join(", ") : "none");
+
+export const buildClinicalQaReportMarkdown = (report: ClinicalQaReportInput): string => {
+  const blockerCount = report.dataParityFindings.filter(
+    (finding) => finding.status === "fail" && finding.humanReviewBlocker,
+  ).length;
+  const checklistLines = report.checklist.map(
+    (item) => `- ${item.status.toUpperCase()} ${item.label}: missing ${formatTermList(item.missingTerms)}`,
+  );
+  const findingLines = report.dataParityFindings.map((finding) => {
+    const sourceSection = finding.sourceSection ?? "unspecified";
+    const snippet = finding.observedTextSnippet ? sanitizeEvidenceText(finding.observedTextSnippet) : "none";
+    return [
+      `- ${finding.status.toUpperCase()} ${finding.label}`,
+      `  - source section: ${sourceSection}`,
+      `  - mismatch type: ${finding.mismatchType}`,
+      `  - severity: ${finding.severity}`,
+      `  - expected: ${formatTermList(finding.expectedTerms)}`,
+      `  - matched: ${formatTermList(finding.matchedTerms)}`,
+      `  - missing: ${formatTermList(finding.missingTerms)}`,
+      `  - observed section missing: ${formatTermList(finding.observedSectionMissingTerms)}`,
+      `  - human review blocker: ${finding.humanReviewBlocker ? "yes" : "no"}`,
+      `  - observed snippet: ${snippet}`,
+    ].join("\n");
+  });
+
+  return [
+    "# Clinical Data Parity Agent Report",
+    "",
+    `generated at: ${report.generatedAt}`,
+    `target route: \`${report.routePath}\``,
+    `base URL: \`${report.baseUrl}\``,
+    `credential label: \`${report.credentialLabel}\``,
+    `screenshot: \`${report.screenshotPath}\``,
+    `human review blockers: ${blockerCount}`,
+    "",
+    "## Checklist",
+    ...(checklistLines.length > 0 ? checklistLines : ["- none"]),
+    "",
+    "## Data Parity Findings",
+    ...(findingLines.length > 0 ? findingLines : ["- none"]),
+    "",
+    "## Disclaimer",
+    report.disclaimer,
+    "",
+  ].join("\n");
 };

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -4,6 +4,7 @@ import {
   assertBrowserOnlyTarget,
   assertRedactedQaFixture,
   buildClinicalQaRoute,
+  buildClinicalQaReportMarkdown,
   evaluateClinicalQaChecklist,
   evaluateClinicalDataParity,
   parseClinicalQaExpectations,
@@ -158,5 +159,51 @@ describe("clinical data parity agent helpers", () => {
         humanReviewBlocker: false,
       },
     ]);
+  });
+
+  it("builds a durable markdown report without leaking browser-visible emails", () => {
+    const markdown = buildClinicalQaReportMarkdown({
+      generatedAt: "2026-06-15T17:30:00.000Z",
+      baseUrl: "https://app.example.test",
+      routePath: "/clients/test-client?tab=programs-goals",
+      credentialLabel: "PW_CLINICAL_QA_EMAIL + PW_CLINICAL_QA_PASSWORD",
+      screenshotPath: "artifacts/latest/clinical-data-parity-agent-test.png",
+      checklist: [
+        {
+          key: "program_goal_surface",
+          label: "Programs/goals review surface is visible",
+          status: "pass",
+          missingTerms: [],
+        },
+      ],
+      dataParityFindings: [
+        {
+          key: "target_behaviors",
+          label: "Target behaviors",
+          sourceSection: "Behavioral Observations",
+          expectedTerms: ["elopement", "property destruction"],
+          observedSectionTerms: ["Programs and Goals"],
+          severity: "high",
+          humanReviewBlocker: true,
+          status: "fail",
+          mismatchType: "partial",
+          matchedTerms: ["elopement"],
+          missingTerms: ["property destruction"],
+          observedSectionMatchedTerms: ["Programs and Goals"],
+          observedSectionMissingTerms: [],
+          observedTextSnippet: "Observed by qa@example.com near Programs and Goals.",
+        },
+      ],
+      disclaimer: "QA evidence only. This is not BCBA approval or clinical sign-off.",
+    });
+
+    expect(markdown).toContain("# Clinical Data Parity Agent Report");
+    expect(markdown).toContain("target route: `/clients/test-client?tab=programs-goals`");
+    expect(markdown).toContain("screenshot: `artifacts/latest/clinical-data-parity-agent-test.png`");
+    expect(markdown).toContain("Target behaviors");
+    expect(markdown).toContain("missing: property destruction");
+    expect(markdown).toContain("human review blocker: yes");
+    expect(markdown).toContain("[redacted-email]");
+    expect(markdown).not.toContain("qa@example.com");
   });
 });


### PR DESCRIPTION
## Summary
- Writes durable JSON and markdown reports for successful clinical data parity agent runs.
- Adds a report markdown builder with email redaction for observed snippets.
- Documents the screenshot, JSON, and markdown artifacts under `artifacts/latest`.

## Route Task
- classification: low-risk autonomous
- lane: standard
- triggering paths: `scripts/clinical-data-parity-agent.ts`, `scripts/lib/clinical-data-parity-agent.ts`, `tests/scripts/clinical-data-parity-agent.test.ts`, `docs/ai/**`
- protected paths touched: none

## Verification Card
- classification: low-risk autonomous
- lane: standard
- change type: QA tooling, script helper, docs
- required checks: `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`, `npm run ci:check-focused`, `npm run typecheck`, `npm run lint`, `npm run build`, `npm run test:ci`, browser runner smoke when credentials are configured, artifact existence/redaction check
- executed checks:
  - `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`: pass, 10 tests
  - `npm run typecheck`: pass
  - `npm run lint`: pass
  - `npm run ci:check-focused`: pass, DB/env-backed checks skipped where local secrets are absent
  - `npm run build`: pass
  - `npm run test:ci`: pass, 317 files / 1875 tests
  - `$env:PW_CLINICAL_QA_EXPECTATIONS_FILE='tests/fixtures/redacted-iehp-expectations.example.json'; npm run playwright:clinical-data-parity-agent`: pass, emitted screenshot/reportJson/reportMarkdown paths
  - artifact check: pass, JSON and markdown files existed and markdown contained no raw email address
- blocked checks: reviewer subagent not run because the active tool policy only permits subagent spawning when explicitly requested by the user
- result: pass-with-blocked-checks
- residual risk: Reports summarize browser-visible parity evidence only. They still depend on curated redacted expectations and are not clinical sign-off.

## PR Hygiene
- pr-ready: no under strict repo policy because reviewer is blocked by tool-use policy; otherwise branch is isolated, single-purpose, and verified.
- linear-ready: not linked; this is non-critical QA tooling and no Linear issue was provided.
- protected-path drift: none.