### PR TITLE
WIN-177 Fix session capture visible-grid save smoke

### DIFF
--- a/scripts/lib/playwright-inprogress-session-setup.ts
+++ b/scripts/lib/playwright-inprogress-session-setup.ts
@@ -362,6 +362,26 @@ const addCalendarDays = (localDate: string, days: number): string => {
 const toZonedGridStart = (localDate: string, hour: number, timeZone: string): Date =>
   zonedTimeToUtc(`${localDate}T${String(hour).padStart(2, "0")}:00:00`, timeZone);
 
+const isRenderedScheduleLocalDate = (localDate: string, timeZone: string): boolean => {
+  const isoWeekday = Number(formatInTimeZone(toZonedGridStart(localDate, 12, timeZone), timeZone, "i"));
+  return isoWeekday >= 1 && isoWeekday <= 6;
+};
+
+const addRenderedScheduleDays = (localDate: string, days: number, timeZone: string): string => {
+  let nextDate = localDate;
+  let renderedDaysRemaining = Math.max(0, Math.trunc(days));
+
+  do {
+    if (isRenderedScheduleLocalDate(nextDate, timeZone)) {
+      if (renderedDaysRemaining === 0) {
+        return nextDate;
+      }
+      renderedDaysRemaining -= 1;
+    }
+    nextDate = addCalendarDays(nextDate, 1);
+  } while (true);
+};
+
 export const buildVisibleScheduleBookingBaseStart = (
   now = new Date(),
   seed = Number(process.env.GITHUB_RUN_ID ?? Date.now()),
@@ -369,10 +389,10 @@ export const buildVisibleScheduleBookingBaseStart = (
 ): Date => {
   const seedNumber = Number.isFinite(seed) ? Math.abs(Math.trunc(seed)) : 0;
   const visibleHour = VISIBLE_SCHEDULE_START_HOURS[seedNumber % VISIBLE_SCHEDULE_START_HOURS.length];
-  const localDate = formatInTimeZone(now, timeZone, "yyyy-MM-dd");
+  const localDate = addRenderedScheduleDays(formatInTimeZone(now, timeZone, "yyyy-MM-dd"), 0, timeZone);
   let start = toZonedGridStart(localDate, visibleHour, timeZone);
   if (start.getTime() <= now.getTime()) {
-    start = toZonedGridStart(addCalendarDays(localDate, 1), visibleHour, timeZone);
+    start = toZonedGridStart(addRenderedScheduleDays(localDate, 1, timeZone), visibleHour, timeZone);
   }
   return start;
 };
@@ -389,7 +409,7 @@ export const buildVisibleScheduleBookingAttemptStart = (
   const sequenceIndex = safeBaseIndex + Math.max(0, Math.trunc(attempt));
   const dayOffset = Math.floor(sequenceIndex / VISIBLE_SCHEDULE_START_HOURS.length);
   const visibleHour = VISIBLE_SCHEDULE_START_HOURS[sequenceIndex % VISIBLE_SCHEDULE_START_HOURS.length];
-  return toZonedGridStart(addCalendarDays(localDate, dayOffset), visibleHour, timeZone);
+  return toZonedGridStart(addRenderedScheduleDays(localDate, dayOffset, timeZone), visibleHour, timeZone);
 };
 
 export const resolveBrowserScheduleTimeZone = async (page: Pick<Page, "evaluate">): Promise<string> => {

--- a/scripts/lib/playwright-inprogress-session-setup.ts
+++ b/scripts/lib/playwright-inprogress-session-setup.ts
@@ -2,7 +2,11 @@
  * Book a session via /api/book, start in-progress via edge/RPC, cancel via edge/service-role.
  * Extracted for Playwright regressions that must not import `playwright-session-lifecycle.ts` entrypoint.
  */
-import { getTimezoneOffset } from "date-fns-tz";
+import {
+  formatInTimeZone,
+  fromZonedTime as zonedTimeToUtc,
+  getTimezoneOffset,
+} from "date-fns-tz";
 import { createClient } from "@supabase/supabase-js";
 import type { Page } from "playwright";
 
@@ -65,6 +69,7 @@ const createSessionViaServiceRole = async (params: {
   goalId: string;
   startIso: string;
   endIso: string;
+  timeZone: string;
 }): Promise<string> => {
   const supabaseUrl = getEnv("VITE_SUPABASE_URL");
   const serviceRole = getEnv("SUPABASE_SERVICE_ROLE_KEY");
@@ -93,7 +98,7 @@ const createSessionViaServiceRole = async (params: {
   const durationMs = Math.max(15 * 60 * 1000, baseEnd.getTime() - baseStart.getTime());
 
   for (let attempt = 0; attempt < 48; attempt += 1) {
-    const start = new Date(baseStart.getTime() + attempt * 2 * 60 * 60 * 1000);
+    const start = buildVisibleScheduleBookingAttemptStart(baseStart, attempt, params.timeZone);
     const end = new Date(start.getTime() + durationMs);
     const { data, error } = await adminClient
       .from("sessions")
@@ -347,12 +352,55 @@ const toDatetimeLocal = (date: Date): string => {
   return local.toISOString().slice(0, 16);
 };
 
-const buildBookingBaseStart = (): Date => {
-  const runSeed = Number(process.env.GITHUB_RUN_ID ?? Date.now());
-  const offsetHours = Number.isFinite(runSeed) ? Math.abs(Math.trunc(runSeed)) % 12 : 0;
-  const start = new Date();
-  start.setHours(start.getHours() + 4 + offsetHours, 0, 0, 0);
+const VISIBLE_SCHEDULE_START_HOURS = [8, 10, 12, 14, 16] as const;
+
+const addCalendarDays = (localDate: string, days: number): string => {
+  const [year, month, day] = localDate.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day + days)).toISOString().slice(0, 10);
+};
+
+const toZonedGridStart = (localDate: string, hour: number, timeZone: string): Date =>
+  zonedTimeToUtc(`${localDate}T${String(hour).padStart(2, "0")}:00:00`, timeZone);
+
+export const buildVisibleScheduleBookingBaseStart = (
+  now = new Date(),
+  seed = Number(process.env.GITHUB_RUN_ID ?? Date.now()),
+  timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
+): Date => {
+  const seedNumber = Number.isFinite(seed) ? Math.abs(Math.trunc(seed)) : 0;
+  const visibleHour = VISIBLE_SCHEDULE_START_HOURS[seedNumber % VISIBLE_SCHEDULE_START_HOURS.length];
+  const localDate = formatInTimeZone(now, timeZone, "yyyy-MM-dd");
+  let start = toZonedGridStart(localDate, visibleHour, timeZone);
+  if (start.getTime() <= now.getTime()) {
+    start = toZonedGridStart(addCalendarDays(localDate, 1), visibleHour, timeZone);
+  }
   return start;
+};
+
+export const buildVisibleScheduleBookingAttemptStart = (
+  baseStart: Date,
+  attempt: number,
+  timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
+): Date => {
+  const localDate = formatInTimeZone(baseStart, timeZone, "yyyy-MM-dd");
+  const localHour = Number(formatInTimeZone(baseStart, timeZone, "H"));
+  const baseIndex = VISIBLE_SCHEDULE_START_HOURS.findIndex((hour) => hour === localHour);
+  const safeBaseIndex = baseIndex >= 0 ? baseIndex : 0;
+  const sequenceIndex = safeBaseIndex + Math.max(0, Math.trunc(attempt));
+  const dayOffset = Math.floor(sequenceIndex / VISIBLE_SCHEDULE_START_HOURS.length);
+  const visibleHour = VISIBLE_SCHEDULE_START_HOURS[sequenceIndex % VISIBLE_SCHEDULE_START_HOURS.length];
+  return toZonedGridStart(addCalendarDays(localDate, dayOffset), visibleHour, timeZone);
+};
+
+export const resolveBrowserScheduleTimeZone = async (page: Pick<Page, "evaluate">): Promise<string> => {
+  const timeZone = await page.evaluate(() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch {
+      return null;
+    }
+  });
+  return typeof timeZone === "string" && timeZone.trim().length > 0 ? timeZone : "UTC";
 };
 
 async function openSessionModal(page: Page) {
@@ -459,15 +507,15 @@ export async function bookSession(
 
   const selected = await chooseSessionTargets(page, { allowedTherapistIds });
 
-  const start = buildBookingBaseStart();
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC";
+  const timeZone = await resolveBrowserScheduleTimeZone(page);
+  const start = buildVisibleScheduleBookingBaseStart(new Date(), undefined, timeZone);
   let finalStartIso = "";
   let finalEndIso = "";
   let payload: BrowserFetchResult<Record<string, unknown>> | null = null;
   let payloadBody: { success?: boolean; data?: { session?: { id?: string } } } | null = null;
 
   for (let attempt = 0; attempt < 48; attempt += 1) {
-    const attemptStart = new Date(start.getTime() + attempt * 2 * 60 * 60 * 1000);
+    const attemptStart = buildVisibleScheduleBookingAttemptStart(start, attempt, timeZone);
     const attemptEnd = new Date(attemptStart.getTime() + 60 * 60 * 1000);
     const startIso = attemptStart.toISOString();
     const endIso = attemptEnd.toISOString();
@@ -549,6 +597,7 @@ export async function bookSession(
         goalId: selected.goalId,
         startIso: finalStartIso,
         endIso: finalEndIso,
+        timeZone,
       });
       return {
         sessionId: fallbackSessionId,

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -1076,6 +1076,7 @@ export function SessionModal({
       }
       const transformed: SessionModalSubmitData = {
         ...working,
+        ...(session?.id ? { id: session.id } : {}),
         session_note_narrative: working.session_note_narrative?.trim() ?? '',
         session_note_goal_notes: normalizedGoalNoteMap,
         session_note_goal_measurements: normalizedGoalMeasurementMap,

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1772,6 +1772,7 @@ describe('SessionModal', () => {
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'session-adhoc-save-skills',
         session_note_persist_requested: true,
         session_note_authorization_id: 'auth-1',
         session_note_service_code: '97153',

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1045,12 +1045,17 @@ export const Schedule = React.memo(() => {
 
   const updateSessionMutation = useMutation({
     mutationFn: async (updatedSession: Partial<Session>) => {
-      if (!selectedSession) {
+      const baseSession =
+        selectedSession ??
+        (updatedSession.id
+          ? displayData.sessions.find((session) => session.id === updatedSession.id)
+          : undefined);
+      if (!baseSession) {
         throw new Error("No session selected for update");
       }
 
       const mergedSession: Session = {
-        ...selectedSession,
+        ...baseSession,
         ...updatedSession,
       };
 
@@ -1069,7 +1074,7 @@ export const Schedule = React.memo(() => {
       const bookingResult = await bookSessionViaApi(
         {
           ...buildBookSessionApiPayload(
-            { ...mergedSession, id: selectedSession.id },
+            { ...mergedSession, id: baseSession.id },
             {
               startOffsetMinutes,
               endOffsetMinutes,
@@ -1083,11 +1088,16 @@ export const Schedule = React.memo(() => {
 
       return bookingResult.session;
     },
-    onSuccess: () => {
-      if (selectedSession?.id && selectedSession.client_id) {
+    onSuccess: (_savedSession, updatedSession) => {
+      const invalidationSession =
+        selectedSession ??
+        (updatedSession.id
+          ? displayData.sessions.find((session) => session.id === updatedSession.id)
+          : undefined);
+      if (invalidationSession?.id && invalidationSession.client_id) {
         invalidateSessionNoteCachesAfterSessionWrite(queryClient, {
-          sessionId: selectedSession.id,
-          clientId: selectedSession.client_id,
+          sessionId: invalidationSession.id,
+          clientId: invalidationSession.client_id,
           organizationId: activeOrganizationId,
         });
       }
@@ -1505,12 +1515,17 @@ export const Schedule = React.memo(() => {
   const handleSubmit = useCallback(
     async (data: ScheduleSubmitData) => {
       const sessionPayload = stripClinicalNoteFields(data);
+      const effectiveSelectedSession =
+        selectedSession ??
+        (typeof sessionPayload.id === "string"
+          ? displayData.sessions.find((session) => session.id === sessionPayload.id)
+          : undefined);
       const mergeCaptureIds = data.session_note_capture_merge_goal_ids?.filter(
         (id): id is string => typeof id === "string" && id.trim().length > 0,
       );
       const clinicalNoteDraft = buildClinicalNoteDraft(data, { captureMergeGoalIds: mergeCaptureIds });
       const decision = decideScheduleSubmitBranch({
-        selectedSession,
+        selectedSession: effectiveSelectedSession,
         data: sessionPayload,
       });
 
@@ -1534,7 +1549,7 @@ export const Schedule = React.memo(() => {
           return;
         }
         case "edit-complete": {
-          let liveInProgress = selectedSession?.status === "in_progress";
+          let liveInProgress = effectiveSelectedSession?.status === "in_progress";
           if (!liveInProgress) {
             const { data: liveRow, error: liveError } = await supabase
               .from("sessions")
@@ -1584,7 +1599,7 @@ export const Schedule = React.memo(() => {
           return;
         }
         case "edit-no-show": {
-          let liveInProgressNoShow = selectedSession?.status === "in_progress";
+          let liveInProgressNoShow = effectiveSelectedSession?.status === "in_progress";
           if (!liveInProgressNoShow) {
             const { data: liveRowNs, error: liveErrorNs } = await supabase
               .from("sessions")
@@ -1634,7 +1649,7 @@ export const Schedule = React.memo(() => {
           return;
         }
         case "edit-update": {
-          if (selectedSession && clinicalNoteDraft) {
+          if (effectiveSelectedSession && clinicalNoteDraft) {
             if (!activeOrganizationId) {
               throw new Error("Organization context is required to save session capture.");
             }
@@ -1653,16 +1668,16 @@ export const Schedule = React.memo(() => {
               );
             }
             await upsertClientSessionNoteForSession({
-              sessionId: selectedSession.id,
-              clientId: sessionPayload.client_id ?? selectedSession.client_id,
+              sessionId: effectiveSelectedSession.id,
+              clientId: sessionPayload.client_id ?? effectiveSelectedSession.client_id,
               authorizationId: clinicalNoteDraft.authorizationId,
-              therapistId: sessionPayload.therapist_id ?? selectedSession.therapist_id,
+              therapistId: sessionPayload.therapist_id ?? effectiveSelectedSession.therapist_id,
               organizationId: activeOrganizationId,
               actorUserId: user.id,
               serviceCode: clinicalNoteDraft.serviceCode,
-              sessionDate: format(parseISO(sessionPayload.start_time ?? selectedSession.start_time), "yyyy-MM-dd"),
-              startTime: format(parseISO(sessionPayload.start_time ?? selectedSession.start_time), "HH:mm:ss"),
-              endTime: format(parseISO(sessionPayload.end_time ?? selectedSession.end_time), "HH:mm:ss"),
+              sessionDate: format(parseISO(sessionPayload.start_time ?? effectiveSelectedSession.start_time), "yyyy-MM-dd"),
+              startTime: format(parseISO(sessionPayload.start_time ?? effectiveSelectedSession.start_time), "HH:mm:ss"),
+              endTime: format(parseISO(sessionPayload.end_time ?? effectiveSelectedSession.end_time), "HH:mm:ss"),
               goalsAddressed: clinicalNoteDraft.goalsAddressed,
               goalIds: clinicalNoteDraft.goalIds,
               goalMeasurements: clinicalNoteDraft.goalMeasurements,
@@ -1697,6 +1712,7 @@ export const Schedule = React.memo(() => {
       completeSessionMutation,
       updateSessionMutation,
       createSessionMutation,
+      displayData.sessions,
     ],
   );
 

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -8,6 +8,7 @@ const showErrorMock = vi.fn();
 const showSuccessMock = vi.fn();
 const buildBookSessionApiPayloadMock = vi.fn((session: unknown) => session);
 const upsertClientSessionNoteForSessionMock = vi.fn();
+const invalidateSessionNoteCachesAfterSessionWriteMock = vi.fn();
 
 const currentSessionStart = new Date();
 currentSessionStart.setHours(10, 0, 0, 0);
@@ -84,6 +85,11 @@ vi.mock("../../lib/toast", () => ({
 vi.mock("../../lib/session-notes", () => ({
   upsertClientSessionNoteForSession: (...args: unknown[]) =>
     upsertClientSessionNoteForSessionMock(...args),
+}));
+
+vi.mock("../../features/scheduling/domain/sessionNoteQueryInvalidation", () => ({
+  invalidateSessionNoteCachesAfterSessionWrite: (...args: unknown[]) =>
+    invalidateSessionNoteCachesAfterSessionWriteMock(...args),
 }));
 
 vi.mock("../../lib/conflictPolicy", () => ({
@@ -197,6 +203,45 @@ vi.mock("../../components/SessionModal", () => ({
           }}
         >
           submit-capture-persist
+        </button>
+        <button
+          aria-label="submit-capture-persist-by-id"
+          onClick={() => {
+            const result = onSubmit({
+              id: "session-1",
+              therapist_id: "therapist-1",
+              client_id: "client-1",
+              program_id: "program-1",
+              goal_id: "goal-1",
+              start_time: originalSessionWindow.start_time,
+              end_time: originalSessionWindow.end_time,
+              status: "in_progress",
+              session_note_goal_ids: ["goal-1", "adhoc-skill-550e8400-e29b-41d4-a716-446655440000"],
+              session_note_goals_addressed: ["Goal 1", "Session target"],
+              session_note_goal_notes: {
+                "goal-1": "Plan note",
+                "adhoc-skill-550e8400-e29b-41d4-a716-446655440000": "Adhoc note",
+              },
+              session_note_goal_measurements: {
+                "adhoc-skill-550e8400-e29b-41d4-a716-446655440000": {
+                  version: 1,
+                  data: { measurement_type: "frequency", metric_value: 1 },
+                },
+              },
+              session_note_authorization_id: "auth-1",
+              session_note_service_code: "97153",
+              session_note_persist_requested: true,
+              session_note_capture_merge_goal_ids: [
+                "goal-1",
+                "adhoc-skill-550e8400-e29b-41d4-a716-446655440000",
+              ],
+            });
+            if (result && typeof (result as Promise<unknown>).catch === "function") {
+              void (result as Promise<unknown>).catch(() => undefined);
+            }
+          }}
+        >
+          submit-capture-persist-by-id
         </button>
         <button
           aria-label="submit-cancel"
@@ -490,6 +535,57 @@ describe("Schedule orchestration integration hardening", () => {
     }));
     expect(bookSessionViaApiMock.mock.calls[0][1]).toBeUndefined();
     expect(showErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("manual live capture persistence can resolve the edit session from submitted id", async () => {
+    scheduleFixtures.sessions[0].status = "in_progress";
+
+    renderWithProviders(<Schedule />);
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+
+    fireEvent.click(screen.getAllByLabelText("Add session")[0]);
+    await screen.findByTestId("session-modal");
+    expect(screen.getByTestId("modal-mode")).toHaveTextContent("create");
+    fireEvent.click(screen.getByLabelText("submit-capture-persist-by-id"));
+
+    await waitFor(() => {
+      expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1);
+      expect(bookSessionViaApiMock).toHaveBeenCalledTimes(1);
+    });
+    expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: "session-1",
+      clientId: "client-1",
+      authorizationId: "auth-1",
+      serviceCode: "97153",
+    }));
+    expect(invalidateSessionNoteCachesAfterSessionWriteMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        sessionId: "session-1",
+        clientId: "client-1",
+      }),
+    );
+    expect(bookSessionViaApiMock.mock.calls[0][1]).toBeUndefined();
+    expect(showErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("does not update the session when live capture persistence fails", async () => {
+    scheduleFixtures.sessions[0].status = "in_progress";
+    upsertClientSessionNoteForSessionMock.mockRejectedValueOnce(new Error("upsert failed"));
+
+    renderWithProviders(<Schedule />);
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+
+    fireEvent.click(screen.getAllByLabelText("Add session")[0]);
+    await screen.findByTestId("session-modal");
+    fireEvent.click(screen.getByLabelText("submit-capture-persist-by-id"));
+
+    await waitFor(() => {
+      expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1);
+    });
+    expect(bookSessionViaApiMock).not.toHaveBeenCalled();
   });
 
   it("manual close clears retry hint without success-style submission", async () => {

--- a/src/scripts/__tests__/playwrightInprogressSessionSetup.test.ts
+++ b/src/scripts/__tests__/playwrightInprogressSessionSetup.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { formatInTimeZone } from "date-fns-tz";
+
+import {
+  buildVisibleScheduleBookingAttemptStart,
+  buildVisibleScheduleBookingBaseStart,
+  resolveBrowserScheduleTimeZone,
+} from "../../../scripts/lib/playwright-inprogress-session-setup";
+
+describe("playwright in-progress session setup", () => {
+  it("chooses a future base start inside the rendered schedule grid timezone", () => {
+    const now = new Date("2026-06-18T23:30:00.000Z");
+    const timeZone = "America/Los_Angeles";
+
+    for (let seed = 0; seed < 24; seed += 1) {
+      const start = buildVisibleScheduleBookingBaseStart(now, seed, timeZone);
+      const localHour = Number(formatInTimeZone(start, timeZone, "H"));
+
+      expect(start.getTime()).toBeGreaterThan(now.getTime());
+      expect(formatInTimeZone(start, timeZone, "m")).toBe("0");
+      expect(formatInTimeZone(start, timeZone, "s")).toBe("0");
+      expect(localHour).toBeGreaterThanOrEqual(8);
+      expect(localHour).toBeLessThan(18);
+    }
+  });
+
+  it("keeps retry attempts inside rendered schedule grid hours", () => {
+    const timeZone = "America/Los_Angeles";
+    const baseStart = new Date("2026-06-18T23:00:00.000Z");
+
+    for (let attempt = 0; attempt < 48; attempt += 1) {
+      const start = buildVisibleScheduleBookingAttemptStart(baseStart, attempt, timeZone);
+      const localHour = Number(formatInTimeZone(start, timeZone, "H"));
+
+      expect(start.getTime()).toBeGreaterThanOrEqual(baseStart.getTime());
+      expect(formatInTimeZone(start, timeZone, "m")).toBe("0");
+      expect(formatInTimeZone(start, timeZone, "s")).toBe("0");
+      expect(localHour).toBeGreaterThanOrEqual(8);
+      expect(localHour).toBeLessThan(18);
+    }
+  });
+
+  it("uses the browser timezone as the schedule grid timezone source", async () => {
+    await expect(resolveBrowserScheduleTimeZone({
+      evaluate: async (callback: () => string | null) => callback(),
+    })).resolves.toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+
+    await expect(resolveBrowserScheduleTimeZone({
+      evaluate: async () => "America/New_York",
+    })).resolves.toBe("America/New_York");
+
+    await expect(resolveBrowserScheduleTimeZone({
+      evaluate: async () => "",
+    })).resolves.toBe("UTC");
+  });
+});

--- a/src/scripts/__tests__/playwrightInprogressSessionSetup.test.ts
+++ b/src/scripts/__tests__/playwrightInprogressSessionSetup.test.ts
@@ -15,28 +15,52 @@ describe("playwright in-progress session setup", () => {
     for (let seed = 0; seed < 24; seed += 1) {
       const start = buildVisibleScheduleBookingBaseStart(now, seed, timeZone);
       const localHour = Number(formatInTimeZone(start, timeZone, "H"));
+      const isoWeekday = Number(formatInTimeZone(start, timeZone, "i"));
 
       expect(start.getTime()).toBeGreaterThan(now.getTime());
       expect(formatInTimeZone(start, timeZone, "m")).toBe("0");
       expect(formatInTimeZone(start, timeZone, "s")).toBe("0");
       expect(localHour).toBeGreaterThanOrEqual(8);
       expect(localHour).toBeLessThan(18);
+      expect(isoWeekday).toBeGreaterThanOrEqual(1);
+      expect(isoWeekday).toBeLessThanOrEqual(6);
     }
   });
 
-  it("keeps retry attempts inside rendered schedule grid hours", () => {
+  it("moves Sunday base bookings to the next rendered weekday", () => {
     const timeZone = "America/Los_Angeles";
-    const baseStart = new Date("2026-06-18T23:00:00.000Z");
+    const sundayBeforeChosenHour = new Date("2026-06-21T14:30:00.000Z");
+
+    const start = buildVisibleScheduleBookingBaseStart(sundayBeforeChosenHour, 0, timeZone);
+
+    expect(formatInTimeZone(start, timeZone, "yyyy-MM-dd HH:mm i")).toBe("2026-06-22 08:00 1");
+  });
+
+  it("moves late Saturday base bookings to Monday instead of Sunday", () => {
+    const timeZone = "America/Los_Angeles";
+    const saturdayAfterChosenHour = new Date("2026-06-21T00:30:00.000Z");
+
+    const start = buildVisibleScheduleBookingBaseStart(saturdayAfterChosenHour, 0, timeZone);
+
+    expect(formatInTimeZone(start, timeZone, "yyyy-MM-dd HH:mm i")).toBe("2026-06-22 08:00 1");
+  });
+
+  it("keeps retry attempts inside rendered schedule grid hours and weekdays", () => {
+    const timeZone = "America/Los_Angeles";
+    const baseStart = new Date("2026-06-20T23:00:00.000Z");
 
     for (let attempt = 0; attempt < 48; attempt += 1) {
       const start = buildVisibleScheduleBookingAttemptStart(baseStart, attempt, timeZone);
       const localHour = Number(formatInTimeZone(start, timeZone, "H"));
+      const isoWeekday = Number(formatInTimeZone(start, timeZone, "i"));
 
       expect(start.getTime()).toBeGreaterThanOrEqual(baseStart.getTime());
       expect(formatInTimeZone(start, timeZone, "m")).toBe("0");
       expect(formatInTimeZone(start, timeZone, "s")).toBe("0");
       expect(localHour).toBeGreaterThanOrEqual(8);
       expect(localHour).toBeLessThan(18);
+      expect(isoWeekday).toBeGreaterThanOrEqual(1);
+      expect(isoWeekday).toBeLessThanOrEqual(6);
     }
   });
 


### PR DESCRIPTION
## Summary
- Keep the session-capture Playwright setup inside rendered Schedule grid hours, including service-role fallback attempts, using the browser schedule timezone.
- Carry existing session ids through `SessionModal` Save skills submits so Schedule can resolve stale edit state by id.
- Preserve real persistence gating: failed `upsertClientSessionNoteForSession` stops the session update path, and resolved-id saves invalidate linked session-note caches.

## Linear
- WIN-177

## Verification
- `npx vitest run src\scripts\__tests__\playwrightInprogressSessionSetup.test.ts`
- `npx vitest run src\pages\__tests__\Schedule.orchestration.integration.test.tsx -t "live capture"`
- `npx vitest run src\components\__tests__\SessionModal.test.tsx -t "submits ad-hoc skill rows"`
- `PW_BASE_URL=http://127.0.0.1:8888 npm run ci:playwright` through local `netlify dev`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run ci:check-focused`
- `npm run test:ci`
- `npm run test:routes:tier0`

## Risk
Critical lane because this touches Schedule session capture and API persistence behavior. No schema, RLS, auth, or Netlify config changes. Requires human review before merge.