### PR TITLE
Harden PreAuth create RPC grants

### DIFF
--- a/cypress/e2e/preauth_workflow.cy.ts
+++ b/cypress/e2e/preauth_workflow.cy.ts
@@ -1,0 +1,311 @@
+/// <reference types="cypress" />
+
+import { installRouteDataStubs } from "../support/routeScenarios";
+
+const jsonHeaders = { "content-type": "application/json" };
+const nowIso = "2026-06-22T00:00:00.000Z";
+const defaultOrganizationId = "5238e88b-6198-4862-80a2-dbe15bbeabdd";
+const stubAdminUser = {
+  id: "stub-admin",
+  email: "admin@test.com",
+  aud: "authenticated",
+  role: "authenticated",
+  app_metadata: {
+    provider: "stub",
+    providers: ["stub"],
+    role: "admin",
+  },
+  user_metadata: {
+    email: "admin@test.com",
+    role: "admin",
+    organization_id: defaultOrganizationId,
+  },
+  identities: [],
+  created_at: nowIso,
+  updated_at: nowIso,
+  last_sign_in_at: nowIso,
+  factors: [],
+  confirmed_at: nowIso,
+  email_confirmed_at: nowIso,
+  phone: "",
+  is_anonymous: false,
+};
+
+const installPreAuthWorkflowStubs = (): void => {
+  installRouteDataStubs();
+
+  cy.intercept("**/(rest|auth|storage)/v1/**", (req) => {
+    throw new Error(`Unstubbed Supabase request in PreAuth workflow spec: ${req.method} ${req.url}`);
+  });
+
+  cy.intercept("GET", "**/rest/v1/profiles**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: {
+      id: "stub-admin",
+      email: "admin@test.com",
+      role: "admin",
+      full_name: "admin tester",
+      first_name: "admin",
+      last_name: "tester",
+      organization_id: defaultOrganizationId,
+      is_active: true,
+      created_at: "2026-06-22T00:00:00.000Z",
+      updated_at: "2026-06-22T00:00:00.000Z",
+    },
+  }).as("profileFetchForPreAuth");
+
+  cy.intercept("GET", "**/auth/v1/user", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: {
+      user: stubAdminUser,
+    },
+  }).as("supabaseUserForPreAuth");
+
+  cy.intercept("GET", "**/rest/v1/clients**", (req) => {
+    const idQuery = req.query.id as string | undefined;
+    const clientId = idQuery?.split("eq.")[1];
+    const client = {
+      id: "client-1",
+      full_name: "Test Client",
+      email: "client@example.com",
+      organization_id: defaultOrganizationId,
+      primary_therapist_id: "therapist-provider-1",
+      one_to_one_units: 5,
+      supervision_units: 2,
+      parent_consult_units: 1,
+    };
+    req.reply({
+      statusCode: 200,
+      headers: jsonHeaders,
+      body: clientId ? (clientId === "client-1" ? client : null) : [client],
+    });
+  }).as("clientsForPreAuth");
+
+  cy.intercept("GET", "**/rest/v1/sessions**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  }).as("sessionsForPreAuth");
+
+  cy.intercept("GET", "**/rest/v1/client_issues**", {
+    statusCode: 200,
+    headers: {
+      ...jsonHeaders,
+      "content-range": "0-0/0",
+    },
+    body: [],
+  }).as("clientIssuesForPreAuth");
+  cy.intercept("HEAD", "**/rest/v1/client_issues**", {
+    statusCode: 200,
+    headers: {
+      "content-range": "0-0/0",
+    },
+  }).as("clientIssuesCountForPreAuth");
+
+  cy.intercept("GET", "**/rest/v1/cpt_codes**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [
+      {
+        code: "97153",
+        short_description: "Adaptive behavior treatment by protocol",
+      },
+    ],
+  }).as("cptCodes");
+
+  cy.intercept("GET", "**/rest/v1/insurance_providers**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [
+      {
+        id: "payer-1",
+        name: "Synthetic Payer",
+      },
+    ],
+  }).as("insuranceProviders");
+
+  cy.intercept("GET", "**/rest/v1/client_therapist_links**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [
+      {
+        client_id: "client-1",
+        therapist_id: "therapist-provider-1",
+      },
+    ],
+  }).as("clientTherapistLinks");
+
+  cy.intercept("GET", "**/rest/v1/therapists**", (req) => {
+    req.reply({
+      statusCode: 200,
+      headers: jsonHeaders,
+      body: [
+        {
+          id: "therapist-provider-1",
+          full_name: "Rendering Therapist",
+          organization_id: defaultOrganizationId,
+        },
+      ],
+    });
+  }).as("therapists");
+
+  cy.intercept("GET", "**/rest/v1/client_session_notes**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  }).as("sessionNotes");
+
+  cy.intercept("GET", "**/rest/v1/authorizations**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  }).as("authorizations");
+
+  cy.intercept("POST", "**/rest/v1/rpc/create_authorization_with_services", (req) => {
+    expect(req.body).to.include({
+      p_client_id: "client-1",
+      p_provider_id: "therapist-provider-1",
+      p_authorization_number: "IEHP-AUTH-CYPRESS",
+      p_diagnosis_code: "F84.0",
+      p_diagnosis_description: "Autistic disorder",
+      p_status: "approved",
+      p_insurance_provider_id: "payer-1",
+      p_plan_type: "Medicaid",
+      p_member_id: "SYNTH-MEMBER",
+    });
+    expect(req.body.p_services).to.deep.equal([
+      {
+        service_code: "97153",
+        service_description: "Adaptive behavior treatment by protocol",
+        from_date: "2026-06-23",
+        to_date: "2026-12-22",
+        requested_units: 120,
+        approved_units: 120,
+        unit_type: "Units",
+        decision_status: "approved",
+      },
+    ]);
+
+    req.reply({
+      statusCode: 200,
+      headers: jsonHeaders,
+      body: {
+        id: "auth-created-id",
+        client_id: "client-1",
+        provider_id: "therapist-provider-1",
+        authorization_number: "IEHP-AUTH-CYPRESS",
+      },
+    });
+  }).as("createAuthorization");
+
+  cy.intercept("POST", "**/storage/v1/object/client-documents/clients/client-1/authorizations/auth-created-id/**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: {
+      Key: "client-documents/clients/client-1/authorizations/auth-created-id/codex-synthetic-preauth-smoke.pdf",
+    },
+  }).as("documentUpload");
+
+  cy.intercept("POST", "**/rest/v1/rpc/update_authorization_documents", (req) => {
+    expect(req.body.p_authorization_id).to.equal("auth-created-id");
+    expect(req.body.p_documents).to.have.length(1);
+    expect(req.body.p_documents[0]).to.include({
+      name: "codex-synthetic-preauth-smoke.pdf",
+      type: "application/pdf",
+    });
+    expect(req.body.p_documents[0].path).to.match(
+      /^clients\/client-1\/authorizations\/auth-created-id\/.+\.pdf$/,
+    );
+
+    req.reply({
+      statusCode: 200,
+      headers: jsonHeaders,
+      body: {
+        id: "auth-created-id",
+        documents: req.body.p_documents,
+      },
+    });
+  }).as("updateAuthorizationDocuments");
+
+};
+
+describe("Pre Authorization workflow", () => {
+  beforeEach(() => {
+    installPreAuthWorkflowStubs();
+  });
+
+  it("creates an authorization and uploads the authorization notice from client details", () => {
+    cy.visit("/", {
+      onBeforeLoad(win) {
+        win.localStorage.setItem(
+          "auth-storage",
+          JSON.stringify({
+            user: {
+              id: "stub-admin",
+              email: "admin@test.com",
+              role: "admin",
+              organization_id: defaultOrganizationId,
+              user_metadata: {
+                role: "admin",
+                organization_id: defaultOrganizationId,
+              },
+              app_metadata: {
+                role: "admin",
+              },
+              full_name: "admin tester",
+              first_name: "admin",
+              last_name: "tester",
+            },
+            accessToken: "stub-access-token-admin",
+            refreshToken: "stub-refresh-token-admin",
+            expiresAt: Date.now() + 3600_000,
+            provider: "stub",
+          }),
+        );
+      },
+    });
+    cy.wait("@runtimeConfig");
+
+    cy.visit("/clients/client-1");
+    cy.wait("@runtimeConfig");
+
+    cy.contains("button", "Pre-Authorizations").scrollIntoView().click({ force: true });
+    cy.contains("button", "New Authorization").scrollIntoView().click({ force: true });
+
+    cy.get("#preauth-authorization-number").type("IEHP-AUTH-CYPRESS");
+    cy.get("#preauth-insurance").select("payer-1");
+    cy.get("#preauth-provider-therapist").select("therapist-provider-1");
+    cy.get("#preauth-plan-type").select("Medicaid");
+    cy.get("#preauth-member-id").type("SYNTH-MEMBER");
+    cy.get("#preauth-start-date").type("2026-06-23");
+    cy.get("#preauth-end-date").type("2026-12-22");
+    cy.get("#preauth-diagnosis-code").clear().type("F84.0");
+    cy.get("#preauth-diagnosis-description").clear().type("Autistic disorder");
+
+    cy.contains("button", "Next").scrollIntoView().click({ force: true });
+    cy.get("#service-97153").check();
+
+    cy.contains("button", "Next").scrollIntoView().click({ force: true });
+    cy.get("#preauth-units-97153").clear().type("120");
+
+    cy.contains("button", "Next").scrollIntoView().click({ force: true });
+    cy.get('input[type="file"]').selectFile(
+      {
+        contents: Cypress.Buffer.from("synthetic authorization notice"),
+        fileName: "codex-synthetic-preauth-smoke.pdf",
+        mimeType: "application/pdf",
+      },
+      { force: true },
+    );
+
+    cy.contains("button", "Next").scrollIntoView().click({ force: true });
+    cy.contains("button", "Submit Request").scrollIntoView().click({ force: true });
+
+    cy.wait("@createAuthorization");
+    cy.wait("@documentUpload");
+    cy.wait("@updateAuthorizationDocuments");
+    cy.contains("Authorization uploaded and saved.").should("be.visible");
+  });
+});

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -4,6 +4,7 @@ import { appendFileSync } from "node:fs";
 const TIER0_SPECS = {
   public: "cypress/e2e/routes_public.cy.ts",
   client: "cypress/e2e/routes_client.cy.ts",
+  preauth: "cypress/e2e/preauth_workflow.cy.ts",
   schedule: "cypress/e2e/routes_schedule.cy.ts",
   admin: "cypress/e2e/routes_admin.cy.ts",
   auth: "cypress/e2e/routes_auth.cy.ts",
@@ -125,6 +126,15 @@ const classifyFile = (file) => {
     /^src\/lib\/(sessions|booking|useRouteQueryRefetch)/,
   ])) {
     return { specs: ["schedule", "auth"], authSmoke: true, reason: "schedule/session route" };
+  }
+
+  if (matchAny(file, [
+    /^cypress\/e2e\/preauth_workflow\.cy\.ts$/,
+    /^src\/pages\/ClientDetails\.tsx$/,
+    /^src\/components\/ClientDetails\/PreAuthTab\.tsx$/,
+    /^src\/components\/__tests__\/PreAuthTab\.test\.tsx$/,
+  ])) {
+    return { specs: ["client", "preauth"], authSmoke: false, reason: "PreAuth workflow route" };
   }
 
   if (matchAny(file, [

--- a/scripts/run-cypress.ts
+++ b/scripts/run-cypress.ts
@@ -31,6 +31,7 @@ const run = async (): Promise<void> => {
   const defaultSpec = [
     'cypress/e2e/routes_public.cy.ts',
     'cypress/e2e/routes_client.cy.ts',
+    'cypress/e2e/preauth_workflow.cy.ts',
     'cypress/e2e/routes_schedule.cy.ts',
     'cypress/e2e/routes_messages.cy.ts',
     'cypress/e2e/routes_admin.cy.ts',

--- a/supabase/migrations/20260622164000_restrict_authorization_create_rpc_anon_execute.sql
+++ b/supabase/migrations/20260622164000_restrict_authorization_create_rpc_anon_execute.sql
@@ -1,0 +1,57 @@
+/*
+  @migration-intent: Remove unauthenticated/default execute access from the PreAuth authorization-create RPC while preserving reviewed authenticated browser callers.
+  @migration-dependencies: 20260105120500_create_authorization_rpc_allowlist.sql, 20260622142046_restrict_authorization_document_rpc_anon_execute.sql
+  @migration-rollback: Re-grant execute to anon only if a reviewed public authorization-create caller is introduced.
+*/
+
+begin;
+
+revoke execute on function public.create_authorization_with_services(
+  uuid,
+  uuid,
+  text,
+  text,
+  text,
+  date,
+  date,
+  text,
+  uuid,
+  text,
+  text,
+  jsonb
+) from public, anon;
+
+grant execute on function public.create_authorization_with_services(
+  uuid,
+  uuid,
+  text,
+  text,
+  text,
+  date,
+  date,
+  text,
+  uuid,
+  text,
+  text,
+  jsonb
+) to authenticated, service_role;
+
+do $$
+declare
+  unsafe_count integer;
+begin
+  select count(*)
+  into unsafe_count
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'public'
+    and p.oid = 'public.create_authorization_with_services(uuid, uuid, text, text, text, date, date, text, uuid, text, text, jsonb)'::regprocedure
+    and has_function_privilege('anon', p.oid, 'EXECUTE');
+
+  if unsafe_count > 0 then
+    raise exception 'Authorization create RPC grant hardening failed: % function(s) still executable by anon', unsafe_count;
+  end if;
+end
+$$;
+
+commit;

--- a/tests/authorizations/authorization-document-rpc-grants.security.spec.ts
+++ b/tests/authorizations/authorization-document-rpc-grants.security.spec.ts
@@ -3,13 +3,21 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('authorization document RPC execute grants', () => {
-  const migrationSql = readFileSync(
+  const documentRpcMigrationSql = readFileSync(
     join(
       process.cwd(),
       'supabase/migrations/20260622142046_restrict_authorization_document_rpc_anon_execute.sql',
     ),
     'utf-8',
   );
+  const createRpcMigrationSql = readFileSync(
+    join(
+      process.cwd(),
+      'supabase/migrations/20260622164000_restrict_authorization_create_rpc_anon_execute.sql',
+    ),
+    'utf-8',
+  );
+  const migrationSql = `${documentRpcMigrationSql}\n${createRpcMigrationSql}`;
   const grantStatements = migrationSql.match(/grant execute on function[^;]+;/gi) ?? [];
 
   it('removes unauthenticated execute access from document RPCs', () => {
@@ -24,6 +32,9 @@ describe('authorization document RPC execute grants', () => {
     );
     expect(migrationSql).toMatch(
       /revoke execute on function public\.update_authorization_with_services\([\s\S]+?\) from public, anon;/i,
+    );
+    expect(migrationSql).toMatch(
+      /revoke execute on function public\.create_authorization_with_services\([\s\S]+?\) from public, anon;/i,
     );
   });
 
@@ -40,16 +51,30 @@ describe('authorization document RPC execute grants', () => {
     expect(migrationSql).toMatch(
       /grant execute on function public\.update_authorization_with_services\([\s\S]+?\) to authenticated, service_role;/i,
     );
+    expect(migrationSql).toMatch(
+      /grant execute on function public\.create_authorization_with_services\([\s\S]+?\) to authenticated, service_role;/i,
+    );
   });
 
   it('asserts anon execute was removed after applying grants', () => {
     expect(migrationSql).toMatch(/has_function_privilege\('anon', p\.oid, 'EXECUTE'\)/i);
     expect(migrationSql).toMatch(/still executable by anon/i);
+    expect(createRpcMigrationSql).toMatch(/has_function_privilege\('anon', p\.oid, 'EXECUTE'\)/i);
+    expect(createRpcMigrationSql).toMatch(
+      /public\.create_authorization_with_services\(uuid, uuid, text, text, text, date, date, text, uuid, text, text, jsonb\)'::regprocedure/i,
+    );
+    expect(createRpcMigrationSql).toMatch(/Authorization create RPC grant hardening failed/i);
   });
 
   it('does not re-grant unauthenticated execute access', () => {
     for (const grantStatement of grantStatements) {
-      expect(grantStatement).not.toMatch(/\bto\s+(public|anon)\b/i);
+      const [, granteeList = ''] = grantStatement.match(/\bto\s+([^;]+);/i) ?? [];
+      const grantees = granteeList
+        .split(',')
+        .map((grantee) => grantee.trim().toLowerCase());
+
+      expect(grantees).not.toContain('public');
+      expect(grantees).not.toContain('anon');
     }
   });
 });

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+
+import { describe, expect, it } from 'vitest';
+
+const runSelector = (...args: string[]) => JSON.parse(execFileSync(process.execPath, [
+  'scripts/ci/select-browser-checks.mjs',
+  ...args,
+], {
+  cwd: process.cwd(),
+  encoding: 'utf8',
+})) as {
+  tier0Required: boolean;
+  authSmokeRequired: boolean;
+  tier0Specs: string[];
+  reasons: string[];
+};
+
+describe('select-browser-checks', () => {
+  it('runs the PreAuth spec when the PreAuth workflow spec changes', () => {
+    const selection = runSelector('--changed-file', 'cypress/e2e/preauth_workflow.cy.ts');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.tier0Specs).toEqual([
+      'cypress/e2e/routes_client.cy.ts',
+      'cypress/e2e/preauth_workflow.cy.ts',
+    ]);
+    expect(selection.reasons).toEqual([
+      'cypress/e2e/preauth_workflow.cy.ts: PreAuth workflow route',
+    ]);
+  });
+
+  it('runs the PreAuth spec when the ClientDetails host route changes', () => {
+    const selection = runSelector('--changed-file', 'src/pages/ClientDetails.tsx');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.tier0Specs).toEqual([
+      'cypress/e2e/routes_client.cy.ts',
+      'cypress/e2e/preauth_workflow.cy.ts',
+    ]);
+    expect(selection.reasons).toEqual([
+      'src/pages/ClientDetails.tsx: PreAuth workflow route',
+    ]);
+  });
+
+  it('runs the PreAuth spec when PreAuth source changes', () => {
+    const selection = runSelector('--changed-file', 'src/components/ClientDetails/PreAuthTab.tsx');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.tier0Specs).toEqual([
+      'cypress/e2e/routes_client.cy.ts',
+      'cypress/e2e/preauth_workflow.cy.ts',
+    ]);
+    expect(selection.reasons).toEqual([
+      'src/components/ClientDetails/PreAuthTab.tsx: PreAuth workflow route',
+    ]);
+  });
+
+  it('runs the PreAuth spec when PreAuth unit coverage changes', () => {
+    const selection = runSelector('--changed-file', 'src/components/__tests__/PreAuthTab.test.tsx');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.tier0Specs).toEqual([
+      'cypress/e2e/routes_client.cy.ts',
+      'cypress/e2e/preauth_workflow.cy.ts',
+    ]);
+    expect(selection.reasons).toEqual([
+      'src/components/__tests__/PreAuthTab.test.tsx: PreAuth workflow route',
+    ]);
+  });
+
+  it('includes the PreAuth spec in the full tier-0 browser fallback', () => {
+    const selection = runSelector('--changed-file', 'scripts/ci/select-browser-checks.mjs');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.authSmokeRequired).toBe(true);
+    expect(selection.tier0Specs).toContain('cypress/e2e/preauth_workflow.cy.ts');
+  });
+
+  it('keeps the PreAuth spec in the default local tier-0 Cypress run', () => {
+    const runCypressSource = readFileSync('scripts/run-cypress.ts', 'utf8');
+
+    expect(runCypressSource).toContain("'cypress/e2e/preauth_workflow.cy.ts'");
+  });
+});


### PR DESCRIPTION
## Summary
- revoke unauthenticated/default execute on `create_authorization_with_services` while preserving `authenticated` and `service_role`
- extend authorization RPC grant regression coverage to the create RPC
- add a Cypress regression for Client Details -> Pre-Authorizations -> New Authorization -> PDF upload -> document attach

## Route task
- classification: `high-risk human-reviewed`
- lane: `critical`
- triggering paths: `supabase/migrations/**`, RPC execute grants, protected PreAuth workflow, `client-documents` upload path
- Linear: WIN-180

## Verification
- `npx vitest run tests/authorizations/authorization-document-rpc-grants.security.spec.ts --reporter=verbose` passed
- `npm run test:routes:tier0 -- --spec cypress/e2e/preauth_workflow.cy.ts` passed
- `npm run ci:check-focused` passed with expected local skips for branch protection / DB-grant live checks
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run validate:tenant` passed
- `npm run build` passed
- `npm run test:ci` passed, 323 files / 1973 tests
- `npm run verify:local` passed
- `npm run playwright:preflight` passed
- `npm run playwright:authorizations-read-scope` passed

## Hosted proof
- hosted PreAuth browser workflow completed against `https://app.allincompassing.ai`
- authorization: `CODEX-PREAUTH-20260622165342`
- authorization id: `55c25cc7-e2d5-4f86-beaa-159507db6b58`
- upload path: `clients/da8e3f4c-6034-4223-948d-fc9ca5f9b6be/authorizations/55c25cc7-e2d5-4f86-beaa-159507db6b58/1782147229652-shc4f7c08hk.pdf`
- Supabase post-check confirmed authorization row, one service row, document metadata, and `storage.objects` PDF object

## Blocked / not counted as pass
- full `npm run ci:playwright` was attempted and timed out at the parent command timeout after partial child progress; this is not counted as passed

## Risk
Critical-lane protected change. Human review required before merge.
