### PR TITLE
Repair live authorization advisor indexes

### DIFF
--- a/supabase/migrations/20260627232920_repair_live_authorization_advisor_covering_indexes.sql
+++ b/supabase/migrations/20260627232920_repair_live_authorization_advisor_covering_indexes.sql
@@ -1,0 +1,16 @@
+-- @migration-intent: Repair hosted Supabase drift after PR #686 when the prior covering-index migration was present in repo history but absent from live migration history.
+-- @migration-dependencies: 20260626052042_add_authorization_performance_covering_indexes.sql
+-- @migration-scope: Index-only; no table, RLS, grant, RPC, or data changes.
+-- @migration-rollback: drop index if exists public.authorization_services_org_auth_idx; drop index if exists public.client_session_notes_authorization_id_idx;
+
+begin;
+
+set search_path = public;
+
+create index if not exists authorization_services_org_auth_idx
+  on public.authorization_services (organization_id, authorization_id);
+
+create index if not exists client_session_notes_authorization_id_idx
+  on public.client_session_notes (authorization_id);
+
+commit;

--- a/tests/authorizations/authorization-advisor-covering-indexes.test.ts
+++ b/tests/authorizations/authorization-advisor-covering-indexes.test.ts
@@ -1,0 +1,35 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('authorization advisor covering index migration', () => {
+  const migrationsDir = join(process.cwd(), 'supabase/migrations');
+  const migrationFile = '20260627232920_repair_live_authorization_advisor_covering_indexes.sql';
+  const migrationSql = readFileSync(join(migrationsDir, migrationFile), 'utf-8');
+  const executableSql = migrationSql
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('--'))
+    .join('\n');
+
+  it('tracks the hosted follow-up migration version for live drift repair', () => {
+    const migrationFiles = readdirSync(migrationsDir).filter((fileName) =>
+      fileName.endsWith('_repair_live_authorization_advisor_covering_indexes.sql'),
+    );
+
+    expect(migrationFiles).toEqual([migrationFile]);
+  });
+
+  it('covers the two advisor-reported foreign key columns', () => {
+    expect(migrationSql).toMatch(
+      /create index if not exists authorization_services_org_auth_idx\s+on public\.authorization_services \(organization_id, authorization_id\);/i,
+    );
+    expect(migrationSql).toMatch(
+      /create index if not exists client_session_notes_authorization_id_idx\s+on public\.client_session_notes \(authorization_id\);/i,
+    );
+  });
+
+  it('stays limited to index-only DDL', () => {
+    expect(executableSql).not.toMatch(/\b(create|alter|drop)\s+(table|policy|function|trigger)\b/i);
+    expect(executableSql).not.toMatch(/\b(grant|revoke|insert|update|delete)\b/i);
+  });
+});


### PR DESCRIPTION
## Summary
- investigated merged PR #686 / commit `a185a29b` against live Supabase project `wnnjeqheqxxyrgsjmygy`
- found live migration history did not include `20260626052042_add_authorization_performance_covering_indexes`, and live catalog lacked covering indexes for both advisor-reported FKs
- applied and tracked a live follow-up migration `20260627232920_repair_live_authorization_advisor_covering_indexes` to create:
  - `public.authorization_services(organization_id, authorization_id)` via `authorization_services_org_auth_idx`
  - `public.client_session_notes(authorization_id)` via `client_session_notes_authorization_id_idx`
- added a focused migration contract test to keep the follow-up version and index-only scope pinned

## Live Supabase evidence
- Before repair: FKs existed, but no index rows with leading `authorization_services.organization_id` or `client_session_notes.authorization_id` were returned from `pg_index`.
- Live migration history before repair: `20260626052042_add_authorization_performance_covering_indexes` absent.
- Applied via Supabase MCP `_apply_migration`: `success: true`.
- After repair: catalog returned both indexes with `indisvalid=true` and `indisready=true`.
- Live migration history after repair: `20260627232920 repair_live_authorization_advisor_covering_indexes` present.

## Route / risk
- classification: high-risk human-reviewed
- lane: critical
- protected surface: `supabase/migrations/**`, live Supabase DDL
- tenant boundary: unchanged; this is index-only and does not alter table data, RLS, grants, RPCs, policies, or application behavior
- Linear: WIN-187

## Verification
- `npm run test -- tests/authorizations/authorization-advisor-covering-indexes.test.ts` passed
- `npm run ci:check-focused` passed; DB-credential-dependent checks skipped locally because `SUPABASE_DB_URL` / `DATABASE_URL` were not configured
- `npm run validate:tenant` passed
- `npm run test:ci` passed: 333 files / 2,038 tests
- `npm run verify:local` passed, including lint, typecheck, repeated test:ci, coverage verification, build, and `test:routes:tier0` with 79 Cypress route tests

## Human review required
This touches a high-risk migration path. Per repo policy, human review is required before merge even though the change is index-only.