### PR TITLE
Harden public security definer RPC grants

### DIFF
--- a/supabase/migrations/20260628165252_harden_public_security_definer_rpc_grants.sql
+++ b/supabase/migrations/20260628165252_harden_public_security_definer_rpc_grants.sql
@@ -1,0 +1,75 @@
+-- @migration-intent: Remove unauthenticated/default execute access from public SECURITY DEFINER functions and lock trigger-backed helpers to service_role.
+-- @migration-dependencies: 20260624125902_restrict_staff_message_thread_rpc_anon_execute.sql, 20260627232920_repair_live_authorization_advisor_covering_indexes.sql
+-- @migration-rollback: Re-grant execute only to reviewed callers for a specific RPC contract; do not restore public or anon default execute.
+
+do $$
+declare
+  target_function regprocedure;
+begin
+  for target_function in
+    select p.oid::regprocedure
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.prosecdef = true
+  loop
+    execute format('revoke execute on function %s from public, anon', target_function);
+  end loop;
+end $$;
+
+do $$
+declare
+  target_function regprocedure;
+begin
+  for target_function in
+    select distinct p.oid::regprocedure
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    join pg_trigger t on t.tgfoid = p.oid
+    where n.nspname = 'public'
+      and p.prosecdef = true
+      and t.tgisinternal = false
+  loop
+    execute format('revoke execute on function %s from public, anon, authenticated', target_function);
+    execute format('grant execute on function %s to service_role', target_function);
+  end loop;
+end $$;
+
+do $$
+declare
+  unsafe_function_count integer;
+begin
+  select count(*)
+    into unsafe_function_count
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'public'
+    and p.prosecdef = true
+    and (
+      has_function_privilege('public', p.oid, 'EXECUTE')
+      or has_function_privilege('anon', p.oid, 'EXECUTE')
+    );
+
+  if unsafe_function_count > 0 then
+    raise exception 'Public SECURITY DEFINER grant hardening failed: % public functions remain executable by public or anon', unsafe_function_count;
+  end if;
+
+  select count(*)
+    into unsafe_function_count
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  join pg_trigger t on t.tgfoid = p.oid
+  where n.nspname = 'public'
+    and p.prosecdef = true
+    and t.tgisinternal = false
+    and (
+      has_function_privilege('public', p.oid, 'EXECUTE')
+      or has_function_privilege('anon', p.oid, 'EXECUTE')
+      or has_function_privilege('authenticated', p.oid, 'EXECUTE')
+      or not has_function_privilege('service_role', p.oid, 'EXECUTE')
+    );
+
+  if unsafe_function_count > 0 then
+    raise exception 'Trigger-backed SECURITY DEFINER grant hardening failed: % public trigger functions are not service_role-only', unsafe_function_count;
+  end if;
+end $$;

--- a/supabase/migrations/20260628171537_restrict_service_only_security_definer_rpc_grants.sql
+++ b/supabase/migrations/20260628171537_restrict_service_only_security_definer_rpc_grants.sql
@@ -1,0 +1,71 @@
+-- @migration-intent: Restrict service-only SECURITY DEFINER RPCs that should not be directly callable by signed-in browser users.
+-- @migration-dependencies: 20260628165252_harden_public_security_definer_rpc_grants.sql
+-- @migration-rollback: Re-grant authenticated only to a reviewed browser RPC with an explicit caller authorization contract.
+
+do $$
+declare
+  service_only_function regprocedure;
+  service_only_functions constant text[] := array[
+    'public.assign_admin_role(text, uuid, text)',
+    'public.assign_role_on_signup()',
+    'public.assign_therapist_role(text, uuid)',
+    'public.assign_therapist_role(uuid)',
+    'public.check_migration_status()',
+    'public.create_admin_invite_token_rate_limited(text, text, uuid, timestamp with time zone, uuid, role_type)',
+    'public.create_user_profile()',
+    'public.ensure_all_users_admin()',
+    'public.ensure_user_has_admin_role()',
+    'public.ensure_user_has_admin_role(uuid)',
+    'public.prune_admin_actions(integer)',
+    'public.prune_admin_invite_tokens()',
+    'public.prune_session_transcripts(integer)',
+    'public.sync_admin_roles_from_auth_metadata()'
+  ];
+begin
+  foreach service_only_function in array service_only_functions::regprocedure[] loop
+    execute format(
+      'revoke execute on function %s from public, anon, authenticated',
+      service_only_function
+    );
+    execute format(
+      'grant execute on function %s to service_role',
+      service_only_function
+    );
+  end loop;
+end $$;
+
+do $$
+declare
+  unsafe_function regprocedure;
+  unsafe_functions text[];
+  service_only_functions constant text[] := array[
+    'public.assign_admin_role(text, uuid, text)',
+    'public.assign_role_on_signup()',
+    'public.assign_therapist_role(text, uuid)',
+    'public.assign_therapist_role(uuid)',
+    'public.check_migration_status()',
+    'public.create_admin_invite_token_rate_limited(text, text, uuid, timestamp with time zone, uuid, role_type)',
+    'public.create_user_profile()',
+    'public.ensure_all_users_admin()',
+    'public.ensure_user_has_admin_role()',
+    'public.ensure_user_has_admin_role(uuid)',
+    'public.prune_admin_actions(integer)',
+    'public.prune_admin_invite_tokens()',
+    'public.prune_session_transcripts(integer)',
+    'public.sync_admin_roles_from_auth_metadata()'
+  ];
+begin
+  foreach unsafe_function in array service_only_functions::regprocedure[] loop
+    if has_function_privilege('public', unsafe_function, 'EXECUTE')
+      or has_function_privilege('anon', unsafe_function, 'EXECUTE')
+      or has_function_privilege('authenticated', unsafe_function, 'EXECUTE')
+      or not has_function_privilege('service_role', unsafe_function, 'EXECUTE')
+    then
+      unsafe_functions := array_append(unsafe_functions, unsafe_function::text);
+    end if;
+  end loop;
+
+  if coalesce(array_length(unsafe_functions, 1), 0) > 0 then
+    raise exception 'Service-only SECURITY DEFINER grant hardening failed for: %', array_to_string(unsafe_functions, ', ');
+  end if;
+end $$;

--- a/supabase/migrations/20260628171537_restrict_service_only_security_definer_rpc_grants.sql
+++ b/supabase/migrations/20260628171537_restrict_service_only_security_definer_rpc_grants.sql
@@ -5,6 +5,7 @@
 do $$
 declare
   service_only_function regprocedure;
+  service_only_function_signature text;
   service_only_functions constant text[] := array[
     'public.assign_admin_role(text, uuid, text)',
     'public.assign_role_on_signup()',
@@ -22,7 +23,13 @@ declare
     'public.sync_admin_roles_from_auth_metadata()'
   ];
 begin
-  foreach service_only_function in array service_only_functions::regprocedure[] loop
+  foreach service_only_function_signature in array service_only_functions loop
+    service_only_function := to_regprocedure(service_only_function_signature);
+
+    if service_only_function is null then
+      continue;
+    end if;
+
     execute format(
       'revoke execute on function %s from public, anon, authenticated',
       service_only_function
@@ -37,6 +44,7 @@ end $$;
 do $$
 declare
   unsafe_function regprocedure;
+  unsafe_function_signature text;
   unsafe_functions text[];
   service_only_functions constant text[] := array[
     'public.assign_admin_role(text, uuid, text)',
@@ -55,7 +63,13 @@ declare
     'public.sync_admin_roles_from_auth_metadata()'
   ];
 begin
-  foreach unsafe_function in array service_only_functions::regprocedure[] loop
+  foreach unsafe_function_signature in array service_only_functions loop
+    unsafe_function := to_regprocedure(unsafe_function_signature);
+
+    if unsafe_function is null then
+      continue;
+    end if;
+
     if has_function_privilege('public', unsafe_function, 'EXECUTE')
       or has_function_privilege('anon', unsafe_function, 'EXECUTE')
       or has_function_privilege('authenticated', unsafe_function, 'EXECUTE')

--- a/tests/security/public-security-definer-rpc-grants.security.spec.ts
+++ b/tests/security/public-security-definer-rpc-grants.security.spec.ts
@@ -88,9 +88,13 @@ describe('public SECURITY DEFINER RPC execute grants', () => {
       /revoke execute on function %s from public, anon, authenticated/i,
     );
     expect(serviceOnlyMigrationSql).toMatch(/grant execute on function %s to service_role/i);
+    expect(serviceOnlyMigrationSql).toMatch(/to_regprocedure\(service_only_function_signature\)/i);
+    expect(serviceOnlyMigrationSql).toMatch(/if service_only_function is null then[\s\S]+continue;/i);
   });
 
   it('asserts service-only RPCs remain service_role-only after migration', () => {
+    expect(serviceOnlyMigrationSql).toMatch(/to_regprocedure\(unsafe_function_signature\)/i);
+    expect(serviceOnlyMigrationSql).toMatch(/if unsafe_function is null then[\s\S]+continue;/i);
     expect(serviceOnlyMigrationSql).toMatch(/has_function_privilege\('public', unsafe_function, 'EXECUTE'\)/i);
     expect(serviceOnlyMigrationSql).toMatch(/has_function_privilege\('anon', unsafe_function, 'EXECUTE'\)/i);
     expect(serviceOnlyMigrationSql).toMatch(/has_function_privilege\('authenticated', unsafe_function, 'EXECUTE'\)/i);

--- a/tests/security/public-security-definer-rpc-grants.security.spec.ts
+++ b/tests/security/public-security-definer-rpc-grants.security.spec.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('public SECURITY DEFINER RPC execute grants', () => {
+  const migrationSql = readFileSync(
+    join(
+      process.cwd(),
+      'supabase/migrations/20260628165252_harden_public_security_definer_rpc_grants.sql',
+    ),
+    'utf-8',
+  );
+  const grantStatements = migrationSql.match(/grant execute on function[^;]+;/gi) ?? [];
+
+  it('removes unauthenticated execute from every public SECURITY DEFINER function', () => {
+    expect(migrationSql).toMatch(/where n\.nspname = 'public'[\s\S]+and p\.prosecdef = true/i);
+    expect(migrationSql).toMatch(
+      /execute format\('revoke execute on function %s from public, anon', target_function\)/i,
+    );
+  });
+
+  it('locks trigger-backed SECURITY DEFINER helpers to service_role only', () => {
+    expect(migrationSql).toMatch(/join pg_trigger t on t\.tgfoid = p\.oid/i);
+    expect(migrationSql).toMatch(/and t\.tgisinternal = false/i);
+    expect(migrationSql).toMatch(
+      /execute format\('revoke execute on function %s from public, anon, authenticated', target_function\)/i,
+    );
+    expect(migrationSql).toMatch(
+      /execute format\('grant execute on function %s to service_role', target_function\)/i,
+    );
+  });
+
+  it('asserts no public or anon SECURITY DEFINER execute remains', () => {
+    expect(migrationSql).toMatch(/has_function_privilege\('public', p\.oid, 'EXECUTE'\)/i);
+    expect(migrationSql).toMatch(/has_function_privilege\('anon', p\.oid, 'EXECUTE'\)/i);
+    expect(migrationSql).toMatch(/remain executable by public or anon/i);
+  });
+
+  it('asserts trigger-backed helpers are not directly executable by authenticated users', () => {
+    expect(migrationSql).toMatch(/has_function_privilege\('authenticated', p\.oid, 'EXECUTE'\)/i);
+    expect(migrationSql).toMatch(/not has_function_privilege\('service_role', p\.oid, 'EXECUTE'\)/i);
+    expect(migrationSql).toMatch(/not service_role-only/i);
+  });
+
+  it('does not re-grant unauthenticated execute access', () => {
+    for (const grantStatement of grantStatements) {
+      const [, granteeList = ''] = grantStatement.match(/\bto\s+([^;]+);/i) ?? [];
+      const grantees = granteeList
+        .split(',')
+        .map((grantee) => grantee.trim().toLowerCase());
+
+      expect(grantees).not.toContain('public');
+      expect(grantees).not.toContain('anon');
+      expect(grantees).not.toContain('authenticated');
+    }
+  });
+});

--- a/tests/security/public-security-definer-rpc-grants.security.spec.ts
+++ b/tests/security/public-security-definer-rpc-grants.security.spec.ts
@@ -10,6 +10,13 @@ describe('public SECURITY DEFINER RPC execute grants', () => {
     ),
     'utf-8',
   );
+  const serviceOnlyMigrationSql = readFileSync(
+    join(
+      process.cwd(),
+      'supabase/migrations/20260628171537_restrict_service_only_security_definer_rpc_grants.sql',
+    ),
+    'utf-8',
+  );
   const grantStatements = migrationSql.match(/grant execute on function[^;]+;/gi) ?? [];
 
   it('removes unauthenticated execute from every public SECURITY DEFINER function', () => {
@@ -53,5 +60,50 @@ describe('public SECURITY DEFINER RPC execute grants', () => {
       expect(grantees).not.toContain('anon');
       expect(grantees).not.toContain('authenticated');
     }
+  });
+
+  it('restricts high-confidence service-only RPCs away from direct signed-in callers', () => {
+    const serviceOnlyFunctions = [
+      'public.assign_admin_role(text, uuid, text)',
+      'public.assign_role_on_signup()',
+      'public.assign_therapist_role(text, uuid)',
+      'public.assign_therapist_role(uuid)',
+      'public.check_migration_status()',
+      'public.create_admin_invite_token_rate_limited(text, text, uuid, timestamp with time zone, uuid, role_type)',
+      'public.create_user_profile()',
+      'public.ensure_all_users_admin()',
+      'public.ensure_user_has_admin_role()',
+      'public.ensure_user_has_admin_role(uuid)',
+      'public.prune_admin_actions(integer)',
+      'public.prune_admin_invite_tokens()',
+      'public.prune_session_transcripts(integer)',
+      'public.sync_admin_roles_from_auth_metadata()',
+    ];
+
+    for (const functionSignature of serviceOnlyFunctions) {
+      expect(serviceOnlyMigrationSql).toContain(`'${functionSignature}'`);
+    }
+
+    expect(serviceOnlyMigrationSql).toMatch(
+      /revoke execute on function %s from public, anon, authenticated/i,
+    );
+    expect(serviceOnlyMigrationSql).toMatch(/grant execute on function %s to service_role/i);
+  });
+
+  it('asserts service-only RPCs remain service_role-only after migration', () => {
+    expect(serviceOnlyMigrationSql).toMatch(/has_function_privilege\('public', unsafe_function, 'EXECUTE'\)/i);
+    expect(serviceOnlyMigrationSql).toMatch(/has_function_privilege\('anon', unsafe_function, 'EXECUTE'\)/i);
+    expect(serviceOnlyMigrationSql).toMatch(/has_function_privilege\('authenticated', unsafe_function, 'EXECUTE'\)/i);
+    expect(serviceOnlyMigrationSql).toMatch(/not has_function_privilege\('service_role', unsafe_function, 'EXECUTE'\)/i);
+    expect(serviceOnlyMigrationSql).toMatch(/Service-only SECURITY DEFINER grant hardening failed/i);
+  });
+
+  it('does not grant service-only functions back to browser roles', () => {
+    expect(serviceOnlyMigrationSql).toMatch(
+      /execute format\(\s*'grant execute on function %s to service_role'/i,
+    );
+    expect(serviceOnlyMigrationSql).not.toMatch(
+      /execute format\(\s*'grant execute on function %s to (?:public|anon|authenticated)/i,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add a migration to revoke `public`/`anon` execute from every current `public` `SECURITY DEFINER` function.
- Lock trigger-backed public security-definer helpers to `service_role` only.
- Add a follow-up migration that removes direct signed-in/browser execution from high-confidence service-only RPCs: role assignment/seeding helpers, trigger-shaped auth helpers, migration-status inspection, and maintenance prune functions.
- Add a static regression spec covering the broad grant clamp, service-only grant list, and migration assertions.

## Hosted Supabase evidence
- Applied `harden_public_security_definer_rpc_grants` to active project `wnnjeqheqxxyrgsjmygy` with Supabase migration tool: success.
- Applied `restrict_service_only_security_definer_rpc_grants` to active project `wnnjeqheqxxyrgsjmygy` with Supabase migration tool: success.
- Rollback-only validation against the live catalog succeeded before each apply.
- Post-apply catalog check: `public_or_anon_executable_security_definer_count = 0`.
- Post-apply trigger-helper check: `authenticated_executable_trigger_security_definer_count = 0`.
- Post-apply service-only target check: `service_only_functions_still_browser_executable = 0`.

## Verification
- `npx vitest run --config vitest.config.ts tests/security/public-security-definer-rpc-grants.security.spec.ts`
- `npm run ci:check-focused`
- `npm run validate:tenant`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci` with non-secret `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` placeholders: 334 files / 2046 tests
- `npm run ci:verify-coverage`: 91.97% line coverage
- `npm run build` with non-secret `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` placeholders
- Earlier in this branch before the second migration, `npm run test:routes:tier0` passed: 79 tests. The second migration changes only DB grants/static migration tests and does not alter route code.

## Residual risk
- Supabase security advisor still reports signed-in users can execute remaining app-facing `SECURITY DEFINER` RPCs. This slice preserves authenticated callers for reviewed browser/server user-token RPCs to avoid launch breakage; a follow-up should classify any remaining advisor warnings one by one.
- Advisor still reports mutable search_path on `public.manage_admin_users` and `public.get_dashboard_data`; those are outside this grant slice.
- Linear issue creation/update is blocked because the Linear connector requires reauthentication.

## Lane
- critical / high-risk protected database authz surface; human review required before merge.
