### PR TITLE
Seed IEHP and Anthem insurance providers

### DIFF
--- a/supabase/migrations/20260622222017_add_iehp_anthem_insurance_providers.sql
+++ b/supabase/migrations/20260622222017_add_iehp_anthem_insurance_providers.sql
@@ -1,0 +1,37 @@
+/*
+  @migration-intent: Seed payer reference data required by the PreAuth insurance provider dropdown.
+  @migration-dependencies: 20250324180437_plain_sky.sql, 20250324183514_frosty_bread.sql
+  @migration-rollback: Delete the inserted provider rows only if the payer options are intentionally retired and no authorizations reference them.
+*/
+
+begin;
+
+insert into public.insurance_providers (name, type)
+values
+  ('Anthem', 'private'),
+  ('IEHP', 'Medicaid')
+on conflict (name) do update
+set
+  type = excluded.type,
+  updated_at = now();
+
+do $$
+declare
+  missing_count integer;
+begin
+  select count(*)
+  into missing_count
+  from (values ('Anthem'), ('IEHP')) as expected(name)
+  where not exists (
+    select 1
+    from public.insurance_providers provider
+    where provider.name = expected.name
+  );
+
+  if missing_count > 0 then
+    raise exception 'Insurance provider seed failed: % expected provider(s) missing', missing_count;
+  end if;
+end
+$$;
+
+commit;


### PR DESCRIPTION
## Summary
- seed missing global insurance provider reference rows for Anthem and IEHP
- keep the PreAuth insurance-provider dropdown data-driven; no UI behavior change
- align source-controlled migration history with hosted Supabase migration `20260622222017_add_iehp_anthem_insurance_providers`

## Risk / Classification
- route-task: high-risk human-reviewed
- lane: critical
- reason: protected Supabase migration touching production reference data
- scope: inserts/upserts only `public.insurance_providers` rows for `Anthem` and `IEHP`; no schema, grants, RLS, RPC, auth, tenant logic, or UI changes

## Hosted Supabase Evidence
- project: `wnnjeqheqxxyrgsjmygy`
- applied via Supabase MCP: `20260622222017_add_iehp_anthem_insurance_providers`
- SQL confirmation: `Anthem/private`, `IEHP/Medicaid`

## Verification
- `npm run ci:check-focused` passed; local DB-connected checks skipped because `SUPABASE_DB_URL`/`DATABASE_URL` is not configured
- `npm run validate:tenant` passed
- `npm run build` passed
- `npm run test:ci` passed: 324 files, 1,979 tests
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run ci:verify-coverage` passed
- `npm run test:routes:tier0` passed: 7 specs, 79 tests, including `preauth_workflow.cy.ts`

## Review
- reviewer: no findings; noted protected migration still requires normal human-reviewed flow

Linear: WIN-180