### PR TITLE
WIN-185 Tighten CalOptima PCP overlay

### DIFF
--- a/docs/fill_docs/caloptima_fba_pdf_render_map.json
+++ b/docs/fill_docs/caloptima_fba_pdf_render_map.json
@@ -136,10 +136,10 @@
         "page": 1,
         "x": 95,
         "y": 602,
-        "font_size": 10,
+        "font_size": 8,
         "max_width": 230,
         "height": 14,
-        "line_height": 12,
+        "line_height": 10,
         "max_lines": 1,
         "field_kind": "text"
       },


### PR DESCRIPTION
Refs WIN-185. Follow-up to merged PR #688 after the authorized hosted CalOptima assessment PDF smoke reported one remaining renderer overflow key: CALOPTIMA_FBA_PCP.\n\nScope:\n- Tighten only CALOPTIMA_FBA_PCP render-map typography from 10pt/12pt to 8pt/10pt.\n- No server, auth, Supabase, or app logic changes.\n\nVerification run:\n- npx vitest run src/server/__tests__/assessmentPlanPdfTemplate.test.ts --reporter=verbose\n\nPending after deploy preview is available:\n- HEADLESS=false PW_BASE_URL=<new deploy preview> npm run playwright:assessment-pdf-smoke