### PR TITLE
Fix clinical QA preflight npm flag

### DIFF
--- a/scripts/clinical-data-parity-agent.ts
+++ b/scripts/clinical-data-parity-agent.ts
@@ -15,6 +15,7 @@ import {
   evaluateClinicalDataParity,
   evaluateClinicalQaChecklist,
   getClinicalQaChecklistHumanReviewBlockers,
+  isClinicalQaPreflightOnly,
   type ClinicalQaEvidenceSection,
   parseClinicalQaExpectations,
   parseClinicalQaVisualRubric,
@@ -31,8 +32,7 @@ import {
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
 
-const isPreflightOnly = (): boolean =>
-  process.env.PW_CLINICAL_QA_PREFLIGHT_ONLY === "true" || process.argv.includes("--preflight");
+const isPreflightOnly = (): boolean => isClinicalQaPreflightOnly({ env: process.env, argv: process.argv });
 
 const collectClinicalQaEvidenceSections = async (page: Page): Promise<ClinicalQaEvidenceSection[]> =>
   page.evaluate(`

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -97,6 +97,11 @@ export type ClinicalQaCapturedGeneratedOutput = {
 
 export type ClinicalQaPreflightEnv = Record<string, string | undefined>;
 
+export type ClinicalQaPreflightModeInput = {
+  env: ClinicalQaPreflightEnv;
+  argv: string[];
+};
+
 export type ClinicalQaPreflightReport = {
   ok: boolean;
   mode: "browser-only-redacted-clinical-data-parity-preflight";
@@ -157,6 +162,11 @@ const REDACTED_PASSWORD_PLACEHOLDER = "****";
 const execFileAsync = promisify(execFile);
 
 export const DEFAULT_CLINICAL_QA_ROUTE = "/";
+
+export const isClinicalQaPreflightOnly = ({ env, argv }: ClinicalQaPreflightModeInput): boolean =>
+  env.PW_CLINICAL_QA_PREFLIGHT_ONLY === "true" ||
+  env.npm_config_preflight === "true" ||
+  argv.includes("--preflight");
 
 export const CLINICAL_DATA_PARITY_CHECKLIST: ClinicalQaChecklistItem[] = [
   {

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -20,6 +20,7 @@ import {
   evaluateClinicalQaChecklist,
   evaluateClinicalDataParity,
   getClinicalQaChecklistHumanReviewBlockers,
+  isClinicalQaPreflightOnly,
   parseClinicalQaVisualRubric,
   parseClinicalQaGeneratedOutputResponse,
   parseClinicalQaExpectations,
@@ -207,6 +208,17 @@ describe("clinical data parity agent helpers", () => {
     );
     expect(JSON.stringify(report)).not.toContain("qa@example.test");
     expect(JSON.stringify(report)).not.toContain("****");
+  });
+
+  it("detects clinical QA preflight mode from direct argv and npm config flags", () => {
+    expect(isClinicalQaPreflightOnly({ env: {}, argv: ["node", "script", "--preflight"] })).toBe(true);
+    expect(isClinicalQaPreflightOnly({ env: { npm_config_preflight: "true" }, argv: ["node", "script"] })).toBe(
+      true,
+    );
+    expect(isClinicalQaPreflightOnly({ env: { PW_CLINICAL_QA_PREFLIGHT_ONLY: "true" }, argv: [] })).toBe(true);
+    expect(isClinicalQaPreflightOnly({ env: { npm_config_preflight: "false" }, argv: ["node", "script"] })).toBe(
+      false,
+    );
   });
 
   it("accepts dedicated generated-output clinical QA preflight configuration", () => {


### PR DESCRIPTION
## Summary
- Detect npm-forwarded `--preflight` as `npm_config_preflight=true` for the clinical QA parity runner.
- Move preflight-mode detection into the helper module so it is unit-tested.
- Preserve existing direct `--preflight` and `PW_CLINICAL_QA_PREFLIGHT_ONLY=true` behavior.

Linear: WIN-150

## Route
- classification: low-risk autonomous
- lane: standard
- triggering paths: `scripts/clinical-data-parity-agent.ts`, `scripts/lib/clinical-data-parity-agent.ts`, `tests/scripts/clinical-data-parity-agent.test.ts`
- protected-path drift: none

## Verification
- `git diff --check` passed.
- `npm test -- tests/scripts/clinical-data-parity-agent.test.ts` passed: 28 tests.
- `npm run playwright:clinical-data-parity-agent -- --preflight` entered preflight mode and exited non-zero only for missing shell-provided redacted QA inputs; no browser launch.
- `npm run ci:check-focused` passed.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run test:ci` passed: 317 files, 1893 tests.
- `npm run build` passed.
- `npm run verify:local` was rerun serially; it reached embedded `test:ci` and failed on one unrelated `Schedule.test.tsx` timeout. The same Schedule file/case passed immediately on targeted rerun, so this is residual local flake evidence rather than a code failure in this script-only diff.

## Notes
- Reviewer/tester subagent delegation was not run because the available multi-agent tool in this session only allows spawning when the user explicitly requests sub-agents.
- Real redacted clinical QA execution still requires operator-provided test credentials, route/client ID, source/expectations, and output/output selector.