### PR TITLE
Compare clinical QA output fixtures

### DIFF
--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -12,6 +12,7 @@ import {
   evaluateClinicalQaChecklist,
   type ClinicalQaEvidenceSection,
   parseClinicalQaExpectations,
+  readClinicalQaOutputFixtureText,
   readClinicalQaSourceFixtureText,
   requireClinicalQaClientId,
   selectClinicalQaCredentials,
@@ -113,6 +114,7 @@ const run = async (): Promise<void> => {
         )
       : [];
   const expectationsSource = expectationsFixture ? "expectations-file" : sourceFixture ? "source-text" : "none";
+  const outputText = outputFixture ? await readClinicalQaOutputFixtureText(outputFixture) : null;
 
   const browser = await chromium.launch({ headless: process.env.HEADLESS !== "false" });
   const context = await browser.newContext();
@@ -127,6 +129,15 @@ const run = async (): Promise<void> => {
     const evidenceSections = await collectClinicalQaEvidenceSections(page);
     const checklist = evaluateClinicalQaChecklist(pageText);
     const dataParityFindings = evaluateClinicalDataParity(pageText, expectations, evidenceSections);
+    const outputDataParityFindings = outputText
+      ? evaluateClinicalDataParity(
+          outputText,
+          expectations.map((expectation) => ({
+            ...expectation,
+            observedSectionTerms: [],
+          })),
+        )
+      : [];
     const runId = Date.now();
     const screenshotPath = path.join(latestDir, `clinical-data-parity-agent-${runId}.png`);
     await page.screenshot({ path: screenshotPath, fullPage: true });
@@ -153,7 +164,11 @@ const run = async (): Promise<void> => {
       })),
       checklist,
       dataParityFindings,
+      outputDataParityFindings,
       humanReviewBlockers: dataParityFindings.filter(
+        (finding) => finding.status === "fail" && finding.humanReviewBlocker,
+      ),
+      outputHumanReviewBlockers: outputDataParityFindings.filter(
         (finding) => finding.status === "fail" && finding.humanReviewBlocker,
       ),
       screenshot: screenshotPath,
@@ -170,6 +185,7 @@ const run = async (): Promise<void> => {
       screenshotPath,
       checklist,
       dataParityFindings,
+      outputDataParityFindings,
       disclaimer,
     });
 

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -73,6 +73,7 @@ export type ClinicalQaReportInput = {
   screenshotPath: string;
   checklist: ClinicalQaChecklistResult[];
   dataParityFindings: ClinicalQaParityFinding[];
+  outputDataParityFindings?: ClinicalQaParityFinding[];
   disclaimer: string;
 };
 
@@ -268,8 +269,8 @@ const extractTextFromSimplePdfBuffer = (buffer: Buffer): string | null => {
   return extractedText.length > 0 ? extractedText : null;
 };
 
-export const readClinicalQaSourceFixtureText = async (fixturePath: string): Promise<string> => {
-  assertRedactedQaFixture(fixturePath, "PW_CLINICAL_QA_SOURCE_FILE");
+const readClinicalQaTextFixture = async (fixturePath: string, label: string): Promise<string> => {
+  assertRedactedQaFixture(fixturePath, label);
   assertSupportedClinicalQaSourceTextFixture(fixturePath);
   const extension = extname(fixturePath).toLowerCase();
   if (extension === ".txt" || extension === ".md") {
@@ -284,6 +285,12 @@ export const readClinicalQaSourceFixtureText = async (fixturePath: string): Prom
   }
   throw new Error("Unsupported clinical QA source fixture extension.");
 };
+
+export const readClinicalQaSourceFixtureText = async (fixturePath: string): Promise<string> =>
+  readClinicalQaTextFixture(fixturePath, "PW_CLINICAL_QA_SOURCE_FILE");
+
+export const readClinicalQaOutputFixtureText = async (fixturePath: string): Promise<string> =>
+  readClinicalQaTextFixture(fixturePath, "PW_CLINICAL_QA_OUTPUT_FILE");
 
 export const selectClinicalQaCredentials = (
   candidates: ClinicalQaCredentialCandidate[],
@@ -696,14 +703,8 @@ const formatSectionEvidence = (finding: ClinicalQaParityFinding): string[] => {
   return [`  - section evidence status: ${finding.sectionEvidenceStatus}`, ...sectionLines];
 };
 
-export const buildClinicalQaReportMarkdown = (report: ClinicalQaReportInput): string => {
-  const blockerCount = report.dataParityFindings.filter(
-    (finding) => finding.status === "fail" && finding.humanReviewBlocker,
-  ).length;
-  const checklistLines = report.checklist.map(
-    (item) => `- ${item.status.toUpperCase()} ${item.label}: missing ${formatTermList(item.missingTerms)}`,
-  );
-  const findingLines = report.dataParityFindings.map((finding) => {
+const formatFindingLines = (findings: ClinicalQaParityFinding[]): string[] =>
+  findings.map((finding) => {
     const sourceSection = finding.sourceSection ?? "unspecified";
     const snippet = finding.observedTextSnippet ? sanitizeEvidenceText(finding.observedTextSnippet) : "none";
     return [
@@ -721,6 +722,18 @@ export const buildClinicalQaReportMarkdown = (report: ClinicalQaReportInput): st
     ].join("\n");
   });
 
+export const buildClinicalQaReportMarkdown = (report: ClinicalQaReportInput): string => {
+  const outputDataParityFindings = report.outputDataParityFindings ?? [];
+  const allFindings = [...report.dataParityFindings, ...outputDataParityFindings];
+  const blockerCount = allFindings.filter(
+    (finding) => finding.status === "fail" && finding.humanReviewBlocker,
+  ).length;
+  const checklistLines = report.checklist.map(
+    (item) => `- ${item.status.toUpperCase()} ${item.label}: missing ${formatTermList(item.missingTerms)}`,
+  );
+  const findingLines = formatFindingLines(report.dataParityFindings);
+  const outputFindingLines = formatFindingLines(outputDataParityFindings);
+
   return [
     "# Clinical Data Parity Agent Report",
     "",
@@ -736,6 +749,9 @@ export const buildClinicalQaReportMarkdown = (report: ClinicalQaReportInput): st
     "",
     "## Data Parity Findings",
     ...(findingLines.length > 0 ? findingLines : ["- none"]),
+    "",
+    "## Output Fixture Parity Findings",
+    ...(outputFindingLines.length > 0 ? outputFindingLines : ["- none"]),
     "",
     "## Disclaimer",
     report.disclaimer,

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -15,6 +15,7 @@ import {
   evaluateClinicalQaChecklist,
   evaluateClinicalDataParity,
   parseClinicalQaExpectations,
+  readClinicalQaOutputFixtureText,
   readClinicalQaSourceFixtureText,
   requireClinicalQaClientId,
   selectClinicalQaCredentials,
@@ -465,6 +466,26 @@ describe("clinical data parity agent helpers", () => {
     }
   });
 
+  it("extracts output text from redacted text, DOCX, and PDF fixtures before comparing expectations", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "clinical-qa-redacted-output-"));
+    const outputLine = "Replacement behavior: functional communication";
+    const textPath = path.join(tempDir, "redacted-iehp-output.txt");
+    const docxPath = path.join(tempDir, "redacted-iehp-output.docx");
+    const pdfPath = path.join(tempDir, "redacted-iehp-output.pdf");
+
+    try {
+      await writeFile(textPath, outputLine);
+      await writeFile(docxPath, buildRedactedDocxFixture(outputLine));
+      await writeFile(pdfPath, buildRedactedPdfFixture(outputLine));
+
+      await expect(readClinicalQaOutputFixtureText(textPath)).resolves.toContain(outputLine);
+      await expect(readClinicalQaOutputFixtureText(docxPath)).resolves.toContain(outputLine);
+      await expect(readClinicalQaOutputFixtureText(pdfPath)).resolves.toContain(outputLine);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("builds a durable markdown report without leaking browser-visible emails", () => {
     const markdown = buildClinicalQaReportMarkdown({
       generatedAt: "2026-06-15T17:30:00.000Z",
@@ -498,6 +519,24 @@ describe("clinical data parity agent helpers", () => {
           observedTextSnippet: "Observed by qa@example.com near Programs and Goals.",
         },
       ],
+      outputDataParityFindings: [
+        {
+          key: "replacement_behavior",
+          label: "Replacement behavior",
+          sourceSection: "Replacement behavior plan",
+          expectedTerms: ["functional communication"],
+          observedSectionTerms: [],
+          severity: "medium",
+          humanReviewBlocker: false,
+          status: "pass",
+          mismatchType: "match",
+          matchedTerms: ["functional communication"],
+          missingTerms: [],
+          observedSectionMatchedTerms: [],
+          observedSectionMissingTerms: [],
+          observedTextSnippet: "Generated report includes functional communication.",
+        },
+      ],
       disclaimer: "QA evidence only. This is not BCBA approval or clinical sign-off.",
     });
 
@@ -506,6 +545,8 @@ describe("clinical data parity agent helpers", () => {
     expect(markdown).toContain("screenshot: `artifacts/latest/clinical-data-parity-agent-test.png`");
     expect(markdown).toContain("Target behaviors");
     expect(markdown).toContain("missing: property destruction");
+    expect(markdown).toContain("## Output Fixture Parity Findings");
+    expect(markdown).toContain("Generated report includes functional communication.");
     expect(markdown).toContain("human review blocker: yes");
     expect(markdown).toContain("[redacted-email]");
     expect(markdown).not.toContain("qa@example.com");


### PR DESCRIPTION
## Summary
- Add `PW_CLINICAL_QA_OUTPUT_FILE` text extraction for redacted `.txt`, `.md`, `.docx`, and `.pdf` output fixtures.
- Compare source-derived or expectations-file terms against the output fixture and emit `outputDataParityFindings` plus `outputHumanReviewBlockers` in the JSON report.
- Add a separate `Output Fixture Parity Findings` section to the markdown report while preserving browser route/UI section evidence separately.

## Tracking
- Linear: WIN-150

## Route Task
- classification: low-risk autonomous
- lane: standard
- triggering paths: `scripts/clinical-data-parity-agent.ts`, `scripts/lib/clinical-data-parity-agent.ts`, `tests/scripts/clinical-data-parity-agent.test.ts`
- protected-path drift: none

## Verification
- `npm test -- tests/scripts/clinical-data-parity-agent.test.ts` - pass
- `npm run typecheck` - pass
- `npm run lint` - pass
- `npm run ci:check-focused` - pass; DB-backed checks skipped locally because `SUPABASE_DB_URL`/`DATABASE_URL` are not configured
- `npm run build` - pass
- `npm run test:ci` - pass, 317 files / 1880 tests
- `PW_CLINICAL_QA_SOURCE_FILE=artifacts/latest/redacted-clinical-qa-source.txt PW_CLINICAL_QA_OUTPUT_FILE=artifacts/latest/redacted-clinical-qa-output.txt npm run playwright:clinical-data-parity-agent` - pass against redacted fixtures
- `npm run verify:local` - pass through policy, lint, typecheck, test:ci, coverage, and build; fails only at `npm run test:routes:tier0` because local Cypress cannot start with `bad option: --smoke-test` / `bad option: --ping=505`

## Reviewer Notes
- Browser-only and redacted-fixture boundaries are unchanged.
- This does not upload, publish, approve, or write Supabase data.
- Subagent reviewer/tester spawning was not invoked because the available multi-agent tool permits spawning only when explicitly requested by the user.