### PR TITLE
Restrict BT session targets to plan criteria

### DIFF
--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -1546,19 +1546,28 @@ export function SessionModal({
     if (!linkedSessionNote || !session?.id || isDirty) {
       return;
     }
+    const linkedMeasurements = (linkedSessionNote.goal_measurements as Record<string, unknown> | null) ?? {};
+    const normalizedLinkedMeasurements = Object.fromEntries(
+      Object.entries(linkedMeasurements)
+        .map(([goalEntryId, rawValue]) => {
+          const normalized = normalizeGoalMeasurementEntry(rawValue, goalsById.get(goalEntryId));
+          return normalized ? [goalEntryId, normalized] : null;
+        })
+        .filter((entry): entry is [string, SessionGoalMeasurementEntry] => Boolean(entry)),
+    );
     setValue(
       'session_note_goal_notes',
       (linkedSessionNote.goal_notes as Record<string, string> | null) ?? {},
     );
     setValue(
       'session_note_goal_measurements',
-      (linkedSessionNote.goal_measurements as Record<string, unknown> | null) ?? {},
+      normalizedLinkedMeasurements,
     );
     setValue('session_note_goal_ids', linkedSessionNote.goal_ids ?? []);
     setValue('session_note_goals_addressed', linkedSessionNote.goals_addressed ?? []);
     setValue('session_note_authorization_id', linkedSessionNote.authorization_id ?? '');
     setValue('session_note_service_code', linkedSessionNote.service_code ?? '');
-  }, [linkedSessionNote, session?.id, setValue, isDirty]);
+  }, [goalsById, linkedSessionNote, session?.id, setValue, isDirty]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -2572,6 +2581,17 @@ export function SessionModal({
                           const mobileGoalSummaryLabel = isAdhocSessionTargetId(selectedGoalId)
                             ? (storedTitle.trim() ? storedTitle : 'Ad-hoc target')
                             : (selectedGoal?.title ?? selectedGoalId);
+                          const isAdhocTarget = isAdhocSessionTargetId(selectedGoalId);
+                          const planTargetText = isAdhocTarget ? '' : selectedGoal?.target_criteria?.trim() ?? '';
+                          const selectedPlanTargets = sessionTargets
+                            .map((target) => target.trim())
+                            .filter((target) => target.length > 0);
+                          const hasSelectedPlanTarget = Boolean(
+                            planTargetText && selectedPlanTargets.includes(planTargetText),
+                          );
+                          const visibleSessionTargets = isAdhocTarget || selectedPlanTargets.length === 0
+                            ? sessionTargets
+                            : selectedPlanTargets;
                           const captureDetailsOpen =
                             !isSessionCaptureNarrow || mobileCaptureOpenGoalId === selectedGoalId;
                           return (
@@ -2598,7 +2618,7 @@ export function SessionModal({
                                     Trials +{correctDisplay} · −{incorrectDisplay}
                                   </p>
                                 </div>
-                                {isAdhocSessionTargetId(selectedGoalId) ? (
+                                {isAdhocTarget ? (
                                   <button
                                     type="button"
                                     onClick={(event) => {
@@ -2618,7 +2638,7 @@ export function SessionModal({
                                 />
                               </summary>
                               <div className="hidden sm:flex sm:items-start sm:justify-between sm:gap-2">
-                                {isAdhocSessionTargetId(selectedGoalId) ? (
+                                {isAdhocTarget ? (
                                   <div className="min-w-0 flex-1">
                                     <label
                                       htmlFor={`adhoc-title-${selectedGoalId}`}
@@ -2642,7 +2662,7 @@ export function SessionModal({
                                     {selectedGoal?.title ?? selectedGoalId}
                                   </p>
                                 )}
-                                {isAdhocSessionTargetId(selectedGoalId) && (
+                                {isAdhocTarget && (
                                   <button
                                     type="button"
                                     onClick={() => removeAdhocSessionTarget(selectedGoalId)}
@@ -2653,7 +2673,7 @@ export function SessionModal({
                                   </button>
                                 )}
                               </div>
-                              {isAdhocSessionTargetId(selectedGoalId) ? (
+                              {isAdhocTarget ? (
                                 <div className="mt-3 sm:hidden">
                                   <label
                                     htmlFor={`adhoc-title-mobile-${selectedGoalId}`}
@@ -2694,22 +2714,46 @@ export function SessionModal({
                                   >
                                     Targets
                                   </label>
-                                  <button
-                                    type="button"
-                                    onClick={() => addGoalTarget(selectedGoalId, sessionTargets)}
-                                    className="inline-flex items-center gap-1 rounded-md border border-indigo-200 bg-white px-2 py-1 text-[11px] font-semibold text-indigo-700 shadow-sm hover:bg-indigo-50 dark:border-indigo-800 dark:bg-dark dark:text-indigo-200 dark:hover:bg-indigo-950/40"
-                                  >
-                                    <Plus className="h-3.5 w-3.5" />
-                                    Add target
-                                  </button>
+                                  {isAdhocTarget ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => addGoalTarget(selectedGoalId, sessionTargets)}
+                                      className="inline-flex items-center gap-1 rounded-md border border-indigo-200 bg-white px-2 py-1 text-[11px] font-semibold text-indigo-700 shadow-sm hover:bg-indigo-50 dark:border-indigo-800 dark:bg-dark dark:text-indigo-200 dark:hover:bg-indigo-950/40"
+                                    >
+                                      <Plus className="h-3.5 w-3.5" />
+                                      Add target
+                                    </button>
+                                  ) : null}
                                 </div>
                                 {minTrials != null && (
                                   <p className="mt-1 text-[11px] font-medium text-indigo-800 dark:text-indigo-100">
                                     Min trials per target (therapist target): {minTrials}
                                   </p>
                                 )}
+                                {!isAdhocTarget ? (
+                                  <div className="mt-2">
+                                    {planTargetText ? (
+                                      <button
+                                        type="button"
+                                        onClick={() => updateGoalTargets(selectedGoalId, [planTargetText])}
+                                        disabled={hasSelectedPlanTarget}
+                                        className="w-full rounded-md border border-indigo-200 bg-white px-3 py-2 text-left text-sm font-medium text-indigo-900 shadow-sm hover:bg-indigo-50 disabled:cursor-default disabled:border-emerald-200 disabled:bg-emerald-50 disabled:text-emerald-900 dark:border-indigo-800 dark:bg-dark dark:text-indigo-100 dark:hover:bg-indigo-950/40 dark:disabled:border-emerald-900/60 dark:disabled:bg-emerald-900/20 dark:disabled:text-emerald-100"
+                                      >
+                                        <span className="block text-[11px] font-semibold uppercase tracking-wide">
+                                          {hasSelectedPlanTarget ? 'Plan target selected' : 'Use plan target'}
+                                        </span>
+                                        <span className="mt-1 block break-words">{planTargetText}</span>
+                                      </button>
+                                    ) : (
+                                      <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-100">
+                                        No plan target is set for this goal. Ask an admin to add the target under
+                                        Programs &amp; Goals.
+                                      </p>
+                                    )}
+                                  </div>
+                                ) : null}
                                 <div className="mt-1 space-y-2">
-                                  {sessionTargets.map((targetValue, targetIndex) => {
+                                  {visibleSessionTargets.map((targetValue, targetIndex) => {
                                     const indexedTargetFieldKey =
                                       `${targetsFieldBaseKey}.${targetIndex}` as const;
                                     const targetTrialMetricValueFieldKey =
@@ -2724,6 +2768,13 @@ export function SessionModal({
                                       `${targetTrialsFieldBaseKey}.${targetIndex}.target` as const;
                                     const targetCorrectDisplay = getTargetTrialValue(targetIndex, 'metric_value');
                                     const targetIncorrectDisplay = getTargetTrialValue(targetIndex, 'incorrect_trials');
+                                    const shouldRenderTargetTrialFields =
+                                      isAdhocTarget ||
+                                      targetValue.trim().length > 0 ||
+                                      targetCorrectDisplay > 0 ||
+                                      targetIncorrectDisplay > 0 ||
+                                      getTargetTrialValue(targetIndex, 'opportunities') > 0 ||
+                                      getTargetTrialNote(targetIndex).trim().length > 0;
                                     const indexedTargetRegistration = register(indexedTargetFieldKey, {
                                       onChange: (event) => {
                                         const nextTargets = sessionTargets.slice();
@@ -2736,34 +2787,53 @@ export function SessionModal({
                                         key={`${selectedGoalId}-target-${targetIndex}`}
                                         className="rounded-md border border-indigo-100 bg-indigo-50/50 p-2 dark:border-indigo-900/40 dark:bg-indigo-900/10"
                                       >
-                                        <div className="flex items-start gap-2">
-                                          <textarea
-                                            id={`goal-target-${selectedGoalId}-${targetIndex}`}
-                                            aria-label={targetIndex === 0 ? 'Target' : `Target ${targetIndex + 1}`}
-                                            {...indexedTargetRegistration}
-                                            rows={2}
-                                            value={targetValue}
-                                            className="w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
-                                            placeholder={selectedGoal?.target_criteria?.trim() || 'Record the target for this session...'}
-                                          />
-                                          {sessionTargets.length > 1 ? (
-                                            <button
-                                              type="button"
-                                              onClick={() => removeGoalTarget(selectedGoalId, targetIndex, sessionTargets)}
-                                              aria-label={`Remove target ${targetIndex + 1}`}
-                                              className="mt-1 shrink-0 rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-rose-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-rose-300"
+                                        {isAdhocTarget ? (
+                                          <div className="flex items-start gap-2">
+                                            <textarea
+                                              id={`goal-target-${selectedGoalId}-${targetIndex}`}
+                                              aria-label={targetIndex === 0 ? 'Target' : `Target ${targetIndex + 1}`}
+                                              {...indexedTargetRegistration}
+                                              rows={2}
+                                              value={targetValue}
+                                              className="w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                              placeholder="Record the target for this session..."
+                                            />
+                                            {sessionTargets.length > 1 ? (
+                                              <button
+                                                type="button"
+                                                onClick={() => removeGoalTarget(selectedGoalId, targetIndex, sessionTargets)}
+                                                aria-label={`Remove target ${targetIndex + 1}`}
+                                                className="mt-1 shrink-0 rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-rose-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-rose-300"
+                                              >
+                                                <Trash2 className="h-4 w-4" />
+                                              </button>
+                                            ) : null}
+                                          </div>
+                                        ) : (
+                                          <div>
+                                            <p
+                                              id={`goal-target-${selectedGoalId}-${targetIndex}`}
+                                              className="break-words rounded-md border border-indigo-200 bg-white px-3 py-2 text-sm font-medium text-indigo-950 shadow-sm dark:border-indigo-800 dark:bg-dark dark:text-indigo-100"
                                             >
-                                              <Trash2 className="h-4 w-4" />
-                                            </button>
-                                          ) : null}
-                                        </div>
-                                        <input
-                                          type="hidden"
-                                          {...register(targetTrialTargetFieldKey)}
-                                          value={targetValue}
-                                          readOnly
-                                        />
-                                        <div className="mt-3">
+                                              {targetValue || planTargetText || 'No target selected'}
+                                            </p>
+                                            <input
+                                              type="hidden"
+                                              {...indexedTargetRegistration}
+                                              value={targetValue}
+                                              readOnly
+                                            />
+                                          </div>
+                                        )}
+                                        {shouldRenderTargetTrialFields ? (
+                                          <div className="contents">
+                                            <input
+                                              type="hidden"
+                                              {...register(targetTrialTargetFieldKey)}
+                                              value={targetValue}
+                                              readOnly
+                                            />
+                                            <div className="mt-3">
                                           <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-200">
                                             Trials for target {targetIndex + 1}
                                           </p>
@@ -2885,7 +2955,9 @@ export function SessionModal({
                                             className="mt-1 w-full rounded-md border-gray-300 bg-white text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                                             placeholder="Record prompts used and client reactions for this target..."
                                           />
-                                        </div>
+                                            </div>
+                                          </div>
+                                        ) : null}
                                       </div>
                                     );
                                   })}
@@ -2924,7 +2996,8 @@ export function SessionModal({
                               <input
                                 type="hidden"
                                 {...register(promptLevelFieldKey)}
-                                defaultValue={existingMeasurementEntry?.data.prompt_level ?? ''}
+                                value={existingMeasurementEntry?.data.prompt_level ?? ''}
+                                readOnly
                               />
                               <input
                                 type="hidden"

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -57,6 +57,7 @@ describe('SessionModal', () => {
       description: 'Default goal for tests',
       original_text: 'Default clinical wording',
       measurement_type: 'frequency',
+      target_criteria: 'Match peer greeting in 4/5 trials',
       status: 'active',
       created_at: '2024-01-01T00:00:00Z',
       updated_at: '2024-01-01T00:00:00Z',
@@ -1658,30 +1659,22 @@ describe('SessionModal', () => {
       />
     );
 
+    const planTargetButton = await screen.findByRole('button', { name: /Use plan target/i });
+    expect(screen.queryByRole('button', { name: /add target/i })).not.toBeInTheDocument();
+    await userEvent.click(planTargetButton);
     await screen.findByRole('button', { name: /Increase correct trials for target 1/i });
     fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
       target: { value: 'Observed steady progress' },
     });
-    fireEvent.change(screen.getByLabelText(/^Target$/i), {
-      target: { value: 'Match peer greeting in 4/5 trials' },
-    });
-    await userEvent.click(screen.getByRole('button', { name: /add target/i }));
-    fireEvent.change(screen.getByLabelText(/^Target 2$/i), {
-      target: { value: 'Wave to peer independently' },
-    });
     for (let i = 0; i < 4; i += 1) {
       await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 1/i }));
     }
-    await userEvent.click(screen.getByRole('button', { name: /Increase incorrect or no-response trials for target 2/i }));
-    await userEvent.click(screen.getByRole('button', { name: /Add 5 correct trials for target 2/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Increase incorrect or no-response trials for target 1/i }));
     fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 1/i), {
       target: { value: 'Needed one reminder at the start' },
     });
-    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 2/i), {
-      target: { value: 'Independent after model' },
-    });
 
-    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Save skills/i }));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
@@ -1694,27 +1687,20 @@ describe('SessionModal', () => {
               measurement_type: 'frequency',
               metric_label: 'Count',
               metric_unit: 'responses',
-              metric_value: 9,
+              metric_value: 4,
               incorrect_trials: 1,
-              targets: ['Match peer greeting in 4/5 trials', 'Wave to peer independently'],
+              targets: ['Match peer greeting in 4/5 trials'],
               target: 'Match peer greeting in 4/5 trials',
               target_trials: [
                 {
                   target: 'Match peer greeting in 4/5 trials',
                   metric_value: 4,
-                  incorrect_trials: null,
+                  incorrect_trials: 1,
                   opportunities: null,
                   trial_prompt_note: 'Needed one reminder at the start',
                 },
-                {
-                  target: 'Wave to peer independently',
-                  metric_value: 5,
-                  incorrect_trials: 1,
-                  opportunities: null,
-                  trial_prompt_note: 'Independent after model',
-                },
               ],
-              trial_prompt_note: 'Needed one reminder at the start; Independent after model',
+              trial_prompt_note: 'Needed one reminder at the start',
             }),
           },
         },
@@ -1777,33 +1763,56 @@ describe('SessionModal', () => {
       />
     );
 
-    await screen.findByRole('button', { name: /Increase correct trials for target 1/i });
+    await screen.findByRole('button', { name: /Use plan target/i });
     fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
+      target: { value: 'Plan goal context' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /Add skill/i }));
+    const titleInputs = await screen.findAllByPlaceholderText('Name this target');
+    const titleInput = titleInputs.find((input) => input.id.startsWith('adhoc-title-')) ?? titleInputs[0];
+    fireEvent.change(titleInput, { target: { value: 'Adhoc skill target' } });
+    const perGoalNotes = screen.getAllByLabelText(/^Per-goal note$/i);
+    fireEvent.change(perGoalNotes[perGoalNotes.length - 1], {
       target: { value: 'Target B remains in treatment' },
     });
-    fireEvent.change(screen.getByLabelText(/^Target$/i), {
+    const targetFields = screen.getAllByLabelText(/^Target$/i);
+    fireEvent.change(targetFields[targetFields.length - 1], {
       target: { value: 'Target A' },
     });
-    await userEvent.click(screen.getByRole('button', { name: /add target/i }));
-    fireEvent.change(screen.getByLabelText(/^Target 2$/i), {
+    const addTargetButtons = screen.getAllByRole('button', { name: /add target/i });
+    await userEvent.click(addTargetButtons[addTargetButtons.length - 1]);
+    const secondTargetFields = screen.getAllByLabelText(/^Target 2$/i);
+    fireEvent.change(secondTargetFields[secondTargetFields.length - 1], {
       target: { value: 'Target B' },
     });
-    await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 1/i }));
-    await userEvent.click(screen.getByRole('button', { name: /Add 5 correct trials for target 2/i }));
-    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 1/i), {
+    const increaseTarget1Buttons = screen.getAllByRole('button', { name: /Increase correct trials for target 1/i });
+    await userEvent.click(increaseTarget1Buttons[increaseTarget1Buttons.length - 1]);
+    const addFiveTarget2Buttons = screen.getAllByRole('button', { name: /Add 5 correct trials for target 2/i });
+    await userEvent.click(addFiveTarget2Buttons[addFiveTarget2Buttons.length - 1]);
+    const target1PromptFields = screen.getAllByLabelText(/Prompts & reactions for target 1/i);
+    fireEvent.change(target1PromptFields[target1PromptFields.length - 1], {
       target: { value: 'Prompt note A' },
     });
-    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 2/i), {
+    const target2PromptFields = screen.getAllByLabelText(/Prompts & reactions for target 2/i);
+    fireEvent.change(target2PromptFields[target2PromptFields.length - 1], {
       target: { value: 'Prompt note B' },
     });
 
-    await userEvent.click(screen.getByRole('button', { name: /Remove target 1/i }));
-    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
+    const removeTargetButtons = screen.getAllByRole('button', { name: /Remove target 1/i });
+    await userEvent.click(removeTargetButtons[removeTargetButtons.length - 1]);
+    const saveSkillsButton = screen.getByRole('button', { name: /Save skills/i });
+    expect(saveSkillsButton).toBeEnabled();
+    await userEvent.click(saveSkillsButton);
 
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
-        session_note_goal_measurements: {
-          'goal-1': {
+      expect(onSubmit).toHaveBeenCalled();
+      const payload = onSubmit.mock.calls[0]?.[0] as {
+        session_note_goal_measurements?: Record<string, unknown>;
+      };
+      const adhocEntry = Object.entries(payload.session_note_goal_measurements ?? {})
+        .find(([goalEntryId]) => goalEntryId.startsWith('adhoc-skill-'))?.[1];
+      expect(adhocEntry).toEqual(
+        expect.objectContaining({
             version: 1,
             data: expect.objectContaining({
               metric_value: 5,
@@ -1820,9 +1829,8 @@ describe('SessionModal', () => {
               ],
               trial_prompt_note: 'Prompt note B',
             }),
-          },
-        },
-      }));
+        }),
+      );
     });
   }, 15000);
 
@@ -1970,6 +1978,7 @@ describe('SessionModal', () => {
       />
     );
 
+    await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
     await screen.findByRole('button', { name: /Add 5 correct trials/i });
     fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
       target: { value: 'Bundled trials' },
@@ -2018,6 +2027,7 @@ describe('SessionModal', () => {
       />
     );
 
+    await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
     await screen.findByRole('button', { name: /Subtract 5 correct trials/i });
     expect(screen.getByRole('button', { name: /Subtract 5 correct trials/i })).toBeDisabled();
   });

--- a/src/lib/__tests__/goal-measurements.test.ts
+++ b/src/lib/__tests__/goal-measurements.test.ts
@@ -55,6 +55,22 @@ describe('goal-measurements helpers', () => {
     });
   });
 
+  it('falls back to legacy promptLevel when canonical prompt_level is empty', () => {
+    expect(
+      normalizeGoalMeasurementEntry({
+        metric_value: 1,
+        prompt_level: '',
+        promptLevel: 'Model',
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          prompt_level: 'Model',
+        }),
+      }),
+    );
+  });
+
   it('normalizes target-scoped trial rows and derives legacy summary fields', () => {
     expect(
       normalizeGoalMeasurementEntry({

--- a/src/lib/goal-measurements.ts
+++ b/src/lib/goal-measurements.ts
@@ -269,9 +269,7 @@ export const normalizeGoalMeasurementEntry = (
       opportunities: sumTargetTrialNumber(resolvedTargetTrials, 'opportunities') ?? toOptionalNumber(
         sourceData.opportunities ?? sourceData.trials,
       ),
-      prompt_level: toOptionalString(
-        sourceData.prompt_level ?? sourceData.promptLevel,
-      ),
+      prompt_level: toOptionalString(sourceData.prompt_level) ?? toOptionalString(sourceData.promptLevel),
       note: toOptionalString(sourceData.note ?? sourceData.comment),
       targets: resolvedTargets.length > 0 ? resolvedTargets : null,
       target: resolvedTargets[0] ?? null,


### PR DESCRIPTION
## Summary
- remove freeform plan-goal target creation from the session capture UI
- let BTs select the goal's existing target_criteria as the session target
- keep ad-hoc session targets editable and preserve legacy measurement normalization

## Verification
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npx vitest run --maxWorkers=1 --no-file-parallelism src/components/__tests__/SessionModal.test.tsx src/lib/__tests__/goal-measurements.test.ts
- npm run build
- VITE_SUPABASE_URL=http://localhost:54321 VITE_SUPABASE_ANON_KEY=test-anon-key npm run test:ci
- npm run ci:verify-coverage
- VITE_SUPABASE_URL=http://localhost:54321 VITE_SUPABASE_ANON_KEY=test-anon-key npm run test:routes:tier0

Notes: ci:check-focused skipped live DB grant/drift checks because SUPABASE_DB_URL is not configured locally; branch-protection check skipped outside CI.