### PR TITLE
WIN-183 Add daily session trend display

### DIFF
--- a/src/components/ClientDetails/ClientSessionTrendsTab.tsx
+++ b/src/components/ClientDetails/ClientSessionTrendsTab.tsx
@@ -192,7 +192,7 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
       x: {
         title: {
           display: true,
-          text: displayPeriod === 'month' ? 'Month' : 'Week',
+          text: displayPeriod === 'month' ? 'Month' : displayPeriod === 'week' ? 'Week' : 'Day',
         },
       },
     },
@@ -279,6 +279,7 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
           >
             <option value="month">Month</option>
             <option value="week">Week</option>
+            <option value="day">Day</option>
           </select>
         </label>
 

--- a/src/components/__tests__/ClientSessionTrendsTab.test.tsx
+++ b/src/components/__tests__/ClientSessionTrendsTab.test.tsx
@@ -135,6 +135,7 @@ describe('ClientSessionTrendsTab', () => {
     expect(screen.getByRole('heading', { name: /Session Trends/i })).toBeInTheDocument();
     expect(screen.getByLabelText('Goal')).toHaveTextContent('Safety: Emergency scenarios');
     expect(screen.getByLabelText('Target')).toHaveTextContent('lost in community');
+    expect(screen.getByRole('option', { name: 'Day' })).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.getAllByText(/80%|100%/).length).toBeGreaterThan(0);
   });

--- a/src/lib/__tests__/session-trends.test.ts
+++ b/src/lib/__tests__/session-trends.test.ts
@@ -77,6 +77,36 @@ describe('buildSessionTrendModel', () => {
     });
   });
 
+  it('computes daily buckets from per-session target trial percentages', () => {
+    const model = buildSessionTrendModel(
+      [
+        note('note-1', '2026-06-01', [{ target: 'lost in community', metric_value: 8, opportunities: 10 }]),
+        note('note-2', '2026-06-01', [{ target: 'lost in community', metric_value: 10, opportunities: 10 }]),
+        note('note-3', '2026-06-02', [{ target: 'lost in community', metric_value: 6, opportunities: 10 }]),
+      ],
+      [goal],
+      {
+        displayPeriod: 'day',
+        dateRange: { startDate: '2026-06-01', endDate: '2026-06-30' },
+      },
+    );
+
+    expect(model.buckets).toEqual([
+      expect.objectContaining({
+        bucketKey: '2026-06-01',
+        label: 'Jun 1',
+        median: 90,
+        sampleSize: 2,
+      }),
+      expect.objectContaining({
+        bucketKey: '2026-06-02',
+        label: 'Jun 2',
+        median: 60,
+        sampleSize: 1,
+      }),
+    ]);
+  });
+
   it('uses correct plus incorrect trials when opportunities are not captured', () => {
     const model = buildSessionTrendModel(
       [

--- a/src/lib/session-trends.ts
+++ b/src/lib/session-trends.ts
@@ -1,6 +1,6 @@
 import type { Goal, SessionGoalMeasurementData, SessionNote, SessionTargetTrialData } from '../types';
 
-export type SessionTrendDisplayPeriod = 'month' | 'week';
+export type SessionTrendDisplayPeriod = 'month' | 'week' | 'day';
 
 export interface SessionTrendDateRange {
   readonly startDate?: string;
@@ -88,6 +88,9 @@ const formatMonthLabel = (date: Date): string =>
 const formatWeekLabel = (date: Date): string =>
   `Week of ${new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(date)}`;
 
+const formatDayLabel = (date: Date): string =>
+  new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(date);
+
 const getWeekStart = (date: Date): Date => {
   const copy = new Date(date);
   const day = copy.getDay();
@@ -114,6 +117,13 @@ const buildBucket = (
     return {
       key: toLocalIsoDate(weekStart),
       label: formatWeekLabel(weekStart),
+    };
+  }
+
+  if (displayPeriod === 'day') {
+    return {
+      key: toLocalIsoDate(date),
+      label: formatDayLabel(date),
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `Day` as a Session Trends display period alongside Month and Week.
- Bucket daily trend data by local ISO date and label days as `Mon D`.
- Add model and component coverage for the daily display option.

## Verification
- `npm run test -- src/lib/__tests__/session-trends.test.ts src/components/__tests__/ClientSessionTrendsTab.test.tsx`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:ci`
- `npm run ci:verify-coverage`
- Protected-route Playwright QA on `http://localhost:5173/clients/5238e88b-6198-4862-80a2-100000000002?tab=session-trends`: selected `Day`, verified `Included session points=12` and `Buckets=12`; screenshot `artifacts/latest/session-trends-day-local.png`.

## Notes
- No Supabase schema, migration, RLS, auth, or server route changes.