### PR TITLE
[codex] Fix session note measurement reliability warning

### DIFF
--- a/scripts/playwright-session-note-measurement-roundtrip.ts
+++ b/scripts/playwright-session-note-measurement-roundtrip.ts
@@ -78,12 +78,12 @@ const isMissingGoalMeasurementsColumnError = (error: unknown): boolean => {
   return /goal_measurements/i.test(text) && /column|does not exist|schema cache/i.test(text);
 };
 
-const detectGoalMeasurementsColumnSupport = async (): Promise<boolean> => {
+const assertGoalMeasurementsColumnSupport = async (): Promise<void> => {
   loadPlaywrightEnv();
   const supabaseUrl = process.env.VITE_SUPABASE_URL;
   const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!supabaseUrl || !serviceRole) {
-    return true;
+    return;
   }
   const admin = createClient(supabaseUrl, serviceRole, {
     auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false },
@@ -93,15 +93,14 @@ const detectGoalMeasurementsColumnSupport = async (): Promise<boolean> => {
     .select("id,goal_measurements")
     .limit(1);
   if (!error) {
-    return true;
+    return;
   }
   if (isMissingGoalMeasurementsColumnError(error)) {
-    return false;
+    throw new Error("goal_measurements column is required for the session note measurement roundtrip.");
   }
-  console.warn(
-    `[session-note-measurement] goal_measurements support probe failed with non-column error; using compatibility mode: ${JSON.stringify(error).slice(0, 400)}`,
+  throw new Error(
+    `[session-note-measurement] goal_measurements support probe failed: ${JSON.stringify(error).slice(0, 400)}`,
   );
-  return false;
 };
 
 const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): Promise<T> => {
@@ -340,7 +339,7 @@ async function run(): Promise<void> {
   const marker = `PW-MEAS-RT-${Date.now()}`;
   const initialMetric = 7;
   const updatedMetric = 8;
-  const goalMeasurementsSupported = await detectGoalMeasurementsColumnSupport();
+  await assertGoalMeasurementsColumnSupport();
 
   const credentialCandidates = assertNonAiSessionsEnvContract(
     "Session note measurement roundtrip Playwright regression",
@@ -485,17 +484,7 @@ async function run(): Promise<void> {
         `session-notes upsert failed: HTTP ${res.status()} body=${JSON.stringify(body).slice(0, 2000)}`,
       );
       assert.ok(body && typeof body === "object", "session-notes upsert must return a JSON object");
-      if (goalMeasurementsSupported) {
-        assertUpsertResponseMetric(body, goalId, initialMetric, "save-clinical-from-schedule");
-      } else {
-        const noteBody = body as { goal_notes?: Record<string, string> | null };
-        const noteText = noteBody.goal_notes?.[goalId] ?? "";
-        assert.equal(
-          noteText,
-          marker,
-          "save-clinical-from-schedule: expected goal note marker in compatibility mode",
-        );
-      }
+      assertUpsertResponseMetric(body, goalId, initialMetric, "save-clinical-from-schedule");
       const noteId = (body as { id?: string }).id;
       if (noteId && typeof noteId === "string") {
         savedNoteId = noteId;
@@ -524,13 +513,10 @@ async function run(): Promise<void> {
       const expandBtn = goalRowExpandButton(card.first());
       await expandBtn.click();
       await activePage.getByText(marker, { exact: false }).first().waitFor({ state: "visible", timeout: 20_000 });
-      if (goalMeasurementsSupported) {
-        await activePage.getByText(String(initialMetric), { exact: false }).first().waitFor({ state: "visible", timeout: 20_000 });
-      }
+      await activePage.getByText(String(initialMetric), { exact: false }).first().waitFor({ state: "visible", timeout: 20_000 });
     });
 
-    if (goalMeasurementsSupported) {
-      await withStepTimeout("edit-via-add-session-note-modal", async () => {
+    await withStepTimeout("edit-via-add-session-note-modal", async () => {
       const goalId = workingGoalId ?? booked.goalId;
       const card = savedNoteId
         ? activePage.locator(`[data-testid="session-note-card"][data-note-id="${savedNoteId}"]`)
@@ -552,9 +538,9 @@ async function run(): Promise<void> {
       assert.ok(editBody && typeof editBody === "object", "edit upsert must return a JSON object");
       assertUpsertResponseMetric(editBody, goalId, updatedMetric, "edit-via-add-session-note-modal");
       await activePage.getByLabel(/Close add session note modal/i).click().catch(() => undefined);
-      });
+    });
 
-      await withStepTimeout("verify-updated-measurement", async () => {
+    await withStepTimeout("verify-updated-measurement", async () => {
       await activePage.reload({ waitUntil: "networkidle", timeout: 90_000 }).catch(() => undefined);
       const card = savedNoteId
         ? activePage.locator(`[data-testid="session-note-card"][data-note-id="${savedNoteId}"]`)
@@ -563,23 +549,15 @@ async function run(): Promise<void> {
       const expandBtn = goalRowExpandButton(card.first());
       await expandBtn.click();
       await activePage.getByText(String(updatedMetric), { exact: false }).first().waitFor({ state: "visible", timeout: 20_000 });
-      });
-    } else {
-      console.log(
-        "[session-note-measurement] compatibility mode: goal_measurements column unavailable; skipped measurement edit assertions.",
-      );
-    }
+    });
 
     await withStepTimeout("cleanup-cancel-session", () => cancelSession(activePage, token, booked.sessionId));
 
     console.log(
       JSON.stringify({
         ok: true,
-        message: goalMeasurementsSupported
-          ? "Session note measurement roundtrip validated"
-          : "Session note roundtrip validated in compatibility mode (goal_measurements unavailable)",
+        message: "Session note measurement roundtrip validated",
         marker,
-        goalMeasurementsSupported,
         ids,
         savedNoteId,
       }),

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
@@ -146,6 +146,14 @@ const createFixture = (
 };
 
 describe("check-e2e-reliability-gates", () => {
+  test("session note measurement roundtrip script does not emit soft-skip reliability warnings", () => {
+    const scriptPath = path.join(repoRoot, "scripts", "playwright-session-note-measurement-roundtrip.ts");
+    const content = readFileSync(scriptPath, "utf8");
+
+    expect(content).not.toMatch(/skip(ped|s)?/i);
+    expect(content).not.toMatch(/smoke skipped/i);
+  });
+
   test("accepts ci:playwright runner invocation semantics", () => {
     const fixtureRoot = createFixture(`tsx scripts/playwright-ci-runner.ts ${runnerChildren.join(" ")}`);
 


### PR DESCRIPTION
## Summary
- remove the compatibility-mode soft-skip path from the session note measurement Playwright roundtrip
- fail closed when goal_measurements support is missing or the support probe errors
- add focused CI-gate coverage so the script cannot reintroduce soft-skip reliability warning language

## Verification
- npm run ci:check:e2e-reliability
- npx vitest run tests/ci/check-e2e-reliability-gates.test.ts
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
- npm run ci:verify-coverage
- npm run test:routes:tier0
- git diff --check

## Notes
- The live Playwright roundtrip itself was not run locally because it requires the configured Playwright/Supabase environment.
- Unrelated local changes were left unstaged: .codex/config.toml and output/.