### PR TITLE
Add advisor covering indexes for authorizations

### DIFF
--- a/supabase/migrations/20260626052042_add_authorization_performance_covering_indexes.sql
+++ b/supabase/migrations/20260626052042_add_authorization_performance_covering_indexes.sql
@@ -1,0 +1,16 @@
+-- @migration-intent: Restore planner coverage for Supabase performance advisor findings on authorization_services.organization_id and client_session_notes.authorization_id.
+-- @migration-dependencies: 20251224161628_20251224120000_authorizations_org_scope.sql, 20260417120000_unused_index_drop_throughput_gamma_win35.sql
+-- @migration-scope: Index-only; no table, RLS, grant, RPC, or data changes.
+-- @migration-rollback: drop index if exists public.authorization_services_org_auth_idx; drop index if exists public.client_session_notes_authorization_id_idx;
+
+begin;
+
+set search_path = public;
+
+create index if not exists authorization_services_org_auth_idx
+  on public.authorization_services (organization_id, authorization_id);
+
+create index if not exists client_session_notes_authorization_id_idx
+  on public.client_session_notes (authorization_id);
+
+commit;


### PR DESCRIPTION
## Summary
- Add index coverage for Supabase advisor findings on authorization_services.organization_id and client_session_notes.authorization_id.
- Keep the migration index-only: no table, RLS, grant, RPC, or data changes.

## Evidence
- Live catalog check found no leading index for authorization_services.organization_id and no index for client_session_notes.authorization_id.
- Current PreAuth/session-note authorization query paths embed authorization_services from org-filtered authorizations.
- Session trends use client_id + organization_id + date filters; the authorization_id index is scoped to the advisor/FK coverage rather than changing the trend query path.

## Verification
- npm run ci:check-focused
- npm run validate:tenant
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run ci:verify-coverage
- npm run build
- npm run verify:local

## Blockers / follow-up
- Critical lane requires Linear linkage before ready-for-review/merge. No issue key was provided in this task.
- DB-backed local policy checks that require SUPABASE_DB_URL/DATABASE_URL were skipped by the local policy runner.
