### PR TITLE
Add clinical QA visual rubric

### DIFF
--- a/.agents/skills/clinical-data-parity-auditor/SKILL.md
+++ b/.agents/skills/clinical-data-parity-auditor/SKILL.md
@@ -41,10 +41,13 @@ Optional scope:
 - `PW_CLINICAL_QA_ROUTE`
 - `PW_CLINICAL_QA_SOURCE_FILE`
 - `PW_CLINICAL_QA_OUTPUT_FILE`
+- `PW_CLINICAL_QA_EXPECTATIONS_FILE`
+- `PW_CLINICAL_QA_VISUAL_RUBRIC_FILE`
 - `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR`
 - `PW_CLINICAL_QA_PREFLIGHT_ONLY`
 
 Source/output fixture paths must include `redacted`, `synthetic`, `smoke`, or `test` in the path.
+When `PW_CLINICAL_QA_VISUAL_RUBRIC_FILE` is set, it must point to a redacted JSON fixture with a non-empty `items` array. Each item requires `key`, `label`, and `requiredTerms`, and may include `severity` (`low`, `medium`, or `high`) plus `humanReviewBlocker`.
 When `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR` is set, the runner clicks that browser selector, captures the completed assessment output response, saves the downloaded artifact under `artifacts/latest` with a redacted filename, and uses that artifact for output parity.
 
 ## Readiness Preflight

--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -33,6 +33,7 @@ Optional:
 - `PW_CLINICAL_QA_SOURCE_FILE`
 - `PW_CLINICAL_QA_OUTPUT_FILE`
 - `PW_CLINICAL_QA_EXPECTATIONS_FILE`
+- `PW_CLINICAL_QA_VISUAL_RUBRIC_FILE`
 - `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR`
 - `PW_CLINICAL_QA_PREFLIGHT_ONLY`
 
@@ -70,6 +71,26 @@ Preflight also writes durable artifacts under `artifacts/latest`:
 - markdown report: `clinical-data-parity-preflight-<timestamp>.md`
 
 When setup is incomplete, preflight exits non-zero after writing these artifacts. Use the markdown artifact as the operator handoff for missing safe-run prerequisites.
+
+## Visual Rubric Fixture Contract
+
+`PW_CLINICAL_QA_VISUAL_RUBRIC_FILE` points to an optional redacted, synthetic, smoke, or test JSON fixture that replaces the default visible-surface checklist. A safe example lives at `tests/fixtures/redacted-clinical-qa-visual-rubric.example.json`:
+
+```json
+{
+  "items": [
+    {
+      "key": "behavior_functions_visible",
+      "label": "Behavior functions are visible",
+      "requiredTerms": ["function", "escape", "attention"],
+      "severity": "high",
+      "humanReviewBlocker": true
+    }
+  ]
+}
+```
+
+The `items` array must contain at least one item. Each item requires `key`, `label`, and a non-empty `requiredTerms` array. `severity` defaults to `medium`; `humanReviewBlocker` defaults to `false`. Checklist results are included in the JSON and markdown report with missing terms, severity, and human-review-blocker status. Failed blocker items are also emitted in `checklistHumanReviewBlockers` and included in the markdown blocker count. This rubric is for QA evidence only and does not approve clinical content.
 
 ## Expectations Fixture Contract
 

--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -14,8 +14,10 @@ import {
   deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalDataParity,
   evaluateClinicalQaChecklist,
+  getClinicalQaChecklistHumanReviewBlockers,
   type ClinicalQaEvidenceSection,
   parseClinicalQaExpectations,
+  parseClinicalQaVisualRubric,
   readClinicalQaOutputFixtureText,
   readClinicalQaSourceFixtureText,
   requireClinicalQaClientId,
@@ -135,6 +137,13 @@ const run = async (): Promise<void> => {
     process.env.PW_CLINICAL_QA_EXPECTATIONS_FILE,
     "PW_CLINICAL_QA_EXPECTATIONS_FILE",
   );
+  const visualRubricFixture = assertRedactedQaFixture(
+    process.env.PW_CLINICAL_QA_VISUAL_RUBRIC_FILE,
+    "PW_CLINICAL_QA_VISUAL_RUBRIC_FILE",
+  );
+  const visualRubric = visualRubricFixture
+    ? parseClinicalQaVisualRubric(await readFile(visualRubricFixture, "utf8"), visualRubricFixture)
+    : undefined;
   const expectations = expectationsFixture
     ? parseClinicalQaExpectations(await readFile(expectationsFixture, "utf8"), expectationsFixture)
     : sourceFixture
@@ -168,7 +177,7 @@ const run = async (): Promise<void> => {
     const outputEvidenceSections = outputText ? buildClinicalQaTextEvidenceSections(outputText) : [];
     const pageText = await page.locator("body").innerText({ timeout: 10_000 });
     const evidenceSections = await collectClinicalQaEvidenceSections(page);
-    const checklist = evaluateClinicalQaChecklist(pageText);
+    const checklist = evaluateClinicalQaChecklist(pageText, visualRubric);
     const dataParityFindings = evaluateClinicalDataParity(pageText, expectations, evidenceSections);
     const outputDataParityFindings = outputText
       ? evaluateClinicalDataParity(
@@ -195,6 +204,7 @@ const run = async (): Promise<void> => {
         outputConfigured: Boolean(outputFixture),
         generatedOutputCaptureConfigured: Boolean(generatedOutputSelector),
         expectationsConfigured: Boolean(expectationsFixture),
+        visualRubricConfigured: Boolean(visualRubricFixture),
         expectationsSource,
         outputSource: capturedGeneratedOutput ? "generated-output-capture" : outputFixture ? "output-fixture" : "none",
       },
@@ -216,6 +226,7 @@ const run = async (): Promise<void> => {
       checklist,
       dataParityFindings,
       outputDataParityFindings,
+      checklistHumanReviewBlockers: getClinicalQaChecklistHumanReviewBlockers(checklist),
       humanReviewBlockers: dataParityFindings.filter(
         (finding) => finding.status === "fail" && finding.humanReviewBlocker,
       ),

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -20,6 +20,8 @@ export type ClinicalQaChecklistItem = {
   key: string;
   label: string;
   requiredTerms: string[];
+  severity?: ClinicalQaParitySeverity;
+  humanReviewBlocker?: boolean;
 };
 
 export type ClinicalQaChecklistResult = {
@@ -27,6 +29,8 @@ export type ClinicalQaChecklistResult = {
   label: string;
   status: "pass" | "fail";
   missingTerms: string[];
+  severity: ClinicalQaParitySeverity;
+  humanReviewBlocker: boolean;
 };
 
 export type ClinicalQaParitySeverity = "low" | "medium" | "high";
@@ -103,6 +107,7 @@ export type ClinicalQaPreflightReport = {
     outputConfigured: boolean;
     expectationsConfigured: boolean;
     generatedOutputCaptureConfigured: boolean;
+    visualRubricConfigured: boolean;
   };
   expectationsSource: "expectations-file" | "source-text" | "none";
   outputSource: "generated-output-capture" | "output-fixture" | "none";
@@ -556,6 +561,11 @@ export const buildClinicalQaPreflightReport = (
     env.PW_CLINICAL_QA_EXPECTATIONS_FILE,
     "PW_CLINICAL_QA_EXPECTATIONS_FILE",
   );
+  const visualRubricFixture = pushFixturePreflightIssue(
+    blockingIssues,
+    env.PW_CLINICAL_QA_VISUAL_RUBRIC_FILE,
+    "PW_CLINICAL_QA_VISUAL_RUBRIC_FILE",
+  );
   const generatedOutputCaptureConfigured = Boolean(env.PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR?.trim());
 
   if (!sourceFixture && !expectationsFixture) {
@@ -586,6 +596,7 @@ export const buildClinicalQaPreflightReport = (
       outputConfigured: Boolean(outputFixture),
       expectationsConfigured: Boolean(expectationsFixture),
       generatedOutputCaptureConfigured,
+      visualRubricConfigured: Boolean(visualRubricFixture),
     },
     expectationsSource,
     outputSource,
@@ -620,6 +631,7 @@ export const buildClinicalQaPreflightReportMarkdown = ({
     `- output configured: ${report.fixtures.outputConfigured ? "yes" : "no"}`,
     `- expectations configured: ${report.fixtures.expectationsConfigured ? "yes" : "no"}`,
     `- generated output capture configured: ${report.fixtures.generatedOutputCaptureConfigured ? "yes" : "no"}`,
+    `- visual rubric configured: ${report.fixtures.visualRubricConfigured ? "yes" : "no"}`,
     "",
     "## Blocking Issues",
     ...(blockingIssueLines.length > 0 ? blockingIssueLines : ["- none"]),
@@ -645,9 +657,16 @@ export const evaluateClinicalQaChecklist = (
       label: item.label,
       status: missingTerms.length === 0 ? "pass" : "fail",
       missingTerms,
+      severity: item.severity ?? "medium",
+      humanReviewBlocker: item.humanReviewBlocker === true,
     };
   });
 };
+
+export const getClinicalQaChecklistHumanReviewBlockers = (
+  checklist: ClinicalQaChecklistResult[],
+): ClinicalQaChecklistResult[] =>
+  checklist.filter((item) => item.status === "fail" && item.humanReviewBlocker);
 
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === "string" && item.trim().length > 0);
@@ -979,6 +998,43 @@ export const parseClinicalQaExpectations = (
   });
 };
 
+export const parseClinicalQaVisualRubric = (
+  rawJson: string,
+  fixturePath: string,
+): ClinicalQaChecklistItem[] => {
+  assertRedactedQaFixture(fixturePath, "PW_CLINICAL_QA_VISUAL_RUBRIC_FILE");
+
+  const parsed = JSON.parse(rawJson) as { items?: unknown };
+  if (!Array.isArray(parsed.items)) {
+    throw new Error("Clinical QA visual rubric fixture must contain an items array.");
+  }
+  if (parsed.items.length === 0) {
+    throw new Error("Clinical QA visual rubric fixture must contain at least one item.");
+  }
+
+  return parsed.items.map((entry, index) => {
+    if (!entry || typeof entry !== "object") {
+      throw new Error(`Clinical QA visual rubric item at index ${index} must be an object.`);
+    }
+    const item = entry as Record<string, unknown>;
+    const key = typeof item.key === "string" ? item.key.trim() : "";
+    const label = typeof item.label === "string" ? item.label.trim() : "";
+    if (!key || !label || !isStringArray(item.requiredTerms) || item.requiredTerms.length === 0) {
+      throw new Error(
+        `Clinical QA visual rubric item at index ${index} requires key, label, and non-empty requiredTerms.`,
+      );
+    }
+
+    return {
+      key,
+      label,
+      requiredTerms: item.requiredTerms.map((term) => term.trim()),
+      severity: normalizeSeverity(item.severity),
+      humanReviewBlocker: item.humanReviewBlocker === true,
+    };
+  });
+};
+
 export const evaluateClinicalDataParity = (
   pageText: string,
   expectations: ClinicalQaParityExpectation[],
@@ -1055,11 +1111,13 @@ const formatFindingLines = (findings: ClinicalQaParityFinding[]): string[] =>
 export const buildClinicalQaReportMarkdown = (report: ClinicalQaReportInput): string => {
   const outputDataParityFindings = report.outputDataParityFindings ?? [];
   const allFindings = [...report.dataParityFindings, ...outputDataParityFindings];
-  const blockerCount = allFindings.filter(
+  const parityBlockerCount = allFindings.filter(
     (finding) => finding.status === "fail" && finding.humanReviewBlocker,
   ).length;
+  const blockerCount = parityBlockerCount + getClinicalQaChecklistHumanReviewBlockers(report.checklist).length;
   const checklistLines = report.checklist.map(
-    (item) => `- ${item.status.toUpperCase()} ${item.label}: missing ${formatTermList(item.missingTerms)}`,
+    (item) =>
+      `- ${item.status.toUpperCase()} ${item.label}: missing ${formatTermList(item.missingTerms)}; severity ${item.severity}; human review blocker ${item.humanReviewBlocker ? "yes" : "no"}`,
   );
   const findingLines = formatFindingLines(report.dataParityFindings);
   const outputFindingLines = formatFindingLines(outputDataParityFindings);

--- a/tests/fixtures/redacted-clinical-qa-visual-rubric.example.json
+++ b/tests/fixtures/redacted-clinical-qa-visual-rubric.example.json
@@ -1,0 +1,25 @@
+{
+  "items": [
+    {
+      "key": "behavior_functions_visible",
+      "label": "Behavior functions are visible",
+      "requiredTerms": ["function", "escape", "attention"],
+      "severity": "high",
+      "humanReviewBlocker": true
+    },
+    {
+      "key": "program_goal_measurement_visible",
+      "label": "Program goal measurement criteria are visible",
+      "requiredTerms": ["baseline", "mastery", "maintenance", "generalization"],
+      "severity": "medium",
+      "humanReviewBlocker": false
+    },
+    {
+      "key": "intervention_context_visible",
+      "label": "Intervention context is visible",
+      "requiredTerms": ["intervention", "replacement behavior"],
+      "severity": "medium",
+      "humanReviewBlocker": false
+    }
+  ]
+}

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -19,6 +19,8 @@ import {
   deriveClinicalQaExpectationsFromSourceText,
   evaluateClinicalQaChecklist,
   evaluateClinicalDataParity,
+  getClinicalQaChecklistHumanReviewBlockers,
+  parseClinicalQaVisualRubric,
   parseClinicalQaGeneratedOutputResponse,
   parseClinicalQaExpectations,
   readClinicalQaOutputFixtureText,
@@ -315,6 +317,158 @@ describe("clinical data parity agent helpers", () => {
 
     expect(results.every((result) => result.status === "pass")).toBe(true);
     expect(evaluateClinicalQaChecklist("Dashboard only").filter((result) => result.status === "fail")).toHaveLength(3);
+  });
+
+  it("parses a redacted clinical QA visual rubric with severity and human review blockers", () => {
+    const rubric = parseClinicalQaVisualRubric(
+      JSON.stringify({
+        items: [
+          {
+            key: "behavior_functions_visible",
+            label: "Behavior functions are visible",
+            requiredTerms: ["function", "escape", "attention"],
+            severity: "high",
+            humanReviewBlocker: true,
+          },
+          {
+            key: "measurement_visible",
+            label: "Measurement terms are visible",
+            requiredTerms: ["baseline", "mastery"],
+          },
+        ],
+      }),
+      "tests/fixtures/redacted-clinical-qa-visual-rubric.example.json",
+    );
+
+    expect(rubric).toEqual([
+      {
+        key: "behavior_functions_visible",
+        label: "Behavior functions are visible",
+        requiredTerms: ["function", "escape", "attention"],
+        severity: "high",
+        humanReviewBlocker: true,
+      },
+      {
+        key: "measurement_visible",
+        label: "Measurement terms are visible",
+        requiredTerms: ["baseline", "mastery"],
+        severity: "medium",
+        humanReviewBlocker: false,
+      },
+    ]);
+  });
+
+  it("requires redacted paths and valid items for clinical QA visual rubrics", () => {
+    expect(() =>
+      parseClinicalQaVisualRubric(
+        JSON.stringify({ items: [] }),
+        "fixtures/private-clinical-qa-visual-rubric.json",
+      ),
+    ).toThrow("PW_CLINICAL_QA_VISUAL_RUBRIC_FILE must point to a clearly redacted");
+
+    expect(() =>
+      parseClinicalQaVisualRubric(
+        JSON.stringify({ entries: [] }),
+        "fixtures/redacted-clinical-qa-visual-rubric.json",
+      ),
+    ).toThrow("must contain an items array");
+
+    expect(() =>
+      parseClinicalQaVisualRubric(
+        JSON.stringify({ items: [] }),
+        "fixtures/redacted-clinical-qa-visual-rubric.json",
+      ),
+    ).toThrow("must contain at least one item");
+
+    expect(() =>
+      parseClinicalQaVisualRubric(
+        JSON.stringify({
+          items: [
+            {
+              key: "missing_terms",
+              label: "Missing terms",
+              requiredTerms: [],
+            },
+          ],
+        }),
+        "fixtures/redacted-clinical-qa-visual-rubric.json",
+      ),
+    ).toThrow("requires key, label, and non-empty requiredTerms");
+  });
+
+  it("carries visual rubric severity and blocker metadata into checklist results", () => {
+    const checklist = parseClinicalQaVisualRubric(
+      JSON.stringify({
+        items: [
+          {
+            key: "behavior_functions_visible",
+            label: "Behavior functions are visible",
+            requiredTerms: ["escape", "attention"],
+            severity: "high",
+            humanReviewBlocker: true,
+          },
+        ],
+      }),
+      "fixtures/redacted-clinical-qa-visual-rubric.json",
+    );
+
+    expect(evaluateClinicalQaChecklist("Function is escape maintained.", checklist)).toEqual([
+      {
+        key: "behavior_functions_visible",
+        label: "Behavior functions are visible",
+        status: "fail",
+        missingTerms: ["attention"],
+        severity: "high",
+        humanReviewBlocker: true,
+      },
+    ]);
+  });
+
+  it("summarizes failed visual rubric human review blockers", () => {
+    const checklistResults = evaluateClinicalQaChecklist(
+      "Function is escape maintained.",
+      [
+        {
+          key: "behavior_functions_visible",
+          label: "Behavior functions are visible",
+          requiredTerms: ["escape", "attention"],
+          severity: "high",
+          humanReviewBlocker: true,
+        },
+        {
+          key: "measurement_visible",
+          label: "Measurement terms are visible",
+          requiredTerms: ["function"],
+          severity: "medium",
+          humanReviewBlocker: true,
+        },
+      ],
+    );
+
+    expect(getClinicalQaChecklistHumanReviewBlockers(checklistResults)).toEqual([
+      {
+        key: "behavior_functions_visible",
+        label: "Behavior functions are visible",
+        status: "fail",
+        missingTerms: ["attention"],
+        severity: "high",
+        humanReviewBlocker: true,
+      },
+    ]);
+  });
+
+  it("reports optional visual rubric readiness in clinical QA preflight", () => {
+    const report = buildClinicalQaPreflightReport({
+      PW_CLINICAL_QA_EMAIL: "qa@example.test",
+      PW_CLINICAL_QA_PASSWORD: "qa-password",
+      PW_CLINICAL_QA_CLIENT_ID: "client-1",
+      PW_CLINICAL_QA_SOURCE_FILE: "tests/fixtures/redacted-iehp-source.example.txt",
+      PW_CLINICAL_QA_OUTPUT_FILE: "tests/fixtures/redacted-output.example.docx",
+      PW_CLINICAL_QA_VISUAL_RUBRIC_FILE: "tests/fixtures/redacted-clinical-qa-visual-rubric.example.json",
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.fixtures.visualRubricConfigured).toBe(true);
   });
 
   it("parses redacted parity expectations and flags missing clinically important terms", () => {
@@ -749,6 +903,16 @@ describe("clinical data parity agent helpers", () => {
           label: "Programs/goals review surface is visible",
           status: "pass",
           missingTerms: [],
+          severity: "medium",
+          humanReviewBlocker: false,
+        },
+        {
+          key: "behavior_functions_visible",
+          label: "Behavior functions are visible",
+          status: "fail",
+          missingTerms: ["attention"],
+          severity: "high",
+          humanReviewBlocker: true,
         },
       ],
       dataParityFindings: [
@@ -794,6 +958,10 @@ describe("clinical data parity agent helpers", () => {
     expect(markdown).toContain("# Clinical Data Parity Agent Report");
     expect(markdown).toContain("target route: `/clients/test-client?tab=programs-goals`");
     expect(markdown).toContain("screenshot: `artifacts/latest/clinical-data-parity-agent-test.png`");
+    expect(markdown).toContain("human review blockers: 2");
+    expect(markdown).toContain(
+      "FAIL Behavior functions are visible: missing attention; severity high; human review blocker yes",
+    );
     expect(markdown).toContain("Target behaviors");
     expect(markdown).toContain("missing: property destruction");
     expect(markdown).toContain("## Generated Output Parity Findings");


### PR DESCRIPTION
## Summary
- add optional `PW_CLINICAL_QA_VISUAL_RUBRIC_FILE` support for a redacted JSON visual/clinical checklist rubric
- propagate checklist `severity` and `humanReviewBlocker` metadata into JSON/markdown reports
- emit failed checklist blockers as `checklistHumanReviewBlockers` and include them in markdown blocker counts
- document the rubric contract and add a safe redacted example fixture

## Route Task
- classification: low-risk autonomous
- lane: standard
- triggering paths: `.agents/skills/**`, `docs/ai/**`, `scripts/**`, `tests/**`
- protected-path drift: none
- Linear: WIN-150

## Verification Card
- change type: browser-only clinical QA runner/test/docs; no auth/server/Supabase/CI/deploy changes
- `npm test -- tests/scripts/clinical-data-parity-agent.test.ts`: pass, 27 tests
- `git diff --check`: pass
- `npm run typecheck`: pass
- `npm run lint`: pass
- `npm run ci:check-focused`: pass with expected local secret/CI-only skips
- `npm run test:ci`: pass, 317 files / 1892 tests
- `npm run build`: pass
- `npm run verify:local`: pass through policy/lint/typecheck/test:ci/coverage/build, then fail at `npm run test:routes:tier0` because local Cypress startup rejects `--smoke-test` / `--ping=873` on this Windows cache

## Reviewer Follow-up
- fixed empty redacted rubric arrays silently disabling checklist evaluation
- fixed rubric-level human-review blockers not appearing in report summary fields

## Residual Risk
- Full browser tier proof remains CI/working-Cypress-environment dependent because local Cypress cannot start on this machine.
- Live clinical QA evidence still requires dedicated redacted test credentials and redacted test client/run configuration.