### PR TITLE
Test clinical QA generated output capture

### DIFF
--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -33,6 +33,7 @@ Optional:
 - `PW_CLINICAL_QA_SOURCE_FILE`
 - `PW_CLINICAL_QA_OUTPUT_FILE`
 - `PW_CLINICAL_QA_EXPECTATIONS_FILE`
+- `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR`
 
 The runner rejects placeholder passwords, API routes, admin-only routes, and fixture paths that are not clearly redacted, synthetic, smoke, or test fixtures.
 
@@ -65,7 +66,7 @@ The browser runner compares each `expectedTerms` entry against the visible brows
 
 ## Source Text Fixture Extraction
 
-When `PW_CLINICAL_QA_EXPECTATIONS_FILE` is omitted and `PW_CLINICAL_QA_SOURCE_FILE` points to a redacted `.txt` or `.md` fixture, the runner derives expectations from supported source labels:
+When `PW_CLINICAL_QA_EXPECTATIONS_FILE` is omitted and `PW_CLINICAL_QA_SOURCE_FILE` points to a redacted `.txt`, `.md`, `.docx`, or `.pdf` fixture, the runner extracts source text and derives expectations from supported source labels:
 
 - `Target behaviors: ...`
 - `Replacement behavior: ...`
@@ -77,7 +78,19 @@ When `PW_CLINICAL_QA_EXPECTATIONS_FILE` is omitted and `PW_CLINICAL_QA_SOURCE_FI
 - `Client identifiers: ...`
 - `Authorization details: ...`
 
-A safe example lives at `tests/fixtures/redacted-iehp-source.example.txt`. Source-only extraction currently does not parse DOCX or PDF. For DOCX/PDF source documents, provide a redacted expectations JSON fixture until a dedicated parser is added.
+A safe example lives at `tests/fixtures/redacted-iehp-source.example.txt`. DOCX/PDF extraction is intended for redacted QA fixtures only; provide a redacted expectations JSON fixture when the source format is not reliably extractable.
+
+## Generated Output Capture
+
+When `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR` is set, the runner:
+
+- waits for the browser `POST /api/assessment-plan-pdf` response triggered by that selector
+- parses the returned `generated_file_type`, `signed_url`, and optional `filename`
+- downloads the signed DOCX/PDF artifact through the Playwright browser context
+- saves the artifact under `artifacts/latest/redacted-clinical-qa-generated-output-<timestamp>.<docx|pdf>`
+- extracts text from that redacted artifact and uses it for output parity
+
+The signed URL is used only for immediate download and is not written to the JSON/markdown report payload.
 
 ## Report Artifacts
 
@@ -86,6 +99,7 @@ Each successful run writes durable artifacts under `artifacts/latest`:
 - screenshot: `clinical-data-parity-agent-<timestamp>.png`
 - JSON report: `clinical-data-parity-agent-<timestamp>.json`
 - markdown report: `clinical-data-parity-agent-<timestamp>.md`
+- optional generated output artifact: `redacted-clinical-qa-generated-output-<timestamp>.<docx|pdf>`
 
 The JSON report matches the stdout payload. The markdown report is intended for reviewer handoff and redacts browser-visible email addresses from observed snippets.
 
@@ -107,5 +121,6 @@ The JSON report matches the stdout payload. The markdown report is intended for 
 
 ## Residual Risk
 
-- Browser evidence now supports source-to-output term parity when a redacted expectations JSON fixture or supported redacted text fixture is configured. It still requires fixture curation and human review of findings.
+- Browser evidence now supports source-to-output term parity when a redacted expectations JSON fixture or supported redacted source fixture is configured. It still requires fixture curation and human review of findings.
+- Live generated-output capture requires an approved redacted test assessment route with a stable generate-control selector.
 - The agent can reduce reviewer workload but cannot replace BCBA sign-off.

--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -5,14 +5,13 @@ import { chromium, type Page } from "playwright";
 import {
   assertRedactedQaFixture,
   assertSupportedClinicalQaSourceTextFixture,
-  buildClinicalQaGeneratedOutputArtifactPath,
   buildClinicalQaReportMarkdown,
   buildClinicalQaRoute,
+  captureClinicalQaGeneratedOutputArtifact,
   deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalDataParity,
   evaluateClinicalQaChecklist,
   type ClinicalQaEvidenceSection,
-  parseClinicalQaGeneratedOutputResponse,
   parseClinicalQaExpectations,
   readClinicalQaOutputFixtureText,
   readClinicalQaSourceFixtureText,
@@ -26,13 +25,6 @@ import {
   ensureArtifactsDir,
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
-
-type ClinicalQaCapturedGeneratedOutput = {
-  artifactPath: string;
-  generatedFileType: "docx" | "pdf";
-  filename: string | null;
-  text: string;
-};
 
 const collectClinicalQaEvidenceSections = async (page: Page): Promise<ClinicalQaEvidenceSection[]> =>
   page.evaluate(`
@@ -81,47 +73,6 @@ const collectClinicalQaEvidenceSections = async (page: Page): Promise<ClinicalQa
       return Array.from(sectionEntries.values());
     })()
   `);
-
-const captureGeneratedOutputArtifact = async (args: {
-  page: Page;
-  selector: string;
-  latestDir: string;
-  runId: number;
-}): Promise<ClinicalQaCapturedGeneratedOutput> => {
-  const responsePromise = args.page.waitForResponse(
-    (response) => {
-      const url = new URL(response.url());
-      return url.pathname === "/api/assessment-plan-pdf" && response.request().method() === "POST";
-    },
-    { timeout: 45_000 },
-  );
-  const popupPromise = args.page.waitForEvent("popup", { timeout: 5_000 }).catch(() => null);
-
-  await args.page.locator(args.selector).click({ timeout: 10_000 });
-  const response = await responsePromise;
-  const responsePayload = await response.json();
-  if (!response.ok()) {
-    throw new Error("Generated output request failed before artifact download.");
-  }
-
-  const metadata = parseClinicalQaGeneratedOutputResponse(responsePayload);
-  const artifactPath = buildClinicalQaGeneratedOutputArtifactPath(args.latestDir, args.runId, metadata);
-  const artifactResponse = await args.page.context().request.get(metadata.signedUrl);
-  if (!artifactResponse.ok()) {
-    throw new Error(`Generated output artifact download failed with HTTP ${artifactResponse.status()}.`);
-  }
-
-  await writeFile(artifactPath, await artifactResponse.body());
-  const popup = await popupPromise;
-  await popup?.close().catch(() => undefined);
-
-  return {
-    artifactPath,
-    generatedFileType: metadata.generatedFileType,
-    filename: metadata.filename,
-    text: await readClinicalQaOutputFixtureText(artifactPath),
-  };
-};
 
 const run = async (): Promise<void> => {
   loadPlaywrightEnv();
@@ -178,7 +129,7 @@ const run = async (): Promise<void> => {
 
     const runId = Date.now();
     const capturedGeneratedOutput = generatedOutputSelector
-      ? await captureGeneratedOutputArtifact({
+      ? await captureClinicalQaGeneratedOutputArtifact({
           page,
           selector: generatedOutputSelector,
           latestDir,

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path, { extname } from "node:path";
 import { promisify } from "node:util";
 import { inflateRawSync } from "node:zlib";
@@ -81,6 +81,45 @@ export type ClinicalQaGeneratedOutputMetadata = {
   generatedFileType: "docx" | "pdf";
   signedUrl: string;
   filename: string | null;
+};
+
+export type ClinicalQaCapturedGeneratedOutput = {
+  artifactPath: string;
+  generatedFileType: "docx" | "pdf";
+  filename: string | null;
+  text: string;
+};
+
+type ClinicalQaGeneratedOutputResponse = {
+  url: () => string;
+  request: () => { method: () => string };
+  json: () => Promise<unknown>;
+  ok: () => boolean;
+};
+
+type ClinicalQaGeneratedOutputArtifactResponse = {
+  ok: () => boolean;
+  status: () => number;
+  body: () => Promise<Buffer>;
+};
+
+export type ClinicalQaGeneratedOutputPage = {
+  waitForResponse: (
+    predicate: (response: ClinicalQaGeneratedOutputResponse) => boolean,
+    options: { timeout: number },
+  ) => Promise<ClinicalQaGeneratedOutputResponse>;
+  waitForEvent: (
+    eventName: "popup",
+    options: { timeout: number },
+  ) => Promise<{ close: () => Promise<unknown> } | null>;
+  locator: (selector: string) => {
+    click: (options: { timeout: number }) => Promise<unknown>;
+  };
+  context: () => {
+    request: {
+      get: (url: string) => Promise<ClinicalQaGeneratedOutputArtifactResponse>;
+    };
+  };
 };
 
 const REDACTED_PASSWORD_PLACEHOLDER = "****";
@@ -182,6 +221,51 @@ export const buildClinicalQaGeneratedOutputArtifactPath = (
     latestDir,
     `redacted-clinical-qa-generated-output-${runId}.${metadata.generatedFileType}`,
   );
+
+export const captureClinicalQaGeneratedOutputArtifact = async (args: {
+  page: ClinicalQaGeneratedOutputPage;
+  selector: string;
+  latestDir: string;
+  runId: number;
+  readOutputText?: (artifactPath: string) => Promise<string>;
+  writeArtifact?: (artifactPath: string, artifactBody: Buffer) => Promise<unknown>;
+}): Promise<ClinicalQaCapturedGeneratedOutput> => {
+  const responsePromise = args.page.waitForResponse(
+    (response) => {
+      const url = new URL(response.url());
+      return url.pathname === "/api/assessment-plan-pdf" && response.request().method() === "POST";
+    },
+    { timeout: 45_000 },
+  );
+  const popupPromise = args.page.waitForEvent("popup", { timeout: 5_000 }).catch(() => null);
+
+  await args.page.locator(args.selector).click({ timeout: 10_000 });
+  const response = await responsePromise;
+  const responsePayload = await response.json();
+  if (!response.ok()) {
+    throw new Error("Generated output request failed before artifact download.");
+  }
+
+  const metadata = parseClinicalQaGeneratedOutputResponse(responsePayload);
+  const artifactPath = buildClinicalQaGeneratedOutputArtifactPath(args.latestDir, args.runId, metadata);
+  const artifactResponse = await args.page.context().request.get(metadata.signedUrl);
+  if (!artifactResponse.ok()) {
+    throw new Error(`Generated output artifact download failed with HTTP ${artifactResponse.status()}.`);
+  }
+
+  const writeArtifact = args.writeArtifact ?? writeFile;
+  const readOutputText = args.readOutputText ?? readClinicalQaOutputFixtureText;
+  await writeArtifact(artifactPath, await artifactResponse.body());
+  const popup = await popupPromise;
+  await popup?.close().catch(() => undefined);
+
+  return {
+    artifactPath,
+    generatedFileType: metadata.generatedFileType,
+    filename: metadata.filename,
+    text: await readOutputText(artifactPath),
+  };
+};
 
 const decodeXmlText = (value: string): string =>
   value

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { deflateRawSync } from "node:zlib";
@@ -12,6 +12,7 @@ import {
   buildClinicalQaRoute,
   buildClinicalQaGeneratedOutputArtifactPath,
   buildClinicalQaReportMarkdown,
+  captureClinicalQaGeneratedOutputArtifact,
   deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalQaChecklist,
   evaluateClinicalDataParity,
@@ -509,6 +510,88 @@ describe("clinical data parity agent helpers", () => {
     expect(() =>
       parseClinicalQaGeneratedOutputResponse({ generated_file_type: "pdf", signed_url: "" }),
     ).toThrow("signed_url");
+  });
+
+  it("captures generated output artifacts through the browser response path", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "clinical-qa-redacted-generated-"));
+    const events: string[] = [];
+    const artifactBody = Buffer.from("Generated output includes functional communication.");
+    const response = {
+      url: () => "https://app.example.test/api/assessment-plan-pdf",
+      request: () => ({ method: () => "POST" }),
+      json: async () => ({
+        generated_file_type: "pdf",
+        signed_url: "https://storage.example.test/generated.pdf?token=secret",
+        filename: "generated-iehp-fba.pdf",
+      }),
+      ok: () => true,
+    };
+    let closedPopup = false;
+
+    const page = {
+      waitForResponse: async (predicate: (candidate: typeof response) => boolean) => {
+        events.push("waitForResponse");
+        expect(predicate(response)).toBe(true);
+        return response;
+      },
+      waitForEvent: async (eventName: string, options: { timeout: number }) => {
+        events.push(`waitForEvent:${eventName}:${options.timeout}`);
+        return {
+          close: async () => {
+            closedPopup = true;
+          },
+        };
+      },
+      locator: (selector: string) => {
+        expect(selector).toBe("[data-testid='generate-final-output']");
+        return {
+          click: async (options: { timeout: number }) => {
+            events.push(`click:${options.timeout}`);
+          },
+        };
+      },
+      context: () => ({
+        request: {
+          get: async (url: string) => {
+            events.push("download");
+            expect(url).toBe("https://storage.example.test/generated.pdf?token=secret");
+            return {
+              ok: () => true,
+              status: () => 200,
+              body: async () => artifactBody,
+            };
+          },
+        },
+      }),
+    };
+
+    try {
+      const captured = await captureClinicalQaGeneratedOutputArtifact({
+        page,
+        selector: "[data-testid='generate-final-output']",
+        latestDir: tempDir,
+        runId: 42,
+        readOutputText: async (artifactPath) => `extracted text from ${path.basename(artifactPath)}`,
+      });
+
+      expect(events).toEqual([
+        "waitForResponse",
+        "waitForEvent:popup:5000",
+        "click:10000",
+        "download",
+      ]);
+      expect(closedPopup).toBe(true);
+      expect(captured).toEqual({
+        artifactPath: path.join(tempDir, "redacted-clinical-qa-generated-output-42.pdf"),
+        generatedFileType: "pdf",
+        filename: "generated-iehp-fba.pdf",
+        text: "extracted text from redacted-clinical-qa-generated-output-42.pdf",
+      });
+      await expect(readFile(captured.artifactPath)).resolves.toEqual(artifactBody);
+      expect(JSON.stringify(captured)).not.toContain("token=secret");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("builds a durable markdown report without leaking browser-visible emails", () => {


### PR DESCRIPTION
## Summary
- move clinical QA generated-output capture into the shared helper layer so the selector/response/download/write/extract path is directly testable
- add focused red-first coverage for the Playwright response path without requiring secrets or a live approved assessment
- keep the CLI behavior unchanged by delegating to the shared helper
- update the clinical QA handoff doc for generated-output selector support and DOCX/PDF source fixture extraction

## Route-task classification
- classification: low-risk autonomous
- lane: standard
- triggering paths: `scripts/clinical-data-parity-agent.ts`, `scripts/lib/clinical-data-parity-agent.ts`, `tests/scripts/clinical-data-parity-agent.test.ts`, `docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md`
- risk rationale: non-trivial QA runner/test-harness work outside protected auth/server/Supabase/deploy paths; browser-only redacted/test-account clinical QA scope
- issue: WIN-150

## Verification card
- `npm test -- tests/scripts/clinical-data-parity-agent.test.ts` red first: failed as expected because `captureClinicalQaGeneratedOutputArtifact` was not exported
- `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`: pass, 17 tests
- `git diff --check`: pass
- `npm run typecheck`: pass
- `npm run lint`: pass
- `npm run ci:check-focused`: pass; local protected-context skips for branch protection, privileged DB grant env, Supabase auth parity env, sensitive-table DB connection, preview drift DB connection; existing E2E skip-language warning remains
- `npm run build`: pass
- `npm run test:ci`: pass, 317 files / 1882 tests; existing stderr warnings from Dashboard MSW and AI documentation fetch/finalize, exit code 0
- `npm run verify:local`: partial; policy/lint/typecheck/test:ci/coverage/build passed, final `npm run test:routes:tier0` failed locally on Cypress startup (`Cypress.exe: bad option: --smoke-test`, `--ping=465`)

## Residual risk
- No shell-provided `PW_CLINICAL_QA_*` or admin browser credentials/client id were present, and I did not read `.env*`; live generated-output selector smoke still requires an approved redacted test assessment route with a stable generate selector.
- Signed URLs are used only for immediate artifact download and are not returned from the capture helper payload or documented report payload.

## PR hygiene
- pr-ready decision: ready with the local Cypress and live-selector caveats above
- protected-path drift: none
- generated artifact drift: none after restoring `reports/test-reliability-latest.json`
- Linear tracking: commented on WIN-150