### PR TITLE
WIN-178 Add manual authorization upload flow

### DIFF
--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -21,6 +21,8 @@ interface Authorization {
   start_date: string;
   end_date: string;
   status: string;
+  diagnosis_code?: string | null;
+  diagnosis_description?: string | null;
   approved_at?: string | null;
   approved_by?: string | null;
   approval_notes?: string | null;
@@ -49,6 +51,52 @@ const ACCEPTED_FILE_TYPES = [
   'image/png'
 ] as const;
 
+type AuthorizationStatus = 'approved' | 'pending' | 'denied';
+
+interface PreAuthWizardData {
+  insurance: string;
+  insuranceProviderId: string;
+  authorizationNumber: string;
+  status: AuthorizationStatus;
+  startDate: string;
+  endDate: string;
+  diagnosisCode: string;
+  diagnosisDescription: string;
+  services: string[];
+  units: Record<string, number>;
+  documents: File[];
+  planType: string;
+  memberId: string;
+}
+
+const AUTHORIZATION_STATUSES: AuthorizationStatus[] = ['approved', 'pending', 'denied'];
+
+const createEmptyWizardData = (): PreAuthWizardData => ({
+  insurance: '',
+  insuranceProviderId: '',
+  authorizationNumber: '',
+  status: 'approved',
+  startDate: '',
+  endDate: '',
+  diagnosisCode: 'F84.0',
+  diagnosisDescription: 'Autistic disorder',
+  services: [],
+  units: {},
+  documents: [],
+  planType: '',
+  memberId: '',
+});
+
+const normalizeAuthorizationStatus = (status?: string | null): AuthorizationStatus => {
+  return AUTHORIZATION_STATUSES.includes(status as AuthorizationStatus)
+    ? (status as AuthorizationStatus)
+    : 'approved';
+};
+
+const getDecisionStatus = (status: AuthorizationStatus) => {
+  return status === 'denied' ? 'denied' : status === 'approved' ? 'approved' : 'pending';
+};
+
 export function PreAuthTab({ client }: PreAuthTabProps) {
   const { user } = useAuth();
   const organizationId = useActiveOrganizationId();
@@ -56,15 +104,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   const [isWizardOpen, setIsWizardOpen] = useState(false);
   const [selectedAuthorizationForView, setSelectedAuthorizationForView] = useState<Authorization | null>(null);
   const [currentStep, setCurrentStep] = useState(1);
-  const [wizardData, setWizardData] = useState({
-    insurance: '',
-    insuranceProviderId: '' as string,
-    services: [] as string[],
-    units: {} as Record<string, number>,
-    documents: [] as File[],
-    planType: '',
-    memberId: '',
-  });
+  const [wizardData, setWizardData] = useState<PreAuthWizardData>(() => createEmptyWizardData());
   const [isDragActive, setIsDragActive] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -325,39 +365,61 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       return;
     }
 
+    const authorizationNumber = wizardData.authorizationNumber.trim();
+    const diagnosisCode = wizardData.diagnosisCode.trim();
+    const diagnosisDescription = wizardData.diagnosisDescription.trim();
+
+    if (!authorizationNumber) {
+      showError('Enter the authorization number from the approval notice.');
+      return;
+    }
+
+    if (!wizardData.startDate || !wizardData.endDate || wizardData.endDate < wizardData.startDate) {
+      showError('Enter a valid authorization date range.');
+      return;
+    }
+
+    if (!diagnosisCode || !diagnosisDescription) {
+      showError('Enter diagnosis code and description from the authorization notice.');
+      return;
+    }
+
     if (wizardData.services.some((code) => !wizardData.units[code] || wizardData.units[code] <= 0)) {
       showError('Enter units for all selected services.');
+      return;
+    }
+
+    if (wizardData.documents.length === 0) {
+      showError('Upload the authorization notice before submitting.');
       return;
     }
 
     setIsSubmitting(true);
 
     try {
-      const startDate = new Date();
-      const endDate = new Date();
-      endDate.setDate(startDate.getDate() + 180);
+      const decisionStatus = getDecisionStatus(wizardData.status);
 
       const { id: authorizationId } = await createAuthorizationWithServices({
-        authorization_number: `AUTH-${Date.now()}`,
+        authorization_number: authorizationNumber,
         client_id: client.id,
         provider_id: user.id,
         insurance_provider_id: wizardData.insuranceProviderId || null,
         plan_type: wizardData.planType || null,
         member_id: wizardData.memberId || null,
-        diagnosis_code: 'TBD',
-        diagnosis_description: wizardData.insurance || null,
-        start_date: startDate.toISOString().slice(0, 10),
-        end_date: endDate.toISOString().slice(0, 10),
-        status: 'approved',
+        diagnosis_code: diagnosisCode,
+        diagnosis_description: diagnosisDescription,
+        start_date: wizardData.startDate,
+        end_date: wizardData.endDate,
+        status: wizardData.status,
         services: wizardData.services.map((serviceCode) => ({
           service_code: serviceCode,
           service_description: serviceCatalog[serviceCode] ?? '',
-          from_date: startDate.toISOString().slice(0, 10),
-          to_date: endDate.toISOString().slice(0, 10),
+          from_date: wizardData.startDate,
+          to_date: wizardData.endDate,
           requested_units: wizardData.units[serviceCode],
-          approved_units: wizardData.units[serviceCode],
-          unit_type: 'unit',
-          decision_status: 'approved',
+          approved_units: wizardData.status === 'approved' ? wizardData.units[serviceCode] : null,
+          unit_type: 'Units',
+          decision_status: decisionStatus,
         })),
       });
 
@@ -391,21 +453,13 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
         });
       }
 
-      showSuccess('Pre-authorization submitted and approved.');
+      showSuccess('Authorization uploaded and saved.');
       await queryClient.invalidateQueries({
         queryKey: ['authorizations', client.id, organizationId ?? 'MISSING_ORG'],
       });
       setIsWizardOpen(false);
       setCurrentStep(1);
-      setWizardData({
-        insurance: '',
-        insuranceProviderId: '',
-        services: [],
-        units: {},
-        documents: [],
-        planType: '',
-        memberId: '',
-      });
+      setWizardData(createEmptyWizardData());
     } catch (error) {
       showError(error instanceof Error ? error.message : 'Failed to submit pre-authorization.');
     } finally {
@@ -415,8 +469,15 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   
   const handleRenewAuthorization = (auth: Authorization) => {
     setWizardData({
+      ...createEmptyWizardData(),
       insurance: auth.insurance_provider?.name ?? '',
       insuranceProviderId: auth.insurance_provider_id ?? '',
+      authorizationNumber: auth.authorization_number ?? '',
+      status: normalizeAuthorizationStatus(auth.status),
+      startDate: auth.start_date ?? '',
+      endDate: auth.end_date ?? '',
+      diagnosisCode: auth.diagnosis_code ?? 'F84.0',
+      diagnosisDescription: auth.diagnosis_description ?? 'Autistic disorder',
       planType: auth.plan_type ?? '',
       memberId: auth.member_id ?? '',
       services: auth.services.map(s => s.service_code),
@@ -424,7 +485,6 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
         acc[s.service_code] = s.requested_units;
         return acc;
       }, {} as Record<string, number>),
-      documents: [],
     });
     setIsWizardOpen(true);
   };
@@ -754,10 +814,10 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                 ))}
               </div>
               <div className="flex justify-between mt-2 text-xs text-gray-500 dark:text-gray-400">
-                <span>Insurance</span>
+                <span>Notice</span>
                 <span>Services</span>
                 <span>Units</span>
-                <span>Documents</span>
+                <span>Upload</span>
                 <span>Submit</span>
               </div>
             </div>
@@ -767,9 +827,101 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
               {currentStep === 1 && (
                 <div>
                   <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-                    Insurance & Plan
+                    Authorization Notice Details
                   </h3>
+                  <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+                    Enter the fields from the payer authorization notice before attaching the PDF.
+                  </p>
                   <div className="space-y-4">
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                      <div>
+                        <label htmlFor="preauth-authorization-number" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          Authorization Number
+                        </label>
+                        <input
+                          id="preauth-authorization-number"
+                          type="text"
+                          value={wizardData.authorizationNumber}
+                          onChange={(e) => setWizardData({ ...wizardData, authorizationNumber: e.target.value })}
+                          className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+                        />
+                      </div>
+
+                      <div>
+                        <label htmlFor="preauth-status" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          Authorization Status
+                        </label>
+                        <select
+                          id="preauth-status"
+                          value={wizardData.status}
+                          onChange={(e) => setWizardData({ ...wizardData, status: e.target.value as AuthorizationStatus })}
+                          className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+                        >
+                          {AUTHORIZATION_STATUSES.map((status) => (
+                            <option key={status} value={status}>
+                              {status.charAt(0).toUpperCase() + status.slice(1)}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                      <div>
+                        <label htmlFor="preauth-start-date" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          Start Date
+                        </label>
+                        <input
+                          id="preauth-start-date"
+                          type="date"
+                          value={wizardData.startDate}
+                          onChange={(e) => setWizardData({ ...wizardData, startDate: e.target.value })}
+                          className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+                        />
+                      </div>
+
+                      <div>
+                        <label htmlFor="preauth-end-date" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          End Date
+                        </label>
+                        <input
+                          id="preauth-end-date"
+                          type="date"
+                          value={wizardData.endDate}
+                          onChange={(e) => setWizardData({ ...wizardData, endDate: e.target.value })}
+                          className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                      <div>
+                        <label htmlFor="preauth-diagnosis-code" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          Diagnosis Code
+                        </label>
+                        <input
+                          id="preauth-diagnosis-code"
+                          type="text"
+                          value={wizardData.diagnosisCode}
+                          onChange={(e) => setWizardData({ ...wizardData, diagnosisCode: e.target.value })}
+                          className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+                        />
+                      </div>
+
+                      <div>
+                        <label htmlFor="preauth-diagnosis-description" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          Diagnosis Description
+                        </label>
+                        <input
+                          id="preauth-diagnosis-description"
+                          type="text"
+                          value={wizardData.diagnosisDescription}
+                          onChange={(e) => setWizardData({ ...wizardData, diagnosisDescription: e.target.value })}
+                          className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+                        />
+                      </div>
+                    </div>
+
                     <div>
                       <label htmlFor="preauth-insurance" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                         Insurance Provider
@@ -953,7 +1105,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
               {currentStep === 4 && (
                 <div>
                   <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-                    Upload Supporting Documents
+                    Upload Authorization Notice
                   </h3>
                   <div
                     className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
@@ -982,7 +1134,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                   >
                     <FileText className="h-12 w-12 text-gray-400 mx-auto mb-4" />
                     <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
-                      Drag and drop files here, or click to select files
+                      Drag and drop the payer authorization notice here, or click to select files
                     </p>
                     <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
                       Supported formats: PDF, DOCX, JPG, PNG (max 10MB)
@@ -1044,6 +1196,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                       Required Documents
                     </h4>
                     <ul className="text-sm text-gray-600 dark:text-gray-400 space-y-1 list-disc list-inside">
+                      <li>Authorization or pre-authorization notice</li>
                       <li>Treatment plan</li>
                       <li>Diagnostic evaluation</li>
                       <li>Progress report (if renewal)</li>
@@ -1061,10 +1214,19 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                   <div className="space-y-4">
                     <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
                       <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                        Insurance & Plan
+                        Authorization Notice
                       </h4>
                       <p className="text-sm text-gray-900 dark:text-white">
-                        {wizardData.insurance || 'Not selected'}
+                        {wizardData.authorizationNumber || 'Missing authorization number'} · {wizardData.status}
+                      </p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {wizardData.startDate || 'Missing start date'} - {wizardData.endDate || 'Missing end date'}
+                      </p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {wizardData.insurance || 'Not selected'} · {wizardData.planType || 'No plan type'}
+                      </p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {wizardData.diagnosisCode || 'No diagnosis code'} - {wizardData.diagnosisDescription || 'No diagnosis description'}
                       </p>
                     </div>
                     
@@ -1086,11 +1248,17 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                     
                     <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
                       <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                        Supporting Documents
+                        Authorization Upload
                       </h4>
-                      <p className="text-sm text-gray-900 dark:text-white">
-                        {wizardData.documents.length} documents uploaded
-                      </p>
+                      <div className="space-y-1 text-sm text-gray-900 dark:text-white">
+                        {wizardData.documents.length > 0 ? (
+                          wizardData.documents.map((file, index) => (
+                            <p key={`${file.name}-${index}`}>{file.name}</p>
+                          ))
+                        ) : (
+                          <p>No authorization notice uploaded</p>
+                        )}
+                      </div>
                     </div>
                     
                     <div className="p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
@@ -1101,8 +1269,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                             Submission Notice
                           </p>
                           <p className="text-xs text-blue-700 dark:text-blue-300 mt-1">
-                            By submitting this request, you certify that all information is accurate and complete.
-                            The authorization will be submitted to the payer for review.
+                            By submitting this upload, you certify that the entered fields match the attached payer authorization notice.
                           </p>
                         </div>
                       </div>

--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { 
   ClipboardCheck, Calendar, AlertCircle, 
@@ -28,6 +28,7 @@ interface Authorization {
   approval_notes?: string | null;
   denied_at?: string | null;
   denial_reason?: string | null;
+  provider_id?: string | null;
   plan_type?: string | null;
   member_id?: string | null;
   insurance_provider_id?: string | null;
@@ -56,6 +57,7 @@ type AuthorizationStatus = 'approved' | 'pending' | 'denied';
 interface PreAuthWizardData {
   insurance: string;
   insuranceProviderId: string;
+  providerId: string;
   authorizationNumber: string;
   status: AuthorizationStatus;
   startDate: string;
@@ -74,6 +76,7 @@ const AUTHORIZATION_STATUSES: AuthorizationStatus[] = ['approved', 'pending', 'd
 const createEmptyWizardData = (): PreAuthWizardData => ({
   insurance: '',
   insuranceProviderId: '',
+  providerId: '',
   authorizationNumber: '',
   status: 'approved',
   startDate: '',
@@ -153,6 +156,91 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       return data as Array<{ id: string; name: string }>;
     },
   });
+
+  const { data: clientPrimaryProvider } = useQuery({
+    queryKey: ['client-authorization-provider', client.id, organizationId ?? 'MISSING_ORG'],
+    queryFn: async () => {
+      if (!organizationId) {
+        throw new Error('Organization context is required to load the client provider.');
+      }
+
+      const { data, error } = await supabase
+        .from('clients')
+        .select('therapist_id')
+        .eq('id', client.id)
+        .eq('organization_id', organizationId)
+        .maybeSingle();
+
+      if (error) throw error;
+      return data as { therapist_id: string | null } | null;
+    },
+    enabled: Boolean(client.id && organizationId),
+  });
+
+  const clientPrimaryProviderId = clientPrimaryProvider?.therapist_id ?? '';
+
+  const { data: linkedClientProviders = [] } = useQuery({
+    queryKey: ['client-authorization-linked-providers', client.id, organizationId ?? 'MISSING_ORG'],
+    queryFn: async () => {
+      if (!organizationId) {
+        throw new Error('Organization context is required to load linked providers.');
+      }
+
+      const { data, error } = await supabase
+        .from('client_therapist_links')
+        .select('therapist_id')
+        .eq('client_id', client.id)
+        .eq('organization_id', organizationId);
+
+      if (error) throw error;
+      return data as Array<{ therapist_id: string }>;
+    },
+    enabled: Boolean(client.id && organizationId),
+  });
+
+  const assignedProviderIds = useMemo(() => {
+    return Array.from(
+      new Set([
+        clientPrimaryProviderId,
+        ...linkedClientProviders.map((provider) => provider.therapist_id),
+      ].filter(Boolean)),
+    );
+  }, [clientPrimaryProviderId, linkedClientProviders]);
+
+  const { data: authorizationProviderTherapists = [] } = useQuery({
+    queryKey: ['authorization-provider-therapists', organizationId ?? 'MISSING_ORG', assignedProviderIds],
+    queryFn: async () => {
+      if (!organizationId) {
+        throw new Error('Organization context is required to load therapists.');
+      }
+
+      const { data, error } = await supabase
+        .from('therapists')
+        .select('id,full_name')
+        .eq('organization_id', organizationId)
+        .in('id', assignedProviderIds)
+        .order('full_name');
+
+      if (error) throw error;
+      return data as Array<{ id: string; full_name: string | null }>;
+    },
+    enabled: Boolean(organizationId && assignedProviderIds.length > 0),
+  });
+
+  useEffect(() => {
+    if (wizardData.providerId || !clientPrimaryProviderId) {
+      return;
+    }
+
+    const primaryProviderExists = authorizationProviderTherapists.some(
+      (therapist) => therapist.id === clientPrimaryProviderId,
+    );
+    if (!primaryProviderExists) {
+      return;
+    }
+
+    setWizardData((prev) => (prev.providerId ? prev : { ...prev, providerId: clientPrimaryProviderId }));
+  }, [authorizationProviderTherapists, clientPrimaryProviderId, wizardData.providerId]);
 
   const { data: sessionNoteUsage = [] } = useQuery({
     queryKey: ['client-session-note-usage', client.id, organizationId ?? 'MISSING_ORG'],
@@ -365,6 +453,11 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       return;
     }
 
+    if (!wizardData.providerId) {
+      showError('Select the therapist/provider for this authorization.');
+      return;
+    }
+
     const authorizationNumber = wizardData.authorizationNumber.trim();
     const diagnosisCode = wizardData.diagnosisCode.trim();
     const diagnosisDescription = wizardData.diagnosisDescription.trim();
@@ -402,7 +495,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       const { id: authorizationId } = await createAuthorizationWithServices({
         authorization_number: authorizationNumber,
         client_id: client.id,
-        provider_id: user.id,
+        provider_id: wizardData.providerId,
         insurance_provider_id: wizardData.insuranceProviderId || null,
         plan_type: wizardData.planType || null,
         member_id: wizardData.memberId || null,
@@ -472,6 +565,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       ...createEmptyWizardData(),
       insurance: auth.insurance_provider?.name ?? '',
       insuranceProviderId: auth.insurance_provider_id ?? '',
+      providerId: auth.provider_id ?? '',
       authorizationNumber: auth.authorization_number ?? '',
       status: normalizeAuthorizationStatus(auth.status),
       startDate: auth.start_date ?? '',
@@ -948,6 +1042,30 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                         ))}
                       </select>
                     </div>
+
+                    <div>
+                      <label htmlFor="preauth-provider-therapist" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                        Rendering Therapist / Provider
+                      </label>
+                      <select
+                        id="preauth-provider-therapist"
+                        value={wizardData.providerId}
+                        onChange={(e) => setWizardData({ ...wizardData, providerId: e.target.value })}
+                        className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+                      >
+                        <option value="">Select therapist/provider</option>
+                        {authorizationProviderTherapists.map((therapist) => (
+                          <option key={therapist.id} value={therapist.id}>
+                            {therapist.full_name ?? 'Unnamed therapist'}
+                          </option>
+                        ))}
+                      </select>
+                      {clientPrimaryProviderId && wizardData.providerId === clientPrimaryProviderId && (
+                        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                          Defaulted from the client primary therapist.
+                        </p>
+                      )}
+                    </div>
                     
                     <div>
                       <label htmlFor="preauth-plan-type" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
@@ -1224,6 +1342,11 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                       </p>
                       <p className="text-sm text-gray-600 dark:text-gray-400">
                         {wizardData.insurance || 'Not selected'} · {wizardData.planType || 'No plan type'}
+                      </p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        Provider:{' '}
+                        {authorizationProviderTherapists.find((therapist) => therapist.id === wizardData.providerId)?.full_name ??
+                          'No provider selected'}
                       </p>
                       <p className="text-sm text-gray-600 dark:text-gray-400">
                         {wizardData.diagnosisCode || 'No diagnosis code'} - {wizardData.diagnosisDescription || 'No diagnosis description'}

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -1,0 +1,200 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
+import { PreAuthTab } from "../ClientDetails/PreAuthTab";
+import { createAuthorizationWithServices, updateAuthorizationDocuments } from "../../lib/authorizations/mutations";
+import { showSuccess } from "../../lib/toast";
+
+const ORG_ID = "5238e88b-6198-4862-80a2-dbe15bbeabdd";
+
+const {
+  createAuthorizationWithServicesMock,
+  updateAuthorizationDocumentsMock,
+  storageUploadMock,
+  supabaseFromMock,
+  useAuthMock,
+  useActiveOrganizationIdMock,
+} = vi.hoisted(() => {
+  const createAuthorizationWithServicesMock = vi.fn();
+  const updateAuthorizationDocumentsMock = vi.fn();
+  const storageUploadMock = vi.fn();
+  const useAuthMock = vi.fn();
+  const useActiveOrganizationIdMock = vi.fn();
+
+  const createEqQuery = (data: unknown[]) => {
+    const query = {
+      eq: vi.fn(() => query),
+      then: (resolve: (value: { data: unknown[]; error: null }) => void, reject: (reason?: unknown) => void) =>
+        Promise.resolve({ data, error: null }).then(resolve, reject),
+    };
+    return query;
+  };
+
+  const supabaseFromMock = vi.fn((table: string) => {
+    if (table === "cpt_codes") {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            order: vi.fn(() =>
+              Promise.resolve({
+                data: [{ code: "97153", short_description: "Adaptive behavior treatment by protocol" }],
+                error: null,
+              }),
+            ),
+          })),
+        })),
+      };
+    }
+
+    if (table === "insurance_providers") {
+      return {
+        select: vi.fn(() => ({
+          order: vi.fn(() =>
+            Promise.resolve({
+              data: [{ id: "payer-1", name: "IEHP" }],
+              error: null,
+            }),
+          ),
+        })),
+      };
+    }
+
+    if (table === "client_session_notes" || table === "authorizations") {
+      return {
+        select: vi.fn(() => createEqQuery([])),
+      };
+    }
+
+    return {
+      select: vi.fn(() => Promise.resolve({ data: [], error: null })),
+    };
+  });
+
+  return {
+    createAuthorizationWithServicesMock,
+    updateAuthorizationDocumentsMock,
+    storageUploadMock,
+    supabaseFromMock,
+    useAuthMock,
+    useActiveOrganizationIdMock,
+  };
+});
+
+vi.mock("../../lib/authContext", () => ({
+  useAuth: () => useAuthMock(),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../../lib/organization", () => ({
+  useActiveOrganizationId: () => useActiveOrganizationIdMock(),
+}));
+
+vi.mock("../../lib/supabase", () => ({
+  supabase: {
+    from: supabaseFromMock,
+    storage: {
+      from: vi.fn(() => ({
+        upload: storageUploadMock,
+      })),
+    },
+  },
+}));
+
+vi.mock("../../lib/authorizations/mutations", () => ({
+  createAuthorizationWithServices: createAuthorizationWithServicesMock,
+  updateAuthorizationDocuments: updateAuthorizationDocumentsMock,
+}));
+
+vi.mock("../../lib/toast", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+describe("PreAuthTab manual authorization upload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthMock.mockReturnValue({ user: { id: "admin-user-id" } });
+    useActiveOrganizationIdMock.mockReturnValue(ORG_ID);
+    createAuthorizationWithServicesMock.mockResolvedValue({ id: "auth-created-id" });
+    updateAuthorizationDocumentsMock.mockResolvedValue(undefined);
+    storageUploadMock.mockResolvedValue({ error: null });
+  });
+
+  it("creates an authorization from entered notice fields and attaches the uploaded PDF", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.type(screen.getByLabelText(/authorization number/i), "IEHP-AUTH-123");
+    await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+    await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
+    await user.type(screen.getByLabelText(/member id/i), "MEM-123");
+    await user.type(screen.getByLabelText(/start date/i), "2026-06-23");
+    await user.type(screen.getByLabelText(/end date/i), "2026-12-22");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(await screen.findByLabelText(/97153/i));
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.type(screen.getByLabelText(/units requested/i), "120");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["synthetic authorization notice"], "auth-notice.pdf", {
+      type: "application/pdf",
+    });
+    await user.upload(fileInput, file);
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /submit request/i }));
+
+    await waitFor(() => {
+      expect(createAuthorizationWithServices).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorization_number: "IEHP-AUTH-123",
+          client_id: "client-1",
+          provider_id: "admin-user-id",
+          insurance_provider_id: "payer-1",
+          plan_type: "Medicaid",
+          member_id: "MEM-123",
+          diagnosis_code: "F84.0",
+          diagnosis_description: "Autistic disorder",
+          start_date: "2026-06-23",
+          end_date: "2026-12-22",
+          status: "approved",
+          services: [
+            expect.objectContaining({
+              service_code: "97153",
+              service_description: "Adaptive behavior treatment by protocol",
+              from_date: "2026-06-23",
+              to_date: "2026-12-22",
+              requested_units: 120,
+              approved_units: 120,
+              unit_type: "Units",
+              decision_status: "approved",
+            }),
+          ],
+        }),
+      );
+    });
+
+    expect(storageUploadMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^clients\/client-1\/authorizations\/auth-created-id\/.+\.pdf$/),
+      file,
+      { upsert: false },
+    );
+    expect(updateAuthorizationDocuments).toHaveBeenCalledWith({
+      authorization_id: "auth-created-id",
+      documents: [
+        expect.objectContaining({
+          name: "auth-notice.pdf",
+          path: expect.stringMatching(/^clients\/client-1\/authorizations\/auth-created-id\/.+\.pdf$/),
+          type: "application/pdf",
+        }),
+      ],
+    });
+    expect(showSuccess).toHaveBeenCalledWith("Authorization uploaded and saved.");
+  });
+});

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -59,6 +59,55 @@ const {
       };
     }
 
+    if (table === "therapists") {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            in: vi.fn(() => ({
+              order: vi.fn(() =>
+                Promise.resolve({
+                  data: [{ id: "therapist-provider-1", full_name: "Provider Therapist" }],
+                  error: null,
+                }),
+              ),
+            })),
+          })),
+        })),
+      };
+    }
+
+    if (table === "clients") {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(() =>
+                Promise.resolve({
+                  data: { therapist_id: "therapist-provider-1" },
+                  error: null,
+                }),
+              ),
+            })),
+          })),
+        })),
+      };
+    }
+
+    if (table === "client_therapist_links") {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() =>
+              Promise.resolve({
+                data: [{ therapist_id: "therapist-provider-1" }],
+                error: null,
+              }),
+            ),
+          })),
+        })),
+      };
+    }
+
     if (table === "client_session_notes" || table === "authorizations") {
       return {
         select: vi.fn(() => createEqQuery([])),
@@ -129,6 +178,9 @@ describe("PreAuthTab manual authorization upload", () => {
     await screen.findByRole("heading", { name: /authorization notice details/i });
     await user.type(screen.getByLabelText(/authorization number/i), "IEHP-AUTH-123");
     await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+    await waitFor(() => {
+      expect(screen.getByLabelText(/rendering therapist/i)).toHaveValue("therapist-provider-1");
+    });
     await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
     await user.type(screen.getByLabelText(/member id/i), "MEM-123");
     await user.type(screen.getByLabelText(/start date/i), "2026-06-23");
@@ -155,7 +207,7 @@ describe("PreAuthTab manual authorization upload", () => {
         expect.objectContaining({
           authorization_number: "IEHP-AUTH-123",
           client_id: "client-1",
-          provider_id: "admin-user-id",
+          provider_id: "therapist-provider-1",
           insurance_provider_id: "payer-1",
           plan_type: "Medicaid",
           member_id: "MEM-123",


### PR DESCRIPTION
## Summary
- Converts the Client Details Pre-Authorizations wizard into a manual authorization notice upload flow for admins/super admins.
- Requires entered authorization number, status, date range, diagnosis, services, units, and an attached authorization notice before saving.
- Reuses existing `create_authorization_with_services`, `client-documents`, and `update_authorization_documents` paths; no schema, RLS, route guard, or storage policy changes.
- Adds focused component coverage for create/upload/attach payload shape using synthetic data.

## Linear
WIN-178: https://linear.app/winningedgeai/issue/WIN-178/add-manual-authorization-pdf-upload-attachment-flow

## Verification Card
- classification: high-risk human-reviewed
- lane: critical
- change type: UI/component; authorization/org-scoped write flow
- required checks: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm test -- --run src/components/__tests__/PreAuthTab.test.tsx`, `npm run test:ci`, `npm run validate:tenant`, `npm run build`, `npm run verify:local`
- executed checks: all required checks passed locally
- blocked checks: local DB grant/drift checks inside policy suite skipped because `SUPABASE_DB_URL`/`DATABASE_URL` is not configured; branch protection checks skipped outside CI
- result: pass-with-environment-limited-skips
- residual risk: no live Supabase/browser upload smoke was run; PR requires human review because this touches authorization document upload behavior.

## PR Hygiene
- pr-ready: yes
- lane: critical
- branch-ready: yes
- linear-ready: yes
- single-purpose: yes
- unrelated changes: none
- generated artifact drift: none
- protected-path drift: none; protected behavior is authorization upload/write flow, contained to existing component/RPC/storage contracts
- reviewer: blocked pending human review