### PR TITLE
Expand clinical QA source text rubric

### DIFF
--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -70,6 +70,12 @@ When `PW_CLINICAL_QA_EXPECTATIONS_FILE` is omitted and `PW_CLINICAL_QA_SOURCE_FI
 - `Target behaviors: ...`
 - `Replacement behavior: ...`
 - `Measurement terms: ...`
+- `Antecedents: ...`
+- `Consequences: ...`
+- `Functions: ...`
+- `Interventions: ...`
+- `Client identifiers: ...`
+- `Authorization details: ...`
 
 A safe example lives at `tests/fixtures/redacted-iehp-source.example.txt`. Source-only extraction currently does not parse DOCX or PDF. For DOCX/PDF source documents, provide a redacted expectations JSON fixture until a dedicated parser is added.
 
@@ -101,5 +107,5 @@ The JSON report matches the stdout payload. The markdown report is intended for 
 
 ## Residual Risk
 
-- Browser evidence now supports source-to-output term parity when a redacted expectations JSON fixture is configured. It still requires fixture curation and human review of findings.
+- Browser evidence now supports source-to-output term parity when a redacted expectations JSON fixture or supported redacted text fixture is configured. It still requires fixture curation and human review of findings.
 - The agent can reduce reviewer workload but cannot replace BCBA sign-off.

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -228,61 +228,123 @@ const extractLabeledTerms = (sourceText: string, labelPattern: RegExp): string[]
   return splitExpectedTerms(match?.[1] ?? null);
 };
 
+type SourceTextExpectationDefinition = {
+  key: string;
+  label: string;
+  sourceSection: string;
+  labelPattern: RegExp;
+  observedSectionTerms: string[];
+  severity: ClinicalQaParitySeverity;
+  humanReviewBlocker: boolean;
+};
+
+const SOURCE_TEXT_EXPECTATION_DEFINITIONS: SourceTextExpectationDefinition[] = [
+  {
+    key: "target_behaviors",
+    label: "Target behaviors",
+    sourceSection: "FBA target behavior summary",
+    labelPattern: /(?:^|\n)\s*target behaviors?\s*:\s*([^\n]+)/i,
+    observedSectionTerms: ["Programs", "Goals"],
+    severity: "high",
+    humanReviewBlocker: true,
+  },
+  {
+    key: "replacement_behavior",
+    label: "Replacement behavior",
+    sourceSection: "Replacement behavior plan",
+    labelPattern: /(?:^|\n)\s*replacement behavior\s*:\s*([^\n]+)/i,
+    observedSectionTerms: ["Programs", "Goals"],
+    severity: "medium",
+    humanReviewBlocker: false,
+  },
+  {
+    key: "program_goal_measurement",
+    label: "Program goal measurement",
+    sourceSection: "Goals and measurement criteria",
+    labelPattern: /(?:^|\n)\s*measurement terms?\s*:\s*([^\n]+)/i,
+    observedSectionTerms: ["Programs", "Goals"],
+    severity: "medium",
+    humanReviewBlocker: false,
+  },
+  {
+    key: "antecedents",
+    label: "Antecedents",
+    sourceSection: "ABC and function summary",
+    labelPattern: /(?:^|\n)\s*antecedents?\s*:\s*([^\n]+)/i,
+    observedSectionTerms: ["Assessment", "Programs", "Goals"],
+    severity: "high",
+    humanReviewBlocker: true,
+  },
+  {
+    key: "consequences",
+    label: "Consequences",
+    sourceSection: "ABC and function summary",
+    labelPattern: /(?:^|\n)\s*consequences?\s*:\s*([^\n]+)/i,
+    observedSectionTerms: ["Assessment", "Programs", "Goals"],
+    severity: "high",
+    humanReviewBlocker: true,
+  },
+  {
+    key: "functions",
+    label: "Behavior functions",
+    sourceSection: "ABC and function summary",
+    labelPattern: /(?:^|\n)\s*functions?\s*:\s*([^\n]+)/i,
+    observedSectionTerms: ["Assessment", "Programs", "Goals"],
+    severity: "high",
+    humanReviewBlocker: true,
+  },
+  {
+    key: "interventions",
+    label: "Interventions",
+    sourceSection: "Intervention plan",
+    labelPattern: /(?:^|\n)\s*interventions?\s*:\s*([^\n]+)/i,
+    observedSectionTerms: ["Programs", "Goals"],
+    severity: "medium",
+    humanReviewBlocker: false,
+  },
+  {
+    key: "client_metadata",
+    label: "Client metadata",
+    sourceSection: "Authorization and client metadata",
+    labelPattern: /(?:^|\n)\s*client identifiers?\s*:\s*([^\n]+)/i,
+    observedSectionTerms: ["Client", "Assessment"],
+    severity: "medium",
+    humanReviewBlocker: false,
+  },
+  {
+    key: "authorization_metadata",
+    label: "Authorization metadata",
+    sourceSection: "Authorization and client metadata",
+    labelPattern: /(?:^|\n)\s*authorization details?\s*:\s*([^\n]+)/i,
+    observedSectionTerms: ["Authorization", "Client"],
+    severity: "medium",
+    humanReviewBlocker: false,
+  },
+];
+
 export const deriveClinicalQaExpectationsFromSourceText = (
   sourceText: string,
 ): ClinicalQaParityExpectation[] => {
   const normalizedSourceText = normalizeSourceText(sourceText);
-  const expectations: ClinicalQaParityExpectation[] = [];
 
-  const targetBehaviorTerms = extractLabeledTerms(
-    normalizedSourceText,
-    /(?:^|\n)\s*target behaviors?\s*:\s*([^\n]+)/i,
-  );
-  if (targetBehaviorTerms.length > 0) {
-    expectations.push({
-      key: "target_behaviors",
-      label: "Target behaviors",
-      sourceSection: "FBA target behavior summary",
-      expectedTerms: targetBehaviorTerms,
-      observedSectionTerms: ["Programs", "Goals"],
-      severity: "high",
-      humanReviewBlocker: true,
-    });
-  }
+  return SOURCE_TEXT_EXPECTATION_DEFINITIONS.flatMap((definition) => {
+    const expectedTerms = extractLabeledTerms(normalizedSourceText, definition.labelPattern);
+    if (expectedTerms.length === 0) {
+      return [];
+    }
 
-  const replacementBehaviorTerms = extractLabeledTerms(
-    normalizedSourceText,
-    /(?:^|\n)\s*replacement behavior\s*:\s*([^\n]+)/i,
-  );
-  if (replacementBehaviorTerms.length > 0) {
-    expectations.push({
-      key: "replacement_behavior",
-      label: "Replacement behavior",
-      sourceSection: "Replacement behavior plan",
-      expectedTerms: replacementBehaviorTerms,
-      observedSectionTerms: ["Programs", "Goals"],
-      severity: "medium",
-      humanReviewBlocker: false,
-    });
-  }
-
-  const measurementTerms = extractLabeledTerms(
-    normalizedSourceText,
-    /(?:^|\n)\s*measurement terms?\s*:\s*([^\n]+)/i,
-  );
-  if (measurementTerms.length > 0) {
-    expectations.push({
-      key: "program_goal_measurement",
-      label: "Program goal measurement",
-      sourceSection: "Goals and measurement criteria",
-      expectedTerms: measurementTerms,
-      observedSectionTerms: ["Programs", "Goals"],
-      severity: "medium",
-      humanReviewBlocker: false,
-    });
-  }
-
-  return expectations;
+    return [
+      {
+        key: definition.key,
+        label: definition.label,
+        sourceSection: definition.sourceSection,
+        expectedTerms,
+        observedSectionTerms: definition.observedSectionTerms,
+        severity: definition.severity,
+        humanReviewBlocker: definition.humanReviewBlocker,
+      },
+    ];
+  });
 };
 
 const buildObservedTextSnippet = (pageText: string, matchedTerms: string[]): string | null => {

--- a/tests/fixtures/redacted-iehp-source.example.txt
+++ b/tests/fixtures/redacted-iehp-source.example.txt
@@ -6,3 +6,15 @@ Replacement behavior: functional communication
 
 Goals and measurement criteria
 Measurement terms: baseline, mastery, maintenance, generalization
+
+ABC and function summary
+Antecedents: transition demand; denied access
+Consequences: adult attention; escape from task
+Functions: escape; access to attention
+
+Intervention plan
+Interventions: visual schedule; first then board
+
+Authorization and client metadata
+Client identifiers: test client 01; redacted medicaid id
+Authorization details: 97153; 12 units weekly

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -185,6 +185,18 @@ describe("clinical data parity agent helpers", () => {
 
       Goals and measurement criteria
       Measurement terms: baseline, mastery, maintenance, generalization
+
+      ABC and function summary
+      Antecedents: transition demand; denied access
+      Consequences: adult attention; escape from task
+      Functions: escape; access to attention
+
+      Intervention plan
+      Interventions: visual schedule; first then board
+
+      Authorization and client metadata
+      Client identifiers: test client 01; redacted medicaid id
+      Authorization details: 97153; 12 units weekly
     `);
 
     expect(expectations).toEqual([
@@ -212,6 +224,60 @@ describe("clinical data parity agent helpers", () => {
         sourceSection: "Goals and measurement criteria",
         expectedTerms: ["baseline", "mastery", "maintenance", "generalization"],
         observedSectionTerms: ["Programs", "Goals"],
+        severity: "medium",
+        humanReviewBlocker: false,
+      },
+      {
+        key: "antecedents",
+        label: "Antecedents",
+        sourceSection: "ABC and function summary",
+        expectedTerms: ["transition demand", "denied access"],
+        observedSectionTerms: ["Assessment", "Programs", "Goals"],
+        severity: "high",
+        humanReviewBlocker: true,
+      },
+      {
+        key: "consequences",
+        label: "Consequences",
+        sourceSection: "ABC and function summary",
+        expectedTerms: ["adult attention", "escape from task"],
+        observedSectionTerms: ["Assessment", "Programs", "Goals"],
+        severity: "high",
+        humanReviewBlocker: true,
+      },
+      {
+        key: "functions",
+        label: "Behavior functions",
+        sourceSection: "ABC and function summary",
+        expectedTerms: ["escape", "access to attention"],
+        observedSectionTerms: ["Assessment", "Programs", "Goals"],
+        severity: "high",
+        humanReviewBlocker: true,
+      },
+      {
+        key: "interventions",
+        label: "Interventions",
+        sourceSection: "Intervention plan",
+        expectedTerms: ["visual schedule", "first then board"],
+        observedSectionTerms: ["Programs", "Goals"],
+        severity: "medium",
+        humanReviewBlocker: false,
+      },
+      {
+        key: "client_metadata",
+        label: "Client metadata",
+        sourceSection: "Authorization and client metadata",
+        expectedTerms: ["test client 01", "redacted medicaid id"],
+        observedSectionTerms: ["Client", "Assessment"],
+        severity: "medium",
+        humanReviewBlocker: false,
+      },
+      {
+        key: "authorization_metadata",
+        label: "Authorization metadata",
+        sourceSection: "Authorization and client metadata",
+        expectedTerms: ["97153", "12 units weekly"],
+        observedSectionTerms: ["Authorization", "Client"],
         severity: "medium",
         humanReviewBlocker: false,
       },


### PR DESCRIPTION
## Summary
- expands source-text derived clinical QA expectations for antecedents, consequences, behavior functions, interventions, client metadata, and authorization metadata
- replaces one-off extraction branches with a definition table for supported redacted source labels
- updates the redacted source fixture and handoff documentation with the expanded label contract

## Route-task
- classification: low-risk autonomous
- lane: standard
- triggering paths: `scripts/**`, `tests/**`, `docs/ai/**`
- protected paths touched: none

## Verification card
- Classification: low-risk autonomous
- Lane: standard
- Change type: non-sensitive QA tooling/test harness/docs
- Required checks: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, targeted helper test, browser runner smoke, `npm run verify:local`
- Executed checks:
  - `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`: pass, 12 tests
  - `npm run lint`: pass
  - `npm run typecheck`: pass
  - `npm run ci:check-focused`: pass
  - `npm run playwright:clinical-data-parity-agent` with only `PW_CLINICAL_QA_SOURCE_FILE=tests/fixtures/redacted-iehp-source.example.txt`: pass, emitted `expectationsSource: source-text` and 9 `dataParityFindings`
  - `npm run build`: pass
  - `npm run test:ci`: pass, 317 files / 1877 tests
  - `npm run verify:local`: partial pass; completed policy, lint, typecheck, test:ci, coverage, and build, then failed at `npm run test:routes:tier0`
- Blocked checks:
  - `npm run test:routes:tier0` inside `verify:local`: local Cypress startup failure on Windows, `Cypress.exe: bad option: --smoke-test` and `--ping=25`; CI tier0-browser should provide authoritative coverage
- Result: pass-with-blocked-checks
- Residual risk: source-text extraction is still deterministic label parsing for redacted `.txt`/`.md`; DOCX/PDF and semantic clinical judgment remain out of scope.

## PR hygiene
- pr-ready: yes, with explicit local Cypress blocker
- branch-ready: yes, `codex/clinical-source-rubric-expansion`
- linear-ready: not linked; Linear issue search/create was not available in this tool surface
- single-purpose: yes
- unrelated changes: none
- generated artifact drift: none; `reports/test-reliability-latest.json` restored after test runs
- protected-path drift: none
- reviewer: local self-review completed for protected-path drift, fixture safety, and parser behavior; human PR review remains available through GitHub