### PR TITLE
[codex] Restrict authorization document RPC anon grants

### DIFF
--- a/supabase/migrations/20260622142046_restrict_authorization_document_rpc_anon_execute.sql
+++ b/supabase/migrations/20260622142046_restrict_authorization_document_rpc_anon_execute.sql
@@ -1,0 +1,70 @@
+/*
+  @migration-intent: Remove unauthenticated/default execute access from authorization-adjacent document RPCs while preserving reviewed authenticated browser callers.
+  @migration-dependencies: 20260105121500_authorization_update_rpc_allowlist.sql, 20260105124500_harden_update_client_documents_path_allowlist.sql
+  @migration-rollback: Re-grant execute to anon only for a specific RPC if a reviewed public caller is introduced.
+*/
+
+begin;
+
+revoke execute on function public.can_access_client_documents(uuid) from public, anon;
+revoke execute on function public.update_client_documents(uuid, jsonb) from public, anon;
+revoke execute on function public.update_authorization_documents(uuid, jsonb) from public, anon;
+revoke execute on function public.update_authorization_with_services(
+  uuid,
+  text,
+  uuid,
+  uuid,
+  text,
+  text,
+  date,
+  date,
+  text,
+  uuid,
+  text,
+  text,
+  jsonb
+) from public, anon;
+
+grant execute on function public.can_access_client_documents(uuid) to authenticated, service_role;
+grant execute on function public.update_client_documents(uuid, jsonb) to authenticated, service_role;
+grant execute on function public.update_authorization_documents(uuid, jsonb) to authenticated, service_role;
+grant execute on function public.update_authorization_with_services(
+  uuid,
+  text,
+  uuid,
+  uuid,
+  text,
+  text,
+  date,
+  date,
+  text,
+  uuid,
+  text,
+  text,
+  jsonb
+) to authenticated, service_role;
+
+do $$
+declare
+  unsafe_count integer;
+begin
+  select count(*)
+  into unsafe_count
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'public'
+    and p.oid in (
+      'public.can_access_client_documents(uuid)'::regprocedure,
+      'public.update_client_documents(uuid, jsonb)'::regprocedure,
+      'public.update_authorization_documents(uuid, jsonb)'::regprocedure,
+      'public.update_authorization_with_services(uuid, text, uuid, uuid, text, text, date, date, text, uuid, text, text, jsonb)'::regprocedure
+    )
+    and has_function_privilege('anon', p.oid, 'EXECUTE');
+
+  if unsafe_count > 0 then
+    raise exception 'Authorization document RPC grant hardening failed: % function(s) still executable by anon', unsafe_count;
+  end if;
+end
+$$;
+
+commit;

--- a/tests/authorizations/authorization-document-rpc-grants.security.spec.ts
+++ b/tests/authorizations/authorization-document-rpc-grants.security.spec.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('authorization document RPC execute grants', () => {
+  const migrationSql = readFileSync(
+    join(
+      process.cwd(),
+      'supabase/migrations/20260622142046_restrict_authorization_document_rpc_anon_execute.sql',
+    ),
+    'utf-8',
+  );
+  const grantStatements = migrationSql.match(/grant execute on function[^;]+;/gi) ?? [];
+
+  it('removes unauthenticated execute access from document RPCs', () => {
+    expect(migrationSql).toMatch(
+      /revoke execute on function public\.can_access_client_documents\(uuid\) from public, anon;/i,
+    );
+    expect(migrationSql).toMatch(
+      /revoke execute on function public\.update_client_documents\(uuid, jsonb\) from public, anon;/i,
+    );
+    expect(migrationSql).toMatch(
+      /revoke execute on function public\.update_authorization_documents\(uuid, jsonb\) from public, anon;/i,
+    );
+    expect(migrationSql).toMatch(
+      /revoke execute on function public\.update_authorization_with_services\([\s\S]+?\) from public, anon;/i,
+    );
+  });
+
+  it('preserves reviewed authenticated and service-role callers', () => {
+    expect(migrationSql).toMatch(
+      /grant execute on function public\.can_access_client_documents\(uuid\) to authenticated, service_role;/i,
+    );
+    expect(migrationSql).toMatch(
+      /grant execute on function public\.update_client_documents\(uuid, jsonb\) to authenticated, service_role;/i,
+    );
+    expect(migrationSql).toMatch(
+      /grant execute on function public\.update_authorization_documents\(uuid, jsonb\) to authenticated, service_role;/i,
+    );
+    expect(migrationSql).toMatch(
+      /grant execute on function public\.update_authorization_with_services\([\s\S]+?\) to authenticated, service_role;/i,
+    );
+  });
+
+  it('asserts anon execute was removed after applying grants', () => {
+    expect(migrationSql).toMatch(/has_function_privilege\('anon', p\.oid, 'EXECUTE'\)/i);
+    expect(migrationSql).toMatch(/still executable by anon/i);
+  });
+
+  it('does not re-grant unauthenticated execute access', () => {
+    for (const grantStatement of grantStatements) {
+      expect(grantStatement).not.toMatch(/\bto\s+(public|anon)\b/i);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a narrow Supabase migration to revoke unauthenticated/default execute access from authorization-adjacent document RPCs.
- Preserves reviewed `authenticated` and `service_role` callers for existing browser upload/prefill flows.
- Adds a focused migration contract test for the grant posture.

## Hosted Supabase Evidence
Project: `wnnjeqheqxxyrgsjmygy`

Before repair, live ACL inspection showed `anon` execute through default `PUBLIC` grants on:
- `public.can_access_client_documents(uuid)`
- `public.update_client_documents(uuid, jsonb)`
- `public.update_authorization_documents(uuid, jsonb)`
- `public.update_authorization_with_services(uuid, text, uuid, uuid, text, text, date, date, text, uuid, text, text, jsonb)`

Applied hosted migration via Supabase connector as `20260622142046 restrict_authorization_document_rpc_anon_execute`.

After repair, live ACL verification showed `anon=false`, `authenticated=true`, and `service_role=true` for all four targeted RPCs.

## Verification
- `npm test -- tests/authorizations/authorization-document-rpc-grants.security.spec.ts --runInBand` passed
- `npm run ci:check-focused` passed
- `npm run validate:tenant` passed
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run test:ci` failed once on corrupted V8 coverage JSON, then passed after clearing coverage temp
- `npm run build` passed
- `npm run verify:local` passed

Notes from local checks:
- DB-URL-backed policy checks were skipped locally because `SUPABASE_DB_URL` / `DATABASE_URL` is not configured.
- Live Supabase connector queries covered the targeted hosted grant state.
- Current advisor still reports the intentional signed-in `SECURITY DEFINER` warning for `update_client_documents`; this PR does not remove authenticated execution because the app still calls that RPC from authenticated browser clients.

## Risk
Critical protected-path change. Scope is limited to four directly related RPC execute grants and one focused test. Unrelated advisor findings are intentionally out of scope.