### PR TITLE
Add clinical QA section evidence scoring

### DIFF
--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { readFile, writeFile } from "node:fs/promises";
-import { chromium } from "playwright";
+import { chromium, type Page } from "playwright";
 
 import {
   assertRedactedQaFixture,
@@ -10,6 +10,7 @@ import {
   deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalDataParity,
   evaluateClinicalQaChecklist,
+  type ClinicalQaEvidenceSection,
   parseClinicalQaExpectations,
   requireClinicalQaClientId,
   selectClinicalQaCredentials,
@@ -21,6 +22,54 @@ import {
   ensureArtifactsDir,
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
+
+const collectClinicalQaEvidenceSections = async (page: Page): Promise<ClinicalQaEvidenceSection[]> =>
+  page.evaluate(`
+    (() => {
+      const normalize = (value) => (value ?? "").replace(/\\s+/g, " ").trim();
+      const isVisible = (element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return style.visibility !== "hidden" && style.display !== "none" && rect.width > 0 && rect.height > 0;
+      };
+      const sectionEntries = new Map();
+      const addSection = (label, text) => {
+        const normalizedLabel = normalize(label);
+        const normalizedText = normalize(text);
+        if (!normalizedLabel || !normalizedText) {
+          return;
+        }
+        sectionEntries.set(\`\${normalizedLabel.toLowerCase()}::\${normalizedText.slice(0, 300)}\`, {
+          label: normalizedLabel,
+          text: normalizedText,
+        });
+      };
+
+      for (const element of document.querySelectorAll('main, article, section, [role="region"], [role="tabpanel"]')) {
+        if (!isVisible(element)) {
+          continue;
+        }
+        const heading = element.querySelector("h1,h2,h3,h4,h5,h6");
+        const label =
+          element.getAttribute("aria-label") ??
+          element.getAttribute("data-testid") ??
+          heading?.textContent ??
+          element.getAttribute("role") ??
+          element.tagName.toLowerCase();
+        addSection(label, element.textContent ?? "");
+      }
+
+      for (const heading of document.querySelectorAll("h1,h2,h3,h4,h5,h6")) {
+        if (!isVisible(heading)) {
+          continue;
+        }
+        const container = heading.closest('section, article, [role="region"], [role="tabpanel"]') ?? heading.parentElement;
+        addSection(heading.textContent ?? "", container?.textContent ?? heading.textContent ?? "");
+      }
+
+      return Array.from(sectionEntries.values());
+    })()
+  `);
 
 const run = async (): Promise<void> => {
   loadPlaywrightEnv();
@@ -74,8 +123,9 @@ const run = async (): Promise<void> => {
     await assertRouteAccessible(page, baseUrl, routePath, { timeoutMs: 20_000 });
 
     const pageText = await page.locator("body").innerText({ timeout: 10_000 });
+    const evidenceSections = await collectClinicalQaEvidenceSections(page);
     const checklist = evaluateClinicalQaChecklist(pageText);
-    const dataParityFindings = evaluateClinicalDataParity(pageText, expectations);
+    const dataParityFindings = evaluateClinicalDataParity(pageText, expectations, evidenceSections);
     const runId = Date.now();
     const screenshotPath = path.join(latestDir, `clinical-data-parity-agent-${runId}.png`);
     await page.screenshot({ path: screenshotPath, fullPage: true });
@@ -96,6 +146,10 @@ const run = async (): Promise<void> => {
         expectationsConfigured: Boolean(expectationsFixture),
         expectationsSource,
       },
+      evidenceSections: evidenceSections.map((section) => ({
+        label: section.label,
+        textLength: section.text.length,
+      })),
       checklist,
       dataParityFindings,
       humanReviewBlockers: dataParityFindings.filter(

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -35,6 +35,18 @@ export type ClinicalQaParityExpectation = {
   humanReviewBlocker: boolean;
 };
 
+export type ClinicalQaEvidenceSection = {
+  label: string;
+  text: string;
+};
+
+export type ClinicalQaSectionEvidenceResult = {
+  sectionLabel: string;
+  matchedTerms: string[];
+  missingTerms: string[];
+  observedTextSnippet: string | null;
+};
+
 export type ClinicalQaParityFinding = ClinicalQaParityExpectation & {
   status: "pass" | "fail";
   mismatchType: "match" | "partial" | "missing";
@@ -43,6 +55,8 @@ export type ClinicalQaParityFinding = ClinicalQaParityExpectation & {
   observedSectionMatchedTerms: string[];
   observedSectionMissingTerms: string[];
   observedTextSnippet: string | null;
+  sectionEvidenceStatus?: "match" | "partial" | "missing" | "not_evaluated";
+  sectionEvidence?: ClinicalQaSectionEvidenceResult[];
 };
 
 export type ClinicalQaReportInput = {
@@ -383,6 +397,61 @@ const classifyMismatch = (
   return "partial";
 };
 
+const sectionLabelMatches = (sectionLabel: string, observedSectionTerms: string[]): boolean => {
+  const normalizedLabel = sectionLabel.toLowerCase();
+  return observedSectionTerms.some((term) => normalizedLabel.includes(term.toLowerCase()));
+};
+
+const evaluateSectionEvidence = (
+  expectation: ClinicalQaParityExpectation,
+  evidenceSections: ClinicalQaEvidenceSection[],
+): Pick<ClinicalQaParityFinding, "sectionEvidence" | "sectionEvidenceStatus"> => {
+  if (expectation.observedSectionTerms.length === 0) {
+    return {
+      sectionEvidence: [],
+      sectionEvidenceStatus: "not_evaluated",
+    };
+  }
+
+  const matchingSections = evidenceSections.filter((section) =>
+    sectionLabelMatches(section.label, expectation.observedSectionTerms),
+  );
+  if (matchingSections.length === 0) {
+    return {
+      sectionEvidence: [],
+      sectionEvidenceStatus: "not_evaluated",
+    };
+  }
+
+  const sectionEvidence = matchingSections.map((section) => {
+    const normalizedSectionText = section.text.toLowerCase();
+    const matchedTerms = expectation.expectedTerms.filter((term) =>
+      normalizedSectionText.includes(term.toLowerCase()),
+    );
+    const missingTerms = expectation.expectedTerms.filter(
+      (term) => !normalizedSectionText.includes(term.toLowerCase()),
+    );
+
+    return {
+      sectionLabel: section.label,
+      matchedTerms,
+      missingTerms,
+      observedTextSnippet: buildObservedTextSnippet(section.text, matchedTerms),
+    };
+  });
+  const matchedAcrossSections = new Set(
+    sectionEvidence.flatMap((section) => section.matchedTerms.map((term) => term.toLowerCase())),
+  );
+  const missingAcrossSections = expectation.expectedTerms.filter(
+    (term) => !matchedAcrossSections.has(term.toLowerCase()),
+  );
+
+  return {
+    sectionEvidence,
+    sectionEvidenceStatus: classifyMismatch(expectation.expectedTerms.length, missingAcrossSections.length),
+  };
+};
+
 export const parseClinicalQaExpectations = (
   rawJson: string,
   fixturePath: string,
@@ -422,6 +491,7 @@ export const parseClinicalQaExpectations = (
 export const evaluateClinicalDataParity = (
   pageText: string,
   expectations: ClinicalQaParityExpectation[],
+  evidenceSections?: ClinicalQaEvidenceSection[],
 ): ClinicalQaParityFinding[] => {
   const normalizedText = pageText.toLowerCase();
   return expectations.map((expectation) => {
@@ -438,6 +508,9 @@ export const evaluateClinicalDataParity = (
       (term) => !normalizedText.includes(term.toLowerCase()),
     );
 
+    const sectionEvidence =
+      evidenceSections === undefined ? {} : evaluateSectionEvidence(expectation, evidenceSections);
+
     return {
       ...expectation,
       status: missingTerms.length === 0 ? "pass" : "fail",
@@ -447,11 +520,27 @@ export const evaluateClinicalDataParity = (
       observedSectionMatchedTerms,
       observedSectionMissingTerms,
       observedTextSnippet: buildObservedTextSnippet(pageText, [...matchedTerms, ...observedSectionMatchedTerms]),
+      ...sectionEvidence,
     };
   });
 };
 
 const formatTermList = (terms: string[]): string => (terms.length > 0 ? terms.join(", ") : "none");
+
+const formatSectionEvidence = (finding: ClinicalQaParityFinding): string[] => {
+  if (!finding.sectionEvidenceStatus || !finding.sectionEvidence) {
+    return [];
+  }
+
+  const sectionLines = finding.sectionEvidence.flatMap((section) => [
+    `  - section evidence: ${section.sectionLabel}`,
+    `    - matched: ${formatTermList(section.matchedTerms)}`,
+    `    - missing: ${formatTermList(section.missingTerms)}`,
+    `    - snippet: ${section.observedTextSnippet ? sanitizeEvidenceText(section.observedTextSnippet) : "none"}`,
+  ]);
+
+  return [`  - section evidence status: ${finding.sectionEvidenceStatus}`, ...sectionLines];
+};
 
 export const buildClinicalQaReportMarkdown = (report: ClinicalQaReportInput): string => {
   const blockerCount = report.dataParityFindings.filter(
@@ -472,6 +561,7 @@ export const buildClinicalQaReportMarkdown = (report: ClinicalQaReportInput): st
       `  - matched: ${formatTermList(finding.matchedTerms)}`,
       `  - missing: ${formatTermList(finding.missingTerms)}`,
       `  - observed section missing: ${formatTermList(finding.observedSectionMissingTerms)}`,
+      ...formatSectionEvidence(finding),
       `  - human review blocker: ${finding.humanReviewBlocker ? "yes" : "no"}`,
       `  - observed snippet: ${snippet}`,
     ].join("\n");

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -175,6 +175,54 @@ describe("clinical data parity agent helpers", () => {
     ]);
   });
 
+  it("distinguishes page-level matches from expected section evidence", () => {
+    const expectations = parseClinicalQaExpectations(
+      JSON.stringify({
+        expectations: [
+          {
+            key: "target_behaviors",
+            label: "Target behaviors",
+            sourceSection: "FBA target behavior summary",
+            expectedTerms: ["elopement", "property destruction"],
+            observedSectionTerms: ["Programs", "Goals"],
+            severity: "high",
+            humanReviewBlocker: true,
+          },
+        ],
+      }),
+      "fixtures/redacted-iehp-expectations.json",
+    );
+
+    const findings = evaluateClinicalDataParity(
+      "Assessment summary mentions elopement and property destruction. Programs and Goals only mention replacement skills.",
+      expectations,
+      [
+        {
+          label: "Assessment",
+          text: "Assessment summary mentions elopement and property destruction.",
+        },
+        {
+          label: "Programs and Goals",
+          text: "Programs and Goals only mention replacement skills.",
+        },
+      ],
+    );
+
+    expect(findings[0]).toMatchObject({
+      status: "pass",
+      mismatchType: "match",
+      matchedTerms: ["elopement", "property destruction"],
+      sectionEvidenceStatus: "missing",
+      sectionEvidence: [
+        {
+          sectionLabel: "Programs and Goals",
+          matchedTerms: [],
+          missingTerms: ["elopement", "property destruction"],
+        },
+      ],
+    });
+  });
+
   it("derives parity expectations from redacted source text sections", () => {
     const expectations = deriveClinicalQaExpectationsFromSourceText(`
       FBA target behavior summary


### PR DESCRIPTION
## Summary
- Adds section-aware evidence scoring to the browser-only clinical data parity agent so findings distinguish page-level term matches from matches inside expected UI/document sections.
- Captures visible browser sections/headings as read-only evidence metadata and includes section evidence status/details in JSON and markdown reports.
- Adds focused unit coverage for page-level match with missing expected-section evidence.

## Route Task
- classification: low-risk autonomous
- lane: standard
- triggering paths: scripts/clinical-data-parity-agent.ts, scripts/lib/clinical-data-parity-agent.ts, tests/scripts/clinical-data-parity-agent.test.ts
- protected-path drift: none
- linear required: no for this non-critical slice; Linear tooling not available in this session

## Verification Card
- classification: low-risk autonomous
- lane: standard
- change type: non-sensitive test harness / browser-only QA utility
- required checks: npm run ci:check-focused; npm run lint; npm run typecheck; npm run test:ci; npm run build; npm run verify:local when locally supported
- executed checks:
  - npm test -- tests/scripts/clinical-data-parity-agent.test.ts: pass
  - npm run lint: pass
  - npm run typecheck: pass
  - npm run ci:check-focused: pass, DB-backed checks skipped because no SUPABASE_DB_URL/DATABASE_URL local env
  - PW_CLINICAL_QA_SOURCE_FILE=tests/fixtures/redacted-iehp-source.example.txt npm run playwright:clinical-data-parity-agent: pass
  - npm run build: pass
  - npm run test:ci: pass, 317 files / 1878 tests
  - npm run verify:local: fail only at final npm run test:routes:tier0 due local Cypress startup: Cypress.exe bad option --smoke-test / --ping=389; preceding ci:check-focused, lint, typecheck, test:ci, coverage, and build passed inside verify:local
- blocked checks: npm run test:routes:tier0 locally blocked by Cypress binary startup issue above; rely on CI for tier0-browser
- result: pass-with-blocked-checks
- residual risk: DOM section collection is heuristic and depends on visible labels/headings; it improves evidence quality but is still QA evidence only, not clinical sign-off.

## PR Hygiene
- pr-ready: yes
- branch-ready: yes, codex/clinical-section-evidence-scoring
- single-purpose: yes
- unrelated changes: none
- generated artifact drift: none
- reviewer: blocked by current tool policy because subagent spawning requires explicit user request; focused self-review completed