### PR TITLE
Fix auth upload skipped-code warning tracking

### DIFF
--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -83,7 +83,7 @@ type PdfPrefillState =
 const AUTHORIZATION_STATUSES: AuthorizationStatus[] = ['approved', 'pending', 'denied'];
 const NO_EMBEDDED_PDF_TEXT_MESSAGE = 'No embedded PDF text was found.';
 const GENERIC_PDF_PREFILL_ERROR_MESSAGE = 'PDF text extraction failed. Enter the authorization fields manually.';
-const getDocumentKey = (file: File) => `${file.name}:${file.size}:${file.lastModified}`;
+const createDocumentUploadKey = (sequence: number) => `upload-${sequence}`;
 
 const createEmptyWizardData = (): PreAuthWizardData => ({
   insurance: '',
@@ -125,10 +125,12 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
     skippedServiceCodes: [],
   });
   const [skippedServiceCodesByDocument, setSkippedServiceCodesByDocument] = useState<Record<string, string[]>>({});
+  const [documentUploadKeys, setDocumentUploadKeys] = useState<string[]>([]);
   const [isDragActive, setIsDragActive] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const pdfPrefillGenerationRef = useRef(0);
+  const documentUploadKeySequenceRef = useRef(0);
   const hasAdminEditedStatusRef = useRef(false);
   const hasAdminEditedDiagnosisCodeRef = useRef(false);
   const hasAdminEditedDiagnosisDescriptionRef = useRef(false);
@@ -486,6 +488,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
     pdfPrefillGenerationRef.current += 1;
     setPdfPrefillState({ status: 'idle', skippedServiceCodes: [] });
     setSkippedServiceCodesByDocument({});
+    setDocumentUploadKeys([]);
     hasAdminEditedStatusRef.current = false;
     hasAdminEditedDiagnosisCodeRef.current = false;
     hasAdminEditedDiagnosisDescriptionRef.current = false;
@@ -520,13 +523,13 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
     );
   };
 
-  const applyPdfPrefillFromFiles = async (files: File[]) => {
-    const pdfFile = files.find((file) => file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf'));
-    if (!pdfFile) {
+  const applyPdfPrefillFromFiles = async (entries: Array<{ file: File; uploadKey: string }>) => {
+    const pdfEntry = entries.find(({ file }) => file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf'));
+    if (!pdfEntry) {
       return;
     }
 
-    const pdfFileKey = getDocumentKey(pdfFile);
+    const { file: pdfFile, uploadKey: pdfFileKey } = pdfEntry;
     const generation = pdfPrefillGenerationRef.current + 1;
     pdfPrefillGenerationRef.current = generation;
     setPdfPrefillState({ status: 'extracting', skippedServiceCodes: [] });
@@ -752,6 +755,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
     }
 
     const acceptedFiles: File[] = [];
+    const acceptedEntries: Array<{ file: File; uploadKey: string }> = [];
     Array.from(fileList).forEach((file) => {
       const isAcceptedType = ACCEPTED_FILE_TYPES.includes(file.type as typeof ACCEPTED_FILE_TYPES[number]);
       if (!isAcceptedType) {
@@ -765,28 +769,33 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       }
 
       acceptedFiles.push(file);
+      documentUploadKeySequenceRef.current += 1;
+      acceptedEntries.push({
+        file,
+        uploadKey: createDocumentUploadKey(documentUploadKeySequenceRef.current),
+      });
     });
 
     if (!acceptedFiles.length) {
       return;
     }
 
-    void applyPdfPrefillFromFiles(acceptedFiles);
+    void applyPdfPrefillFromFiles(acceptedEntries);
     setWizardData((prev) => ({
       ...prev,
       documents: [...prev.documents, ...acceptedFiles],
     }));
+    setDocumentUploadKeys((prev) => [...prev, ...acceptedEntries.map((entry) => entry.uploadKey)]);
   };
 
   const handleDocumentRemove = (index: number) => {
     pdfPrefillGenerationRef.current += 1;
     setPdfPrefillState({ status: 'idle', skippedServiceCodes: [] });
-    const removedFile = wizardData.documents[index];
-    if (removedFile) {
-      const removedFileKey = getDocumentKey(removedFile);
+    const removedDocumentUploadKey = documentUploadKeys[index];
+    if (removedDocumentUploadKey) {
       setSkippedServiceCodesByDocument((skippedByDocument) => {
         const next = { ...skippedByDocument };
-        delete next[removedFileKey];
+        delete next[removedDocumentUploadKey];
         return next;
       });
     }
@@ -794,6 +803,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
       ...prev,
       documents: prev.documents.filter((_, i) => i !== index),
     }));
+    setDocumentUploadKeys((prev) => prev.filter((_, i) => i !== index));
   };
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -593,6 +593,133 @@ describe("PreAuthTab manual authorization upload", () => {
     ).toBeInTheDocument();
   });
 
+  it("preserves skipped service-code review warnings after a later extractable PDF has no skipped codes", async () => {
+    extractPdfTextMock
+      .mockResolvedValueOnce(`
+        Authorization Number: IEHP-PDF-780
+        Diagnosis: F84.0 - Autistic disorder
+        Service From: 07/01/2026 to 12/31/2026
+        97153 approved units: 20
+        H2019 approved units: 10
+      `)
+      .mockResolvedValueOnce(`
+        Authorization Number: IEHP-PDF-781
+        Diagnosis: F84.0 - Autistic disorder
+        Service From: 07/01/2026 to 12/31/2026
+        97153 approved units: 20
+      `);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+    await waitFor(() => {
+      expect(screen.getByLabelText(/rendering therapist/i)).toHaveValue("therapist-provider-1");
+    });
+    await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["synthetic authorization notice"], "auth-notice.pdf", {
+        type: "application/pdf",
+        lastModified: 1,
+      }),
+    );
+
+    expect(await screen.findByText(/Unsupported service codes skipped: H2019/i)).toBeInTheDocument();
+
+    await user.upload(
+      fileInput,
+      new File(["synthetic clean authorization notice"], "clean-auth-notice.pdf", {
+        type: "application/pdf",
+        lastModified: 2,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Unsupported service codes skipped: H2019/i)).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(
+      screen.getByText(
+        /Some service codes from the PDF were not added because they are not active in the service catalog: H2019./i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("removes only the selected duplicate-metadata document skipped-code warning", async () => {
+    extractPdfTextMock
+      .mockResolvedValueOnce(`
+        Authorization Number: IEHP-PDF-782
+        Diagnosis: F84.0 - Autistic disorder
+        Service From: 07/01/2026 to 12/31/2026
+        97153 approved units: 20
+        H2019 approved units: 10
+      `)
+      .mockResolvedValueOnce(`
+        Authorization Number: IEHP-PDF-783
+        Diagnosis: F84.0 - Autistic disorder
+        Service From: 07/01/2026 to 12/31/2026
+        97153 approved units: 20
+        H2014 approved units: 8
+      `);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+    await waitFor(() => {
+      expect(screen.getByLabelText(/rendering therapist/i)).toHaveValue("therapist-provider-1");
+    });
+    await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const duplicateFileOptions = {
+      type: "application/pdf",
+      lastModified: 123,
+    };
+    await user.upload(
+      fileInput,
+      new File(["same synthetic bytes"], "duplicate-auth.pdf", duplicateFileOptions),
+    );
+
+    expect(await screen.findByText(/Unsupported service codes skipped: H2019/i)).toBeInTheDocument();
+
+    await user.upload(
+      fileInput,
+      new File(["same synthetic bytes"], "duplicate-auth.pdf", duplicateFileOptions),
+    );
+
+    expect(await screen.findByText(/Unsupported service codes skipped: H2014/i)).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("button", { name: /remove/i })[0]);
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(
+      screen.getByText(
+        /Some service codes from the PDF were not added because they are not active in the service catalog: H2014./i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        /Some service codes from the PDF were not added because they are not active in the service catalog: H2019/i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("uses the latest admin status edit when delayed PDF prefill resolves", async () => {
     const deferredText = createDeferred<string>();
     extractPdfTextMock.mockReturnValueOnce(deferredText.promise);

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -537,6 +537,58 @@ describe("PreAuthTab manual authorization upload", () => {
     ).toBeInTheDocument();
   });
 
+  it("clears the blank member ID review warning when an admin enters the member ID after PDF prefill", async () => {
+    extractPdfTextMock.mockResolvedValue(`
+      Authorization Number: IEHP-PDF-784
+      Diagnosis: F84.0 - Autistic disorder
+      Service From: 07/01/2026 to 12/31/2026
+      97153 approved units: 20
+      H2019 approved units: 10
+    `);
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+    await waitFor(() => {
+      expect(screen.getByLabelText(/rendering therapist/i)).toHaveValue("therapist-provider-1");
+    });
+    await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(
+      fileInput,
+      new File(["synthetic authorization notice"], "auth-notice.pdf", {
+        type: "application/pdf",
+      }),
+    );
+
+    expect(await screen.findByText(/PDF prefill applied/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    await user.type(screen.getByLabelText(/member id/i), "MEM-ADMIN-784");
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(
+      screen.queryByText(/Member ID is blank. Confirm the payer notice does not include a member ID before submitting./i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Some service codes from the PDF were not added because they are not active in the service catalog: H2019./i,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("preserves skipped service-code review warnings after a later no-text upload", async () => {
     extractPdfTextMock
       .mockResolvedValueOnce(`


### PR DESCRIPTION
Fixes skipped service-code review warning tracking to use per-upload instance keys instead of file metadata, so duplicate files and later clean uploads do not erase prior warning contributions. Adds focused regression coverage for later extractable PDFs, duplicate-metadata removal, and clearing the blank member ID review warning after an admin enters the member ID.