### PR TITLE
[codex] Restrict staff message thread RPC anon execute

### DIFF
--- a/supabase/migrations/20260624125902_restrict_staff_message_thread_rpc_anon_execute.sql
+++ b/supabase/migrations/20260624125902_restrict_staff_message_thread_rpc_anon_execute.sql
@@ -1,0 +1,28 @@
+-- @migration-intent: Repair staff messaging thread-creation RPC execute grants so only reviewed authenticated callers can create threads.
+-- @migration-dependencies: 20260520143000_staff_messaging_tables_and_rls.sql
+-- @migration-rollback: Re-grant execute to anon only if a reviewed public staff-messaging caller is introduced.
+
+begin;
+
+revoke execute on function public.create_staff_message_thread(text, uuid[], text) from public, anon;
+
+grant execute on function public.create_staff_message_thread(text, uuid[], text) to authenticated, service_role;
+
+do $$
+declare
+  target_function regprocedure := 'public.create_staff_message_thread(text, uuid[], text)'::regprocedure;
+begin
+  if has_function_privilege('anon', target_function::oid, 'EXECUTE') then
+    raise exception 'Staff message thread RPC grant hardening failed: % still executable by anon', target_function;
+  end if;
+
+  if not has_function_privilege('authenticated', target_function::oid, 'EXECUTE') then
+    raise exception 'Staff message thread RPC grant hardening failed: % not executable by authenticated', target_function;
+  end if;
+
+  if not has_function_privilege('service_role', target_function::oid, 'EXECUTE') then
+    raise exception 'Staff message thread RPC grant hardening failed: % not executable by service_role', target_function;
+  end if;
+end $$;
+
+commit;

--- a/tests/messages/staff-message-thread-rpc-grants.security.spec.ts
+++ b/tests/messages/staff-message-thread-rpc-grants.security.spec.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('staff message thread RPC execute grants', () => {
+  const migrationSql = readFileSync(
+    join(
+      process.cwd(),
+      'supabase/migrations/20260624125902_restrict_staff_message_thread_rpc_anon_execute.sql',
+    ),
+    'utf-8',
+  );
+  const grantStatements = migrationSql.match(/grant execute on function[^;]+;/gi) ?? [];
+
+  it('removes unauthenticated execute access from thread creation', () => {
+    expect(migrationSql).toMatch(
+      /revoke execute on function public\.create_staff_message_thread\(text, uuid\[\], text\) from public, anon;/i,
+    );
+  });
+
+  it('preserves reviewed authenticated and service-role callers', () => {
+    expect(migrationSql).toMatch(
+      /grant execute on function public\.create_staff_message_thread\(text, uuid\[\], text\) to authenticated, service_role;/i,
+    );
+  });
+
+  it('asserts anon execute was removed after applying grants', () => {
+    expect(migrationSql).toMatch(/has_function_privilege\('anon', target_function::oid, 'EXECUTE'\)/i);
+    expect(migrationSql).toMatch(/public\.create_staff_message_thread\(text, uuid\[\], text\)'::regprocedure/i);
+    expect(migrationSql).toMatch(/Staff message thread RPC grant hardening failed/i);
+    expect(migrationSql).toMatch(/still executable by anon/i);
+  });
+
+  it('does not re-grant unauthenticated execute access', () => {
+    for (const grantStatement of grantStatements) {
+      const [, granteeList = ''] = grantStatement.match(/\bto\s+([^;]+);/i) ?? [];
+      const grantees = granteeList
+        .split(',')
+        .map((grantee) => grantee.trim().toLowerCase());
+
+      expect(grantees).not.toContain('public');
+      expect(grantees).not.toContain('anon');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a forward-only Supabase migration that revokes `public, anon` execute from `public.create_staff_message_thread(text, uuid[], text)` and preserves `authenticated, service_role` execute.
- Adds a focused migration-content security spec so this grant boundary is asserted locally.

## Hosted evidence
- Before repair, hosted project `wnnjeqheqxxyrgsjmygy` exposed the exact RPC to `anon` (`anon_execute=true`, ACL included `anon=X`).
- Applied hosted migration `20260624125902_restrict_staff_message_thread_rpc_anon_execute` via Supabase connector.
- After repair, hosted ACL for the exact RPC is `postgres`, `authenticated`, `service_role`; `anon_execute=false`, `authenticated_execute=true`, `service_role_execute=true`.

## Verification
- `npm test -- tests/messages/staff-message-thread-rpc-grants.security.spec.ts` passed.
- `npm run ci:check-focused` passed; DB-backed checks skipped because `SUPABASE_DB_URL`/`DATABASE_URL` is not configured locally.
- `npm run validate:tenant` passed.
- `npm run build` passed.
- `npm run test:ci -- tests/messages/staff-message-thread-rpc-grants.security.spec.ts tests/integration/rls.message-threads.access.test.ts` timed out after 3 minutes because the repo script did not remain scoped and entered unrelated broad suites.

## Notes
- Scope intentionally excludes unread-badge UX, participant-name fetch optimization, and general Supabase advisor cleanup.
- Critical-lane human review and Linear linkage are still required before merge per repo policy.
- Local worktree had unrelated dirty/untracked files that were not staged or committed: `.codex/config.toml`, `output/`, `supabase/migrations/20260624153000_drop_duplicate_transcript_session_indexes.sql`, `tests/transcriptDuplicateIndexesMigration.test.ts`.