### PR TITLE
WIN-179 Harden authorization PDF prefill for real notices

### DIFF
--- a/src/lib/authorizations/__tests__/pdfPrefill.test.ts
+++ b/src/lib/authorizations/__tests__/pdfPrefill.test.ts
@@ -248,6 +248,19 @@ describe('parseAuthorizationPdfText', () => {
     });
   });
 
+  it('does not parse HCPCS service rows as multiline diagnosis codes', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Diagnosis
+        H2019 Therapeutic Behavioral Services
+        Requested Units: 120
+        Approved Units: 96
+      `),
+    ).toEqual({
+      services: [{ serviceCode: 'H2019', requestedUnits: 120, approvedUnits: 96 }],
+    });
+  });
+
   it('does not infer full approval from negative or partial authorization prose', () => {
     expect(
       parseAuthorizationPdfText('Based on review, not all requested services have been authorized.'),

--- a/src/lib/authorizations/__tests__/pdfPrefill.test.ts
+++ b/src/lib/authorizations/__tests__/pdfPrefill.test.ts
@@ -108,6 +108,21 @@ describe('parseAuthorizationPdfText', () => {
     expect(result).not.toHaveProperty('endDate');
   });
 
+  it('prefers labeled authorization dates over service-row dates', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Service From: 06/01/2026
+        Service To: 12/31/2026
+        Code Description From To Requested Approved
+        H2019 Behavioral services 06/23/2026 12/22/2026 1560 1560
+      `),
+    ).toMatchObject({
+      startDate: '2026-06-01',
+      endDate: '2026-12-31',
+      services: [{ serviceCode: 'H2019', requestedUnits: 1560, approvedUnits: 1560 }],
+    });
+  });
+
   it('does not infer status from requested or approved unit labels', () => {
     expect(
       parseAuthorizationPdfText(`
@@ -232,6 +247,177 @@ describe('parseAuthorizationPdfText', () => {
       services: [],
     });
   });
+
+  it('does not infer full approval from negative or partial authorization prose', () => {
+    expect(
+      parseAuthorizationPdfText('Based on review, not all requested services have been authorized.'),
+    ).toEqual({
+      services: [],
+    });
+    expect(
+      parseAuthorizationPdfText('Based on review, requested services have not been authorized.'),
+    ).toEqual({
+      services: [],
+    });
+    expect(
+      parseAuthorizationPdfText('Based on review, requested services have been authorized in part.'),
+    ).toEqual({
+      services: [],
+    });
+    expect(
+      parseAuthorizationPdfText('Based on review, requested services have been authorized, not all at the requested level.'),
+    ).toEqual({
+      services: [],
+    });
+    expect(
+      parseAuthorizationPdfText('Based on review, requested services have been authorized with modifications.'),
+    ).toEqual({
+      services: [],
+    });
+  });
+
+  it('extracts IEHP vertical procedure blocks with modifier rows', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Referral ID: IEHP-AUTH-REAL-SHAPE
+        Diagnosis
+        1 (F84.0) - Autistic disorder
+        Status: Approved Priority: Standard-Preservice
+        1 Code
+        H2019
+        Requested
+        Units
+        Approved
+        2080 Units
+        Decision
+        Approved
+        Dates
+        6/16/2026 -12/13/2026
+        2 Code
+        H0032
+        Requested
+        Units
+        Approved
+        832 Units
+        Decision
+        Approved
+        Dates
+        6/16/2026 -12/13/2026
+        3 Code (Modifier)
+        H0032 (HO)
+        Requested
+        Units
+        Approved
+        312 Units
+        Decision
+        Approved
+        Dates
+        6/16/2026 -12/13/2026
+      `),
+    ).toMatchObject({
+      authorizationNumber: 'IEHP-AUTH-REAL-SHAPE',
+      status: 'approved',
+      diagnosisCode: 'F84.0',
+      diagnosisDescription: 'Autistic disorder',
+      startDate: '2026-06-16',
+      endDate: '2026-12-13',
+      services: [
+        { serviceCode: 'H2019', approvedUnits: 2080 },
+        { serviceCode: 'H0032', approvedUnits: 832 },
+        { serviceCode: 'H0032-HO', approvedUnits: 312 },
+      ],
+    });
+  });
+
+  it('extracts approved IEHP vertical units when requested and approved rows differ', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Referral ID: IEHP-AUTH-REQUESTED-APPROVED
+        1 Code
+        H2019
+        Requested
+        3000 Units
+        Approved
+        2080 Units
+        Decision
+        Approved
+        Dates
+        6/16/2026 -12/13/2026
+      `),
+    ).toMatchObject({
+      authorizationNumber: 'IEHP-AUTH-REQUESTED-APPROVED',
+      services: [{ serviceCode: 'H2019', approvedUnits: 2080 }],
+    });
+  });
+
+  it('extracts IEHP vertical units from browser PDF text without row numbers', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Status: Approved Priority: Standard-Preservice
+        Code
+        Requested
+        Approved
+        Dates
+        H2019
+        Units
+        2080 Units
+        Approved
+        Code
+        Requested
+        Approved
+        Dates
+        H0032
+        Units
+        832 Units
+        Approved
+        Code (Modifier)
+        Requested
+        Approved
+        Dates
+        H0032 (HO)
+        Units
+        312 Units
+        Approved
+      `),
+    ).toMatchObject({
+      status: 'approved',
+      services: [
+        { serviceCode: 'H2019', approvedUnits: 2080 },
+        { serviceCode: 'H0032', approvedUnits: 832 },
+        { serviceCode: 'H0032-HO', approvedUnits: 312 },
+      ],
+    });
+  });
+
+  it('extracts CalOptima rows with OCR-like code and date separators', () => {
+    expect(
+      parseAuthorizationPdfText(`
+        Provider Notice of Action / Preauthorization for Outpatient Services
+        Member Name: Example Member CIN #: Z1234567Q
+        Date of Birth: 09/04/2020 Authorization #: SYNTHAUTH1
+        Diagnosis: Codes and Descriptions
+        F84.0 - Autistic disorder
+        Req Appr { Unit | Decision Code Description From Date{ To Date Units | Units | Type Status
+        HO032HN SERVICE PLAN DVLP 06/23/2026 {12/22/2026{ 208 208 Units | Approved
+        HO032HO | SERVICE PLAN DVLP 06/23/2026 {12/22/2026:] 104 104 Units | Approved
+        H2019 BEHAVIORAL SERVICES {06/23/2026 {12/22/2026 1560 i 1560 i} Units | Approved
+        Based on review, the above requested services has been authorized
+      `),
+    ).toMatchObject({
+      authorizationNumber: 'SYNTHAUTH1',
+      status: 'approved',
+      memberId: 'Z1234567Q',
+      diagnosisCode: 'F84.0',
+      diagnosisDescription: 'Autistic disorder',
+      startDate: '2026-06-23',
+      endDate: '2026-12-22',
+      services: [
+        { serviceCode: 'H0032-HN', requestedUnits: 208, approvedUnits: 208 },
+        { serviceCode: 'H0032-HO', requestedUnits: 104, approvedUnits: 104 },
+        { serviceCode: 'H2019', requestedUnits: 1560, approvedUnits: 1560 },
+      ],
+    });
+  });
 });
 
 describe('mergeAuthorizationPdfPrefill', () => {
@@ -242,6 +428,7 @@ describe('mergeAuthorizationPdfPrefill', () => {
     '97154': 'Group adaptive behavior treatment',
     '97155': 'Adaptive behavior treatment with protocol modification',
     '97157': 'Multiple-family adaptive behavior treatment guidance',
+    'H0032-HN': 'Treatment planning by non-physician',
     'H0032-HO': 'Treatment planning supervision',
   };
 
@@ -330,6 +517,7 @@ describe('mergeAuthorizationPdfPrefill', () => {
             { serviceCode: '97152', approvedUnits: 8 },
             { serviceCode: '97154', approvedUnits: 16 },
             { serviceCode: '97157', approvedUnits: 12 },
+            { serviceCode: 'H0032-HN', approvedUnits: 6 },
             { serviceCode: 'H0032-HO', approvedUnits: 10 },
           ],
         },
@@ -338,12 +526,13 @@ describe('mergeAuthorizationPdfPrefill', () => {
     ).toEqual({
       data: {
         ...current,
-        services: ['97151', '97152', '97154', '97157', 'H0032-HO'],
+        services: ['97151', '97152', '97154', '97157', 'H0032-HN', 'H0032-HO'],
         units: {
           '97151': 28,
           '97152': 8,
           '97154': 16,
           '97157': 12,
+          'H0032-HN': 6,
           'H0032-HO': 10,
         },
       },

--- a/src/lib/authorizations/pdfPrefill.ts
+++ b/src/lib/authorizations/pdfPrefill.ts
@@ -48,6 +48,7 @@ const SERVICE_CODE_PATTERN_SOURCE = String.raw`(?:97(?:151|152|153|154|155|156|1
 const SERVICE_CODE_PATTERN = new RegExp(String.raw`\b${SERVICE_CODE_PATTERN_SOURCE}\b`, 'g');
 const SERVICE_ROW_START_PATTERN = new RegExp(String.raw`^${SERVICE_CODE_PATTERN_SOURCE}\b`, 'i');
 const SERVICE_CONTEXT_PATTERN = /\b(?:procedure|service|code|cpt|hcpcs)\b/i;
+const ICD_CODE_PATTERN_SOURCE = String.raw`[A-Z]\d{2}(?:\.\d+)?(?![A-Z0-9])`;
 const DEFAULT_DIAGNOSIS_CODE = 'F84.0';
 const DEFAULT_DIAGNOSIS_DESCRIPTION = 'Autistic disorder';
 
@@ -178,13 +179,16 @@ const parseDates = (text: string): Pick<AuthorizationPdfPrefill, 'startDate' | '
 const parseDiagnosis = (
   text: string,
 ): Pick<AuthorizationPdfPrefill, 'diagnosisCode' | 'diagnosisDescription'> => {
+  const inlineDiagnosisPattern = new RegExp(
+    String.raw`\b(?:diagnosis|icd-?10(?: code)?)\s*:?\s*(${ICD_CODE_PATTERN_SOURCE})\s*(?:-|:)?\s*([A-Za-z][^\n\r]{2,80})?`,
+    'i',
+  );
+  const multilineDiagnosisPattern = new RegExp(
+    String.raw`\b(?:diagnosis|icd-?10(?: code)?)[^\n\r]*[\n\r]+\s*(?:\d+\s*)?\(?(${ICD_CODE_PATTERN_SOURCE})\)?\s*(?:-|:)?\s*([A-Za-z][^\n\r]{2,80})?`,
+    'i',
+  );
   const match =
-    /\b(?:diagnosis|icd-?10(?: code)?)\s*:?\s*([A-Z]\d{2}(?:\.\d+)?)\s*(?:-|:)?\s*([A-Za-z][^\n\r]{2,80})?/i.exec(
-      text,
-    ) ??
-    /\b(?:diagnosis|icd-?10(?: code)?)[^\n\r]*[\n\r]+\s*(?:\d+\s*)?\(?([A-Z]\d{2}(?:\.\d+)?)\)?\s*(?:-|:)?\s*([A-Za-z][^\n\r]{2,80})?/i.exec(
-      text,
-    );
+    inlineDiagnosisPattern.exec(text) ?? multilineDiagnosisPattern.exec(text);
   if (!match) {
     return {};
   }

--- a/src/lib/authorizations/pdfPrefill.ts
+++ b/src/lib/authorizations/pdfPrefill.ts
@@ -44,7 +44,7 @@ export interface AuthorizationPdfMergeOptions {
 }
 
 const DATE_PATTERN = String.raw`(?:\d{1,2}[/.]\d{1,2}[/.]\d{2,4}|\d{4}-\d{1,2}-\d{1,2})`;
-const SERVICE_CODE_PATTERN_SOURCE = String.raw`(?:97(?:151|152|153|154|155|156|157|158)|0\d{3}T|[A-Z]\d{4}(?:-?[A-Z0-9]{2})?)`;
+const SERVICE_CODE_PATTERN_SOURCE = String.raw`(?:97(?:151|152|153|154|155|156|157|158)|0\d{3}T|H[O0]\d{3}(?:-?[A-Z0-9]{2})?|[A-Z]\d{4}(?:-?[A-Z0-9]{2})?)`;
 const SERVICE_CODE_PATTERN = new RegExp(String.raw`\b${SERVICE_CODE_PATTERN_SOURCE}\b`, 'g');
 const SERVICE_ROW_START_PATTERN = new RegExp(String.raw`^${SERVICE_CODE_PATTERN_SOURCE}\b`, 'i');
 const SERVICE_CONTEXT_PATTERN = /\b(?:procedure|service|code|cpt|hcpcs)\b/i;
@@ -111,6 +111,14 @@ const parseStatus = (text: string): AuthorizationPdfStatus | undefined => {
   if (value === 'denied') return 'denied';
   if (value === 'approved') return 'approved';
   if (value === 'pending' || value === 'requested') return 'pending';
+  const authorizedProse = /\b(?:requested\s+services?|services?)\s+ha(?:s|ve)\s+been\s+authorized\b/i;
+  const negativeOrPartialProse =
+    /\b(?:not\s+all|not|partially|partial|in\s+part|modifications?|modified)\b[\s\S]{0,80}\b(?:requested\s+services?|services?|authorized)\b/i;
+  const qualifiedAuthorizationProse =
+    /\bauthorized\b[\s\S]{0,80}\b(?:not\s+all|not|in\s+part|partially|partial|modifications?|modified)\b/i;
+  if (authorizedProse.test(text) && !negativeOrPartialProse.test(text) && !qualifiedAuthorizationProse.test(text)) {
+    return 'approved';
+  }
   return undefined;
 };
 
@@ -149,6 +157,21 @@ const parseDates = (text: string): Pick<AuthorizationPdfPrefill, 'startDate' | '
     };
   }
 
+  const serviceRowRange = new RegExp(
+    `${SERVICE_CODE_PATTERN_SOURCE}[\\s\\S]{0,120}?(${DATE_PATTERN})\\D{0,20}?(${DATE_PATTERN})`,
+    'i',
+  ).exec(text);
+  if (serviceRowRange) {
+    const startDate = normalizeDate(serviceRowRange[1]);
+    const endDate = normalizeDate(serviceRowRange[2]);
+    if (startDate && endDate) {
+      return {
+        startDate,
+        endDate,
+      };
+    }
+  }
+
   return {};
 };
 
@@ -157,6 +180,9 @@ const parseDiagnosis = (
 ): Pick<AuthorizationPdfPrefill, 'diagnosisCode' | 'diagnosisDescription'> => {
   const match =
     /\b(?:diagnosis|icd-?10(?: code)?)\s*:?\s*([A-Z]\d{2}(?:\.\d+)?)\s*(?:-|:)?\s*([A-Za-z][^\n\r]{2,80})?/i.exec(
+      text,
+    ) ??
+    /\b(?:diagnosis|icd-?10(?: code)?)[^\n\r]*[\n\r]+\s*(?:\d+\s*)?\(?([A-Z]\d{2}(?:\.\d+)?)\)?\s*(?:-|:)?\s*([A-Za-z][^\n\r]{2,80})?/i.exec(
       text,
     );
   if (!match) {
@@ -179,25 +205,38 @@ const parseServices = (text: string): AuthorizationPdfPrefillService[] => {
   const lines = text.split(/\r?\n/).map(collapseWhitespace).filter(Boolean);
   const globalRequestedUnits = parseLabeledUnits(text, 'requested');
   const globalApprovedUnits = parseLabeledUnits(text, 'approved');
+  const setService = (service: AuthorizationPdfPrefillService) => {
+    const serviceCode = normalizeParsedServiceCode(service.serviceCode);
+    const existing = services.get(serviceCode) ?? { serviceCode };
+    services.set(serviceCode, {
+      serviceCode,
+      requestedUnits: service.requestedUnits ?? existing.requestedUnits,
+      approvedUnits: service.approvedUnits ?? existing.approvedUnits,
+    });
+  };
 
   for (const line of lines) {
     if (!SERVICE_CONTEXT_PATTERN.test(line) && !SERVICE_ROW_START_PATTERN.test(line)) {
       continue;
     }
 
-    const codes = [...line.matchAll(SERVICE_CODE_PATTERN)].map((match) => match[0].toUpperCase());
+    const codes = getServiceCodesFromLine(line);
     for (const serviceCode of codes) {
       const existing = services.get(serviceCode) ?? { serviceCode };
       const requestedUnits = parseLabeledUnits(line, 'requested') ?? existing.requestedUnits;
       const approvedUnits = parseLabeledUnits(line, 'approved') ?? existing.approvedUnits;
       const compactUnits = parseCompactServiceRowUnits(line, serviceCode);
 
-      services.set(serviceCode, {
+      setService({
         serviceCode,
         requestedUnits: requestedUnits ?? compactUnits?.requestedUnits,
         approvedUnits: approvedUnits ?? compactUnits?.approvedUnits,
       });
     }
+  }
+
+  for (const service of parseVerticalServiceBlocks(lines)) {
+    setService(service);
   }
 
   if (services.size === 1) {
@@ -207,6 +246,59 @@ const parseServices = (text: string): AuthorizationPdfPrefillService[] => {
   }
 
   return [...services.values()];
+};
+
+const getServiceCodesFromLine = (line: string): string[] => {
+  const normalizedLine = line.replace(
+    /\b(H[O0]\d{3})\s*\(\s*([A-Z0-9]{2})\s*\)/gi,
+    (_, code: string, modifier: string) => `${code}-${modifier}`,
+  );
+  return [...normalizedLine.matchAll(SERVICE_CODE_PATTERN)].map((match) =>
+    normalizeParsedServiceCode(match[0]),
+  );
+};
+
+const normalizeParsedServiceCode = (code: string): string => {
+  const upper = code.toUpperCase().replace(/\s+/g, '');
+  const ocrHCode = /^HO(\d{3})(?:-?([A-Z0-9]{2}))?$/.exec(upper);
+  if (ocrHCode) {
+    return `H0${ocrHCode[1]}${ocrHCode[2] ? `-${ocrHCode[2]}` : ''}`;
+  }
+
+  const parentheticalModifier = /^([A-Z]\d{4})\(([A-Z0-9]{2})\)$/.exec(upper);
+  if (parentheticalModifier) {
+    return `${parentheticalModifier[1]}-${parentheticalModifier[2]}`;
+  }
+
+  return upper;
+};
+
+const parseVerticalServiceBlocks = (lines: string[]): AuthorizationPdfPrefillService[] => {
+  const services: AuthorizationPdfPrefillService[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/^(?:\d+\s+)?Code(?:\s+\(Modifier\))?$/i.test(lines[index])) {
+      continue;
+    }
+
+    const block = lines.slice(index + 1, index + 18);
+    const codeLine = block.find((line) => getServiceCodesFromLine(line).length > 0);
+    const serviceCode = codeLine ? getServiceCodesFromLine(codeLine)[0] : undefined;
+    if (!serviceCode) {
+      continue;
+    }
+
+    const approvedIndex = block.findIndex((line) => /^Approved\b/i.test(line));
+    const approvedBlock = approvedIndex >= 0 ? block.slice(approvedIndex + 1) : block;
+    const unitsLine = approvedBlock.find((line) => /\b\d+\s+Units\b/i.test(line));
+    const approvedUnits = unitsLine ? Number(/\b(\d+)\s+Units\b/i.exec(unitsLine)?.[1]) : undefined;
+    services.push({
+      serviceCode,
+      approvedUnits: Number.isFinite(approvedUnits) ? approvedUnits : undefined,
+    });
+  }
+
+  return services;
 };
 
 const parseCompactServiceRowUnits = (
@@ -236,7 +328,7 @@ export const parseAuthorizationPdfText = (text: string): AuthorizationPdfPrefill
   ]);
   const memberId = firstMatch(normalizedText, [
     /\bmember\s*(?:(?:id|#|number)\s*:?\s*|:\s*)((?=[A-Z0-9-]*\d)[A-Z0-9][A-Z0-9-]{2,})/i,
-    /\bcin\s*:?\s*([A-Z0-9][A-Z0-9-]{2,})/i,
+    /\bcin\s*(?:#|id|number)?\s*:?\s*([A-Z0-9][A-Z0-9-]{2,})/i,
   ]);
 
   return stripUndefined({


### PR DESCRIPTION
## Summary
- Harden authorization PDF prefill for the two real reference auth notices without committing PHI.
- Parse IEHP vertical service blocks, browser PDF.js block shape, CalOptima OCR-like H-code rows, labeled date precedence, CIN variants, and positive authorization prose.
- Add synthetic parser regressions for negative/partial approval language and active `H0032-HN` catalog handling.

## Verification
- PASS `npm test -- src/lib/authorizations/__tests__/pdfPrefill.test.ts`
- PASS `npm test -- src/components/__tests__/PreAuthTab.test.tsx`
- PASS `npm run typecheck`
- PASS `npm run lint`
- PASS `npm run build`
- PASS `npm run ci:check-focused` with existing local env skips for branch protection / DB grant / function auth parity
- PASS `npm run test:routes:tier0`
- PASS `npm run test:ci` on rerun
- PASS no-submit browser wizard acceptance for both reference PDFs
- PASS `npm run playwright:preflight`
- PASS `npm run playwright:auth`
- PASS `npm run playwright:authorizations-read-scope`
- BLOCKED/TIMEOUT `npm run ci:playwright` locally at 15 minutes with no captured output; targeted hosted Playwright checks passed and CI should complete the aggregate gate.

## Risk
Critical-lane, auth-adjacent authorization upload data handling. No schema, RLS, RPC, route-guard, or submit-path changes. OCR is intentionally out of scope because both reference PDFs expose embedded text.