### PR TITLE
WIN-179 Authorization PDF prefill

### DIFF
--- a/docs/superpowers/plans/2026-06-19-authorization-pdf-prefill.md
+++ b/docs/superpowers/plans/2026-06-19-authorization-pdf-prefill.md
@@ -1,0 +1,1045 @@
+# Authorization PDF Prefill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add browser-side extraction-assisted prefill for uploaded authorization PDFs in the existing admin/super-admin pre-authorization wizard.
+
+**Architecture:** Keep extraction local to the browser with a small PDF text helper, parse extracted text through a pure deterministic authorization parser, then merge recognized values into the existing wizard without overwriting admin-entered fields. The save path remains the existing `createAuthorizationWithServices` RPC plus document upload flow.
+
+**Tech Stack:** React 18, Vite, TypeScript, Vitest, Testing Library, Supabase client, `pdfjs-dist` for embedded PDF text extraction.
+
+---
+
+## Route And Scope
+
+- `exact issue key used`: `WIN-179`
+- `classification`: `high-risk human-reviewed`
+- `lane`: `critical`
+- `reviewer required`: yes
+- `verify-change required`: yes
+- `linear required`: yes
+
+Allowed implementation surfaces:
+
+- `package.json`
+- `package-lock.json`
+- `src/lib/authorizations/pdfText.ts`
+- `src/lib/authorizations/pdfPrefill.ts`
+- `src/lib/authorizations/__tests__/pdfPrefill.test.ts`
+- `src/components/ClientDetails/PreAuthTab.tsx`
+- `src/components/__tests__/PreAuthTab.test.tsx`
+
+Non-goals:
+
+- No server-side OCR.
+- No AI extraction.
+- No Supabase schema, RLS, RPC, grant, migration, or storage policy changes.
+- No BT/therapist access changes.
+- No raw extracted text logging or persistence.
+
+Stop conditions:
+
+- Stop and re-route if implementation needs `src/server/**`, `supabase/**`, route guards, auth context changes, or external OCR/API credentials.
+- Stop if `pdfjs-dist` does not work in the Vite build without config changes beyond package dependency/import setup.
+- Stop if parser behavior would require storing raw text or committing real document fixtures.
+
+## File Responsibilities
+
+- `src/lib/authorizations/pdfText.ts`: browser-only embedded PDF text extraction wrapper.
+- `src/lib/authorizations/pdfPrefill.ts`: pure parsing and merge helpers for authorization prefill values.
+- `src/lib/authorizations/__tests__/pdfPrefill.test.ts`: synthetic parser and merge unit tests.
+- `src/components/ClientDetails/PreAuthTab.tsx`: upload-step extraction state, prefill application, and status banner.
+- `src/components/__tests__/PreAuthTab.test.tsx`: wizard integration tests with mocked PDF text extraction.
+
+---
+
+### Task 1: Add PDF Text Extraction Dependency
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+- [ ] **Step 1: Install `pdfjs-dist`**
+
+Run:
+
+```powershell
+npm install pdfjs-dist
+```
+
+Expected: `package.json` includes `pdfjs-dist` under `dependencies`, and `package-lock.json` is updated.
+
+- [ ] **Step 2: Confirm dependency only**
+
+Run:
+
+```powershell
+git diff -- package.json package-lock.json
+```
+
+Expected: dependency lockfile changes only. No application code changed by this task.
+
+- [ ] **Step 3: Commit dependency**
+
+Run:
+
+```powershell
+git add package.json package-lock.json
+git commit -m "build: add WIN-179 PDF text extraction dependency"
+```
+
+Expected: commit succeeds. If the pre-commit hook runs policy checks, record the result.
+
+---
+
+### Task 2: Add Parser And Merge Unit Tests
+
+**Files:**
+- Create: `src/lib/authorizations/__tests__/pdfPrefill.test.ts`
+
+- [ ] **Step 1: Write failing parser and merge tests**
+
+Create `src/lib/authorizations/__tests__/pdfPrefill.test.ts` with synthetic-only text:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  mergeAuthorizationPdfPrefill,
+  parseAuthorizationPdfText,
+  type AuthorizationPdfPrefill,
+} from "../pdfPrefill";
+
+describe("parseAuthorizationPdfText", () => {
+  it("extracts IEHP-style authorization fields from synthetic notice text", () => {
+    const text = `
+      Referral ID: IEHP-AUTH-12345
+      Status: Approved
+      Member ID: MEM-0001
+      Diagnosis: F84.0 Autistic disorder
+      Service From: 06/23/2026
+      Service To: 12/22/2026
+      Procedure Code 97153
+      Requested Units: 120
+      Approved Units: 96
+    `;
+
+    expect(parseAuthorizationPdfText(text)).toEqual({
+      authorizationNumber: "IEHP-AUTH-12345",
+      status: "approved",
+      memberId: "MEM-0001",
+      diagnosisCode: "F84.0",
+      diagnosisDescription: "Autistic disorder",
+      startDate: "2026-06-23",
+      endDate: "2026-12-22",
+      services: [{ serviceCode: "97153", requestedUnits: 120, approvedUnits: 96 }],
+    });
+  });
+
+  it("extracts CalOptima-style authorization fields from synthetic notice text", () => {
+    const text = `
+      Authorization #: CAL-987654
+      Decision: Approved
+      CIN: CIN-222333
+      ICD-10 Code F84.0 - Autistic disorder
+      Code Description From To Requested Approved
+      97155 Adaptive behavior treatment 6.23.2026 12.22.2026 48 40
+    `;
+
+    expect(parseAuthorizationPdfText(text)).toMatchObject({
+      authorizationNumber: "CAL-987654",
+      status: "approved",
+      memberId: "CIN-222333",
+      diagnosisCode: "F84.0",
+      diagnosisDescription: "Autistic disorder",
+      startDate: "2026-06-23",
+      endDate: "2026-12-22",
+      services: [{ serviceCode: "97155", requestedUnits: 48, approvedUnits: 40 }],
+    });
+  });
+
+  it("leaves ambiguous values unset", () => {
+    expect(parseAuthorizationPdfText("Authorization notice with no structured values")).toEqual({
+      services: [],
+    });
+  });
+});
+
+describe("mergeAuthorizationPdfPrefill", () => {
+  const catalog = {
+    "97153": "Adaptive behavior treatment by protocol",
+    "97155": "Adaptive behavior treatment with protocol modification",
+  };
+
+  it("fills empty fields and catalog-matched services without overwriting entered values", () => {
+    const current = {
+      authorizationNumber: "ADMIN-TYPED",
+      status: "pending" as const,
+      startDate: "",
+      endDate: "",
+      diagnosisCode: "F84.0",
+      diagnosisDescription: "Autistic disorder",
+      memberId: "",
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+    const prefill: AuthorizationPdfPrefill = {
+      authorizationNumber: "PDF-AUTH-1",
+      status: "approved",
+      startDate: "2026-06-23",
+      endDate: "2026-12-22",
+      memberId: "MEM-0001",
+      services: [
+        { serviceCode: "97153", requestedUnits: 120, approvedUnits: 96 },
+        { serviceCode: "99999", requestedUnits: 1, approvedUnits: 1 },
+      ],
+    };
+
+    expect(mergeAuthorizationPdfPrefill(current, prefill, catalog)).toEqual({
+      data: {
+        authorizationNumber: "ADMIN-TYPED",
+        status: "pending",
+        startDate: "2026-06-23",
+        endDate: "2026-12-22",
+        diagnosisCode: "F84.0",
+        diagnosisDescription: "Autistic disorder",
+        memberId: "MEM-0001",
+        services: ["97153"],
+        units: { "97153": 96 },
+      },
+      appliedFields: ["startDate", "endDate", "memberId", "services", "units"],
+      skippedServiceCodes: ["99999"],
+    });
+  });
+
+  it("does not replace units for a service already selected by the admin", () => {
+    const current = {
+      authorizationNumber: "",
+      status: "approved" as const,
+      startDate: "",
+      endDate: "",
+      diagnosisCode: "",
+      diagnosisDescription: "",
+      memberId: "",
+      services: ["97153"],
+      units: { "97153": 44 },
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(
+        current,
+        { services: [{ serviceCode: "97153", requestedUnits: 120, approvedUnits: 96 }] },
+        catalog,
+      ).data.units,
+    ).toEqual({ "97153": 44 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run:
+
+```powershell
+npm test -- src/lib/authorizations/__tests__/pdfPrefill.test.ts
+```
+
+Expected: FAIL because `src/lib/authorizations/pdfPrefill.ts` does not exist.
+
+- [ ] **Step 3: Commit failing tests only if following strict checkpointing**
+
+Preferred for this repo: do not leave failing tests committed. Continue directly to Task 3, then commit tests plus implementation together.
+
+---
+
+### Task 3: Implement Pure Parser And Merge Helper
+
+**Files:**
+- Create: `src/lib/authorizations/pdfPrefill.ts`
+- Test: `src/lib/authorizations/__tests__/pdfPrefill.test.ts`
+
+- [ ] **Step 1: Add parser and merge helper**
+
+Create `src/lib/authorizations/pdfPrefill.ts`:
+
+```ts
+export type AuthorizationPdfStatus = "approved" | "pending" | "denied";
+
+export interface AuthorizationPdfPrefillService {
+  serviceCode: string;
+  requestedUnits?: number;
+  approvedUnits?: number;
+}
+
+export interface AuthorizationPdfPrefill {
+  authorizationNumber?: string;
+  status?: AuthorizationPdfStatus;
+  startDate?: string;
+  endDate?: string;
+  diagnosisCode?: string;
+  diagnosisDescription?: string;
+  memberId?: string;
+  services: AuthorizationPdfPrefillService[];
+}
+
+export interface AuthorizationPdfMergeInput {
+  authorizationNumber: string;
+  status: AuthorizationPdfStatus;
+  startDate: string;
+  endDate: string;
+  diagnosisCode: string;
+  diagnosisDescription: string;
+  memberId: string;
+  services: string[];
+  units: Record<string, number>;
+}
+
+export interface AuthorizationPdfMergeResult<T extends AuthorizationPdfMergeInput> {
+  data: T;
+  appliedFields: string[];
+  skippedServiceCodes: string[];
+}
+
+const DATE_PATTERN = String.raw`(?:\d{1,2}[/.]\d{1,2}[/.]\d{2,4}|\d{4}-\d{1,2}-\d{1,2})`;
+const SERVICE_CODE_PATTERN = /\b(?:97(?:153|155|156|158)|0362T|0373T|H\d{4}|[A-Z]\d{4})\b/g;
+
+const collapseWhitespace = (value: string): string => value.replace(/\s+/g, " ").trim();
+
+const normalizeDate = (value: string): string | undefined => {
+  const raw = value.trim();
+  const isoMatch = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(raw);
+  if (isoMatch) {
+    return `${isoMatch[1]}-${isoMatch[2].padStart(2, "0")}-${isoMatch[3].padStart(2, "0")}`;
+  }
+
+  const dateMatch = /^(\d{1,2})[/.](\d{1,2})[/.](\d{2,4})$/.exec(raw);
+  if (!dateMatch) {
+    return undefined;
+  }
+
+  const month = Number(dateMatch[1]);
+  const day = Number(dateMatch[2]);
+  const year = Number(dateMatch[3].length === 2 ? `20${dateMatch[3]}` : dateMatch[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31 || year < 2000) {
+    return undefined;
+  }
+
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+};
+
+const firstMatch = (text: string, patterns: RegExp[]): string | undefined => {
+  for (const pattern of patterns) {
+    const match = pattern.exec(text);
+    pattern.lastIndex = 0;
+    const value = match?.[1]?.trim();
+    if (value) {
+      return collapseWhitespace(value);
+    }
+  }
+  return undefined;
+};
+
+const parseStatus = (text: string): AuthorizationPdfStatus | undefined => {
+  if (/\bdenied\b/i.test(text)) return "denied";
+  if (/\bapproved\b/i.test(text)) return "approved";
+  if (/\bpending\b|\brequested\b/i.test(text)) return "pending";
+  return undefined;
+};
+
+const parseDates = (text: string): Pick<AuthorizationPdfPrefill, "startDate" | "endDate"> => {
+  const serviceRange = new RegExp(`(?:service\\s*)?(?:from|start)\\s*:?\\s*(${DATE_PATTERN})[\\s\\S]{0,80}?(?:to|end)\\s*:?\\s*(${DATE_PATTERN})`, "i").exec(text);
+  if (serviceRange) {
+    return {
+      startDate: normalizeDate(serviceRange[1]),
+      endDate: normalizeDate(serviceRange[2]),
+    };
+  }
+
+  const compactRange = new RegExp(`(${DATE_PATTERN})\\s*(?:-|to|through)\\s*(${DATE_PATTERN})`, "i").exec(text);
+  if (compactRange) {
+    return {
+      startDate: normalizeDate(compactRange[1]),
+      endDate: normalizeDate(compactRange[2]),
+    };
+  }
+
+  return {};
+};
+
+const parseDiagnosis = (text: string): Pick<AuthorizationPdfPrefill, "diagnosisCode" | "diagnosisDescription"> => {
+  const match = /\b(?:diagnosis|icd-?10(?: code)?)\s*:?\s*([A-Z]\d{2}(?:\.\d+)?)\s*(?:-|:)?\s*([A-Za-z][^\n\r]{2,80})?/i.exec(text);
+  if (!match) {
+    return {};
+  }
+  return {
+    diagnosisCode: match[1].toUpperCase(),
+    diagnosisDescription: match[2] ? collapseWhitespace(match[2]) : undefined,
+  };
+};
+
+const parseServices = (text: string): AuthorizationPdfPrefillService[] => {
+  const services = new Map<string, AuthorizationPdfPrefillService>();
+  const lines = text.split(/\r?\n/).map(collapseWhitespace).filter(Boolean);
+
+  for (const line of lines) {
+    const codes = [...line.matchAll(SERVICE_CODE_PATTERN)].map((match) => match[0].toUpperCase());
+    for (const serviceCode of codes) {
+      const existing = services.get(serviceCode) ?? { serviceCode };
+      const requested = /requested(?:\s+units)?\s*:?\s*(\d+)/i.exec(line)?.[1];
+      const approved = /approved(?:\s+units)?\s*:?\s*(\d+)/i.exec(line)?.[1];
+      const trailingNumbers = line.match(/\b\d+\b/g)?.map(Number).filter((value) => value > 0) ?? [];
+
+      services.set(serviceCode, {
+        serviceCode,
+        requestedUnits: requested ? Number(requested) : existing.requestedUnits ?? trailingNumbers.at(-2),
+        approvedUnits: approved ? Number(approved) : existing.approvedUnits ?? trailingNumbers.at(-1),
+      });
+    }
+  }
+
+  return [...services.values()];
+};
+
+export const parseAuthorizationPdfText = (text: string): AuthorizationPdfPrefill => {
+  const normalizedText = text.replace(/\u00a0/g, " ");
+  const authorizationNumber = firstMatch(normalizedText, [
+    /\b(?:authorization|auth)\s*(?:#|number|no\.?)\s*:?\s*([A-Z0-9][A-Z0-9-]{3,})/i,
+    /\breferral\s*(?:id|#|number)?\s*:?\s*([A-Z0-9][A-Z0-9-]{3,})/i,
+  ]);
+  const memberId = firstMatch(normalizedText, [
+    /\bmember\s*(?:id|#|number)?\s*:?\s*([A-Z0-9][A-Z0-9-]{2,})/i,
+    /\bcin\s*:?\s*([A-Z0-9][A-Z0-9-]{2,})/i,
+  ]);
+
+  return {
+    authorizationNumber,
+    status: parseStatus(normalizedText),
+    memberId,
+    ...parseDiagnosis(normalizedText),
+    ...parseDates(normalizedText),
+    services: parseServices(normalizedText),
+  };
+};
+
+export const mergeAuthorizationPdfPrefill = <T extends AuthorizationPdfMergeInput>(
+  current: T,
+  prefill: AuthorizationPdfPrefill,
+  serviceCatalog: Record<string, string>,
+): AuthorizationPdfMergeResult<T> => {
+  const next: T = {
+    ...current,
+    services: [...current.services],
+    units: { ...current.units },
+  };
+  const appliedFields = new Set<string>();
+  const skippedServiceCodes = new Set<string>();
+
+  const fillIfBlank = <K extends keyof T>(field: K, value: T[K] | undefined) => {
+    if (!next[field] && value) {
+      next[field] = value;
+      appliedFields.add(String(field));
+    }
+  };
+
+  fillIfBlank("authorizationNumber", prefill.authorizationNumber as T["authorizationNumber"]);
+  fillIfBlank("startDate", prefill.startDate as T["startDate"]);
+  fillIfBlank("endDate", prefill.endDate as T["endDate"]);
+  fillIfBlank("diagnosisCode", prefill.diagnosisCode as T["diagnosisCode"]);
+  fillIfBlank("diagnosisDescription", prefill.diagnosisDescription as T["diagnosisDescription"]);
+  fillIfBlank("memberId", prefill.memberId as T["memberId"]);
+
+  if (prefill.status && !current.status) {
+    next.status = prefill.status as T["status"];
+    appliedFields.add("status");
+  }
+
+  for (const service of prefill.services) {
+    const code = service.serviceCode.toUpperCase();
+    if (!serviceCatalog[code]) {
+      skippedServiceCodes.add(code);
+      continue;
+    }
+    if (!next.services.includes(code)) {
+      next.services.push(code);
+      appliedFields.add("services");
+    }
+    const units = service.approvedUnits ?? service.requestedUnits;
+    if (units && units > 0 && !next.units[code]) {
+      next.units[code] = units;
+      appliedFields.add("units");
+    }
+  }
+
+  return {
+    data: next,
+    appliedFields: [...appliedFields],
+    skippedServiceCodes: [...skippedServiceCodes],
+  };
+};
+```
+
+- [ ] **Step 2: Run parser tests**
+
+Run:
+
+```powershell
+npm test -- src/lib/authorizations/__tests__/pdfPrefill.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit parser**
+
+Run:
+
+```powershell
+git add src/lib/authorizations/pdfPrefill.ts src/lib/authorizations/__tests__/pdfPrefill.test.ts
+git commit -m "feat: add WIN-179 authorization PDF prefill parser"
+```
+
+---
+
+### Task 4: Add Browser PDF Text Extraction Helper
+
+**Files:**
+- Create: `src/lib/authorizations/pdfText.ts`
+
+- [ ] **Step 1: Add extraction helper**
+
+Create `src/lib/authorizations/pdfText.ts`:
+
+```ts
+import * as pdfjs from "pdfjs-dist";
+import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
+
+pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+
+const PDF_MIME_TYPE = "application/pdf";
+
+export class PdfTextExtractionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PdfTextExtractionError";
+  }
+}
+
+export const extractPdfText = async (file: File): Promise<string> => {
+  if (file.type !== PDF_MIME_TYPE && !file.name.toLowerCase().endsWith(".pdf")) {
+    throw new PdfTextExtractionError("Only PDF files can be parsed for authorization prefill.");
+  }
+
+  const data = await file.arrayBuffer();
+  const loadingTask = pdfjs.getDocument({ data });
+  const document = await loadingTask.promise;
+  const pageTexts: string[] = [];
+
+  for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+    const page = await document.getPage(pageNumber);
+    const content = await page.getTextContent();
+    const text = content.items
+      .map((item) => ("str" in item ? item.str : ""))
+      .filter(Boolean)
+      .join(" ");
+    if (text.trim()) {
+      pageTexts.push(text);
+    }
+  }
+
+  const text = pageTexts.join("\n").trim();
+  if (!text) {
+    throw new PdfTextExtractionError("No embedded PDF text was found.");
+  }
+
+  return text;
+};
+```
+
+- [ ] **Step 2: Typecheck helper**
+
+Run:
+
+```powershell
+npm run typecheck
+```
+
+Expected: PASS. If `pdfjs-dist` type imports differ for the installed version, adjust imports in `pdfText.ts` only.
+
+- [ ] **Step 3: Commit helper**
+
+Run:
+
+```powershell
+git add src/lib/authorizations/pdfText.ts
+git commit -m "feat: add WIN-179 browser PDF text extraction"
+```
+
+---
+
+### Task 5: Add Wizard Prefill Integration Tests
+
+**Files:**
+- Modify: `src/components/__tests__/PreAuthTab.test.tsx`
+
+- [ ] **Step 1: Mock PDF extraction**
+
+Add `extractPdfTextMock` to the hoisted mock block:
+
+```ts
+const extractPdfTextMock = vi.fn();
+```
+
+Return it from the hoisted object and add:
+
+```ts
+vi.mock("../../lib/authorizations/pdfText", () => ({
+  extractPdfText: extractPdfTextMock,
+}));
+```
+
+Reset it in `beforeEach`:
+
+```ts
+extractPdfTextMock.mockResolvedValue("");
+```
+
+- [ ] **Step 2: Add prefill integration test**
+
+Append this test to `PreAuthTab.test.tsx`:
+
+```ts
+it("prefills empty wizard fields from uploaded PDF text and submits reviewed values", async () => {
+  extractPdfTextMock.mockResolvedValue(`
+    Authorization #: PDF-AUTH-777
+    Status: Approved
+    Member ID: MEM-PDF-777
+    Diagnosis: F84.0 Autistic disorder
+    Service From: 06/23/2026
+    Service To: 12/22/2026
+    Procedure Code 97153
+    Approved Units: 96
+  `);
+
+  const user = userEvent.setup();
+  renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+  await user.click(screen.getByRole("button", { name: /new authorization/i }));
+  await screen.findByRole("heading", { name: /authorization notice details/i });
+  await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+  await waitFor(() => {
+    expect(screen.getByLabelText(/rendering therapist/i)).toHaveValue("therapist-provider-1");
+  });
+  await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
+
+  await user.click(screen.getByRole("button", { name: /next/i }));
+  await user.click(screen.getByRole("button", { name: /next/i }));
+  await user.click(screen.getByRole("button", { name: /next/i }));
+
+  const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+  const file = new File(["synthetic pdf bytes"], "prefill-auth.pdf", { type: "application/pdf" });
+  await user.upload(fileInput, file);
+
+  expect(await screen.findByText(/PDF prefill applied/i)).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: /next/i }));
+  expect(screen.getByText(/PDF-AUTH-777/)).toBeInTheDocument();
+  expect(screen.getByText(/2026-06-23 - 2026-12-22/)).toBeInTheDocument();
+  expect(screen.getByText(/97153/)).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: /submit request/i }));
+
+  await waitFor(() => {
+    expect(createAuthorizationWithServices).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization_number: "PDF-AUTH-777",
+        member_id: "MEM-PDF-777",
+        start_date: "2026-06-23",
+        end_date: "2026-12-22",
+        services: [
+          expect.objectContaining({
+            service_code: "97153",
+            requested_units: 96,
+            approved_units: 96,
+          }),
+        ],
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Add no-overwrite integration test**
+
+Append:
+
+```ts
+it("does not overwrite admin-entered notice fields when PDF prefill runs", async () => {
+  extractPdfTextMock.mockResolvedValue(`
+    Authorization #: PDF-AUTH-SHOULD-NOT-WIN
+    Service From: 06/23/2026
+    Service To: 12/22/2026
+    Procedure Code 97153
+    Approved Units: 96
+  `);
+
+  const user = userEvent.setup();
+  renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+  await user.click(screen.getByRole("button", { name: /new authorization/i }));
+  await screen.findByRole("heading", { name: /authorization notice details/i });
+  await user.type(screen.getByLabelText(/authorization number/i), "ADMIN-AUTH-1");
+  await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+  await waitFor(() => {
+    expect(screen.getByLabelText(/rendering therapist/i)).toHaveValue("therapist-provider-1");
+  });
+  await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
+
+  await user.click(screen.getByRole("button", { name: /next/i }));
+  await user.click(screen.getByRole("button", { name: /next/i }));
+  await user.click(screen.getByRole("button", { name: /next/i }));
+
+  const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+  await user.upload(fileInput, new File(["synthetic pdf bytes"], "prefill-auth.pdf", { type: "application/pdf" }));
+  expect(await screen.findByText(/PDF prefill applied/i)).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: /next/i }));
+  expect(screen.getByText(/ADMIN-AUTH-1/)).toBeInTheDocument();
+  expect(screen.queryByText(/PDF-AUTH-SHOULD-NOT-WIN/)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 4: Run component tests and confirm they fail**
+
+Run:
+
+```powershell
+npm test -- src/components/__tests__/PreAuthTab.test.tsx
+```
+
+Expected: FAIL because `PreAuthTab.tsx` does not call `extractPdfText` or render status yet.
+
+---
+
+### Task 6: Implement Wizard Extraction State And UI Banner
+
+**Files:**
+- Modify: `src/components/ClientDetails/PreAuthTab.tsx`
+- Test: `src/components/__tests__/PreAuthTab.test.tsx`
+
+- [ ] **Step 1: Import helpers**
+
+Add imports:
+
+```ts
+import { extractPdfText, PdfTextExtractionError } from '../../lib/authorizations/pdfText';
+import { mergeAuthorizationPdfPrefill, parseAuthorizationPdfText } from '../../lib/authorizations/pdfPrefill';
+```
+
+- [ ] **Step 2: Add extraction state type near wizard data**
+
+Add:
+
+```ts
+type PdfPrefillState =
+  | { status: 'idle' }
+  | { status: 'extracting'; fileName: string }
+  | { status: 'applied'; appliedFields: string[]; skippedServiceCodes: string[] }
+  | { status: 'no_text'; fileName: string }
+  | { status: 'failed'; fileName: string; message: string };
+```
+
+- [ ] **Step 3: Add component state**
+
+Inside `PreAuthTab` state declarations:
+
+```ts
+const [pdfPrefillState, setPdfPrefillState] = useState<PdfPrefillState>({ status: 'idle' });
+```
+
+- [ ] **Step 4: Reset state on successful submit and wizard cancel/open**
+
+After successful submit reset:
+
+```ts
+setPdfPrefillState({ status: 'idle' });
+```
+
+Replace `onClick={() => setIsWizardOpen(true)}` for new authorization with:
+
+```ts
+onClick={() => {
+  setPdfPrefillState({ status: 'idle' });
+  setIsWizardOpen(true);
+}}
+```
+
+In current-step cancel branch before closing:
+
+```ts
+setPdfPrefillState({ status: 'idle' });
+```
+
+- [ ] **Step 5: Add prefill application function**
+
+Add above `handleFilesAdded`:
+
+```ts
+const applyPdfPrefillFromFiles = async (files: File[]) => {
+  const pdfFile = files.find((file) => file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf'));
+  if (!pdfFile) {
+    return;
+  }
+
+  setPdfPrefillState({ status: 'extracting', fileName: pdfFile.name });
+
+  try {
+    const text = await extractPdfText(pdfFile);
+    const prefill = parseAuthorizationPdfText(text);
+    if (
+      !prefill.authorizationNumber &&
+      !prefill.startDate &&
+      !prefill.endDate &&
+      !prefill.memberId &&
+      !prefill.diagnosisCode &&
+      prefill.services.length === 0
+    ) {
+      setPdfPrefillState({ status: 'no_text', fileName: pdfFile.name });
+      return;
+    }
+
+    let appliedFields: string[] = [];
+    let skippedServiceCodes: string[] = [];
+    setWizardData((prev) => {
+      const result = mergeAuthorizationPdfPrefill(prev, prefill, serviceCatalog);
+      appliedFields = result.appliedFields;
+      skippedServiceCodes = result.skippedServiceCodes;
+      return result.data;
+    });
+
+    setPdfPrefillState({ status: 'applied', appliedFields, skippedServiceCodes });
+  } catch (error) {
+    const message =
+      error instanceof PdfTextExtractionError || error instanceof Error
+        ? error.message
+        : 'PDF text extraction failed.';
+    setPdfPrefillState({ status: 'failed', fileName: pdfFile.name, message });
+  }
+};
+```
+
+- [ ] **Step 6: Trigger extraction after accepted files are stored**
+
+At the end of `handleFilesAdded`, after `setWizardData`:
+
+```ts
+void applyPdfPrefillFromFiles(acceptedFiles);
+```
+
+- [ ] **Step 7: Render status banner in Step 4**
+
+Add below the upload drop zone:
+
+```tsx
+{pdfPrefillState.status !== 'idle' && (
+  <div className="mt-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-200">
+    {pdfPrefillState.status === 'extracting' && (
+      <p>Reading {pdfPrefillState.fileName} for authorization prefill...</p>
+    )}
+    {pdfPrefillState.status === 'applied' && (
+      <div>
+        <p className="font-medium">PDF prefill applied. Review extracted values before submitting.</p>
+        <p className="text-xs">
+          Applied fields: {pdfPrefillState.appliedFields.length > 0 ? pdfPrefillState.appliedFields.join(', ') : 'none'}
+        </p>
+        {pdfPrefillState.skippedServiceCodes.length > 0 && (
+          <p className="text-xs">
+            Skipped service codes not in catalog: {pdfPrefillState.skippedServiceCodes.join(', ')}
+          </p>
+        )}
+      </div>
+    )}
+    {pdfPrefillState.status === 'no_text' && (
+      <p>No embedded authorization text was found in {pdfPrefillState.fileName}. Enter the notice fields manually.</p>
+    )}
+    {pdfPrefillState.status === 'failed' && (
+      <p>
+        Could not prefill from {pdfPrefillState.fileName}: {pdfPrefillState.message} Enter the notice fields manually.
+      </p>
+    )}
+  </div>
+)}
+```
+
+- [ ] **Step 8: Run component tests**
+
+Run:
+
+```powershell
+npm test -- src/components/__tests__/PreAuthTab.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit wizard integration**
+
+Run:
+
+```powershell
+git add src/components/ClientDetails/PreAuthTab.tsx src/components/__tests__/PreAuthTab.test.tsx
+git commit -m "feat: add WIN-179 authorization PDF prefill to wizard"
+```
+
+---
+
+### Task 7: Focused Verification
+
+**Files:**
+- No code edits expected.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```powershell
+npm test -- src/lib/authorizations/__tests__/pdfPrefill.test.ts src/components/__tests__/PreAuthTab.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run policy checks**
+
+Run:
+
+```powershell
+npm run ci:check-focused
+```
+
+Expected: PASS. Record any local-only skips separately.
+
+- [ ] **Step 3: Run lint**
+
+Run:
+
+```powershell
+npm run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run typecheck**
+
+Run:
+
+```powershell
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run CI tests**
+
+Run:
+
+```powershell
+npm run test:ci
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run tenant safety**
+
+Run:
+
+```powershell
+npm run validate:tenant
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run build**
+
+Run:
+
+```powershell
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run local verification bundle if feasible**
+
+Run:
+
+```powershell
+npm run verify:local
+```
+
+Expected: PASS or explicitly blocked with reason. If it fails on unrelated broad harness issues, keep the focused verification evidence and report the failing command and first actionable failure.
+
+---
+
+### Task 8: Verify-Change, Review, PR Hygiene, And PR
+
+**Files:**
+- No code edits expected unless review finds a required fix.
+
+- [ ] **Step 1: Produce verify-change card**
+
+Use `.agents/skills/verify-change/SKILL.md` and report:
+
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Change type: UI/component/page, tenant-scoped authorization document handling
+- Required checks: exact command list from Task 7
+- Executed checks: command results
+- Blocked checks: command plus reason, or `none`
+- Result: `pass`, `pass-with-blocked-checks`, or `fail`
+- Residual risk: embedded-text PDFs only; scanned PDFs require separately routed OCR
+
+- [ ] **Step 2: Run reviewer pass**
+
+Reviewer focus:
+
+- no raw extracted PDF text is logged, stored, submitted, or committed
+- no route guard or role boundary regression
+- no schema/RLS/RPC/storage-policy drift
+- no admin-entered value overwrite
+- no unsupported service code saved
+
+- [ ] **Step 3: Run pr-hygiene**
+
+Use `.agents/skills/pr-hygiene/SKILL.md`.
+
+Expected:
+
+- `pr-ready`: yes only if verification and reviewer pass
+- `linear-ready`: yes for `WIN-179`
+- `single-purpose`: yes
+- `protected-path drift`: none beyond classified critical behavior
+
+- [ ] **Step 4: Push branch and open PR**
+
+Run:
+
+```powershell
+git status --short --branch
+git push -u origin codex/win-179-auth-pdf-prefill
+gh pr create --draft --title "WIN-179 Add authorization PDF extraction-assisted prefill" --body "## Summary
+- add browser-side embedded PDF text extraction for the admin authorization upload wizard
+- parse authorization notice fields into conservative prefill candidates
+- require admin review and preserve the existing authorization save path
+
+## Verification
+- npm test -- src/lib/authorizations/__tests__/pdfPrefill.test.ts src/components/__tests__/PreAuthTab.test.tsx
+- npm run ci:check-focused
+- npm run lint
+- npm run typecheck
+- npm run test:ci
+- npm run validate:tenant
+- npm run build
+- npm run verify:local
+
+## Risk
+- critical-lane change because uploaded authorization documents influence tenant-scoped authorization writes
+- no OCR, AI extraction, server/API changes, schema changes, or raw extracted text persistence"
+```
+
+Expected: draft PR created for human review. Do not merge autonomously without live branch protection allowing it and required human review being satisfied.

--- a/docs/superpowers/specs/2026-06-19-authorization-pdf-prefill-design.md
+++ b/docs/superpowers/specs/2026-06-19-authorization-pdf-prefill-design.md
@@ -1,0 +1,132 @@
+# Authorization PDF Prefill Design
+
+## Summary
+
+Add extraction-assisted prefill to the existing admin/super-admin authorization upload wizard. When an admin uploads an authorization PDF, the browser extracts embedded PDF text, parses known authorization fields, and fills only safe empty wizard fields before the admin reviews and submits.
+
+This first slice does not add server-side OCR, AI extraction, background processing, schema changes, or automatic submission.
+
+## Route Classification
+
+- `exact issue key used`: `WIN-179`
+- `classification`: `high-risk human-reviewed`
+- `lane`: `critical`
+- `why`: the feature handles authorization documents and influences tenant-scoped authorization records.
+- `triggering paths`:
+  - `src/components/ClientDetails/PreAuthTab.tsx`
+  - `src/lib/authorizations/**`
+  - `src/components/__tests__/PreAuthTab.test.tsx`
+  - package dependency files if a browser PDF text extraction dependency is required
+- `required agents`: `specification-engineer` -> `software-architect` -> `implementation-engineer` -> `code-review-engineer` -> `test-engineer` -> `security-engineer`
+- `reviewer required`: yes
+- `verify-change required`: yes
+- `linear required`: yes before PR-ready state
+
+## Goals
+
+- Help admins reduce manual data entry when uploading authorization PDFs.
+- Preserve the current manual upload workflow when extraction fails or returns incomplete data.
+- Keep all extraction local to the browser for this slice.
+- Require admin review before any authorization data is saved.
+- Avoid storing raw extracted text.
+- Use synthetic test fixtures only.
+
+## Non-Goals
+
+- No BT or therapist access changes.
+- No route guard changes.
+- No server-side OCR or AI document processing.
+- No Supabase schema, RLS, grant, RPC, or storage policy changes.
+- No automatic authorization creation from PDF upload alone.
+- No use of real member documents in tests or committed fixtures.
+
+## User Flow
+
+1. An admin opens the client record and selects the Pre-Authorizations tab.
+2. The admin starts the existing new authorization wizard.
+3. The admin uploads one or more authorization PDF documents in the document upload step.
+4. For each PDF candidate, the app attempts embedded text extraction in the browser.
+5. The parser maps recognized fields into a prefill candidate.
+6. The wizard applies the candidate only to empty fields or safe service-code matches.
+7. The UI shows extraction status and reminds the admin to review values.
+8. The admin edits any value and submits through the existing authorization save path.
+
+## Architecture
+
+### PDF Text Extraction
+
+Create a small browser-only helper that accepts a `File` and returns extracted text for PDFs with embedded text. It should reject unsupported files and return a clear failure for scanned image-only PDFs.
+
+The helper must not upload the file, call external services, or persist raw text.
+
+### Deterministic Parser
+
+Create a pure parser that accepts plain text and returns a partial prefill object. It should recognize common authorization notice shapes seen in IEHP and CalOptima-style documents:
+
+- authorization or referral number
+- status
+- start and end dates
+- member ID or CIN
+- diagnosis code and nearby description
+- service codes and requested or approved units
+
+The parser should normalize dates to `YYYY-MM-DD` and leave ambiguous values unset.
+
+### Wizard Merge Rules
+
+The wizard should merge extracted values conservatively:
+
+- Fill blank scalar fields only.
+- Do not overwrite values the admin already typed.
+- Add service codes only when the code exists in the loaded CPT/service catalog.
+- Set units only for services that are selected by the merge and have a valid positive integer unit value.
+- Prefer approved units over requested units when both are present.
+- Leave unknown service codes visible only as extraction status text, not as saved service rows.
+
+### UI Feedback
+
+The document step should show one compact extraction status banner:
+
+- extracting PDF text
+- prefilled fields applied and review required
+- no embedded text found, manual entry required
+- extraction failed, manual entry still available
+- extracted unsupported service codes skipped
+
+The status must not display raw document text.
+
+## Security And Privacy
+
+- Extraction runs client-side only.
+- Raw extracted text is held in memory only while parsing.
+- Raw extracted text is not logged, stored, submitted, or committed.
+- Existing admin/super-admin route and tab access remains the enforcement boundary.
+- Existing tenant/org-scoped save behavior remains the only write path.
+- Real PHI documents must not be added to the repository as fixtures.
+
+## Testing Strategy
+
+Add pure parser tests using synthetic text that resembles authorization notices without real member data.
+
+Add component coverage for the wizard by mocking PDF text extraction:
+
+- uploading a PDF can prefill empty authorization fields
+- admin-entered fields are not overwritten
+- recognized service codes are selected only when present in the service catalog
+- unknown service codes are skipped and shown in status
+- extraction failure leaves the manual flow usable
+
+Required verification for implementation:
+
+- `npm run ci:check-focused`
+- `npm run lint`
+- `npm run typecheck`
+- targeted Vitest tests for parser and wizard behavior
+- `npm run test:ci`
+- `npm run validate:tenant`
+- `npm run build`
+- `npm run verify:local` when local environment supports the required checks
+
+## Residual Risk
+
+Embedded-text PDF extraction will not work for scanned image-only documents. This is an intentional limitation of the first slice. If scanned PDFs are common, OCR must be evaluated as a separate routed slice with explicit PHI, server/API, cost, and security review.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "geolib": "^3.3.4",
         "isomorphic-dompurify": "^3.1.0",
         "lucide-react": "^0.344.0",
-        "pdfjs-dist": "^5.1.91",
+        "pdfjs-dist": "5.1.91",
         "pg": "^8.20.0",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "geolib": "^3.3.4",
         "isomorphic-dompurify": "^3.1.0",
         "lucide-react": "^0.344.0",
-        "pdfjs-dist": "^6.0.227",
+        "pdfjs-dist": "^5.1.91",
         "pg": "^8.20.0",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.3.1",
@@ -1680,9 +1680,9 @@
       }
     },
     "node_modules/@napi-rs/canvas": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.0.tgz",
-      "integrity": "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
       "license": "MIT",
       "optional": true,
       "workspaces": [
@@ -1696,23 +1696,23 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "1.0.0",
-        "@napi-rs/canvas-darwin-arm64": "1.0.0",
-        "@napi-rs/canvas-darwin-x64": "1.0.0",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0",
-        "@napi-rs/canvas-linux-arm64-gnu": "1.0.0",
-        "@napi-rs/canvas-linux-arm64-musl": "1.0.0",
-        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0",
-        "@napi-rs/canvas-linux-x64-gnu": "1.0.0",
-        "@napi-rs/canvas-linux-x64-musl": "1.0.0",
-        "@napi-rs/canvas-win32-arm64-msvc": "1.0.0",
-        "@napi-rs/canvas-win32-x64-msvc": "1.0.0"
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.0.tgz",
-      "integrity": "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
       "cpu": [
         "arm64"
       ],
@@ -1730,9 +1730,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.0.tgz",
-      "integrity": "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
       "cpu": [
         "arm64"
       ],
@@ -1750,9 +1750,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.0.tgz",
-      "integrity": "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
       "cpu": [
         "x64"
       ],
@@ -1770,9 +1770,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.0.tgz",
-      "integrity": "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
       "cpu": [
         "arm"
       ],
@@ -1790,9 +1790,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.0.tgz",
-      "integrity": "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
       "cpu": [
         "arm64"
       ],
@@ -1810,9 +1810,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.0.tgz",
-      "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
       ],
@@ -1830,9 +1830,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.0.tgz",
-      "integrity": "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
       "cpu": [
         "riscv64"
       ],
@@ -1850,9 +1850,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.0.tgz",
-      "integrity": "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
       "cpu": [
         "x64"
       ],
@@ -1870,9 +1870,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.0.tgz",
-      "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
       ],
@@ -1890,9 +1890,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.0.tgz",
-      "integrity": "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
       "cpu": [
         "arm64"
       ],
@@ -1910,9 +1910,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.0.tgz",
-      "integrity": "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
       "cpu": [
         "x64"
       ],
@@ -8360,15 +8360,15 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "6.0.227",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.0.227.tgz",
-      "integrity": "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==",
+      "version": "5.1.91",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.1.91.tgz",
+      "integrity": "sha512-qSIADdagooJB4wWCBnrBJjRvASevmxL0BwafvOuKJG5uTQdYoFBrhrRYnucKNiSc9qS6JIk0hC5y1yktFljXkA==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=22.13.0 || >=24"
+        "node": ">=20"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^1.0.0"
+        "@napi-rs/canvas": "^0.1.67"
       }
     },
     "node_modules/pend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "geolib": "^3.3.4",
         "isomorphic-dompurify": "^3.1.0",
         "lucide-react": "^0.344.0",
+        "pdfjs-dist": "^6.0.227",
         "pg": "^8.20.0",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.3.1",
@@ -1676,6 +1677,256 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.0.tgz",
+      "integrity": "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-x64": "1.0.0",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.0",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.0",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.0",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8106,6 +8357,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "6.0.227",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.0.227.tgz",
+      "integrity": "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^1.0.0"
       }
     },
     "node_modules/pend": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "geolib": "^3.3.4",
     "isomorphic-dompurify": "^3.1.0",
     "lucide-react": "^0.344.0",
-    "pdfjs-dist": "^5.1.91",
+    "pdfjs-dist": "5.1.91",
     "pg": "^8.20.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "geolib": "^3.3.4",
     "isomorphic-dompurify": "^3.1.0",
     "lucide-react": "^0.344.0",
-    "pdfjs-dist": "^6.0.227",
+    "pdfjs-dist": "^5.1.91",
     "pg": "^8.20.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "geolib": "^3.3.4",
     "isomorphic-dompurify": "^3.1.0",
     "lucide-react": "^0.344.0",
+    "pdfjs-dist": "^6.0.227",
     "pg": "^8.20.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.1",

--- a/scripts/playwright-session-note-measurement-roundtrip.ts
+++ b/scripts/playwright-session-note-measurement-roundtrip.ts
@@ -123,25 +123,58 @@ const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): P
   }
 };
 
-const openEditSessionModalFromCalendar = async (page: Page, scheduleUrl: string, sessionId: string): Promise<void> => {
-  for (let attempt = 0; attempt < 12; attempt += 1) {
-    await page.goto(`${scheduleUrl}?_${Date.now()}`, {
-      waitUntil: "networkidle",
-      timeout: 60000,
-    });
-    const sessionCard = page.locator(`[data-session-id="${sessionId}"]`).first();
-    try {
-      await sessionCard.waitFor({ state: "visible", timeout: 12_000 });
-      await sessionCard.scrollIntoViewIfNeeded();
-      await sessionCard.click();
-      const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
-      await dialog.waitFor({ state: "visible", timeout: 12_000 });
-      return;
-    } catch {
-      await page.waitForTimeout(500 + attempt * 250);
+const openEditSessionModalFromCalendar = async (
+  page: Page,
+  scheduleUrl: string,
+  sessionId: string,
+  sessionStartIso?: string,
+): Promise<void> => {
+  await page.goto(`${scheduleUrl}?_${Date.now()}`, {
+    waitUntil: "networkidle",
+    timeout: 60000,
+  });
+
+  let visitedPeriods = 0;
+  for (let periodAttempt = 0; periodAttempt < 8; periodAttempt += 1) {
+    visitedPeriods = periodAttempt + 1;
+    let sessionCardVisible = false;
+
+    for (let samePeriodAttempt = 0; samePeriodAttempt < 3; samePeriodAttempt += 1) {
+      const sessionCard = page.locator(`[data-session-id="${sessionId}"]`).first();
+      sessionCardVisible = await sessionCard
+        .waitFor({ state: "visible", timeout: samePeriodAttempt === 0 ? 12_000 : 4_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (!sessionCardVisible) {
+        break;
+      }
+
+      try {
+        await sessionCard.scrollIntoViewIfNeeded();
+        await sessionCard.click();
+        const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
+        await dialog.waitFor({ state: "visible", timeout: 12_000 });
+        return;
+      } catch {
+        await page.waitForTimeout(500 + samePeriodAttempt * 250);
+      }
     }
+
+    if (sessionCardVisible) {
+      continue;
+    }
+
+    const nextPeriodButton = page.getByRole("button", { name: /next period/i }).first();
+    if ((await nextPeriodButton.count()) === 0) {
+      break;
+    }
+    await nextPeriodButton.click();
+    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
+    await page.waitForTimeout(500 + periodAttempt * 250);
   }
-  throw new Error("Session modal (Edit Session / Live session) did not open from the rendered schedule card.");
+  throw new Error(
+    `Session modal (Edit Session / Live session) did not open from the rendered schedule card after ${visitedPeriods} schedule period(s). sessionStartIso=${sessionStartIso ?? "unknown"}`,
+  );
 };
 
 const ensureGoalCaptureFieldsVisible = async (dialog: ReturnType<Page["locator"]>, goalId: string): Promise<void> => {
@@ -410,7 +443,7 @@ async function run(): Promise<void> {
     });
 
     await withStepTimeout("open-session-modal-clinical", async () => {
-      await openEditSessionModalFromCalendar(activePage, scheduleUrl, booked.sessionId);
+      await openEditSessionModalFromCalendar(activePage, scheduleUrl, booked.sessionId, booked.startIso);
       const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
       await selectFirstOptionIfEmpty(
         editDialog.first().locator('#session-note-auth-select, select[name="session_note_authorization_id"]'),

--- a/scripts/playwright-session-note-measurement-roundtrip.ts
+++ b/scripts/playwright-session-note-measurement-roundtrip.ts
@@ -29,11 +29,6 @@ import {
   type LifecycleIds,
 } from "./lib/playwright-inprogress-session-setup";
 
-const SCHEDULE_MODAL_MODE_KEY = "scheduleModal";
-const SCHEDULE_MODAL_SESSION_KEY = "scheduleSessionId";
-const SCHEDULE_MODAL_EXPIRY_KEY = "scheduleExp";
-const SCHEDULE_MODAL_URL_TTL_MS = 30 * 60 * 1000;
-
 const getEnv = (key: string, fallback?: string): string => {
   const value = process.env[key] ?? fallback;
   if (!value) {
@@ -128,30 +123,25 @@ const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): P
   }
 };
 
-const buildScheduleEditSessionUrl = (scheduleUrl: string, sessionId: string): string => {
-  const url = new URL(scheduleUrl);
-  const expiresAtMs = Date.now() + SCHEDULE_MODAL_URL_TTL_MS;
-  url.searchParams.set(SCHEDULE_MODAL_MODE_KEY, "edit");
-  url.searchParams.set(SCHEDULE_MODAL_SESSION_KEY, sessionId);
-  url.searchParams.set(SCHEDULE_MODAL_EXPIRY_KEY, String(expiresAtMs));
-  return url.toString();
-};
-
-const openEditSessionModalFromUrl = async (page: Page, scheduleUrl: string, sessionId: string): Promise<void> => {
+const openEditSessionModalFromCalendar = async (page: Page, scheduleUrl: string, sessionId: string): Promise<void> => {
   for (let attempt = 0; attempt < 12; attempt += 1) {
-    await page.goto(buildScheduleEditSessionUrl(scheduleUrl, sessionId), {
+    await page.goto(`${scheduleUrl}?_${Date.now()}`, {
       waitUntil: "networkidle",
       timeout: 60000,
     });
-    const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
+    const sessionCard = page.locator(`[data-session-id="${sessionId}"]`).first();
     try {
+      await sessionCard.waitFor({ state: "visible", timeout: 12_000 });
+      await sessionCard.scrollIntoViewIfNeeded();
+      await sessionCard.click();
+      const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
       await dialog.waitFor({ state: "visible", timeout: 12_000 });
       return;
     } catch {
       await page.waitForTimeout(500 + attempt * 250);
     }
   }
-  throw new Error("Session modal (Edit Session / Live session) did not open from schedule deep link.");
+  throw new Error("Session modal (Edit Session / Live session) did not open from the rendered schedule card.");
 };
 
 const ensureGoalCaptureFieldsVisible = async (dialog: ReturnType<Page["locator"]>, goalId: string): Promise<void> => {
@@ -420,7 +410,7 @@ async function run(): Promise<void> {
     });
 
     await withStepTimeout("open-session-modal-clinical", async () => {
-      await openEditSessionModalFromUrl(activePage, scheduleUrl, booked.sessionId);
+      await openEditSessionModalFromCalendar(activePage, scheduleUrl, booked.sessionId);
       const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
       await selectFirstOptionIfEmpty(
         editDialog.first().locator('#session-note-auth-select, select[name="session_note_authorization_id"]'),

--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -10,6 +10,8 @@ import { showError, showSuccess } from '../../lib/toast';
 import { useActiveOrganizationId } from '../../lib/organization';
 import { useAuth } from '../../lib/authContext';
 import { createAuthorizationWithServices, updateAuthorizationDocuments } from '../../lib/authorizations/mutations';
+import { parseAuthorizationPdfText, mergeAuthorizationPdfPrefill } from '../../lib/authorizations/pdfPrefill';
+import { extractPdfText, PdfTextExtractionError } from '../../lib/authorizations/pdfText';
 
 interface PreAuthTabProps {
   client: { id: string };
@@ -71,7 +73,16 @@ interface PreAuthWizardData {
   memberId: string;
 }
 
+type PdfPrefillState =
+  | { status: 'idle'; skippedServiceCodes: string[] }
+  | { status: 'extracting'; skippedServiceCodes: string[] }
+  | { status: 'applied'; skippedServiceCodes: string[] }
+  | { status: 'no_text'; message: string; skippedServiceCodes: string[] }
+  | { status: 'failed'; message: string; skippedServiceCodes: string[] };
+
 const AUTHORIZATION_STATUSES: AuthorizationStatus[] = ['approved', 'pending', 'denied'];
+const NO_EMBEDDED_PDF_TEXT_MESSAGE = 'No embedded PDF text was found.';
+const GENERIC_PDF_PREFILL_ERROR_MESSAGE = 'PDF text extraction failed. Enter the authorization fields manually.';
 
 const createEmptyWizardData = (): PreAuthWizardData => ({
   insurance: '',
@@ -108,6 +119,11 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   const [selectedAuthorizationForView, setSelectedAuthorizationForView] = useState<Authorization | null>(null);
   const [currentStep, setCurrentStep] = useState(1);
   const [wizardData, setWizardData] = useState<PreAuthWizardData>(() => createEmptyWizardData());
+  const [pdfPrefillState, setPdfPrefillState] = useState<PdfPrefillState>({
+    status: 'idle',
+    skippedServiceCodes: [],
+  });
+  const [hasAdminEditedStatus, setHasAdminEditedStatus] = useState(false);
   const [isDragActive, setIsDragActive] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -436,6 +452,84 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   const handlePrevStep = () => {
     setCurrentStep(prev => Math.max(prev - 1, 1));
   };
+
+  const resetPdfPrefillState = () => {
+    setPdfPrefillState({ status: 'idle', skippedServiceCodes: [] });
+    setHasAdminEditedStatus(false);
+  };
+
+  const resetWizardForNewAuthorization = () => {
+    setCurrentStep(1);
+    setWizardData(createEmptyWizardData());
+    resetPdfPrefillState();
+  };
+
+  const openNewAuthorizationWizard = () => {
+    resetWizardForNewAuthorization();
+    setIsWizardOpen(true);
+  };
+
+  const closeWizard = () => {
+    setIsWizardOpen(false);
+    resetWizardForNewAuthorization();
+  };
+
+  const prefillHasStructuredValues = (prefill: ReturnType<typeof parseAuthorizationPdfText>) => {
+    return Boolean(
+      prefill.authorizationNumber ||
+        prefill.status ||
+        prefill.startDate ||
+        prefill.endDate ||
+        prefill.diagnosisCode ||
+        prefill.diagnosisDescription ||
+        prefill.memberId ||
+        prefill.services.length > 0,
+    );
+  };
+
+  const applyPdfPrefillFromFiles = async (files: File[]) => {
+    const pdfFile = files.find((file) => file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf'));
+    if (!pdfFile) {
+      return;
+    }
+
+    setPdfPrefillState({ status: 'extracting', skippedServiceCodes: [] });
+
+    try {
+      const extractedText = await extractPdfText(pdfFile);
+      const parsedPrefill = parseAuthorizationPdfText(extractedText);
+
+      if (!prefillHasStructuredValues(parsedPrefill)) {
+        setPdfPrefillState({
+          status: 'no_text',
+          message: NO_EMBEDDED_PDF_TEXT_MESSAGE,
+          skippedServiceCodes: [],
+        });
+        return;
+      }
+
+      setWizardData((prev) => {
+        const mergeResult = mergeAuthorizationPdfPrefill(prev, parsedPrefill, serviceCatalog, {
+          statusFieldIsDefault: !hasAdminEditedStatus,
+        });
+        setPdfPrefillState({
+          status: 'applied',
+          skippedServiceCodes: mergeResult.skippedServiceCodes,
+        });
+        return mergeResult.data;
+      });
+    } catch (error) {
+      const message =
+        error instanceof PdfTextExtractionError
+          ? error.message
+          : GENERIC_PDF_PREFILL_ERROR_MESSAGE;
+      setPdfPrefillState({
+        status: message === NO_EMBEDDED_PDF_TEXT_MESSAGE ? 'no_text' : 'failed',
+        message,
+        skippedServiceCodes: [],
+      });
+    }
+  };
   
   const handleWizardSubmit = async () => {
     if (!organizationId || !user?.id) {
@@ -553,6 +647,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       setIsWizardOpen(false);
       setCurrentStep(1);
       setWizardData(createEmptyWizardData());
+      resetPdfPrefillState();
     } catch (error) {
       showError(error instanceof Error ? error.message : 'Failed to submit pre-authorization.');
     } finally {
@@ -561,6 +656,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   };
   
   const handleRenewAuthorization = (auth: Authorization) => {
+    resetPdfPrefillState();
     setWizardData({
       ...createEmptyWizardData(),
       insurance: auth.insurance_provider?.name ?? '',
@@ -608,6 +704,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       return;
     }
 
+    void applyPdfPrefillFromFiles(acceptedFiles);
     setWizardData((prev) => ({
       ...prev,
       documents: [...prev.documents, ...acceptedFiles],
@@ -636,7 +733,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
             Authorization Tracker
           </h3>
           <button
-            onClick={() => setIsWizardOpen(true)}
+            onClick={openNewAuthorizationWizard}
             className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 flex items-center"
           >
             <Plus className="w-4 h-4 mr-1" />
@@ -948,7 +1045,10 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                         <select
                           id="preauth-status"
                           value={wizardData.status}
-                          onChange={(e) => setWizardData({ ...wizardData, status: e.target.value as AuthorizationStatus })}
+                          onChange={(e) => {
+                            setHasAdminEditedStatus(true);
+                            setWizardData({ ...wizardData, status: e.target.value as AuthorizationStatus });
+                          }}
                           className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                         >
                           {AUTHORIZATION_STATUSES.map((status) => (
@@ -1278,6 +1378,37 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                       }}
                     />
                   </div>
+
+                  {pdfPrefillState.status !== 'idle' && (
+                    <div className="mt-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-200">
+                      {pdfPrefillState.status === 'extracting' && (
+                        <p className="font-medium">Extracting authorization PDF...</p>
+                      )}
+                      {pdfPrefillState.status === 'applied' && (
+                        <>
+                          <p className="font-medium">PDF prefill applied.</p>
+                          <p className="mt-1">Review extracted fields before submitting.</p>
+                        </>
+                      )}
+                      {pdfPrefillState.status === 'no_text' && (
+                        <>
+                          <p className="font-medium">{pdfPrefillState.message}</p>
+                          <p className="mt-1">Manual entry remains available.</p>
+                        </>
+                      )}
+                      {pdfPrefillState.status === 'failed' && (
+                        <>
+                          <p className="font-medium">{pdfPrefillState.message}</p>
+                          <p className="mt-1">Manual entry remains available.</p>
+                        </>
+                      )}
+                      {pdfPrefillState.skippedServiceCodes.length > 0 && (
+                        <p className="mt-1">
+                          Unsupported service codes skipped: {pdfPrefillState.skippedServiceCodes.join(', ')}
+                        </p>
+                      )}
+                    </div>
+                  )}
                   
                   {wizardData.documents.length > 0 && (
                     <div className="mt-4">
@@ -1408,7 +1539,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                 type="button"
                 onClick={() => {
                   if (currentStep === 1) {
-                    setIsWizardOpen(false);
+                    closeWizard();
                   } else {
                     handlePrevStep();
                   }

--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -153,10 +153,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       return acc;
     }, {});
   }, [cptCodes]);
-
-  useEffect(() => {
-    serviceCatalogRef.current = serviceCatalog;
-  }, [serviceCatalog]);
+  serviceCatalogRef.current = serviceCatalog;
 
   const cptCodeOptions = useMemo(() => {
     return cptCodes.map((code) => ({

--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -127,6 +127,9 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   const [isDragActive, setIsDragActive] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const pdfPrefillGenerationRef = useRef(0);
+  const hasAdminEditedStatusRef = useRef(false);
+  const serviceCatalogRef = useRef<Record<string, string>>({});
   const {
     data: cptCodes = [],
     isLoading: isLoadingCptCodes,
@@ -150,6 +153,10 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       return acc;
     }, {});
   }, [cptCodes]);
+
+  useEffect(() => {
+    serviceCatalogRef.current = serviceCatalog;
+  }, [serviceCatalog]);
 
   const cptCodeOptions = useMemo(() => {
     return cptCodes.map((code) => ({
@@ -454,7 +461,9 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   };
 
   const resetPdfPrefillState = () => {
+    pdfPrefillGenerationRef.current += 1;
     setPdfPrefillState({ status: 'idle', skippedServiceCodes: [] });
+    hasAdminEditedStatusRef.current = false;
     setHasAdminEditedStatus(false);
   };
 
@@ -493,11 +502,20 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       return;
     }
 
+    const generation = pdfPrefillGenerationRef.current + 1;
+    pdfPrefillGenerationRef.current = generation;
     setPdfPrefillState({ status: 'extracting', skippedServiceCodes: [] });
 
     try {
       const extractedText = await extractPdfText(pdfFile);
+      if (generation !== pdfPrefillGenerationRef.current) {
+        return;
+      }
+
       const parsedPrefill = parseAuthorizationPdfText(extractedText);
+      if (generation !== pdfPrefillGenerationRef.current) {
+        return;
+      }
 
       if (!prefillHasStructuredValues(parsedPrefill)) {
         setPdfPrefillState({
@@ -509,8 +527,12 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       }
 
       setWizardData((prev) => {
-        const mergeResult = mergeAuthorizationPdfPrefill(prev, parsedPrefill, serviceCatalog, {
-          statusFieldIsDefault: !hasAdminEditedStatus,
+        if (generation !== pdfPrefillGenerationRef.current) {
+          return prev;
+        }
+
+        const mergeResult = mergeAuthorizationPdfPrefill(prev, parsedPrefill, serviceCatalogRef.current, {
+          statusFieldIsDefault: !hasAdminEditedStatusRef.current,
         });
         setPdfPrefillState({
           status: 'applied',
@@ -519,6 +541,10 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
         return mergeResult.data;
       });
     } catch (error) {
+      if (generation !== pdfPrefillGenerationRef.current) {
+        return;
+      }
+
       const message =
         error instanceof PdfTextExtractionError
           ? error.message
@@ -1046,6 +1072,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                           id="preauth-status"
                           value={wizardData.status}
                           onChange={(e) => {
+                            hasAdminEditedStatusRef.current = true;
                             setHasAdminEditedStatus(true);
                             setWizardData({ ...wizardData, status: e.target.value as AuthorizationStatus });
                           }}

--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -733,6 +733,8 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   };
 
   const handleDocumentRemove = (index: number) => {
+    pdfPrefillGenerationRef.current += 1;
+    setPdfPrefillState({ status: 'idle', skippedServiceCodes: [] });
     setWizardData((prev) => ({
       ...prev,
       documents: prev.documents.filter((_, i) => i !== index),

--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -123,7 +123,6 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
     status: 'idle',
     skippedServiceCodes: [],
   });
-  const [hasAdminEditedStatus, setHasAdminEditedStatus] = useState(false);
   const [isDragActive, setIsDragActive] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -461,7 +460,6 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
     pdfPrefillGenerationRef.current += 1;
     setPdfPrefillState({ status: 'idle', skippedServiceCodes: [] });
     hasAdminEditedStatusRef.current = false;
-    setHasAdminEditedStatus(false);
   };
 
   const resetWizardForNewAuthorization = () => {
@@ -1070,7 +1068,6 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                           value={wizardData.status}
                           onChange={(e) => {
                             hasAdminEditedStatusRef.current = true;
-                            setHasAdminEditedStatus(true);
                             setWizardData({ ...wizardData, status: e.target.value as AuthorizationStatus });
                           }}
                           className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"

--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -128,6 +128,8 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const pdfPrefillGenerationRef = useRef(0);
   const hasAdminEditedStatusRef = useRef(false);
+  const hasAdminEditedDiagnosisCodeRef = useRef(false);
+  const hasAdminEditedDiagnosisDescriptionRef = useRef(false);
   const serviceCatalogRef = useRef<Record<string, string>>({});
   const {
     data: cptCodes = [],
@@ -460,6 +462,8 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
     pdfPrefillGenerationRef.current += 1;
     setPdfPrefillState({ status: 'idle', skippedServiceCodes: [] });
     hasAdminEditedStatusRef.current = false;
+    hasAdminEditedDiagnosisCodeRef.current = false;
+    hasAdminEditedDiagnosisDescriptionRef.current = false;
   };
 
   const resetWizardForNewAuthorization = () => {
@@ -528,6 +532,8 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
 
         const mergeResult = mergeAuthorizationPdfPrefill(prev, parsedPrefill, serviceCatalogRef.current, {
           statusFieldIsDefault: !hasAdminEditedStatusRef.current,
+          diagnosisCodeFieldIsDefault: !hasAdminEditedDiagnosisCodeRef.current,
+          diagnosisDescriptionFieldIsDefault: !hasAdminEditedDiagnosisDescriptionRef.current,
         });
         setPdfPrefillState({
           status: 'applied',
@@ -1120,7 +1126,10 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                           id="preauth-diagnosis-code"
                           type="text"
                           value={wizardData.diagnosisCode}
-                          onChange={(e) => setWizardData({ ...wizardData, diagnosisCode: e.target.value })}
+                          onChange={(e) => {
+                            hasAdminEditedDiagnosisCodeRef.current = true;
+                            setWizardData({ ...wizardData, diagnosisCode: e.target.value });
+                          }}
                           className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                         />
                       </div>
@@ -1133,7 +1142,10 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                           id="preauth-diagnosis-description"
                           type="text"
                           value={wizardData.diagnosisDescription}
-                          onChange={(e) => setWizardData({ ...wizardData, diagnosisDescription: e.target.value })}
+                          onChange={(e) => {
+                            hasAdminEditedDiagnosisDescriptionRef.current = true;
+                            setWizardData({ ...wizardData, diagnosisDescription: e.target.value });
+                          }}
                           className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                         />
                       </div>

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -299,7 +299,7 @@ describe("PreAuthTab manual authorization upload", () => {
       Authorization Number: IEHP-PDF-456
       Decision: pending
       Member ID: MEM-PDF-456
-      Diagnosis: F84.0 - Autistic disorder
+      Diagnosis: F90.2 - Attention-deficit hyperactivity disorder, combined type
       Service From: 07/01/2026 to 12/31/2026
       97153 requested units: 96 approved units: 88
     `);
@@ -336,6 +336,8 @@ describe("PreAuthTab manual authorization upload", () => {
         expect.objectContaining({
           authorization_number: "IEHP-PDF-456",
           member_id: "MEM-PDF-456",
+          diagnosis_code: "F90.2",
+          diagnosis_description: "Attention-deficit hyperactivity disorder, combined type",
           start_date: "2026-07-01",
           end_date: "2026-12-31",
           status: "pending",
@@ -357,6 +359,7 @@ describe("PreAuthTab manual authorization upload", () => {
       Authorization Number: IEHP-PDF-999
       Decision: approved
       Member ID: MEM-PDF-999
+      Diagnosis: F84.0 - Autistic disorder
       Service From: 08/01/2026 to 09/30/2026
       97153 approved units: 40
     `);
@@ -371,6 +374,13 @@ describe("PreAuthTab manual authorization upload", () => {
     await user.type(screen.getByLabelText(/start date/i), "2026-06-01");
     await user.type(screen.getByLabelText(/end date/i), "2026-06-30");
     await user.type(screen.getByLabelText(/member id/i), "ADMIN-MEMBER-1");
+    await user.clear(screen.getByLabelText(/diagnosis code/i));
+    await user.type(screen.getByLabelText(/diagnosis code/i), "F90.2");
+    await user.clear(screen.getByLabelText(/diagnosis description/i));
+    await user.type(
+      screen.getByLabelText(/diagnosis description/i),
+      "Attention-deficit hyperactivity disorder, combined type",
+    );
 
     await user.click(screen.getByRole("button", { name: /next/i }));
     await user.click(screen.getByRole("button", { name: /next/i }));
@@ -395,6 +405,10 @@ describe("PreAuthTab manual authorization upload", () => {
     expect(screen.getByLabelText(/start date/i)).toHaveValue("2026-06-01");
     expect(screen.getByLabelText(/end date/i)).toHaveValue("2026-06-30");
     expect(screen.getByLabelText(/member id/i)).toHaveValue("ADMIN-MEMBER-1");
+    expect(screen.getByLabelText(/diagnosis code/i)).toHaveValue("F90.2");
+    expect(screen.getByLabelText(/diagnosis description/i)).toHaveValue(
+      "Attention-deficit hyperactivity disorder, combined type",
+    );
   });
 
   it("keeps manual submission usable and shows manual-entry status when PDF text is unavailable", async () => {
@@ -512,6 +526,55 @@ describe("PreAuthTab manual authorization upload", () => {
     await waitFor(() => {
       expect(screen.getByLabelText(/authorization number/i)).toHaveValue("IEHP-DELAYED-1");
       expect(screen.getByLabelText(/authorization status/i)).toHaveValue("denied");
+    });
+  });
+
+  it("uses the latest admin diagnosis edit when delayed PDF prefill resolves", async () => {
+    const deferredText = createDeferred<string>();
+    extractPdfTextMock.mockReturnValueOnce(deferredText.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["synthetic authorization notice"], "auth-diagnosis-notice.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    expect(await screen.findByText(/Extracting authorization PDF/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.clear(screen.getByLabelText(/diagnosis code/i));
+    await user.type(screen.getByLabelText(/diagnosis code/i), "F90.2");
+    await user.clear(screen.getByLabelText(/diagnosis description/i));
+    await user.type(
+      screen.getByLabelText(/diagnosis description/i),
+      "Attention-deficit hyperactivity disorder, combined type",
+    );
+
+    deferredText.resolve(`
+      Authorization Number: IEHP-DELAYED-DX-1
+      Diagnosis: F84.0 - Autistic disorder
+      Service From: 07/01/2026 to 12/31/2026
+      97153 approved units: 24
+    `);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/authorization number/i)).toHaveValue("IEHP-DELAYED-DX-1");
+      expect(screen.getByLabelText(/diagnosis code/i)).toHaveValue("F90.2");
+      expect(screen.getByLabelText(/diagnosis description/i)).toHaveValue(
+        "Attention-deficit hyperactivity disorder, combined type",
+      );
     });
   });
 

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
+import { act, renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
 import { PreAuthTab } from "../ClientDetails/PreAuthTab";
 import { createAuthorizationWithServices, updateAuthorizationDocuments } from "../../lib/authorizations/mutations";
 import { showSuccess } from "../../lib/toast";
@@ -16,6 +16,8 @@ const {
   useActiveOrganizationIdMock,
   extractPdfTextMock,
   MockPdfTextExtractionError,
+  cptCodesMockData,
+  cptCodesQueryMock,
 } = vi.hoisted(() => {
   const createAuthorizationWithServicesMock = vi.fn();
   const updateAuthorizationDocumentsMock = vi.fn();
@@ -23,6 +25,13 @@ const {
   const useAuthMock = vi.fn();
   const useActiveOrganizationIdMock = vi.fn();
   const extractPdfTextMock = vi.fn();
+  const cptCodesMockData = [{ code: "97153", short_description: "Adaptive behavior treatment by protocol" }];
+  const cptCodesQueryMock = vi.fn(() =>
+    Promise.resolve({
+      data: cptCodesMockData,
+      error: null,
+    }),
+  );
   class MockPdfTextExtractionError extends Error {
     constructor(message: string) {
       super(message);
@@ -44,12 +53,7 @@ const {
       return {
         select: vi.fn(() => ({
           eq: vi.fn(() => ({
-            order: vi.fn(() =>
-              Promise.resolve({
-                data: [{ code: "97153", short_description: "Adaptive behavior treatment by protocol" }],
-                error: null,
-              }),
-            ),
+            order: cptCodesQueryMock,
           })),
         })),
       };
@@ -137,6 +141,8 @@ const {
     useActiveOrganizationIdMock,
     extractPdfTextMock,
     MockPdfTextExtractionError,
+    cptCodesMockData,
+    cptCodesQueryMock,
   };
 });
 
@@ -195,6 +201,16 @@ describe("PreAuthTab manual authorization upload", () => {
     updateAuthorizationDocumentsMock.mockResolvedValue(undefined);
     storageUploadMock.mockResolvedValue({ error: null });
     extractPdfTextMock.mockResolvedValue("");
+    cptCodesMockData.splice(0, cptCodesMockData.length, {
+      code: "97153",
+      short_description: "Adaptive behavior treatment by protocol",
+    });
+    cptCodesQueryMock.mockImplementation(() =>
+      Promise.resolve({
+        data: cptCodesMockData,
+        error: null,
+      }),
+    );
   });
 
   it("creates an authorization from entered notice fields and attaches the uploaded PDF", async () => {
@@ -586,5 +602,56 @@ describe("PreAuthTab manual authorization upload", () => {
         { upsert: false },
       );
     });
+  });
+
+  it("uses CPT codes loaded during delayed PDF extraction for service prefill", async () => {
+    const deferredText = createDeferred<string>();
+    const deferredCptCodes = createDeferred<Array<{ code: string; short_description: string }>>();
+    cptCodesQueryMock.mockReturnValueOnce(deferredCptCodes.promise.then((data) => ({ data, error: null })));
+    extractPdfTextMock.mockReturnValueOnce(deferredText.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    expect(await screen.findByText(/Loading CPT codes/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["synthetic authorization notice"], "catalog-refresh-auth-notice.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    expect(await screen.findByText(/Extracting authorization PDF/i)).toBeInTheDocument();
+
+    await act(async () => {
+      deferredCptCodes.resolve([
+        { code: "97155", short_description: "Adaptive behavior treatment with protocol modification" },
+      ]);
+    });
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    expect(await screen.findByLabelText(/97155/i)).not.toBeChecked();
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    await act(async () => {
+      deferredText.resolve(`
+        Authorization Number: IEHP-CATALOG-1
+        Decision: approved
+        Service From: 07/01/2026 to 12/31/2026
+        97155 approved units: 32
+      `);
+    });
+
+    expect(await screen.findByText(/PDF prefill applied/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Unsupported service codes skipped: 97155/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    expect(screen.getByLabelText(/units requested/i)).toHaveValue(32);
   });
 });

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { act, renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
+import { renderWithProviders, screen, userEvent, waitFor } from "../../test/utils";
 import { PreAuthTab } from "../ClientDetails/PreAuthTab";
 import { createAuthorizationWithServices, updateAuthorizationDocuments } from "../../lib/authorizations/mutations";
 import { showSuccess } from "../../lib/toast";
@@ -609,6 +609,23 @@ describe("PreAuthTab manual authorization upload", () => {
     const deferredCptCodes = createDeferred<Array<{ code: string; short_description: string }>>();
     cptCodesQueryMock.mockReturnValueOnce(deferredCptCodes.promise.then((data) => ({ data, error: null })));
     extractPdfTextMock.mockReturnValueOnce(deferredText.promise);
+    let resolvedPdfTextDuringCatalogRender = false;
+    const catalogCode = {
+      code: "97155",
+      get short_description() {
+        if (!resolvedPdfTextDuringCatalogRender) {
+          resolvedPdfTextDuringCatalogRender = true;
+          deferredText.resolve(`
+            Authorization Number: IEHP-CATALOG-1
+            Decision: approved
+            Service From: 07/01/2026 to 12/31/2026
+            97155 approved units: 32
+          `);
+        }
+
+        return "Adaptive behavior treatment with protocol modification";
+      },
+    };
     const user = userEvent.setup();
     renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
 
@@ -628,27 +645,10 @@ describe("PreAuthTab manual authorization upload", () => {
     );
     expect(await screen.findByText(/Extracting authorization PDF/i)).toBeInTheDocument();
 
-    await act(async () => {
-      deferredCptCodes.resolve([
-        { code: "97155", short_description: "Adaptive behavior treatment with protocol modification" },
-      ]);
-    });
-    await user.click(screen.getByRole("button", { name: /back/i }));
-    await user.click(screen.getByRole("button", { name: /back/i }));
-    expect(await screen.findByLabelText(/97155/i)).not.toBeChecked();
-    await user.click(screen.getByRole("button", { name: /next/i }));
-    await user.click(screen.getByRole("button", { name: /next/i }));
-
-    await act(async () => {
-      deferredText.resolve(`
-        Authorization Number: IEHP-CATALOG-1
-        Decision: approved
-        Service From: 07/01/2026 to 12/31/2026
-        97155 approved units: 32
-      `);
-    });
+    deferredCptCodes.resolve([catalogCode]);
 
     expect(await screen.findByText(/PDF prefill applied/i)).toBeInTheDocument();
+    expect(resolvedPdfTextDuringCatalogRender).toBe(true);
     expect(screen.queryByText(/Unsupported service codes skipped: 97155/i)).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /back/i }));

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -558,6 +558,51 @@ describe("PreAuthTab manual authorization upload", () => {
     expect(screen.queryByText(/PDF prefill applied/i)).not.toBeInTheDocument();
   });
 
+  it("ignores delayed PDF prefill after the source document is removed", async () => {
+    const deferredText = createDeferred<string>();
+    extractPdfTextMock.mockReturnValueOnce(deferredText.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["synthetic authorization notice"], "removed-auth-notice.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    expect(await screen.findByText(/Extracting authorization PDF/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+
+    deferredText.resolve(`
+      Authorization Number: REMOVED-AUTH-1
+      Decision: denied
+      Member ID: REMOVED-MEMBER
+      Service From: 07/01/2026 to 12/31/2026
+      97153 approved units: 24
+    `);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Extracting authorization PDF/i)).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText(/PDF prefill applied/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+
+    expect(screen.getByLabelText(/authorization number/i)).toHaveValue("");
+    expect(screen.getByLabelText(/member id/i)).toHaveValue("");
+    expect(screen.getByLabelText(/authorization status/i)).toHaveValue("approved");
+  });
+
   it("preserves the uploaded file while delayed PDF prefill resolves", async () => {
     const deferredText = createDeferred<string>();
     extractPdfTextMock.mockReturnValueOnce(deferredText.promise);

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -175,6 +175,17 @@ vi.mock("../../lib/toast", () => ({
   showSuccess: vi.fn(),
 }));
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+};
+
 describe("PreAuthTab manual authorization upload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -446,5 +457,134 @@ describe("PreAuthTab manual authorization upload", () => {
 
     expect(await screen.findByText(/PDF prefill applied/i)).toBeInTheDocument();
     expect(screen.getByText(/Unsupported service codes skipped: H2019/i)).toBeInTheDocument();
+  });
+
+  it("uses the latest admin status edit when delayed PDF prefill resolves", async () => {
+    const deferredText = createDeferred<string>();
+    extractPdfTextMock.mockReturnValueOnce(deferredText.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["synthetic authorization notice"], "auth-notice.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    expect(await screen.findByText(/Extracting authorization PDF/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.selectOptions(screen.getByLabelText(/authorization status/i), "denied");
+
+    deferredText.resolve(`
+      Authorization Number: IEHP-DELAYED-1
+      Decision: approved
+      Service From: 07/01/2026 to 12/31/2026
+      97153 approved units: 24
+    `);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/authorization number/i)).toHaveValue("IEHP-DELAYED-1");
+      expect(screen.getByLabelText(/authorization status/i)).toHaveValue("denied");
+    });
+  });
+
+  it("ignores delayed PDF prefill after the wizard is cancelled and reopened", async () => {
+    const deferredText = createDeferred<string>();
+    extractPdfTextMock.mockReturnValueOnce(deferredText.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["synthetic authorization notice"], "stale-auth-notice.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    expect(await screen.findByText(/Extracting authorization PDF/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+
+    deferredText.resolve(`
+      Authorization Number: STALE-AUTH-999
+      Decision: denied
+      Member ID: STALE-MEMBER
+      Service From: 07/01/2026 to 12/31/2026
+      97153 approved units: 24
+    `);
+
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await waitFor(() => {
+      expect(screen.getByLabelText(/authorization number/i)).toHaveValue("");
+    });
+    expect(screen.getByLabelText(/authorization status/i)).toHaveValue("approved");
+    expect(screen.queryByText(/PDF prefill applied/i)).not.toBeInTheDocument();
+  });
+
+  it("preserves the uploaded file while delayed PDF prefill resolves", async () => {
+    const deferredText = createDeferred<string>();
+    extractPdfTextMock.mockReturnValueOnce(deferredText.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+    await waitFor(() => {
+      expect(screen.getByLabelText(/rendering therapist/i)).toHaveValue("therapist-provider-1");
+    });
+    await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["synthetic authorization notice"], "delayed-auth-notice.pdf", {
+      type: "application/pdf",
+    });
+    await user.upload(fileInput, file);
+
+    deferredText.resolve(`
+      Authorization Number: IEHP-DELAYED-2
+      Decision: approved
+      Member ID: MEM-DELAYED-2
+      Diagnosis: F84.0 - Autistic disorder
+      Service From: 07/01/2026 to 12/31/2026
+      97153 approved units: 24
+    `);
+
+    expect(await screen.findByText(/PDF prefill applied/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /submit request/i }));
+
+    await waitFor(() => {
+      expect(storageUploadMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^clients\/client-1\/authorizations\/auth-created-id\/.+\.pdf$/),
+        file,
+        { upsert: false },
+      );
+    });
   });
 });

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -14,12 +14,21 @@ const {
   supabaseFromMock,
   useAuthMock,
   useActiveOrganizationIdMock,
+  extractPdfTextMock,
+  MockPdfTextExtractionError,
 } = vi.hoisted(() => {
   const createAuthorizationWithServicesMock = vi.fn();
   const updateAuthorizationDocumentsMock = vi.fn();
   const storageUploadMock = vi.fn();
   const useAuthMock = vi.fn();
   const useActiveOrganizationIdMock = vi.fn();
+  const extractPdfTextMock = vi.fn();
+  class MockPdfTextExtractionError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "PdfTextExtractionError";
+    }
+  }
 
   const createEqQuery = (data: unknown[]) => {
     const query = {
@@ -126,6 +135,8 @@ const {
     supabaseFromMock,
     useAuthMock,
     useActiveOrganizationIdMock,
+    extractPdfTextMock,
+    MockPdfTextExtractionError,
   };
 });
 
@@ -154,6 +165,11 @@ vi.mock("../../lib/authorizations/mutations", () => ({
   updateAuthorizationDocuments: updateAuthorizationDocumentsMock,
 }));
 
+vi.mock("../../lib/authorizations/pdfText", () => ({
+  extractPdfText: extractPdfTextMock,
+  PdfTextExtractionError: MockPdfTextExtractionError,
+}));
+
 vi.mock("../../lib/toast", () => ({
   showError: vi.fn(),
   showSuccess: vi.fn(),
@@ -167,6 +183,7 @@ describe("PreAuthTab manual authorization upload", () => {
     createAuthorizationWithServicesMock.mockResolvedValue({ id: "auth-created-id" });
     updateAuthorizationDocumentsMock.mockResolvedValue(undefined);
     storageUploadMock.mockResolvedValue({ error: null });
+    extractPdfTextMock.mockResolvedValue("");
   });
 
   it("creates an authorization from entered notice fields and attaches the uploaded PDF", async () => {
@@ -248,5 +265,186 @@ describe("PreAuthTab manual authorization upload", () => {
       ],
     });
     expect(showSuccess).toHaveBeenCalledWith("Authorization uploaded and saved.");
+  });
+
+  it("prefills empty wizard fields from an uploaded PDF and submits extracted values", async () => {
+    extractPdfTextMock.mockResolvedValue(`
+      Authorization Number: IEHP-PDF-456
+      Decision: pending
+      Member ID: MEM-PDF-456
+      Diagnosis: F84.0 - Autistic disorder
+      Service From: 07/01/2026 to 12/31/2026
+      97153 requested units: 96 approved units: 88
+    `);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+    await waitFor(() => {
+      expect(screen.getByLabelText(/rendering therapist/i)).toHaveValue("therapist-provider-1");
+    });
+    await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["synthetic authorization notice"], "auth-notice.pdf", {
+      type: "application/pdf",
+    });
+    await user.upload(fileInput, file);
+
+    expect(await screen.findByText(/PDF prefill applied/i)).toBeInTheDocument();
+    expect(screen.getByText(/review extracted fields before submitting/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /submit request/i }));
+
+    await waitFor(() => {
+      expect(createAuthorizationWithServices).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorization_number: "IEHP-PDF-456",
+          member_id: "MEM-PDF-456",
+          start_date: "2026-07-01",
+          end_date: "2026-12-31",
+          status: "pending",
+          services: [
+            expect.objectContaining({
+              service_code: "97153",
+              requested_units: 88,
+              approved_units: null,
+              decision_status: "pending",
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it("does not overwrite admin-entered notice fields during PDF prefill", async () => {
+    extractPdfTextMock.mockResolvedValue(`
+      Authorization Number: IEHP-PDF-999
+      Decision: approved
+      Member ID: MEM-PDF-999
+      Service From: 08/01/2026 to 09/30/2026
+      97153 approved units: 40
+    `);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.type(screen.getByLabelText(/authorization number/i), "ADMIN-AUTH-1");
+    await user.selectOptions(screen.getByLabelText(/authorization status/i), "denied");
+    await user.type(screen.getByLabelText(/start date/i), "2026-06-01");
+    await user.type(screen.getByLabelText(/end date/i), "2026-06-30");
+    await user.type(screen.getByLabelText(/member id/i), "ADMIN-MEMBER-1");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["synthetic authorization notice"], "auth-notice.pdf", {
+        type: "application/pdf",
+      }),
+    );
+
+    expect(await screen.findByText(/PDF prefill applied/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+
+    expect(screen.getByLabelText(/authorization number/i)).toHaveValue("ADMIN-AUTH-1");
+    expect(screen.getByLabelText(/authorization status/i)).toHaveValue("denied");
+    expect(screen.getByLabelText(/start date/i)).toHaveValue("2026-06-01");
+    expect(screen.getByLabelText(/end date/i)).toHaveValue("2026-06-30");
+    expect(screen.getByLabelText(/member id/i)).toHaveValue("ADMIN-MEMBER-1");
+  });
+
+  it("keeps manual submission usable and shows manual-entry status when PDF text is unavailable", async () => {
+    extractPdfTextMock.mockRejectedValue(new MockPdfTextExtractionError("No embedded PDF text was found."));
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.type(screen.getByLabelText(/authorization number/i), "MANUAL-AUTH-1");
+    await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+    await waitFor(() => {
+      expect(screen.getByLabelText(/rendering therapist/i)).toHaveValue("therapist-provider-1");
+    });
+    await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
+    await user.type(screen.getByLabelText(/member id/i), "MANUAL-MEMBER-1");
+    await user.type(screen.getByLabelText(/start date/i), "2026-06-23");
+    await user.type(screen.getByLabelText(/end date/i), "2026-12-22");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(await screen.findByLabelText(/97153/i));
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.type(screen.getByLabelText(/units requested/i), "120");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["synthetic authorization notice"], "scanned-auth-notice.pdf", {
+        type: "application/pdf",
+      }),
+    );
+
+    expect(await screen.findByText(/No embedded PDF text was found/i)).toBeInTheDocument();
+    expect(screen.getByText(/manual entry remains available/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /submit request/i }));
+
+    await waitFor(() => {
+      expect(createAuthorizationWithServices).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorization_number: "MANUAL-AUTH-1",
+          member_id: "MANUAL-MEMBER-1",
+          status: "approved",
+        }),
+      );
+    });
+  });
+
+  it("skips unsupported PDF service codes and shows them in the status banner", async () => {
+    extractPdfTextMock.mockResolvedValue(`
+      Authorization Number: IEHP-PDF-777
+      Service From: 07/01/2026 to 12/31/2026
+      97153 approved units: 20
+      H2019 approved units: 10
+    `);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["synthetic authorization notice"], "auth-notice.pdf", {
+        type: "application/pdf",
+      }),
+    );
+
+    expect(await screen.findByText(/PDF prefill applied/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unsupported service codes skipped: H2019/i)).toBeInTheDocument();
   });
 });

--- a/src/lib/authorizations/__tests__/pdfPrefill.test.ts
+++ b/src/lib/authorizations/__tests__/pdfPrefill.test.ts
@@ -76,6 +76,38 @@ describe('parseAuthorizationPdfText', () => {
     expect(result).not.toHaveProperty('endDate');
   });
 
+  it('drops a labeled date range when either side is invalid', () => {
+    const result = parseAuthorizationPdfText(`
+      Authorization #: PDF-AUTH-MIXED-DATES
+      Service From: 02/31/2026
+      Service To: 04/30/2026
+      Procedure Code 97153
+      Requested Units: 12
+    `);
+
+    expect(result).toMatchObject({
+      authorizationNumber: 'PDF-AUTH-MIXED-DATES',
+      services: [{ serviceCode: '97153', requestedUnits: 12 }],
+    });
+    expect(result).not.toHaveProperty('startDate');
+    expect(result).not.toHaveProperty('endDate');
+  });
+
+  it('drops a compact date range when either side is invalid', () => {
+    const result = parseAuthorizationPdfText(`
+      Authorization #: PDF-AUTH-MIXED-TABLE
+      Code Description From To Requested Approved
+      97155 Adaptive behavior treatment 02.31.2026 04.30.2026 48 40
+    `);
+
+    expect(result).toMatchObject({
+      authorizationNumber: 'PDF-AUTH-MIXED-TABLE',
+      services: [{ serviceCode: '97155', requestedUnits: 48, approvedUnits: 40 }],
+    });
+    expect(result).not.toHaveProperty('startDate');
+    expect(result).not.toHaveProperty('endDate');
+  });
+
   it('does not infer status from requested or approved unit labels', () => {
     expect(
       parseAuthorizationPdfText(`
@@ -104,6 +136,21 @@ describe('parseAuthorizationPdfText', () => {
       services: [{ serviceCode: '97155', requestedUnits: 48, approvedUnits: 40 }],
     });
     expect(result).not.toHaveProperty('status');
+  });
+
+  it('does not apply global requested or approved units across multiple service codes', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Authorization #: PDF-AUTH-MULTI-SERVICE
+        Procedure Code 97153
+        Procedure Code 97155
+        Requested Units: 120
+        Approved Units: 96
+      `),
+    ).toEqual({
+      authorizationNumber: 'PDF-AUTH-MULTI-SERVICE',
+      services: [{ serviceCode: '97153' }, { serviceCode: '97155' }],
+    });
   });
 
   it('extracts pending status only from explicit status or decision wording', () => {

--- a/src/lib/authorizations/__tests__/pdfPrefill.test.ts
+++ b/src/lib/authorizations/__tests__/pdfPrefill.test.ts
@@ -59,6 +59,23 @@ describe('parseAuthorizationPdfText', () => {
     });
   });
 
+  it('does not return impossible calendar dates', () => {
+    const result = parseAuthorizationPdfText(`
+      Authorization #: PDF-AUTH-BAD-DATES
+      Service From: 02/31/2026
+      Service To: 04/31/2026
+      Procedure Code 97153
+      Requested Units: 12
+    `);
+
+    expect(result).toMatchObject({
+      authorizationNumber: 'PDF-AUTH-BAD-DATES',
+      services: [{ serviceCode: '97153', requestedUnits: 12 }],
+    });
+    expect(result).not.toHaveProperty('startDate');
+    expect(result).not.toHaveProperty('endDate');
+  });
+
   it('does not infer status from requested or approved unit labels', () => {
     expect(
       parseAuthorizationPdfText(`
@@ -168,5 +185,54 @@ describe('mergeAuthorizationPdfPrefill', () => {
         catalog,
       ).data.units,
     ).toEqual({ '97153': 44 });
+  });
+
+  it('does not overwrite status by default when current status has a value', () => {
+    const current = {
+      authorizationNumber: '',
+      status: 'approved' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: '',
+      diagnosisDescription: '',
+      memberId: '',
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(current, { status: 'denied', services: [] }, catalog),
+    ).toEqual({
+      data: current,
+      appliedFields: [],
+      skippedServiceCodes: [],
+    });
+  });
+
+  it('applies status when the current status field is still defaulted', () => {
+    const current = {
+      authorizationNumber: '',
+      status: 'approved' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: '',
+      diagnosisDescription: '',
+      memberId: '',
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(
+        current,
+        { status: 'denied', services: [] },
+        catalog,
+        { statusFieldIsDefault: true },
+      ),
+    ).toEqual({
+      data: { ...current, status: 'denied' },
+      appliedFields: ['status'],
+      skippedServiceCodes: [],
+    });
   });
 });

--- a/src/lib/authorizations/__tests__/pdfPrefill.test.ts
+++ b/src/lib/authorizations/__tests__/pdfPrefill.test.ts
@@ -163,12 +163,86 @@ describe('parseAuthorizationPdfText', () => {
       services: [],
     });
   });
+
+  it('recognizes active catalog service codes and split modifier codes exactly', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Code Description From To Requested Approved
+        97151 Behavior identification assessment 06/23/2026 12/22/2026 32 28
+        97152 Behavior identification supporting assessment 06/23/2026 12/22/2026 8 8
+        97154 Group adaptive behavior treatment 06/23/2026 12/22/2026 20 16
+        97157 Multiple-family adaptive behavior treatment guidance 06/23/2026 12/22/2026 12 12
+        H0032-HO Treatment planning supervision 06/23/2026 12/22/2026 10 10
+      `),
+    ).toMatchObject({
+      services: [
+        { serviceCode: '97151', requestedUnits: 32, approvedUnits: 28 },
+        { serviceCode: '97152', requestedUnits: 8, approvedUnits: 8 },
+        { serviceCode: '97154', requestedUnits: 20, approvedUnits: 16 },
+        { serviceCode: '97157', requestedUnits: 12, approvedUnits: 12 },
+        { serviceCode: 'H0032-HO', requestedUnits: 10, approvedUnits: 10 },
+      ],
+    });
+  });
+
+  it('does not treat generic leading numeric identifiers as service rows', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        12345 Member authorization tracking row 06/23/2026 12/22/2026 32 28
+        ZIP Code 92345
+      `),
+    ).toEqual({
+      startDate: '2026-06-23',
+      endDate: '2026-12-22',
+      services: [],
+    });
+  });
+
+  it('recognizes split modifier codes when PDF text drops the hyphen', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Code Description From To Requested Approved
+        H0032HO Treatment planning supervision 06/23/2026 12/22/2026 10 10
+      `),
+    ).toMatchObject({
+      services: [{ serviceCode: 'H0032HO', requestedUnits: 10, approvedUnits: 10 }],
+    });
+  });
+
+  it('does not treat member names as member IDs', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Member: Jane Doe
+        Member ID: MEM-0001
+        CIN: CIN-222333
+      `),
+    ).toMatchObject({
+      memberId: 'MEM-0001',
+      services: [],
+    });
+  });
+
+  it('accepts unlabeled member values when they look like IDs', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Member: MEM-0001
+      `),
+    ).toMatchObject({
+      memberId: 'MEM-0001',
+      services: [],
+    });
+  });
 });
 
 describe('mergeAuthorizationPdfPrefill', () => {
   const catalog = {
+    '97151': 'Behavior identification assessment',
+    '97152': 'Behavior identification supporting assessment',
     '97153': 'Adaptive behavior treatment by protocol',
+    '97154': 'Group adaptive behavior treatment',
     '97155': 'Adaptive behavior treatment with protocol modification',
+    '97157': 'Multiple-family adaptive behavior treatment guidance',
+    'H0032-HO': 'Treatment planning supervision',
   };
 
   it('fills empty fields and catalog-matched services without overwriting entered values', () => {
@@ -234,6 +308,139 @@ describe('mergeAuthorizationPdfPrefill', () => {
     ).toEqual({ '97153': 44 });
   });
 
+  it('merges active catalog service codes and split modifier codes without skipping them', () => {
+    const current = {
+      authorizationNumber: '',
+      status: 'approved' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: '',
+      diagnosisDescription: '',
+      memberId: '',
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(
+        current,
+        {
+          services: [
+            { serviceCode: '97151', approvedUnits: 28 },
+            { serviceCode: '97152', approvedUnits: 8 },
+            { serviceCode: '97154', approvedUnits: 16 },
+            { serviceCode: '97157', approvedUnits: 12 },
+            { serviceCode: 'H0032-HO', approvedUnits: 10 },
+          ],
+        },
+        catalog,
+      ),
+    ).toEqual({
+      data: {
+        ...current,
+        services: ['97151', '97152', '97154', '97157', 'H0032-HO'],
+        units: {
+          '97151': 28,
+          '97152': 8,
+          '97154': 16,
+          '97157': 12,
+          'H0032-HO': 10,
+        },
+      },
+      appliedFields: ['services', 'units'],
+      skippedServiceCodes: [],
+    });
+  });
+
+  it('matches split modifier PDF codes to unhyphenated catalog codes when unambiguous', () => {
+    const current = {
+      authorizationNumber: '',
+      status: 'approved' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: '',
+      diagnosisDescription: '',
+      memberId: '',
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(
+        current,
+        { services: [{ serviceCode: 'H0032-HO', approvedUnits: 10 }] },
+        { H0032HO: 'Treatment planning supervision' },
+      ),
+    ).toEqual({
+      data: {
+        ...current,
+        services: ['H0032HO'],
+        units: { H0032HO: 10 },
+      },
+      appliedFields: ['services', 'units'],
+      skippedServiceCodes: [],
+    });
+  });
+
+  it('matches hyphenless split modifier PDF codes to hyphenated catalog codes when unambiguous', () => {
+    const current = {
+      authorizationNumber: '',
+      status: 'approved' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: '',
+      diagnosisDescription: '',
+      memberId: '',
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(
+        current,
+        { services: [{ serviceCode: 'H0032HO', approvedUnits: 10 }] },
+        catalog,
+      ),
+    ).toEqual({
+      data: {
+        ...current,
+        services: ['H0032-HO'],
+        units: { 'H0032-HO': 10 },
+      },
+      appliedFields: ['services', 'units'],
+      skippedServiceCodes: [],
+    });
+  });
+
+  it('skips split modifier PDF codes when normalized catalog matching is ambiguous', () => {
+    const current = {
+      authorizationNumber: '',
+      status: 'approved' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: '',
+      diagnosisDescription: '',
+      memberId: '',
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(
+        current,
+        { services: [{ serviceCode: 'H0032HO', approvedUnits: 10 }] },
+        {
+          'H0032-HO': 'Treatment planning supervision',
+          H0032HO: 'Treatment planning supervision duplicate',
+        },
+      ),
+    ).toEqual({
+      data: current,
+      appliedFields: [],
+      skippedServiceCodes: ['H0032HO'],
+    });
+  });
+
   it('does not overwrite status by default when current status has a value', () => {
     const current = {
       authorizationNumber: '',
@@ -281,5 +488,103 @@ describe('mergeAuthorizationPdfPrefill', () => {
       appliedFields: ['status'],
       skippedServiceCodes: [],
     });
+  });
+
+  it('applies PDF diagnosis when the current diagnosis fields are still defaulted', () => {
+    const current = {
+      authorizationNumber: '',
+      status: 'approved' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: 'F84.0',
+      diagnosisDescription: 'Autistic disorder',
+      memberId: '',
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(
+        current,
+        {
+          diagnosisCode: 'F90.2',
+          diagnosisDescription: 'Attention-deficit hyperactivity disorder, combined type',
+          services: [],
+        },
+        catalog,
+        {
+          diagnosisCodeFieldIsDefault: true,
+          diagnosisDescriptionFieldIsDefault: true,
+        },
+      ),
+    ).toEqual({
+      data: {
+        ...current,
+        diagnosisCode: 'F90.2',
+        diagnosisDescription: 'Attention-deficit hyperactivity disorder, combined type',
+      },
+      appliedFields: ['diagnosisCode', 'diagnosisDescription'],
+      skippedServiceCodes: [],
+    });
+  });
+
+  it('does not overwrite admin-entered diagnosis fields when defaults were edited', () => {
+    const current = {
+      authorizationNumber: '',
+      status: 'approved' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: 'F90.2',
+      diagnosisDescription: 'Attention-deficit hyperactivity disorder, combined type',
+      memberId: '',
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(
+        current,
+        {
+          diagnosisCode: 'F84.0',
+          diagnosisDescription: 'Autistic disorder',
+          services: [],
+        },
+        catalog,
+      ),
+    ).toEqual({
+      data: current,
+      appliedFields: [],
+      skippedServiceCodes: [],
+    });
+  });
+
+  it('does not overwrite non-default diagnosis fields even when default flags are mistakenly true', () => {
+    const current = {
+      authorizationNumber: '',
+      status: 'approved' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: 'F90.2',
+      diagnosisDescription: 'Attention-deficit hyperactivity disorder, combined type',
+      memberId: '',
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(
+        current,
+        {
+          diagnosisCode: 'F84.0',
+          diagnosisDescription: 'Autistic disorder',
+          services: [],
+        },
+        catalog,
+        {
+          diagnosisCodeFieldIsDefault: true,
+          diagnosisDescriptionFieldIsDefault: true,
+        },
+      ).data,
+    ).toEqual(current);
   });
 });

--- a/src/lib/authorizations/__tests__/pdfPrefill.test.ts
+++ b/src/lib/authorizations/__tests__/pdfPrefill.test.ts
@@ -58,6 +58,47 @@ describe('parseAuthorizationPdfText', () => {
       services: [],
     });
   });
+
+  it('does not infer status from requested or approved unit labels', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Authorization #: PDF-AUTH-UNITS
+        Procedure Code 97153
+        Requested Units: 120
+        Approved Units: 96
+      `),
+    ).toEqual({
+      authorizationNumber: 'PDF-AUTH-UNITS',
+      services: [{ serviceCode: '97153', requestedUnits: 120, approvedUnits: 96 }],
+    });
+  });
+
+  it('does not infer status from requested or approved table columns', () => {
+    const result = parseAuthorizationPdfText(`
+      Authorization #: PDF-AUTH-TABLE
+      Code Description From To Requested Approved
+      97155 Adaptive behavior treatment 6.23.2026 12.22.2026 48 40
+    `);
+
+    expect(result).toMatchObject({
+      authorizationNumber: 'PDF-AUTH-TABLE',
+      startDate: '2026-06-23',
+      endDate: '2026-12-22',
+      services: [{ serviceCode: '97155', requestedUnits: 48, approvedUnits: 40 }],
+    });
+    expect(result).not.toHaveProperty('status');
+  });
+
+  it('extracts pending status only from explicit status or decision wording', () => {
+    expect(parseAuthorizationPdfText('Status: Pending')).toEqual({
+      status: 'pending',
+      services: [],
+    });
+    expect(parseAuthorizationPdfText('Decision: Requested')).toEqual({
+      status: 'pending',
+      services: [],
+    });
+  });
 });
 
 describe('mergeAuthorizationPdfPrefill', () => {

--- a/src/lib/authorizations/__tests__/pdfPrefill.test.ts
+++ b/src/lib/authorizations/__tests__/pdfPrefill.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeAuthorizationPdfPrefill,
+  parseAuthorizationPdfText,
+  type AuthorizationPdfPrefill,
+} from '../pdfPrefill';
+
+describe('parseAuthorizationPdfText', () => {
+  it('extracts IEHP-style authorization fields from synthetic notice text', () => {
+    const text = `
+      Referral ID: IEHP-AUTH-12345
+      Status: Approved
+      Member ID: MEM-0001
+      Diagnosis: F84.0 Autistic disorder
+      Service From: 06/23/2026
+      Service To: 12/22/2026
+      Procedure Code 97153
+      Requested Units: 120
+      Approved Units: 96
+    `;
+
+    expect(parseAuthorizationPdfText(text)).toEqual({
+      authorizationNumber: 'IEHP-AUTH-12345',
+      status: 'approved',
+      memberId: 'MEM-0001',
+      diagnosisCode: 'F84.0',
+      diagnosisDescription: 'Autistic disorder',
+      startDate: '2026-06-23',
+      endDate: '2026-12-22',
+      services: [{ serviceCode: '97153', requestedUnits: 120, approvedUnits: 96 }],
+    });
+  });
+
+  it('extracts CalOptima-style authorization fields from synthetic notice text', () => {
+    const text = `
+      Authorization #: CAL-987654
+      Decision: Approved
+      CIN: CIN-222333
+      ICD-10 Code F84.0 - Autistic disorder
+      Code Description From To Requested Approved
+      97155 Adaptive behavior treatment 6.23.2026 12.22.2026 48 40
+    `;
+
+    expect(parseAuthorizationPdfText(text)).toMatchObject({
+      authorizationNumber: 'CAL-987654',
+      status: 'approved',
+      memberId: 'CIN-222333',
+      diagnosisCode: 'F84.0',
+      diagnosisDescription: 'Autistic disorder',
+      startDate: '2026-06-23',
+      endDate: '2026-12-22',
+      services: [{ serviceCode: '97155', requestedUnits: 48, approvedUnits: 40 }],
+    });
+  });
+
+  it('leaves ambiguous values unset', () => {
+    expect(parseAuthorizationPdfText('Authorization notice with no structured values')).toEqual({
+      services: [],
+    });
+  });
+});
+
+describe('mergeAuthorizationPdfPrefill', () => {
+  const catalog = {
+    '97153': 'Adaptive behavior treatment by protocol',
+    '97155': 'Adaptive behavior treatment with protocol modification',
+  };
+
+  it('fills empty fields and catalog-matched services without overwriting entered values', () => {
+    const current = {
+      authorizationNumber: 'ADMIN-TYPED',
+      status: 'pending' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: 'F84.0',
+      diagnosisDescription: 'Autistic disorder',
+      memberId: '',
+      services: [] as string[],
+      units: {} as Record<string, number>,
+    };
+    const prefill: AuthorizationPdfPrefill = {
+      authorizationNumber: 'PDF-AUTH-1',
+      status: 'approved',
+      startDate: '2026-06-23',
+      endDate: '2026-12-22',
+      memberId: 'MEM-0001',
+      services: [
+        { serviceCode: '97153', requestedUnits: 120, approvedUnits: 96 },
+        { serviceCode: '99999', requestedUnits: 1, approvedUnits: 1 },
+      ],
+    };
+
+    expect(mergeAuthorizationPdfPrefill(current, prefill, catalog)).toEqual({
+      data: {
+        authorizationNumber: 'ADMIN-TYPED',
+        status: 'pending',
+        startDate: '2026-06-23',
+        endDate: '2026-12-22',
+        diagnosisCode: 'F84.0',
+        diagnosisDescription: 'Autistic disorder',
+        memberId: 'MEM-0001',
+        services: ['97153'],
+        units: { '97153': 96 },
+      },
+      appliedFields: ['startDate', 'endDate', 'memberId', 'services', 'units'],
+      skippedServiceCodes: ['99999'],
+    });
+  });
+
+  it('does not replace units for a service already selected by the admin', () => {
+    const current = {
+      authorizationNumber: '',
+      status: 'approved' as const,
+      startDate: '',
+      endDate: '',
+      diagnosisCode: '',
+      diagnosisDescription: '',
+      memberId: '',
+      services: ['97153'],
+      units: { '97153': 44 },
+    };
+
+    expect(
+      mergeAuthorizationPdfPrefill(
+        current,
+        { services: [{ serviceCode: '97153', requestedUnits: 120, approvedUnits: 96 }] },
+        catalog,
+      ).data.units,
+    ).toEqual({ '97153': 44 });
+  });
+});

--- a/src/lib/authorizations/pdfPrefill.ts
+++ b/src/lib/authorizations/pdfPrefill.ts
@@ -35,15 +35,35 @@ export interface AuthorizationPdfMergeResult<T extends AuthorizationPdfMergeInpu
   skippedServiceCodes: string[];
 }
 
+export interface AuthorizationPdfMergeOptions {
+  statusFieldIsDefault?: boolean;
+}
+
 const DATE_PATTERN = String.raw`(?:\d{1,2}[/.]\d{1,2}[/.]\d{2,4}|\d{4}-\d{1,2}-\d{1,2})`;
 const SERVICE_CODE_PATTERN = /\b(?:97(?:153|155|156|158)|0362T|0373T|H\d{4}|[A-Z]\d{4})\b/g;
 
 const collapseWhitespace = (value: string): string => value.replace(/\s+/g, ' ').trim();
 
+const isRealCalendarDate = (year: number, month: number, day: number): boolean => {
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+};
+
 const normalizeDate = (value: string): string | undefined => {
   const raw = value.trim();
   const isoMatch = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(raw);
   if (isoMatch) {
+    const year = Number(isoMatch[1]);
+    const month = Number(isoMatch[2]);
+    const day = Number(isoMatch[3]);
+    if (!isRealCalendarDate(year, month, day)) {
+      return undefined;
+    }
+
     return `${isoMatch[1]}-${isoMatch[2].padStart(2, '0')}-${isoMatch[3].padStart(2, '0')}`;
   }
 
@@ -55,7 +75,7 @@ const normalizeDate = (value: string): string | undefined => {
   const month = Number(dateMatch[1]);
   const day = Number(dateMatch[2]);
   const year = Number(dateMatch[3].length === 2 ? `20${dateMatch[3]}` : dateMatch[3]);
-  if (month < 1 || month > 12 || day < 1 || day > 31 || year < 2000) {
+  if (year < 2000 || !isRealCalendarDate(year, month, day)) {
     return undefined;
   }
 
@@ -204,6 +224,7 @@ export const mergeAuthorizationPdfPrefill = <T extends AuthorizationPdfMergeInpu
   current: T,
   prefill: AuthorizationPdfPrefill,
   serviceCatalog: Record<string, string>,
+  options: AuthorizationPdfMergeOptions = {},
 ): AuthorizationPdfMergeResult<T> => {
   const next: T = {
     ...current,
@@ -227,7 +248,7 @@ export const mergeAuthorizationPdfPrefill = <T extends AuthorizationPdfMergeInpu
   fillIfBlank('diagnosisDescription', prefill.diagnosisDescription as T['diagnosisDescription']);
   fillIfBlank('memberId', prefill.memberId as T['memberId']);
 
-  if (prefill.status && !current.status) {
+  if (prefill.status && (!current.status || options.statusFieldIsDefault)) {
     next.status = prefill.status as T['status'];
     appliedFields.add('status');
   }

--- a/src/lib/authorizations/pdfPrefill.ts
+++ b/src/lib/authorizations/pdfPrefill.ts
@@ -37,10 +37,19 @@ export interface AuthorizationPdfMergeResult<T extends AuthorizationPdfMergeInpu
 
 export interface AuthorizationPdfMergeOptions {
   statusFieldIsDefault?: boolean;
+  diagnosisCodeFieldIsDefault?: boolean;
+  diagnosisDescriptionFieldIsDefault?: boolean;
+  defaultDiagnosisCode?: string;
+  defaultDiagnosisDescription?: string;
 }
 
 const DATE_PATTERN = String.raw`(?:\d{1,2}[/.]\d{1,2}[/.]\d{2,4}|\d{4}-\d{1,2}-\d{1,2})`;
-const SERVICE_CODE_PATTERN = /\b(?:97(?:153|155|156|158)|0362T|0373T|H\d{4}|[A-Z]\d{4})\b/g;
+const SERVICE_CODE_PATTERN_SOURCE = String.raw`(?:97(?:151|152|153|154|155|156|157|158)|0\d{3}T|[A-Z]\d{4}(?:-?[A-Z0-9]{2})?)`;
+const SERVICE_CODE_PATTERN = new RegExp(String.raw`\b${SERVICE_CODE_PATTERN_SOURCE}\b`, 'g');
+const SERVICE_ROW_START_PATTERN = new RegExp(String.raw`^${SERVICE_CODE_PATTERN_SOURCE}\b`, 'i');
+const SERVICE_CONTEXT_PATTERN = /\b(?:procedure|service|code|cpt|hcpcs)\b/i;
+const DEFAULT_DIAGNOSIS_CODE = 'F84.0';
+const DEFAULT_DIAGNOSIS_DESCRIPTION = 'Autistic disorder';
 
 const collapseWhitespace = (value: string): string => value.replace(/\s+/g, ' ').trim();
 
@@ -172,12 +181,16 @@ const parseServices = (text: string): AuthorizationPdfPrefillService[] => {
   const globalApprovedUnits = parseLabeledUnits(text, 'approved');
 
   for (const line of lines) {
+    if (!SERVICE_CONTEXT_PATTERN.test(line) && !SERVICE_ROW_START_PATTERN.test(line)) {
+      continue;
+    }
+
     const codes = [...line.matchAll(SERVICE_CODE_PATTERN)].map((match) => match[0].toUpperCase());
     for (const serviceCode of codes) {
       const existing = services.get(serviceCode) ?? { serviceCode };
       const requestedUnits = parseLabeledUnits(line, 'requested') ?? existing.requestedUnits;
       const approvedUnits = parseLabeledUnits(line, 'approved') ?? existing.approvedUnits;
-      const compactUnits = parseCompactServiceRowUnits(line);
+      const compactUnits = parseCompactServiceRowUnits(line, serviceCode);
 
       services.set(serviceCode, {
         serviceCode,
@@ -198,10 +211,14 @@ const parseServices = (text: string): AuthorizationPdfPrefillService[] => {
 
 const parseCompactServiceRowUnits = (
   line: string,
+  serviceCode: string,
 ): Pick<AuthorizationPdfPrefillService, 'requestedUnits' | 'approvedUnits'> | undefined => {
-  const withoutDates = line.replace(new RegExp(DATE_PATTERN, 'g'), ' ');
+  const escapedServiceCode = serviceCode.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const withoutDates = line
+    .replace(new RegExp(DATE_PATTERN, 'g'), ' ')
+    .replace(new RegExp(`\\b${escapedServiceCode}\\b`, 'i'), ' ');
   const numbers = withoutDates.match(/\b\d+\b/g)?.map(Number).filter((value) => value > 0) ?? [];
-  if (numbers.length < 3) {
+  if (numbers.length < 2) {
     return undefined;
   }
 
@@ -218,7 +235,7 @@ export const parseAuthorizationPdfText = (text: string): AuthorizationPdfPrefill
     /\breferral\s*(?:id|#|number)?\s*:?\s*([A-Z0-9][A-Z0-9-]{3,})/i,
   ]);
   const memberId = firstMatch(normalizedText, [
-    /\bmember\s*(?:id|#|number)?\s*:?\s*([A-Z0-9][A-Z0-9-]{2,})/i,
+    /\bmember\s*(?:(?:id|#|number)\s*:?\s*|:\s*)((?=[A-Z0-9-]*\d)[A-Z0-9][A-Z0-9-]{2,})/i,
     /\bcin\s*:?\s*([A-Z0-9][A-Z0-9-]{2,})/i,
   ]);
 
@@ -245,6 +262,9 @@ export const mergeAuthorizationPdfPrefill = <T extends AuthorizationPdfMergeInpu
   };
   const appliedFields = new Set<string>();
   const skippedServiceCodes = new Set<string>();
+  const defaultDiagnosisCode = options.defaultDiagnosisCode ?? DEFAULT_DIAGNOSIS_CODE;
+  const defaultDiagnosisDescription =
+    options.defaultDiagnosisDescription ?? DEFAULT_DIAGNOSIS_DESCRIPTION;
 
   const fillIfBlank = <K extends keyof T>(field: K, value: T[K] | undefined) => {
     if (!next[field] && value) {
@@ -256,8 +276,6 @@ export const mergeAuthorizationPdfPrefill = <T extends AuthorizationPdfMergeInpu
   fillIfBlank('authorizationNumber', prefill.authorizationNumber as T['authorizationNumber']);
   fillIfBlank('startDate', prefill.startDate as T['startDate']);
   fillIfBlank('endDate', prefill.endDate as T['endDate']);
-  fillIfBlank('diagnosisCode', prefill.diagnosisCode as T['diagnosisCode']);
-  fillIfBlank('diagnosisDescription', prefill.diagnosisDescription as T['diagnosisDescription']);
   fillIfBlank('memberId', prefill.memberId as T['memberId']);
 
   if (prefill.status && (!current.status || options.statusFieldIsDefault)) {
@@ -265,10 +283,34 @@ export const mergeAuthorizationPdfPrefill = <T extends AuthorizationPdfMergeInpu
     appliedFields.add('status');
   }
 
+  const currentDiagnosisCodeIsDefault =
+    current.diagnosisCode.trim().toUpperCase() === defaultDiagnosisCode.toUpperCase();
+  const currentDiagnosisDescriptionIsDefault =
+    collapseWhitespace(current.diagnosisDescription).toLowerCase() ===
+    collapseWhitespace(defaultDiagnosisDescription).toLowerCase();
+
+  if (
+    prefill.diagnosisCode &&
+    (!current.diagnosisCode || (options.diagnosisCodeFieldIsDefault && currentDiagnosisCodeIsDefault))
+  ) {
+    next.diagnosisCode = prefill.diagnosisCode as T['diagnosisCode'];
+    appliedFields.add('diagnosisCode');
+  }
+
+  if (
+    prefill.diagnosisDescription &&
+    (!current.diagnosisDescription ||
+      (options.diagnosisDescriptionFieldIsDefault && currentDiagnosisDescriptionIsDefault))
+  ) {
+    next.diagnosisDescription = prefill.diagnosisDescription as T['diagnosisDescription'];
+    appliedFields.add('diagnosisDescription');
+  }
+
   for (const service of prefill.services) {
-    const code = service.serviceCode.toUpperCase();
-    if (!serviceCatalog[code]) {
-      skippedServiceCodes.add(code);
+    const parsedCode = service.serviceCode.toUpperCase();
+    const code = resolveCatalogServiceCode(parsedCode, serviceCatalog);
+    if (!code) {
+      skippedServiceCodes.add(parsedCode);
       continue;
     }
 
@@ -289,6 +331,21 @@ export const mergeAuthorizationPdfPrefill = <T extends AuthorizationPdfMergeInpu
     appliedFields: [...appliedFields],
     skippedServiceCodes: [...skippedServiceCodes],
   };
+};
+
+const normalizeServiceCodeForCatalogMatch = (code: string): string => {
+  return code.toUpperCase().replace(/[^A-Z0-9]/g, '');
+};
+
+const resolveCatalogServiceCode = (
+  parsedCode: string,
+  serviceCatalog: Record<string, string>,
+): string | undefined => {
+  const normalizedParsedCode = normalizeServiceCodeForCatalogMatch(parsedCode);
+  const matches = Object.keys(serviceCatalog).filter(
+    (catalogCode) => normalizeServiceCodeForCatalogMatch(catalogCode) === normalizedParsedCode,
+  );
+  return matches.length === 1 ? matches[0] : undefined;
 };
 
 const stripUndefined = (prefill: AuthorizationPdfPrefill): AuthorizationPdfPrefill => {

--- a/src/lib/authorizations/pdfPrefill.ts
+++ b/src/lib/authorizations/pdfPrefill.ts
@@ -1,0 +1,261 @@
+export type AuthorizationPdfStatus = 'approved' | 'pending' | 'denied';
+
+export interface AuthorizationPdfPrefillService {
+  serviceCode: string;
+  requestedUnits?: number;
+  approvedUnits?: number;
+}
+
+export interface AuthorizationPdfPrefill {
+  authorizationNumber?: string;
+  status?: AuthorizationPdfStatus;
+  startDate?: string;
+  endDate?: string;
+  diagnosisCode?: string;
+  diagnosisDescription?: string;
+  memberId?: string;
+  services: AuthorizationPdfPrefillService[];
+}
+
+export interface AuthorizationPdfMergeInput {
+  authorizationNumber: string;
+  status: AuthorizationPdfStatus;
+  startDate: string;
+  endDate: string;
+  diagnosisCode: string;
+  diagnosisDescription: string;
+  memberId: string;
+  services: string[];
+  units: Record<string, number>;
+}
+
+export interface AuthorizationPdfMergeResult<T extends AuthorizationPdfMergeInput> {
+  data: T;
+  appliedFields: string[];
+  skippedServiceCodes: string[];
+}
+
+const DATE_PATTERN = String.raw`(?:\d{1,2}[/.]\d{1,2}[/.]\d{2,4}|\d{4}-\d{1,2}-\d{1,2})`;
+const SERVICE_CODE_PATTERN = /\b(?:97(?:153|155|156|158)|0362T|0373T|H\d{4}|[A-Z]\d{4})\b/g;
+
+const collapseWhitespace = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+const normalizeDate = (value: string): string | undefined => {
+  const raw = value.trim();
+  const isoMatch = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(raw);
+  if (isoMatch) {
+    return `${isoMatch[1]}-${isoMatch[2].padStart(2, '0')}-${isoMatch[3].padStart(2, '0')}`;
+  }
+
+  const dateMatch = /^(\d{1,2})[/.](\d{1,2})[/.](\d{2,4})$/.exec(raw);
+  if (!dateMatch) {
+    return undefined;
+  }
+
+  const month = Number(dateMatch[1]);
+  const day = Number(dateMatch[2]);
+  const year = Number(dateMatch[3].length === 2 ? `20${dateMatch[3]}` : dateMatch[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31 || year < 2000) {
+    return undefined;
+  }
+
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+};
+
+const firstMatch = (text: string, patterns: RegExp[]): string | undefined => {
+  for (const pattern of patterns) {
+    const match = pattern.exec(text);
+    pattern.lastIndex = 0;
+    const value = match?.[1]?.trim();
+    if (value) {
+      return collapseWhitespace(value);
+    }
+  }
+  return undefined;
+};
+
+const parseStatus = (text: string): AuthorizationPdfStatus | undefined => {
+  if (/\bdenied\b/i.test(text)) return 'denied';
+  if (/\bapproved\b/i.test(text)) return 'approved';
+  if (/\bpending\b|\brequested\b/i.test(text)) return 'pending';
+  return undefined;
+};
+
+const parseDates = (text: string): Pick<AuthorizationPdfPrefill, 'startDate' | 'endDate'> => {
+  const serviceRange = new RegExp(
+    `(?:service\\s*)?(?:from|start)\\s*:?\\s*(${DATE_PATTERN})[\\s\\S]{0,80}?(?:to|end)\\s*:?\\s*(${DATE_PATTERN})`,
+    'i',
+  ).exec(text);
+  if (serviceRange) {
+    return {
+      startDate: normalizeDate(serviceRange[1]),
+      endDate: normalizeDate(serviceRange[2]),
+    };
+  }
+
+  const compactRange = new RegExp(
+    `(${DATE_PATTERN})\\s*(?:-|to|through|\\s+)\\s*(${DATE_PATTERN})`,
+    'i',
+  ).exec(text);
+  if (compactRange) {
+    return {
+      startDate: normalizeDate(compactRange[1]),
+      endDate: normalizeDate(compactRange[2]),
+    };
+  }
+
+  return {};
+};
+
+const parseDiagnosis = (
+  text: string,
+): Pick<AuthorizationPdfPrefill, 'diagnosisCode' | 'diagnosisDescription'> => {
+  const match =
+    /\b(?:diagnosis|icd-?10(?: code)?)\s*:?\s*([A-Z]\d{2}(?:\.\d+)?)\s*(?:-|:)?\s*([A-Za-z][^\n\r]{2,80})?/i.exec(
+      text,
+    );
+  if (!match) {
+    return {};
+  }
+
+  return {
+    diagnosisCode: match[1].toUpperCase(),
+    diagnosisDescription: match[2] ? collapseWhitespace(match[2]) : undefined,
+  };
+};
+
+const parseLabeledUnits = (text: string, label: 'requested' | 'approved'): number | undefined => {
+  const match = new RegExp(`\\b${label}(?:\\s+units)?\\s*:?\\s*(\\d+)`, 'i').exec(text);
+  return match ? Number(match[1]) : undefined;
+};
+
+const parseServices = (text: string): AuthorizationPdfPrefillService[] => {
+  const services = new Map<string, AuthorizationPdfPrefillService>();
+  const lines = text.split(/\r?\n/).map(collapseWhitespace).filter(Boolean);
+  const globalRequestedUnits = parseLabeledUnits(text, 'requested');
+  const globalApprovedUnits = parseLabeledUnits(text, 'approved');
+
+  for (const line of lines) {
+    const codes = [...line.matchAll(SERVICE_CODE_PATTERN)].map((match) => match[0].toUpperCase());
+    for (const serviceCode of codes) {
+      const existing = services.get(serviceCode) ?? { serviceCode };
+      const requestedUnits = parseLabeledUnits(line, 'requested') ?? existing.requestedUnits;
+      const approvedUnits = parseLabeledUnits(line, 'approved') ?? existing.approvedUnits;
+      const compactUnits = parseCompactServiceRowUnits(line);
+
+      services.set(serviceCode, {
+        serviceCode,
+        requestedUnits: requestedUnits ?? compactUnits?.requestedUnits,
+        approvedUnits: approvedUnits ?? compactUnits?.approvedUnits,
+      });
+    }
+  }
+
+  if (services.size === 1) {
+    const [service] = services.values();
+    service.requestedUnits ??= globalRequestedUnits;
+    service.approvedUnits ??= globalApprovedUnits;
+  }
+
+  return [...services.values()];
+};
+
+const parseCompactServiceRowUnits = (
+  line: string,
+): Pick<AuthorizationPdfPrefillService, 'requestedUnits' | 'approvedUnits'> | undefined => {
+  const withoutDates = line.replace(new RegExp(DATE_PATTERN, 'g'), ' ');
+  const numbers = withoutDates.match(/\b\d+\b/g)?.map(Number).filter((value) => value > 0) ?? [];
+  if (numbers.length < 3) {
+    return undefined;
+  }
+
+  return {
+    requestedUnits: numbers.at(-2),
+    approvedUnits: numbers.at(-1),
+  };
+};
+
+export const parseAuthorizationPdfText = (text: string): AuthorizationPdfPrefill => {
+  const normalizedText = text.replace(/\u00a0/g, ' ');
+  const authorizationNumber = firstMatch(normalizedText, [
+    /\b(?:authorization|auth)\s*(?:(?:#|number)\s*:?\s*|no\.?(?:\s+|:\s*)|:\s*)([A-Z0-9][A-Z0-9-]{3,})/i,
+    /\breferral\s*(?:id|#|number)?\s*:?\s*([A-Z0-9][A-Z0-9-]{3,})/i,
+  ]);
+  const memberId = firstMatch(normalizedText, [
+    /\bmember\s*(?:id|#|number)?\s*:?\s*([A-Z0-9][A-Z0-9-]{2,})/i,
+    /\bcin\s*:?\s*([A-Z0-9][A-Z0-9-]{2,})/i,
+  ]);
+
+  return stripUndefined({
+    authorizationNumber,
+    status: parseStatus(normalizedText),
+    memberId,
+    ...parseDiagnosis(normalizedText),
+    ...parseDates(normalizedText),
+    services: parseServices(normalizedText),
+  });
+};
+
+export const mergeAuthorizationPdfPrefill = <T extends AuthorizationPdfMergeInput>(
+  current: T,
+  prefill: AuthorizationPdfPrefill,
+  serviceCatalog: Record<string, string>,
+): AuthorizationPdfMergeResult<T> => {
+  const next: T = {
+    ...current,
+    services: [...current.services],
+    units: { ...current.units },
+  };
+  const appliedFields = new Set<string>();
+  const skippedServiceCodes = new Set<string>();
+
+  const fillIfBlank = <K extends keyof T>(field: K, value: T[K] | undefined) => {
+    if (!next[field] && value) {
+      next[field] = value;
+      appliedFields.add(String(field));
+    }
+  };
+
+  fillIfBlank('authorizationNumber', prefill.authorizationNumber as T['authorizationNumber']);
+  fillIfBlank('startDate', prefill.startDate as T['startDate']);
+  fillIfBlank('endDate', prefill.endDate as T['endDate']);
+  fillIfBlank('diagnosisCode', prefill.diagnosisCode as T['diagnosisCode']);
+  fillIfBlank('diagnosisDescription', prefill.diagnosisDescription as T['diagnosisDescription']);
+  fillIfBlank('memberId', prefill.memberId as T['memberId']);
+
+  if (prefill.status && !current.status) {
+    next.status = prefill.status as T['status'];
+    appliedFields.add('status');
+  }
+
+  for (const service of prefill.services) {
+    const code = service.serviceCode.toUpperCase();
+    if (!serviceCatalog[code]) {
+      skippedServiceCodes.add(code);
+      continue;
+    }
+
+    if (!next.services.includes(code)) {
+      next.services.push(code);
+      appliedFields.add('services');
+    }
+
+    const units = service.approvedUnits ?? service.requestedUnits;
+    if (units && units > 0 && !next.units[code]) {
+      next.units[code] = units;
+      appliedFields.add('units');
+    }
+  }
+
+  return {
+    data: next,
+    appliedFields: [...appliedFields],
+    skippedServiceCodes: [...skippedServiceCodes],
+  };
+};
+
+const stripUndefined = (prefill: AuthorizationPdfPrefill): AuthorizationPdfPrefill => {
+  return Object.fromEntries(
+    Object.entries(prefill).filter(([, value]) => value !== undefined),
+  ) as unknown as AuthorizationPdfPrefill;
+};

--- a/src/lib/authorizations/pdfPrefill.ts
+++ b/src/lib/authorizations/pdfPrefill.ts
@@ -111,9 +111,15 @@ const parseDates = (text: string): Pick<AuthorizationPdfPrefill, 'startDate' | '
     'i',
   ).exec(text);
   if (serviceRange) {
+    const startDate = normalizeDate(serviceRange[1]);
+    const endDate = normalizeDate(serviceRange[2]);
+    if (!startDate || !endDate) {
+      return {};
+    }
+
     return {
-      startDate: normalizeDate(serviceRange[1]),
-      endDate: normalizeDate(serviceRange[2]),
+      startDate,
+      endDate,
     };
   }
 
@@ -122,9 +128,15 @@ const parseDates = (text: string): Pick<AuthorizationPdfPrefill, 'startDate' | '
     'i',
   ).exec(text);
   if (compactRange) {
+    const startDate = normalizeDate(compactRange[1]);
+    const endDate = normalizeDate(compactRange[2]);
+    if (!startDate || !endDate) {
+      return {};
+    }
+
     return {
-      startDate: normalizeDate(compactRange[1]),
-      endDate: normalizeDate(compactRange[2]),
+      startDate,
+      endDate,
     };
   }
 

--- a/src/lib/authorizations/pdfPrefill.ts
+++ b/src/lib/authorizations/pdfPrefill.ts
@@ -75,9 +75,13 @@ const firstMatch = (text: string, patterns: RegExp[]): string | undefined => {
 };
 
 const parseStatus = (text: string): AuthorizationPdfStatus | undefined => {
-  if (/\bdenied\b/i.test(text)) return 'denied';
-  if (/\bapproved\b/i.test(text)) return 'approved';
-  if (/\bpending\b|\brequested\b/i.test(text)) return 'pending';
+  const explicitStatus =
+    /\b(?:status|decision)\s*(?:is\s+|:\s*)?(approved|pending|denied|requested)\b/i.exec(text) ??
+    /\b(approved|pending|denied|requested)\s+(?:status|decision)\b/i.exec(text);
+  const value = explicitStatus?.[1]?.toLowerCase();
+  if (value === 'denied') return 'denied';
+  if (value === 'approved') return 'approved';
+  if (value === 'pending' || value === 'requested') return 'pending';
   return undefined;
 };
 

--- a/src/lib/authorizations/pdfText.ts
+++ b/src/lib/authorizations/pdfText.ts
@@ -14,8 +14,16 @@ const isPdfFile = (file: File): boolean => {
   return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
 };
 
-const hasText = (item: unknown): item is { str: string } => {
+const hasText = (item: unknown): item is { str: string; hasEOL?: boolean } => {
   return typeof item === 'object' && item !== null && 'str' in item && typeof item.str === 'string';
+};
+
+const getPageText = (items: unknown[]): string => {
+  return items
+    .filter(hasText)
+    .map((item) => `${item.str}${item.hasEOL ? '\n' : ' '}`)
+    .join('')
+    .trimEnd();
 };
 
 export async function extractPdfText(file: File): Promise<string> {
@@ -23,25 +31,47 @@ export async function extractPdfText(file: File): Promise<string> {
     throw new PdfTextExtractionError('Unsupported file type. Please select a PDF file.');
   }
 
-  const data = await file.arrayBuffer();
-  const document = await pdfjs.getDocument({ data }).promise;
-  const pageTexts: string[] = [];
+  let loadingTask: pdfjs.PDFDocumentLoadingTask | undefined;
+  let document: pdfjs.PDFDocumentProxy | undefined;
 
-  for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
-    const page = await document.getPage(pageNumber);
-    const textContent = await page.getTextContent();
-    const pageText = textContent.items
-      .filter(hasText)
-      .map((item) => item.str)
-      .join(' ');
+  try {
+    let data: ArrayBuffer | undefined = await file.arrayBuffer();
+    loadingTask = pdfjs.getDocument({ data });
+    data = undefined;
+    document = await loadingTask.promise;
+    const pageTexts: string[] = [];
 
-    pageTexts.push(pageText);
+    for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+      const page = await document.getPage(pageNumber);
+      const textContent = await page.getTextContent();
+      pageTexts.push(getPageText(textContent.items));
+    }
+
+    const text = pageTexts.join('\n').trim();
+    if (!text) {
+      throw new PdfTextExtractionError('No embedded PDF text was found.');
+    }
+
+    return text;
+  } catch (error) {
+    if (error instanceof PdfTextExtractionError) {
+      throw error;
+    }
+
+    throw new PdfTextExtractionError(
+      'PDF text extraction failed. Enter the authorization fields manually.'
+    );
+  } finally {
+    try {
+      await document?.cleanup();
+    } catch {
+      // Ignore cleanup failures so user-facing extraction errors stay bounded.
+    }
+
+    try {
+      await loadingTask?.destroy();
+    } catch {
+      // Ignore cleanup failures so user-facing extraction errors stay bounded.
+    }
   }
-
-  const text = pageTexts.join('\n').trim();
-  if (!text) {
-    throw new PdfTextExtractionError('No embedded PDF text was found.');
-  }
-
-  return text;
 }

--- a/src/lib/authorizations/pdfText.ts
+++ b/src/lib/authorizations/pdfText.ts
@@ -1,0 +1,47 @@
+import * as pdfjs from 'pdfjs-dist';
+import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
+
+pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+
+export class PdfTextExtractionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PdfTextExtractionError';
+  }
+}
+
+const isPdfFile = (file: File): boolean => {
+  return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+};
+
+const hasText = (item: unknown): item is { str: string } => {
+  return typeof item === 'object' && item !== null && 'str' in item && typeof item.str === 'string';
+};
+
+export async function extractPdfText(file: File): Promise<string> {
+  if (!isPdfFile(file)) {
+    throw new PdfTextExtractionError('Unsupported file type. Please select a PDF file.');
+  }
+
+  const data = await file.arrayBuffer();
+  const document = await pdfjs.getDocument({ data }).promise;
+  const pageTexts: string[] = [];
+
+  for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+    const page = await document.getPage(pageNumber);
+    const textContent = await page.getTextContent();
+    const pageText = textContent.items
+      .filter(hasText)
+      .map((item) => item.str)
+      .join(' ');
+
+    pageTexts.push(pageText);
+  }
+
+  const text = pageTexts.join('\n').trim();
+  if (!text) {
+    throw new PdfTextExtractionError('No embedded PDF text was found.');
+  }
+
+  return text;
+}

--- a/src/lib/authorizations/pdfText.ts
+++ b/src/lib/authorizations/pdfText.ts
@@ -14,16 +14,83 @@ const isPdfFile = (file: File): boolean => {
   return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
 };
 
-const hasText = (item: unknown): item is { str: string; hasEOL?: boolean } => {
+const LINE_Y_TOLERANCE = 2;
+
+interface PdfTextItem {
+  str: string;
+  hasEOL?: boolean;
+  transform?: unknown[];
+}
+
+interface PositionedTextItem extends PdfTextItem {
+  x: number;
+  y: number;
+}
+
+const hasText = (item: unknown): item is PdfTextItem => {
   return typeof item === 'object' && item !== null && 'str' in item && typeof item.str === 'string';
 };
 
+const getCoordinate = (item: PdfTextItem, index: 4 | 5): number | undefined => {
+  const value = item.transform?.[index];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+};
+
+const getPositionedItem = (item: PdfTextItem): PositionedTextItem | undefined => {
+  const x = getCoordinate(item, 4);
+  const y = getCoordinate(item, 5);
+  return x === undefined || y === undefined ? undefined : { ...item, x, y };
+};
+
+const getLineText = (items: PdfTextItem[]): string => {
+  return items.map((item) => item.str).join(' ').trimEnd();
+};
+
+const getPositionedPageText = (items: PositionedTextItem[]): string => {
+  const lines: PositionedTextItem[][] = [];
+
+  for (const item of [...items].sort((a, b) => b.y - a.y || a.x - b.x)) {
+    const line = lines.find((candidate) => Math.abs(candidate[0].y - item.y) <= LINE_Y_TOLERANCE);
+    if (line) {
+      line.push(item);
+    } else {
+      lines.push([item]);
+    }
+  }
+
+  return lines
+    .flatMap((line) => {
+      const splitLines: PositionedTextItem[][] = [[]];
+      for (const item of line.sort((a, b) => a.x - b.x)) {
+        splitLines[splitLines.length - 1].push(item);
+        if (item.hasEOL) {
+          splitLines.push([]);
+        }
+      }
+
+      return splitLines;
+    })
+    .map(getLineText)
+    .join('\n');
+};
+
 const getPageText = (items: unknown[]): string => {
-  return items
-    .filter(hasText)
-    .map((item) => `${item.str}${item.hasEOL ? '\n' : ' '}`)
-    .join('')
-    .trimEnd();
+  const textItems = items.filter(hasText);
+  const positionedItems = textItems.map(getPositionedItem).filter((item) => item !== undefined);
+
+  if (positionedItems.length > 0) {
+    return getPositionedPageText(positionedItems);
+  }
+
+  const lines: PdfTextItem[][] = [[]];
+  for (const item of textItems) {
+    lines[lines.length - 1].push(item);
+    if (item.hasEOL) {
+      lines.push([]);
+    }
+  }
+
+  return lines.map(getLineText).join('\n').trimEnd();
 };
 
 export async function extractPdfText(file: File): Promise<string> {

--- a/src/pages/ClientDetails.tsx
+++ b/src/pages/ClientDetails.tsx
@@ -57,6 +57,7 @@ export function ClientDetails() {
 
   const isTherapistViewer = effectiveRole === 'therapist';
   const isClientViewer = effectiveRole === 'client';
+  const isAuthorizationAdminViewer = effectiveRole === 'admin' || effectiveRole === 'super_admin';
   const viewingOwnClientRecord = Boolean(isClientViewer && client?.id === profile?.id);
   const canViewClientRecord = Boolean(
     client &&
@@ -113,43 +114,52 @@ export function ClientDetails() {
     enabled: Boolean(clientId && activeOrganizationId && canViewClientRecord),
   });
 
-  const tabs = [
-    {
-      id: 'profile' as TabType,
-      name: 'Profile / Notes & Issues',
-      mobileName: 'Profile',
-      icon: User,
-    },
-    {
-      id: 'session-notes' as TabType,
-      name: 'Session Notes / Physical Auth',
-      mobileName: 'Notes',
-      icon: FileText,
-    },
-    {
-      id: 'programs-goals' as TabType,
-      name: 'Programs & Goals',
-      mobileName: 'Programs',
-      icon: FileText,
-    },
-    {
-      id: 'pre-auth' as TabType,
-      name: 'Pre-Authorizations',
-      mobileName: 'Pre-Auth',
-      icon: ClipboardCheck,
-    },
-    {
-      id: 'contracts' as TabType,
-      name: 'Service Contracts',
-      mobileName: 'Contracts',
-      icon: FileContract,
-    },
-  ];
+  const tabs = useMemo(
+    () => [
+      {
+        id: 'profile' as TabType,
+        name: 'Profile / Notes & Issues',
+        mobileName: 'Profile',
+        icon: User,
+      },
+      {
+        id: 'session-notes' as TabType,
+        name: 'Session Notes / Physical Auth',
+        mobileName: 'Notes',
+        icon: FileText,
+      },
+      {
+        id: 'programs-goals' as TabType,
+        name: 'Programs & Goals',
+        mobileName: 'Programs',
+        icon: FileText,
+      },
+      {
+        id: 'pre-auth' as TabType,
+        name: 'Pre-Authorizations',
+        mobileName: 'Pre-Auth',
+        icon: ClipboardCheck,
+      },
+      {
+        id: 'contracts' as TabType,
+        name: 'Service Contracts',
+        mobileName: 'Contracts',
+        icon: FileContract,
+      },
+    ],
+    [],
+  );
 
   const visibleTabs = useMemo(
-    () => tabs.filter((tab) => !(isTherapistViewer && tab.id === 'pre-auth')),
-    [isTherapistViewer, tabs],
+    () => tabs.filter((tab) => tab.id !== 'pre-auth' || isAuthorizationAdminViewer),
+    [isAuthorizationAdminViewer, tabs],
   );
+
+  useEffect(() => {
+    if (!visibleTabs.some((tab) => tab.id === activeTab)) {
+      setActiveTab('profile');
+    }
+  }, [activeTab, visibleTabs]);
 
   if (!activeOrganizationId) {
     return (
@@ -313,7 +323,7 @@ export function ClientDetails() {
           {activeTab === 'profile' && <ProfileTab client={client} viewerRole={effectiveRole} />}
           {activeTab === 'session-notes' && <SessionNotesTab client={client} />}
           {activeTab === 'programs-goals' && <ProgramsGoalsTab client={client} />}
-          {activeTab === 'pre-auth' && !isTherapistViewer && <PreAuthTab client={client} />}
+          {activeTab === 'pre-auth' && isAuthorizationAdminViewer && <PreAuthTab client={client} />}
           {activeTab === 'contracts' && <ServiceContractsTab client={client} />}
         </div>
       </div>

--- a/src/pages/__tests__/ClientDetails.test.tsx
+++ b/src/pages/__tests__/ClientDetails.test.tsx
@@ -162,6 +162,28 @@ describe('ClientDetails page', () => {
     expect(screen.queryByRole('button', { name: /Pre-Authorizations/i })).not.toBeInTheDocument();
   });
 
+  it('renders the Pre-Authorizations tab for super admin viewers', async () => {
+    renderWithProviders(<ClientDetails />, {
+      auth: { role: 'super_admin', userId: 'super-admin-user-id' },
+    });
+
+    await waitFor(() => expect(screen.getByText('ProfileTabContent')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Pre-Authorizations/i }));
+    expect(screen.getByText('PreAuthTabContent')).toBeInTheDocument();
+  });
+
+  it('hides the Pre-Authorizations tab for client viewers', async () => {
+    renderWithProviders(<ClientDetails />, {
+      auth: { role: 'client', userId: 'client-1' },
+    });
+
+    await waitFor(() => expect(screen.getByText('ProfileTabContent')).toBeInTheDocument());
+
+    expect(screen.queryByRole('button', { name: /Pre-Authorizations/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('PreAuthTabContent')).not.toBeInTheDocument();
+  });
+
   it('allows a therapist whose auth user maps to a separate therapist row id', async () => {
     mockLocationSearch = '?tab=programs-goals';
     vi.mocked(fetchClientByIdForViewer).mockResolvedValue({


### PR DESCRIPTION
## Summary
- Adds authorization PDF text extraction-assisted prefill for the admin/super-admin manual upload wizard.
- Keeps prefill conservative: no raw PDF text storage, no overwrite of admin-entered fields, skipped unsupported CPT codes surfaced in UI.
- Closes review blockers: pre-auth tab/render is admin/super_admin-only, removed source PDFs invalidate in-flight extraction, and `pdfjs-dist` is exactly pinned to `5.1.91` for Node 20 compatibility.

## Route / Lane
- classification: high-risk human-reviewed
- lane: critical
- issue: WIN-179
- change type: UI/component/page, auth/role visibility, dependency config

## Verification
Executed:
- `npm test -- src/pages/__tests__/ClientDetails.test.tsx src/components/__tests__/PreAuthTab.test.tsx` PASS (19 tests)
- `npm run lint` PASS
- `npm run typecheck` PASS
- `npm run ci:check-focused` PASS (local DB/CI-only skips noted)
- `npm run build` PASS
- `npm run test:routes:tier0` PASS on rerun (78/78)
- `npm run validate:tenant` PASS
- Reviewer agent: approved latest closeout diff, no findings

Blocked / incomplete local gates:
- `npm run verify:local` FAIL during `npm run test:ci` on existing `src/components/__tests__/SessionModal.test.tsx` timeout/failure unrelated to this authorization PDF diff; the originally timed-out targeted measurement test passed when rerun, but the same `-t` pattern also selected an existing Close Session test that failed independently.
- `npm run ci:playwright` TIMED OUT locally after 5 minutes while running `playwright:session-no-show`; exact child process group was stopped. Needs CI or separate session-flow triage, not part of this auth PDF slice.
- First `npm run test:routes:tier0` attempt failed only while `npm run build` was concurrently rebuilding `dist`; rerun after build settled passed 78/78.

## Residual Risk
- Critical-lane feature requires human review before merge.
- OCR is not implemented in this slice; this is embedded-text extraction-assisted prefill only, with manual entry fallback.