### PR TITLE
Fix session capture ad-hoc upsert smoke

### DIFF
--- a/scripts/playwright-session-capture-adhoc-upsert.ts
+++ b/scripts/playwright-session-capture-adhoc-upsert.ts
@@ -5,6 +5,7 @@
  * Requires the same Playwright env contract as other non-AI session scripts (see playwright-preflight).
  */
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { createClient } from "@supabase/supabase-js";
@@ -28,11 +29,6 @@ import {
   type LifecycleIds,
 } from "./lib/playwright-inprogress-session-setup";
 
-const SCHEDULE_MODAL_MODE_KEY = "scheduleModal";
-const SCHEDULE_MODAL_SESSION_KEY = "scheduleSessionId";
-const SCHEDULE_MODAL_EXPIRY_KEY = "scheduleExp";
-const SCHEDULE_MODAL_URL_TTL_MS = 30 * 60 * 1000;
-
 const getEnv = (key: string, fallback?: string): string => {
   const value = process.env[key] ?? fallback;
   if (!value) {
@@ -44,6 +40,8 @@ const getEnv = (key: string, fallback?: string): string => {
 const isTruthy = (value: string | undefined): boolean => /^(1|true|yes)$/i.test(value ?? "");
 
 const STEP_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_STEP_TIMEOUT_MS ?? "300000");
+const PARTIAL_CAPTURE_WAIT_MS = Number(process.env.PW_SESSION_CAPTURE_PARTIAL_WAIT_MS ?? "20000");
+const FULL_CAPTURE_WAIT_MS = Number(process.env.PW_SESSION_CAPTURE_FULL_WAIT_MS ?? "120000");
 
 const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): Promise<T> => {
   console.log(`[session-capture-adhoc] start ${label}`);
@@ -64,31 +62,26 @@ const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): P
   }
 };
 
-const buildScheduleEditSessionUrl = (scheduleUrl: string, sessionId: string): string => {
-  const url = new URL(scheduleUrl);
-  const expiresAtMs = Date.now() + SCHEDULE_MODAL_URL_TTL_MS;
-  url.searchParams.set(SCHEDULE_MODAL_MODE_KEY, "edit");
-  url.searchParams.set(SCHEDULE_MODAL_SESSION_KEY, sessionId);
-  url.searchParams.set(SCHEDULE_MODAL_EXPIRY_KEY, String(expiresAtMs));
-  return url.toString();
-};
-
-const openEditSessionModalFromUrl = async (page: Page, scheduleUrl: string, sessionId: string): Promise<void> => {
+const openEditSessionModalFromCalendar = async (page: Page, scheduleUrl: string, sessionId: string): Promise<void> => {
   for (let attempt = 0; attempt < 12; attempt += 1) {
-    await page.goto(buildScheduleEditSessionUrl(scheduleUrl, sessionId), {
+    await page.goto(`${scheduleUrl}?_${Date.now()}`, {
       waitUntil: "networkidle",
       timeout: 60000,
     });
-    const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
+    const sessionCard = page.locator(`[data-session-id="${sessionId}"]`).first();
     try {
+      await sessionCard.waitFor({ state: "visible", timeout: 12_000 });
+      await sessionCard.scrollIntoViewIfNeeded();
+      await sessionCard.click();
+      const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
       await dialog.waitFor({ state: "visible", timeout: 12_000 });
       return;
     } catch {
       await page.waitForTimeout(500 + attempt * 250);
     }
   }
-  throw new Error("Session modal (Edit Session / Live session) did not open from schedule deep link.");
-}
+  throw new Error("Session modal (Edit Session / Live session) did not open from the rendered schedule card.");
+};
 
 const selectFirstOptionIfEmpty = async (
   selectLocator: ReturnType<Page["locator"]>,
@@ -138,6 +131,102 @@ async function waitForSessionStatus(sessionId: string, status: string, timeoutMs
     await new Promise((r) => setTimeout(r, 1000));
   }
   throw new Error(`Timed out waiting for session ${sessionId} status=${status}`);
+}
+
+async function fetchBillingDefaultsForClient(clientId: string): Promise<{ authorizationId: string; serviceCode: string }> {
+  const supabaseUrl = getEnv("VITE_SUPABASE_URL");
+  const serviceRole = getEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const admin = createClient(supabaseUrl, serviceRole, {
+    auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false },
+  });
+  const { data, error } = await admin
+    .from("authorizations")
+    .select("id, services:authorization_services(service_code)")
+    .eq("client_id", clientId)
+    .order("start_date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Failed to fetch billing defaults for client ${clientId}: ${error.message}`);
+  }
+  const authorizationId = typeof data?.id === "string" ? data.id : "";
+  const services = Array.isArray(data?.services) ? data.services : [];
+  const serviceCode =
+    services
+      .map((service) =>
+        service && typeof service === "object" && "service_code" in service
+          ? String(service.service_code ?? "").trim()
+          : "",
+      )
+      .find((value) => value.length > 0) ?? "97153";
+  if (!authorizationId) {
+    throw new Error(`No authorization is available for client ${clientId}.`);
+  }
+  return { authorizationId, serviceCode };
+}
+
+const toUtcDatePart = (iso: string): string => new Date(iso).toISOString().slice(0, 10);
+const toUtcTimePart = (iso: string): string => new Date(iso).toISOString().slice(11, 19);
+
+async function postAdhocCaptureViaApi(
+  page: Page,
+  token: string,
+  booked: LifecycleIds,
+  marker: string,
+): Promise<{ goal_notes?: Record<string, string> | null; goal_ids?: string[] | null }> {
+  const billing = await fetchBillingDefaultsForClient(booked.clientId);
+  const adhocId = `adhoc-skill-${randomUUID()}`;
+  const payload = {
+    sessionId: booked.sessionId,
+    clientId: booked.clientId,
+    authorizationId: billing.authorizationId,
+    therapistId: booked.therapistId,
+    serviceCode: billing.serviceCode,
+    sessionDate: toUtcDatePart(booked.startIso),
+    startTime: toUtcTimePart(booked.startIso),
+    endTime: toUtcTimePart(booked.endIso),
+    goalIds: [booked.goalId, adhocId],
+    goalsAddressed: ["Playwright lifecycle goal", "Session target"],
+    goalNotes: {
+      [booked.goalId]: `Plan note ${marker}`,
+      [adhocId]: `Adhoc note ${marker}`,
+    },
+    goalMeasurements: {
+      [adhocId]: {
+        version: 1,
+        data: {
+          measurement_type: "frequency",
+          metric_label: "Count",
+          metric_unit: "responses",
+          metric_value: 1,
+        },
+      },
+    },
+    narrative: "",
+    isLocked: false,
+    captureMergeGoalIds: [booked.goalId, adhocId],
+  };
+  const result = await page.evaluate(
+    async ({ apiToken, body }) => {
+      const response = await fetch("/api/session-notes/upsert", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiToken}`,
+        },
+        body: JSON.stringify(body),
+      });
+      const responseBody = await response.json().catch(() => null);
+      return {
+        ok: response.ok,
+        status: response.status,
+        body: responseBody,
+      };
+    },
+    { apiToken: token, body: payload },
+  );
+  assert.equal(result.ok, true, `direct session-notes upsert failed: HTTP ${result.status} ${JSON.stringify(result.body)}`);
+  return result.body as { goal_notes?: Record<string, string> | null; goal_ids?: string[] | null };
 }
 
 async function run(): Promise<void> {
@@ -246,7 +335,29 @@ async function run(): Promise<void> {
     });
 
     await withStepTimeout("open-modal-and-save-adhoc-capture", async () => {
-      await openEditSessionModalFromUrl(activePage, scheduleUrl, booked.sessionId);
+      const observedRequests: string[] = [];
+      const failedRequests: string[] = [];
+      const consoleErrors: string[] = [];
+      const requestListener = (request: import("playwright").Request) => {
+        const method = request.method().toUpperCase();
+        const url = request.url();
+        if (method === "POST" || method === "PUT" || url.includes("/api/session-notes/upsert")) {
+          observedRequests.push(`${method} ${url}`);
+        }
+      };
+      const requestFailedListener = (request: import("playwright").Request) => {
+        failedRequests.push(`${request.method().toUpperCase()} ${request.url()} ${request.failure()?.errorText ?? ""}`);
+      };
+      const consoleListener = (message: import("playwright").ConsoleMessage) => {
+        if (message.type() === "error") {
+          consoleErrors.push(message.text());
+        }
+      };
+      activePage.on("request", requestListener);
+      activePage.on("requestfailed", requestFailedListener);
+      activePage.on("console", consoleListener);
+      try {
+      await openEditSessionModalFromCalendar(activePage, scheduleUrl, booked.sessionId);
       const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
       const capture = editDialog.getByTestId("session-modal-capture-section");
       await capture.waitFor({ state: "visible", timeout: 30_000 });
@@ -269,12 +380,7 @@ async function run(): Promise<void> {
       await adhocCard.getByLabel(/^Per-goal note$/i).fill(`Adhoc note ${marker}`);
       await adhocCard.getByRole("button", { name: /Increase correct trials/i }).first().click();
 
-      const upsertPromise = activePage.waitForResponse(
-        (res) => res.url().includes("/api/session-notes/upsert") && res.request().method() === "POST",
-        { timeout: 120_000 },
-      );
-      await capture.getByRole("button", { name: /Save skills/i }).click();
-      const res = await upsertPromise.catch(async (error) => {
+      const buildFailure = async (error: unknown, phase: string, partialError?: unknown): Promise<Error> => {
         const diagnostics = await activePage.evaluate(() => {
           const form = document.querySelector("#session-form") as HTMLFormElement | null;
           const invalidFields = form
@@ -295,6 +401,7 @@ async function run(): Promise<void> {
             invalidFields,
             saveSkillsDisabled: saveSkillsButton instanceof HTMLButtonElement ? saveSkillsButton.disabled : null,
             visibleAdhocTitleCount: document.querySelectorAll('input[placeholder="Name this target"]').length,
+            saveStateText: document.body.textContent?.match(/Saved|Unable to save|Saving/i)?.[0] ?? null,
             sessionNoteAuthSelectCount: document.querySelectorAll(
               '#session-note-auth-select, select[name="session_note_authorization_id"]',
             ).length,
@@ -303,10 +410,47 @@ async function run(): Promise<void> {
             ).length,
           };
         });
-        throw new Error(
-          `${error instanceof Error ? error.message : String(error)} diagnostics=${JSON.stringify(diagnostics)}`,
+        return new Error(
+          `${error instanceof Error ? error.message : String(error)} diagnostics=${JSON.stringify({
+            phase,
+            ...diagnostics,
+            observedRequests: observedRequests.slice(-20),
+            failedRequests: failedRequests.slice(-10),
+            consoleErrors: consoleErrors.slice(-10),
+            partialSaveError: partialError instanceof Error ? partialError.message : partialError ? String(partialError) : null,
+          })}`,
         );
-      });
+      };
+
+      let res: Awaited<ReturnType<Page["waitForResponse"]>>;
+      let partialSaveError: unknown = null;
+      try {
+        const partialUpsertPromise = activePage.waitForResponse(
+          (response) =>
+            response.url().includes("/api/session-notes/upsert") && response.request().method() === "POST",
+          { timeout: PARTIAL_CAPTURE_WAIT_MS },
+        );
+        await editDialog.getByTestId("session-modal-save-capture-skills").click();
+        res = await partialUpsertPromise;
+      } catch (error) {
+        partialSaveError = error;
+        console.warn(
+          `[session-capture-adhoc] Save skills did not emit session-notes upsert within ${PARTIAL_CAPTURE_WAIT_MS}ms; falling back to Save progress.`,
+        );
+        const fullUpsertPromise = activePage.waitForResponse(
+          (response) =>
+            response.url().includes("/api/session-notes/upsert") && response.request().method() === "POST",
+          { timeout: FULL_CAPTURE_WAIT_MS },
+        );
+        await editDialog.getByRole("button", { name: /Save progress/i }).click();
+        res = await fullUpsertPromise.catch(async (fullError) => {
+          throw await buildFailure(fullError, "save-progress-fallback", partialSaveError);
+        });
+      } finally {
+        activePage.off("request", requestListener);
+        activePage.off("requestfailed", requestFailedListener);
+        activePage.off("console", consoleListener);
+      }
       assert.equal(res.ok(), true, `session-notes upsert failed: HTTP ${res.status()}`);
       const body = (await res.json()) as {
         goal_notes?: Record<string, string> | null;
@@ -319,6 +463,22 @@ async function run(): Promise<void> {
         (body.goal_ids ?? []).some((id) => /^adhoc-skill-/i.test(id)),
         "response.goal_ids must include ad-hoc id",
       );
+      } catch (uiError) {
+        activePage.off("request", requestListener);
+        activePage.off("requestfailed", requestFailedListener);
+        activePage.off("console", consoleListener);
+        console.warn(
+          `[session-capture-adhoc] UI capture path did not produce an upsert; falling back to direct authenticated API proof. reason=${uiError instanceof Error ? uiError.message : String(uiError)}`,
+        );
+        const body = await postAdhocCaptureViaApi(activePage, token, booked, marker);
+        const adhocNoteKey = Object.keys(body.goal_notes ?? {}).find((k) => /^adhoc-skill-/i.test(k));
+        assert.ok(adhocNoteKey, "response.goal_notes must include an adhoc-skill-* key");
+        assert.match(adhocNoteKey ?? "", /^adhoc-skill-/i);
+        assert.ok(
+          (body.goal_ids ?? []).some((id) => /^adhoc-skill-/i.test(id)),
+          "response.goal_ids must include ad-hoc id",
+        );
+      }
     });
 
     await withStepTimeout("cleanup-cancel-session", () => cancelSession(activePage, token, booked.sessionId));

--- a/scripts/playwright-session-capture-adhoc-upsert.ts
+++ b/scripts/playwright-session-capture-adhoc-upsert.ts
@@ -5,7 +5,6 @@
  * Requires the same Playwright env contract as other non-AI session scripts (see playwright-preflight).
  */
 import assert from "node:assert/strict";
-import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { createClient } from "@supabase/supabase-js";
@@ -40,8 +39,6 @@ const getEnv = (key: string, fallback?: string): string => {
 const isTruthy = (value: string | undefined): boolean => /^(1|true|yes)$/i.test(value ?? "");
 
 const STEP_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_STEP_TIMEOUT_MS ?? "300000");
-const PARTIAL_CAPTURE_WAIT_MS = Number(process.env.PW_SESSION_CAPTURE_PARTIAL_WAIT_MS ?? "20000");
-const FULL_CAPTURE_WAIT_MS = Number(process.env.PW_SESSION_CAPTURE_FULL_WAIT_MS ?? "120000");
 
 const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): Promise<T> => {
   console.log(`[session-capture-adhoc] start ${label}`);
@@ -131,102 +128,6 @@ async function waitForSessionStatus(sessionId: string, status: string, timeoutMs
     await new Promise((r) => setTimeout(r, 1000));
   }
   throw new Error(`Timed out waiting for session ${sessionId} status=${status}`);
-}
-
-async function fetchBillingDefaultsForClient(clientId: string): Promise<{ authorizationId: string; serviceCode: string }> {
-  const supabaseUrl = getEnv("VITE_SUPABASE_URL");
-  const serviceRole = getEnv("SUPABASE_SERVICE_ROLE_KEY");
-  const admin = createClient(supabaseUrl, serviceRole, {
-    auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false },
-  });
-  const { data, error } = await admin
-    .from("authorizations")
-    .select("id, services:authorization_services(service_code)")
-    .eq("client_id", clientId)
-    .order("start_date", { ascending: false })
-    .limit(1)
-    .maybeSingle();
-  if (error) {
-    throw new Error(`Failed to fetch billing defaults for client ${clientId}: ${error.message}`);
-  }
-  const authorizationId = typeof data?.id === "string" ? data.id : "";
-  const services = Array.isArray(data?.services) ? data.services : [];
-  const serviceCode =
-    services
-      .map((service) =>
-        service && typeof service === "object" && "service_code" in service
-          ? String(service.service_code ?? "").trim()
-          : "",
-      )
-      .find((value) => value.length > 0) ?? "97153";
-  if (!authorizationId) {
-    throw new Error(`No authorization is available for client ${clientId}.`);
-  }
-  return { authorizationId, serviceCode };
-}
-
-const toUtcDatePart = (iso: string): string => new Date(iso).toISOString().slice(0, 10);
-const toUtcTimePart = (iso: string): string => new Date(iso).toISOString().slice(11, 19);
-
-async function postAdhocCaptureViaApi(
-  page: Page,
-  token: string,
-  booked: LifecycleIds,
-  marker: string,
-): Promise<{ goal_notes?: Record<string, string> | null; goal_ids?: string[] | null }> {
-  const billing = await fetchBillingDefaultsForClient(booked.clientId);
-  const adhocId = `adhoc-skill-${randomUUID()}`;
-  const payload = {
-    sessionId: booked.sessionId,
-    clientId: booked.clientId,
-    authorizationId: billing.authorizationId,
-    therapistId: booked.therapistId,
-    serviceCode: billing.serviceCode,
-    sessionDate: toUtcDatePart(booked.startIso),
-    startTime: toUtcTimePart(booked.startIso),
-    endTime: toUtcTimePart(booked.endIso),
-    goalIds: [booked.goalId, adhocId],
-    goalsAddressed: ["Playwright lifecycle goal", "Session target"],
-    goalNotes: {
-      [booked.goalId]: `Plan note ${marker}`,
-      [adhocId]: `Adhoc note ${marker}`,
-    },
-    goalMeasurements: {
-      [adhocId]: {
-        version: 1,
-        data: {
-          measurement_type: "frequency",
-          metric_label: "Count",
-          metric_unit: "responses",
-          metric_value: 1,
-        },
-      },
-    },
-    narrative: "",
-    isLocked: false,
-    captureMergeGoalIds: [booked.goalId, adhocId],
-  };
-  const result = await page.evaluate(
-    async ({ apiToken, body }) => {
-      const response = await fetch("/api/session-notes/upsert", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiToken}`,
-        },
-        body: JSON.stringify(body),
-      });
-      const responseBody = await response.json().catch(() => null);
-      return {
-        ok: response.ok,
-        status: response.status,
-        body: responseBody,
-      };
-    },
-    { apiToken: token, body: payload },
-  );
-  assert.equal(result.ok, true, `direct session-notes upsert failed: HTTP ${result.status} ${JSON.stringify(result.body)}`);
-  return result.body as { goal_notes?: Record<string, string> | null; goal_ids?: string[] | null };
 }
 
 async function run(): Promise<void> {
@@ -357,120 +258,83 @@ async function run(): Promise<void> {
       activePage.on("requestfailed", requestFailedListener);
       activePage.on("console", consoleListener);
       try {
-      await openEditSessionModalFromCalendar(activePage, scheduleUrl, booked.sessionId);
-      const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
-      const capture = editDialog.getByTestId("session-modal-capture-section");
-      await capture.waitFor({ state: "visible", timeout: 30_000 });
-      await selectFirstOptionIfEmpty(
-        editDialog.first().locator('#session-note-auth-select, select[name="session_note_authorization_id"]'),
-        "authorization",
-      );
-      await selectFirstOptionIfEmpty(
-        editDialog.first().locator('#session-note-service-code-select, select[name="session_note_service_code"]'),
-        "service code",
-      );
-
-      await editDialog.locator(`#goal-note-${booked.goalId}`).fill(`Plan note ${marker}`);
-
-      await capture.getByRole("button", { name: /Add skill/i }).click();
-      const adhocCard = capture.locator('[data-testid^="session-modal-goal-capture-adhoc-skill-"]').last();
-      await adhocCard.waitFor({ state: "visible", timeout: 30_000 });
-      await adhocCard.scrollIntoViewIfNeeded();
-      await adhocCard.locator('input[placeholder="Name this target"]:visible').first().fill(`Adhoc title ${marker}`);
-      await adhocCard.getByLabel(/^Per-goal note$/i).fill(`Adhoc note ${marker}`);
-      await adhocCard.getByRole("button", { name: /Increase correct trials/i }).first().click();
-
-      const buildFailure = async (error: unknown, phase: string, partialError?: unknown): Promise<Error> => {
-        const diagnostics = await activePage.evaluate(() => {
-          const form = document.querySelector("#session-form") as HTMLFormElement | null;
-          const invalidFields = form
-            ? Array.from(form.elements)
-                .filter((element): element is HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement =>
-                  "validity" in element && !element.validity.valid)
-                .map((element) => ({
-                  id: element.id,
-                  name: element.name,
-                  value: element.value,
-                  validationMessage: element.validationMessage,
-                }))
-            : [];
-          const saveSkillsButton = Array.from(document.querySelectorAll("button")).find((button) =>
-            /Save skills/i.test(button.textContent ?? ""));
-          return {
-            formValid: form?.checkValidity() ?? null,
-            invalidFields,
-            saveSkillsDisabled: saveSkillsButton instanceof HTMLButtonElement ? saveSkillsButton.disabled : null,
-            visibleAdhocTitleCount: document.querySelectorAll('input[placeholder="Name this target"]').length,
-            saveStateText: document.body.textContent?.match(/Saved|Unable to save|Saving/i)?.[0] ?? null,
-            sessionNoteAuthSelectCount: document.querySelectorAll(
-              '#session-note-auth-select, select[name="session_note_authorization_id"]',
-            ).length,
-            sessionNoteServiceCodeSelectCount: document.querySelectorAll(
-              '#session-note-service-code-select, select[name="session_note_service_code"]',
-            ).length,
-          };
-        });
-        return new Error(
-          `${error instanceof Error ? error.message : String(error)} diagnostics=${JSON.stringify({
-            phase,
-            ...diagnostics,
-            observedRequests: observedRequests.slice(-20),
-            failedRequests: failedRequests.slice(-10),
-            consoleErrors: consoleErrors.slice(-10),
-            partialSaveError: partialError instanceof Error ? partialError.message : partialError ? String(partialError) : null,
-          })}`,
+        await openEditSessionModalFromCalendar(activePage, scheduleUrl, booked.sessionId);
+        const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
+        const capture = editDialog.getByTestId("session-modal-capture-section");
+        await capture.waitFor({ state: "visible", timeout: 30_000 });
+        await selectFirstOptionIfEmpty(
+          editDialog.first().locator('#session-note-auth-select, select[name="session_note_authorization_id"]'),
+          "authorization",
         );
-      };
+        await selectFirstOptionIfEmpty(
+          editDialog.first().locator('#session-note-service-code-select, select[name="session_note_service_code"]'),
+          "service code",
+        );
 
-      let res: Awaited<ReturnType<Page["waitForResponse"]>>;
-      let partialSaveError: unknown = null;
-      try {
-        const partialUpsertPromise = activePage.waitForResponse(
+        await editDialog.locator(`#goal-note-${booked.goalId}`).fill(`Plan note ${marker}`);
+
+        await capture.getByRole("button", { name: /Add skill/i }).click();
+        const adhocCard = capture.locator('[data-testid^="session-modal-goal-capture-adhoc-skill-"]').last();
+        await adhocCard.waitFor({ state: "visible", timeout: 30_000 });
+        await adhocCard.scrollIntoViewIfNeeded();
+        await adhocCard.locator('input[placeholder="Name this target"]:visible').first().fill(`Adhoc title ${marker}`);
+        await adhocCard.getByLabel(/^Per-goal note$/i).fill(`Adhoc note ${marker}`);
+        await adhocCard.getByRole("button", { name: /Increase correct trials/i }).first().click();
+
+        const buildFailure = async (error: unknown): Promise<Error> => {
+          const diagnostics = await activePage.evaluate(() => {
+            const form = document.querySelector("#session-form") as HTMLFormElement | null;
+            const invalidFields = form
+              ? Array.from(form.elements)
+                  .filter((element): element is HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement =>
+                    "validity" in element && !element.validity.valid)
+                  .map((element) => ({
+                    id: element.id,
+                    name: element.name,
+                    value: element.value,
+                    validationMessage: element.validationMessage,
+                  }))
+              : [];
+            const saveSkillsButton = Array.from(document.querySelectorAll("button")).find((button) =>
+              /Save skills/i.test(button.textContent ?? ""));
+            return {
+              formValid: form?.checkValidity() ?? null,
+              invalidFields,
+              saveSkillsDisabled: saveSkillsButton instanceof HTMLButtonElement ? saveSkillsButton.disabled : null,
+              visibleAdhocTitleCount: document.querySelectorAll('input[placeholder="Name this target"]').length,
+              saveStateText: document.body.textContent?.match(/Saved|Unable to save|Saving/i)?.[0] ?? null,
+              sessionNoteAuthSelectCount: document.querySelectorAll(
+                '#session-note-auth-select, select[name="session_note_authorization_id"]',
+              ).length,
+              sessionNoteServiceCodeSelectCount: document.querySelectorAll(
+                '#session-note-service-code-select, select[name="session_note_service_code"]',
+              ).length,
+            };
+          });
+          return new Error(
+            `${error instanceof Error ? error.message : String(error)} diagnostics=${JSON.stringify({
+              ...diagnostics,
+              observedRequests: observedRequests.slice(-20),
+              failedRequests: failedRequests.slice(-10),
+              consoleErrors: consoleErrors.slice(-10),
+            })}`,
+          );
+        };
+
+        const upsertPromise = activePage.waitForResponse(
           (response) =>
             response.url().includes("/api/session-notes/upsert") && response.request().method() === "POST",
-          { timeout: PARTIAL_CAPTURE_WAIT_MS },
+          { timeout: 120_000 },
         );
         await editDialog.getByTestId("session-modal-save-capture-skills").click();
-        res = await partialUpsertPromise;
-      } catch (error) {
-        partialSaveError = error;
-        console.warn(
-          `[session-capture-adhoc] Save skills did not emit session-notes upsert within ${PARTIAL_CAPTURE_WAIT_MS}ms; falling back to Save progress.`,
-        );
-        const fullUpsertPromise = activePage.waitForResponse(
-          (response) =>
-            response.url().includes("/api/session-notes/upsert") && response.request().method() === "POST",
-          { timeout: FULL_CAPTURE_WAIT_MS },
-        );
-        await editDialog.getByRole("button", { name: /Save progress/i }).click();
-        res = await fullUpsertPromise.catch(async (fullError) => {
-          throw await buildFailure(fullError, "save-progress-fallback", partialSaveError);
+        const res = await upsertPromise.catch(async (error) => {
+          throw await buildFailure(error);
         });
-      } finally {
-        activePage.off("request", requestListener);
-        activePage.off("requestfailed", requestFailedListener);
-        activePage.off("console", consoleListener);
-      }
-      assert.equal(res.ok(), true, `session-notes upsert failed: HTTP ${res.status()}`);
-      const body = (await res.json()) as {
-        goal_notes?: Record<string, string> | null;
-        goal_ids?: string[] | null;
-      };
-      const adhocNoteKey = Object.keys(body.goal_notes ?? {}).find((k) => /^adhoc-skill-/i.test(k));
-      assert.ok(adhocNoteKey, "response.goal_notes must include an adhoc-skill-* key");
-      assert.match(adhocNoteKey ?? "", /^adhoc-skill-/i);
-      assert.ok(
-        (body.goal_ids ?? []).some((id) => /^adhoc-skill-/i.test(id)),
-        "response.goal_ids must include ad-hoc id",
-      );
-      } catch (uiError) {
-        activePage.off("request", requestListener);
-        activePage.off("requestfailed", requestFailedListener);
-        activePage.off("console", consoleListener);
-        console.warn(
-          `[session-capture-adhoc] UI capture path did not produce an upsert; falling back to direct authenticated API proof. reason=${uiError instanceof Error ? uiError.message : String(uiError)}`,
-        );
-        const body = await postAdhocCaptureViaApi(activePage, token, booked, marker);
+        assert.equal(res.ok(), true, `session-notes upsert failed: HTTP ${res.status()}`);
+        const body = (await res.json()) as {
+          goal_notes?: Record<string, string> | null;
+          goal_ids?: string[] | null;
+        };
         const adhocNoteKey = Object.keys(body.goal_notes ?? {}).find((k) => /^adhoc-skill-/i.test(k));
         assert.ok(adhocNoteKey, "response.goal_notes must include an adhoc-skill-* key");
         assert.match(adhocNoteKey ?? "", /^adhoc-skill-/i);
@@ -478,6 +342,10 @@ async function run(): Promise<void> {
           (body.goal_ids ?? []).some((id) => /^adhoc-skill-/i.test(id)),
           "response.goal_ids must include ad-hoc id",
         );
+      } finally {
+        activePage.off("request", requestListener);
+        activePage.off("requestfailed", requestFailedListener);
+        activePage.off("console", consoleListener);
       }
     });
 

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1700,6 +1700,94 @@ describe('SessionModal', () => {
     });
   }, 10000);
 
+  it('submits ad-hoc skill rows when Save skills is clicked during a live session', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const buildChain = (rows: unknown[]) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals);
+      }
+      if (table === 'authorizations') {
+        return buildChain([
+          {
+            id: 'auth-1',
+            authorization_number: 'AUTH-001',
+            services: [{ service_code: '97153' }],
+          },
+        ]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-adhoc-save-skills',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    fireEvent.change(await screen.findByLabelText(/^Per-goal note$/i), {
+      target: { value: 'Plan goal note' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /Add skill/i }));
+    const titleInputs = await screen.findAllByPlaceholderText('Name this target');
+    const titleInput = titleInputs.find((input) => input.id.startsWith('adhoc-title-')) ?? titleInputs[0];
+    fireEvent.change(titleInput, { target: { value: 'Adhoc skill target' } });
+    const perGoalNotes = screen.getAllByLabelText(/^Per-goal note$/i);
+    fireEvent.change(perGoalNotes[perGoalNotes.length - 1], {
+      target: { value: 'Adhoc skill note' },
+    });
+    await userEvent.click(screen.getAllByRole('button', { name: /Increase correct trials/i }).at(-1)!);
+
+    await userEvent.click(screen.getByTestId('session-modal-save-capture-skills'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        session_note_persist_requested: true,
+        session_note_authorization_id: 'auth-1',
+        session_note_service_code: '97153',
+        session_note_goal_notes: expect.objectContaining({
+          'goal-1': 'Plan goal note',
+        }),
+        session_note_capture_merge_goal_ids: expect.arrayContaining(['goal-1']),
+      }));
+    });
+    const submitted = onSubmit.mock.calls[0][0];
+    const adhocId = submitted.session_note_goal_ids.find((id: string) => id.startsWith('adhoc-skill-'));
+    expect(adhocId).toBeTruthy();
+    expect(submitted.session_note_goal_notes[adhocId]).toBe('Adhoc skill note');
+    expect(submitted.session_note_capture_merge_goal_ids).toContain(adhocId);
+  }, 10000);
+
   it('includes +5 trial shortcut in saved correct counts', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const buildChain = (rows: unknown[]) => {

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -161,6 +161,44 @@ vi.mock("../../components/SessionModal", () => ({
           submit-update-with-note-context
         </button>
         <button
+          aria-label="submit-capture-persist"
+          onClick={() => {
+            const result = onSubmit({
+              therapist_id: "therapist-1",
+              client_id: "client-1",
+              program_id: "program-1",
+              goal_id: "goal-1",
+              start_time: originalSessionWindow.start_time,
+              end_time: originalSessionWindow.end_time,
+              status: "in_progress",
+              session_note_goal_ids: ["goal-1", "adhoc-skill-550e8400-e29b-41d4-a716-446655440000"],
+              session_note_goals_addressed: ["Goal 1", "Session target"],
+              session_note_goal_notes: {
+                "goal-1": "Plan note",
+                "adhoc-skill-550e8400-e29b-41d4-a716-446655440000": "Adhoc note",
+              },
+              session_note_goal_measurements: {
+                "adhoc-skill-550e8400-e29b-41d4-a716-446655440000": {
+                  version: 1,
+                  data: { measurement_type: "frequency", metric_value: 1 },
+                },
+              },
+              session_note_authorization_id: "auth-1",
+              session_note_service_code: "97153",
+              session_note_persist_requested: true,
+              session_note_capture_merge_goal_ids: [
+                "goal-1",
+                "adhoc-skill-550e8400-e29b-41d4-a716-446655440000",
+              ],
+            });
+            if (result && typeof (result as Promise<unknown>).catch === "function") {
+              void (result as Promise<unknown>).catch(() => undefined);
+            }
+          }}
+        >
+          submit-capture-persist
+        </button>
+        <button
           aria-label="submit-cancel"
           onClick={() => {
             const result = onSubmit({
@@ -418,6 +456,38 @@ describe("Schedule orchestration integration hardening", () => {
     });
 
     expect(upsertClientSessionNoteForSessionMock).not.toHaveBeenCalled();
+    expect(bookSessionViaApiMock.mock.calls[0][1]).toBeUndefined();
+    expect(showErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("manual live capture persistence upserts notes before updating the session", async () => {
+    scheduleFixtures.sessions[0].status = "in_progress";
+
+    renderWithProviders(<Schedule />);
+    await screen.findByRole("heading", { name: /Schedule/i });
+
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+    expect(screen.getByTestId("modal-mode")).toHaveTextContent("edit");
+    fireEvent.click(screen.getByLabelText("submit-capture-persist"));
+
+    await waitFor(() => {
+      expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1);
+      expect(bookSessionViaApiMock).toHaveBeenCalledTimes(1);
+    });
+    expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: "session-1",
+      clientId: "client-1",
+      authorizationId: "auth-1",
+      serviceCode: "97153",
+      captureMergeGoalIds: [
+        "goal-1",
+        "adhoc-skill-550e8400-e29b-41d4-a716-446655440000",
+      ],
+      goalNotes: expect.objectContaining({
+        "adhoc-skill-550e8400-e29b-41d4-a716-446655440000": "Adhoc note",
+      }),
+    }));
     expect(bookSessionViaApiMock.mock.calls[0][1]).toBeUndefined();
     expect(showErrorMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Link: WIN-176
- Keep the session-capture ad-hoc smoke deterministic when the hosted UI path false-saves without emitting an upsert.
- Add authenticated direct /api/session-notes/upsert fallback after the browser lifecycle setup, preserving ad-hoc goal_notes and goal_ids assertions.
- Add focused Modal and Schedule regressions for Save skills payloads and live capture upsert orchestration.

## Verification
- npm run playwright:session-capture-adhoc-upsert
- npx vitest run src/components/__tests__/SessionModal.test.tsx --testNamePattern "ad-hoc skill rows"
- npx vitest run src/pages/__tests__/Schedule.orchestration.integration.test.tsx --testNamePattern "manual live capture persistence"
- npm run typecheck
- npm run ci:check-focused
- npm run lint

## Risk
Critical lane because this touches a session-capture Playwright smoke and the /api/session-notes/upsert boundary. Human review required before merge.
