### PR TITLE
WIN-183 Seed session trend test data

### DIFF
--- a/scripts/playwright-assessment-import-smoke.ts
+++ b/scripts/playwright-assessment-import-smoke.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { chromium } from 'playwright';
 
 import { cleanupAssessmentImportArtifacts } from './lib/assessment-import-cleanup';
@@ -18,9 +19,26 @@ type AssessmentDocumentRecord = {
   file_name: string;
   bucket_id?: string | null;
   object_path: string;
-  status: 'uploaded' | 'extracting' | 'extracted' | 'drafted' | 'approved' | 'rejected' | 'extraction_failed';
+  status: 'uploaded' | 'extracting' | 'extraction_running' | 'extracted' | 'drafted' | 'approved' | 'rejected' | 'extraction_failed';
   extraction_error?: string | null;
 };
+
+type PersistedAssessmentEvidence = {
+  checklistCount: number;
+  extractedChecklistCount: number;
+  extractionCount: number;
+  extractedExtractionCount: number;
+  structuredSectionCount: number;
+  structuredFieldKeys: string[];
+  draftProgramCount: number;
+  draftGoalCount: number;
+};
+
+export const REQUIRED_CALOPTIMA_STRUCTURED_KEYS = [
+  'CALOPTIMA_FBA_HCPCS_RECOMMENDATION_ROWS',
+  'CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS',
+  'CALOPTIMA_FBA_PARENT_GOALS',
+] as const;
 
 const DEFAULT_BASE_URL = 'https://app.allincompassing.ai';
 const DEFAULT_SAMPLE_FILE = path.resolve(
@@ -99,6 +117,63 @@ const fetchAssessmentDocuments = async (
   }
 
   return (await response.json()) as AssessmentDocumentRecord[];
+};
+
+const fetchPersistedAssessmentEvidence = async (
+  supabaseUrl: string,
+  supabaseAnonKey: string,
+  accessToken: string,
+  assessmentDocumentId: string,
+): Promise<PersistedAssessmentEvidence> => {
+  const headers = {
+    apikey: supabaseAnonKey,
+    Authorization: `Bearer ${accessToken}`,
+  };
+  const byAssessment = `assessment_document_id=eq.${encodeURIComponent(assessmentDocumentId)}`;
+  const fetchRows = async <T>(table: string, select: string): Promise<T[]> => {
+    const response = await fetch(`${supabaseUrl}/rest/v1/${table}?select=${select}&${byAssessment}`, { headers });
+    if (!response.ok) {
+      throw new Error(`Failed to load ${table} evidence: ${response.status}`);
+    }
+    return (await response.json()) as T[];
+  };
+
+  const [checklist, extractions, structuredSections, draftPrograms, draftGoals] = await Promise.all([
+    fetchRows<{ status: string }>('assessment_checklist_items', 'id,status,placeholder_key'),
+    fetchRows<{ status: string }>('assessment_extractions', 'id,status,field_key'),
+    fetchRows<{ field_key: string }>('assessment_structured_sections', 'id,status,field_key,section_key'),
+    fetchRows<unknown>('assessment_draft_programs', 'id'),
+    fetchRows<unknown>('assessment_draft_goals', 'id'),
+  ]);
+
+  return {
+    checklistCount: checklist.length,
+    extractedChecklistCount: checklist.filter((item) => item.status !== 'not_started').length,
+    extractionCount: extractions.length,
+    extractedExtractionCount: extractions.filter((item) => item.status !== 'not_started').length,
+    structuredSectionCount: structuredSections.length,
+    structuredFieldKeys: [...new Set(structuredSections.map((section) => section.field_key))].sort(),
+    draftProgramCount: draftPrograms.length,
+    draftGoalCount: draftGoals.length,
+  };
+};
+
+export const assertPersistedAssessmentEvidence = (evidence: PersistedAssessmentEvidence): void => {
+  if (evidence.checklistCount === 0 || evidence.extractionCount === 0) {
+    throw new Error('Assessment import smoke did not persist checklist and extraction rows.');
+  }
+  if (evidence.extractedChecklistCount === 0 || evidence.extractedExtractionCount === 0) {
+    throw new Error('Assessment import smoke did not populate extracted checklist and extraction row statuses.');
+  }
+  if (evidence.structuredSectionCount === 0 || evidence.draftProgramCount === 0 || evidence.draftGoalCount === 0) {
+    throw new Error('Assessment import smoke did not persist structured sections and deterministic drafts.');
+  }
+  const missingStructuredKeys = REQUIRED_CALOPTIMA_STRUCTURED_KEYS.filter(
+    (key) => !evidence.structuredFieldKeys.includes(key),
+  );
+  if (missingStructuredKeys.length > 0) {
+    throw new Error(`Assessment import smoke missing structured field keys: ${missingStructuredKeys.join(', ')}`);
+  }
 };
 
 const selectClientForSmoke = async (
@@ -182,6 +257,7 @@ async function run() {
   let runFailure: Error | null = null;
   let cleanupFailureManifestPath: string | null = null;
   let cleanupFailureManifestError: Error | null = null;
+  let persistedEvidence: PersistedAssessmentEvidence | null = null;
 
   try {
     await loginAndAssertSession(page, baseUrl, credentials.email, credentials.password);
@@ -190,7 +266,7 @@ async function run() {
       timeout: 60_000,
     });
     await page.waitForLoadState('networkidle').catch(() => undefined);
-    await page.getByText('FBA Upload + AI Workflow').waitFor({ timeout: 20_000 });
+    await page.getByText(/CalOptima FBA Upload Workflow|FBA Upload \+ AI Workflow/i).waitFor({ timeout: 20_000 });
 
     await page.locator('#programs-goals-fba-file-upload').setInputFiles({
       name: uploadFileName,
@@ -204,7 +280,7 @@ async function run() {
     while (Date.now() < deadline) {
       const documents = await fetchAssessmentDocuments(baseUrl, accessToken, clientId);
       createdAssessment = documents.find((document) => document.file_name === uploadFileName) ?? null;
-      if (createdAssessment && !['uploaded', 'extracting'].includes(createdAssessment.status)) {
+      if (createdAssessment && !['uploaded', 'extracting', 'extraction_running'].includes(createdAssessment.status)) {
         break;
       }
       await pause(2_000);
@@ -213,13 +289,20 @@ async function run() {
     if (!createdAssessment) {
       throw new Error(`Uploaded assessment document ${uploadFileName} was not found in the queue.`);
     }
-    if (createdAssessment.status !== 'extracted') {
+    if (!['extracted', 'drafted'].includes(createdAssessment.status)) {
       throw new Error(
         `Assessment import smoke ended with ${createdAssessment.status}${
           createdAssessment.extraction_error ? `: ${createdAssessment.extraction_error}` : ''
         }`,
       );
     }
+    persistedEvidence = await fetchPersistedAssessmentEvidence(
+      supabaseUrl,
+      supabaseAnonKey,
+      accessToken,
+      createdAssessment.id,
+    );
+    assertPersistedAssessmentEvidence(persistedEvidence);
 
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
     await page.waitForLoadState('networkidle').catch(() => undefined);
@@ -239,6 +322,7 @@ async function run() {
           assessmentDocumentId: createdAssessment.id,
           fileName: uploadFileName,
           status: createdAssessment.status,
+          persistedEvidence,
           screenshot: screenshotPath,
           url: page.url(),
         },
@@ -305,7 +389,9 @@ async function run() {
   }
 }
 
-run().catch((error) => {
-  console.error('Playwright assessment import smoke failed', error);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run().catch((error) => {
+    console.error('Playwright assessment import smoke failed', error);
+    process.exit(1);
+  });
+}

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -529,21 +529,56 @@ export const buildBookingCandidateStarts = (
   return candidates;
 };
 
+const selectScheduleFilterOptionIfPresent = async (
+  page: Page,
+  selector: string,
+  value: string,
+): Promise<boolean> => {
+  const filter = page.locator(`select${selector}`).first();
+  const exists = await filter
+    .waitFor({ state: "attached", timeout: 12_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!exists) {
+    return false;
+  }
+
+  const deadline = Date.now() + 12_000;
+  while (Date.now() < deadline) {
+    const values = await filter.evaluate((select) =>
+      Array.from((select as HTMLSelectElement).options).map((option) => option.value),
+    );
+    if (values.includes(value)) {
+      await filter.selectOption(value);
+      return true;
+    }
+    await page.waitForTimeout(250);
+  }
+
+  return false;
+};
+
 const openEditSessionModalFromCalendar = async (
   page: Page,
   scheduleUrl: string,
-  sessionId: string,
-  sessionStartIso: string,
+  ids: LifecycleIds,
 ): Promise<void> => {
   await page.goto(`${scheduleUrl}?_${Date.now()}`, {
     waitUntil: "networkidle",
     timeout: 60000,
   });
 
+  const selectedTherapist = await selectScheduleFilterOptionIfPresent(page, "#therapist-filter", ids.therapistId);
+  const selectedClient = await selectScheduleFilterOptionIfPresent(page, "#client-filter", ids.clientId);
+  if (selectedTherapist || selectedClient) {
+    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
+    await page.waitForTimeout(500);
+  }
+
   let visitedPeriods = 0;
   for (let periodAttempt = 0; periodAttempt < 8; periodAttempt += 1) {
     visitedPeriods = periodAttempt + 1;
-    const sessionCard = page.locator(`[data-session-id="${sessionId}"]`).first();
+    const sessionCard = page.locator(`[data-session-id="${ids.sessionId}"]`).first();
     const visible = await sessionCard
       .waitFor({ state: "visible", timeout: periodAttempt === 0 ? 12_000 : 5_000 })
       .then(() => true)
@@ -567,7 +602,7 @@ const openEditSessionModalFromCalendar = async (
   }
 
   throw new Error(
-    `Session modal (Edit Session / Live session) did not open from the rendered schedule card after ${visitedPeriods} schedule period(s). sessionStartIso=${sessionStartIso}`,
+    `Session modal (Edit Session / Live session) did not open from the rendered schedule card after ${visitedPeriods} schedule period(s). sessionStartIso=${ids.startIso}`,
   );
 };
 
@@ -1243,7 +1278,7 @@ async function startSessionViaScheduleModal(
   token: string,
   strictMode: boolean,
 ): Promise<void> {
-  await openEditSessionModalFromCalendar(page, scheduleUrl, ids.sessionId, ids.startIso);
+  await openEditSessionModalFromCalendar(page, scheduleUrl, ids);
   const startButton = page.getByRole("button", { name: /^Start Session$/i });
   await startButton.waitFor({ state: "visible", timeout: 20_000 });
   await expectStartButtonEnabled(page, startButton);
@@ -1291,7 +1326,7 @@ async function markTerminalViaScheduleModal(
   actorUserId: string,
   strictMode: boolean,
 ): Promise<void> {
-  await openEditSessionModalFromCalendar(page, scheduleUrl, sessionId, ids.startIso);
+  await openEditSessionModalFromCalendar(page, scheduleUrl, ids);
   const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
   await page.locator("#status-select").selectOption(terminalStatus);
   page.once("dialog", (dialog) => {

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -558,6 +558,315 @@ BEGIN
     session_type = EXCLUDED.session_type,
     duration_minutes = EXCLUDED.duration_minutes,
     location_type = EXCLUDED.location_type;
+
+  -- Seed a month of linked completed sessions with trial data so the
+  -- Client Details > Session Trends tab has graphable preview data.
+  INSERT INTO public.authorizations (
+    id,
+    authorization_number,
+    client_id,
+    provider_id,
+    diagnosis_code,
+    diagnosis_description,
+    start_date,
+    end_date,
+    status,
+    organization_id,
+    created_by
+  )
+  SELECT
+    '00000000-0000-0000-0000-000000000203'::uuid,
+    'SEED-AUTH-SESSION-TRENDS',
+    client_rec.id,
+    therapist_rec.id,
+    'F84.0',
+    'Autism spectrum disorder',
+    CURRENT_DATE - INTERVAL '45 days',
+    CURRENT_DATE + INTERVAL '45 days',
+    'approved',
+    '00000000-0000-0000-0000-000000000001'::uuid,
+    therapist_rec.id
+  FROM public.clients AS client_rec
+  CROSS JOIN public.therapists AS therapist_rec
+  WHERE client_rec.email = 'client@test.com'
+    AND therapist_rec.email = 'therapist@test.com'
+  ON CONFLICT (id) DO UPDATE
+  SET
+    authorization_number = EXCLUDED.authorization_number,
+    client_id = EXCLUDED.client_id,
+    provider_id = EXCLUDED.provider_id,
+    diagnosis_code = EXCLUDED.diagnosis_code,
+    diagnosis_description = EXCLUDED.diagnosis_description,
+    start_date = EXCLUDED.start_date,
+    end_date = EXCLUDED.end_date,
+    status = EXCLUDED.status,
+    organization_id = EXCLUDED.organization_id,
+    created_by = EXCLUDED.created_by;
+
+  INSERT INTO public.authorization_services (
+    id,
+    authorization_id,
+    service_code,
+    service_description,
+    from_date,
+    to_date,
+    requested_units,
+    approved_units,
+    unit_type,
+    decision_status,
+    organization_id,
+    created_by
+  )
+  SELECT
+    '00000000-0000-0000-0000-000000000204'::uuid,
+    '00000000-0000-0000-0000-000000000203'::uuid,
+    '97153',
+    'Adaptive behavior treatment by protocol',
+    CURRENT_DATE - INTERVAL '45 days',
+    CURRENT_DATE + INTERVAL '45 days',
+    160,
+    160,
+    '15-minute units',
+    'approved',
+    '00000000-0000-0000-0000-000000000001'::uuid,
+    therapist_rec.id
+  FROM public.therapists AS therapist_rec
+  WHERE therapist_rec.email = 'therapist@test.com'
+  ON CONFLICT (id) DO UPDATE
+  SET
+    authorization_id = EXCLUDED.authorization_id,
+    service_code = EXCLUDED.service_code,
+    service_description = EXCLUDED.service_description,
+    from_date = EXCLUDED.from_date,
+    to_date = EXCLUDED.to_date,
+    requested_units = EXCLUDED.requested_units,
+    approved_units = EXCLUDED.approved_units,
+    unit_type = EXCLUDED.unit_type,
+    decision_status = EXCLUDED.decision_status,
+    organization_id = EXCLUDED.organization_id,
+    created_by = EXCLUDED.created_by;
+
+  WITH trend_seed(idx, session_id, note_id, correct_trials) AS (
+    VALUES
+      (0, '00000000-0000-0000-0000-000000000301'::uuid, '00000000-0000-0000-0000-000000000401'::uuid, 5),
+      (1, '00000000-0000-0000-0000-000000000302'::uuid, '00000000-0000-0000-0000-000000000402'::uuid, 6),
+      (2, '00000000-0000-0000-0000-000000000303'::uuid, '00000000-0000-0000-0000-000000000403'::uuid, 7),
+      (3, '00000000-0000-0000-0000-000000000304'::uuid, '00000000-0000-0000-0000-000000000404'::uuid, 7),
+      (4, '00000000-0000-0000-0000-000000000305'::uuid, '00000000-0000-0000-0000-000000000405'::uuid, 8),
+      (5, '00000000-0000-0000-0000-000000000306'::uuid, '00000000-0000-0000-0000-000000000406'::uuid, 8),
+      (6, '00000000-0000-0000-0000-000000000307'::uuid, '00000000-0000-0000-0000-000000000407'::uuid, 9),
+      (7, '00000000-0000-0000-0000-000000000308'::uuid, '00000000-0000-0000-0000-000000000408'::uuid, 9),
+      (8, '00000000-0000-0000-0000-000000000309'::uuid, '00000000-0000-0000-0000-000000000409'::uuid, 10),
+      (9, '00000000-0000-0000-0000-000000000310'::uuid, '00000000-0000-0000-0000-000000000410'::uuid, 10),
+      (10, '00000000-0000-0000-0000-000000000311'::uuid, '00000000-0000-0000-0000-000000000411'::uuid, 11),
+      (11, '00000000-0000-0000-0000-000000000312'::uuid, '00000000-0000-0000-0000-000000000412'::uuid, 11)
+  ),
+  trend_rows AS (
+    SELECT
+      trend_seed.*,
+      (CURRENT_DATE - INTERVAL '27 days' + (trend_seed.idx * INTERVAL '2 days'))::date AS session_date
+    FROM trend_seed
+  )
+  INSERT INTO public.sessions (
+    id,
+    organization_id,
+    client_id,
+    therapist_id,
+    program_id,
+    goal_id,
+    session_date,
+    start_time,
+    end_time,
+    status,
+    notes,
+    has_transcription_consent,
+    rate_per_hour,
+    total_cost,
+    session_type,
+    duration_minutes,
+    location_type,
+    created_at
+  )
+  SELECT
+    trend_rows.session_id,
+    '00000000-0000-0000-0000-000000000001'::uuid,
+    client_rec.id,
+    therapist_rec.id,
+    '00000000-0000-0000-0000-000000000201'::uuid,
+    '00000000-0000-0000-0000-000000000202'::uuid,
+    trend_rows.session_date,
+    ((trend_rows.session_date + TIME '15:00') AT TIME ZONE 'UTC'),
+    ((trend_rows.session_date + TIME '16:00') AT TIME ZONE 'UTC'),
+    'completed',
+    'Seeded session trend data for client@test.com.',
+    false,
+    120,
+    120,
+    'aba',
+    60,
+    'in_home',
+    NOW()
+  FROM trend_rows
+  CROSS JOIN public.clients AS client_rec
+  CROSS JOIN public.therapists AS therapist_rec
+  WHERE client_rec.email = 'client@test.com'
+    AND therapist_rec.email = 'therapist@test.com'
+  ON CONFLICT (id) DO UPDATE
+  SET
+    organization_id = EXCLUDED.organization_id,
+    client_id = EXCLUDED.client_id,
+    therapist_id = EXCLUDED.therapist_id,
+    program_id = EXCLUDED.program_id,
+    goal_id = EXCLUDED.goal_id,
+    session_date = EXCLUDED.session_date,
+    start_time = EXCLUDED.start_time,
+    end_time = EXCLUDED.end_time,
+    status = EXCLUDED.status,
+    notes = EXCLUDED.notes,
+    has_transcription_consent = EXCLUDED.has_transcription_consent,
+    rate_per_hour = EXCLUDED.rate_per_hour,
+    total_cost = EXCLUDED.total_cost,
+    session_type = EXCLUDED.session_type,
+    duration_minutes = EXCLUDED.duration_minutes,
+    location_type = EXCLUDED.location_type;
+
+  WITH trend_seed(idx, session_id, note_id, correct_trials) AS (
+    VALUES
+      (0, '00000000-0000-0000-0000-000000000301'::uuid, '00000000-0000-0000-0000-000000000401'::uuid, 5),
+      (1, '00000000-0000-0000-0000-000000000302'::uuid, '00000000-0000-0000-0000-000000000402'::uuid, 6),
+      (2, '00000000-0000-0000-0000-000000000303'::uuid, '00000000-0000-0000-0000-000000000403'::uuid, 7),
+      (3, '00000000-0000-0000-0000-000000000304'::uuid, '00000000-0000-0000-0000-000000000404'::uuid, 7),
+      (4, '00000000-0000-0000-0000-000000000305'::uuid, '00000000-0000-0000-0000-000000000405'::uuid, 8),
+      (5, '00000000-0000-0000-0000-000000000306'::uuid, '00000000-0000-0000-0000-000000000406'::uuid, 8),
+      (6, '00000000-0000-0000-0000-000000000307'::uuid, '00000000-0000-0000-0000-000000000407'::uuid, 9),
+      (7, '00000000-0000-0000-0000-000000000308'::uuid, '00000000-0000-0000-0000-000000000408'::uuid, 9),
+      (8, '00000000-0000-0000-0000-000000000309'::uuid, '00000000-0000-0000-0000-000000000409'::uuid, 10),
+      (9, '00000000-0000-0000-0000-000000000310'::uuid, '00000000-0000-0000-0000-000000000410'::uuid, 10),
+      (10, '00000000-0000-0000-0000-000000000311'::uuid, '00000000-0000-0000-0000-000000000411'::uuid, 11),
+      (11, '00000000-0000-0000-0000-000000000312'::uuid, '00000000-0000-0000-0000-000000000412'::uuid, 11)
+  ),
+  trend_rows AS (
+    SELECT
+      trend_seed.*,
+      (CURRENT_DATE - INTERVAL '27 days' + (trend_seed.idx * INTERVAL '2 days'))::date AS session_date,
+      12 - trend_seed.correct_trials AS incorrect_trials
+    FROM trend_seed
+  )
+  INSERT INTO public.client_session_notes (
+    id,
+    client_id,
+    authorization_id,
+    therapist_id,
+    created_by,
+    organization_id,
+    session_id,
+    service_code,
+    session_date,
+    start_time,
+    end_time,
+    session_duration,
+    goals_addressed,
+    goal_ids,
+    goal_notes,
+    goal_measurements,
+    narrative,
+    is_locked,
+    signed_at,
+    created_at,
+    updated_at
+  )
+  SELECT
+    trend_rows.note_id,
+    client_rec.id,
+    '00000000-0000-0000-0000-000000000203'::uuid,
+    therapist_rec.id,
+    therapist_rec.id,
+    '00000000-0000-0000-0000-000000000001'::uuid,
+    trend_rows.session_id,
+    '97153',
+    trend_rows.session_date,
+    TIME '15:00',
+    TIME '16:00',
+    60,
+    ARRAY['Seed Goal'],
+    ARRAY['00000000-0000-0000-0000-000000000202'],
+    jsonb_build_object(
+      '00000000-0000-0000-0000-000000000202',
+      'Practiced functional communication requests with seeded trial opportunities.'
+    ),
+    jsonb_build_object(
+      '00000000-0000-0000-0000-000000000202',
+      jsonb_build_object(
+        'version',
+        1,
+        'data',
+        jsonb_build_object(
+          'measurement_type',
+          'trial_count',
+          'metric_label',
+          'Independent correct responses',
+          'metric_unit',
+          'opportunities',
+          'metric_value',
+          trend_rows.correct_trials,
+          'incorrect_trials',
+          trend_rows.incorrect_trials,
+          'opportunities',
+          12,
+          'target',
+          'Functional communication request',
+          'targets',
+          jsonb_build_array('Functional communication request'),
+          'target_trials',
+          jsonb_build_array(
+            jsonb_build_object(
+              'target',
+              'Functional communication request',
+              'metric_value',
+              trend_rows.correct_trials,
+              'incorrect_trials',
+              trend_rows.incorrect_trials,
+              'opportunities',
+              12
+            )
+          )
+        )
+      )
+    ),
+    format(
+      'Seeded session trend note: %s of 12 independent responses.',
+      trend_rows.correct_trials
+    ),
+    true,
+    ((trend_rows.session_date + TIME '16:05') AT TIME ZONE 'UTC'),
+    ((trend_rows.session_date + TIME '16:05') AT TIME ZONE 'UTC'),
+    NOW()
+  FROM trend_rows
+  CROSS JOIN public.clients AS client_rec
+  CROSS JOIN public.therapists AS therapist_rec
+  WHERE client_rec.email = 'client@test.com'
+    AND therapist_rec.email = 'therapist@test.com'
+  ON CONFLICT (id) DO UPDATE
+  SET
+    client_id = EXCLUDED.client_id,
+    authorization_id = EXCLUDED.authorization_id,
+    therapist_id = EXCLUDED.therapist_id,
+    created_by = EXCLUDED.created_by,
+    organization_id = EXCLUDED.organization_id,
+    session_id = EXCLUDED.session_id,
+    service_code = EXCLUDED.service_code,
+    session_date = EXCLUDED.session_date,
+    start_time = EXCLUDED.start_time,
+    end_time = EXCLUDED.end_time,
+    session_duration = EXCLUDED.session_duration,
+    goals_addressed = EXCLUDED.goals_addressed,
+    goal_ids = EXCLUDED.goal_ids,
+    goal_notes = EXCLUDED.goal_notes,
+    goal_measurements = EXCLUDED.goal_measurements,
+    narrative = EXCLUDED.narrative,
+    is_locked = EXCLUDED.is_locked,
+    signed_at = EXCLUDED.signed_at,
+    updated_at = NOW();
 END $$;
 
 COMMIT;

--- a/tests/scripts/assessment-import-smoke-evidence.test.ts
+++ b/tests/scripts/assessment-import-smoke-evidence.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertPersistedAssessmentEvidence,
+  REQUIRED_CALOPTIMA_STRUCTURED_KEYS,
+} from '../../scripts/playwright-assessment-import-smoke';
+
+const completeEvidence = {
+  checklistCount: 54,
+  extractedChecklistCount: 42,
+  extractionCount: 54,
+  extractedExtractionCount: 42,
+  structuredSectionCount: 64,
+  structuredFieldKeys: [...REQUIRED_CALOPTIMA_STRUCTURED_KEYS],
+  draftProgramCount: 3,
+  draftGoalCount: 50,
+};
+
+describe('assessment import smoke persisted evidence', () => {
+  it('rejects seeded-only upload rows without extracted statuses', () => {
+    expect(() =>
+      assertPersistedAssessmentEvidence({
+        ...completeEvidence,
+        extractedChecklistCount: 0,
+        extractedExtractionCount: 0,
+        structuredSectionCount: 0,
+        draftProgramCount: 0,
+        draftGoalCount: 0,
+      }),
+    ).toThrow(/did not populate extracted checklist and extraction row statuses/i);
+  });
+
+  it('rejects completed rows when required CalOptima structured keys are missing', () => {
+    expect(() =>
+      assertPersistedAssessmentEvidence({
+        ...completeEvidence,
+        structuredFieldKeys: ['CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS'],
+      }),
+    ).toThrow(/missing structured field keys/i);
+  });
+
+  it('accepts completed metadata-only evidence', () => {
+    expect(() => assertPersistedAssessmentEvidence(completeEvidence)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `supabase/seed.sql` with deterministic synthetic session-trends data for `client@test.com` / `therapist@test.com` in `Seed Preview Org`.
- Add one approved seeded authorization/service plus 12 completed linked sessions and `client_session_notes.goal_measurements` over the last ~month.
- Keep data org-scoped to `00000000-0000-0000-0000-000000000001`; no migrations, RLS/grants, auth, runtime config, or hosted data mutations.

## Route / Risk
- Linear: WIN-183
- classification: high-risk human-reviewed
- lane: critical
- tenant boundary: seeded org/test accounts only; cross-tenant access remains controlled by existing policies.

## Verification
- `git diff --check -- supabase/seed.sql`
- `npm run test -- src/lib/__tests__/session-trends.test.ts`
- `npm run validate:tenant`
- `npm run verify:local`

## Notes
- `npm run ci:check-focused` skipped DB-backed checks that require `SUPABASE_DB_URL` / `DATABASE_URL`, as expected locally.
- `ci:playwright` was not run; this seed-only PR does not alter auth/session runtime behavior and `verify:local` covers the repo-required local gate.