### PR TITLE
WIN-181 restrict public client wrapper RPC grants

### DIFF
--- a/supabase/migrations/20260623135118_restrict_public_client_wrapper_rpc_anon_execute.sql
+++ b/supabase/migrations/20260623135118_restrict_public_client_wrapper_rpc_anon_execute.sql
@@ -1,0 +1,36 @@
+-- @migration-intent: Restrict public client wrapper RPC execute privileges to reviewed authenticated callers only.
+-- @migration-dependencies: 20251121103000_public_client_rpc_wrappers
+-- @migration-rollback: Re-grant execute to anon only if a reviewed public client-creation caller is introduced.
+
+begin;
+
+revoke execute on function public.create_client(jsonb) from public, anon;
+revoke execute on function public.client_email_exists(text) from public, anon;
+
+grant execute on function public.create_client(jsonb) to authenticated, service_role;
+grant execute on function public.client_email_exists(text) to authenticated, service_role;
+
+do $$
+declare
+  target_function regprocedure;
+begin
+  foreach target_function in array array[
+    'public.create_client(jsonb)'::regprocedure,
+    'public.client_email_exists(text)'::regprocedure
+  ]
+  loop
+    if has_function_privilege('anon', target_function::oid, 'EXECUTE') then
+      raise exception 'Public client wrapper RPC grant hardening failed: % still executable by anon', target_function;
+    end if;
+
+    if not has_function_privilege('authenticated', target_function::oid, 'EXECUTE') then
+      raise exception 'Public client wrapper RPC grant hardening failed: % not executable by authenticated', target_function;
+    end if;
+
+    if not has_function_privilege('service_role', target_function::oid, 'EXECUTE') then
+      raise exception 'Public client wrapper RPC grant hardening failed: % not executable by service_role', target_function;
+    end if;
+  end loop;
+end $$;
+
+commit;

--- a/tests/clients/public-client-wrapper-rpc-grants.security.spec.ts
+++ b/tests/clients/public-client-wrapper-rpc-grants.security.spec.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('public client wrapper RPC execute grants', () => {
+  const migrationSql = readFileSync(
+    join(
+      process.cwd(),
+      'supabase/migrations/20260623135118_restrict_public_client_wrapper_rpc_anon_execute.sql',
+    ),
+    'utf-8',
+  );
+  const grantStatements = migrationSql.match(/grant execute on function[^;]+;/gi) ?? [];
+
+  it('removes unauthenticated execute access from client wrapper RPCs', () => {
+    expect(migrationSql).toMatch(
+      /revoke execute on function public\.create_client\(jsonb\) from public, anon;/i,
+    );
+    expect(migrationSql).toMatch(
+      /revoke execute on function public\.client_email_exists\(text\) from public, anon;/i,
+    );
+  });
+
+  it('preserves reviewed authenticated and service-role callers', () => {
+    expect(migrationSql).toMatch(
+      /grant execute on function public\.create_client\(jsonb\) to authenticated, service_role;/i,
+    );
+    expect(migrationSql).toMatch(
+      /grant execute on function public\.client_email_exists\(text\) to authenticated, service_role;/i,
+    );
+  });
+
+  it('asserts anon execute was removed after applying grants', () => {
+    expect(migrationSql).toMatch(/has_function_privilege\('anon', target_function::oid, 'EXECUTE'\)/i);
+    expect(migrationSql).toMatch(/still executable by anon/i);
+    expect(migrationSql).toMatch(/public\.create_client\(jsonb\)'::regprocedure/i);
+    expect(migrationSql).toMatch(/public\.client_email_exists\(text\)'::regprocedure/i);
+    expect(migrationSql).toMatch(/Public client wrapper RPC grant hardening failed/i);
+  });
+
+  it('does not re-grant unauthenticated execute access', () => {
+    for (const grantStatement of grantStatements) {
+      const [, granteeList = ''] = grantStatement.match(/\bto\s+([^;]+);/i) ?? [];
+      const grantees = granteeList
+        .split(',')
+        .map((grantee) => grantee.trim().toLowerCase());
+
+      expect(grantees).not.toContain('public');
+      expect(grantees).not.toContain('anon');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused Supabase migration to revoke `PUBLIC`/`anon` execute on `public.create_client(jsonb)` and `public.client_email_exists(text)`.
- Preserves `authenticated` and `service_role` execute grants for the reviewed client wrapper callers.
- Adds a migration contract test that verifies the grant shape and in-migration privilege assertions.

## Hosted Supabase evidence
- Project: `wnnjeqheqxxyrgsjmygy` (`AllIncompassing`, active healthy).
- Before repair, both target wrappers were `SECURITY DEFINER` and executable by `anon`; Security Advisor flagged both as `anon_security_definer_function_executable`.
- Applied hosted migration: `20260623135118 restrict_public_client_wrapper_rpc_anon_execute` through the Supabase connector.
- After repair, live grant query shows both target functions have `anon_can_execute=false`, `authenticated_can_execute=true`, and `service_role_can_execute=true`.
- Remaining advisor findings are unrelated and intentionally out of scope.

## Route-task
- classification: `high-risk human-reviewed`
- lane: `critical`
- triggering paths: `supabase/migrations/**`, RPC exposure/grants
- Linear: `WIN-181`

## Verification
- `npm test -- tests/clients/public-client-wrapper-rpc-grants.security.spec.ts` passed.
- `npm run validate:tenant` passed.
- `npm run ci:check-focused` passed.
- `npm run verify:local` passed before local filename alignment; after aligning the filename to the hosted migration version, the focused test, `validate:tenant`, and `ci:check-focused` were rerun and passed.
- Commit hook also reran `npm run ci:check-focused` and passed.

## Reviewer notes
- Required human review: yes, critical protected-path migration.
- No app auth behavior, RLS policy, function body, or unrelated advisor cleanup is included.