### PR TITLE
Persist clinical QA preflight artifacts

### DIFF
--- a/.agents/skills/clinical-data-parity-auditor/SKILL.md
+++ b/.agents/skills/clinical-data-parity-auditor/SKILL.md
@@ -57,6 +57,13 @@ PW_CLINICAL_QA_PREFLIGHT_ONLY=true npm run playwright:clinical-data-parity-agent
 
 The preflight path must run before the normal Playwright env loader. It inspects only already-provided process environment values, does not read `.env*` files, does not launch a browser, does not print email/password values, and returns a machine-readable JSON report with `ok`, `blockingIssues`, `warnings`, `routePath`, and fixture readiness.
 
+Preflight writes durable artifacts under `artifacts/latest` before exiting:
+
+- `clinical-data-parity-preflight-<timestamp>.json`
+- `clinical-data-parity-preflight-<timestamp>.md`
+
+A not-ready preflight exits non-zero after writing the artifacts. Treat that as expected setup evidence when `blockingIssues` lists missing credentials, route, source/expectations, or output-capture inputs.
+
 ## Browser Reachability Check
 
 Run:

--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -64,6 +64,13 @@ Preflight exits before the normal Playwright env loader, so it does not read `.e
 - `outputSource`
 - `nextAction`
 
+Preflight also writes durable artifacts under `artifacts/latest`:
+
+- JSON report: `clinical-data-parity-preflight-<timestamp>.json`
+- markdown report: `clinical-data-parity-preflight-<timestamp>.md`
+
+When setup is incomplete, preflight exits non-zero after writing these artifacts. Use the markdown artifact as the operator handoff for missing safe-run prerequisites.
+
 ## Expectations Fixture Contract
 
 `PW_CLINICAL_QA_EXPECTATIONS_FILE` points to a redacted, synthetic, smoke, or test JSON fixture. A safe example lives at `tests/fixtures/redacted-iehp-expectations.example.json`:
@@ -125,6 +132,8 @@ The signed URL is used only for immediate download and is not written to the JSO
 
 Each successful run writes durable artifacts under `artifacts/latest`:
 
+- preflight JSON report: `clinical-data-parity-preflight-<timestamp>.json`
+- preflight markdown report: `clinical-data-parity-preflight-<timestamp>.md`
 - screenshot: `clinical-data-parity-agent-<timestamp>.png`
 - JSON report: `clinical-data-parity-agent-<timestamp>.json`
 - markdown report: `clinical-data-parity-agent-<timestamp>.md`

--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -6,6 +6,7 @@ import {
   assertRedactedQaFixture,
   assertSupportedClinicalQaSourceTextFixture,
   buildClinicalQaPreflightReport,
+  buildClinicalQaPreflightReportMarkdown,
   buildClinicalQaReportMarkdown,
   buildClinicalQaRoute,
   buildClinicalQaTextEvidenceSections,
@@ -81,8 +82,23 @@ const collectClinicalQaEvidenceSections = async (page: Page): Promise<ClinicalQa
 
 const run = async (): Promise<void> => {
   if (isPreflightOnly()) {
+    const latestDir = ensureArtifactsDir();
+    const runId = Date.now();
+    const generatedAt = new Date(runId).toISOString();
     const preflight = buildClinicalQaPreflightReport(process.env);
-    console.log(JSON.stringify(preflight, null, 2));
+    const reportJsonPath = path.join(latestDir, `clinical-data-parity-preflight-${runId}.json`);
+    const reportMarkdownPath = path.join(latestDir, `clinical-data-parity-preflight-${runId}.md`);
+    const payload = {
+      ...preflight,
+      generatedAt,
+      reportJson: reportJsonPath,
+      reportMarkdown: reportMarkdownPath,
+    };
+
+    await writeFile(reportJsonPath, JSON.stringify(payload, null, 2));
+    await writeFile(reportMarkdownPath, buildClinicalQaPreflightReportMarkdown({ generatedAt, report: preflight }));
+
+    console.log(JSON.stringify(payload, null, 2));
     process.exitCode = preflight.ok ? 0 : 1;
     return;
   }

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -111,6 +111,11 @@ export type ClinicalQaPreflightReport = {
   nextAction: string;
 };
 
+export type ClinicalQaPreflightReportMarkdownInput = {
+  generatedAt: string;
+  report: ClinicalQaPreflightReport;
+};
+
 type ClinicalQaGeneratedOutputResponse = {
   url: () => string;
   request: () => { method: () => string };
@@ -590,6 +595,42 @@ export const buildClinicalQaPreflightReport = (
       ? "Run npm run playwright:clinical-data-parity-agent with the same environment to collect browser evidence."
       : "Set the missing redacted clinical QA environment values, then rerun preflight.",
   };
+};
+
+export const buildClinicalQaPreflightReportMarkdown = ({
+  generatedAt,
+  report,
+}: ClinicalQaPreflightReportMarkdownInput): string => {
+  const blockingIssueLines = report.blockingIssues.map((issue) => `- ${issue}`);
+  const warningLines = report.warnings.map((warning) => `- ${warning}`);
+
+  return [
+    "# Clinical Data Parity Agent Preflight",
+    "",
+    `generated at: ${generatedAt}`,
+    `ready: ${report.ok ? "yes" : "no"}`,
+    `mode: \`${report.mode}\``,
+    `credential label: \`${report.credentialLabel ?? "none"}\``,
+    `target route: \`${report.routePath ?? "none"}\``,
+    `expectations source: \`${report.expectationsSource}\``,
+    `output source: \`${report.outputSource}\``,
+    "",
+    "## Fixture Readiness",
+    `- source configured: ${report.fixtures.sourceConfigured ? "yes" : "no"}`,
+    `- output configured: ${report.fixtures.outputConfigured ? "yes" : "no"}`,
+    `- expectations configured: ${report.fixtures.expectationsConfigured ? "yes" : "no"}`,
+    `- generated output capture configured: ${report.fixtures.generatedOutputCaptureConfigured ? "yes" : "no"}`,
+    "",
+    "## Blocking Issues",
+    ...(blockingIssueLines.length > 0 ? blockingIssueLines : ["- none"]),
+    "",
+    "## Warnings",
+    ...(warningLines.length > 0 ? warningLines : ["- none"]),
+    "",
+    "## Next Action",
+    report.nextAction,
+    "",
+  ].join("\n");
 };
 
 export const evaluateClinicalQaChecklist = (

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -9,6 +9,7 @@ import {
   assertBrowserOnlyTarget,
   assertRedactedQaFixture,
   assertSupportedClinicalQaSourceTextFixture,
+  buildClinicalQaPreflightReportMarkdown,
   buildClinicalQaPreflightReport,
   buildClinicalQaRoute,
   buildClinicalQaGeneratedOutputArtifactPath,
@@ -243,6 +244,31 @@ describe("clinical data parity agent helpers", () => {
     expect(report.blockingIssues).toContain(
       "PW_CLINICAL_QA_SOURCE_FILE must point to a clearly redacted, synthetic, smoke, or test fixture.",
     );
+  });
+
+  it("builds a redacted clinical QA preflight markdown artifact", () => {
+    const report = buildClinicalQaPreflightReport({
+      PW_CLINICAL_QA_EMAIL: "qa@example.test",
+      PW_CLINICAL_QA_PASSWORD: "qa-password",
+      PW_CLINICAL_QA_CLIENT_ID: "client-1",
+      PW_CLINICAL_QA_SOURCE_FILE: "tests/fixtures/redacted-iehp-source.example.txt",
+      PW_CLINICAL_QA_OUTPUT_FILE: "tests/fixtures/redacted-output.example.docx",
+    });
+
+    const markdown = buildClinicalQaPreflightReportMarkdown({
+      generatedAt: "2026-06-15T21:30:00.000Z",
+      report,
+    });
+
+    expect(markdown).toContain("# Clinical Data Parity Agent Preflight");
+    expect(markdown).toContain("generated at: 2026-06-15T21:30:00.000Z");
+    expect(markdown).toContain("ready: yes");
+    expect(markdown).toContain("credential label: `PW_CLINICAL_QA_EMAIL + PW_CLINICAL_QA_PASSWORD`");
+    expect(markdown).toContain("target route: `/clients/client-1?tab=programs-goals`");
+    expect(markdown).toContain("output source: `output-fixture`");
+    expect(markdown).toContain("- none");
+    expect(markdown).not.toContain("qa@example.test");
+    expect(markdown).not.toContain("qa-password");
   });
 
   it("matches route reachability by pathname when the expected route includes a query string", () => {


### PR DESCRIPTION
## Summary
- persist clinical QA preflight JSON and markdown reports under `artifacts/latest`
- keep not-ready preflight non-zero while still leaving shareable readiness evidence
- document the preflight artifact contract in the clinical QA skill and handoff

## Verification Card
- classification: low-risk autonomous
- lane: standard
- change type: non-sensitive QA runner/test harness/docs
- required checks: `git diff --check`, `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, `npm run verify:local`
- executed checks: RED targeted test failed first for missing formatter; targeted test passed with 22 tests; manual preflight artifact run wrote JSON/markdown and preserved expected not-ready exit `1`; `git diff --check` passed; `npm run typecheck` passed; `npm run lint` passed; `npm run ci:check-focused` passed; `npm run build` passed; `npm run test:ci` passed with 317 files / 1887 tests; commit hook `ci:check-focused` passed
- blocked checks: `npm run verify:local` failed only at local `test:routes:tier0` after policy/lint/typecheck/test:ci/coverage/build passed because Cypress 13.17.0 rejected `--smoke-test` / `--ping=702`
- result: pass-with-blocked-checks
- residual risk: live browser evidence still requires dedicated redacted test credentials and clinical QA target env values

## PR Hygiene
- branch-ready: yes, `codex/clinical-qa-preflight-artifacts`
- linear-ready: yes, WIN-150 updated
- protected-path drift: none
- unrelated changes: none
- generated artifact drift: none
- reviewer: focused self-review completed; no subagent spawned because available multi-agent tooling requires explicit user request