### PR TITLE
WIN-154 Guard IEHP FBA template parity

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -52,6 +52,16 @@ const ACTIVE_ASSESSMENT_POLL_STATUSES: ReadonlySet<AssessmentDocumentRecord["sta
   "extraction_running",
 ]);
 
+const detectAssessmentTemplateTypeFromFileName = (fileName: string): AssessmentTemplateType | null => {
+  const normalized = fileName.toLowerCase();
+  const hasIehp = /(?:^|[^a-z0-9])iehp(?:[^a-z0-9]|$)/.test(normalized);
+  const hasCalOptima = /(?:^|[^a-z0-9])caloptima(?:[^a-z0-9]|$)/.test(normalized);
+  const hasFba = /(?:^|[^a-z0-9])fba(?:[^a-z0-9]|$)/.test(normalized);
+  if (hasIehp && hasFba) return "iehp_fba";
+  if (hasCalOptima && hasFba) return "caloptima_fba";
+  return null;
+};
+
 const isStructuredChildGoalSection = (section: AssessmentStructuredSection): boolean =>
   section.field_key === "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS" ||
   section.field_key === "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS" ||
@@ -979,6 +989,14 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     }
   };
 
+  const handleAssessmentFileChange = (file: File | null) => {
+    setAssessmentFile(file);
+    const detectedTemplateType = file ? detectAssessmentTemplateTypeFromFileName(file.name) : null;
+    if (detectedTemplateType) {
+      setAssessmentTemplateType(detectedTemplateType);
+    }
+  };
+
   const updateChecklistItem = useMutation({
     mutationFn: async (itemId: string) => {
       const edit = checklistEdits[itemId];
@@ -1605,7 +1623,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 id="programs-goals-fba-file-upload"
                 type="file"
                 accept=".pdf,.docx"
-                onChange={(event) => setAssessmentFile(event.target.files?.[0] ?? null)}
+                onChange={(event) => handleAssessmentFileChange(event.target.files?.[0] ?? null)}
                 className="w-full text-sm"
               />
               <button

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1695,6 +1695,69 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
   });
 
+  it("auto-selects IEHP template when the uploaded FBA filename identifies IEHP", async () => {
+    const baseCallApiImpl = vi.mocked(callApi).getMockImplementation();
+    if (!baseCallApiImpl) {
+      throw new Error("Missing base API mock implementation.");
+    }
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "POST" && path === "/api/assessment-documents") {
+        return new Response(
+          JSON.stringify({
+            id: ASSESSMENT_ID,
+            organization_id: ORG_ID,
+            client_id: "client-1",
+            template_type: "iehp_fba",
+            file_name: "Le, Ki IEHP FBA December 2025 (1).docx",
+            mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            file_size: 1000,
+            bucket_id: "client-documents",
+            object_path: "clients/client-1/assessments/le-ki-iehp-fba.docx",
+            status: "uploaded",
+            created_at: "2026-02-11T00:00:00.000Z",
+          }),
+          { status: 201 },
+        );
+      }
+      return baseCallApiImpl(path, init);
+    });
+
+    renderWithProviders(
+      <ProgramsGoalsTab client={buildClient()} />,
+      {
+        auth: {
+          role: "therapist",
+          organizationId: ORG_ID,
+          accessToken: "test-access-token",
+        },
+      },
+    );
+
+    await screen.findByText(/CalOptima FBA Upload Workflow/i);
+    const templateSelect = screen.getByRole("combobox", { name: /FBA template/i });
+    expect(templateSelect).toHaveValue("caloptima_fba");
+    const uploadInput = screen.getByLabelText(/FBA file \(PDF or DOCX\)/i);
+    const file = new File(["mock iehp content"], "Le, Ki IEHP FBA December 2025 (1).docx", {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    await user.upload(uploadInput, file);
+
+    expect(templateSelect).toHaveValue("iehp_fba");
+    expect(await screen.findByText(/IEHP FBA Upload Workflow/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Upload IEHP FBA/i }));
+
+    await waitFor(() => {
+      expect(callApi).toHaveBeenCalledWith(
+        "/api/assessment-documents",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining("\"template_type\":\"iehp_fba\""),
+        }),
+      );
+    });
+  });
+
   it("renders IEHP-specific review labels for a selected uploaded assessment", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -455,6 +455,9 @@ describe("Schedule", () => {
       dryRun: true,
     });
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Apply this week forward/i })).toBeEnabled();
+    });
     await userEvent.click(screen.getByRole("button", { name: /Apply this week forward/i }));
 
     await waitFor(() => {

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -2168,6 +2168,86 @@ describe("assessmentDocumentsHandler", () => {
     expect(response.status).toBe(400);
   });
 
+  it("rejects an assessment upload when the filename identifies a different FBA template", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "Le, Ki IEHP FBA December 2025 (1).docx",
+          mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/le-ki-iehp-fba.docx",
+          template_type: "caloptima_fba",
+        }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/appears to be an IEHP FBA document/i);
+  });
+
+  it("rejects an IEHP upload when the filename identifies a CalOptima FBA template", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/clients?select=id")) {
+        return { ok: true, status: 200, data: [{ id: "client-1" }] };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDocumentsHandler(
+      new Request("http://localhost/api/assessment-documents", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "11111111-1111-1111-1111-111111111111",
+          file_name: "CalOptima FBA assessment.docx",
+          mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          file_size: 1234,
+          object_path: "clients/11111111-1111-1111-1111-111111111111/assessments/caloptima-fba.docx",
+          template_type: "iehp_fba",
+        }),
+      }),
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/appears to be a CalOptima FBA document/i);
+  });
+
   it("rejects assessment uploads outside the approved storage bucket", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({

--- a/src/server/__tests__/assessmentPlanPdfHandler.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfHandler.test.ts
@@ -380,7 +380,14 @@ describe("assessmentPlanPdfHandler", () => {
       })
       .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
       .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
-      .mockResolvedValueOnce({ ok: true, status: 200, data: [{ id: "program-1", name: "Program", description: null, accept_state: "accepted" }] })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          { id: "program-1", name: "Program", description: null, accept_state: "accepted" },
+          { id: "program-2", name: "Edited Program", description: "Second program", accept_state: "edited" },
+        ],
+      })
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -465,7 +472,14 @@ describe("assessmentPlanPdfHandler", () => {
       })
       .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
       .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
-      .mockResolvedValueOnce({ ok: true, status: 200, data: [{ id: "program-1", name: "Program", description: null, accept_state: "accepted" }] })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          { id: "program-1", name: "Program", description: null, accept_state: "accepted" },
+          { id: "program-2", name: "Edited Program", description: "Second program", accept_state: "edited" },
+        ],
+      })
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -562,8 +576,11 @@ describe("assessmentPlanPdfHandler", () => {
     expect(buildIehpDocxPayload).toHaveBeenCalledWith(
       expect.objectContaining({
         authorizationMemberId: "AUTH-MEMBER-999",
-        acceptedPrograms: [],
-        acceptedGoals: [],
+        acceptedPrograms: expect.arrayContaining([
+          expect.objectContaining({ id: "program-1", accept_state: "accepted" }),
+          expect.objectContaining({ id: "program-2", accept_state: "edited" }),
+        ]),
+        acceptedGoals: expect.arrayContaining([expect.objectContaining({ id: "goal-1", accept_state: "accepted" })]),
         pendingDraftProgramCount: 0,
         pendingDraftGoalCount: 0,
       }),
@@ -653,8 +670,8 @@ describe("assessmentPlanPdfHandler", () => {
     expect(buildIehpDocxPayload).toHaveBeenCalledWith(
       expect.objectContaining({
         authorizationMemberId: "OTHER-MEMBER-222",
-        acceptedPrograms: [],
-        acceptedGoals: [],
+        acceptedPrograms: expect.arrayContaining([expect.objectContaining({ id: "program-1", accept_state: "accepted" })]),
+        acceptedGoals: expect.arrayContaining([expect.objectContaining({ id: "goal-1", accept_state: "accepted" })]),
         pendingDraftProgramCount: 0,
         pendingDraftGoalCount: 0,
       }),

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -48,6 +48,16 @@ const isAllowedAssessmentObjectPath = (objectPath: string, clientId: string): bo
     normalized.startsWith(`clients/${clientId}/assessments/`);
 };
 
+const detectAssessmentTemplateTypeFromFileName = (fileName: string): AssessmentTemplateType | null => {
+  const normalized = fileName.toLowerCase();
+  const hasIehp = /(?:^|[^a-z0-9])iehp(?:[^a-z0-9]|$)/.test(normalized);
+  const hasCalOptima = /(?:^|[^a-z0-9])caloptima(?:[^a-z0-9]|$)/.test(normalized);
+  const hasFba = /(?:^|[^a-z0-9])fba(?:[^a-z0-9]|$)/.test(normalized);
+  if (hasIehp && hasFba) return "iehp_fba";
+  if (hasCalOptima && hasFba) return "caloptima_fba";
+  return null;
+};
+
 interface AssessmentDocumentRow {
   id: string;
   organization_id: string;
@@ -1227,6 +1237,16 @@ export async function assessmentDocumentsHandler(
 
     const actorId = getAccessTokenSubject(accessToken);
     const templateType = parsed.data.template_type ?? "caloptima_fba";
+    const detectedTemplateType = detectAssessmentTemplateTypeFromFileName(parsed.data.file_name);
+    if (detectedTemplateType && detectedTemplateType !== templateType) {
+      return jsonForRequest(
+        request,
+        {
+          error: `Uploaded file name appears to be ${detectedTemplateType === "iehp_fba" ? "an IEHP FBA" : "a CalOptima FBA"} document. Select the matching FBA template before uploading.`,
+        },
+        400,
+      );
+    }
     let templateVersionId: string | null;
     try {
       templateVersionId = await resolveActiveTemplateVersionId({ supabaseUrl, headers, templateType });

--- a/src/server/api/assessment-plan-pdf.ts
+++ b/src/server/api/assessment-plan-pdf.ts
@@ -261,9 +261,10 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
     ...structuredSections.filter((item) => item.required && item.status !== "approved").map((item) => item.field_key),
   ];
 
-  const acceptedProgram =
-    (draftProgramsResult.data ?? []).find((program) => program.accept_state === "accepted" || program.accept_state === "edited") ??
-    null;
+  const acceptedPrograms = (draftProgramsResult.data ?? []).filter(
+    (program) => program.accept_state === "accepted" || program.accept_state === "edited",
+  );
+  const acceptedProgram = acceptedPrograms[0] ?? null;
   const acceptedGoals = (draftGoalsResult.data ?? []).filter(
     (goal) => goal.accept_state === "accepted" || goal.accept_state === "edited",
   );
@@ -342,8 +343,8 @@ export async function assessmentPlanPdfHandler(request: Request): Promise<Respon
       client,
       authorizationMemberId,
       writer,
-      acceptedPrograms: [],
-      acceptedGoals: [],
+      acceptedPrograms,
+      acceptedGoals,
       pendingDraftProgramCount: 0,
       pendingDraftGoalCount: 0,
     });


### PR DESCRIPTION
## Summary
- Auto-detect obvious IEHP/CalOptima FBA filenames in Programs & Goals upload and select the matching template before upload.
- Reject server-side assessment uploads when the filename clearly identifies a different FBA template than the submitted template_type.
- Pass all accepted/edited draft programs and goals into IEHP DOCX payload generation instead of empty fallback arrays.
- Stabilize the Schedule week-forward test by waiting for the Apply button to re-enable after preview before clicking.

## Linear
- WIN-154

## Verification
- `npx vitest run src/pages/__tests__/Schedule.test.tsx -t "previews and applies the visible week with the displayed week payload"`
- `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx src/server/__tests__/assessmentDocumentsHandler.test.ts src/server/__tests__/assessmentPlanPdfHandler.test.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run ci:verify-coverage`
- `npm run build`
- `npm run test:routes:tier0`

## Risk
- Critical lane because this touches `src/server/**` and assessment upload/generation boundaries.
- Filename detection is intentionally heuristic: unusual filenames can still fall through to manual template selection.
- DB-backed policy checks in `ci:check-focused` were skipped locally because `SUPABASE_DB_URL` / `DATABASE_URL` is not configured.
