### PR TITLE
WIN-178 Fix preauth upload file selection fallback

### DIFF
--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -53,6 +53,7 @@ const ACCEPTED_FILE_TYPES = [
   'image/jpeg',
   'image/png'
 ] as const;
+const ACCEPTED_FILE_EXTENSIONS = ['pdf', 'doc', 'docx', 'jpg', 'jpeg', 'png'] as const;
 
 type AuthorizationStatus = 'approved' | 'pending' | 'denied';
 
@@ -84,6 +85,21 @@ const AUTHORIZATION_STATUSES: AuthorizationStatus[] = ['approved', 'pending', 'd
 const NO_EMBEDDED_PDF_TEXT_MESSAGE = 'No embedded PDF text was found.';
 const GENERIC_PDF_PREFILL_ERROR_MESSAGE = 'PDF text extraction failed. Enter the authorization fields manually.';
 const createDocumentUploadKey = (sequence: number) => `upload-${sequence}`;
+
+const getFileExtension = (fileName: string) => {
+  const extension = fileName.split('.').pop()?.toLowerCase();
+  return extension && extension !== fileName.toLowerCase() ? extension : '';
+};
+
+const isAcceptedFile = (file: File) => {
+  const hasAcceptedType = ACCEPTED_FILE_TYPES.includes(file.type as typeof ACCEPTED_FILE_TYPES[number]);
+  if (hasAcceptedType) {
+    return true;
+  }
+
+  const extension = getFileExtension(file.name);
+  return ACCEPTED_FILE_EXTENSIONS.includes(extension as typeof ACCEPTED_FILE_EXTENSIONS[number]);
+};
 
 const createEmptyWizardData = (): PreAuthWizardData => ({
   insurance: '',
@@ -757,8 +773,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
     const acceptedFiles: File[] = [];
     const acceptedEntries: Array<{ file: File; uploadKey: string }> = [];
     Array.from(fileList).forEach((file) => {
-      const isAcceptedType = ACCEPTED_FILE_TYPES.includes(file.type as typeof ACCEPTED_FILE_TYPES[number]);
-      if (!isAcceptedType) {
+      if (!isAcceptedFile(file)) {
         showError(`Unsupported file type: ${file.name}`);
         return;
       }

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -294,6 +294,48 @@ describe("PreAuthTab manual authorization upload", () => {
     expect(showSuccess).toHaveBeenCalledWith("Authorization uploaded and saved.");
   });
 
+  it("accepts an uploaded PDF when the browser does not provide a MIME type", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    await user.click(screen.getByRole("button", { name: /new authorization/i }));
+
+    await screen.findByRole("heading", { name: /authorization notice details/i });
+    await user.type(screen.getByLabelText(/authorization number/i), "IEHP-AUTH-EMPTY-MIME");
+    await user.selectOptions(await screen.findByLabelText(/insurance provider/i), "payer-1");
+    await waitFor(() => {
+      expect(screen.getByLabelText(/rendering therapist/i)).toHaveValue("therapist-provider-1");
+    });
+    await user.selectOptions(screen.getByLabelText(/plan type/i), "Medicaid");
+    await user.type(screen.getByLabelText(/member id/i), "MEM-EMPTY-MIME");
+    await user.type(screen.getByLabelText(/start date/i), "2026-06-23");
+    await user.type(screen.getByLabelText(/end date/i), "2026-12-22");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(await screen.findByLabelText(/97153/i));
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.type(screen.getByLabelText(/units requested/i), "120");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["synthetic authorization notice"], "Behavioral Referral - IEHP Provider SeAp 6.15.pdf");
+    await user.upload(fileInput, file);
+
+    expect(await screen.findByText("Behavioral Referral - IEHP Provider SeAp 6.15.pdf")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /submit request/i }));
+
+    await waitFor(() => {
+      expect(storageUploadMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^clients\/client-1\/authorizations\/auth-created-id\/.+\.pdf$/),
+        file,
+        { upsert: false },
+      );
+    });
+  });
+
   it("prefills empty wizard fields from an uploaded PDF and submits extracted values", async () => {
     extractPdfTextMock.mockResolvedValue(`
       Authorization Number: IEHP-PDF-456


### PR DESCRIPTION
## Summary
- Accept authorization notice uploads by approved file extension when the browser omits or misreports the MIME type.
- Add a regression test using `Behavioral Referral - IEHP Provider SeAp 6.15.pdf` with no MIME type to prove the file is retained and submitted.

## Verification
- classification: low-risk autonomous
- lane: standard
- change type: UI/component upload validation
- required checks: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, `npm run verify:local`
- executed checks:
  - `npx vitest run --config vitest.config.ts src/components/__tests__/PreAuthTab.test.tsx --testNamePattern "accepts an uploaded PDF when the browser does not provide a MIME type" --reporter=verbose` - pass after red/green
  - `npx vitest run --config vitest.config.ts src/components/__tests__/PreAuthTab.test.tsx --reporter=verbose` - pass, 17/17
  - `npm run ci:check-focused` - pass; local DB/branch-protection checks skipped due missing env/outside CI
  - `npm run lint` - pass
  - `npm run typecheck` - pass
  - `npm run test:ci` - pass, 328 files / 1996 tests; unrelated stderr noise from existing dashboard/MSW and AI transcription tests
  - `npm run build` - pass
  - `npm run verify:local` - pass, includes tier-0 Cypress routes and `preauth_workflow.cy.ts`
- blocked checks: none
- residual risk: Browser-provided file MIME behavior varies; this keeps the existing allow-list and only falls back to already-advertised extensions.

## Notes
- Linear: WIN-178
- Protected-path drift: none
