### PR TITLE
Capture clinical QA generated outputs

### DIFF
--- a/.agents/skills/clinical-data-parity-auditor/SKILL.md
+++ b/.agents/skills/clinical-data-parity-auditor/SKILL.md
@@ -41,8 +41,10 @@ Optional scope:
 - `PW_CLINICAL_QA_ROUTE`
 - `PW_CLINICAL_QA_SOURCE_FILE`
 - `PW_CLINICAL_QA_OUTPUT_FILE`
+- `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR`
 
 Source/output fixture paths must include `redacted`, `synthetic`, `smoke`, or `test` in the path.
+When `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR` is set, the runner clicks that browser selector, captures the completed assessment output response, saves the downloaded artifact under `artifacts/latest` with a redacted filename, and uses that artifact for output parity.
 
 ## Browser Reachability Check
 

--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -5,12 +5,14 @@ import { chromium, type Page } from "playwright";
 import {
   assertRedactedQaFixture,
   assertSupportedClinicalQaSourceTextFixture,
+  buildClinicalQaGeneratedOutputArtifactPath,
   buildClinicalQaReportMarkdown,
   buildClinicalQaRoute,
   deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalDataParity,
   evaluateClinicalQaChecklist,
   type ClinicalQaEvidenceSection,
+  parseClinicalQaGeneratedOutputResponse,
   parseClinicalQaExpectations,
   readClinicalQaOutputFixtureText,
   readClinicalQaSourceFixtureText,
@@ -24,6 +26,13 @@ import {
   ensureArtifactsDir,
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
+
+type ClinicalQaCapturedGeneratedOutput = {
+  artifactPath: string;
+  generatedFileType: "docx" | "pdf";
+  filename: string | null;
+  text: string;
+};
 
 const collectClinicalQaEvidenceSections = async (page: Page): Promise<ClinicalQaEvidenceSection[]> =>
   page.evaluate(`
@@ -73,6 +82,47 @@ const collectClinicalQaEvidenceSections = async (page: Page): Promise<ClinicalQa
     })()
   `);
 
+const captureGeneratedOutputArtifact = async (args: {
+  page: Page;
+  selector: string;
+  latestDir: string;
+  runId: number;
+}): Promise<ClinicalQaCapturedGeneratedOutput> => {
+  const responsePromise = args.page.waitForResponse(
+    (response) => {
+      const url = new URL(response.url());
+      return url.pathname === "/api/assessment-plan-pdf" && response.request().method() === "POST";
+    },
+    { timeout: 45_000 },
+  );
+  const popupPromise = args.page.waitForEvent("popup", { timeout: 5_000 }).catch(() => null);
+
+  await args.page.locator(args.selector).click({ timeout: 10_000 });
+  const response = await responsePromise;
+  const responsePayload = await response.json();
+  if (!response.ok()) {
+    throw new Error("Generated output request failed before artifact download.");
+  }
+
+  const metadata = parseClinicalQaGeneratedOutputResponse(responsePayload);
+  const artifactPath = buildClinicalQaGeneratedOutputArtifactPath(args.latestDir, args.runId, metadata);
+  const artifactResponse = await args.page.context().request.get(metadata.signedUrl);
+  if (!artifactResponse.ok()) {
+    throw new Error(`Generated output artifact download failed with HTTP ${artifactResponse.status()}.`);
+  }
+
+  await writeFile(artifactPath, await artifactResponse.body());
+  const popup = await popupPromise;
+  await popup?.close().catch(() => undefined);
+
+  return {
+    artifactPath,
+    generatedFileType: metadata.generatedFileType,
+    filename: metadata.filename,
+    text: await readClinicalQaOutputFixtureText(artifactPath),
+  };
+};
+
 const run = async (): Promise<void> => {
   loadPlaywrightEnv();
 
@@ -114,7 +164,8 @@ const run = async (): Promise<void> => {
         )
       : [];
   const expectationsSource = expectationsFixture ? "expectations-file" : sourceFixture ? "source-text" : "none";
-  const outputText = outputFixture ? await readClinicalQaOutputFixtureText(outputFixture) : null;
+  const outputFixtureText = outputFixture ? await readClinicalQaOutputFixtureText(outputFixture) : null;
+  const generatedOutputSelector = process.env.PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR?.trim() || null;
 
   const browser = await chromium.launch({ headless: process.env.HEADLESS !== "false" });
   const context = await browser.newContext();
@@ -125,6 +176,16 @@ const run = async (): Promise<void> => {
     await loginAndAssertSession(page, baseUrl, credentials.email, credentials.password);
     await assertRouteAccessible(page, baseUrl, routePath, { timeoutMs: 20_000 });
 
+    const runId = Date.now();
+    const capturedGeneratedOutput = generatedOutputSelector
+      ? await captureGeneratedOutputArtifact({
+          page,
+          selector: generatedOutputSelector,
+          latestDir,
+          runId,
+        })
+      : null;
+    const outputText = capturedGeneratedOutput?.text ?? outputFixtureText;
     const pageText = await page.locator("body").innerText({ timeout: 10_000 });
     const evidenceSections = await collectClinicalQaEvidenceSections(page);
     const checklist = evaluateClinicalQaChecklist(pageText);
@@ -138,7 +199,6 @@ const run = async (): Promise<void> => {
           })),
         )
       : [];
-    const runId = Date.now();
     const screenshotPath = path.join(latestDir, `clinical-data-parity-agent-${runId}.png`);
     await page.screenshot({ path: screenshotPath, fullPage: true });
     const reportJsonPath = path.join(latestDir, `clinical-data-parity-agent-${runId}.json`);
@@ -155,9 +215,18 @@ const run = async (): Promise<void> => {
       fixtures: {
         sourceConfigured: Boolean(sourceFixture),
         outputConfigured: Boolean(outputFixture),
+        generatedOutputCaptureConfigured: Boolean(generatedOutputSelector),
         expectationsConfigured: Boolean(expectationsFixture),
         expectationsSource,
+        outputSource: capturedGeneratedOutput ? "generated-output-capture" : outputFixture ? "output-fixture" : "none",
       },
+      generatedOutputArtifact: capturedGeneratedOutput
+        ? {
+            path: capturedGeneratedOutput.artifactPath,
+            generatedFileType: capturedGeneratedOutput.generatedFileType,
+            filename: capturedGeneratedOutput.filename,
+          }
+        : null,
       evidenceSections: evidenceSections.map((section) => ({
         label: section.label,
         textLength: section.text.length,

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
-import { extname } from "node:path";
+import path, { extname } from "node:path";
 import { promisify } from "node:util";
 import { inflateRawSync } from "node:zlib";
 
@@ -77,6 +77,12 @@ export type ClinicalQaReportInput = {
   disclaimer: string;
 };
 
+export type ClinicalQaGeneratedOutputMetadata = {
+  generatedFileType: "docx" | "pdf";
+  signedUrl: string;
+  filename: string | null;
+};
+
 const REDACTED_PASSWORD_PLACEHOLDER = "****";
 const execFileAsync = promisify(execFile);
 
@@ -138,6 +144,44 @@ export const assertSupportedClinicalQaSourceTextFixture = (fixturePath: string):
   }
   return fixturePath;
 };
+
+export const parseClinicalQaGeneratedOutputResponse = (
+  value: unknown,
+): ClinicalQaGeneratedOutputMetadata => {
+  if (!value || typeof value !== "object") {
+    throw new Error("Generated output response must be a JSON object.");
+  }
+  const response = value as Record<string, unknown>;
+  const generatedFileType = response.generated_file_type;
+  if (generatedFileType !== "docx" && generatedFileType !== "pdf") {
+    throw new Error("Generated output response must include generated_file_type of docx or pdf.");
+  }
+
+  const signedUrl = typeof response.signed_url === "string" ? response.signed_url.trim() : "";
+  if (!signedUrl) {
+    throw new Error("Generated output response must include a non-empty signed_url.");
+  }
+
+  const filename = typeof response.filename === "string" && response.filename.trim()
+    ? response.filename.trim()
+    : null;
+
+  return {
+    generatedFileType,
+    signedUrl,
+    filename,
+  };
+};
+
+export const buildClinicalQaGeneratedOutputArtifactPath = (
+  latestDir: string,
+  runId: number,
+  metadata: ClinicalQaGeneratedOutputMetadata,
+): string =>
+  path.join(
+    latestDir,
+    `redacted-clinical-qa-generated-output-${runId}.${metadata.generatedFileType}`,
+  );
 
 const decodeXmlText = (value: string): string =>
   value

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -10,10 +10,12 @@ import {
   assertRedactedQaFixture,
   assertSupportedClinicalQaSourceTextFixture,
   buildClinicalQaRoute,
+  buildClinicalQaGeneratedOutputArtifactPath,
   buildClinicalQaReportMarkdown,
   deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalQaChecklist,
   evaluateClinicalDataParity,
+  parseClinicalQaGeneratedOutputResponse,
   parseClinicalQaExpectations,
   readClinicalQaOutputFixtureText,
   readClinicalQaSourceFixtureText,
@@ -484,6 +486,29 @@ describe("clinical data parity agent helpers", () => {
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("parses generated output metadata and saves artifacts under redacted names", () => {
+    const metadata = parseClinicalQaGeneratedOutputResponse({
+      generated_file_type: "docx",
+      signed_url: "https://example.test/generated-iehp-fba.docx?token=redacted",
+      filename: "generated-iehp-fba.docx",
+    });
+
+    expect(metadata).toEqual({
+      generatedFileType: "docx",
+      signedUrl: "https://example.test/generated-iehp-fba.docx?token=redacted",
+      filename: "generated-iehp-fba.docx",
+    });
+    expect(
+      buildClinicalQaGeneratedOutputArtifactPath("artifacts/latest", 1234, metadata),
+    ).toBe(path.join("artifacts/latest", "redacted-clinical-qa-generated-output-1234.docx"));
+    expect(() => parseClinicalQaGeneratedOutputResponse({ signed_url: "https://example.test/file.exe" })).toThrow(
+      "generated_file_type",
+    );
+    expect(() =>
+      parseClinicalQaGeneratedOutputResponse({ generated_file_type: "pdf", signed_url: "" }),
+    ).toThrow("signed_url");
   });
 
   it("builds a durable markdown report without leaking browser-visible emails", () => {


### PR DESCRIPTION
## Summary
- add optional `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR` support to the clinical data parity runner
- capture `/api/assessment-plan-pdf` POST responses, download the returned signed DOCX/PDF artifact through Playwright, and save it under a redacted artifact filename
- use captured generated artifact text for output parity when configured, while preserving explicit redacted output fixture behavior
- document the optional selector and add focused helper coverage for generated-output metadata/path handling

## Route-task classification
- classification: low-risk autonomous
- lane: standard
- triggering paths: `.agents/skills/clinical-data-parity-auditor/SKILL.md`, `scripts/clinical-data-parity-agent.ts`, `scripts/lib/clinical-data-parity-agent.ts`, `tests/scripts/clinical-data-parity-agent.test.ts`
- risk rationale: browser-only QA runner enhancement using redacted/test artifacts; no auth, server/API, Supabase, deploy, or production data path changes
- issue: WIN-150

## Verification card
- `npm test -- tests/scripts/clinical-data-parity-agent.test.ts` red first: failed as expected before implementation because `parseClinicalQaGeneratedOutputResponse` did not exist
- `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`: pass, 16 tests
- `npm run typecheck`: pass
- `git diff --check`: pass
- `npm run lint`: pass
- `npm run ci:check-focused`: pass; local CI/protected-context skips for branch protection, privileged DB grant env, Supabase auth parity env, sensitive-table DB connection, preview drift DB connection; existing E2E skip-language warning remains
- `npm run build`: pass
- `npm run test:ci`: pass, 317 files / 1881 tests; existing stderr warnings from Dashboard MSW and AI documentation fetch/finalize, exit code 0
- `npm run playwright:clinical-data-parity-agent` with redacted source/output fixtures and selector unset: pass; output source remained `output-fixture`
- `npm run verify:local`: partial; policy/lint/typecheck/test:ci/coverage/build passed, final `npm run test:routes:tier0` failed locally on Cypress startup (`Cypress.exe: bad option: --smoke-test`, `--ping=...`)

## Residual risk
- The generated-output selector path has helper coverage and code review, but was not live-smoked with a real selector because this environment does not have a configured approved test assessment ready to generate a final artifact.
- Signed URLs are used only for immediate Playwright download and are not written to the report payload.

## PR hygiene
- pr-ready decision: ready with the residual live-smoke caveat above
- affected files are limited to the QA skill, runner/helper script, and focused tests