### PR TITLE
WIN-185 Fix CalOptima goal overflow with appendix pages

### DIFF
--- a/docs/fill_docs/caloptima_fba_pdf_render_map.json
+++ b/docs/fill_docs/caloptima_fba_pdf_render_map.json
@@ -95,10 +95,10 @@
         "page": 1,
         "x": 95,
         "y": 618,
-        "font_size": 10,
+        "font_size": 8,
         "max_width": 230,
         "height": 14,
-        "line_height": 12,
+        "line_height": 10,
         "max_lines": 1,
         "field_kind": "text"
       },
@@ -216,12 +216,12 @@
         "page": 2,
         "x": 64,
         "y": 655,
-        "font_size": 10,
+        "font_size": 8,
         "max_width": 208,
         "height": 12,
         "max_lines": 1,
         "field_kind": "date",
-        "line_height": 12
+        "line_height": 10
       },
       "target": "caloptima_fba_pdf_overlay",
       "not_exported": false

--- a/src/server/__tests__/assessmentPlanPdfTemplate.test.ts
+++ b/src/server/__tests__/assessmentPlanPdfTemplate.test.ts
@@ -2,19 +2,45 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { loadCalOptimaChecklistTemplateRows } from "../assessmentChecklistTemplate";
-import { buildCalOptimaTemplatePayload, loadCalOptimaPdfRenderMap } from "../assessmentPlanPdf";
+import {
+  buildCalOptimaTemplatePayload,
+  loadCalOptimaPdfRenderMap,
+} from "../assessmentPlanPdf";
 
-const registryPath = resolve(process.cwd(), "docs", "fill_docs", "caloptima_fba_template_field_map.json");
-const checklistPath = resolve(process.cwd(), "docs", "fill_docs", "caloptima_fba_field_extraction_checklist.json");
-const renderMapPath = resolve(process.cwd(), "docs", "fill_docs", "caloptima_fba_pdf_render_map.json");
-const extractorPath = resolve(process.cwd(), "supabase", "functions", "extract-assessment-fields", "index.ts");
+const registryPath = resolve(
+  process.cwd(),
+  "docs",
+  "fill_docs",
+  "caloptima_fba_template_field_map.json",
+);
+const checklistPath = resolve(
+  process.cwd(),
+  "docs",
+  "fill_docs",
+  "caloptima_fba_field_extraction_checklist.json",
+);
+const renderMapPath = resolve(
+  process.cwd(),
+  "docs",
+  "fill_docs",
+  "caloptima_fba_pdf_render_map.json",
+);
+const extractorPath = resolve(
+  process.cwd(),
+  "supabase",
+  "functions",
+  "extract-assessment-fields",
+  "index.ts",
+);
 
 const readJsonFile = async (path: string): Promise<Record<string, unknown>> => {
   return JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
 };
 
 const asRecord = (value: unknown): Record<string, unknown> => {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
 };
 
 const asRecordArray = (value: unknown): Record<string, unknown>[] => {
@@ -22,11 +48,15 @@ const asRecordArray = (value: unknown): Record<string, unknown>[] => {
 };
 
 const asStringArray = (value: unknown): string[] => {
-  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
 };
 
 const placeholderKeys = (entries: Record<string, unknown>[]): string[] => {
-  return entries.map((entry) => entry.placeholder_key).filter((key): key is string => typeof key === "string");
+  return entries
+    .map((entry) => entry.placeholder_key)
+    .filter((key): key is string => typeof key === "string");
 };
 
 describe("CalOptima PDF render map", () => {
@@ -36,10 +66,16 @@ describe("CalOptima PDF render map", () => {
       loadCalOptimaPdfRenderMap(),
     ]);
 
-    const checklistKeys = new Set(checklistRows.map((row) => row.placeholder_key));
-    const renderMapKeys = new Set(renderMap.map((entry) => entry.placeholder_key));
+    const checklistKeys = new Set(
+      checklistRows.map((row) => row.placeholder_key),
+    );
+    const renderMapKeys = new Set(
+      renderMap.map((entry) => entry.placeholder_key),
+    );
 
-    const missingKeys = Array.from(checklistKeys).filter((key) => !renderMapKeys.has(key));
+    const missingKeys = Array.from(checklistKeys).filter(
+      (key) => !renderMapKeys.has(key),
+    );
     expect(missingKeys).toEqual([]);
   });
 
@@ -61,16 +97,35 @@ describe("CalOptima PDF render map", () => {
 
   it("keeps tail-section overlay fields anchored to their actual template pages", async () => {
     const renderMap = await loadCalOptimaPdfRenderMap();
-    const entriesByKey = new Map(renderMap.map((entry) => [entry.placeholder_key, entry]));
+    const entriesByKey = new Map(
+      renderMap.map((entry) => [entry.placeholder_key, entry]),
+    );
 
-    expect(entriesByKey.get("CALOPTIMA_FBA_SUMMARY_RECOMMENDATIONS")?.fallback.page).toBe(27);
-    expect(entriesByKey.get("CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS")?.fallback.page).toBe(27);
-    expect(entriesByKey.get("CALOPTIMA_FBA_TELEHEALTH_CONSENT")?.fallback.page).toBe(27);
-    expect(entriesByKey.get("CALOPTIMA_FBA_PARENT_INVOLVEMENT")?.fallback.page).toBe(28);
-    expect(entriesByKey.get("CALOPTIMA_FBA_REPORT_WRITTEN_BY")?.fallback.page).toBe(28);
-    expect(entriesByKey.get("CALOPTIMA_FBA_WRITER_CREDENTIALS")?.fallback.page).toBe(28);
-    expect(entriesByKey.get("CALOPTIMA_FBA_REPORT_COMPLETED_DATE")?.fallback.page).toBe(28);
-    expect(entriesByKey.get("CALOPTIMA_FBA_SIGNATURES")?.fallback.page).toBe(28);
+    expect(
+      entriesByKey.get("CALOPTIMA_FBA_SUMMARY_RECOMMENDATIONS")?.fallback.page,
+    ).toBe(27);
+    expect(
+      entriesByKey.get("CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS")?.fallback
+        .page,
+    ).toBe(27);
+    expect(
+      entriesByKey.get("CALOPTIMA_FBA_TELEHEALTH_CONSENT")?.fallback.page,
+    ).toBe(27);
+    expect(
+      entriesByKey.get("CALOPTIMA_FBA_PARENT_INVOLVEMENT")?.fallback.page,
+    ).toBe(28);
+    expect(
+      entriesByKey.get("CALOPTIMA_FBA_REPORT_WRITTEN_BY")?.fallback.page,
+    ).toBe(28);
+    expect(
+      entriesByKey.get("CALOPTIMA_FBA_WRITER_CREDENTIALS")?.fallback.page,
+    ).toBe(28);
+    expect(
+      entriesByKey.get("CALOPTIMA_FBA_REPORT_COMPLETED_DATE")?.fallback.page,
+    ).toBe(28);
+    expect(entriesByKey.get("CALOPTIMA_FBA_SIGNATURES")?.fallback.page).toBe(
+      28,
+    );
   });
 
   it("keeps registry, checklist, and render placeholder keys in parity", async () => {
@@ -84,8 +139,12 @@ describe("CalOptima PDF render map", () => {
     const checklistRows = asRecordArray(checklist.rows);
     const renderEntries = asRecordArray(renderMap.entries);
 
-    expect(placeholderKeys(checklistRows).sort()).toEqual(placeholderKeys(registryLabels).sort());
-    expect(placeholderKeys(renderEntries).sort()).toEqual(placeholderKeys(registryLabels).sort());
+    expect(placeholderKeys(checklistRows).sort()).toEqual(
+      placeholderKeys(registryLabels).sort(),
+    );
+    expect(placeholderKeys(renderEntries).sort()).toEqual(
+      placeholderKeys(registryLabels).sort(),
+    );
   });
 
   it("defines implementation metadata for every registry field", async () => {
@@ -95,7 +154,9 @@ describe("CalOptima PDF render map", () => {
     registryLabels.forEach((label) => {
       const pdfRender = asRecord(label.pdf_render);
 
-      expect(label.placeholder_key).toEqual(expect.stringMatching(/^CALOPTIMA_FBA_/));
+      expect(label.placeholder_key).toEqual(
+        expect.stringMatching(/^CALOPTIMA_FBA_/),
+      );
       expect(label.input_type).toEqual(expect.any(String));
       expect(label.destination).toEqual(expect.any(String));
       expect(pdfRender.target).toEqual("caloptima_fba_pdf_render_map");
@@ -105,10 +166,15 @@ describe("CalOptima PDF render map", () => {
   });
 
   it("keeps CalOptima extraction metadata deterministic and alias-backed for redacted report headings", async () => {
-    const [registry, checklist] = await Promise.all([readJsonFile(registryPath), readJsonFile(checklistPath)]);
+    const [registry, checklist] = await Promise.all([
+      readJsonFile(registryPath),
+      readJsonFile(checklistPath),
+    ]);
     const registryLabels = asRecordArray(asRecord(registry.FBA).labels);
     const checklistRows = asRecordArray(checklist.rows);
-    const rowsByKey = new Map(checklistRows.map((row) => [row.placeholder_key, row]));
+    const rowsByKey = new Map(
+      checklistRows.map((row) => [row.placeholder_key, row]),
+    );
     const aliasRequiredKeys = [
       "CALOPTIMA_FBA_ADMIN_CONTACT_NAME_TITLE",
       "CALOPTIMA_FBA_CHIEF_COMPLAINT",
@@ -130,17 +196,25 @@ describe("CalOptima PDF render map", () => {
     });
 
     aliasRequiredKeys.forEach((key) => {
-      const registryLabel = asRecord(registryLabels.find((label) => label.placeholder_key === key));
+      const registryLabel = asRecord(
+        registryLabels.find((label) => label.placeholder_key === key),
+      );
       const checklistRow = asRecord(rowsByKey.get(key));
 
-      expect(asStringArray(registryLabel.extraction_aliases).length).toBeGreaterThan(0);
-      expect(asStringArray(checklistRow.extraction_aliases).length).toBeGreaterThan(0);
+      expect(
+        asStringArray(registryLabel.extraction_aliases).length,
+      ).toBeGreaterThan(0);
+      expect(
+        asStringArray(checklistRow.extraction_aliases).length,
+      ).toBeGreaterThan(0);
     });
   });
 
   it("keeps deterministic structured extraction metadata aligned with runtime structured outputs", async () => {
     const checklist = await readJsonFile(checklistPath);
-    const rowsByKey = new Map(asRecordArray(checklist.rows).map((row) => [row.placeholder_key, row]));
+    const rowsByKey = new Map(
+      asRecordArray(checklist.rows).map((row) => [row.placeholder_key, row]),
+    );
     const deterministicStructuredKeys = [
       "CALOPTIMA_FBA_COORDINATION_OF_CARE",
       "CALOPTIMA_FBA_VINELAND_DOMAIN_SCORES",
@@ -154,7 +228,9 @@ describe("CalOptima PDF render map", () => {
     ];
 
     deterministicStructuredKeys.forEach((key) => {
-      expect(asRecord(rowsByKey.get(key)).extraction_method).toBe("deterministic_structured_extraction_plus_review");
+      expect(asRecord(rowsByKey.get(key)).extraction_method).toBe(
+        "deterministic_structured_extraction_plus_review",
+      );
     });
   });
 
@@ -162,11 +238,17 @@ describe("CalOptima PDF render map", () => {
     const extractorSource = await readFile(extractorPath, "utf8");
 
     expect(extractorSource).not.toContain("isTargetBehaviorBlock");
-    expect(extractorSource).toContain('field_key: "CALOPTIMA_FBA_TRANSITION_PLAN"');
-    expect(extractorSource).toContain('/XII\\.\\s+/i');
-    expect(extractorSource).toContain('/\\*\\*\\s+By\\s+signing/i');
-    expect(extractorSource).toContain('"CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS"');
-    expect(extractorSource).not.toContain("CALOPTIMA_FBA_HCPCS_RECOMMENDATIONS");
+    expect(extractorSource).toContain(
+      'field_key: "CALOPTIMA_FBA_TRANSITION_PLAN"',
+    );
+    expect(extractorSource).toContain("/XII\\.\\s+/i");
+    expect(extractorSource).toContain("/\\*\\*\\s+By\\s+signing/i");
+    expect(extractorSource).toContain(
+      '"CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS"',
+    );
+    expect(extractorSource).not.toContain(
+      "CALOPTIMA_FBA_HCPCS_RECOMMENDATIONS",
+    );
     expect(extractorSource).not.toContain("CALOPTIMA_FBA_DAILY_SCHEDULES");
   });
 
@@ -178,9 +260,18 @@ describe("CalOptima PDF render map", () => {
     ]);
 
     const registryLabels = asRecordArray(asRecord(registry.FBA).labels);
-    const checklistRowsByKey = new Map(asRecordArray(checklist.rows).map((row) => [row.placeholder_key, row]));
-    const renderEntriesByKey = new Map(asRecordArray(renderMap.entries).map((entry) => [entry.placeholder_key, entry]));
-    const structuredLabels = registryLabels.filter((label) => typeof label.structured_section === "string");
+    const checklistRowsByKey = new Map(
+      asRecordArray(checklist.rows).map((row) => [row.placeholder_key, row]),
+    );
+    const renderEntriesByKey = new Map(
+      asRecordArray(renderMap.entries).map((entry) => [
+        entry.placeholder_key,
+        entry,
+      ]),
+    );
+    const structuredLabels = registryLabels.filter(
+      (label) => typeof label.structured_section === "string",
+    );
 
     expect(structuredLabels.length).toBeGreaterThan(0);
 
@@ -191,7 +282,9 @@ describe("CalOptima PDF render map", () => {
 
       expect(label.input_type).toEqual("structured_section");
       expect(label.destination).toEqual("assessment_checklist.value_json");
-      expect(label.review_behavior).toEqual("structured_clinical_review_required");
+      expect(label.review_behavior).toEqual(
+        "structured_clinical_review_required",
+      );
       expect(checklistRow.structured_section).toEqual(label.structured_section);
       expect(checklistRow.input_type).toEqual(label.input_type);
       expect(checklistRow.destination).toEqual(label.destination);
@@ -200,7 +293,7 @@ describe("CalOptima PDF render map", () => {
     });
   });
 
-  it("prefers approved structured sections over checklist summary values for the same placeholder", async () => {
+  it("moves approved structured goal details into the CalOptima appendix while keeping the template field short", async () => {
     const payload = await buildCalOptimaTemplatePayload({
       checklistItems: [
         {
@@ -230,8 +323,109 @@ describe("CalOptima PDF render map", () => {
       acceptedGoals: [],
     });
 
-    expect(payload.values.CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS).toContain("Reviewed communication goal");
-    expect(payload.values.CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS).not.toContain("structured sections extracted");
-    expect(payload.values.CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS).not.toContain("Unreviewed summary payload");
+    expect(payload.values.CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS).toBe(
+      "See Goal Detail Appendix for 1 complete skill acquisition goal.",
+    );
+    expect(payload.values.CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS).not.toContain(
+      "Reviewed communication goal",
+    );
+    expect(payload.values.CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX).toContain(
+      "Skill acquisition goals",
+    );
+    expect(payload.values.CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX).toContain(
+      "Reviewed communication goal",
+    );
+    expect(payload.values.CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS).not.toContain(
+      "structured sections extracted",
+    );
+    expect(payload.values.CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS).not.toContain(
+      "Unreviewed summary payload",
+    );
+  });
+
+  it("does not point goal fields to an appendix when approved structured goal rows are empty", async () => {
+    const payload = await buildCalOptimaTemplatePayload({
+      checklistItems: [
+        {
+          placeholder_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+          required: true,
+          status: "approved",
+          value_text: null,
+          value_json: null,
+        },
+      ],
+      structuredSections: [
+        {
+          field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+          section_key: "goals_treatment_planning",
+          section_index: 0,
+          payload: null,
+          status: "approved",
+          required: true,
+        },
+      ],
+      client: { full_name: "Test Client" },
+      writer: { full_name: "Test Writer" },
+      acceptedProgram: null,
+      acceptedGoals: [],
+    });
+
+    expect(payload.values.CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS).toBe("");
+    expect(payload.values).not.toHaveProperty(
+      "CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX",
+    );
+    expect(payload.missing_required_keys).toContain(
+      "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+    );
+  });
+
+  it("keeps accepted draft goals in the appendix when only some goal fields have structured sections", async () => {
+    const payload = await buildCalOptimaTemplatePayload({
+      checklistItems: [],
+      structuredSections: [
+        {
+          field_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+          section_key: "goals_treatment_planning",
+          section_index: 0,
+          payload: {
+            title: "Reviewed communication goal",
+            target_criteria: "80% independent requests across two weeks.",
+          },
+          status: "approved",
+          required: true,
+        },
+      ],
+      client: { full_name: "Test Client" },
+      writer: { full_name: "Test Writer" },
+      acceptedProgram: null,
+      acceptedGoals: [
+        {
+          title: "Fallback parent participation goal",
+          description:
+            "Caregiver will implement prompting steps during routines.",
+          original_text:
+            "Caregiver will implement prompting steps during routines.",
+        },
+      ],
+    });
+
+    expect(payload.values.CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS).toBe(
+      "See Goal Detail Appendix for 1 complete skill acquisition goal.",
+    );
+    expect(payload.values.CALOPTIMA_FBA_PARENT_GOALS).toBe(
+      "See Goal Detail Appendix for 1 accepted draft goal.",
+    );
+    expect(payload.values.CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX).toContain(
+      "Skill acquisition goals",
+    );
+    expect(payload.values.CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX).toContain(
+      "Reviewed communication goal",
+    );
+    expect(payload.values.CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX).toContain(
+      "Accepted draft goals",
+    );
+    expect(payload.values.CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX).toContain(
+      "Fallback parent participation goal",
+    );
   });
 });

--- a/src/server/assessmentPlanPdf.ts
+++ b/src/server/assessmentPlanPdf.ts
@@ -102,14 +102,51 @@ export interface BuiltTemplatePayload {
 
 let cachedCalOptimaMap: PdfRenderMapEntry[] | null = null;
 
-const CALOPTIMA_RENDER_MAP_PATH = resolveServerAssetPath("docs/fill_docs/caloptima_fba_pdf_render_map.json");
+const CALOPTIMA_RENDER_MAP_PATH = resolveServerAssetPath(
+  "docs/fill_docs/caloptima_fba_pdf_render_map.json",
+);
+const CALOPTIMA_GOAL_DETAIL_APPENDIX_KEY = "CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX";
+
+const CALOPTIMA_GOAL_APPENDIX_FIELDS = new Map<
+  string,
+  { heading: string; singular: string; plural: string }
+>([
+  [
+    "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS",
+    {
+      heading: "Target and replacement behavior goals",
+      singular: "target and replacement behavior goal",
+      plural: "target and replacement behavior goals",
+    },
+  ],
+  [
+    "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+    {
+      heading: "Skill acquisition goals",
+      singular: "skill acquisition goal",
+      plural: "skill acquisition goals",
+    },
+  ],
+  [
+    "CALOPTIMA_FBA_PARENT_GOALS",
+    {
+      heading: "Parent/caregiver goals",
+      singular: "parent/caregiver goal",
+      plural: "parent/caregiver goals",
+    },
+  ],
+]);
 
 const toText = (value: unknown): string => {
   if (value === null || value === undefined) return "";
   if (typeof value === "string") return value.trim();
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
   if (Array.isArray(value)) {
-    return value.map((entry) => toText(entry)).filter((entry) => entry.length > 0).join(", ");
+    return value
+      .map((entry) => toText(entry))
+      .filter((entry) => entry.length > 0)
+      .join(", ");
   }
   if (typeof value === "object") {
     try {
@@ -141,14 +178,19 @@ const normalizeMapEntry = (entry: unknown): PdfRenderMapEntry | null => {
     typeof fallback.font_size !== "number" ||
     typeof fallback.max_width !== "number" ||
     (fallback.height !== undefined && typeof fallback.height !== "number") ||
-    (fallback.line_height !== undefined && typeof fallback.line_height !== "number") ||
-    (fallback.max_lines !== undefined && typeof fallback.max_lines !== "number") ||
-    (fallback.field_kind !== undefined && typeof fallback.field_kind !== "string")
+    (fallback.line_height !== undefined &&
+      typeof fallback.line_height !== "number") ||
+    (fallback.max_lines !== undefined &&
+      typeof fallback.max_lines !== "number") ||
+    (fallback.field_kind !== undefined &&
+      typeof fallback.field_kind !== "string")
   ) {
     return null;
   }
 
-  const formFieldCandidates = record.form_field_candidates.filter((candidate) => typeof candidate === "string") as string[];
+  const formFieldCandidates = record.form_field_candidates.filter(
+    (candidate) => typeof candidate === "string",
+  ) as string[];
   if (formFieldCandidates.length === 0) {
     return null;
   }
@@ -162,22 +204,34 @@ const normalizeMapEntry = (entry: unknown): PdfRenderMapEntry | null => {
       y: fallback.y,
       font_size: fallback.font_size,
       max_width: fallback.max_width,
-      ...(typeof fallback.height === "number" ? { height: fallback.height } : {}),
-      ...(typeof fallback.line_height === "number" ? { line_height: fallback.line_height } : {}),
-      ...(typeof fallback.max_lines === "number" ? { max_lines: fallback.max_lines } : {}),
-      ...(typeof fallback.field_kind === "string" ? { field_kind: fallback.field_kind } : {}),
+      ...(typeof fallback.height === "number"
+        ? { height: fallback.height }
+        : {}),
+      ...(typeof fallback.line_height === "number"
+        ? { line_height: fallback.line_height }
+        : {}),
+      ...(typeof fallback.max_lines === "number"
+        ? { max_lines: fallback.max_lines }
+        : {}),
+      ...(typeof fallback.field_kind === "string"
+        ? { field_kind: fallback.field_kind }
+        : {}),
     },
   };
 };
 
-export async function loadCalOptimaPdfRenderMap(): Promise<PdfRenderMapEntry[]> {
+export async function loadCalOptimaPdfRenderMap(): Promise<
+  PdfRenderMapEntry[]
+> {
   if (cachedCalOptimaMap) {
     return cachedCalOptimaMap;
   }
 
   const raw = await readFile(CALOPTIMA_RENDER_MAP_PATH, "utf8");
   const parsed = JSON.parse(raw) as PdfRenderMapFile;
-  const entries = Array.isArray(parsed.entries) ? parsed.entries.map(normalizeMapEntry).filter(Boolean) : [];
+  const entries = Array.isArray(parsed.entries)
+    ? parsed.entries.map(normalizeMapEntry).filter(Boolean)
+    : [];
 
   if (entries.length === 0) {
     throw new Error("CalOptima PDF render map is missing or invalid.");
@@ -198,7 +252,12 @@ const formatDate = (value: string | null | undefined): string => {
 };
 
 const formatWriterCredentials = (writer: AssessmentWriterSnapshot): string => {
-  const parts = [writer.title, writer.license_number, writer.bcba_number, writer.rbt_number]
+  const parts = [
+    writer.title,
+    writer.license_number,
+    writer.bcba_number,
+    writer.rbt_number,
+  ]
     .map((item) => (typeof item === "string" ? item.trim() : ""))
     .filter((item) => item.length > 0);
   return parts.join(" | ");
@@ -206,7 +265,10 @@ const formatWriterCredentials = (writer: AssessmentWriterSnapshot): string => {
 
 const formatDiagnosis = (diagnosis: string[] | null | undefined): string => {
   if (!Array.isArray(diagnosis) || diagnosis.length === 0) return "";
-  return diagnosis.map((entry) => entry.trim()).filter((entry) => entry.length > 0).join("; ");
+  return diagnosis
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .join("; ");
 };
 
 const formatAcceptedGoals = (goals: DraftGoalSnapshot[]): string => {
@@ -216,7 +278,9 @@ const formatAcceptedGoals = (goals: DraftGoalSnapshot[]): string => {
     .join("\n");
 };
 
-const formatStructuredPayload = (payload: Record<string, unknown> | null): string => {
+const formatStructuredPayload = (
+  payload: Record<string, unknown> | null,
+): string => {
   if (!payload) return "";
   if (Array.isArray(payload.rows)) {
     return payload.rows
@@ -245,27 +309,86 @@ const formatStructuredPayload = (payload: Record<string, unknown> | null): strin
     })
     .filter(Boolean);
   const objectiveRows = Array.isArray(payload.objective_data_points)
-    ? payload.objective_data_points.map((row, index) => `objective ${index + 1}: ${toText(row)}`)
+    ? payload.objective_data_points.map(
+        (row, index) => `objective ${index + 1}: ${toText(row)}`,
+      )
     : [];
   return [...lines, ...objectiveRows].join("\n");
 };
 
-const formatStructuredSectionsForKey = (placeholderKey: string, args: BuildTemplatePayloadArgs): string => {
-  const sections = (args.structuredSections ?? [])
-    .filter((section) => section.field_key === placeholderKey && section.status === "approved")
+const getApprovedStructuredSectionsForKey = (
+  placeholderKey: string,
+  args: BuildTemplatePayloadArgs,
+): AssessmentStructuredSectionValueRow[] =>
+  (args.structuredSections ?? [])
+    .filter(
+      (section) =>
+        section.field_key === placeholderKey && section.status === "approved",
+    )
     .sort((left, right) => left.section_index - right.section_index);
-  if (sections.length === 0) return "";
-  return sections
+
+const formatStructuredSections = (
+  sections: AssessmentStructuredSectionValueRow[],
+): string => {
+  const blocks = sections
     .map((section, index) => {
       const formatted = formatStructuredPayload(section.payload);
       return formatted ? `${index + 1}. ${formatted}` : "";
     })
-    .filter(Boolean)
-    .join("\n\n");
+    .filter(Boolean);
+  if (blocks.length === 0) return "";
+  return blocks.join("\n\n");
+};
+
+const formatStructuredSectionsForKey = (
+  placeholderKey: string,
+  args: BuildTemplatePayloadArgs,
+): string =>
+  formatStructuredSections(
+    getApprovedStructuredSectionsForKey(placeholderKey, args),
+  );
+
+const countFormattedStructuredSectionsForKey = (
+  placeholderKey: string,
+  args: BuildTemplatePayloadArgs,
+): number =>
+  getApprovedStructuredSectionsForKey(placeholderKey, args).filter(
+    (section) => formatStructuredPayload(section.payload).length > 0,
+  ).length;
+
+const formatGoalAppendixNotice = (
+  config: { singular: string; plural: string },
+  count: number,
+): string => {
+  const label = count === 1 ? config.singular : config.plural;
+  return `See Goal Detail Appendix for ${count} complete ${label}.`;
+};
+
+const buildGoalDetailAppendix = (args: BuildTemplatePayloadArgs): string => {
+  const sections: string[] = [];
+
+  CALOPTIMA_GOAL_APPENDIX_FIELDS.forEach((config, placeholderKey) => {
+    const structuredText = formatStructuredSectionsForKey(placeholderKey, args);
+    if (!structuredText) return;
+    sections.push(`${config.heading}\n${structuredText}`);
+  });
+
+  const acceptedGoalsText = formatAcceptedGoals(args.acceptedGoals);
+  if (acceptedGoalsText) {
+    sections.push(`Accepted draft goals\n${acceptedGoalsText}`);
+  }
+
+  return sections.join("\n\n");
 };
 
 const formatAddress = (client: AssessmentClientSnapshot): string => {
-  return [client.address_line1, client.address_line2, client.city, client.state, client.zip_code]
+  return [
+    client.address_line1,
+    client.address_line2,
+    client.city,
+    client.state,
+    client.zip_code,
+  ]
     .map((item) => (typeof item === "string" ? item.trim() : ""))
     .filter((item) => item.length > 0)
     .join(", ");
@@ -276,19 +399,46 @@ const getDerivedValue = (
   args: BuildTemplatePayloadArgs,
   checklistValue: AssessmentChecklistValueRow | undefined,
 ): string => {
+  const goalAppendixConfig = CALOPTIMA_GOAL_APPENDIX_FIELDS.get(placeholderKey);
+  if (goalAppendixConfig) {
+    const structuredSectionCount = countFormattedStructuredSectionsForKey(
+      placeholderKey,
+      args,
+    );
+    if (structuredSectionCount > 0) {
+      return formatGoalAppendixNotice(
+        goalAppendixConfig,
+        structuredSectionCount,
+      );
+    }
+  }
+
   const structuredText = formatStructuredSectionsForKey(placeholderKey, args);
   if (structuredText.length > 0) {
     return structuredText;
   }
-  const checklistText = checklistValue ? toText(checklistValue.value_text ?? checklistValue.value_json) : "";
+  const checklistText = checklistValue
+    ? toText(checklistValue.value_text ?? checklistValue.value_json)
+    : "";
   if (checklistText.length > 0) {
     return checklistText;
   }
 
   const { client, writer, acceptedProgram, acceptedGoals } = args;
+  if (goalAppendixConfig && acceptedGoals.length > 0) {
+    const label =
+      acceptedGoals.length === 1
+        ? "accepted draft goal"
+        : "accepted draft goals";
+    return `See Goal Detail Appendix for ${acceptedGoals.length} ${label}.`;
+  }
+
   switch (placeholderKey) {
     case "CALOPTIMA_FBA_MEMBER_NAME":
-      return client.full_name?.trim() || `${client.first_name ?? ""} ${client.last_name ?? ""}`.trim();
+      return (
+        client.full_name?.trim() ||
+        `${client.first_name ?? ""} ${client.last_name ?? ""}`.trim()
+      );
     case "CALOPTIMA_FBA_MEMBER_DOB":
       return formatDate(client.date_of_birth);
     case "CALOPTIMA_FBA_CIN":
@@ -323,9 +473,13 @@ const getDerivedValue = (
   }
 };
 
-export async function buildCalOptimaTemplatePayload(args: BuildTemplatePayloadArgs): Promise<BuiltTemplatePayload> {
+export async function buildCalOptimaTemplatePayload(
+  args: BuildTemplatePayloadArgs,
+): Promise<BuiltTemplatePayload> {
   const renderMap = await loadCalOptimaPdfRenderMap();
-  const checklistByKey = new Map(args.checklistItems.map((item) => [item.placeholder_key, item]));
+  const checklistByKey = new Map(
+    args.checklistItems.map((item) => [item.placeholder_key, item]),
+  );
 
   const values: Record<string, string> = {};
   const missingRequiredKeys: string[] = [];
@@ -341,10 +495,19 @@ export async function buildCalOptimaTemplatePayload(args: BuildTemplatePayloadAr
   });
 
   (args.structuredSections ?? []).forEach((section) => {
-    if (section.required && section.status === "approved" && !values[section.field_key]?.trim()) {
+    if (
+      section.required &&
+      section.status === "approved" &&
+      !values[section.field_key]?.trim()
+    ) {
       missingRequiredKeys.push(section.field_key);
     }
   });
+
+  const goalDetailAppendix = buildGoalDetailAppendix(args);
+  if (goalDetailAppendix) {
+    values[CALOPTIMA_GOAL_DETAIL_APPENDIX_KEY] = goalDetailAppendix;
+  }
 
   return {
     values,

--- a/supabase/functions/generate-assessment-plan-pdf/index.test.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.test.ts
@@ -78,7 +78,11 @@ const createRequestClientForDocument = (
 const createAdminStorage = () => ({
   storage: {
     from: () => ({
-      upload: () => Promise.resolve({ data: {}, error: null }),
+      upload: (
+        _objectPath: string,
+        _bytes: Uint8Array,
+        _options: { contentType: string; upsert: boolean },
+      ) => Promise.resolve({ data: {}, error: null }),
       createSignedUrl: () =>
         Promise.resolve({
           data: { signedUrl: "https://example.supabase.co/generated.pdf" },
@@ -87,6 +91,31 @@ const createAdminStorage = () => ({
     }),
   },
 });
+
+const createCapturingAdminStorage = () => {
+  let uploadedBytes: Uint8Array | null = null;
+
+  return {
+    getUploadedBytes: () => uploadedBytes,
+    storage: {
+      from: () => ({
+        upload: (
+          _objectPath: string,
+          bytes: Uint8Array,
+          _options: { contentType: string; upsert: boolean },
+        ) => {
+          uploadedBytes = bytes;
+          return Promise.resolve({ data: {}, error: null });
+        },
+        createSignedUrl: () =>
+          Promise.resolve({
+            data: { signedUrl: "https://example.supabase.co/generated.pdf" },
+            error: null,
+          }),
+      }),
+    },
+  };
+};
 
 const createPdfWithFieldsBase64 = async (): Promise<string> => {
   const pdfDoc = await PDFDocument.create();
@@ -392,4 +421,105 @@ Deno.test("generateAssessmentPlanPdfHandler reports filled_pages from visible re
   const body = await response.json();
   expect(body.filled_pages).toEqual([1, 4]);
   expect(body.fill_mode).toBe("mixed");
+});
+
+Deno.test("generateAssessmentPlanPdfHandler appends readable goal appendix pages without layout warnings", async () => {
+  const templatePdfBase64 = await createPdfWithFieldsBase64();
+  const admin = createCapturingAdminStorage();
+  const payload = {
+    ...validPayload,
+    template_pdf_base64: templatePdfBase64,
+    render_map_entries: [
+      {
+        placeholder_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+        form_field_candidates: ["Missing Skill Goals"],
+        fallback: {
+          page: 1,
+          x: 20,
+          y: 720,
+          font_size: 8,
+          max_width: 260,
+          height: 20,
+          line_height: 10,
+          max_lines: 2,
+          field_kind: "structured_section",
+        },
+      },
+    ],
+    field_values: {
+      CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS:
+        "See Goal Detail Appendix for 2 complete skill acquisition goals.",
+      CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX: [
+        "Skill acquisition goals",
+        "1. Communication goal: request help independently across three settings.",
+        "2. Daily living goal: complete hygiene routine with visual supports.",
+        ...Array.from(
+          { length: 120 },
+          (_, index) =>
+            `${index + 3}. Continuation detail ${
+              index + 1
+            }: maintain clinically reviewed goal details across appended PDF pages.`,
+        ),
+      ].join("\n"),
+    },
+  };
+  const handler = createTestHandler({ admin });
+  const response = await handler(postRequest(payload));
+
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.overflow_keys).toEqual([]);
+  expect(body.layout_warnings).toEqual([]);
+
+  const uploadedBytes = admin.getUploadedBytes();
+  if (!uploadedBytes) {
+    throw new Error("Expected generated PDF bytes to be uploaded.");
+  }
+  const pdfDoc = await PDFDocument.load(uploadedBytes);
+  expect(pdfDoc.getPageCount()).toBeGreaterThan(5);
+});
+
+Deno.test("generateAssessmentPlanPdfHandler skips appendix pages when appendix content sanitizes to empty", async () => {
+  const templatePdfBase64 = await createPdfWithFieldsBase64();
+  const admin = createCapturingAdminStorage();
+  const payload = {
+    ...validPayload,
+    template_pdf_base64: templatePdfBase64,
+    render_map_entries: [
+      {
+        placeholder_key: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS",
+        form_field_candidates: ["Missing Skill Goals"],
+        fallback: {
+          page: 1,
+          x: 20,
+          y: 720,
+          font_size: 8,
+          max_width: 260,
+          height: 20,
+          line_height: 10,
+          max_lines: 2,
+          field_kind: "structured_section",
+        },
+      },
+    ],
+    field_values: {
+      CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS:
+        "See Goal Detail Appendix for 1 complete skill acquisition goal.",
+      CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX: "☢",
+    },
+  };
+  const handler = createTestHandler({ admin });
+  const response = await handler(postRequest(payload));
+
+  expect(response.status).toBe(200);
+  const body = await response.json();
+  expect(body.overflow_keys).toEqual([]);
+  expect(body.layout_warnings).toEqual([]);
+
+  const uploadedBytes = admin.getUploadedBytes();
+  if (!uploadedBytes) {
+    throw new Error("Expected generated PDF bytes to be uploaded.");
+  }
+  const pdfDoc = await PDFDocument.load(uploadedBytes);
+  expect(pdfDoc.getPageCount()).toBe(4);
 });

--- a/supabase/functions/generate-assessment-plan-pdf/index.ts
+++ b/supabase/functions/generate-assessment-plan-pdf/index.ts
@@ -1,6 +1,7 @@
 import {
   PDFCheckBox,
   PDFDocument,
+  type PDFFont,
   PDFTextField,
   rgb,
   StandardFonts,
@@ -16,6 +17,7 @@ import { resolveOrgId } from "../_shared/org.ts";
 import {
   layoutOverlayText,
   type OverlayLayoutWarning,
+  wrapOverlayText,
 } from "./overlay-layout.ts";
 import {
   isPdfCheckboxNotApplicableValue,
@@ -52,6 +54,14 @@ const requestSchema = z.object({
   output_bucket_id: z.string().trim().min(1).default("client-documents"),
   output_object_path: z.string().trim().min(1),
 });
+
+const GOAL_DETAIL_APPENDIX_KEY = "CALOPTIMA_FBA_GOAL_DETAIL_APPENDIX";
+const APPENDIX_PAGE_SIZE: [number, number] = [612, 792];
+const APPENDIX_MARGIN = 54;
+const APPENDIX_TITLE_FONT_SIZE = 14;
+const APPENDIX_BODY_FONT_SIZE = 9;
+const APPENDIX_LINE_HEIGHT = 12;
+const APPENDIX_PARAGRAPH_GAP = 4;
 
 interface AssessmentDocumentScopeRow {
   id: string;
@@ -107,6 +117,71 @@ const toUint8Array = (base64Value: string): Uint8Array => {
     bytes[index] = binary.charCodeAt(index);
   }
   return bytes;
+};
+
+const appendGoalDetailAppendixPages = (
+  pdfDoc: PDFDocument,
+  appendixText: string,
+  regularFont: PDFFont,
+  boldFont: PDFFont,
+): number[] => {
+  const pageNumbers: number[] = [];
+  const maxTextWidth = APPENDIX_PAGE_SIZE[0] - APPENDIX_MARGIN * 2;
+  let page = pdfDoc.addPage(APPENDIX_PAGE_SIZE);
+  let y = APPENDIX_PAGE_SIZE[1] - APPENDIX_MARGIN;
+
+  const drawHeader = (continued: boolean) => {
+    pageNumbers.push(pdfDoc.getPageCount());
+    page.drawText(`Goal Detail Appendix${continued ? " (continued)" : ""}`, {
+      x: APPENDIX_MARGIN,
+      y,
+      size: APPENDIX_TITLE_FONT_SIZE,
+      font: boldFont,
+      color: rgb(0.12, 0.12, 0.12),
+    });
+    y -= APPENDIX_LINE_HEIGHT + APPENDIX_PARAGRAPH_GAP;
+  };
+
+  const addContinuationPage = () => {
+    page = pdfDoc.addPage(APPENDIX_PAGE_SIZE);
+    y = APPENDIX_PAGE_SIZE[1] - APPENDIX_MARGIN;
+    drawHeader(true);
+  };
+
+  drawHeader(false);
+
+  sanitizePdfText(appendixText).split(/\n/).forEach((paragraph) => {
+    const normalized = paragraph.trim();
+    if (!normalized) {
+      y -= APPENDIX_PARAGRAPH_GAP;
+      return;
+    }
+
+    const lines = wrapOverlayText(
+      normalized,
+      maxTextWidth,
+      regularFont,
+      APPENDIX_BODY_FONT_SIZE,
+    );
+
+    lines.forEach((line) => {
+      if (y < APPENDIX_MARGIN + APPENDIX_LINE_HEIGHT) {
+        addContinuationPage();
+      }
+      page.drawText(line, {
+        x: APPENDIX_MARGIN,
+        y,
+        size: APPENDIX_BODY_FONT_SIZE,
+        font: regularFont,
+        color: rgb(0.12, 0.12, 0.12),
+      });
+      y -= APPENDIX_LINE_HEIGHT;
+    });
+
+    y -= APPENDIX_PARAGRAPH_GAP;
+  });
+
+  return pageNumbers;
 };
 
 export const createGenerateAssessmentPlanPdfHandler =
@@ -211,6 +286,16 @@ export const createGenerateAssessmentPlanPdfHandler =
       let filledAcroFormCount = 0;
       const acroFormFilledKeys = new Set<string>();
       const filledPages = new Set<number>();
+      let regularFont: PDFFont | null = null;
+      let boldFont: PDFFont | null = null;
+      const getRegularFont = async () => {
+        regularFont ??= await pdfDoc.embedFont(StandardFonts.Helvetica);
+        return regularFont;
+      };
+      const getBoldFont = async () => {
+        boldFont ??= await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+        return boldFont;
+      };
 
       for (const entry of parsed.data.render_map_entries) {
         const rawValue = parsed.data.field_values[entry.placeholder_key];
@@ -254,7 +339,7 @@ export const createGenerateAssessmentPlanPdfHandler =
       const layoutWarnings: OverlayLayoutWarning[] = [];
       let overlayFilledCount = 0;
       if (acroFormFilledKeys.size < parsed.data.render_map_entries.length) {
-        const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+        const overlayFont = await getRegularFont();
 
         for (const entry of parsed.data.render_map_entries) {
           if (acroFormFilledKeys.has(entry.placeholder_key)) continue;
@@ -270,7 +355,7 @@ export const createGenerateAssessmentPlanPdfHandler =
           const page = pdfDoc.getPage(pageIndex);
           if (!page) continue;
 
-          const layout = layoutOverlayText(entry, value, regularFont);
+          const layout = layoutOverlayText(entry, value, overlayFont);
           if (layout.warning) {
             layoutWarnings.push(layout.warning);
           }
@@ -283,14 +368,30 @@ export const createGenerateAssessmentPlanPdfHandler =
               x: entry.fallback.x,
               y: entry.fallback.y - lineIndex * layout.line_height,
               size: entry.fallback.font_size,
-              font: regularFont,
+              font: overlayFont,
               color: rgb(0.12, 0.12, 0.12),
             });
           });
         }
       }
+
+      const appendixText = parsed.data.field_values[GOAL_DETAIL_APPENDIX_KEY];
+      const sanitizedAppendixText = typeof appendixText === "string"
+        ? sanitizePdfText(appendixText).trim()
+        : "";
+      const appendixPages = sanitizedAppendixText.length > 0
+        ? appendGoalDetailAppendixPages(
+          pdfDoc,
+          sanitizedAppendixText,
+          await getRegularFont(),
+          await getBoldFont(),
+        )
+        : [];
+      appendixPages.forEach((pageNumber) => filledPages.add(pageNumber));
+
       const fillMode: "acroform" | "overlay" | "mixed" =
-        filledAcroFormCount > 0 && overlayFilledCount > 0
+        filledAcroFormCount > 0 &&
+          (overlayFilledCount > 0 || appendixPages.length > 0)
           ? "mixed"
           : filledAcroFormCount > 0
           ? "acroform"


### PR DESCRIPTION
## Summary
- Moves full CalOptima structured goal details out of constrained template boxes and into generated Goal Detail Appendix pages.
- Keeps template goal fields short with appendix notices while preserving accepted draft-goal fallback content.
- Tightens the one-line CalOptima PCP and Service Initiation Date render-map typography to address the small 2-line overflow reports without changing field values.
- Adds payload and edge-function coverage for empty structured rows, mixed structured/fallback goals, multi-page appendix pagination, and sanitized-empty appendix suppression.

## Verification
- route-task: critical / high-risk human-reviewed (`src/server/**`, `supabase/functions/**`, `docs/fill_docs/**`)
- `npx vitest run src/server/__tests__/assessmentPlanPdfTemplate.test.ts --reporter=verbose` — pass, 12 tests after final render-map add-on
- `deno test --no-check --node-modules-dir=auto --allow-env --allow-net --allow-read supabase/functions/generate-assessment-plan-pdf/index.test.ts` — pass, 14 tests after final render-map add-on
- `npm run lint` — pass after final render-map add-on
- `npm run typecheck` — pass after final render-map add-on
- `npx vitest run src/server/__tests__/assessmentPlanPdfTemplate.test.ts src/server/__tests__/assessmentPlanPdfHandler.test.ts src/components/__tests__/ProgramsGoalsTab.test.tsx --reporter=verbose` — pass, 82 tests before final render-map add-on
- `npm run ci:check-focused` — pass; DB-backed checks skipped locally because `SUPABASE_DB_URL`/`DATABASE_URL` absent
- `npm run test:ci` — pass on rerun, 331 files / 2031 tests; prior run had one unrelated schedule test flake that passed on focused rerun
- `npm run ci:verify-coverage` — pass, 91.97% line coverage
- `npm run build` — pass
- `npm run validate:tenant` — pass
- `npm run test:routes:tier0` — pass, 79 Cypress tests

## Blocked / Not Run
- `HEADLESS=false npm run playwright:assessment-pdf-smoke` was not run locally: required admin and Supabase env vars are not present in this shell (`PW_ADMIN_EMAIL`/`PW_ADMIN_PASSWORD` and Supabase URL/key envs). Do not treat hosted PDF smoke as passed until this PR deploy preview can run with those envs.

## Risk
- Protected server and Supabase Edge function paths are touched, so human review remains required before merge.
- No auth/org/storage scoping changes were made; existing assessment document scope and generated-PDF storage validation remain intact.

Refs WIN-185.