### PR TITLE
[codex] Fix Playwright CI timeout attribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "playwright:schedule-blocked-close": "tsx scripts/playwright-schedule-blocked-close.ts",
     "playwright:session-note-measurement-roundtrip": "tsx scripts/playwright-session-note-measurement-roundtrip.ts",
     "playwright:session-capture-adhoc-upsert": "tsx scripts/playwright-session-capture-adhoc-upsert.ts",
-    "ci:playwright": "npm run playwright:preflight && npm run playwright:auth && npm run playwright:schedule-conflict && npm run playwright:therapist-onboarding && npm run playwright:therapist-authorization && npm run playwright:session-no-show && npm run playwright:session-complete && npm run playwright:schedule-blocked-close && npm run playwright:session-note-measurement-roundtrip && npm run playwright:session-capture-adhoc-upsert",
+    "ci:playwright": "tsx scripts/playwright-ci-runner.ts playwright:preflight playwright:auth playwright:schedule-conflict playwright:therapist-onboarding playwright:therapist-authorization playwright:session-no-show playwright:session-complete playwright:schedule-blocked-close playwright:session-note-measurement-roundtrip playwright:session-capture-adhoc-upsert",
     "contract:runtime-config": "node scripts/contracts/check-runtime-config.mjs",
     "bolt:dev": "vite --host 0.0.0.0",
     "bolt:build": "tsc && vite build --mode production",

--- a/scripts/playwright-ci-runner.ts
+++ b/scripts/playwright-ci-runner.ts
@@ -1,0 +1,171 @@
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+
+const DEFAULT_CHILD_TIMEOUT_MS = 12 * 60 * 1000;
+const DEFAULT_HEARTBEAT_MS = 60 * 1000;
+
+type RunResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+};
+
+const parsePositiveInteger = (value: string | undefined, fallback: number): number => {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const childTimeoutMs = parsePositiveInteger(
+  process.env.PW_CI_CHILD_TIMEOUT_MS,
+  DEFAULT_CHILD_TIMEOUT_MS,
+);
+const heartbeatMs = parsePositiveInteger(
+  process.env.PW_CI_HEARTBEAT_MS,
+  DEFAULT_HEARTBEAT_MS,
+);
+
+const useShell = process.platform === "win32";
+const npmCommand = "npm";
+const scriptNames = process.argv.slice(2);
+
+const formatDuration = (durationMs: number): string => {
+  const totalSeconds = Math.round(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds}s`;
+};
+
+const log = (message: string): void => {
+  console.log(`[ci:playwright ${new Date().toISOString()}] ${message}`);
+};
+
+const terminateChild = (child: ChildProcess, signal: NodeJS.Signals = "SIGTERM"): void => {
+  if (process.platform === "win32" && child.pid) {
+    spawn("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+      stdio: "ignore",
+      windowsHide: true,
+    }).on("error", () => {
+      child.kill(signal);
+    });
+    return;
+  }
+
+  child.kill(signal);
+};
+
+const runScript = (scriptName: string, index: number, total: number): Promise<RunResult> =>
+  new Promise((resolve) => {
+    const startedAt = Date.now();
+    let timedOut = false;
+    let settled = false;
+    let resolved = false;
+
+    log(
+      `START ${index}/${total}: npm run ${scriptName} ` +
+        `(timeout ${formatDuration(childTimeoutMs)})`,
+    );
+
+    const child = spawn(npmCommand, ["run", scriptName], {
+      stdio: "inherit",
+      shell: useShell,
+      windowsHide: true,
+    });
+
+    const resolveOnce = (result: RunResult): void => {
+      if (resolved) {
+        return;
+      }
+      resolved = true;
+      resolve(result);
+    };
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      clearInterval(heartbeat);
+      log(
+        `TIMEOUT ${index}/${total}: npm run ${scriptName} exceeded ` +
+          `${formatDuration(childTimeoutMs)}; terminating child process.`,
+      );
+      terminateChild(child);
+
+      setTimeout(() => {
+        if (!settled) {
+          terminateChild(child, "SIGKILL");
+        }
+      }, 5000).unref();
+    }, childTimeoutMs);
+
+    const heartbeat = setInterval(() => {
+      log(
+        `STILL RUNNING ${index}/${total}: npm run ${scriptName} ` +
+          `after ${formatDuration(Date.now() - startedAt)}`,
+      );
+    }, heartbeatMs);
+
+    const cleanup = () => {
+      settled = true;
+      clearTimeout(timeout);
+      clearInterval(heartbeat);
+    };
+
+    child.on("error", (error) => {
+      cleanup();
+      log(`ERROR ${index}/${total}: failed to start npm run ${scriptName}: ${error.message}`);
+      resolveOnce({ code: 1, signal: null, timedOut });
+    });
+
+    child.on("close", (code, signal) => {
+      if (resolved) {
+        return;
+      }
+      cleanup();
+      const elapsed = formatDuration(Date.now() - startedAt);
+      if (timedOut) {
+        log(
+          `FAILED ${index}/${total}: npm run ${scriptName} timed out after ${elapsed} ` +
+            `(exit ${code ?? "null"}, signal ${signal ?? "null"}).`,
+        );
+      } else if (code === 0) {
+        log(`PASS ${index}/${total}: npm run ${scriptName} completed in ${elapsed}.`);
+      } else {
+        log(
+          `FAILED ${index}/${total}: npm run ${scriptName} exited with code ` +
+            `${code ?? "null"} signal ${signal ?? "null"} after ${elapsed}.`,
+        );
+      }
+      resolveOnce({ code, signal, timedOut });
+    });
+  });
+
+const run = async (): Promise<void> => {
+  if (scriptNames.length === 0) {
+    throw new Error("ci:playwright runner requires at least one npm script name.");
+  }
+
+  log(`Running ${scriptNames.length} Playwright smoke scripts with child attribution.`);
+
+  for (let index = 0; index < scriptNames.length; index += 1) {
+    const scriptName = scriptNames[index];
+    const result = await runScript(scriptName, index + 1, scriptNames.length);
+    if (result.code !== 0 || result.signal !== null || result.timedOut) {
+      process.exitCode = result.timedOut ? 124 : result.code ?? 1;
+      log(`STOP after failed child: npm run ${scriptName}`);
+      return;
+    }
+  }
+
+  log("PASS all Playwright smoke scripts.");
+};
+
+run().catch((error) => {
+  console.error(
+    `[ci:playwright ${new Date().toISOString()}] FAILED runner setup: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+  process.exitCode = 1;
+});

--- a/scripts/playwright-session-capture-adhoc-upsert.ts
+++ b/scripts/playwright-session-capture-adhoc-upsert.ts
@@ -326,7 +326,10 @@ async function run(): Promise<void> {
             response.url().includes("/api/session-notes/upsert") && response.request().method() === "POST",
           { timeout: 120_000 },
         );
-        await editDialog.getByTestId("session-modal-save-capture-skills").click();
+        activePage.once("dialog", (dialog) => {
+          void dialog.accept();
+        });
+        await editDialog.getByRole("button", { name: /^Save progress$/i }).click();
         const res = await upsertPromise.catch(async (error) => {
           throw await buildFailure(error);
         });

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -27,6 +27,8 @@ interface LifecycleIds {
   clientId: string;
   programId: string;
   goalId: string;
+  startIso: string;
+  endIso: string;
   createdProgramId?: string;
   createdGoalId?: string;
 }
@@ -42,12 +44,6 @@ interface BrowserFetchResult<TBody> {
 }
 
 const isTruthy = (value: string | undefined): boolean => /^(1|true|yes)$/i.test(value ?? "");
-/** Mirrors `src/pages/schedule-modal-url-state.ts` query keys for deep-linking the SessionModal. */
-const SCHEDULE_MODAL_MODE_KEY = "scheduleModal";
-const SCHEDULE_MODAL_SESSION_KEY = "scheduleSessionId";
-const SCHEDULE_MODAL_EXPIRY_KEY = "scheduleExp";
-const SCHEDULE_MODAL_URL_TTL_MS = 30 * 60 * 1000;
-
 /** UI wait (90s) + edge/RPC fallback can exceed 120s on cold paths. */
 const STEP_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_STEP_TIMEOUT_MS ?? "300000");
 
@@ -181,7 +177,7 @@ const createSessionViaServiceRole = async (params: {
   goalId: string;
   startIso: string;
   endIso: string;
-}): Promise<string> => {
+}): Promise<{ sessionId: string; startIso: string; endIso: string }> => {
   const supabaseUrl = getEnv("VITE_SUPABASE_URL");
   const serviceRole = getEnv("SUPABASE_SERVICE_ROLE_KEY");
   const adminClient = createClient(supabaseUrl, serviceRole, {
@@ -207,9 +203,9 @@ const createSessionViaServiceRole = async (params: {
   const baseStart = new Date(params.startIso);
   const baseEnd = new Date(params.endIso);
   const durationMs = Math.max(15 * 60 * 1000, baseEnd.getTime() - baseStart.getTime());
+  const fallbackStarts = buildBookingCandidateStarts().filter((candidate) => candidate.getTime() >= baseStart.getTime());
 
-  for (let attempt = 0; attempt < 48; attempt += 1) {
-    const start = new Date(baseStart.getTime() + attempt * 2 * 60 * 60 * 1000);
+  for (const start of fallbackStarts) {
     const end = new Date(start.getTime() + durationMs);
     const { data, error } = await adminClient
       .from("sessions")
@@ -224,11 +220,15 @@ const createSessionViaServiceRole = async (params: {
         status: "scheduled",
         notes: "Playwright lifecycle fallback booking",
       })
-      .select("id")
+      .select("id,start_time,end_time")
       .single();
 
     if (!error && data?.id) {
-      return data.id;
+      return {
+        sessionId: data.id,
+        startIso: typeof data.start_time === "string" ? data.start_time : start.toISOString(),
+        endIso: typeof data.end_time === "string" ? data.end_time : end.toISOString(),
+      };
     }
     const message = error?.message ?? "";
     if (!message.includes("sessions_no_overlap")) {
@@ -498,39 +498,71 @@ const toDatetimeLocal = (date: Date): string => {
   return local.toISOString().slice(0, 16);
 };
 
-const buildBookingBaseStart = (): Date => {
+const buildBookingCandidateStarts = (): Date[] => {
   const runSeed = Number(process.env.GITHUB_RUN_ID ?? Date.now());
-  const offsetHours = Number.isFinite(runSeed) ? Math.abs(Math.trunc(runSeed)) % 12 : 0;
-  const start = new Date();
-  start.setHours(start.getHours() + 4 + offsetHours, 0, 0, 0);
-  return start;
-};
+  const daytimeHours = [9, 11, 13, 15];
+  const rotation = Number.isFinite(runSeed) ? Math.abs(Math.trunc(runSeed)) % daytimeHours.length : 0;
+  const hours = [...daytimeHours.slice(rotation), ...daytimeHours.slice(0, rotation)];
+  const candidates: Date[] = [];
+  const day = new Date();
+  day.setHours(0, 0, 0, 0);
+  day.setDate(day.getDate() + 1);
 
-const buildScheduleEditSessionUrl = (scheduleUrl: string, sessionId: string): string => {
-  const url = new URL(scheduleUrl);
-  const expiresAtMs = Date.now() + SCHEDULE_MODAL_URL_TTL_MS;
-  url.searchParams.set(SCHEDULE_MODAL_MODE_KEY, "edit");
-  url.searchParams.set(SCHEDULE_MODAL_SESSION_KEY, sessionId);
-  url.searchParams.set(SCHEDULE_MODAL_EXPIRY_KEY, String(expiresAtMs));
-  return url.toString();
-};
-
-const openEditSessionModalFromUrl = async (page: Page, scheduleUrl: string, sessionId: string): Promise<void> => {
-  for (let attempt = 0; attempt < 12; attempt += 1) {
-    await page.goto(buildScheduleEditSessionUrl(scheduleUrl, sessionId), {
-      waitUntil: "networkidle",
-      timeout: 60000,
-    });
-    const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
-    try {
-      await dialog.waitFor({ state: "visible", timeout: 12_000 });
-      return;
-    } catch {
-      await page.waitForTimeout(500 + attempt * 250);
+  for (let dayOffset = 0; dayOffset < 14; dayOffset += 1) {
+    const candidateDay = new Date(day);
+    candidateDay.setDate(day.getDate() + dayOffset);
+    if (candidateDay.getDay() === 0) {
+      continue;
+    }
+    for (const hour of hours) {
+      const candidate = new Date(candidateDay);
+      candidate.setHours(hour, 0, 0, 0);
+      candidates.push(candidate);
     }
   }
+
+  return candidates;
+};
+
+const openEditSessionModalFromCalendar = async (
+  page: Page,
+  scheduleUrl: string,
+  sessionId: string,
+  sessionStartIso: string,
+): Promise<void> => {
+  await page.goto(`${scheduleUrl}?_${Date.now()}`, {
+    waitUntil: "networkidle",
+    timeout: 60000,
+  });
+
+  let visitedPeriods = 0;
+  for (let periodAttempt = 0; periodAttempt < 8; periodAttempt += 1) {
+    visitedPeriods = periodAttempt + 1;
+    const sessionCard = page.locator(`[data-session-id="${sessionId}"]`).first();
+    const visible = await sessionCard
+      .waitFor({ state: "visible", timeout: periodAttempt === 0 ? 12_000 : 5_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (visible) {
+      await sessionCard.scrollIntoViewIfNeeded();
+      await sessionCard.click();
+      const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
+      await dialog.waitFor({ state: "visible", timeout: 12_000 });
+      return;
+    }
+
+    const nextPeriodButton = page.getByRole("button", { name: /next period/i }).first();
+    if ((await nextPeriodButton.count()) === 0) {
+      break;
+    }
+    await nextPeriodButton.click();
+    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
+    await page.waitForTimeout(500 + periodAttempt * 250);
+  }
+
   throw new Error(
-    "Session modal (Edit Session / Live session) did not open from schedule deep link; session may not be loaded in schedule data yet.",
+    `Session modal (Edit Session / Live session) did not open from the rendered schedule card after ${visitedPeriods} schedule period(s). sessionStartIso=${sessionStartIso}`,
   );
 };
 
@@ -645,14 +677,14 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
 
   const selected = await chooseSessionTargets(page);
 
-  const start = buildBookingBaseStart();
+  const candidateStarts = buildBookingCandidateStarts();
   let finalStartIso = "";
   let finalEndIso = "";
   let payload: BrowserFetchResult<Record<string, unknown>> | null = null;
   let payloadBody: { success?: boolean; data?: { session?: { id?: string } }; code?: string } | null = null;
 
-  for (let attempt = 0; attempt < 48; attempt += 1) {
-    const attemptStart = new Date(start.getTime() + attempt * 2 * 60 * 60 * 1000);
+  for (let attempt = 0; attempt < candidateStarts.length; attempt += 1) {
+    const attemptStart = candidateStarts[attempt];
     const attemptEnd = new Date(attemptStart.getTime() + 60 * 60 * 1000);
     const startIso = attemptStart.toISOString();
     const endIso = attemptEnd.toISOString();
@@ -720,7 +752,7 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
       httpStatus === 401 ||
       (typeof payloadBody?.code === "string" && payloadBody.code.toLowerCase() === "unauthorized");
     if (!strictMode && bodyUnauthorized && finalStartIso && finalEndIso) {
-      const fallbackSessionId = await createSessionViaServiceRole({
+      const fallbackSession = await createSessionViaServiceRole({
         therapistId: selected.therapistId,
         clientId: selected.clientId,
         programId: selected.programId,
@@ -729,11 +761,13 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
         endIso: finalEndIso,
       });
       return {
-        sessionId: fallbackSessionId,
+        sessionId: fallbackSession.sessionId,
         therapistId: selected.therapistId,
         clientId: selected.clientId,
         programId: selected.programId,
         goalId: selected.goalId,
+        startIso: fallbackSession.startIso,
+        endIso: fallbackSession.endIso,
         createdProgramId: selected.createdProgramId,
         createdGoalId: selected.createdGoalId,
       };
@@ -752,6 +786,8 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
     clientId: selected.clientId,
     programId: selected.programId,
     goalId: selected.goalId,
+    startIso: finalStartIso,
+    endIso: finalEndIso,
     createdProgramId: selected.createdProgramId,
     createdGoalId: selected.createdGoalId,
   };
@@ -1152,7 +1188,7 @@ async function startSessionViaScheduleModal(
   token: string,
   strictMode: boolean,
 ): Promise<void> {
-  await openEditSessionModalFromUrl(page, scheduleUrl, ids.sessionId);
+  await openEditSessionModalFromCalendar(page, scheduleUrl, ids.sessionId, ids.startIso);
   const startButton = page.getByRole("button", { name: /^Start Session$/i });
   await startButton.waitFor({ state: "visible", timeout: 20_000 });
   await expectStartButtonEnabled(page, startButton);
@@ -1200,7 +1236,7 @@ async function markTerminalViaScheduleModal(
   actorUserId: string,
   strictMode: boolean,
 ): Promise<void> {
-  await openEditSessionModalFromUrl(page, scheduleUrl, sessionId);
+  await openEditSessionModalFromCalendar(page, scheduleUrl, sessionId, ids.startIso);
   const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
   await page.locator("#status-select").selectOption(terminalStatus);
   page.once("dialog", (dialog) => {


### PR DESCRIPTION
## Summary
- replace the long `ci:playwright` shell chain with a sequential runner that logs child start/pass/fail/heartbeat/timeout attribution
- keep local timeouts actionable by terminating the active child and exiting `124` on per-child timeout
- adjust the affected Playwright smoke scripts so the aggregate run completes locally with rendered schedule-card attribution and the expected session-note upsert path

## Root cause
PR #665 and #666 showed local aggregate stalls without useful output because `ci:playwright` delegated through a single shell `&&` chain of nested `npm run` processes. When the aggregate was killed or a child went quiet, the active child script was not reliably identified.

## Verification
- `npm run ci:playwright` passed all 10 child scripts with attribution
- forced runner timeout check exited `124` and named the timed-out child
- `npm run playwright:session-no-show` passed
- `npm run playwright:session-capture-adhoc-upsert` passed
- `npm run verify:local` passed

## Notes
- no auth behavior, server API, Supabase schema, or GitHub workflow files were changed
- local verification still reports expected non-fatal local warnings for missing DB URL / CI-only branch protection checks