### PR TITLE
Filter saved plan-goal targets to target criteria

### DIFF
--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -105,6 +105,106 @@ const hasNestedDirtyEntries = (value: unknown): boolean => {
   return Object.values(value as Record<string, unknown>).some((entry) => hasNestedDirtyEntries(entry));
 };
 
+const trimString = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const sumPlanTargetTrials = (
+  trials: NonNullable<SessionGoalMeasurementEntry['data']['target_trials']>,
+  field: 'metric_value' | 'incorrect_trials' | 'opportunities',
+): number | null => {
+  let sum = 0;
+  let hasValue = false;
+
+  for (const trial of trials) {
+    const value = trial[field];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      sum += value;
+      hasValue = true;
+    }
+  }
+
+  return hasValue ? sum : null;
+};
+
+const summarizePlanTargetTrialNotes = (
+  trials: NonNullable<SessionGoalMeasurementEntry['data']['target_trials']>,
+): string | null => {
+  const notes = trials
+    .map((trial) => trial.trial_prompt_note?.trim() ?? '')
+    .filter((note) => note.length > 0);
+  return notes.length > 0 ? notes.join('; ') : null;
+};
+
+const filterPlanGoalMeasurementToTargetCriteria = (
+  entry: SessionGoalMeasurementEntry | null,
+  goal: Goal | undefined,
+  goalId: string,
+): SessionGoalMeasurementEntry | null => {
+  if (!entry || isAdhocSessionTargetId(goalId)) {
+    return entry;
+  }
+  if (!goal) {
+    return entry;
+  }
+
+  const planTarget = goal?.target_criteria?.trim() ?? '';
+  const sourceTargets = Array.isArray(entry.data.targets) ? entry.data.targets : [];
+  const sourceTrials = Array.isArray(entry.data.target_trials) ? entry.data.target_trials : [];
+  const hasSavedTargetData =
+    sourceTargets.length > 0 ||
+    Boolean(entry.data.target?.trim()) ||
+    sourceTrials.some((trial) => Boolean(trial.target?.trim()));
+  if (!hasSavedTargetData) {
+    return entry;
+  }
+  const targetIndex = sourceTargets.findIndex((target) => target.trim() === planTarget);
+  const hasPlanTarget =
+    planTarget.length > 0 &&
+    (targetIndex >= 0 || entry.data.target?.trim() === planTarget);
+  const filteredTrials = planTarget
+    ? sourceTrials
+        .filter((trial, index) => {
+          const trialTarget = trimString(trial.target) ?? trimString(sourceTargets[index]);
+          return trialTarget === planTarget || index === targetIndex;
+        })
+        .map((trial) => ({
+          ...trial,
+          target: planTarget,
+        }))
+    : [];
+  const shouldKeepPlanTarget = hasPlanTarget || filteredTrials.length > 0;
+  const nextTrials = filteredTrials.length > 0 ? filteredTrials : null;
+  const nextEntry: SessionGoalMeasurementEntry = {
+    version: entry.version,
+    data: {
+      ...entry.data,
+      metric_value: nextTrials
+        ? sumPlanTargetTrials(nextTrials, 'metric_value')
+        : (shouldKeepPlanTarget ? entry.data.metric_value : null),
+      incorrect_trials: nextTrials
+        ? sumPlanTargetTrials(nextTrials, 'incorrect_trials')
+        : (shouldKeepPlanTarget ? entry.data.incorrect_trials : null),
+      opportunities: nextTrials
+        ? sumPlanTargetTrials(nextTrials, 'opportunities')
+        : (shouldKeepPlanTarget ? entry.data.opportunities : null),
+      targets: shouldKeepPlanTarget ? [planTarget] : null,
+      target: shouldKeepPlanTarget ? planTarget : null,
+      target_trials: nextTrials,
+      trial_prompt_note: nextTrials
+        ? summarizePlanTargetTrialNotes(nextTrials)
+        : (shouldKeepPlanTarget ? entry.data.trial_prompt_note : null),
+    },
+  };
+
+  return hasMeaningfulGoalMeasurementEntry(nextEntry) ? nextEntry : null;
+};
+
 interface SessionModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -998,9 +1098,14 @@ export function SessionModal({
       const normalizedGoalMeasurementMap = Object.fromEntries(
         mergedGoalIds
           .map((goalEntryId) => {
-            const entry = normalizeGoalMeasurementEntry(
-              working.session_note_goal_measurements?.[goalEntryId],
-              goalsById.get(goalEntryId),
+            const goal = goalsById.get(goalEntryId);
+            const entry = filterPlanGoalMeasurementToTargetCriteria(
+              normalizeGoalMeasurementEntry(
+                working.session_note_goal_measurements?.[goalEntryId],
+                goal,
+              ),
+              goal,
+              goalEntryId,
             );
             return entry ? [goalEntryId, entry] : null;
           })
@@ -1030,7 +1135,11 @@ export function SessionModal({
             }
             const rawValue = working.session_note_goal_measurements?.[goalKey];
             return hasMeaningfulGoalMeasurementEntry(
-              normalizeGoalMeasurementEntry(rawValue, goalsById.get(goalKey)),
+              filterPlanGoalMeasurementToTargetCriteria(
+                normalizeGoalMeasurementEntry(rawValue, goalsById.get(goalKey)),
+                goalsById.get(goalKey),
+                goalKey,
+              ),
             );
           })
         : Object.values(working.session_note_goal_notes ?? {}).some(
@@ -1038,7 +1147,11 @@ export function SessionModal({
           ) ||
           Object.entries(working.session_note_goal_measurements ?? {}).some(([goalKey, rawValue]) =>
             hasMeaningfulGoalMeasurementEntry(
-              normalizeGoalMeasurementEntry(rawValue, goalsById.get(goalKey)),
+              filterPlanGoalMeasurementToTargetCriteria(
+                normalizeGoalMeasurementEntry(rawValue, goalsById.get(goalKey)),
+                goalsById.get(goalKey),
+                goalKey,
+              ),
             ),
           );
       const goalIdsRequiringNotes = isPartialCaptureSave
@@ -1550,7 +1663,12 @@ export function SessionModal({
     const normalizedLinkedMeasurements = Object.fromEntries(
       Object.entries(linkedMeasurements)
         .map(([goalEntryId, rawValue]) => {
-          const normalized = normalizeGoalMeasurementEntry(rawValue, goalsById.get(goalEntryId));
+          const goal = goalsById.get(goalEntryId);
+          const normalized = filterPlanGoalMeasurementToTargetCriteria(
+            normalizeGoalMeasurementEntry(rawValue, goal),
+            goal,
+            goalEntryId,
+          );
           return normalized ? [goalEntryId, normalized] : null;
         })
         .filter((entry): entry is [string, SessionGoalMeasurementEntry] => Boolean(entry)),
@@ -2515,6 +2633,11 @@ export function SessionModal({
                             sessionNoteGoalMeasurements?.[selectedGoalId],
                             selectedGoal,
                           );
+                          const filteredMeasurementEntry = filterPlanGoalMeasurementToTargetCriteria(
+                            existingMeasurementEntry,
+                            selectedGoal,
+                            selectedGoalId,
+                          );
                           const minTrials = getTherapistMinTrialsTarget(selectedGoal);
                           const fieldKey = `session_note_goal_notes.${selectedGoalId}` as const;
                           const metricLabelFieldKey =
@@ -2537,6 +2660,8 @@ export function SessionModal({
                             `session_note_goal_measurements.${selectedGoalId}.data.target_trials` as const;
                           const watchedTargets = watch(targetsFieldBaseKey) as unknown;
                           const watchedTargetTrials = watch(targetTrialsFieldBaseKey) as unknown;
+                          const isAdhocTarget = isAdhocSessionTargetId(selectedGoalId);
+                          const planTargetText = isAdhocTarget ? '' : selectedGoal?.target_criteria?.trim() ?? '';
                           const sessionTargets = (() => {
                             if (Array.isArray(watchedTargets)) {
                               const normalizedWatchedTargets = watchedTargets
@@ -2545,17 +2670,17 @@ export function SessionModal({
                                 return normalizedWatchedTargets;
                               }
                             }
-                            const normalizedExistingTargets = getGoalMeasurementTargets(existingMeasurementEntry?.data);
+                            const normalizedExistingTargets = getGoalMeasurementTargets(filteredMeasurementEntry?.data);
                             return normalizedExistingTargets.length > 0 ? normalizedExistingTargets : [''];
                           })();
-                          const targetTrialRows = Array.isArray(watchedTargetTrials)
+                          const rawTargetTrialRows = Array.isArray(watchedTargetTrials)
                             ? watchedTargetTrials
-                            : existingMeasurementEntry?.data.target_trials ?? [];
+                            : filteredMeasurementEntry?.data.target_trials ?? [];
                           const getTargetTrialValue = (
                             targetIndex: number,
                             field: 'metric_value' | 'incorrect_trials' | 'opportunities',
                           ) => {
-                            const trialRow = targetTrialRows[targetIndex];
+                            const trialRow = rawTargetTrialRows[targetIndex];
                             if (!trialRow || typeof trialRow !== 'object') {
                               return 0;
                             }
@@ -2563,35 +2688,36 @@ export function SessionModal({
                             return typeof raw === 'number' && Number.isFinite(raw) ? raw : Number(raw) || 0;
                           };
                           const getTargetTrialNote = (targetIndex: number) => {
-                            const trialRow = targetTrialRows[targetIndex];
+                            const trialRow = rawTargetTrialRows[targetIndex];
                             if (!trialRow || typeof trialRow !== 'object') {
                               return '';
                             }
                             const raw = (trialRow as Record<string, unknown>).trial_prompt_note;
                             return typeof raw === 'string' ? raw : '';
                           };
-                          const correctDisplay = sessionTargets.reduce(
-                            (sum, _target, targetIndex) => sum + getTargetTrialValue(targetIndex, 'metric_value'),
-                            0,
-                          );
-                          const incorrectDisplay = sessionTargets.reduce(
-                            (sum, _target, targetIndex) => sum + getTargetTrialValue(targetIndex, 'incorrect_trials'),
-                            0,
-                          );
                           const mobileGoalSummaryLabel = isAdhocSessionTargetId(selectedGoalId)
                             ? (storedTitle.trim() ? storedTitle : 'Ad-hoc target')
                             : (selectedGoal?.title ?? selectedGoalId);
-                          const isAdhocTarget = isAdhocSessionTargetId(selectedGoalId);
-                          const planTargetText = isAdhocTarget ? '' : selectedGoal?.target_criteria?.trim() ?? '';
-                          const selectedPlanTargets = sessionTargets
-                            .map((target) => target.trim())
-                            .filter((target) => target.length > 0);
+                          const selectedPlanTargets = sessionTargets.flatMap((target, sourceIndex) => {
+                            const trimmed = target.trim();
+                            return trimmed.length > 0 && trimmed === planTargetText
+                              ? [{ targetValue: trimmed, sourceIndex }]
+                              : [];
+                          });
                           const hasSelectedPlanTarget = Boolean(
-                            planTargetText && selectedPlanTargets.includes(planTargetText),
+                            planTargetText && selectedPlanTargets.length > 0,
                           );
-                          const visibleSessionTargets = isAdhocTarget || selectedPlanTargets.length === 0
-                            ? sessionTargets
-                            : selectedPlanTargets;
+                          const visibleSessionTargetItems = isAdhocTarget
+                            ? sessionTargets.map((targetValue, sourceIndex) => ({ targetValue, sourceIndex }))
+                            : (selectedPlanTargets.length > 0 ? selectedPlanTargets : [{ targetValue: '', sourceIndex: 0 }]);
+                          const correctDisplay = visibleSessionTargetItems.reduce(
+                            (sum, item) => sum + getTargetTrialValue(item.sourceIndex, 'metric_value'),
+                            0,
+                          );
+                          const incorrectDisplay = visibleSessionTargetItems.reduce(
+                            (sum, item) => sum + getTargetTrialValue(item.sourceIndex, 'incorrect_trials'),
+                            0,
+                          );
                           const captureDetailsOpen =
                             !isSessionCaptureNarrow || mobileCaptureOpenGoalId === selectedGoalId;
                           return (
@@ -2753,32 +2879,32 @@ export function SessionModal({
                                   </div>
                                 ) : null}
                                 <div className="mt-1 space-y-2">
-                                  {visibleSessionTargets.map((targetValue, targetIndex) => {
+                                  {visibleSessionTargetItems.map(({ targetValue, sourceIndex }, targetIndex) => {
                                     const indexedTargetFieldKey =
-                                      `${targetsFieldBaseKey}.${targetIndex}` as const;
+                                      `${targetsFieldBaseKey}.${sourceIndex}` as const;
                                     const targetTrialMetricValueFieldKey =
-                                      `${targetTrialsFieldBaseKey}.${targetIndex}.metric_value` as const;
+                                      `${targetTrialsFieldBaseKey}.${sourceIndex}.metric_value` as const;
                                     const targetTrialIncorrectTrialsFieldKey =
-                                      `${targetTrialsFieldBaseKey}.${targetIndex}.incorrect_trials` as const;
+                                      `${targetTrialsFieldBaseKey}.${sourceIndex}.incorrect_trials` as const;
                                     const targetTrialOpportunitiesFieldKey =
-                                      `${targetTrialsFieldBaseKey}.${targetIndex}.opportunities` as const;
+                                      `${targetTrialsFieldBaseKey}.${sourceIndex}.opportunities` as const;
                                     const targetTrialPromptNoteFieldKey =
-                                      `${targetTrialsFieldBaseKey}.${targetIndex}.trial_prompt_note` as const;
+                                      `${targetTrialsFieldBaseKey}.${sourceIndex}.trial_prompt_note` as const;
                                     const targetTrialTargetFieldKey =
-                                      `${targetTrialsFieldBaseKey}.${targetIndex}.target` as const;
-                                    const targetCorrectDisplay = getTargetTrialValue(targetIndex, 'metric_value');
-                                    const targetIncorrectDisplay = getTargetTrialValue(targetIndex, 'incorrect_trials');
+                                      `${targetTrialsFieldBaseKey}.${sourceIndex}.target` as const;
+                                    const targetCorrectDisplay = getTargetTrialValue(sourceIndex, 'metric_value');
+                                    const targetIncorrectDisplay = getTargetTrialValue(sourceIndex, 'incorrect_trials');
                                     const shouldRenderTargetTrialFields =
                                       isAdhocTarget ||
                                       targetValue.trim().length > 0 ||
                                       targetCorrectDisplay > 0 ||
                                       targetIncorrectDisplay > 0 ||
-                                      getTargetTrialValue(targetIndex, 'opportunities') > 0 ||
-                                      getTargetTrialNote(targetIndex).trim().length > 0;
+                                      getTargetTrialValue(sourceIndex, 'opportunities') > 0 ||
+                                      getTargetTrialNote(sourceIndex).trim().length > 0;
                                     const indexedTargetRegistration = register(indexedTargetFieldKey, {
                                       onChange: (event) => {
                                         const nextTargets = sessionTargets.slice();
-                                        nextTargets[targetIndex] = String(event.target.value ?? '');
+                                        nextTargets[sourceIndex] = String(event.target.value ?? '');
                                         updateGoalTargets(selectedGoalId, nextTargets);
                                       },
                                     });
@@ -2847,7 +2973,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Increase correct trials for target ${targetIndex + 1}`}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white shadow-sm hover:bg-emerald-700"
-                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'metric_value', 1)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', 1)}
                                               >
                                                 +
                                               </button>
@@ -2858,7 +2984,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Decrease correct trials for target ${targetIndex + 1}`}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full border border-emerald-700 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-200"
-                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'metric_value', -1)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -1)}
                                               >
                                                 −
                                               </button>
@@ -2866,7 +2992,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Add 5 correct trials for target ${targetIndex + 1}`}
                                                 className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'metric_value', 5)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', 5)}
                                               >
                                                 +5
                                               </button>
@@ -2875,7 +3001,7 @@ export function SessionModal({
                                                 aria-label={`Subtract 5 correct trials for target ${targetIndex + 1}`}
                                                 disabled={targetCorrectDisplay < 5}
                                                 className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'metric_value', -5)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -5)}
                                               >
                                                 −5
                                               </button>
@@ -2886,7 +3012,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Increase incorrect or no-response trials for target ${targetIndex + 1}`}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full bg-rose-600 text-lg font-bold text-white shadow-sm hover:bg-rose-700"
-                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'incorrect_trials', 1)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', 1)}
                                               >
                                                 +
                                               </button>
@@ -2897,7 +3023,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Decrease incorrect trials for target ${targetIndex + 1}`}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full border border-rose-700 text-rose-700 hover:bg-rose-50 dark:border-rose-400 dark:text-rose-200"
-                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'incorrect_trials', -1)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -1)}
                                               >
                                                 −
                                               </button>
@@ -2905,7 +3031,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Add 5 incorrect or no-response trials for target ${targetIndex + 1}`}
                                                 className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'incorrect_trials', 5)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', 5)}
                                               >
                                                 +5
                                               </button>
@@ -2914,7 +3040,7 @@ export function SessionModal({
                                                 aria-label={`Subtract 5 incorrect trials for target ${targetIndex + 1}`}
                                                 disabled={targetIncorrectDisplay < 5}
                                                 className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, targetIndex, 'incorrect_trials', -5)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -5)}
                                               >
                                                 −5
                                               </button>
@@ -2939,7 +3065,7 @@ export function SessionModal({
                                           <input
                                             type="hidden"
                                             {...register(targetTrialOpportunitiesFieldKey, { setValueAs: toFormNumber })}
-                                            defaultValue={getTargetTrialValue(targetIndex, 'opportunities') || ''}
+                                            defaultValue={getTargetTrialValue(sourceIndex, 'opportunities') || ''}
                                           />
                                           <label
                                             htmlFor={`trial-prompt-note-${selectedGoalId}-${targetIndex}`}
@@ -2951,7 +3077,7 @@ export function SessionModal({
                                             id={`trial-prompt-note-${selectedGoalId}-${targetIndex}`}
                                             {...register(targetTrialPromptNoteFieldKey)}
                                             rows={2}
-                                            defaultValue={getTargetTrialNote(targetIndex)}
+                                            defaultValue={getTargetTrialNote(sourceIndex)}
                                             className="mt-1 w-full rounded-md border-gray-300 bg-white text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                                             placeholder="Record prompts used and client reactions for this target..."
                                           />

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -2168,6 +2168,185 @@ describe('SessionModal', () => {
     });
   }, 10000);
 
+  it('filters saved plan-goal targets to target_criteria when resaving legacy capture', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const planTarget = 'Match peer greeting in 4/5 trials';
+    const legacyFreeformTarget = 'Legacy freeform target';
+    const linkedSessionNote = {
+      id: 'linked-note-mixed-plan-targets',
+      authorization_id: 'auth-1',
+      service_code: '97153',
+      narrative: '',
+      goal_notes: {
+        'goal-1': 'Observed mixed saved targets',
+      },
+      goal_measurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_label: 'Count',
+            metric_unit: 'responses',
+            targets: [legacyFreeformTarget, planTarget],
+            target: planTarget,
+            target_trials: [
+              {
+                target: legacyFreeformTarget,
+                metric_value: 5,
+                incorrect_trials: 4,
+                opportunities: 9,
+                trial_prompt_note: 'Legacy target prompt note',
+              },
+              {
+                target: planTarget,
+                metric_value: 2,
+                incorrect_trials: 1,
+                opportunities: 3,
+                trial_prompt_note: 'Plan target prompt note',
+              },
+            ],
+          },
+        },
+      },
+      goal_ids: ['goal-1'],
+      goals_addressed: ['Default Goal'],
+    };
+
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'linked-note-mixed-plan-targets',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: linkedSessionNote.goals_addressed,
+      goal_ids: linkedSessionNote.goal_ids,
+      goal_measurements: linkedSessionNote.goal_measurements as Record<string, unknown>,
+      goal_notes: linkedSessionNote.goal_notes,
+      session_id: 'session-linked-mixed-plan-targets',
+      narrative: linkedSessionNote.narrative,
+      is_locked: false,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: null,
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T09:00:00.000Z',
+    });
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: mockPrograms, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
+      if (table === 'goals') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: mockGoals, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
+      if (table === 'authorizations') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          order: vi.fn(async () => ({
+            data: [{ id: 'auth-1', authorization_number: 'AUTH-001', services: [{ service_code: '97153' }] }],
+            error: null,
+          })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: [], error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-linked-mixed-plan-targets',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Observed mixed saved targets')).toBeInTheDocument();
+    });
+
+    const planTargetButton = await screen.findByRole('button', { name: /Plan target selected/i });
+    expect(planTargetButton).toHaveTextContent(planTarget);
+    expect(screen.queryByText(legacyFreeformTarget)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 1/i }));
+    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 1/i), {
+      target: { value: 'Edited plan target prompt note' },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        session_note_persist_requested: true,
+        session_note_goal_measurements: {
+          'goal-1': {
+            version: 1,
+            data: expect.objectContaining({
+              metric_value: 3,
+              incorrect_trials: 1,
+              opportunities: 3,
+              targets: [planTarget],
+              target: planTarget,
+              target_trials: [
+                expect.objectContaining({
+                  target: planTarget,
+                  metric_value: 3,
+                  incorrect_trials: 1,
+                  opportunities: 3,
+                  trial_prompt_note: 'Edited plan target prompt note',
+                }),
+              ],
+              trial_prompt_note: 'Edited plan target prompt note',
+            }),
+          },
+        },
+      }));
+    });
+  }, 10000);
+
   it('preserves linked note measurements for drifted saved goals when saving', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const linkedSessionNote = {


### PR DESCRIPTION
## Summary
- filter linked/saved plan-goal measurement targets to the goal `target_criteria` before hydration, render, meaningful-entry checks, and submit normalization
- hide stale non-plan target rows from non-ad-hoc plan goals even when legacy form state includes them
- add regression coverage for a legacy saved session containing the plan target plus an older freeform target/trials

## Verification
- `npx vitest run --maxWorkers=1 --no-file-parallelism src/components/__tests__/SessionModal.test.tsx src/lib/__tests__/goal-measurements.test.ts` PASS
- `npm run lint` PASS
- `npm run typecheck` PASS
- `npm run build` PASS
- `npm run ci:check-focused` PASS; local DB-backed grant/drift checks skipped because `SUPABASE_DB_URL` is not configured
- Prior equivalent tree before the follow-up branch split also passed `npm run test:ci`, `npm run ci:verify-coverage`, and `npm run test:routes:tier0`
- `npm run ci:playwright` BLOCKED locally: missing `PW_SUPERADMIN_EMAIL` + `PW_SUPERADMIN_PASSWORD` or `PW_ADMIN_EMAIL` + `PW_ADMIN_PASSWORD`

## Notes
This follows merged PR #682 and only adds the legacy saved-target filter that was caught after merge.