### PR TITLE
WIN-184 Resolve hosted assessment PDF asset lookup

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   NODE_VERSION = "20"
 
 [functions]
-  included_files = ["docs/fill_docs/*.json", "CalOptima Health FBA Template (2).pdf"]
+  included_files = ["docs/fill_docs/*.json", "CalOptima Health FBA Template*.pdf"]
 
 [context.staging]
   command = "npm run build"

--- a/src/server/__tests__/serverAssetPath.test.ts
+++ b/src/server/__tests__/serverAssetPath.test.ts
@@ -1,0 +1,94 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveServerAssetPath } from "../serverAssetPath";
+
+const createdDirs: string[] = [];
+
+const makeTempDir = (name: string): string => {
+  const dir = join(tmpdir(), `${name}-${process.pid}-${Date.now()}-${createdDirs.length}`);
+  mkdirSync(dir, { recursive: true });
+  createdDirs.push(dir);
+  return dir;
+};
+
+describe("resolveServerAssetPath", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    createdDirs.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true }));
+  });
+
+  it("prefers the cwd asset when both local and bundled copies exist", () => {
+    const cwd = makeTempDir("cwd-with-assets");
+    const bundleDir = makeTempDir("netlify-function-bundle");
+    const localAssetDir = join(cwd, "docs", "fill_docs");
+    const bundledAssetDir = join(bundleDir, "docs", "fill_docs");
+    mkdirSync(localAssetDir, { recursive: true });
+    mkdirSync(bundledAssetDir, { recursive: true });
+    const localAsset = join(localAssetDir, "caloptima_fba_pdf_render_map.json");
+    const bundledAsset = join(bundledAssetDir, "caloptima_fba_pdf_render_map.json");
+    writeFileSync(localAsset, "{}");
+    writeFileSync(bundledAsset, "{}");
+
+    const moduleUrl = pathToFileURL(join(bundleDir, "assessment-plan-pdf.mjs")).href;
+
+    expect(
+      resolveServerAssetPath("docs/fill_docs/caloptima_fba_pdf_render_map.json", {
+        cwd,
+        moduleUrl,
+      }),
+    ).toBe(resolve(localAsset));
+  });
+
+  it("finds assets in LAMBDA_TASK_ROOT when cwd does not contain them", () => {
+    const cwd = makeTempDir("cwd-without-assets");
+    const lambdaTaskRoot = makeTempDir("lambda-task-root");
+    const assetDir = join(lambdaTaskRoot, "docs", "fill_docs");
+    mkdirSync(assetDir, { recursive: true });
+    const lambdaAsset = join(assetDir, "caloptima_fba_pdf_render_map.json");
+    writeFileSync(lambdaAsset, "{}");
+    vi.stubEnv("LAMBDA_TASK_ROOT", lambdaTaskRoot);
+
+    expect(
+      resolveServerAssetPath("docs/fill_docs/caloptima_fba_pdf_render_map.json", {
+        cwd,
+      }),
+    ).toBe(resolve(lambdaAsset));
+  });
+
+  it("finds Netlify included files next to the bundled function module when cwd differs", () => {
+    const cwd = makeTempDir("cwd-without-assets");
+    const bundleDir = makeTempDir("netlify-function-bundle");
+    const assetDir = join(bundleDir, "docs", "fill_docs");
+    mkdirSync(assetDir, { recursive: true });
+    const bundledAsset = join(assetDir, "caloptima_fba_pdf_render_map.json");
+    writeFileSync(bundledAsset, "{}");
+
+    const moduleUrl = pathToFileURL(join(bundleDir, "assessment-plan-pdf.mjs")).href;
+
+    expect(
+      resolveServerAssetPath("docs/fill_docs/caloptima_fba_pdf_render_map.json", {
+        cwd,
+        moduleUrl,
+      }),
+    ).toBe(resolve(bundledAsset));
+  });
+
+  it("resolves root-level Netlify included PDF assets next to the bundled function module", () => {
+    const cwd = makeTempDir("cwd-without-assets");
+    const bundleDir = makeTempDir("netlify-function-bundle");
+    const bundledAsset = join(bundleDir, "CalOptima Health FBA Template (2).pdf");
+    writeFileSync(bundledAsset, "pdf");
+
+    const moduleUrl = pathToFileURL(join(bundleDir, "assessment-plan-pdf.mjs")).href;
+
+    expect(
+      resolveServerAssetPath("CalOptima Health FBA Template (2).pdf", {
+        cwd,
+        moduleUrl,
+      }),
+    ).toBe(resolve(bundledAsset));
+  });
+});

--- a/src/server/api/assessment-plan-pdf.ts
+++ b/src/server/api/assessment-plan-pdf.ts
@@ -144,9 +144,7 @@ interface GenerateDocxTemplateHealthResponse {
   byte_count: number;
 }
 
-const CALOPTIMA_TEMPLATE_PATH = resolveServerAssetPath("CalOptima Health FBA Template (2).pdf", {
-  moduleUrl: import.meta.url,
-});
+const CALOPTIMA_TEMPLATE_PATH = resolveServerAssetPath("CalOptima Health FBA Template (2).pdf");
 const IEHP_DOCX_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const ASSESSMENT_GENERATION_SECRET_HEADER = "x-assessment-generation-secret";
 

--- a/src/server/api/assessment-plan-pdf.ts
+++ b/src/server/api/assessment-plan-pdf.ts
@@ -1,5 +1,4 @@
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
 import { z } from "zod";
 import {
   CORS_HEADERS,
@@ -12,6 +11,7 @@ import {
 } from "./shared";
 import { buildCalOptimaTemplatePayload, loadCalOptimaPdfRenderMap } from "../assessmentPlanPdf";
 import { buildIehpDocxPayload } from "../iehpAssessmentDocx";
+import { resolveServerAssetPath } from "../serverAssetPath";
 
 const requestSchema = z.object({
   assessment_document_id: z.string().uuid(),
@@ -144,7 +144,9 @@ interface GenerateDocxTemplateHealthResponse {
   byte_count: number;
 }
 
-const CALOPTIMA_TEMPLATE_PATH = resolve(process.cwd(), "CalOptima Health FBA Template (2).pdf");
+const CALOPTIMA_TEMPLATE_PATH = resolveServerAssetPath("CalOptima Health FBA Template (2).pdf", {
+  moduleUrl: import.meta.url,
+});
 const IEHP_DOCX_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const ASSESSMENT_GENERATION_SECRET_HEADER = "x-assessment-generation-secret";
 

--- a/src/server/assessmentPlanPdf.ts
+++ b/src/server/assessmentPlanPdf.ts
@@ -102,9 +102,7 @@ export interface BuiltTemplatePayload {
 
 let cachedCalOptimaMap: PdfRenderMapEntry[] | null = null;
 
-const CALOPTIMA_RENDER_MAP_PATH = resolveServerAssetPath("docs/fill_docs/caloptima_fba_pdf_render_map.json", {
-  moduleUrl: import.meta.url,
-});
+const CALOPTIMA_RENDER_MAP_PATH = resolveServerAssetPath("docs/fill_docs/caloptima_fba_pdf_render_map.json");
 
 const toText = (value: unknown): string => {
   if (value === null || value === undefined) return "";

--- a/src/server/assessmentPlanPdf.ts
+++ b/src/server/assessmentPlanPdf.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+
+import { resolveServerAssetPath } from "./serverAssetPath";
 
 interface PdfFallbackCoordinates {
   page: number;
@@ -101,7 +102,9 @@ export interface BuiltTemplatePayload {
 
 let cachedCalOptimaMap: PdfRenderMapEntry[] | null = null;
 
-const CALOPTIMA_RENDER_MAP_PATH = resolve(process.cwd(), "docs", "fill_docs", "caloptima_fba_pdf_render_map.json");
+const CALOPTIMA_RENDER_MAP_PATH = resolveServerAssetPath("docs/fill_docs/caloptima_fba_pdf_render_map.json", {
+  moduleUrl: import.meta.url,
+});
 
 const toText = (value: unknown): string => {
   if (value === null || value === undefined) return "";

--- a/src/server/serverAssetPath.ts
+++ b/src/server/serverAssetPath.ts
@@ -1,0 +1,29 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface ResolveServerAssetPathOptions {
+  cwd?: string;
+  moduleUrl?: string;
+}
+
+const unique = (paths: string[]): string[] => Array.from(new Set(paths));
+
+export function resolveServerAssetPath(relativePath: string, options: ResolveServerAssetPathOptions = {}): string {
+  const cwd = options.cwd ?? process.cwd();
+  const candidates = [resolve(cwd, relativePath)];
+
+  const lambdaTaskRoot = process.env.LAMBDA_TASK_ROOT?.trim();
+  if (lambdaTaskRoot) {
+    candidates.push(resolve(lambdaTaskRoot, relativePath));
+  }
+
+  if (options.moduleUrl) {
+    const moduleDir = dirname(fileURLToPath(options.moduleUrl));
+    candidates.push(resolve(moduleDir, relativePath));
+    candidates.push(resolve(moduleDir, "..", relativePath));
+    candidates.push(resolve(moduleDir, "..", "..", relativePath));
+  }
+
+  return unique(candidates).find((candidate) => existsSync(candidate)) ?? candidates[0];
+}


### PR DESCRIPTION
## Summary
- add a server asset resolver for Netlify-included function assets when `process.cwd()` is not the function bundle root
- route CalOptima assessment PDF template and render-map reads through that resolver
- update Netlify function asset includes so the root `CalOptima Health FBA Template (2).pdf` is present in `assessment-plan-pdf.zip`
- add regression coverage for cwd precedence, `LAMBDA_TASK_ROOT`, module-relative bundled assets, and root-level PDF assets

## Linear
- WIN-184

## Route task
- classification: `high-risk human-reviewed`
- lane: `critical`
- triggering paths: `src/server/**`, `netlify.toml`, hosted `/api/assessment-plan-pdf` production blocker

## Verification
- RED: `npx vitest run src/server/__tests__/serverAssetPath.test.ts --reporter=verbose` failed before implementation with missing `../serverAssetPath`
- `npx vitest run src/server/__tests__/serverAssetPath.test.ts src/server/__tests__/assessmentPlanPdfHandler.test.ts src/server/__tests__/assessmentPlanPdfTemplate.test.ts --reporter=verbose` passed, 3 files / 23 tests
- `npm run ci:check-focused` passed with expected local skips for branch protection / DB-backed checks
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run build` passed
- `npx netlify build --offline --context deploy-preview` passed; inspected `.netlify/functions/assessment-plan-pdf.zip` and confirmed it contains `CalOptima Health FBA Template (2).pdf` plus the CalOptima JSON maps
- `npm run verify:local` passed with expected local skips for branch protection / DB-backed checks

## Hosted proof
- Previous deploy-preview hosted smoke failed with `PDF generation failed with status 500: {"error":"Internal Server Error"}`.
- Fresh deploy-preview on commit `02a2aed0` returns `200` from `/api/assessment-plan-pdf` for client `93f82e82-0ad0-4d90-9f84-2ee054cb56bf` and generated signed PDF metadata.
- The full visual smoke now progresses past generation but fails the stricter no-overflow gate for existing output-layout warnings: `CALOPTIMA_FBA_PCP`, `CALOPTIMA_FBA_SERVICE_INITIATION_DATE`, `CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS`, `CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS`, `CALOPTIMA_FBA_PARENT_GOALS`.

## Reviewer
- focused reviewer found no blocking security/regression issues on the resolver change; requested extra resolver tests, which are included in this PR

## Risk
Critical-lane server/API and Netlify packaging change. It only changes lookup/packaging for static code-owned assets and does not alter request auth, organization scoping, Supabase queries, or PreAuth behavior. Remaining visual-smoke overflow is content-layout quality debt, not the hosted 500 path fixed here.