### PR TITLE
[codex] Drop duplicate transcript session indexes

### DIFF
--- a/supabase/migrations/20260624131146_drop_duplicate_transcript_session_indexes.sql
+++ b/supabase/migrations/20260624131146_drop_duplicate_transcript_session_indexes.sql
@@ -1,0 +1,76 @@
+-- @migration-intent: Remove redundant transcript session_id indexes reported by the duplicate-index advisor.
+-- @migration-dependencies: 20250905120000_fk_indexes_concurrently.sql, 20260316160000_ensure_transcript_tables_exist.sql
+-- @migration-rollback: Recreate the dropped idx_* indexes if a downstream query plan unexpectedly depends on their names.
+
+set search_path = public;
+
+begin;
+
+do $$
+begin
+  if to_regclass('public.session_transcripts') is not null
+    and exists (
+      select 1
+      from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'session_transcripts'
+        and column_name = 'session_id'
+    ) then
+    create index if not exists session_transcripts_session_id_idx
+      on public.session_transcripts(session_id);
+  end if;
+
+  if to_regclass('public.session_transcript_segments') is not null
+    and exists (
+      select 1
+      from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'session_transcript_segments'
+        and column_name = 'session_id'
+    ) then
+    create index if not exists session_transcript_segments_session_id_idx
+      on public.session_transcript_segments(session_id);
+  end if;
+end
+$$;
+
+drop index if exists public.idx_session_transcripts_session_id;
+drop index if exists public.idx_session_transcript_segments_session_id;
+
+do $$
+begin
+  if to_regclass('public.idx_session_transcripts_session_id') is not null then
+    raise exception 'Duplicate transcript index cleanup failed: public.idx_session_transcripts_session_id still exists';
+  end if;
+
+  if to_regclass('public.idx_session_transcript_segments_session_id') is not null then
+    raise exception 'Duplicate transcript index cleanup failed: public.idx_session_transcript_segments_session_id still exists';
+  end if;
+
+  if to_regclass('public.session_transcripts') is not null
+    and exists (
+      select 1
+      from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'session_transcripts'
+        and column_name = 'session_id'
+    )
+    and to_regclass('public.session_transcripts_session_id_idx') is null then
+    raise exception 'Duplicate transcript index cleanup failed: public.session_transcripts_session_id_idx missing';
+  end if;
+
+  if to_regclass('public.session_transcript_segments') is not null
+    and exists (
+      select 1
+      from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'session_transcript_segments'
+        and column_name = 'session_id'
+    )
+    and to_regclass('public.session_transcript_segments_session_id_idx') is null then
+    raise exception 'Duplicate transcript index cleanup failed: public.session_transcript_segments_session_id_idx missing';
+  end if;
+end
+$$;
+
+commit;

--- a/tests/transcriptDuplicateIndexesMigration.test.ts
+++ b/tests/transcriptDuplicateIndexesMigration.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('transcript duplicate session_id index cleanup migration', () => {
+  const migrationSql = readFileSync(
+    join(
+      process.cwd(),
+      'supabase/migrations/20260624131146_drop_duplicate_transcript_session_indexes.sql',
+    ),
+    'utf-8',
+  );
+
+  it('keeps the FK-covering session_id index names canonical', () => {
+    expect(migrationSql).toMatch(
+      /create index if not exists session_transcripts_session_id_idx\s+on public\.session_transcripts\(session_id\);/i,
+    );
+    expect(migrationSql).toMatch(
+      /create index if not exists session_transcript_segments_session_id_idx\s+on public\.session_transcript_segments\(session_id\);/i,
+    );
+  });
+
+  it('drops only the redundant idx-prefixed session_id indexes', () => {
+    expect(migrationSql).toMatch(/drop index if exists public\.idx_session_transcripts_session_id;/i);
+    expect(migrationSql).toMatch(
+      /drop index if exists public\.idx_session_transcript_segments_session_id;/i,
+    );
+    expect(migrationSql).not.toMatch(/drop index if exists public\.session_transcripts_session_id_idx;/i);
+    expect(migrationSql).not.toMatch(
+      /drop index if exists public\.session_transcript_segments_session_id_idx;/i,
+    );
+  });
+
+  it('asserts duplicate names are gone and canonical indexes remain', () => {
+    expect(migrationSql).toMatch(/to_regclass\('public\.idx_session_transcripts_session_id'\) is not null/i);
+    expect(migrationSql).toMatch(
+      /to_regclass\('public\.idx_session_transcript_segments_session_id'\) is not null/i,
+    );
+    expect(migrationSql).toMatch(/to_regclass\('public\.session_transcripts_session_id_idx'\) is null/i);
+    expect(migrationSql).toMatch(
+      /to_regclass\('public\.session_transcript_segments_session_id_idx'\) is null/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an idempotent Supabase migration that preserves canonical `session_id` indexes for transcript tables and drops legacy `idx_*` duplicate index names when present.
- Adds a focused migration-content test asserting the canonical indexes are retained, duplicate names are dropped, and the migration contains post-apply assertions.

## Live evidence
- Hosted project `wnnjeqheqxxyrgsjmygy` currently has `session_transcript_segments_session_id_idx` and `session_transcripts_session_id_idx` present.
- Hosted project does not currently show `idx_session_transcripts_session_id` or `idx_session_transcript_segments_session_id`, so this PR is an idempotent replay/guard rather than an urgent hosted repair.
- No hosted migration was applied directly for this slice; this should flow through PR review/CI.

## Verification
- `npm test -- tests/transcriptDuplicateIndexesMigration.test.ts` passed.
- `npm run ci:check-focused` passed; DB-backed checks skipped because `SUPABASE_DB_URL`/`DATABASE_URL` is not configured locally.
- `npm run validate:tenant` passed.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run build` passed.
- `npm run test:ci` passed: 328 files, 1995 tests.
- `npm run ci:verify-coverage` passed.
- `npm run test:routes:tier0` passed: 79 Cypress route tests.

## Notes
- Scope is limited to duplicate transcript session-id indexes.
- Critical-lane human review and Linear linkage are still required before merge per repo policy.
- Local unrelated files were preserved and not committed: `.codex/config.toml`, `output/`.