### PR TITLE
Add clinical QA output section evidence

### DIFF
--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -63,6 +63,7 @@ The browser runner compares each `expectedTerms` entry against the visible brows
 - `observedSectionTerms`: visible UI terms expected near the reviewed surface.
 - `mismatchType`: `match`, `partial`, or `missing`.
 - `observedTextSnippet`: a compact browser-text excerpt around matched evidence when available.
+- `sectionEvidenceStatus`: whether matched terms also appear inside the expected browser or generated-output section.
 
 ## Source Text Fixture Extraction
 
@@ -89,6 +90,7 @@ When `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR` is set, the runner:
 - downloads the signed DOCX/PDF artifact through the Playwright browser context
 - saves the artifact under `artifacts/latest/redacted-clinical-qa-generated-output-<timestamp>.<docx|pdf>`
 - extracts text from that redacted artifact and uses it for output parity
+- records generated-output section evidence from labeled text blocks when the artifact text is extractable
 
 The signed URL is used only for immediate download and is not written to the JSON/markdown report payload.
 

--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -7,6 +7,7 @@ import {
   assertSupportedClinicalQaSourceTextFixture,
   buildClinicalQaReportMarkdown,
   buildClinicalQaRoute,
+  buildClinicalQaTextEvidenceSections,
   captureClinicalQaGeneratedOutputArtifact,
   deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalDataParity,
@@ -137,6 +138,7 @@ const run = async (): Promise<void> => {
         })
       : null;
     const outputText = capturedGeneratedOutput?.text ?? outputFixtureText;
+    const outputEvidenceSections = outputText ? buildClinicalQaTextEvidenceSections(outputText) : [];
     const pageText = await page.locator("body").innerText({ timeout: 10_000 });
     const evidenceSections = await collectClinicalQaEvidenceSections(page);
     const checklist = evaluateClinicalQaChecklist(pageText);
@@ -144,10 +146,8 @@ const run = async (): Promise<void> => {
     const outputDataParityFindings = outputText
       ? evaluateClinicalDataParity(
           outputText,
-          expectations.map((expectation) => ({
-            ...expectation,
-            observedSectionTerms: [],
-          })),
+          expectations,
+          outputEvidenceSections,
         )
       : [];
     const screenshotPath = path.join(latestDir, `clinical-data-parity-agent-${runId}.png`);
@@ -182,6 +182,10 @@ const run = async (): Promise<void> => {
         label: section.label,
         textLength: section.text.length,
       })),
+      outputEvidenceSections: outputEvidenceSections.map((section) => ({
+        label: section.label,
+        textLength: section.text.length,
+      })),
       checklist,
       dataParityFindings,
       outputDataParityFindings,
@@ -206,6 +210,9 @@ const run = async (): Promise<void> => {
       checklist,
       dataParityFindings,
       outputDataParityFindings,
+      outputFindingsHeading: capturedGeneratedOutput
+        ? "Generated Output Parity Findings"
+        : "Output Fixture Parity Findings",
       disclaimer,
     });
 

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -74,6 +74,7 @@ export type ClinicalQaReportInput = {
   checklist: ClinicalQaChecklistResult[];
   dataParityFindings: ClinicalQaParityFinding[];
   outputDataParityFindings?: ClinicalQaParityFinding[];
+  outputFindingsHeading?: string;
   disclaimer: string;
 };
 
@@ -650,6 +651,28 @@ export const deriveClinicalQaExpectationsFromSourceText = (
   });
 };
 
+export const buildClinicalQaTextEvidenceSections = (text: string): ClinicalQaEvidenceSection[] => {
+  const blocks = text
+    .replace(/\r\n?/g, "\n")
+    .split(/\n\s*\n/)
+    .map((block) =>
+      block
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0),
+    )
+    .filter((lines) => lines.length > 0);
+
+  return blocks.map((lines, index) => {
+    const [label, ...bodyLines] = lines;
+    const sectionText = bodyLines.length > 0 ? bodyLines.join(" ") : label;
+    return {
+      label: label || `Output section ${index + 1}`,
+      text: sectionText.replace(/\s+/g, " ").trim(),
+    };
+  });
+};
+
 const buildObservedTextSnippet = (pageText: string, matchedTerms: string[]): string | null => {
   const compactText = sanitizeEvidenceText(pageText.replace(/\s+/g, " ").trim());
   if (!compactText) {
@@ -861,6 +884,7 @@ export const buildClinicalQaReportMarkdown = (report: ClinicalQaReportInput): st
   );
   const findingLines = formatFindingLines(report.dataParityFindings);
   const outputFindingLines = formatFindingLines(outputDataParityFindings);
+  const outputFindingsHeading = report.outputFindingsHeading ?? "Output Fixture Parity Findings";
 
   return [
     "# Clinical Data Parity Agent Report",
@@ -878,7 +902,7 @@ export const buildClinicalQaReportMarkdown = (report: ClinicalQaReportInput): st
     "## Data Parity Findings",
     ...(findingLines.length > 0 ? findingLines : ["- none"]),
     "",
-    "## Output Fixture Parity Findings",
+    `## ${outputFindingsHeading}`,
     ...(outputFindingLines.length > 0 ? outputFindingLines : ["- none"]),
     "",
     "## Disclaimer",

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -12,6 +12,7 @@ import {
   buildClinicalQaRoute,
   buildClinicalQaGeneratedOutputArtifactPath,
   buildClinicalQaReportMarkdown,
+  buildClinicalQaTextEvidenceSections,
   captureClinicalQaGeneratedOutputArtifact,
   deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalQaChecklist,
@@ -343,6 +344,60 @@ describe("clinical data parity agent helpers", () => {
     });
   });
 
+  it("evaluates generated output parity against output section evidence", () => {
+    const expectations = parseClinicalQaExpectations(
+      JSON.stringify({
+        expectations: [
+          {
+            key: "target_behaviors",
+            label: "Target behaviors",
+            sourceSection: "FBA target behavior summary",
+            expectedTerms: ["elopement", "property destruction"],
+            observedSectionTerms: ["Target behaviors"],
+            severity: "high",
+            humanReviewBlocker: true,
+          },
+        ],
+      }),
+      "fixtures/redacted-iehp-expectations.json",
+    );
+    const outputText = `
+      Target behaviors
+      Elopement is included in the generated plan.
+
+      Intervention plan
+      Property destruction appears only in the intervention discussion.
+    `;
+    const outputSections = buildClinicalQaTextEvidenceSections(outputText);
+
+    expect(outputSections).toEqual([
+      {
+        label: "Target behaviors",
+        text: "Elopement is included in the generated plan.",
+      },
+      {
+        label: "Intervention plan",
+        text: "Property destruction appears only in the intervention discussion.",
+      },
+    ]);
+
+    const findings = evaluateClinicalDataParity(outputText, expectations, outputSections);
+
+    expect(findings[0]).toMatchObject({
+      status: "pass",
+      mismatchType: "match",
+      matchedTerms: ["elopement", "property destruction"],
+      sectionEvidenceStatus: "partial",
+      sectionEvidence: [
+        {
+          sectionLabel: "Target behaviors",
+          matchedTerms: ["elopement"],
+          missingTerms: ["property destruction"],
+        },
+      ],
+    });
+  });
+
   it("derives parity expectations from redacted source text sections", () => {
     const expectations = deriveClinicalQaExpectationsFromSourceText(`
       FBA target behavior summary
@@ -645,6 +700,7 @@ describe("clinical data parity agent helpers", () => {
           observedTextSnippet: "Generated report includes functional communication.",
         },
       ],
+      outputFindingsHeading: "Generated Output Parity Findings",
       disclaimer: "QA evidence only. This is not BCBA approval or clinical sign-off.",
     });
 
@@ -653,7 +709,7 @@ describe("clinical data parity agent helpers", () => {
     expect(markdown).toContain("screenshot: `artifacts/latest/clinical-data-parity-agent-test.png`");
     expect(markdown).toContain("Target behaviors");
     expect(markdown).toContain("missing: property destruction");
-    expect(markdown).toContain("## Output Fixture Parity Findings");
+    expect(markdown).toContain("## Generated Output Parity Findings");
     expect(markdown).toContain("Generated report includes functional communication.");
     expect(markdown).toContain("human review blocker: yes");
     expect(markdown).toContain("[redacted-email]");


### PR DESCRIPTION
## Summary
- add labeled text-section extraction for generated/output artifact text
- evaluate output parity with section evidence instead of clearing section expectations for output checks
- emit output evidence section metadata in the clinical QA payload
- label generated-output report findings separately from output-fixture findings
- update the clinical QA handoff doc for generated-output section evidence

## Route-task classification
- classification: low-risk autonomous
- lane: standard
- triggering paths: `scripts/clinical-data-parity-agent.ts`, `scripts/lib/clinical-data-parity-agent.ts`, `tests/scripts/clinical-data-parity-agent.test.ts`, `docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md`
- risk rationale: non-trivial QA runner/test-harness work outside protected auth/server/Supabase/deploy paths; browser-only redacted/test-account clinical QA scope
- issue: WIN-150

## Verification card
- `npm test -- tests/scripts/clinical-data-parity-agent.test.ts` red first: failed as expected for missing `buildClinicalQaTextEvidenceSections` and fixed output heading
- `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`: pass, 18 tests
- `git diff --check`: pass
- `npm run typecheck`: pass
- `npm run lint`: pass
- `npm run ci:check-focused`: pass; local protected-context skips for branch protection, privileged DB grant env, Supabase auth parity env, sensitive-table DB connection, preview drift DB connection; existing E2E skip-language warning remains
- `npm run build`: pass
- `npm run test:ci`: pass, 317 files / 1883 tests; existing stderr warnings from Dashboard MSW and AI documentation fetch/finalize, exit code 0
- `npm run verify:local`: partial; policy/lint/typecheck/test:ci/coverage/build passed, final `npm run test:routes:tier0` failed locally on Cypress startup (`Cypress.exe: bad option: --smoke-test`, `--ping=808`)

## Residual risk
- Live generated-output capture still requires shell-provided test credentials, a dedicated approved redacted test assessment route, and a stable generate selector.
- Output section extraction depends on extractable labeled text blocks in the generated DOCX/PDF text; unlabeled artifacts still get page-level output parity but weaker section evidence.

## PR hygiene
- pr-ready decision: ready with local Cypress and live-selector caveats above
- protected-path drift: none
- generated artifact drift: none after restoring `reports/test-reliability-latest.json`
- Linear tracking: commented on WIN-150