### PR TITLE
WIN-175 Restrict authorization routes to admin and super_admin

### DIFF
--- a/cypress/support/routeScenarios.ts
+++ b/cypress/support/routeScenarios.ts
@@ -25,7 +25,7 @@ export const routeGroups = {
     { path: "/clients", roles: ["therapist", "admin", "super_admin"] },
     { path: "/clients/client-1", roles: ["therapist", "admin", "super_admin"] },
     { path: "/documentation", roles: ["client", "therapist", "admin", "super_admin"] },
-    { path: "/authorizations", roles: ["therapist", "admin", "super_admin"] },
+    { path: "/authorizations", roles: ["admin", "super_admin"] },
     { path: "/family", roles: [] },
   ],
   schedule: [

--- a/docs/ai/WIN-175-authorization-routes-handoff.md
+++ b/docs/ai/WIN-175-authorization-routes-handoff.md
@@ -1,0 +1,91 @@
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: the slice changes role-based access to a protected authorization route and client-detail tab visibility, so it affects authz and routing behavior even though it stays outside the listed high-risk file globs.
+- triggering paths:
+  - `src/App.tsx`
+  - `src/pages/ClientDetails.tsx`
+  - `src/server/routes/guards.ts`
+  - `scripts/route-audit.ts`
+  - `scripts/route-audit.cjs`
+  - `cypress/support/routeScenarios.ts`
+
+## Scope
+
+- task intent: block therapist and BT access to the standalone `/authorizations` route and hide the client `Pre-Authorizations` tab for therapist viewers while preserving `admin` and `super_admin` access.
+- files touched:
+  - `cypress/support/routeScenarios.ts`
+  - `scripts/route-audit.cjs`
+  - `scripts/route-audit.ts`
+  - `src/App.tsx`
+  - `src/pages/ClientDetails.tsx`
+  - `src/pages/__tests__/AppNavigation.test.tsx`
+  - `src/pages/__tests__/ClientDetails.test.tsx`
+  - `src/server/routes/guards.ts`
+- single-purpose diff: yes
+
+## Required Agents
+
+- required sequence:
+  - `specification-engineer`
+  - `software-architect`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+  - `security-engineer`
+- agents used:
+  - main Codex agent for inspection, implementation, and verification
+  - repo-local skills: `route-task`, `auth-routing-guard`, `verify-change`, `pr-hygiene`
+- reviewer: blocked
+
+## Verification Card
+
+- required checks:
+  - `npm ci`
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run test:routes:tier0`
+  - `npm run build`
+  - `npm run ci:playwright`
+  - `npm run verify:local`
+- executed checks:
+  - `npm ci`: pass
+  - `npx vitest run src/pages/__tests__/AppNavigation.test.tsx src/pages/__tests__/ClientDetails.test.tsx`: pass
+  - `npx vitest run src/pages/__tests__/Authorizations.test.tsx src/pages/__tests__/ClientDetails.test.tsx src/components/__tests__/SidebarNavigation.test.tsx src/pages/__tests__/AppNavigation.test.tsx src/components/__tests__/RoleGuard.test.tsx`: pass
+  - `npx vitest run tests/edge/route-audit-policy.test.ts tests/edge/route-guards-parity.test.ts src/server/routes/__tests__/guards.test.ts`: pass
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run test:routes:tier0`: pass
+  - `npm run build`: pass
+  - `npm run ci:playwright`: fail
+  - `npm run verify:local`: fail
+- blocked checks:
+  - `npm run test:ci`: not rerun to full green after unrelated suite instability; focused auth, route, and parity coverage above passed.
+  - `npm run ci:playwright`: env-loading issue was resolved via `PLAYWRIGHT_ENV_FILE`, but the aggregate command still fails on unrelated `playwright:session-capture-adhoc-upsert` timeout outside this slice.
+  - `npm run verify:local`: still fails because it wraps broader suites that include unrelated failures.
+- result: pass-with-blocked-checks
+- residual risk: merge still requires human review and a decision on whether the unrelated aggregate Playwright/session-capture failure must be cleared first or can stay outside this PR's scope.
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes
+- protected-path drift:
+  - `src/App.tsx`
+  - `src/server/routes/guards.ts`
+- unrelated changes: none
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: yes
+- required follow-up:
+  - push branch and open PR linked to `WIN-175`
+  - request human review for protected auth/routing behavior
+  - decide whether to treat unrelated `playwright:session-capture-adhoc-upsert` failure as a separate follow-up issue
+
+## Handoff Summary
+
+This slice tightens authorization visibility so therapist and BT users can no longer reach the standalone `/authorizations` route and therapist viewers no longer see the client `Pre-Authorizations` tab. The change stays isolated to route guards, client tab filtering, and matching audit/test fixtures, with focused vitest, route-audit parity, policy, tier-0 route, and build checks passing. Aggregate Playwright now runs with the supported env-loading path and reaches a different unrelated failure in `playwright:session-capture-adhoc-upsert`, so that broader blocker remains outside this PR's scope and should be triaged separately.

--- a/docs/ai/WIN-175-authorization-routes-handoff.md
+++ b/docs/ai/WIN-175-authorization-routes-handoff.md
@@ -63,12 +63,11 @@
   - `npm run typecheck`: pass
   - `npm run test:routes:tier0`: pass
   - `npm run build`: pass
-  - `npm run playwright:authorizations-read-scope`: fail against production because production still serves the old `/authorizations` therapist access behavior until this branch deploys.
+  - `PW_BASE_URL=https://deploy-preview-658--velvety-cendol-dae4d6.netlify.app npm run playwright:authorizations-read-scope`: pass
   - `npm run ci:playwright`: fail
   - `npm run verify:local`: fail
 - blocked checks:
   - `npm run test:ci`: not rerun to full green after unrelated suite instability; focused auth, route, and parity coverage above passed.
-  - `npm run playwright:authorizations-read-scope`: updated for the new blocked-therapist expectation; runtime proof requires a deployed target containing this PR's route guard.
   - `npm run ci:playwright`: env-loading issue was resolved via `PLAYWRIGHT_ENV_FILE`, but the aggregate command still fails on unrelated `playwright:session-capture-adhoc-upsert` timeout outside this slice.
   - `npm run verify:local`: still fails because it wraps broader suites that include unrelated failures.
 - result: pass-with-blocked-checks
@@ -92,4 +91,4 @@
 
 ## Handoff Summary
 
-This slice tightens authorization visibility so therapist and BT users can no longer reach the standalone `/authorizations` route and therapist viewers no longer see the client `Pre-Authorizations` tab. The change stays isolated to route guards, client tab filtering, and matching audit/test fixtures, with focused vitest, route-audit parity, policy, tier-0 route, and build checks passing. Aggregate Playwright now runs with the supported env-loading path and reaches a different unrelated failure in `playwright:session-capture-adhoc-upsert`, so that broader blocker remains outside this PR's scope and should be triaged separately.
+This slice tightens authorization visibility so therapist and BT users can no longer reach the standalone `/authorizations` route and therapist viewers no longer see the client `Pre-Authorizations` tab. The change stays isolated to route guards, client tab filtering, matching audit/test fixtures, and the authorizations read-scope smoke. Focused vitest, route-audit parity, policy, tier-0 route, build, and deploy-preview `playwright:authorizations-read-scope` checks pass. Aggregate Playwright now runs with the supported env-loading path and reaches a different unrelated failure in `playwright:session-capture-adhoc-upsert`, so that broader blocker remains outside this PR's scope and should be triaged separately.

--- a/docs/ai/WIN-175-authorization-routes-handoff.md
+++ b/docs/ai/WIN-175-authorization-routes-handoff.md
@@ -7,6 +7,7 @@
   - `src/App.tsx`
   - `src/pages/ClientDetails.tsx`
   - `src/server/routes/guards.ts`
+  - `scripts/playwright-authorizations-read-scope-smoke.ts`
   - `scripts/route-audit.ts`
   - `scripts/route-audit.cjs`
   - `cypress/support/routeScenarios.ts`
@@ -18,6 +19,7 @@
   - `cypress/support/routeScenarios.ts`
   - `scripts/route-audit.cjs`
   - `scripts/route-audit.ts`
+  - `scripts/playwright-authorizations-read-scope-smoke.ts`
   - `src/App.tsx`
   - `src/pages/ClientDetails.tsx`
   - `src/pages/__tests__/AppNavigation.test.tsx`
@@ -61,10 +63,12 @@
   - `npm run typecheck`: pass
   - `npm run test:routes:tier0`: pass
   - `npm run build`: pass
+  - `npm run playwright:authorizations-read-scope`: fail against production because production still serves the old `/authorizations` therapist access behavior until this branch deploys.
   - `npm run ci:playwright`: fail
   - `npm run verify:local`: fail
 - blocked checks:
   - `npm run test:ci`: not rerun to full green after unrelated suite instability; focused auth, route, and parity coverage above passed.
+  - `npm run playwright:authorizations-read-scope`: updated for the new blocked-therapist expectation; runtime proof requires a deployed target containing this PR's route guard.
   - `npm run ci:playwright`: env-loading issue was resolved via `PLAYWRIGHT_ENV_FILE`, but the aggregate command still fails on unrelated `playwright:session-capture-adhoc-upsert` timeout outside this slice.
   - `npm run verify:local`: still fails because it wraps broader suites that include unrelated failures.
 - result: pass-with-blocked-checks

--- a/scripts/playwright-authorizations-read-scope-smoke.ts
+++ b/scripts/playwright-authorizations-read-scope-smoke.ts
@@ -1,6 +1,7 @@
 /**
- * Production (or PW_BASE_URL) smoke: therapist and org admin reach /authorizations and
- * expose REST authorizations row counts for comparison. Does not mutate data.
+ * Production (or PW_BASE_URL) smoke: therapist is blocked from /authorizations while
+ * org admin can reach /authorizations and expose REST authorizations row counts.
+ * Does not mutate data.
  *
  * Env: PW_BASE_URL, PW_THERAPIST_*, PW_ADMIN_* (see scripts/lib/load-playwright-env.ts).
  */
@@ -9,7 +10,34 @@ import { chromium } from "playwright";
 import { loadPlaywrightEnv, resolvePlaywrightBaseUrl } from "./lib/load-playwright-env";
 import { loginAndAssertSession, preflightCredentials } from "./lib/playwright-smoke";
 
-type CountPayload = { persona: string; url: string; authorizationsRows: number; restStatus?: number };
+type BlockedPayload = { persona: string; url: string; access: "blocked" };
+type CountPayload = {
+  persona: string;
+  url: string;
+  access: "allowed";
+  authorizationsRows: number;
+  restStatus?: number;
+};
+type SmokePayload = BlockedPayload | CountPayload;
+
+const assertBlockedFromAuthorizations = async (
+  page: import("playwright").Page,
+  baseUrl: string,
+  persona: string,
+): Promise<BlockedPayload> => {
+  await page.goto(`${baseUrl.replace(/\/$/, "")}/authorizations`, {
+    waitUntil: "domcontentloaded",
+    timeout: 90_000,
+  });
+
+  await page.waitForURL(/\/unauthorized(?:[/?#]|$)/i, { timeout: 30_000 });
+
+  return {
+    persona,
+    url: page.url(),
+    access: "blocked",
+  };
+};
 
 const countAuthorizationsFromPage = async (
   page: import("playwright").Page,
@@ -50,6 +78,7 @@ const countAuthorizationsFromPage = async (
   return {
     persona,
     url: page.url(),
+    access: "allowed",
     authorizationsRows: rows,
     restStatus,
   };
@@ -76,14 +105,14 @@ async function run(): Promise<void> {
   ]);
 
   const browser = await chromium.launch({ headless });
-  const results: CountPayload[] = [];
+  const results: SmokePayload[] = [];
 
   try {
     const ctxT = await browser.newContext();
     const pageT = await ctxT.newPage();
     try {
       await loginAndAssertSession(pageT, baseUrl, therapistCreds.email, therapistCreds.password);
-      results.push(await countAuthorizationsFromPage(pageT, baseUrl, "therapist"));
+      results.push(await assertBlockedFromAuthorizations(pageT, baseUrl, "therapist"));
     } finally {
       await ctxT.close();
     }
@@ -97,27 +126,6 @@ async function run(): Promise<void> {
       await ctxA.close();
     }
 
-    const therapist = results.find((r) => r.persona === "therapist");
-    const admin = results.find((r) => r.persona === "org_admin");
-
-    const comparison =
-      therapist && admin
-        ? {
-            therapistRows: therapist.authorizationsRows,
-            adminRows: admin.authorizationsRows,
-            note:
-              admin.authorizationsRows >= therapist.authorizationsRows
-                ? "admin visible count >= therapist (consistent with broader admin read where data exists)"
-                : "admin returned fewer rows than therapist (regression: org_admin read narrower than therapist)",
-          }
-        : {};
-
-    if (therapist && admin && admin.authorizationsRows < therapist.authorizationsRows) {
-      throw new Error(
-        `authorizations read-scope smoke failed: org_admin rows (${admin.authorizationsRows}) < therapist rows (${therapist.authorizationsRows}); expected admin org-wide read >= therapist caseload read.`,
-      );
-    }
-
     // eslint-disable-next-line no-console
     console.log(
       JSON.stringify(
@@ -125,7 +133,6 @@ async function run(): Promise<void> {
           ok: true,
           baseUrl,
           results,
-          comparison,
         },
         null,
         2,

--- a/scripts/route-audit.cjs
+++ b/scripts/route-audit.cjs
@@ -28,7 +28,7 @@ const ROUTES = [
   { path: '/therapists/:therapistId', component: 'TherapistDetails', roles: ['client', 'therapist', 'admin', 'super_admin'], permissions: [] },
   { path: '/therapists/new', component: 'TherapistOnboarding', roles: ['admin', 'super_admin'], permissions: [] },
   { path: '/documentation', component: 'Documentation', roles: ['client', 'therapist', 'admin', 'super_admin'], permissions: [] },
-  { path: '/authorizations', component: 'Authorizations', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
+  { path: '/authorizations', component: 'Authorizations', roles: ['admin', 'super_admin'], permissions: [] },
   { path: '/billing', component: 'Billing', roles: ['admin', 'super_admin'], permissions: [] },
   { path: '/monitoring', component: 'MonitoringDashboard', roles: ['admin', 'super_admin'], permissions: [] },
   { path: '/reports', component: 'Reports', roles: ['admin', 'super_admin'], permissions: [] },

--- a/scripts/route-audit.ts
+++ b/scripts/route-audit.ts
@@ -117,7 +117,7 @@ export const ROUTES: readonly RouteDefinition[] = [
   { path: '/therapists/new', component: 'TherapistOnboarding', roles: ['admin', 'super_admin'], permissions: [] },
   { path: '/documentation', component: 'Documentation', roles: ['client', 'therapist', 'admin', 'super_admin'], permissions: [] },
   { path: '/fill-docs', component: 'FillDocs', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
-  { path: '/authorizations', component: 'Authorizations', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
+  { path: '/authorizations', component: 'Authorizations', roles: ['admin', 'super_admin'], permissions: [] },
   { path: '/messages', component: 'MessagesInbox', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
   { path: '/messages/new', component: 'MessagesNew', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
   {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,9 +233,9 @@ function App() {
                       )}
                     />
 
-                    {/* Authorizations - accessible to therapists and above */}
+                    {/* Authorizations - accessible to admins and above */}
                     <Route path="authorizations" element={
-                      <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                      <RoleGuard roles={['admin', 'super_admin']}>
                         <Authorizations />
                       </RoleGuard>
                     } />

--- a/src/pages/ClientDetails.tsx
+++ b/src/pages/ClientDetails.tsx
@@ -146,6 +146,11 @@ export function ClientDetails() {
     },
   ];
 
+  const visibleTabs = useMemo(
+    () => tabs.filter((tab) => !(isTherapistViewer && tab.id === 'pre-auth')),
+    [isTherapistViewer, tabs],
+  );
+
   if (!activeOrganizationId) {
     return (
       <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-900/40 rounded-lg shadow p-8 text-amber-800 dark:text-amber-100">
@@ -266,8 +271,8 @@ export function ClientDetails() {
 
       <div className="bg-white dark:bg-dark-lighter rounded-lg shadow mb-6">
         <div className="border-b dark:border-gray-700 px-3 py-2 sm:px-4">
-          <div className="-mx-1 flex items-center gap-2 overflow-x-auto px-1 pb-1">
-            {tabs.map((tab) => {
+            <div className="-mx-1 flex items-center gap-2 overflow-x-auto px-1 pb-1">
+            {visibleTabs.map((tab) => {
               const Icon = tab.icon;
               const isActive = activeTab === tab.id;
 
@@ -308,7 +313,7 @@ export function ClientDetails() {
           {activeTab === 'profile' && <ProfileTab client={client} viewerRole={effectiveRole} />}
           {activeTab === 'session-notes' && <SessionNotesTab client={client} />}
           {activeTab === 'programs-goals' && <ProgramsGoalsTab client={client} />}
-          {activeTab === 'pre-auth' && <PreAuthTab client={client} />}
+          {activeTab === 'pre-auth' && !isTherapistViewer && <PreAuthTab client={client} />}
           {activeTab === 'contracts' && <ServiceContractsTab client={client} />}
         </div>
       </div>

--- a/src/pages/__tests__/AppNavigation.test.tsx
+++ b/src/pages/__tests__/AppNavigation.test.tsx
@@ -195,4 +195,14 @@ describe('App navigation landing', () => {
       expect(window.location.pathname).toBe('/unauthorized');
     });
   });
+
+  it('blocks therapists from authorizations route', async () => {
+    authRole = 'therapist';
+    window.history.pushState({}, '', '/authorizations');
+    renderApp();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/unauthorized');
+    });
+  });
 });

--- a/src/pages/__tests__/ClientDetails.test.tsx
+++ b/src/pages/__tests__/ClientDetails.test.tsx
@@ -152,6 +152,16 @@ describe('ClientDetails page', () => {
     });
   });
 
+  it('hides the Pre-Authorizations tab for therapist viewers', async () => {
+    renderWithProviders(<ClientDetails />, {
+      auth: { role: 'therapist', userId: 'therapist-user-id' },
+    });
+
+    await waitFor(() => expect(screen.getByText('ProfileTabContent')).toBeInTheDocument());
+
+    expect(screen.queryByRole('button', { name: /Pre-Authorizations/i })).not.toBeInTheDocument();
+  });
+
   it('allows a therapist whose auth user maps to a separate therapist row id', async () => {
     mockLocationSearch = '?tab=programs-goals';
     vi.mocked(fetchClientByIdForViewer).mockResolvedValue({

--- a/src/server/routes/guards.ts
+++ b/src/server/routes/guards.ts
@@ -88,7 +88,7 @@ const guardDefinitions: readonly GuardWithMatcher[] = [
   }),
   createGuard({
     path: '/authorizations',
-    allowedRoles: ['therapist', 'admin', 'super_admin'],
+    allowedRoles: ['admin', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.authorizations: authorizations_org_read'],
   }),


### PR DESCRIPTION
## Summary
- block therapist/BT access to the standalone `/authorizations` route
- hide the client `Pre-Authorizations` tab for therapist viewers while preserving `admin` and `super_admin` access
- update route-audit and route-scenario metadata plus regression coverage to match the new access policy
- update `playwright:authorizations-read-scope` so therapist `/authorizations` redirects to `/unauthorized` are expected, while admin reachability/count coverage remains

## Verification
- `npm ci`
- `npx vitest run src/pages/__tests__/AppNavigation.test.tsx src/pages/__tests__/ClientDetails.test.tsx`
- `npx vitest run src/pages/__tests__/Authorizations.test.tsx src/pages/__tests__/ClientDetails.test.tsx src/components/__tests__/SidebarNavigation.test.tsx src/pages/__tests__/AppNavigation.test.tsx src/components/__tests__/RoleGuard.test.tsx`
- `npx vitest run tests/edge/route-audit-policy.test.ts tests/edge/route-guards-parity.test.ts src/server/routes/__tests__/guards.test.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:routes:tier0`
- `npm run build`
- post-rebase rerun: focused vitest auth/route/parity suite, `npm run test:routes:tier0`, `npm run typecheck`
- after smoke update: `npm run lint`, `npm run typecheck`, commit hook `npm run ci:check-focused`
- `PW_BASE_URL=https://deploy-preview-658--velvety-cendol-dae4d6.netlify.app npm run playwright:authorizations-read-scope`

## Blocked / follow-up
- `npm run ci:playwright` now loads env correctly via `PLAYWRIGHT_ENV_FILE`, but the aggregate run still fails in unrelated `playwright:session-capture-adhoc-upsert`
- `npm run verify:local` still fails because it wraps broader unrelated suites
- tracking: `WIN-175`