### PR TITLE
Support clinical QA DOCX and PDF source fixtures

### DIFF
--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -12,6 +12,7 @@ import {
   evaluateClinicalQaChecklist,
   type ClinicalQaEvidenceSection,
   parseClinicalQaExpectations,
+  readClinicalQaSourceFixtureText,
   requireClinicalQaClientId,
   selectClinicalQaCredentials,
 } from "./lib/clinical-data-parity-agent";
@@ -108,7 +109,7 @@ const run = async (): Promise<void> => {
     ? parseClinicalQaExpectations(await readFile(expectationsFixture, "utf8"), expectationsFixture)
     : sourceFixture
       ? deriveClinicalQaExpectationsFromSourceText(
-          await readFile(assertSupportedClinicalQaSourceTextFixture(sourceFixture), "utf8"),
+          await readClinicalQaSourceFixtureText(assertSupportedClinicalQaSourceTextFixture(sourceFixture)),
         )
       : [];
   const expectationsSource = expectationsFixture ? "expectations-file" : sourceFixture ? "source-text" : "none";

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -1,3 +1,9 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { extname } from "node:path";
+import { promisify } from "node:util";
+import { inflateRawSync } from "node:zlib";
+
 export type ClinicalQaCredentialCandidate = {
   email?: string;
   password?: string;
@@ -71,6 +77,7 @@ export type ClinicalQaReportInput = {
 };
 
 const REDACTED_PASSWORD_PLACEHOLDER = "****";
+const execFileAsync = promisify(execFile);
 
 export const DEFAULT_CLINICAL_QA_ROUTE = "/";
 
@@ -123,12 +130,139 @@ export const assertRedactedQaFixture = (value: string | undefined, label: string
 };
 
 export const assertSupportedClinicalQaSourceTextFixture = (fixturePath: string): string => {
-  if (!/\.(?:txt|md)$/i.test(fixturePath)) {
+  if (!/\.(?:txt|md|docx|pdf)$/i.test(fixturePath)) {
     throw new Error(
-      "PW_CLINICAL_QA_SOURCE_FILE text extraction currently supports .txt or .md fixtures; provide PW_CLINICAL_QA_EXPECTATIONS_FILE for DOCX/PDF.",
+      "PW_CLINICAL_QA_SOURCE_FILE text extraction supports .txt, .md, .docx, or .pdf fixtures.",
     );
   }
   return fixturePath;
+};
+
+const decodeXmlText = (value: string): string =>
+  value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+
+const extractTextFromDocxBuffer = (buffer: Buffer): string => {
+  const eocdSignature = 0x06054b50;
+  let eocdOffset = -1;
+  for (let offset = buffer.length - 22; offset >= 0; offset -= 1) {
+    if (buffer.readUInt32LE(offset) === eocdSignature) {
+      eocdOffset = offset;
+      break;
+    }
+  }
+  if (eocdOffset < 0) {
+    throw new Error("DOCX source fixture is not a readable ZIP archive.");
+  }
+
+  const centralDirectoryEntryCount = buffer.readUInt16LE(eocdOffset + 10);
+  let centralDirectoryOffset = buffer.readUInt32LE(eocdOffset + 16);
+  const xmlTextParts: string[] = [];
+
+  for (let index = 0; index < centralDirectoryEntryCount; index += 1) {
+    if (buffer.readUInt32LE(centralDirectoryOffset) !== 0x02014b50) {
+      throw new Error("DOCX source fixture has an invalid ZIP central directory.");
+    }
+
+    const compressionMethod = buffer.readUInt16LE(centralDirectoryOffset + 10);
+    const compressedSize = buffer.readUInt32LE(centralDirectoryOffset + 20);
+    const fileNameLength = buffer.readUInt16LE(centralDirectoryOffset + 28);
+    const extraLength = buffer.readUInt16LE(centralDirectoryOffset + 30);
+    const commentLength = buffer.readUInt16LE(centralDirectoryOffset + 32);
+    const localHeaderOffset = buffer.readUInt32LE(centralDirectoryOffset + 42);
+    const fileName = buffer
+      .subarray(centralDirectoryOffset + 46, centralDirectoryOffset + 46 + fileNameLength)
+      .toString("utf8");
+
+    if (/^word\/(?:document|header\d+|footer\d+)\.xml$/i.test(fileName)) {
+      if (buffer.readUInt32LE(localHeaderOffset) !== 0x04034b50) {
+        throw new Error(`DOCX source fixture has an invalid local ZIP header for ${fileName}.`);
+      }
+      const localNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
+      const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
+      const dataStart = localHeaderOffset + 30 + localNameLength + localExtraLength;
+      const compressed = buffer.subarray(dataStart, dataStart + compressedSize);
+      const xmlBuffer =
+        compressionMethod === 0
+          ? compressed
+          : compressionMethod === 8
+            ? inflateRawSync(compressed)
+            : null;
+      if (!xmlBuffer) {
+        throw new Error(`DOCX source fixture uses unsupported ZIP compression method ${compressionMethod}.`);
+      }
+      const xml = xmlBuffer
+        .toString("utf8")
+        .replace(/<\/w:p>/g, "\n")
+        .replace(/<w:tab\s*\/>/g, " ");
+      xmlTextParts.push(decodeXmlText(xml.replace(/<[^>]+>/g, " ")));
+    }
+
+    centralDirectoryOffset += 46 + fileNameLength + extraLength + commentLength;
+  }
+
+  const extractedText = xmlTextParts.join("\n").replace(/[ \t]+/g, " ").replace(/\n\s+/g, "\n").trim();
+  if (!extractedText) {
+    throw new Error("DOCX source fixture did not contain extractable document text.");
+  }
+  return extractedText;
+};
+
+const extractTextFromPdfWithPython = async (fixturePath: string): Promise<string> => {
+  const script = [
+    "import sys",
+    "try:",
+    "    from pypdf import PdfReader",
+    "except Exception as exc:",
+    "    raise SystemExit(f'pypdf is required to extract PDF source fixtures: {exc}')",
+    "reader = PdfReader(sys.argv[1])",
+    "parts = []",
+    "for page in reader.pages:",
+    "    parts.append(page.extract_text() or '')",
+    "print('\\n'.join(parts))",
+  ].join("\n");
+
+  let lastError: unknown;
+  for (const command of ["python", "python3"]) {
+    try {
+      const { stdout } = await execFileAsync(command, ["-c", script, fixturePath], {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      const extractedText = stdout.trim();
+      if (!extractedText) {
+        throw new Error("PDF source fixture did not contain extractable text.");
+      }
+      return extractedText;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw new Error(
+    `Unable to extract PDF source fixture text. Install Python with pypdf or provide PW_CLINICAL_QA_EXPECTATIONS_FILE. ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  );
+};
+
+export const readClinicalQaSourceFixtureText = async (fixturePath: string): Promise<string> => {
+  assertRedactedQaFixture(fixturePath, "PW_CLINICAL_QA_SOURCE_FILE");
+  assertSupportedClinicalQaSourceTextFixture(fixturePath);
+  const extension = extname(fixturePath).toLowerCase();
+  if (extension === ".txt" || extension === ".md") {
+    return readFile(fixturePath, "utf8");
+  }
+  if (extension === ".docx") {
+    return extractTextFromDocxBuffer(await readFile(fixturePath));
+  }
+  if (extension === ".pdf") {
+    return extractTextFromPdfWithPython(fixturePath);
+  }
+  throw new Error("Unsupported clinical QA source fixture extension.");
 };
 
 export const selectClinicalQaCredentials = (

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -249,6 +249,25 @@ const extractTextFromPdfWithPython = async (fixturePath: string): Promise<string
   );
 };
 
+const decodePdfLiteralString = (value: string): string =>
+  value.replace(/\\([()\\nrtbf])/g, (_match, escaped: string) => {
+    if (escaped === "n") return "\n";
+    if (escaped === "r") return "\r";
+    if (escaped === "t") return "\t";
+    if (escaped === "b") return "\b";
+    if (escaped === "f") return "\f";
+    return escaped;
+  });
+
+const extractTextFromSimplePdfBuffer = (buffer: Buffer): string | null => {
+  const rawPdf = buffer.toString("latin1");
+  const textParts = Array.from(rawPdf.matchAll(/\(((?:\\.|[^\\()])*)\)\s*Tj/g), (match) =>
+    decodePdfLiteralString(match[1]),
+  );
+  const extractedText = textParts.join("\n").trim();
+  return extractedText.length > 0 ? extractedText : null;
+};
+
 export const readClinicalQaSourceFixtureText = async (fixturePath: string): Promise<string> => {
   assertRedactedQaFixture(fixturePath, "PW_CLINICAL_QA_SOURCE_FILE");
   assertSupportedClinicalQaSourceTextFixture(fixturePath);
@@ -260,7 +279,8 @@ export const readClinicalQaSourceFixtureText = async (fixturePath: string): Prom
     return extractTextFromDocxBuffer(await readFile(fixturePath));
   }
   if (extension === ".pdf") {
-    return extractTextFromPdfWithPython(fixturePath);
+    const simpleText = extractTextFromSimplePdfBuffer(await readFile(fixturePath));
+    return simpleText ?? extractTextFromPdfWithPython(fixturePath);
   }
   throw new Error("Unsupported clinical QA source fixture extension.");
 };

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -1,3 +1,8 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { deflateRawSync } from "node:zlib";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -10,10 +15,115 @@ import {
   evaluateClinicalQaChecklist,
   evaluateClinicalDataParity,
   parseClinicalQaExpectations,
+  readClinicalQaSourceFixtureText,
   requireClinicalQaClientId,
   selectClinicalQaCredentials,
 } from "../../scripts/lib/clinical-data-parity-agent";
 import { routeMatchesPathname } from "../../scripts/lib/playwright-smoke";
+
+const crc32Table = Array.from({ length: 256 }, (_, index) => {
+  let value = index;
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+  }
+  return value >>> 0;
+});
+
+const crc32 = (buffer: Buffer): number => {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc = crc32Table[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+};
+
+const buildZip = (files: Record<string, string>): Buffer => {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const [name, content] of Object.entries(files)) {
+    const nameBuffer = Buffer.from(name);
+    const contentBuffer = Buffer.from(content);
+    const compressed = deflateRawSync(contentBuffer);
+    const checksum = crc32(contentBuffer);
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(8, 8);
+    localHeader.writeUInt32LE(checksum, 14);
+    localHeader.writeUInt32LE(compressed.length, 18);
+    localHeader.writeUInt32LE(contentBuffer.length, 22);
+    localHeader.writeUInt16LE(nameBuffer.length, 26);
+    localParts.push(localHeader, nameBuffer, compressed);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(8, 10);
+    centralHeader.writeUInt32LE(checksum, 16);
+    centralHeader.writeUInt32LE(compressed.length, 20);
+    centralHeader.writeUInt32LE(contentBuffer.length, 24);
+    centralHeader.writeUInt16LE(nameBuffer.length, 28);
+    centralHeader.writeUInt32LE(offset, 42);
+    centralParts.push(centralHeader, nameBuffer);
+    offset += localHeader.length + nameBuffer.length + compressed.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(Object.keys(files).length, 8);
+  end.writeUInt16LE(Object.keys(files).length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(offset, 16);
+
+  return Buffer.concat([...localParts, centralDirectory, end]);
+};
+
+const buildRedactedDocxFixture = (text: string): Buffer =>
+  buildZip({
+    "[Content_Types].xml": '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" />',
+    "word/document.xml": `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>${text}</w:t></w:r></w:p></w:body></w:document>`,
+  });
+
+const buildRedactedPdfFixture = (text: string): Buffer => {
+  const escapedText = text.replace(/[()\\]/g, (match) => `\\${match}`);
+  return Buffer.from(`%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length ${escapedText.length + 34} >>
+stream
+BT /F1 12 Tf 72 720 Td (${escapedText}) Tj ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000241 00000 n
+0000000311 00000 n
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+456
+%%EOF
+`);
+};
 
 describe("clinical data parity agent helpers", () => {
   it("selects dedicated clinical QA credentials before admin fallback", () => {
@@ -83,16 +193,22 @@ describe("clinical data parity agent helpers", () => {
     );
   });
 
-  it("allows only text fixtures for source-derived expectations", () => {
+  it("allows redacted text, DOCX, and PDF fixtures for source-derived expectations", () => {
     expect(assertSupportedClinicalQaSourceTextFixture("fixtures/redacted-iehp-source.txt")).toBe(
       "fixtures/redacted-iehp-source.txt",
     );
     expect(assertSupportedClinicalQaSourceTextFixture("fixtures/synthetic-iehp-source.md")).toBe(
       "fixtures/synthetic-iehp-source.md",
     );
-    expect(() =>
-      assertSupportedClinicalQaSourceTextFixture("fixtures/redacted-iehp-source.docx"),
-    ).toThrow("text extraction currently supports .txt or .md fixtures");
+    expect(assertSupportedClinicalQaSourceTextFixture("fixtures/redacted-iehp-source.docx")).toBe(
+      "fixtures/redacted-iehp-source.docx",
+    );
+    expect(assertSupportedClinicalQaSourceTextFixture("fixtures/redacted-iehp-source.pdf")).toBe(
+      "fixtures/redacted-iehp-source.pdf",
+    );
+    expect(() => assertSupportedClinicalQaSourceTextFixture("fixtures/redacted-iehp-source.png")).toThrow(
+      "supports .txt, .md, .docx, or .pdf fixtures",
+    );
   });
 
   it("normalizes optional client IDs", () => {
@@ -330,6 +446,23 @@ describe("clinical data parity agent helpers", () => {
         humanReviewBlocker: false,
       },
     ]);
+  });
+
+  it("extracts source text from redacted DOCX and PDF fixtures before deriving expectations", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "clinical-qa-redacted-"));
+    const sourceLine = "Target behaviors: elopement; property destruction";
+    const docxPath = path.join(tempDir, "redacted-iehp-source.docx");
+    const pdfPath = path.join(tempDir, "redacted-iehp-source.pdf");
+
+    try {
+      await writeFile(docxPath, buildRedactedDocxFixture(sourceLine));
+      await writeFile(pdfPath, buildRedactedPdfFixture(sourceLine));
+
+      await expect(readClinicalQaSourceFixtureText(docxPath)).resolves.toContain(sourceLine);
+      await expect(readClinicalQaSourceFixtureText(pdfPath)).resolves.toContain(sourceLine);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("builds a durable markdown report without leaking browser-visible emails", () => {


### PR DESCRIPTION
## Summary
- Allows the browser-only clinical data parity agent to derive source expectations from redacted `.docx` and `.pdf` fixtures, in addition to `.txt` and `.md`.
- Adds dependency-light DOCX extraction using Node built-ins and PDF extraction through the existing Python/pypdf environment pattern.
- Keeps source-file ingestion gated to redacted/synthetic/smoke/test paths and adds focused coverage for generated redacted DOCX/PDF fixtures.

## Route Task
- classification: low-risk autonomous
- lane: standard
- triggering paths: scripts/clinical-data-parity-agent.ts, scripts/lib/clinical-data-parity-agent.ts, tests/scripts/clinical-data-parity-agent.test.ts
- protected-path drift: none
- linear required: no for this non-critical slice; Linear tooling not available in this session

## Verification Card
- classification: low-risk autonomous
- lane: standard
- change type: non-sensitive test harness / browser-only QA utility
- required checks: npm run ci:check-focused; npm run lint; npm run typecheck; npm run test:ci; npm run build; npm run verify:local when locally supported
- executed checks:
  - npm test -- tests/scripts/clinical-data-parity-agent.test.ts: pass
  - npm run typecheck: pass
  - npm run lint: pass
  - npm run ci:check-focused: pass, DB-backed checks skipped because no SUPABASE_DB_URL/DATABASE_URL local env
  - PW_CLINICAL_QA_SOURCE_FILE=artifacts/latest/redacted-clinical-qa-source.docx npm run playwright:clinical-data-parity-agent: pass
  - PW_CLINICAL_QA_SOURCE_FILE=artifacts/latest/redacted-clinical-qa-source.pdf npm run playwright:clinical-data-parity-agent: pass
  - npm run build: pass
  - npm run test:ci: pass, 317 files / 1879 tests
  - npm run verify:local: fail only at final npm run test:routes:tier0 due local Cypress startup: Cypress.exe bad option --smoke-test / --ping=126; preceding ci:check-focused, lint, typecheck, test:ci, coverage, and build passed inside verify:local
- blocked checks: npm run test:routes:tier0 locally blocked by Cypress binary startup issue above; rely on CI for tier0-browser
- result: pass-with-blocked-checks
- residual risk: PDF extraction requires Python with pypdf on the runner host; if unavailable, the agent reports a clear dependency error and users can still provide PW_CLINICAL_QA_EXPECTATIONS_FILE.

## PR Hygiene
- pr-ready: yes
- branch-ready: yes, codex/clinical-source-document-ingestion
- single-purpose: yes
- unrelated changes: none
- generated artifact drift: none
- reviewer: blocked by current tool policy because subagent spawning requires explicit user request; focused self-review completed