### PR TITLE
Recognize ci:playwright runner in e2e reliability gate

### DIFF
--- a/scripts/ci/check-e2e-reliability-gates.mjs
+++ b/scripts/ci/check-e2e-reliability-gates.mjs
@@ -32,6 +32,35 @@ const CRITICAL_PLAYWRIGHT_SCRIPTS = [
 
 const readJson = async (filePath) => JSON.parse(await readFile(filePath, "utf8"));
 
+const parseCiPlaywrightRunner = (script) => {
+  const tokens = script.trim().split(/\s+/).filter(Boolean);
+  const runnerIndex = tokens.findIndex((token) => token === "scripts/playwright-ci-runner.ts");
+  return {
+    tokens,
+    runnerIndex,
+    runnerCommand: runnerIndex > 0 ? tokens[runnerIndex - 1] : "",
+    children: runnerIndex >= 0 ? tokens.slice(runnerIndex + 1) : [],
+  };
+};
+
+const childIndex = (children, scriptName) => children.indexOf(scriptName);
+
+const ciPlaywrightRunnerHasChild = (runner, scriptName) => childIndex(runner.children, scriptName) !== -1;
+
+const ciWorkflowRunsPlaywrightScript = (workflow, scriptName) =>
+  workflow.includes(`npm run ${scriptName}`) || workflow.includes("npm run ci:playwright");
+
+const extractWorkflowJob = (workflow, jobName) => {
+  const lines = workflow.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === `  ${jobName}:`);
+  if (start < 0) {
+    return "";
+  }
+
+  const nextJob = lines.findIndex((line, index) => index > start && /^  [A-Za-z0-9_-]+:\s*$/.test(line));
+  return lines.slice(start, nextJob === -1 ? lines.length : nextJob).join("\n");
+};
+
 const run = async () => {
   const errors = [];
   const warnings = [];
@@ -43,6 +72,7 @@ const run = async () => {
   const combinedRouteSpecs = routeSpecs.join("\n");
   const cypressCommands = await readFile(CYPRESS_COMMANDS_PATH, "utf8");
   const ciWorkflow = await readFile(CI_WORKFLOW_PATH, "utf8");
+  const authBrowserSmokeJob = extractWorkflowJob(ciWorkflow, "auth_browser_smoke");
   const supabasePreviewWorkflow = await readFile(SUPABASE_PREVIEW_WORKFLOW_PATH, "utf8");
   const rollbackDrillWorkflow = await readFile(ROLLBACK_DRILL_WORKFLOW_PATH, "utf8");
 
@@ -66,38 +96,48 @@ const run = async () => {
 
   const scripts = packageJson?.scripts ?? {};
   const ciPlaywright = String(scripts["ci:playwright"] ?? "");
-  if (!ciPlaywright.includes("playwright:preflight")) {
-    errors.push("package.json script ci:playwright must start with playwright:preflight.");
+  const ciPlaywrightRunner = parseCiPlaywrightRunner(ciPlaywright);
+  if (ciPlaywrightRunner.runnerIndex < 0 || ciPlaywrightRunner.runnerCommand !== "tsx") {
+    errors.push("package.json script ci:playwright must invoke scripts/playwright-ci-runner.ts through tsx.");
   }
-  if (!ciPlaywright.includes("playwright:session-no-show")) {
-    errors.push("package.json script ci:playwright must include playwright:session-no-show for explicit no-show terminal coverage.");
+  if (ciPlaywrightRunner.tokens.includes("&&") || ciPlaywrightRunner.tokens.includes("npm")) {
+    errors.push("package.json script ci:playwright must use the attributed runner, not an npm shell chain.");
   }
-  if (!ciPlaywright.includes("playwright:session-complete")) {
-    errors.push("package.json script ci:playwright must include playwright:session-complete for completed terminal coverage.");
+  if (ciPlaywrightRunner.runnerIndex !== 1 || ciPlaywrightRunner.tokens[0] !== "tsx") {
+    errors.push("package.json script ci:playwright must start with tsx scripts/playwright-ci-runner.ts.");
   }
-  if (
-    ciPlaywright.includes("playwright:session-no-show") &&
-    ciPlaywright.includes("playwright:session-complete") &&
-    ciPlaywright.indexOf("playwright:session-complete") < ciPlaywright.indexOf("playwright:session-no-show")
-  ) {
-    errors.push("package.json script ci:playwright must run playwright:session-no-show before playwright:session-complete.");
+  if (ciPlaywrightRunner.children[0] !== "playwright:preflight") {
+    errors.push("package.json script ci:playwright runner arguments must start with playwright:preflight.");
   }
-  if (!ciPlaywright.includes("playwright:session-note-measurement-roundtrip")) {
-    errors.push("package.json script ci:playwright must include playwright:session-note-measurement-roundtrip.");
+  if (childIndex(ciPlaywrightRunner.children, "playwright:session-no-show") === -1) {
+    errors.push("package.json script ci:playwright runner arguments must include playwright:session-no-show for explicit no-show terminal coverage.");
   }
-  if (
-    ciPlaywright.includes("playwright:session-complete") &&
-    ciPlaywright.includes("playwright:session-note-measurement-roundtrip") &&
-    ciPlaywright.indexOf("playwright:session-note-measurement-roundtrip") < ciPlaywright.indexOf("playwright:session-complete")
-  ) {
-    errors.push("package.json script ci:playwright must run playwright:session-complete before playwright:session-note-measurement-roundtrip.");
+  if (childIndex(ciPlaywrightRunner.children, "playwright:session-complete") === -1) {
+    errors.push("package.json script ci:playwright runner arguments must include playwright:session-complete for completed terminal coverage.");
   }
   if (
-    ciPlaywright.includes("playwright:schedule-blocked-close") &&
-    ciPlaywright.includes("playwright:session-note-measurement-roundtrip") &&
-    ciPlaywright.indexOf("playwright:session-note-measurement-roundtrip") < ciPlaywright.indexOf("playwright:schedule-blocked-close")
+    childIndex(ciPlaywrightRunner.children, "playwright:session-no-show") !== -1 &&
+    childIndex(ciPlaywrightRunner.children, "playwright:session-complete") !== -1 &&
+    childIndex(ciPlaywrightRunner.children, "playwright:session-complete") < childIndex(ciPlaywrightRunner.children, "playwright:session-no-show")
   ) {
-    errors.push("package.json script ci:playwright must run playwright:schedule-blocked-close before playwright:session-note-measurement-roundtrip.");
+    errors.push("package.json script ci:playwright runner arguments must run playwright:session-no-show before playwright:session-complete.");
+  }
+  if (childIndex(ciPlaywrightRunner.children, "playwright:session-note-measurement-roundtrip") === -1) {
+    errors.push("package.json script ci:playwright runner arguments must include playwright:session-note-measurement-roundtrip.");
+  }
+  if (
+    childIndex(ciPlaywrightRunner.children, "playwright:session-complete") !== -1 &&
+    childIndex(ciPlaywrightRunner.children, "playwright:session-note-measurement-roundtrip") !== -1 &&
+    childIndex(ciPlaywrightRunner.children, "playwright:session-note-measurement-roundtrip") < childIndex(ciPlaywrightRunner.children, "playwright:session-complete")
+  ) {
+    errors.push("package.json script ci:playwright runner arguments must run playwright:session-complete before playwright:session-note-measurement-roundtrip.");
+  }
+  if (
+    childIndex(ciPlaywrightRunner.children, "playwright:schedule-blocked-close") !== -1 &&
+    childIndex(ciPlaywrightRunner.children, "playwright:session-note-measurement-roundtrip") !== -1 &&
+    childIndex(ciPlaywrightRunner.children, "playwright:session-note-measurement-roundtrip") < childIndex(ciPlaywrightRunner.children, "playwright:schedule-blocked-close")
+  ) {
+    errors.push("package.json script ci:playwright runner arguments must run playwright:schedule-blocked-close before playwright:session-note-measurement-roundtrip.");
   }
   if (!scripts["playwright:preflight"]) {
     errors.push("package.json is missing playwright:preflight script.");
@@ -152,28 +192,38 @@ const run = async () => {
   if (!ciWorkflow.includes("needs.iehp_assessment_import_smoke.result")) {
     errors.push(".github/workflows/ci.yml ci-gate must depend on the IEHP assessment import smoke result.");
   }
-  if (!ciWorkflow.includes("npm run playwright:session-no-show")) {
-    errors.push(".github/workflows/ci.yml auth-browser-smoke gate must run playwright:session-no-show.");
+  if (!ciWorkflowRunsPlaywrightScript(authBrowserSmokeJob, "playwright:session-no-show")) {
+    errors.push(".github/workflows/ci.yml auth-browser-smoke gate must run playwright:session-no-show directly or via ci:playwright.");
   }
-  if (!ciWorkflow.includes("npm run playwright:session-complete")) {
-    errors.push(".github/workflows/ci.yml auth-browser-smoke gate must run playwright:session-complete.");
+  if (!ciWorkflowRunsPlaywrightScript(authBrowserSmokeJob, "playwright:session-complete")) {
+    errors.push(".github/workflows/ci.yml auth-browser-smoke gate must run playwright:session-complete directly or via ci:playwright.");
   }
-  if (!ciWorkflow.includes("npm run playwright:session-note-measurement-roundtrip")) {
-    errors.push(".github/workflows/ci.yml auth-browser-smoke gate must run playwright:session-note-measurement-roundtrip.");
+  if (!ciWorkflowRunsPlaywrightScript(authBrowserSmokeJob, "playwright:session-note-measurement-roundtrip")) {
+    errors.push(
+      ".github/workflows/ci.yml auth-browser-smoke gate must run playwright:session-note-measurement-roundtrip directly or via ci:playwright.",
+    );
   }
   if (
-    ciWorkflow.includes("npm run playwright:session-no-show") &&
-    ciWorkflow.includes("npm run playwright:session-complete") &&
-    ciWorkflow.indexOf("npm run playwright:session-complete") < ciWorkflow.indexOf("npm run playwright:session-no-show")
+    authBrowserSmokeJob.includes("npm run playwright:session-no-show") &&
+    authBrowserSmokeJob.includes("npm run playwright:session-complete") &&
+    authBrowserSmokeJob.indexOf("npm run playwright:session-complete") < authBrowserSmokeJob.indexOf("npm run playwright:session-no-show")
   ) {
     errors.push(".github/workflows/ci.yml must run playwright:session-no-show before playwright:session-complete.");
   }
   if (
-    ciWorkflow.includes("npm run playwright:schedule-blocked-close") &&
-    ciWorkflow.includes("npm run playwright:session-note-measurement-roundtrip") &&
-    ciWorkflow.indexOf("npm run playwright:session-note-measurement-roundtrip") < ciWorkflow.indexOf("npm run playwright:schedule-blocked-close")
+    authBrowserSmokeJob.includes("npm run playwright:schedule-blocked-close") &&
+    authBrowserSmokeJob.includes("npm run playwright:session-note-measurement-roundtrip") &&
+    authBrowserSmokeJob.indexOf("npm run playwright:session-note-measurement-roundtrip") < authBrowserSmokeJob.indexOf("npm run playwright:schedule-blocked-close")
   ) {
     errors.push(".github/workflows/ci.yml must run playwright:schedule-blocked-close before playwright:session-note-measurement-roundtrip.");
+  }
+  if (
+    authBrowserSmokeJob.includes("npm run ci:playwright") &&
+    !ciPlaywrightRunnerHasChild(ciPlaywrightRunner, "playwright:schedule-blocked-close")
+  ) {
+    errors.push(
+      ".github/workflows/ci.yml auth-browser-smoke aggregate ci:playwright gate requires playwright:schedule-blocked-close in the runner arguments.",
+    );
   }
   if (!ciWorkflow.includes("if: always()")) {
     errors.push(".github/workflows/ci.yml must retain artifacts with if: always() for deterministic evidence collection.");

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -498,10 +498,15 @@ const toDatetimeLocal = (date: Date): string => {
   return local.toISOString().slice(0, 16);
 };
 
-const buildBookingCandidateStarts = (): Date[] => {
+export const buildBookingCandidateStarts = (
+  terminalStatus = process.env.PW_LIFECYCLE_TERMINAL_STATUS,
+): Date[] => {
   const runSeed = Number(process.env.GITHUB_RUN_ID ?? Date.now());
   const daytimeHours = [9, 11, 13, 15];
-  const rotation = Number.isFinite(runSeed) ? Math.abs(Math.trunc(runSeed)) % daytimeHours.length : 0;
+  const terminalStatusOffset = terminalStatus?.trim().toLowerCase() === "completed" ? 1 : 0;
+  const rotation = Number.isFinite(runSeed)
+    ? (Math.abs(Math.trunc(runSeed)) + terminalStatusOffset) % daytimeHours.length
+    : terminalStatusOffset;
   const hours = [...daytimeHours.slice(rotation), ...daytimeHours.slice(0, rotation)];
   const candidates: Date[] = [];
   const day = new Date();

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -613,13 +613,16 @@ const selectOptionWhenAvailable = async (
   return false;
 };
 
-async function chooseSessionTargets(page: Page): Promise<{
+const lifecyclePairKey = (therapistId: string, clientId: string): string => `${therapistId}:${clientId}`;
+
+async function chooseSessionTargetsExcluding(page: Page, excludedPairKeys: Set<string>): Promise<{
   therapistId: string;
   clientId: string;
   programId: string;
   goalId: string;
   createdProgramId?: string;
   createdGoalId?: string;
+  pairKey: string;
 }> {
   const therapistValues = await waitForSelectOptions(page, "#therapist-select");
   const clientValues = await waitForSelectOptions(page, "#client-select");
@@ -641,6 +644,10 @@ async function chooseSessionTargets(page: Page): Promise<{
   });
 
   for (const { therapistId, clientId } of candidatePairs) {
+    const pairKey = lifecyclePairKey(therapistId, clientId);
+    if (excludedPairKeys.has(pairKey)) {
+      continue;
+    }
     await page.selectOption("#therapist-select", therapistId);
     const seeded = await ensureProgramAndGoalForPair(therapistId, clientId);
     await page.selectOption("#client-select", clientId);
@@ -665,6 +672,7 @@ async function chooseSessionTargets(page: Page): Promise<{
       goalId: seeded.goalId,
       createdProgramId: seeded.createdProgramId,
       createdGoalId: seeded.createdGoalId,
+      pairKey,
     };
   }
 
@@ -680,78 +688,119 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
   await page.waitForSelector("text=Schedule", { timeout: 15_000 }).catch(() => undefined);
   await openSessionModal(page);
 
-  const selected = await chooseSessionTargets(page);
-
   const candidateStarts = buildBookingCandidateStarts();
-  let finalStartIso = "";
-  let finalEndIso = "";
-  let payload: BrowserFetchResult<Record<string, unknown>> | null = null;
-  let payloadBody: { success?: boolean; data?: { session?: { id?: string } }; code?: string } | null = null;
+  const excludedPairKeys = new Set<string>();
+  let lastFailure: {
+    selected: Awaited<ReturnType<typeof chooseSessionTargetsExcluding>>;
+    finalStartIso: string;
+    finalEndIso: string;
+    payload: BrowserFetchResult<Record<string, unknown>> | null;
+    payloadBody: { success?: boolean; data?: { session?: { id?: string } }; code?: string } | null;
+  } | null = null;
 
-  for (let attempt = 0; attempt < candidateStarts.length; attempt += 1) {
-    const attemptStart = candidateStarts[attempt];
-    const attemptEnd = new Date(attemptStart.getTime() + 60 * 60 * 1000);
-    const startIso = attemptStart.toISOString();
-    const endIso = attemptEnd.toISOString();
-    finalStartIso = startIso;
-    finalEndIso = endIso;
-
-    await page.locator("#start-time-input").fill(toDatetimeLocal(attemptStart));
-    await page.locator("#end-time-input").fill(toDatetimeLocal(attemptEnd));
-
-    page.once("dialog", (dialog) => {
-      void dialog.accept().catch(() => undefined);
-    });
-    const responsePromise = page
-      .waitForResponse(
-        (res) => res.url().includes("/api/book") && res.request().method() === "POST",
-        { timeout: 90_000 },
-      )
-      .then((response) => ({ kind: "response" as const, response }))
-      .catch(() => null);
-    const blockedPromise = Promise.any([
-      page.getByRole("region").filter({ hasText: "Scheduling Conflicts" }).first().waitFor({
-        state: "visible",
-        timeout: 2500,
-      }),
-      page.getByText(/No active programs found/i).first().waitFor({ state: "visible", timeout: 2500 }),
-    ])
-      .then(() => ({ kind: "blocked" as const }))
-      .catch(() => new Promise<never>(() => undefined));
-
-    await page.getByRole("button", { name: /Create Session/i }).click();
-    const outcome = await Promise.race([responsePromise, blockedPromise]);
-    if (!outcome) {
-      continue;
+  while (true) {
+    let selected: Awaited<ReturnType<typeof chooseSessionTargetsExcluding>>;
+    try {
+      selected = await chooseSessionTargetsExcluding(page, excludedPairKeys);
+    } catch (error) {
+      if (lastFailure) {
+        break;
+      }
+      throw error;
     }
-    if (outcome.kind === "blocked") {
-      responsePromise.catch(() => undefined);
-      continue;
-    }
+    let finalStartIso = "";
+    let finalEndIso = "";
+    let payload: BrowserFetchResult<Record<string, unknown>> | null = null;
+    let payloadBody: { success?: boolean; data?: { session?: { id?: string } }; code?: string } | null = null;
 
-    const bookResponse = outcome.response;
-    const body = await bookResponse.json().catch(() => null);
-    const httpStatus = bookResponse.status();
-    payload = { ok: bookResponse.ok(), status: httpStatus, body };
-    payloadBody = body as typeof payloadBody;
+    for (let attempt = 0; attempt < candidateStarts.length; attempt += 1) {
+      const attemptStart = candidateStarts[attempt];
+      const attemptEnd = new Date(attemptStart.getTime() + 60 * 60 * 1000);
+      const startIso = attemptStart.toISOString();
+      const endIso = attemptEnd.toISOString();
+      finalStartIso = startIso;
+      finalEndIso = endIso;
 
-    if (payload.ok && payloadBody?.success && payloadBody?.data?.session?.id) {
+      await page.locator("#start-time-input").fill(toDatetimeLocal(attemptStart));
+      await page.locator("#end-time-input").fill(toDatetimeLocal(attemptEnd));
+
+      page.once("dialog", (dialog) => {
+        void dialog.accept().catch(() => undefined);
+      });
+      const responsePromise = page
+        .waitForResponse(
+          (res) => res.url().includes("/api/book") && res.request().method() === "POST",
+          { timeout: 90_000 },
+        )
+        .then((response) => ({ kind: "response" as const, response }))
+        .catch(() => null);
+      const blockedPromise = Promise.any([
+        page.getByRole("region").filter({ hasText: "Scheduling Conflicts" }).first().waitFor({
+          state: "visible",
+          timeout: 2500,
+        }),
+        page.getByText(/No active programs found/i).first().waitFor({ state: "visible", timeout: 2500 }),
+      ])
+        .then(() => ({ kind: "blocked" as const }))
+        .catch(() => new Promise<never>(() => undefined));
+
+      await page.getByRole("button", { name: /Create Session/i }).click();
+      const outcome = await Promise.race([responsePromise, blockedPromise]);
+      if (!outcome) {
+        continue;
+      }
+      if (outcome.kind === "blocked") {
+        responsePromise.catch(() => undefined);
+        continue;
+      }
+
+      const bookResponse = outcome.response;
+      const body = await bookResponse.json().catch(() => null);
+      const httpStatus = bookResponse.status();
+      payload = { ok: bookResponse.ok(), status: httpStatus, body };
+      payloadBody = body as typeof payloadBody;
+
+      if (payload.ok && payloadBody?.success && payloadBody?.data?.session?.id) {
+        const sessionId = payloadBody.data.session.id as string;
+        return {
+          sessionId,
+          therapistId: selected.therapistId,
+          clientId: selected.clientId,
+          programId: selected.programId,
+          goalId: selected.goalId,
+          startIso: finalStartIso,
+          endIso: finalEndIso,
+          createdProgramId: selected.createdProgramId,
+          createdGoalId: selected.createdGoalId,
+        };
+      }
+      if (httpStatus === 409 || [500, 502, 503, 504].includes(httpStatus)) {
+        await new Promise((resolve) => setTimeout(resolve, 500 + attempt * 250));
+        continue;
+      }
+      const bookUnauthorized =
+        httpStatus === 401 ||
+        (typeof payloadBody?.code === "string" && payloadBody.code.toLowerCase() === "unauthorized");
+      if (!strictMode && bookUnauthorized && finalStartIso && finalEndIso) {
+        break;
+      }
       break;
     }
-    if (httpStatus === 409 || [500, 502, 503, 504].includes(httpStatus)) {
-      await new Promise((resolve) => setTimeout(resolve, 500 + attempt * 250));
+
+    lastFailure = { selected, finalStartIso, finalEndIso, payload, payloadBody };
+    if (payload?.status === 409) {
+      console.warn("[lifecycle] booking conflict exhausted candidate starts; trying next therapist-client pair", {
+        pairKey: selected.pairKey,
+      });
+      await cleanupCreatedProgramGoal(selected);
+      excludedPairKeys.add(selected.pairKey);
       continue;
-    }
-    const bookUnauthorized =
-      httpStatus === 401 ||
-      (typeof payloadBody?.code === "string" && payloadBody.code.toLowerCase() === "unauthorized");
-    if (!strictMode && bookUnauthorized && finalStartIso && finalEndIso) {
-      break;
     }
     break;
   }
 
-  if (!payload || !payloadBody?.success || !payloadBody?.data?.session?.id) {
+  if (lastFailure) {
+    const { selected, finalStartIso, finalEndIso, payload, payloadBody } = lastFailure;
     const httpStatus = typeof payload?.status === "number" ? payload.status : 0;
     const bodyUnauthorized =
       httpStatus === 401 ||
@@ -783,19 +832,7 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
     );
   }
 
-  const sessionId = payloadBody.data!.session!.id as string;
-
-  return {
-    sessionId,
-    therapistId: selected.therapistId,
-    clientId: selected.clientId,
-    programId: selected.programId,
-    goalId: selected.goalId,
-    startIso: finalStartIso,
-    endIso: finalEndIso,
-    createdProgramId: selected.createdProgramId,
-    createdGoalId: selected.createdGoalId,
-  };
+  throw new Error("Booking did not succeed. No therapist-client pair was attempted.");
 }
 
 const expectStartButtonEnabled = async (

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -589,6 +589,18 @@ async function openSessionModal(page: Page) {
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
+async function ensureSessionModalOpen(page: Page) {
+  const modal = page
+    .locator(
+      '[role="dialog"]:has-text("New Session"), [role="dialog"]:has-text("Edit Session"), [role="dialog"]:has-text("Live session")',
+    )
+    .first();
+  if (await modal.isVisible().catch(() => false)) {
+    return;
+  }
+  await openSessionModal(page);
+}
+
 const selectOptionWhenAvailable = async (
   page: Page,
   selector: string,
@@ -699,6 +711,7 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
   } | null = null;
 
   while (true) {
+    await ensureSessionModalOpen(page);
     let selected: Awaited<ReturnType<typeof chooseSessionTargetsExcluding>>;
     try {
       selected = await chooseSessionTargetsExcluding(page, excludedPairKeys);

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -576,10 +576,13 @@ async function openSessionModal(page: Page) {
     const browserGlobal = globalThis as unknown as {
       dispatchEvent: (event: unknown) => boolean;
       CustomEvent: new (name: string, init?: { detail?: unknown }) => unknown;
+      document?: { dispatchEvent: (event: unknown) => boolean };
     };
     const now = new Date();
     now.setHours(now.getHours() + 2);
-    browserGlobal.dispatchEvent(new browserGlobal.CustomEvent("openScheduleModal", { detail: { start_time: now.toISOString() } }));
+    const eventDetail = { start_time: now.toISOString() };
+    browserGlobal.dispatchEvent(new browserGlobal.CustomEvent("openScheduleModal", { detail: eventDetail }));
+    browserGlobal.document?.dispatchEvent(new browserGlobal.CustomEvent("openScheduleModal", { detail: eventDetail }));
   });
   await page
     .locator(
@@ -587,15 +590,12 @@ async function openSessionModal(page: Page) {
     )
     .first()
     .waitFor({ state: "visible", timeout: 10_000 });
+  await page.getByRole("button", { name: /Create Session/i }).waitFor({ state: "visible", timeout: 10_000 });
 }
 
 async function ensureSessionModalOpen(page: Page) {
-  const modal = page
-    .locator(
-      '[role="dialog"]:has-text("New Session"), [role="dialog"]:has-text("Edit Session"), [role="dialog"]:has-text("Live session")',
-    )
-    .first();
-  if (await modal.isVisible().catch(() => false)) {
+  const createSessionButton = page.getByRole("button", { name: /Create Session/i });
+  if (await createSessionButton.isVisible().catch(() => false)) {
     return;
   }
   await openSessionModal(page);

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -1,0 +1,193 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const gatePath = path.join(repoRoot, "scripts", "ci", "check-e2e-reliability-gates.mjs");
+const runnerChildren = [
+  "playwright:preflight",
+  "playwright:auth",
+  "playwright:schedule-conflict",
+  "playwright:therapist-onboarding",
+  "playwright:therapist-authorization",
+  "playwright:session-no-show",
+  "playwright:session-complete",
+  "playwright:schedule-blocked-close",
+  "playwright:session-note-measurement-roundtrip",
+  "playwright:session-capture-adhoc-upsert",
+];
+
+const write = (root: string, relativePath: string, content: string) => {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+};
+
+const directAuthBrowserSmokeLines = [
+  "npm run playwright:session-no-show",
+  "npm run playwright:session-complete",
+  "npm run playwright:schedule-blocked-close",
+  "npm run playwright:session-note-measurement-roundtrip",
+];
+
+const createFixture = (
+  ciPlaywright: string,
+  authBrowserSmokeLines = directAuthBrowserSmokeLines,
+  extraWorkflowLines: string[] = [],
+) => {
+  const root = mkdtempSync(path.join(tmpdir(), "e2e-reliability-gate-"));
+
+  write(
+    root,
+    "tests/reliability/policy.json",
+    JSON.stringify({
+      e2e: {
+        maxSkippedCriticalFlows: 0,
+        retryBudget: { cypressRunMode: 0, playwright: 0 },
+        tier0PassRatePctFloor: 99,
+      },
+    }),
+  );
+  write(root, "cypress.config.cjs", "module.exports = { retries: 0 };\n");
+  write(
+    root,
+    "package.json",
+    JSON.stringify({
+      scripts: {
+        "ci:playwright": ciPlaywright,
+        "playwright:preflight": "tsx scripts/playwright-preflight.ts",
+      },
+    }),
+  );
+  write(
+    root,
+    "cypress/support/routeScenarios.ts",
+    [
+      'roles: ["therapist", "admin", "super_admin"]',
+      'cy.intercept("GET", "**/api/runtime-config").as("runtimeConfig");',
+      'cy.wait("@runtimeConfig");',
+    ].join("\n"),
+  );
+  write(
+    root,
+    "cypress/support/commands.ts",
+    [
+      "cy.intercept('GET', '**/api/runtime-config').as('runtimeConfigBootstrap');",
+      "cy.wait('@runtimeConfigBootstrap');",
+    ].join("\n"),
+  );
+
+  for (const specName of [
+    "routes_public.cy.ts",
+    "routes_client.cy.ts",
+    "routes_schedule.cy.ts",
+    "routes_admin.cy.ts",
+    "routes_auth.cy.ts",
+  ]) {
+    write(root, `cypress/e2e/${specName}`, "runRoleMatrix();\n");
+  }
+
+  write(
+    root,
+    ".github/workflows/ci.yml",
+    [
+      "jobs:",
+      "  tier0_browser:",
+      "    steps:",
+      "      - name: Record tier-0 evidence",
+      "        run: npm run ci:write-evidence -- tier0-browser success",
+      "  unrelated_browser_smoke:",
+      "    steps:",
+      ...extraWorkflowLines.map((line) => `      ${line}`),
+      "  auth_browser_smoke:",
+      "    name: auth-browser-smoke",
+      "    steps:",
+      "      - name: Auth browser smoke gate",
+      "        run: |",
+      ...authBrowserSmokeLines.map((line) => `          ${line}`),
+      "      - name: Record auth smoke evidence",
+      "        if: always()",
+      '        run: npm run ci:write-evidence -- auth-browser-smoke "${{ job.status }}"',
+      "  iehp_assessment_import_smoke:",
+      "    name: iehp-assessment-import-smoke",
+      "    steps:",
+      "      - run: npm run playwright:iehp-assessment-import-smoke",
+      "      - name: Record IEHP import smoke evidence",
+      "        if: always()",
+      "  ci_gate:",
+      "    needs:",
+      "      - auth_browser_smoke",
+      "      - iehp_assessment_import_smoke",
+      "    steps:",
+      "      - run: echo needs.iehp_assessment_import_smoke.result",
+    ].join("\n"),
+  );
+  write(root, ".github/workflows/supabase-preview.yml", "Run preview smoke suite\n");
+  write(root, ".github/workflows/rollback-drill.yml", "Run rollback drill contract checks\n");
+
+  for (const scriptName of [
+    "playwright-auth-smoke.ts",
+    "playwright-schedule-conflict.ts",
+    "playwright-therapist-onboarding.ts",
+    "playwright-therapist-authorization.ts",
+    "playwright-session-lifecycle.ts",
+    "playwright-session-no-show.ts",
+    "playwright-session-complete.ts",
+    "playwright-schedule-blocked-close.ts",
+    "playwright-session-note-measurement-roundtrip.ts",
+    "playwright-iehp-assessment-import-smoke.ts",
+  ]) {
+    write(root, `scripts/${scriptName}`, "console.log('fixture smoke');\n");
+  }
+
+  return root;
+};
+
+describe("check-e2e-reliability-gates", () => {
+  test("accepts ci:playwright runner invocation semantics", () => {
+    const fixtureRoot = createFixture(`tsx scripts/playwright-ci-runner.ts ${runnerChildren.join(" ")}`);
+
+    const result = spawnSync("node", [gatePath], { cwd: fixtureRoot, encoding: "utf8" });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("E2E reliability gate check passed.");
+  });
+
+  test("accepts workflow aggregate ci:playwright runner semantics", () => {
+    const fixtureRoot = createFixture(
+      `tsx scripts/playwright-ci-runner.ts ${runnerChildren.join(" ")}`,
+      ["npm run ci:playwright"],
+    );
+
+    const result = spawnSync("node", [gatePath], { cwd: fixtureRoot, encoding: "utf8" });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("E2E reliability gate check passed.");
+  });
+
+  test("rejects ci:playwright outside auth-browser-smoke job", () => {
+    const fixtureRoot = createFixture(
+      `tsx scripts/playwright-ci-runner.ts ${runnerChildren.join(" ")}`,
+      [],
+      ["- run: npm run ci:playwright"],
+    );
+
+    const result = spawnSync("node", [gatePath], { cwd: fixtureRoot, encoding: "utf8" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "auth-browser-smoke gate must run playwright:session-no-show directly or via ci:playwright",
+    );
+  });
+
+  test("rejects old ci:playwright shell-chain semantics", () => {
+    const fixtureRoot = createFixture(runnerChildren.map((scriptName) => `npm run ${scriptName}`).join(" && "));
+
+    const result = spawnSync("node", [gatePath], { cwd: fixtureRoot, encoding: "utf8" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("ci:playwright must invoke scripts/playwright-ci-runner.ts");
+  });
+});

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildBookingCandidateStarts } from "../../scripts/playwright-session-lifecycle";
+
+const originalGithubRunId = process.env.GITHUB_RUN_ID;
+const originalTerminalStatus = process.env.PW_LIFECYCLE_TERMINAL_STATUS;
+
+describe("playwright session lifecycle booking starts", () => {
+  afterEach(() => {
+    process.env.GITHUB_RUN_ID = originalGithubRunId;
+    process.env.PW_LIFECYCLE_TERMINAL_STATUS = originalTerminalStatus;
+  });
+
+  it("offsets completed lifecycle runs from no-show runs in the same CI run", () => {
+    process.env.GITHUB_RUN_ID = "28030829838";
+
+    const noShowStarts = buildBookingCandidateStarts("no-show");
+    const completedStarts = buildBookingCandidateStarts("completed");
+
+    expect(noShowStarts[0].getHours()).toBe(13);
+    expect(completedStarts[0].getHours()).toBe(15);
+    expect(completedStarts[0].toISOString()).not.toBe(noShowStarts[0].toISOString());
+  });
+});


### PR DESCRIPTION
## Summary
- teach the e2e reliability gate to recognize the sequential `ci:playwright` runner arguments from PR #669
- scope aggregate `npm run ci:playwright` detection to the `auth_browser_smoke` workflow job so unrelated jobs cannot satisfy auth-smoke coverage
- offset completed lifecycle booking starts from no-show starts in the same CI run
- retry lifecycle booking against the next authorized therapist/client pair when one pair exhausts candidate starts with 409 scheduling conflicts
- reopen the session modal before each target-pair retry so retries do not accidentally interact with schedule-page filter selects

## Verification
- `npm test -- tests/ci/check-e2e-reliability-gates.test.ts --runInBand`
- `npm test -- tests/scripts/playwright-session-lifecycle.test.ts --runInBand`
- `npm run ci:check:e2e-reliability` (passes; retains pre-existing skip-language warning for `scripts/playwright-session-note-measurement-roundtrip.ts`)
- `npm run typecheck`
- `npm run lint`
- `npm run ci:check-focused` (passes; local protected-system checks skip without DB URL/CI branch protection)