### PR TITLE
Derive clinical QA expectations from source text

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,9 +119,11 @@ PW_CLINICAL_QA_CLIENT_ID=
 # Optional explicit app route. Must start with "/" and cannot be /api or admin-only.
 PW_CLINICAL_QA_ROUTE=
 # Optional local redacted source/output fixtures for reviewer context.
-PW_CLINICAL_QA_SOURCE_FILE=fixtures/redacted-iehp-source.docx
+# Source-derived expectations currently support .txt or .md fixtures.
+PW_CLINICAL_QA_SOURCE_FILE=tests/fixtures/redacted-iehp-source.example.txt
 PW_CLINICAL_QA_OUTPUT_FILE=fixtures/redacted-iehp-output.pdf
 # Optional redacted JSON fixture with expected source terms to compare against the browser-visible output.
+# When omitted, the runner derives supported expectations from PW_CLINICAL_QA_SOURCE_FILE.
 PW_CLINICAL_QA_EXPECTATIONS_FILE=tests/fixtures/redacted-iehp-expectations.example.json
 
 # ---------------------------------------------------------------------------

--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -63,6 +63,16 @@ The browser runner compares each `expectedTerms` entry against the visible brows
 - `mismatchType`: `match`, `partial`, or `missing`.
 - `observedTextSnippet`: a compact browser-text excerpt around matched evidence when available.
 
+## Source Text Fixture Extraction
+
+When `PW_CLINICAL_QA_EXPECTATIONS_FILE` is omitted and `PW_CLINICAL_QA_SOURCE_FILE` points to a redacted `.txt` or `.md` fixture, the runner derives expectations from supported source labels:
+
+- `Target behaviors: ...`
+- `Replacement behavior: ...`
+- `Measurement terms: ...`
+
+A safe example lives at `tests/fixtures/redacted-iehp-source.example.txt`. Source-only extraction currently does not parse DOCX or PDF. For DOCX/PDF source documents, provide a redacted expectations JSON fixture until a dedicated parser is added.
+
 ## Report Artifacts
 
 Each successful run writes durable artifacts under `artifacts/latest`:

--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -4,8 +4,10 @@ import { chromium } from "playwright";
 
 import {
   assertRedactedQaFixture,
+  assertSupportedClinicalQaSourceTextFixture,
   buildClinicalQaReportMarkdown,
   buildClinicalQaRoute,
+  deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalDataParity,
   evaluateClinicalQaChecklist,
   parseClinicalQaExpectations,
@@ -55,7 +57,12 @@ const run = async (): Promise<void> => {
   );
   const expectations = expectationsFixture
     ? parseClinicalQaExpectations(await readFile(expectationsFixture, "utf8"), expectationsFixture)
-    : [];
+    : sourceFixture
+      ? deriveClinicalQaExpectationsFromSourceText(
+          await readFile(assertSupportedClinicalQaSourceTextFixture(sourceFixture), "utf8"),
+        )
+      : [];
+  const expectationsSource = expectationsFixture ? "expectations-file" : sourceFixture ? "source-text" : "none";
 
   const browser = await chromium.launch({ headless: process.env.HEADLESS !== "false" });
   const context = await browser.newContext();
@@ -87,6 +94,7 @@ const run = async (): Promise<void> => {
         sourceConfigured: Boolean(sourceFixture),
         outputConfigured: Boolean(outputFixture),
         expectationsConfigured: Boolean(expectationsFixture),
+        expectationsSource,
       },
       checklist,
       dataParityFindings,

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -108,6 +108,15 @@ export const assertRedactedQaFixture = (value: string | undefined, label: string
   return fixturePath;
 };
 
+export const assertSupportedClinicalQaSourceTextFixture = (fixturePath: string): string => {
+  if (!/\.(?:txt|md)$/i.test(fixturePath)) {
+    throw new Error(
+      "PW_CLINICAL_QA_SOURCE_FILE text extraction currently supports .txt or .md fixtures; provide PW_CLINICAL_QA_EXPECTATIONS_FILE for DOCX/PDF.",
+    );
+  }
+  return fixturePath;
+};
+
 export const selectClinicalQaCredentials = (
   candidates: ClinicalQaCredentialCandidate[],
 ): ClinicalQaCredentials => {
@@ -187,6 +196,94 @@ const normalizeOptionalStringArray = (value: unknown): string[] => {
 
 const sanitizeEvidenceText = (value: string): string =>
   value.replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, "[redacted-email]");
+
+const normalizeSourceText = (value: string): string =>
+  sanitizeEvidenceText(value)
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n");
+
+const splitExpectedTerms = (value: string | null): string[] => {
+  if (!value) {
+    return [];
+  }
+  const seen = new Set<string>();
+  return value
+    .split(/[;,]|\n/)
+    .map((term) => term.trim().replace(/[.]+$/g, ""))
+    .filter((term) => term.length > 0)
+    .filter((term) => {
+      const normalized = term.toLowerCase();
+      if (seen.has(normalized)) {
+        return false;
+      }
+      seen.add(normalized);
+      return true;
+    });
+};
+
+const extractLabeledTerms = (sourceText: string, labelPattern: RegExp): string[] => {
+  const match = sourceText.match(labelPattern);
+  return splitExpectedTerms(match?.[1] ?? null);
+};
+
+export const deriveClinicalQaExpectationsFromSourceText = (
+  sourceText: string,
+): ClinicalQaParityExpectation[] => {
+  const normalizedSourceText = normalizeSourceText(sourceText);
+  const expectations: ClinicalQaParityExpectation[] = [];
+
+  const targetBehaviorTerms = extractLabeledTerms(
+    normalizedSourceText,
+    /(?:^|\n)\s*target behaviors?\s*:\s*([^\n]+)/i,
+  );
+  if (targetBehaviorTerms.length > 0) {
+    expectations.push({
+      key: "target_behaviors",
+      label: "Target behaviors",
+      sourceSection: "FBA target behavior summary",
+      expectedTerms: targetBehaviorTerms,
+      observedSectionTerms: ["Programs", "Goals"],
+      severity: "high",
+      humanReviewBlocker: true,
+    });
+  }
+
+  const replacementBehaviorTerms = extractLabeledTerms(
+    normalizedSourceText,
+    /(?:^|\n)\s*replacement behavior\s*:\s*([^\n]+)/i,
+  );
+  if (replacementBehaviorTerms.length > 0) {
+    expectations.push({
+      key: "replacement_behavior",
+      label: "Replacement behavior",
+      sourceSection: "Replacement behavior plan",
+      expectedTerms: replacementBehaviorTerms,
+      observedSectionTerms: ["Programs", "Goals"],
+      severity: "medium",
+      humanReviewBlocker: false,
+    });
+  }
+
+  const measurementTerms = extractLabeledTerms(
+    normalizedSourceText,
+    /(?:^|\n)\s*measurement terms?\s*:\s*([^\n]+)/i,
+  );
+  if (measurementTerms.length > 0) {
+    expectations.push({
+      key: "program_goal_measurement",
+      label: "Program goal measurement",
+      sourceSection: "Goals and measurement criteria",
+      expectedTerms: measurementTerms,
+      observedSectionTerms: ["Programs", "Goals"],
+      severity: "medium",
+      humanReviewBlocker: false,
+    });
+  }
+
+  return expectations;
+};
 
 const buildObservedTextSnippet = (pageText: string, matchedTerms: string[]): string | null => {
   const compactText = sanitizeEvidenceText(pageText.replace(/\s+/g, " ").trim());

--- a/tests/fixtures/redacted-iehp-source.example.txt
+++ b/tests/fixtures/redacted-iehp-source.example.txt
@@ -1,0 +1,8 @@
+FBA target behavior summary
+Target behaviors: elopement; property destruction
+
+Replacement behavior plan
+Replacement behavior: functional communication
+
+Goals and measurement criteria
+Measurement terms: baseline, mastery, maintenance, generalization

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   assertBrowserOnlyTarget,
   assertRedactedQaFixture,
+  assertSupportedClinicalQaSourceTextFixture,
   buildClinicalQaRoute,
   buildClinicalQaReportMarkdown,
+  deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalQaChecklist,
   evaluateClinicalDataParity,
   parseClinicalQaExpectations,
@@ -79,6 +81,18 @@ describe("clinical data parity agent helpers", () => {
     expect(() => assertRedactedQaFixture("fixtures/real-client-iehp-fba.docx", "fixture")).toThrow(
       "clearly redacted",
     );
+  });
+
+  it("allows only text fixtures for source-derived expectations", () => {
+    expect(assertSupportedClinicalQaSourceTextFixture("fixtures/redacted-iehp-source.txt")).toBe(
+      "fixtures/redacted-iehp-source.txt",
+    );
+    expect(assertSupportedClinicalQaSourceTextFixture("fixtures/synthetic-iehp-source.md")).toBe(
+      "fixtures/synthetic-iehp-source.md",
+    );
+    expect(() =>
+      assertSupportedClinicalQaSourceTextFixture("fixtures/redacted-iehp-source.docx"),
+    ).toThrow("text extraction currently supports .txt or .md fixtures");
   });
 
   it("normalizes optional client IDs", () => {
@@ -156,6 +170,49 @@ describe("clinical data parity agent helpers", () => {
         observedSectionMissingTerms: [],
         observedTextSnippet:
           "Programs and goals include elopement and functional communication. Logged in as [redacted-email].",
+        humanReviewBlocker: false,
+      },
+    ]);
+  });
+
+  it("derives parity expectations from redacted source text sections", () => {
+    const expectations = deriveClinicalQaExpectationsFromSourceText(`
+      FBA target behavior summary
+      Target behaviors: elopement; property destruction
+
+      Replacement behavior plan
+      Replacement behavior: functional communication
+
+      Goals and measurement criteria
+      Measurement terms: baseline, mastery, maintenance, generalization
+    `);
+
+    expect(expectations).toEqual([
+      {
+        key: "target_behaviors",
+        label: "Target behaviors",
+        sourceSection: "FBA target behavior summary",
+        expectedTerms: ["elopement", "property destruction"],
+        observedSectionTerms: ["Programs", "Goals"],
+        severity: "high",
+        humanReviewBlocker: true,
+      },
+      {
+        key: "replacement_behavior",
+        label: "Replacement behavior",
+        sourceSection: "Replacement behavior plan",
+        expectedTerms: ["functional communication"],
+        observedSectionTerms: ["Programs", "Goals"],
+        severity: "medium",
+        humanReviewBlocker: false,
+      },
+      {
+        key: "program_goal_measurement",
+        label: "Program goal measurement",
+        sourceSection: "Goals and measurement criteria",
+        expectedTerms: ["baseline", "mastery", "maintenance", "generalization"],
+        observedSectionTerms: ["Programs", "Goals"],
+        severity: "medium",
         humanReviewBlocker: false,
       },
     ]);


### PR DESCRIPTION
## Summary
- derive clinical QA parity expectations from redacted `.txt`/`.md` source fixtures when no expectations JSON is configured
- record `fixtures.expectationsSource` in the browser runner payload
- add a redacted source text example fixture and update operator docs/env examples

## Route-task
- classification: low-risk autonomous
- lane: standard
- triggering paths: `scripts/**`, `tests/**`, `.env.example`, `docs/ai/**`
- protected paths touched: none

## Verification card
- Classification: low-risk autonomous
- Lane: standard
- Change type: non-sensitive QA tooling/test harness/docs
- Required checks: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, targeted helper test, browser runner smoke; `npm run verify:local` attempted as repo superset
- Executed checks:
  - `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`: pass, 12 tests
  - `npm run typecheck`: pass
  - `npm run lint`: pass
  - `npm run playwright:clinical-data-parity-agent` with only `PW_CLINICAL_QA_SOURCE_FILE=tests/fixtures/redacted-iehp-source.example.txt`: pass, emitted `expectationsSource: source-text` and durable JSON/markdown/screenshot artifacts
  - `npm run ci:check-focused`: pass
  - `npm run build`: pass
  - `npm run test:ci`: pass, 317 files / 1877 tests
  - `npm run verify:local`: partial pass; completed policy, lint, typecheck, test:ci, coverage, and build, then failed at `npm run test:routes:tier0`
- Blocked checks:
  - `npm run test:routes:tier0` inside `verify:local`: local Cypress startup failure on Windows, `Cypress.exe: bad option: --smoke-test` and `--ping=902`; this is an environment/tooling startup blocker, not an app assertion failure
- Result: pass-with-blocked-checks
- Residual risk: source-derived extraction is intentionally limited to deterministic `.txt`/`.md` labels; DOCX/PDF source-only mode still requires expectations JSON until a parser is added.

## PR hygiene
- pr-ready: yes, with explicit local Cypress blocker
- branch-ready: yes, `codex/clinical-source-fixture-extraction`
- linear-ready: not linked; Linear issue search/create was not available in this tool surface
- single-purpose: yes
- unrelated changes: none
- generated artifact drift: none; `reports/test-reliability-latest.json` restored after test runs
- protected-path drift: none