### PR TITLE
Append evidence terms for structured IEHP goals

### DIFF
--- a/src/server/__tests__/iehpAssessmentDocx.test.ts
+++ b/src/server/__tests__/iehpAssessmentDocx.test.ts
@@ -441,7 +441,7 @@ describe("buildIehpDocxPayload", () => {
           section_index: 0,
           payload: {
             raw_text:
-              "Structured goal text notes escape behaviors, access to tangibles, and preferred items but lacks explicit parity phrases.",
+              "Structured goal text notes escape behaviors and access to tangibles but lacks explicit parity phrases.",
           },
           status: "approved" as const,
           required: true,

--- a/src/server/__tests__/iehpAssessmentDocx.test.ts
+++ b/src/server/__tests__/iehpAssessmentDocx.test.ts
@@ -421,6 +421,42 @@ describe("buildIehpDocxPayload", () => {
     expect(result.values.IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS).toContain("allowing escape");
   });
 
+  it("adds explicit function and consequence evidence to structured IEHP goal blocks", () => {
+    const result = buildIehpDocxPayload({
+      ...baseArgs,
+      templateFields: [{ field_key: "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS", required: true }],
+      checklistItems: [
+        {
+          placeholder_key: "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
+          required: true,
+          status: "approved" as const,
+          value_text: null,
+          value_json: null,
+        },
+      ],
+      structuredSections: [
+        {
+          field_key: "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS",
+          section_key: "goals",
+          section_index: 0,
+          payload: {
+            raw_text:
+              "Structured goal text notes escape behaviors, access to tangibles, and preferred items but lacks explicit parity phrases.",
+          },
+          status: "approved" as const,
+          required: true,
+        },
+      ],
+      acceptedGoals: [],
+    });
+
+    expect(result.preflight.ready).toBe(true);
+    expect(result.values.IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS).toContain("access to tangibles");
+    expect(result.values.IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS).toContain("escape/avoidance");
+    expect(result.values.IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS).toContain("desired item");
+    expect(result.values.IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS).toContain("allowing escape");
+  });
+
   it("ignores staged draft review state and blocks only unresolved required output values", () => {
     const result = buildIehpDocxPayload({
       ...baseArgs,

--- a/src/server/iehpAssessmentDocx.ts
+++ b/src/server/iehpAssessmentDocx.ts
@@ -260,7 +260,9 @@ const derivedValue = (
 ): string => {
   const structuredText = formatSectionsForKey(fieldKey, args.structuredSections);
   if (structuredText) {
-    return fieldKey === "IEHP_FBA_TEACHING_INTERVENTION_STRATEGIES"
+    return fieldKey === "IEHP_FBA_TEACHING_INTERVENTION_STRATEGIES" ||
+      fieldKey === "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS" ||
+      fieldKey === "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS"
       ? appendFunctionConsequenceEvidence(structuredText)
       : structuredText;
   }

--- a/src/server/iehpAssessmentDocx.ts
+++ b/src/server/iehpAssessmentDocx.ts
@@ -210,7 +210,8 @@ const appendFunctionConsequenceEvidence = (value: string, evidenceSource = value
   const renderedNormalized = value.toLowerCase();
   const hasTangibleEvidence = normalized.includes("access to tangibles") || normalized.includes("preferred item");
   const hasEscapeEvidence = normalized.includes("escape");
-  const hasDesiredItemEvidence = normalized.includes("preferred item") || normalized.includes("access to a tangible");
+  const hasDesiredItemEvidence =
+    normalized.includes("preferred item") || normalized.includes("access to a tangible") || normalized.includes("access to tangibles");
   const missingExplicitFunction = !renderedNormalized.includes("escape/avoidance") && hasTangibleEvidence && hasEscapeEvidence;
   const missingExplicitConsequence =
     (!renderedNormalized.includes("desired item") || !renderedNormalized.includes("allowing escape")) && hasDesiredItemEvidence;


### PR DESCRIPTION
## Summary
- Applies IEHP function/consequence evidence appending to structured target/skill goal block output, not only draft goals and teaching intervention text.
- Adds a regression where approved structured `IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS` contains access/escape evidence but lacks explicit parity phrases.

## Verification
- `npm test -- src/server/__tests__/iehpAssessmentDocx.test.ts` passed
- `npm run ci:check-focused` passed
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run build` passed
- `npm run test:ci` timed out locally after 180s before completion; rely on GitHub unit-tests for full-suite signal

## Risk
Critical-lane server renderer change in `src/server/**`; no schema, auth, storage, or upload behavior changes.