### PR TITLE
Validate clinical QA fixture preflight inputs

### DIFF
--- a/.agents/skills/clinical-data-parity-auditor/SKILL.md
+++ b/.agents/skills/clinical-data-parity-auditor/SKILL.md
@@ -46,7 +46,7 @@ Optional scope:
 - `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR`
 - `PW_CLINICAL_QA_PREFLIGHT_ONLY`
 
-Source/output fixture paths must include `redacted`, `synthetic`, `smoke`, or `test` in the path.
+Source/output fixture paths must exist and include `redacted`, `synthetic`, `smoke`, or `test` in the path.
 When `PW_CLINICAL_QA_VISUAL_RUBRIC_FILE` is set, it must point to a redacted JSON fixture with a non-empty `items` array. Each item requires `key`, `label`, and `requiredTerms`, and may include `severity` (`low`, `medium`, or `high`) plus `humanReviewBlocker`.
 When `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR` is set, the runner clicks that browser selector, captures the completed assessment output response, saves the downloaded artifact under `artifacts/latest` with a redacted filename, and uses that artifact for output parity.
 

--- a/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
+++ b/docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md
@@ -37,7 +37,7 @@ Optional:
 - `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR`
 - `PW_CLINICAL_QA_PREFLIGHT_ONLY`
 
-The runner rejects placeholder passwords, API routes, admin-only routes, and fixture paths that are not clearly redacted, synthetic, smoke, or test fixtures.
+The runner rejects placeholder passwords, API routes, admin-only routes, missing fixture files, and fixture paths that are not clearly redacted, synthetic, smoke, or test fixtures.
 
 ## Readiness Preflight
 
@@ -119,6 +119,16 @@ The browser runner compares each `expectedTerms` entry against the visible brows
 - `mismatchType`: `match`, `partial`, or `missing`.
 - `observedTextSnippet`: a compact browser-text excerpt around matched evidence when available.
 - `sectionEvidenceStatus`: whether matched terms also appear inside the expected browser or generated-output section.
+
+## Output Fixture Contract
+
+`PW_CLINICAL_QA_OUTPUT_FILE` points to a redacted, synthetic, smoke, or test `.txt`, `.md`, `.docx`, or `.pdf` fixture. A safe text example lives at `tests/fixtures/redacted-output.example.txt`. Use this path when validating the fixture-based workflow before a generated-output selector is stable:
+
+```bash
+PW_CLINICAL_QA_OUTPUT_FILE=tests/fixtures/redacted-output.example.txt
+```
+
+When both `PW_CLINICAL_QA_OUTPUT_FILE` and `PW_CLINICAL_QA_GENERATED_OUTPUT_SELECTOR` are omitted, preflight blocks because the agent has no output surface for source-to-output parity. When an output fixture path is configured, preflight verifies that the file exists and that its path is clearly redacted, synthetic, smoke, or test scoped.
 
 ## Source Text Fixture Extraction
 

--- a/scripts/lib/clinical-data-parity-agent.ts
+++ b/scripts/lib/clinical-data-parity-agent.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import path, { extname } from "node:path";
 import { promisify } from "node:util";
@@ -504,6 +505,9 @@ const pushFixturePreflightIssue = (
     const fixturePath = assertRedactedQaFixture(value, label);
     if (fixturePath && validateSupportedSource) {
       assertSupportedClinicalQaSourceTextFixture(fixturePath);
+    }
+    if (fixturePath && !existsSync(fixturePath)) {
+      throw new Error(`${label} must point to an existing redacted, synthetic, smoke, or test fixture.`);
     }
     return fixturePath;
   } catch (error) {

--- a/tests/fixtures/redacted-output.example.txt
+++ b/tests/fixtures/redacted-output.example.txt
@@ -1,0 +1,15 @@
+Generated IEHP/FBA output summary for redacted test client 01.
+
+Programs and Goals
+Target behaviors: elopement; property destruction
+Replacement behavior: functional communication
+Measurement criteria: baseline, mastery, maintenance, generalization
+
+ABC and function summary
+Antecedents: transition demand; denied access
+Consequences: adult attention; escape from task
+Functions: escape; access to attention
+
+Intervention context
+Interventions: visual schedule; first then board
+Authorization details: 97153; 12 units weekly

--- a/tests/scripts/clinical-data-parity-agent.test.ts
+++ b/tests/scripts/clinical-data-parity-agent.test.ts
@@ -260,13 +260,39 @@ describe("clinical data parity agent helpers", () => {
     );
   });
 
+  it("blocks clinical QA preflight when configured redacted fixture files are missing", () => {
+    const report = buildClinicalQaPreflightReport({
+      PW_CLINICAL_QA_EMAIL: "qa@example.test",
+      PW_CLINICAL_QA_PASSWORD: "qa-password",
+      PW_CLINICAL_QA_ROUTE: "/clients/client-1",
+      PW_CLINICAL_QA_SOURCE_FILE: "tests/fixtures/redacted-missing-source.example.txt",
+      PW_CLINICAL_QA_OUTPUT_FILE: "tests/fixtures/redacted-missing-output.example.txt",
+      PW_CLINICAL_QA_EXPECTATIONS_FILE: "tests/fixtures/redacted-missing-expectations.example.json",
+      PW_CLINICAL_QA_VISUAL_RUBRIC_FILE: "tests/fixtures/redacted-missing-rubric.example.json",
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.blockingIssues).toContain(
+      "PW_CLINICAL_QA_SOURCE_FILE must point to an existing redacted, synthetic, smoke, or test fixture.",
+    );
+    expect(report.blockingIssues).toContain(
+      "PW_CLINICAL_QA_OUTPUT_FILE must point to an existing redacted, synthetic, smoke, or test fixture.",
+    );
+    expect(report.blockingIssues).toContain(
+      "PW_CLINICAL_QA_EXPECTATIONS_FILE must point to an existing redacted, synthetic, smoke, or test fixture.",
+    );
+    expect(report.blockingIssues).toContain(
+      "PW_CLINICAL_QA_VISUAL_RUBRIC_FILE must point to an existing redacted, synthetic, smoke, or test fixture.",
+    );
+  });
+
   it("builds a redacted clinical QA preflight markdown artifact", () => {
     const report = buildClinicalQaPreflightReport({
       PW_CLINICAL_QA_EMAIL: "qa@example.test",
       PW_CLINICAL_QA_PASSWORD: "qa-password",
       PW_CLINICAL_QA_CLIENT_ID: "client-1",
       PW_CLINICAL_QA_SOURCE_FILE: "tests/fixtures/redacted-iehp-source.example.txt",
-      PW_CLINICAL_QA_OUTPUT_FILE: "tests/fixtures/redacted-output.example.docx",
+      PW_CLINICAL_QA_OUTPUT_FILE: "tests/fixtures/redacted-output.example.txt",
     });
 
     const markdown = buildClinicalQaPreflightReportMarkdown({
@@ -475,7 +501,7 @@ describe("clinical data parity agent helpers", () => {
       PW_CLINICAL_QA_PASSWORD: "qa-password",
       PW_CLINICAL_QA_CLIENT_ID: "client-1",
       PW_CLINICAL_QA_SOURCE_FILE: "tests/fixtures/redacted-iehp-source.example.txt",
-      PW_CLINICAL_QA_OUTPUT_FILE: "tests/fixtures/redacted-output.example.docx",
+      PW_CLINICAL_QA_OUTPUT_FILE: "tests/fixtures/redacted-output.example.txt",
       PW_CLINICAL_QA_VISUAL_RUBRIC_FILE: "tests/fixtures/redacted-clinical-qa-visual-rubric.example.json",
     });
 


### PR DESCRIPTION
## Summary
- Require configured clinical QA fixture paths to exist during preflight, not just look redacted/synthetic/smoke/test scoped.
- Add a real `tests/fixtures/redacted-output.example.txt` fixture for source-to-output packet validation.
- Update the clinical QA handoff and repo-local skill with the fixture-existence requirement.

Linear: WIN-150

## Route
- classification: low-risk autonomous
- lane: standard
- triggering paths: `.agents/skills/clinical-data-parity-auditor/SKILL.md`, `docs/ai/2026-06-15-clinical-data-parity-agent-handoff.md`, `scripts/lib/clinical-data-parity-agent.ts`, `tests/scripts/clinical-data-parity-agent.test.ts`, `tests/fixtures/redacted-output.example.txt`
- protected-path drift: none

## Verification Card
- Classification: low-risk autonomous
- Lane: standard
- Change type: script/test fixture + docs/process
- Required checks: `git diff --check`, targeted clinical QA helper test, real preflight with bundled redacted fixtures, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, `npm run verify:local`
- Executed checks:
  - RED `npm test -- tests/scripts/clinical-data-parity-agent.test.ts` failed before implementation because missing redacted fixtures still reported `ok: true`.
  - GREEN `npm test -- tests/scripts/clinical-data-parity-agent.test.ts` passed: 29 tests.
  - Real preflight with bundled redacted source/output/expectations/rubric fixtures returned `ok: true` and did not launch the browser.
  - `git diff --check` passed.
  - `npm run ci:check-focused` passed.
  - `npm run lint` passed.
  - `npm run typecheck` passed.
  - `npm run test:ci` passed: 317 files, 1894 tests.
  - `npm run build` passed.
  - `npm run verify:local` passed through policy/lint/typecheck/test:ci/coverage/build, then failed at local Cypress startup with `Cypress.exe: bad option: --smoke-test` / `--ping`.
- Blocked checks: full local `verify:local` route tier-0 completion is blocked by local Cypress startup behavior; CI should provide the browser gate.
- Result: pass-with-blocked-checks
- Residual risk: real end-to-end browser parity still needs shell-provided dedicated test credentials and a hosted redacted test client/route.

## PR Hygiene
- Branch-ready: yes
- Linear-ready: yes (`WIN-150` updated)
- Single-purpose: yes
- Generated artifact drift: none
- Protected-path drift: none
- Reviewer/tester: blocked by tool contract requiring explicit user authorization for subagents in this session