### PR TITLE
Add clinical QA preflight

### DIFF
--- a/.agents/skills/clinical-data-parity-auditor/SKILL.md
+++ b/.agents/skills/clinical-data-parity-auditor/SKILL.md
@@ -42,9 +42,20 @@ Optional scope:
 - `PW_CLINICAL_QA_SOURCE_FILE`
 - `PW_CLINICAL_QA_OUTPUT_FILE`
 - `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR`
+- `PW_CLINICAL_QA_PREFLIGHT_ONLY`
 
 Source/output fixture paths must include `redacted`, `synthetic`, `smoke`, or `test` in the path.
 When `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR` is set, the runner clicks that browser selector, captures the completed assessment output response, saves the downloaded artifact under `artifacts/latest` with a redacted filename, and uses that artifact for output parity.
+
+## Readiness Preflight
+
+Run this before opening the browser when validating operator setup:
+
+```bash
+PW_CLINICAL_QA_PREFLIGHT_ONLY=true npm run playwright:clinical-data-parity-agent
+```
+
+The preflight path must run before the normal Playwright env loader. It inspects only already-provided process environment values, does not read `.env*` files, does not launch a browser, does not print email/password values, and returns a machine-readable JSON report with `ok`, `blockingIssues`, `warnings`, `routePath`, and fixture readiness.
 
 ## Browser Reachability Check
 

--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -34,8 +34,35 @@ Optional:
 - `PW_CLINICAL_QA_OUTPUT_FILE`
 - `PW_CLINICAL_QA_EXPECTATIONS_FILE`
 - `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR`
+- `PW_CLINICAL_QA_PREFLIGHT_ONLY`
 
 The runner rejects placeholder passwords, API routes, admin-only routes, and fixture paths that are not clearly redacted, synthetic, smoke, or test fixtures.
+
+## Readiness Preflight
+
+Before launching a browser run, execute:
+
+```bash
+PW_CLINICAL_QA_PREFLIGHT_ONLY=true npm run playwright:clinical-data-parity-agent
+```
+
+The equivalent CLI form is:
+
+```bash
+npm run playwright:clinical-data-parity-agent -- --preflight
+```
+
+Preflight exits before the normal Playwright env loader, so it does not read `.env.local`, `.env`, or `.env.codex`. It inspects only shell-provided process env, does not launch Playwright, and does not echo email/password values. The JSON report includes:
+
+- `ok`
+- `blockingIssues`
+- `warnings`
+- `credentialLabel`
+- `routePath`
+- fixture readiness
+- `expectationsSource`
+- `outputSource`
+- `nextAction`
 
 ## Expectations Fixture Contract
 

--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -5,6 +5,7 @@ import { chromium, type Page } from "playwright";
 import {
   assertRedactedQaFixture,
   assertSupportedClinicalQaSourceTextFixture,
+  buildClinicalQaPreflightReport,
   buildClinicalQaReportMarkdown,
   buildClinicalQaRoute,
   buildClinicalQaTextEvidenceSections,
@@ -26,6 +27,9 @@ import {
   ensureArtifactsDir,
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
+
+const isPreflightOnly = (): boolean =>
+  process.env.PW_CLINICAL_QA_PREFLIGHT_ONLY === "true" || process.argv.includes("--preflight");
 
 const collectClinicalQaEvidenceSections = async (page: Page): Promise<ClinicalQaEvidenceSection[]> =>
   page.evaluate(`
@@ -76,6 +80,13 @@ const collectClinicalQaEvidenceSections = async (page: Page): Promise<ClinicalQa
   `);
 
 const run = async (): Promise<void> => {
+  if (isPreflightOnly()) {
+    const preflight = buildClinicalQaPreflightReport(process.env);
+    console.log(JSON.stringify(preflight, null, 2));
+    process.exitCode = preflight.ok ? 0 : 1;
+    return;
+  }
+
   loadPlaywrightEnv();
 
   const baseUrl = resolvePlaywrightBaseUrl().replace(/\/$/, "");

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -91,6 +91,26 @@ export type ClinicalQaCapturedGeneratedOutput = {
   text: string;
 };
 
+export type ClinicalQaPreflightEnv = Record<string, string | undefined>;
+
+export type ClinicalQaPreflightReport = {
+  ok: boolean;
+  mode: "browser-only-redacted-clinical-data-parity-preflight";
+  credentialLabel: string | null;
+  routePath: string | null;
+  fixtures: {
+    sourceConfigured: boolean;
+    outputConfigured: boolean;
+    expectationsConfigured: boolean;
+    generatedOutputCaptureConfigured: boolean;
+  };
+  expectationsSource: "expectations-file" | "source-text" | "none";
+  outputSource: "generated-output-capture" | "output-fixture" | "none";
+  blockingIssues: string[];
+  warnings: string[];
+  nextAction: string;
+};
+
 type ClinicalQaGeneratedOutputResponse = {
   url: () => string;
   request: () => { method: () => string };
@@ -452,6 +472,124 @@ export const buildClinicalQaRoute = (args: {
     return `/clients/${encodeURIComponent(args.clientId)}?tab=programs-goals`;
   }
   return DEFAULT_CLINICAL_QA_ROUTE;
+};
+
+const pushFixturePreflightIssue = (
+  blockingIssues: string[],
+  value: string | undefined,
+  label: string,
+  validateSupportedSource = false,
+): string | null => {
+  try {
+    const fixturePath = assertRedactedQaFixture(value, label);
+    if (fixturePath && validateSupportedSource) {
+      assertSupportedClinicalQaSourceTextFixture(fixturePath);
+    }
+    return fixturePath;
+  } catch (error) {
+    blockingIssues.push(error instanceof Error ? error.message : String(error));
+    return null;
+  }
+};
+
+export const buildClinicalQaPreflightReport = (
+  env: ClinicalQaPreflightEnv,
+): ClinicalQaPreflightReport => {
+  const blockingIssues: string[] = [];
+  const warnings: string[] = [];
+
+  let credentialLabel: string | null = null;
+  try {
+    credentialLabel = selectClinicalQaCredentials([
+      {
+        email: env.PW_CLINICAL_QA_EMAIL,
+        password: env.PW_CLINICAL_QA_PASSWORD,
+        label: "PW_CLINICAL_QA_EMAIL + PW_CLINICAL_QA_PASSWORD",
+      },
+      {
+        email: env.PW_ADMIN_EMAIL ?? env.PLAYWRIGHT_ADMIN_EMAIL,
+        password: env.PW_ADMIN_PASSWORD ?? env.PLAYWRIGHT_ADMIN_PASSWORD,
+        label: "PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD",
+      },
+    ]).label;
+  } catch {
+    blockingIssues.push("Set PW_CLINICAL_QA_EMAIL/PW_CLINICAL_QA_PASSWORD or PW_ADMIN_EMAIL/PW_ADMIN_PASSWORD.");
+  }
+  if (!env.PW_CLINICAL_QA_EMAIL?.trim() && (env.PW_ADMIN_EMAIL?.trim() || env.PLAYWRIGHT_ADMIN_EMAIL?.trim())) {
+    warnings.push("Dedicated PW_CLINICAL_QA_EMAIL credentials are preferred over admin fallback credentials.");
+  }
+
+  let routePath: string | null = null;
+  try {
+    const clientId = requireClinicalQaClientId(env.PW_CLINICAL_QA_CLIENT_ID);
+    if (!clientId && !env.PW_CLINICAL_QA_ROUTE?.trim()) {
+      blockingIssues.push("Set PW_CLINICAL_QA_CLIENT_ID or PW_CLINICAL_QA_ROUTE.");
+    } else {
+      routePath = buildClinicalQaRoute({
+        clientId,
+        routePath: env.PW_CLINICAL_QA_ROUTE,
+      });
+    }
+  } catch (error) {
+    blockingIssues.push(error instanceof Error ? error.message : String(error));
+  }
+
+  const sourceFixture = pushFixturePreflightIssue(
+    blockingIssues,
+    env.PW_CLINICAL_QA_SOURCE_FILE,
+    "PW_CLINICAL_QA_SOURCE_FILE",
+    true,
+  );
+  const outputFixture = pushFixturePreflightIssue(
+    blockingIssues,
+    env.PW_CLINICAL_QA_OUTPUT_FILE,
+    "PW_CLINICAL_QA_OUTPUT_FILE",
+    true,
+  );
+  const expectationsFixture = pushFixturePreflightIssue(
+    blockingIssues,
+    env.PW_CLINICAL_QA_EXPECTATIONS_FILE,
+    "PW_CLINICAL_QA_EXPECTATIONS_FILE",
+  );
+  const generatedOutputCaptureConfigured = Boolean(env.PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR?.trim());
+
+  if (!sourceFixture && !expectationsFixture) {
+    blockingIssues.push("Set PW_CLINICAL_QA_SOURCE_FILE or PW_CLINICAL_QA_EXPECTATIONS_FILE.");
+  }
+  if (!outputFixture && !generatedOutputCaptureConfigured) {
+    blockingIssues.push("Set PW_CLINICAL_QA_OUTPUT_FILE or PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR.");
+  }
+  if (outputFixture && !generatedOutputCaptureConfigured) {
+    warnings.push("Generated output capture is not configured; parity will use the redacted output fixture.");
+  }
+
+  const outputSource = generatedOutputCaptureConfigured
+    ? "generated-output-capture"
+    : outputFixture
+      ? "output-fixture"
+      : "none";
+  const expectationsSource = expectationsFixture ? "expectations-file" : sourceFixture ? "source-text" : "none";
+  const ok = blockingIssues.length === 0;
+
+  return {
+    ok,
+    mode: "browser-only-redacted-clinical-data-parity-preflight",
+    credentialLabel,
+    routePath,
+    fixtures: {
+      sourceConfigured: Boolean(sourceFixture),
+      outputConfigured: Boolean(outputFixture),
+      expectationsConfigured: Boolean(expectationsFixture),
+      generatedOutputCaptureConfigured,
+    },
+    expectationsSource,
+    outputSource,
+    blockingIssues,
+    warnings,
+    nextAction: ok
+      ? "Run npm run playwright:clinical-data-parity-agent with the same environment to collect browser evidence."
+      : "Set the missing redacted clinical QA environment values, then rerun preflight.",
+  };
 };
 
 export const evaluateClinicalQaChecklist = (

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -9,6 +9,7 @@ import {
   assertBrowserOnlyTarget,
   assertRedactedQaFixture,
   assertSupportedClinicalQaSourceTextFixture,
+  buildClinicalQaPreflightReport,
   buildClinicalQaRoute,
   buildClinicalQaGeneratedOutputArtifactPath,
   buildClinicalQaReportMarkdown,
@@ -182,6 +183,66 @@ describe("clinical data parity agent helpers", () => {
     );
     expect(buildClinicalQaRoute({ routePath: "/dashboard", clientId: "client id" })).toBe("/dashboard");
     expect(buildClinicalQaRoute({})).toBe("/");
+  });
+
+  it("reports missing clinical QA preflight inputs without leaking secret values", () => {
+    const report = buildClinicalQaPreflightReport({
+      PW_CLINICAL_QA_EMAIL: "qa@example.test",
+      PW_CLINICAL_QA_PASSWORD: "****",
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.blockingIssues).toContain(
+      "Set PW_CLINICAL_QA_EMAIL/PW_CLINICAL_QA_PASSWORD or PW_ADMIN_EMAIL/PW_ADMIN_PASSWORD.",
+    );
+    expect(report.blockingIssues).toContain("Set PW_CLINICAL_QA_CLIENT_ID or PW_CLINICAL_QA_ROUTE.");
+    expect(report.blockingIssues).toContain(
+      "Set PW_CLINICAL_QA_SOURCE_FILE or PW_CLINICAL_QA_EXPECTATIONS_FILE.",
+    );
+    expect(report.blockingIssues).toContain(
+      "Set PW_CLINICAL_QA_OUTPUT_FILE or PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR.",
+    );
+    expect(JSON.stringify(report)).not.toContain("qa@example.test");
+    expect(JSON.stringify(report)).not.toContain("****");
+  });
+
+  it("accepts dedicated generated-output clinical QA preflight configuration", () => {
+    const report = buildClinicalQaPreflightReport({
+      PW_CLINICAL_QA_EMAIL: "qa@example.test",
+      PW_CLINICAL_QA_PASSWORD: "qa-password",
+      PW_CLINICAL_QA_CLIENT_ID: "client id",
+      PW_CLINICAL_QA_SOURCE_FILE: "tests/fixtures/redacted-iehp-source.example.txt",
+      PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR: "[data-testid='generate-redacted-output']",
+    });
+
+    expect(report).toMatchObject({
+      ok: true,
+      credentialLabel: "PW_CLINICAL_QA_EMAIL + PW_CLINICAL_QA_PASSWORD",
+      routePath: "/clients/client%20id?tab=programs-goals",
+      outputSource: "generated-output-capture",
+      fixtures: {
+        sourceConfigured: true,
+        outputConfigured: false,
+        expectationsConfigured: false,
+        generatedOutputCaptureConfigured: true,
+      },
+    });
+    expect(report.blockingIssues).toEqual([]);
+  });
+
+  it("blocks clinical QA preflight on non-redacted fixture paths", () => {
+    const report = buildClinicalQaPreflightReport({
+      PW_CLINICAL_QA_EMAIL: "qa@example.test",
+      PW_CLINICAL_QA_PASSWORD: "qa-password",
+      PW_CLINICAL_QA_ROUTE: "/clients/client-1",
+      PW_CLINICAL_QA_SOURCE_FILE: "fixtures/private-client-source.docx",
+      PW_CLINICAL_QA_OUTPUT_FILE: "fixtures/redacted-output.docx",
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.blockingIssues).toContain(
+      "PW_CLINICAL_QA_SOURCE_FILE must point to a clearly redacted, synthetic, smoke, or test fixture.",
+    );
   });
 
   it("matches route reachability by pathname when the expected route includes a query string", () => {


### PR DESCRIPTION
## Summary
- add `PW_CLINICAL_QA_PREFLIGHT_ONLY=true` / `--preflight` mode for the browser-only redacted clinical data parity agent
- report missing credentials, route, source/expectations, and output-capture prerequisites without printing secrets
- document the readiness workflow in the clinical QA skill and handoff doc

## Verification Card
- classification: low-risk autonomous
- lane: standard
- change type: non-sensitive QA runner/test harness/docs
- required checks: `git diff --check`, `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, `npm run verify:local`
- executed checks: `git diff --check` passed; targeted test passed; manual preflight output/exit-shape check passed; `npm run ci:check-focused` passed; `npm run lint` passed; `npm run typecheck` passed; `npm run test:ci` passed with 317 files / 1886 tests; `npm run build` passed; commit hook `ci:check-focused` passed
- blocked checks: `npm run verify:local` failed at local `test:routes:tier0` after policy/lint/typecheck/test:ci/coverage/build passed because Cypress 13.17.0 rejected `--smoke-test` / `--ping=685`
- result: pass-with-blocked-checks
- residual risk: live browser evidence still requires dedicated redacted test credentials, a target client or route, a redacted source or expectations fixture, and either a redacted output fixture or generated-output selector

## PR Hygiene
- branch-ready: yes, `codex/clinical-qa-preflight`
- linear-ready: yes, WIN-150 updated
- protected-path drift: none
- unrelated changes: none
- reviewer: self-review completed; no subagent spawned because available multi-agent tooling requires explicit user request