### PR TITLE
Refactor session trials per target

### DIFF
--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -1273,8 +1273,8 @@ export function SessionModal({
   }, [sessionCaptureBxGoalIds, sessionCaptureSkillGoalIds, sessionCaptureTab]);
 
   const bumpTrialCount = useCallback(
-    (goalId: string, field: 'metric_value' | 'incorrect_trials', delta: number) => {
-      const path = `session_note_goal_measurements.${goalId}.data.${field}` as const;
+    (goalId: string, targetIndex: number, field: 'metric_value' | 'incorrect_trials', delta: number) => {
+      const path = `session_note_goal_measurements.${goalId}.data.target_trials.${targetIndex}.${field}` as const;
       const raw = getValues(path);
       const cur =
         typeof raw === 'number' && Number.isFinite(raw)
@@ -1292,6 +1292,16 @@ export function SessionModal({
     (goalId: string, nextTargets: string[]) => {
       const targetsPath = `session_note_goal_measurements.${goalId}.data.targets` as const;
       const targetPath = `session_note_goal_measurements.${goalId}.data.target` as const;
+      const targetTrialsPath = `session_note_goal_measurements.${goalId}.data.target_trials` as const;
+      const currentTargetTrials = getValues(targetTrialsPath);
+      const nextTargetTrials = Array.isArray(currentTargetTrials)
+        ? nextTargets.map((target, index) => ({
+          ...(typeof currentTargetTrials[index] === 'object' && currentTargetTrials[index] !== null
+            ? currentTargetTrials[index]
+            : {}),
+          target,
+        }))
+        : nextTargets.map((target) => ({ target }));
       setValue(targetsPath, nextTargets, { shouldDirty: true, shouldTouch: true });
       setValue(
         targetPath,
@@ -1300,8 +1310,9 @@ export function SessionModal({
           .find((target) => target.length > 0) ?? '',
         { shouldDirty: true, shouldTouch: true },
       );
+      setValue(targetTrialsPath, nextTargetTrials, { shouldDirty: true, shouldTouch: true });
     },
-    [setValue],
+    [getValues, setValue],
   );
 
   const addGoalTarget = useCallback(
@@ -2492,12 +2503,6 @@ export function SessionModal({
                           );
                           const minTrials = getTherapistMinTrialsTarget(selectedGoal);
                           const fieldKey = `session_note_goal_notes.${selectedGoalId}` as const;
-                          const metricValueFieldKey =
-                            `session_note_goal_measurements.${selectedGoalId}.data.metric_value` as const;
-                          const incorrectTrialsFieldKey =
-                            `session_note_goal_measurements.${selectedGoalId}.data.incorrect_trials` as const;
-                          const trialPromptNoteFieldKey =
-                            `session_note_goal_measurements.${selectedGoalId}.data.trial_prompt_note` as const;
                           const metricLabelFieldKey =
                             `session_note_goal_measurements.${selectedGoalId}.data.metric_label` as const;
                           const metricUnitFieldKey =
@@ -2514,9 +2519,10 @@ export function SessionModal({
                             `session_note_goal_measurements.${selectedGoalId}.data.targets` as const;
                           const targetFieldKey =
                             `session_note_goal_measurements.${selectedGoalId}.data.target` as const;
-                          const correctWatch = watch(metricValueFieldKey);
-                          const incorrectWatch = watch(incorrectTrialsFieldKey);
+                          const targetTrialsFieldBaseKey =
+                            `session_note_goal_measurements.${selectedGoalId}.data.target_trials` as const;
                           const watchedTargets = watch(targetsFieldBaseKey) as unknown;
+                          const watchedTargetTrials = watch(targetTrialsFieldBaseKey) as unknown;
                           const sessionTargets = (() => {
                             if (Array.isArray(watchedTargets)) {
                               const normalizedWatchedTargets = watchedTargets
@@ -2528,14 +2534,36 @@ export function SessionModal({
                             const normalizedExistingTargets = getGoalMeasurementTargets(existingMeasurementEntry?.data);
                             return normalizedExistingTargets.length > 0 ? normalizedExistingTargets : [''];
                           })();
-                          const correctDisplay =
-                            typeof correctWatch === 'number' && Number.isFinite(correctWatch)
-                              ? correctWatch
-                              : Number(correctWatch) || 0;
-                          const incorrectDisplay =
-                            typeof incorrectWatch === 'number' && Number.isFinite(incorrectWatch)
-                              ? incorrectWatch
-                              : Number(incorrectWatch) || 0;
+                          const targetTrialRows = Array.isArray(watchedTargetTrials)
+                            ? watchedTargetTrials
+                            : existingMeasurementEntry?.data.target_trials ?? [];
+                          const getTargetTrialValue = (
+                            targetIndex: number,
+                            field: 'metric_value' | 'incorrect_trials' | 'opportunities',
+                          ) => {
+                            const trialRow = targetTrialRows[targetIndex];
+                            if (!trialRow || typeof trialRow !== 'object') {
+                              return 0;
+                            }
+                            const raw = (trialRow as Record<string, unknown>)[field];
+                            return typeof raw === 'number' && Number.isFinite(raw) ? raw : Number(raw) || 0;
+                          };
+                          const getTargetTrialNote = (targetIndex: number) => {
+                            const trialRow = targetTrialRows[targetIndex];
+                            if (!trialRow || typeof trialRow !== 'object') {
+                              return '';
+                            }
+                            const raw = (trialRow as Record<string, unknown>).trial_prompt_note;
+                            return typeof raw === 'string' ? raw : '';
+                          };
+                          const correctDisplay = sessionTargets.reduce(
+                            (sum, _target, targetIndex) => sum + getTargetTrialValue(targetIndex, 'metric_value'),
+                            0,
+                          );
+                          const incorrectDisplay = sessionTargets.reduce(
+                            (sum, _target, targetIndex) => sum + getTargetTrialValue(targetIndex, 'incorrect_trials'),
+                            0,
+                          );
                           const mobileGoalSummaryLabel = isAdhocSessionTargetId(selectedGoalId)
                             ? (storedTitle.trim() ? storedTitle : 'Ad-hoc target')
                             : (selectedGoal?.title ?? selectedGoalId);
@@ -2670,10 +2698,27 @@ export function SessionModal({
                                     Add target
                                   </button>
                                 </div>
+                                {minTrials != null && (
+                                  <p className="mt-1 text-[11px] font-medium text-indigo-800 dark:text-indigo-100">
+                                    Min trials per target (therapist target): {minTrials}
+                                  </p>
+                                )}
                                 <div className="mt-1 space-y-2">
                                   {sessionTargets.map((targetValue, targetIndex) => {
                                     const indexedTargetFieldKey =
                                       `${targetsFieldBaseKey}.${targetIndex}` as const;
+                                    const targetTrialMetricValueFieldKey =
+                                      `${targetTrialsFieldBaseKey}.${targetIndex}.metric_value` as const;
+                                    const targetTrialIncorrectTrialsFieldKey =
+                                      `${targetTrialsFieldBaseKey}.${targetIndex}.incorrect_trials` as const;
+                                    const targetTrialOpportunitiesFieldKey =
+                                      `${targetTrialsFieldBaseKey}.${targetIndex}.opportunities` as const;
+                                    const targetTrialPromptNoteFieldKey =
+                                      `${targetTrialsFieldBaseKey}.${targetIndex}.trial_prompt_note` as const;
+                                    const targetTrialTargetFieldKey =
+                                      `${targetTrialsFieldBaseKey}.${targetIndex}.target` as const;
+                                    const targetCorrectDisplay = getTargetTrialValue(targetIndex, 'metric_value');
+                                    const targetIncorrectDisplay = getTargetTrialValue(targetIndex, 'incorrect_trials');
                                     const indexedTargetRegistration = register(indexedTargetFieldKey, {
                                       onChange: (event) => {
                                         const nextTargets = sessionTargets.slice();
@@ -2684,27 +2729,158 @@ export function SessionModal({
                                     return (
                                       <div
                                         key={`${selectedGoalId}-target-${targetIndex}`}
-                                        className="flex items-start gap-2"
+                                        className="rounded-md border border-indigo-100 bg-indigo-50/50 p-2 dark:border-indigo-900/40 dark:bg-indigo-900/10"
                                       >
-                                        <textarea
-                                          id={`goal-target-${selectedGoalId}-${targetIndex}`}
-                                          aria-label={targetIndex === 0 ? 'Target' : `Target ${targetIndex + 1}`}
-                                          {...indexedTargetRegistration}
-                                          rows={2}
-                                          defaultValue={targetValue}
-                                          className="w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
-                                          placeholder={selectedGoal?.target_criteria?.trim() || 'Record the target for this session...'}
+                                        <div className="flex items-start gap-2">
+                                          <textarea
+                                            id={`goal-target-${selectedGoalId}-${targetIndex}`}
+                                            aria-label={targetIndex === 0 ? 'Target' : `Target ${targetIndex + 1}`}
+                                            {...indexedTargetRegistration}
+                                            rows={2}
+                                            defaultValue={targetValue}
+                                            className="w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                            placeholder={selectedGoal?.target_criteria?.trim() || 'Record the target for this session...'}
+                                          />
+                                          {sessionTargets.length > 1 ? (
+                                            <button
+                                              type="button"
+                                              onClick={() => removeGoalTarget(selectedGoalId, targetIndex, sessionTargets)}
+                                              aria-label={`Remove target ${targetIndex + 1}`}
+                                              className="mt-1 shrink-0 rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-rose-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-rose-300"
+                                            >
+                                              <Trash2 className="h-4 w-4" />
+                                            </button>
+                                          ) : null}
+                                        </div>
+                                        <input
+                                          type="hidden"
+                                          {...register(targetTrialTargetFieldKey)}
+                                          value={targetValue}
+                                          readOnly
                                         />
-                                        {sessionTargets.length > 1 ? (
-                                          <button
-                                            type="button"
-                                            onClick={() => removeGoalTarget(selectedGoalId, targetIndex, sessionTargets)}
-                                            aria-label={`Remove target ${targetIndex + 1}`}
-                                            className="mt-1 shrink-0 rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-rose-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-rose-300"
+                                        <div className="mt-3">
+                                          <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-200">
+                                            Trials for target {targetIndex + 1}
+                                          </p>
+                                          <p className="mt-1 text-[11px] text-indigo-700/90 dark:text-indigo-200/80">
+                                            + correct or achieved · − incorrect or no response.
+                                          </p>
+                                          <div className="mt-3 flex flex-wrap items-center gap-3">
+                                            <div className="flex flex-wrap items-center gap-2">
+                                              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">+</span>
+                                              <button
+                                                type="button"
+                                                aria-label={`Increase correct trials for target ${targetIndex + 1}`}
+                                                className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white shadow-sm hover:bg-emerald-700"
+                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'metric_value', 1)}
+                                              >
+                                                +
+                                              </button>
+                                              <span className="min-w-[2rem] rounded-md border border-gray-200 bg-white px-2 py-1 text-center text-sm dark:border-gray-600 dark:bg-dark">
+                                                {targetCorrectDisplay}
+                                              </span>
+                                              <button
+                                                type="button"
+                                                aria-label={`Decrease correct trials for target ${targetIndex + 1}`}
+                                                className="flex h-10 w-10 items-center justify-center rounded-full border border-emerald-700 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-200"
+                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'metric_value', -1)}
+                                              >
+                                                −
+                                              </button>
+                                              <button
+                                                type="button"
+                                                aria-label={`Add 5 correct trials for target ${targetIndex + 1}`}
+                                                className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
+                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'metric_value', 5)}
+                                              >
+                                                +5
+                                              </button>
+                                              <button
+                                                type="button"
+                                                aria-label={`Subtract 5 correct trials for target ${targetIndex + 1}`}
+                                                disabled={targetCorrectDisplay < 5}
+                                                className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
+                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'metric_value', -5)}
+                                              >
+                                                −5
+                                              </button>
+                                            </div>
+                                            <div className="flex flex-wrap items-center gap-2">
+                                              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">−</span>
+                                              <button
+                                                type="button"
+                                                aria-label={`Increase incorrect or no-response trials for target ${targetIndex + 1}`}
+                                                className="flex h-10 w-10 items-center justify-center rounded-full bg-rose-600 text-lg font-bold text-white shadow-sm hover:bg-rose-700"
+                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'incorrect_trials', 1)}
+                                              >
+                                                +
+                                              </button>
+                                              <span className="min-w-[2rem] rounded-md border border-gray-200 bg-white px-2 py-1 text-center text-sm dark:border-gray-600 dark:bg-dark">
+                                                {targetIncorrectDisplay}
+                                              </span>
+                                              <button
+                                                type="button"
+                                                aria-label={`Decrease incorrect trials for target ${targetIndex + 1}`}
+                                                className="flex h-10 w-10 items-center justify-center rounded-full border border-rose-700 text-rose-700 hover:bg-rose-50 dark:border-rose-400 dark:text-rose-200"
+                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'incorrect_trials', -1)}
+                                              >
+                                                −
+                                              </button>
+                                              <button
+                                                type="button"
+                                                aria-label={`Add 5 incorrect or no-response trials for target ${targetIndex + 1}`}
+                                                className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
+                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'incorrect_trials', 5)}
+                                              >
+                                                +5
+                                              </button>
+                                              <button
+                                                type="button"
+                                                aria-label={`Subtract 5 incorrect trials for target ${targetIndex + 1}`}
+                                                disabled={targetIncorrectDisplay < 5}
+                                                className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
+                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'incorrect_trials', -5)}
+                                              >
+                                                −5
+                                              </button>
+                                            </div>
+                                          </div>
+                                          <input
+                                            type="number"
+                                            className="sr-only"
+                                            tabIndex={-1}
+                                            aria-hidden
+                                            {...register(targetTrialMetricValueFieldKey, { setValueAs: toFormNumber })}
+                                            defaultValue={targetCorrectDisplay || ''}
+                                          />
+                                          <input
+                                            type="number"
+                                            className="sr-only"
+                                            tabIndex={-1}
+                                            aria-hidden
+                                            {...register(targetTrialIncorrectTrialsFieldKey, { setValueAs: toFormNumber })}
+                                            defaultValue={targetIncorrectDisplay || ''}
+                                          />
+                                          <input
+                                            type="hidden"
+                                            {...register(targetTrialOpportunitiesFieldKey, { setValueAs: toFormNumber })}
+                                            defaultValue={getTargetTrialValue(targetIndex, 'opportunities') || ''}
+                                          />
+                                          <label
+                                            htmlFor={`trial-prompt-note-${selectedGoalId}-${targetIndex}`}
+                                            className="mt-3 block text-xs font-medium text-gray-600 dark:text-gray-300"
                                           >
-                                            <Trash2 className="h-4 w-4" />
-                                          </button>
-                                        ) : null}
+                                            Prompts &amp; reactions for target {targetIndex + 1}
+                                          </label>
+                                          <textarea
+                                            id={`trial-prompt-note-${selectedGoalId}-${targetIndex}`}
+                                            {...register(targetTrialPromptNoteFieldKey)}
+                                            rows={2}
+                                            defaultValue={getTargetTrialNote(targetIndex)}
+                                            className="mt-1 w-full rounded-md border-gray-300 bg-white text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                            placeholder="Record prompts used and client reactions for this target..."
+                                          />
+                                        </div>
                                       </div>
                                     );
                                   })}
@@ -2750,129 +2926,6 @@ export function SessionModal({
                                 {...register(noteFieldKey)}
                                 defaultValue={existingMeasurementEntry?.data.note ?? ''}
                               />
-                              <div className="mt-3 rounded-md border border-indigo-100 bg-indigo-50/70 p-3 dark:border-indigo-900/40 dark:bg-indigo-900/10">
-                                <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-200">
-                                  Trials
-                                </p>
-                                <p className="mt-1 text-[11px] text-indigo-700/90 dark:text-indigo-200/80">
-                                  + correct or achieved · − incorrect or no response. Admin or BCBA can complete
-                                  additional measurement fields in Client Details.
-                                </p>
-                                {minTrials != null && (
-                                  <p className="mt-2 text-[11px] font-medium text-indigo-800 dark:text-indigo-100">
-                                    Min trials (therapist target): {minTrials}
-                                  </p>
-                                )}
-                                <div className="mt-3 flex flex-wrap items-center gap-3">
-                                  <div className="flex flex-wrap items-center gap-2">
-                                    <span className="text-xs font-medium text-gray-700 dark:text-gray-300">+</span>
-                                    <button
-                                      type="button"
-                                      aria-label="Increase correct trials"
-                                      className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white shadow-sm hover:bg-emerald-700"
-                                      onClick={() => bumpTrialCount(selectedGoalId, 'metric_value', 1)}
-                                    >
-                                      +
-                                    </button>
-                                    <span className="min-w-[2rem] rounded-md border border-gray-200 bg-white px-2 py-1 text-center text-sm dark:border-gray-600 dark:bg-dark">
-                                      {correctDisplay}
-                                    </span>
-                                    <button
-                                      type="button"
-                                      aria-label="Decrease correct trials"
-                                      className="flex h-10 w-10 items-center justify-center rounded-full border border-emerald-700 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-200"
-                                      onClick={() => bumpTrialCount(selectedGoalId, 'metric_value', -1)}
-                                    >
-                                      −
-                                    </button>
-                                    <button
-                                      type="button"
-                                      aria-label="Add 5 correct trials"
-                                      className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
-                                      onClick={() => bumpTrialCount(selectedGoalId, 'metric_value', 5)}
-                                    >
-                                      +5
-                                    </button>
-                                    <button
-                                      type="button"
-                                      aria-label="Subtract 5 correct trials"
-                                      disabled={correctDisplay < 5}
-                                      className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
-                                      onClick={() => bumpTrialCount(selectedGoalId, 'metric_value', -5)}
-                                    >
-                                      −5
-                                    </button>
-                                  </div>
-                                  <div className="flex flex-wrap items-center gap-2">
-                                    <span className="text-xs font-medium text-gray-700 dark:text-gray-300">−</span>
-                                    <button
-                                      type="button"
-                                      aria-label="Increase incorrect or no-response trials"
-                                      className="flex h-10 w-10 items-center justify-center rounded-full bg-rose-600 text-lg font-bold text-white shadow-sm hover:bg-rose-700"
-                                      onClick={() => bumpTrialCount(selectedGoalId, 'incorrect_trials', 1)}
-                                    >
-                                      +
-                                    </button>
-                                    <span className="min-w-[2rem] rounded-md border border-gray-200 bg-white px-2 py-1 text-center text-sm dark:border-gray-600 dark:bg-dark">
-                                      {incorrectDisplay}
-                                    </span>
-                                    <button
-                                      type="button"
-                                      aria-label="Decrease incorrect trials"
-                                      className="flex h-10 w-10 items-center justify-center rounded-full border border-rose-700 text-rose-700 hover:bg-rose-50 dark:border-rose-400 dark:text-rose-200"
-                                      onClick={() => bumpTrialCount(selectedGoalId, 'incorrect_trials', -1)}
-                                    >
-                                      −
-                                    </button>
-                                    <button
-                                      type="button"
-                                      aria-label="Add 5 incorrect or no-response trials"
-                                      className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
-                                      onClick={() => bumpTrialCount(selectedGoalId, 'incorrect_trials', 5)}
-                                    >
-                                      +5
-                                    </button>
-                                    <button
-                                      type="button"
-                                      aria-label="Subtract 5 incorrect trials"
-                                      disabled={incorrectDisplay < 5}
-                                      className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
-                                      onClick={() => bumpTrialCount(selectedGoalId, 'incorrect_trials', -5)}
-                                    >
-                                      −5
-                                    </button>
-                                  </div>
-                                </div>
-                                <input
-                                  type="number"
-                                  className="sr-only"
-                                  tabIndex={-1}
-                                  aria-hidden
-                                  {...register(metricValueFieldKey, { setValueAs: toFormNumber })}
-                                  defaultValue={toFormNumber(existingMeasurementEntry?.data.metric_value) ?? ''}
-                                />
-                                <input
-                                  type="number"
-                                  className="sr-only"
-                                  tabIndex={-1}
-                                  aria-hidden
-                                  {...register(incorrectTrialsFieldKey, { setValueAs: toFormNumber })}
-                                  defaultValue={toFormNumber(existingMeasurementEntry?.data.incorrect_trials) ?? ''}
-                                />
-                                <label
-                                  htmlFor={`trial-prompt-note-${selectedGoalId}`}
-                                  className="mt-3 block text-xs font-medium text-gray-600 dark:text-gray-300"
-                                >
-                                  Prompts &amp; reactions (verbal / physical)
-                                </label>
-                                <textarea
-                                  id={`trial-prompt-note-${selectedGoalId}`}
-                                  {...register(trialPromptNoteFieldKey)}
-                                  rows={2}
-                                  className="mt-1 w-full rounded-md border-gray-300 bg-white text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
-                                  placeholder="Record prompts used and client reactions for these trials..."
-                                />
-                              </div>
                             </details>
                           );
                         })}

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -1289,11 +1289,11 @@ export function SessionModal({
   );
 
   const updateGoalTargets = useCallback(
-    (goalId: string, nextTargets: string[]) => {
+    (goalId: string, nextTargets: string[], nextTargetTrialsSource?: unknown[]) => {
       const targetsPath = `session_note_goal_measurements.${goalId}.data.targets` as const;
       const targetPath = `session_note_goal_measurements.${goalId}.data.target` as const;
       const targetTrialsPath = `session_note_goal_measurements.${goalId}.data.target_trials` as const;
-      const currentTargetTrials = getValues(targetTrialsPath);
+      const currentTargetTrials = nextTargetTrialsSource ?? getValues(targetTrialsPath);
       const nextTargetTrials = Array.isArray(currentTargetTrials)
         ? nextTargets.map((target, index) => ({
           ...(typeof currentTargetTrials[index] === 'object' && currentTargetTrials[index] !== null
@@ -1325,9 +1325,14 @@ export function SessionModal({
   const removeGoalTarget = useCallback(
     (goalId: string, targetIndex: number, existingTargets: string[]) => {
       const nextTargets = existingTargets.filter((_, index) => index !== targetIndex);
-      updateGoalTargets(goalId, nextTargets.length > 0 ? nextTargets : ['']);
+      const targetTrialsPath = `session_note_goal_measurements.${goalId}.data.target_trials` as const;
+      const currentTargetTrials = getValues(targetTrialsPath);
+      const nextTargetTrials = Array.isArray(currentTargetTrials)
+        ? currentTargetTrials.filter((_, index) => index !== targetIndex)
+        : undefined;
+      updateGoalTargets(goalId, nextTargets.length > 0 ? nextTargets : [''], nextTargetTrials);
     },
-    [updateGoalTargets],
+    [getValues, updateGoalTargets],
   );
 
   const addAdhocSessionTarget = useCallback(
@@ -2737,7 +2742,7 @@ export function SessionModal({
                                             aria-label={targetIndex === 0 ? 'Target' : `Target ${targetIndex + 1}`}
                                             {...indexedTargetRegistration}
                                             rows={2}
-                                            defaultValue={targetValue}
+                                            value={targetValue}
                                             className="w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                                             placeholder={selectedGoal?.target_criteria?.trim() || 'Record the target for this session...'}
                                           />

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -448,6 +448,15 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
               note: 'Needed one reminder at the start',
               targets: ['Match peer greeting in 4/5 trials', 'Wave to peer independently'],
               target: 'Match peer greeting in 4/5 trials',
+              target_trials: [
+                {
+                  target: 'Match peer greeting in 4/5 trials',
+                  metric_value: 4,
+                  incorrect_trials: null,
+                  opportunities: 5,
+                  trial_prompt_note: null,
+                },
+              ],
               trial_prompt_note: null,
             },
           },

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1603,7 +1603,7 @@ describe('SessionModal', () => {
     expect(screen.getByRole('tab', { name: /^BX$/i })).toBeInTheDocument();
   });
 
-  it('submits normalized per-goal measurements with session capture', async () => {
+  it('submits normalized per-target trials with session capture', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const buildChain = (rows: unknown[]) => {
       const chain: SupabaseQueryChain = {
@@ -1658,7 +1658,7 @@ describe('SessionModal', () => {
       />
     );
 
-    await screen.findByRole('button', { name: /Increase correct trials/i });
+    await screen.findByRole('button', { name: /Increase correct trials for target 1/i });
     fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
       target: { value: 'Observed steady progress' },
     });
@@ -1670,10 +1670,15 @@ describe('SessionModal', () => {
       target: { value: 'Wave to peer independently' },
     });
     for (let i = 0; i < 4; i += 1) {
-      await userEvent.click(screen.getByRole('button', { name: /Increase correct trials/i }));
+      await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 1/i }));
     }
-    fireEvent.change(screen.getByLabelText(/Prompts & reactions/i), {
+    await userEvent.click(screen.getByRole('button', { name: /Increase incorrect or no-response trials for target 2/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Add 5 correct trials for target 2/i }));
+    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 1/i), {
       target: { value: 'Needed one reminder at the start' },
+    });
+    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 2/i), {
+      target: { value: 'Independent after model' },
     });
 
     await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
@@ -1689,16 +1694,33 @@ describe('SessionModal', () => {
               measurement_type: 'frequency',
               metric_label: 'Count',
               metric_unit: 'responses',
-              metric_value: 4,
+              metric_value: 9,
+              incorrect_trials: 1,
               targets: ['Match peer greeting in 4/5 trials', 'Wave to peer independently'],
               target: 'Match peer greeting in 4/5 trials',
-              trial_prompt_note: 'Needed one reminder at the start',
+              target_trials: [
+                {
+                  target: 'Match peer greeting in 4/5 trials',
+                  metric_value: 4,
+                  incorrect_trials: null,
+                  opportunities: null,
+                  trial_prompt_note: 'Needed one reminder at the start',
+                },
+                {
+                  target: 'Wave to peer independently',
+                  metric_value: 5,
+                  incorrect_trials: 1,
+                  opportunities: null,
+                  trial_prompt_note: 'Independent after model',
+                },
+              ],
+              trial_prompt_note: 'Needed one reminder at the start; Independent after model',
             }),
           },
         },
       }));
     });
-  }, 10000);
+  }, 15000);
 
   it('submits ad-hoc skill rows when Save skills is clicked during a live session', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1722,6 +1722,110 @@ describe('SessionModal', () => {
     });
   }, 15000);
 
+  it('preserves remaining target trials when deleting an earlier target', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const buildChain = (rows: unknown[]) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals);
+      }
+      if (table === 'authorizations') {
+        return buildChain([
+          {
+            id: 'auth-1',
+            authorization_number: 'AUTH-001',
+            services: [{ service_code: '97153' }],
+          },
+        ]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-target-removal',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    await screen.findByRole('button', { name: /Increase correct trials for target 1/i });
+    fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
+      target: { value: 'Target B remains in treatment' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Target$/i), {
+      target: { value: 'Target A' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /add target/i }));
+    fireEvent.change(screen.getByLabelText(/^Target 2$/i), {
+      target: { value: 'Target B' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 1/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Add 5 correct trials for target 2/i }));
+    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 1/i), {
+      target: { value: 'Prompt note A' },
+    });
+    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 2/i), {
+      target: { value: 'Prompt note B' },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Remove target 1/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        session_note_goal_measurements: {
+          'goal-1': {
+            version: 1,
+            data: expect.objectContaining({
+              metric_value: 5,
+              targets: ['Target B'],
+              target: 'Target B',
+              target_trials: [
+                {
+                  target: 'Target B',
+                  metric_value: 5,
+                  incorrect_trials: null,
+                  opportunities: null,
+                  trial_prompt_note: 'Prompt note B',
+                },
+              ],
+              trial_prompt_note: 'Prompt note B',
+            }),
+          },
+        },
+      }));
+    });
+  }, 15000);
+
   it('submits ad-hoc skill rows when Save skills is clicked during a live session', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const buildChain = (rows: unknown[]) => {

--- a/src/lib/__tests__/goal-measurements.test.ts
+++ b/src/lib/__tests__/goal-measurements.test.ts
@@ -41,7 +41,68 @@ describe('goal-measurements helpers', () => {
         note: 'Needed one reminder',
         targets: ['Match peer greeting in 4/5 trials'],
         target: 'Match peer greeting in 4/5 trials',
+        target_trials: [
+          {
+            target: 'Match peer greeting in 4/5 trials',
+            metric_value: 4,
+            incorrect_trials: null,
+            opportunities: 5,
+            trial_prompt_note: null,
+          },
+        ],
         trial_prompt_note: null,
+      },
+    });
+  });
+
+  it('normalizes target-scoped trial rows and derives legacy summary fields', () => {
+    expect(
+      normalizeGoalMeasurementEntry({
+        targets: ['Tie shoes', 'Ask for help'],
+        target_trials: [
+          {
+            metric_value: '3',
+            incorrect_trials: '1',
+            trialPromptNote: 'Verbal prompt',
+          },
+          {
+            metric_value: 2,
+            incorrectTrials: 0,
+            opportunities: '4',
+            trial_prompt_note: 'Independent',
+          },
+        ],
+      }),
+    ).toEqual({
+      version: 1,
+      data: {
+        measurement_type: null,
+        metric_label: 'Count',
+        metric_unit: 'responses',
+        metric_value: 5,
+        incorrect_trials: 1,
+        opportunities: 4,
+        prompt_level: null,
+        note: null,
+        targets: ['Tie shoes', 'Ask for help'],
+        target: 'Tie shoes',
+        target_trials: [
+          {
+            target: 'Tie shoes',
+            metric_value: 3,
+            incorrect_trials: 1,
+            opportunities: null,
+            trial_prompt_note: 'Verbal prompt',
+          },
+          {
+            target: 'Ask for help',
+            metric_value: 2,
+            incorrect_trials: 0,
+            opportunities: 4,
+            trial_prompt_note: 'Independent',
+          },
+        ],
+        trial_prompt_note: 'Verbal prompt; Independent',
       },
     });
   });
@@ -65,6 +126,15 @@ describe('goal-measurements helpers', () => {
         note: null,
         targets: null,
         target: null,
+        target_trials: [
+          {
+            target: null,
+            metric_value: 12,
+            incorrect_trials: null,
+            opportunities: null,
+            trial_prompt_note: null,
+          },
+        ],
         trial_prompt_note: null,
       },
     });
@@ -86,6 +156,15 @@ describe('goal-measurements helpers', () => {
       'Second',
     ]);
     expect(getGoalMeasurementTargets({ target: ' Legacy only ' } as any)).toEqual(['Legacy only']);
+  });
+
+  it('drops whitespace-only targets and empty target trial rows', () => {
+    expect(
+      normalizeGoalMeasurementEntry({
+        targets: ['  '],
+        target_trials: [{ target: ' ', metric_value: '', incorrect_trials: null, trial_prompt_note: '  ' }],
+      }),
+    ).toBeNull();
   });
 
   it('merges unique goal ids while trimming blanks', () => {

--- a/src/lib/__tests__/session-notes.test.ts
+++ b/src/lib/__tests__/session-notes.test.ts
@@ -117,6 +117,15 @@ describe('fetchClientSessionNotes', () => {
           note: 'Legacy payload still loads',
           targets: null,
           target: null,
+          target_trials: [
+            {
+              target: null,
+              metric_value: 4,
+              incorrect_trials: null,
+              opportunities: 5,
+              trial_prompt_note: null,
+            },
+          ],
           trial_prompt_note: null,
         },
       },

--- a/src/lib/goal-measurements.ts
+++ b/src/lib/goal-measurements.ts
@@ -1,4 +1,4 @@
-import type { Goal, SessionGoalMeasurementData, SessionGoalMeasurementEntry } from '../types';
+import type { Goal, SessionGoalMeasurementData, SessionGoalMeasurementEntry, SessionTargetTrialData } from '../types';
 
 export const GOAL_MEASUREMENT_VERSION = 1 as const;
 
@@ -53,6 +53,78 @@ const normalizeEditableStringList = (value: unknown): string[] => {
 
 const getPrimaryNonEmptyTarget = (targets: readonly string[]): string | null =>
   targets.map((target) => toOptionalString(target)).find((target): target is string => Boolean(target)) ?? null;
+
+const hasTargetTrialData = (trial: SessionTargetTrialData | null | undefined): trial is SessionTargetTrialData =>
+  Boolean(
+    trial &&
+      ((trial.metric_value !== null && trial.metric_value !== undefined) ||
+        (trial.incorrect_trials !== null && trial.incorrect_trials !== undefined) ||
+        (trial.opportunities !== null && trial.opportunities !== undefined) ||
+        (trial.trial_prompt_note?.trim().length ?? 0) > 0 ||
+        (trial.target?.trim().length ?? 0) > 0),
+  );
+
+const normalizeTargetTrials = (
+  value: unknown,
+  targets: readonly string[],
+): SessionTargetTrialData[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry, index) => {
+      const source = entry && typeof entry === 'object' ? entry as Record<string, unknown> : {};
+      const trial: SessionTargetTrialData = {
+        target: toOptionalString(source.target) ?? toOptionalString(targets[index]) ?? null,
+        metric_value: toOptionalNumber(source.metric_value ?? source.count ?? source.value),
+        incorrect_trials: toOptionalNumber(source.incorrect_trials ?? source.incorrectTrials),
+        opportunities: toOptionalNumber(source.opportunities ?? source.trials),
+        trial_prompt_note: toOptionalString(source.trial_prompt_note ?? source.trialPromptNote),
+      };
+      return hasTargetTrialData(trial) ? trial : null;
+    })
+    .filter((entry): entry is SessionTargetTrialData => Boolean(entry));
+};
+
+const buildLegacyTargetTrial = (
+  sourceData: Record<string, unknown>,
+  targets: readonly string[],
+): SessionTargetTrialData | null => {
+  const trial: SessionTargetTrialData = {
+    target: getPrimaryNonEmptyTarget(targets),
+    metric_value: toOptionalNumber(sourceData.metric_value ?? sourceData.count ?? sourceData.value),
+    incorrect_trials: toOptionalNumber(sourceData.incorrect_trials ?? sourceData.incorrectTrials),
+    opportunities: toOptionalNumber(sourceData.opportunities ?? sourceData.trials),
+    trial_prompt_note: toOptionalString(sourceData.trial_prompt_note ?? sourceData.trialPromptNote),
+  };
+  return hasTargetTrialData(trial) ? trial : null;
+};
+
+const sumTargetTrialNumber = (
+  trials: readonly SessionTargetTrialData[],
+  field: 'metric_value' | 'incorrect_trials' | 'opportunities',
+): number | null => {
+  let sum = 0;
+  let hasValue = false;
+
+  for (const trial of trials) {
+    const value = trial[field];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      sum += value;
+      hasValue = true;
+    }
+  }
+
+  return hasValue ? sum : null;
+};
+
+const summarizeTargetTrialPromptNotes = (trials: readonly SessionTargetTrialData[]): string | null => {
+  const notes = trials
+    .map((trial) => trial.trial_prompt_note?.trim() ?? '')
+    .filter((note) => note.length > 0);
+  return notes.length > 0 ? notes.join('; ') : null;
+};
 
 export const getGoalMeasurementTargets = (
   data: SessionGoalMeasurementData | null | undefined,
@@ -141,6 +213,7 @@ export const hasMeaningfulGoalMeasurementEntry = (
     (data.prompt_level?.trim().length ?? 0) > 0 ||
     (data.note?.trim().length ?? 0) > 0 ||
     getGoalMeasurementTargets(data).length > 0 ||
+    (data.target_trials ?? []).some(hasTargetTrialData) ||
     (data.trial_prompt_note?.trim().length ?? 0) > 0
   );
 };
@@ -174,19 +247,26 @@ export const normalizeGoalMeasurementEntry = (
     normalizedTargets.length > 0
       ? normalizedTargets
       : (fallbackLegacyTarget ? [fallbackLegacyTarget] : []);
+  const normalizedTargetTrials = normalizeTargetTrials(sourceData.target_trials, resolvedTargets);
+  const legacyTargetTrial = normalizedTargetTrials.length === 0
+    ? buildLegacyTargetTrial(sourceData, resolvedTargets)
+    : null;
+  const resolvedTargetTrials = normalizedTargetTrials.length > 0
+    ? normalizedTargetTrials
+    : (legacyTargetTrial ? [legacyTargetTrial] : []);
   const normalizedEntry: SessionGoalMeasurementEntry = {
     version: GOAL_MEASUREMENT_VERSION,
     data: {
       measurement_type: goal?.measurement_type ?? toOptionalString(sourceData.measurement_type),
       metric_label: toOptionalString(sourceData.metric_label) ?? fieldMeta.primaryLabel,
       metric_unit: toOptionalString(sourceData.metric_unit) ?? fallbackMetricUnit,
-      metric_value: toOptionalNumber(
+      metric_value: sumTargetTrialNumber(resolvedTargetTrials, 'metric_value') ?? toOptionalNumber(
         sourceData.metric_value ?? sourceData.count ?? sourceData.value,
       ),
-      incorrect_trials: toOptionalNumber(
+      incorrect_trials: sumTargetTrialNumber(resolvedTargetTrials, 'incorrect_trials') ?? toOptionalNumber(
         sourceData.incorrect_trials ?? sourceData.incorrectTrials,
       ),
-      opportunities: toOptionalNumber(
+      opportunities: sumTargetTrialNumber(resolvedTargetTrials, 'opportunities') ?? toOptionalNumber(
         sourceData.opportunities ?? sourceData.trials,
       ),
       prompt_level: toOptionalString(
@@ -195,7 +275,8 @@ export const normalizeGoalMeasurementEntry = (
       note: toOptionalString(sourceData.note ?? sourceData.comment),
       targets: resolvedTargets.length > 0 ? resolvedTargets : null,
       target: resolvedTargets[0] ?? null,
-      trial_prompt_note: toOptionalString(
+      target_trials: resolvedTargetTrials.length > 0 ? resolvedTargetTrials : null,
+      trial_prompt_note: summarizeTargetTrialPromptNotes(resolvedTargetTrials) ?? toOptionalString(
         sourceData.trial_prompt_note ?? sourceData.trialPromptNote,
       ),
     },
@@ -218,6 +299,10 @@ export const buildGoalMeasurementEntry = (
     sourceData && typeof sourceData === 'object' && 'targets' in sourceData ? sourceData.targets : undefined,
   );
   const existingTargets = editableTargets.length > 0 ? editableTargets : getGoalMeasurementTargets(normalizedExisting?.data);
+  const existingTargetTrials =
+    sourceData && typeof sourceData === 'object' && 'target_trials' in sourceData
+      ? normalizeTargetTrials(sourceData.target_trials, existingTargets)
+      : normalizedExisting?.data.target_trials ?? [];
   const nextEntry: SessionGoalMeasurementEntry = {
     version: GOAL_MEASUREMENT_VERSION,
     data: {
@@ -231,7 +316,8 @@ export const buildGoalMeasurementEntry = (
       note: normalizedExisting?.data.note ?? null,
       targets: existingTargets.length > 0 ? existingTargets : null,
       target: getPrimaryNonEmptyTarget(existingTargets),
-      trial_prompt_note: normalizedExisting?.data.trial_prompt_note ?? null,
+      target_trials: existingTargetTrials.length > 0 ? existingTargetTrials : null,
+      trial_prompt_note: summarizeTargetTrialPromptNotes(existingTargetTrials) ?? normalizedExisting?.data.trial_prompt_note ?? null,
     },
   };
 
@@ -254,6 +340,38 @@ export const mergeGoalMeasurementEntry = (
   const resolvedTargets = nextTargets.length > 0
     ? nextTargets
     : (normalizedLegacyTarget ? [normalizedLegacyTarget] : []);
+  const existingTargetTrials = normalizeTargetTrials(existing?.data.target_trials, resolvedTargets);
+  const hasFlatTrialUpdates =
+    updates.metric_value !== undefined ||
+    updates.incorrect_trials !== undefined ||
+    updates.opportunities !== undefined ||
+    updates.trial_prompt_note !== undefined;
+  const nextTargetTrials = updates.target_trials !== undefined
+    ? normalizeTargetTrials(updates.target_trials, resolvedTargets)
+    : hasFlatTrialUpdates
+      ? normalizeTargetTrials(
+        [
+          {
+            ...(existingTargetTrials[0] ?? {}),
+            target: getPrimaryNonEmptyTarget(resolvedTargets),
+            metric_value: updates.metric_value !== undefined
+              ? updates.metric_value ?? null
+              : existingTargetTrials[0]?.metric_value ?? null,
+            incorrect_trials: updates.incorrect_trials !== undefined
+              ? updates.incorrect_trials ?? null
+              : existingTargetTrials[0]?.incorrect_trials ?? null,
+            opportunities: updates.opportunities !== undefined
+              ? updates.opportunities ?? null
+              : existingTargetTrials[0]?.opportunities ?? null,
+            trial_prompt_note: updates.trial_prompt_note !== undefined
+              ? updates.trial_prompt_note ?? null
+              : existingTargetTrials[0]?.trial_prompt_note ?? null,
+          },
+          ...existingTargetTrials.slice(1),
+        ],
+        resolvedTargets,
+      )
+      : existingTargetTrials;
   const nextEntry: SessionGoalMeasurementEntry = {
     version: GOAL_MEASUREMENT_VERSION,
     data: {
@@ -277,9 +395,10 @@ export const mergeGoalMeasurementEntry = (
         : existing?.data.note ?? null,
       targets: resolvedTargets.length > 0 ? resolvedTargets : null,
       target: getPrimaryNonEmptyTarget(resolvedTargets),
-      trial_prompt_note: updates.trial_prompt_note !== undefined
+      target_trials: nextTargetTrials.length > 0 ? nextTargetTrials : null,
+      trial_prompt_note: summarizeTargetTrialPromptNotes(nextTargetTrials) ?? (updates.trial_prompt_note !== undefined
         ? updates.trial_prompt_note ?? null
-        : existing?.data.trial_prompt_note ?? null,
+        : existing?.data.trial_prompt_note ?? null),
     },
   };
 

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -151,6 +151,15 @@ describe("sessionNotesUpsertHandler", () => {
               note: "measured",
               targets: ["Match peer greeting in 4/5 trials"],
               target: "Match peer greeting in 4/5 trials",
+              target_trials: [
+                {
+                  target: "Match peer greeting in 4/5 trials",
+                  metric_value: 4,
+                  incorrect_trials: null,
+                  opportunities: 5,
+                  trial_prompt_note: null,
+                },
+              ],
               trial_prompt_note: null,
             },
           },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -337,7 +337,17 @@ export interface SessionGoalMeasurementData {
   note?: string | null;
   targets?: string[] | null;
   target?: string | null;
+  target_trials?: SessionTargetTrialData[] | null;
   /** Verbal / physical prompts and reactions for trial data (therapist capture). */
+  trial_prompt_note?: string | null;
+}
+
+export interface SessionTargetTrialData {
+  target?: string | null;
+  metric_value?: number | null;
+  incorrect_trials?: number | null;
+  opportunities?: number | null;
+  /** Verbal / physical prompts and reactions for this target's trial data. */
   trial_prompt_note?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- Move session trial capture from shared goal-level counters to target-scoped counters inside each target row.
- Persist normalized `goal_measurements[goalId].data.target_trials` while keeping legacy summary fields derived for existing consumers.
- Update modal, normalization, API-contract, and regression tests for per-target trials.

## Verification
- npm test -- src/components/__tests__/SessionModal.test.tsx
- npm test -- src/lib/__tests__/goal-measurements.test.ts src/components/__tests__/SessionModal.test.tsx
- npm test -- src/components/__tests__/AddSessionNoteModal.test.tsx
- npm test -- src/lib/__tests__/goal-measurements.test.ts src/components/__tests__/SessionModal.test.tsx src/components/__tests__/AddSessionNoteModal.test.tsx
- npm test -- src/lib/__tests__/goal-measurements.test.ts src/lib/__tests__/session-notes.test.ts src/server/__tests__/sessionNotesUpsertHandler.test.ts src/components/__tests__/SessionModal.test.tsx src/components/__tests__/AddSessionNoteModal.test.tsx
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
- npm run verify:local

## Notes
- No Linear issue was provided for this bounded standard-lane refactor.
- Policy checks passed locally; DB-backed Supabase drift/grant checks were skipped because SUPABASE_DB_URL/DATABASE_URL were not configured.