### PR TITLE
Close route coverage gaps

### DIFF
--- a/cypress/e2e/routes_public.cy.ts
+++ b/cypress/e2e/routes_public.cy.ts
@@ -13,7 +13,7 @@ describe("Public route coverage", () => {
       cy.wait("@runtimeConfig");
       cy.get("body").should("be.visible");
       cy.get('[data-testid="error-boundary"]').should("not.exist");
-      cy.url().should("include", route.path);
+      cy.location("pathname").should("eq", route.expectedPath ?? route.path);
     });
   });
 });

--- a/cypress/support/routeScenarios.ts
+++ b/cypress/support/routeScenarios.ts
@@ -4,6 +4,8 @@ export type AppRole = "client" | "therapist" | "admin" | "super_admin";
 export type RouteScenario = {
   path: string;
   roles: readonly (AppRole | "public")[];
+  expectedPath?: string;
+  expectedPathByRole?: Partial<Record<AppRole | "public", string>>;
 };
 
 export const password = "password123";
@@ -18,6 +20,11 @@ export const routeGroups = {
   public: [
     { path: "/login", roles: ["public"] },
     { path: "/signup", roles: ["public"] },
+    {
+      path: "/auth/recovery?type=recovery&access_token=test-access-token&refresh_token=test-refresh-token",
+      roles: ["public"],
+      expectedPath: "/auth/recovery",
+    },
     { path: "/unauthorized", roles: ["public"] },
   ],
   client: [
@@ -42,8 +49,24 @@ export const routeGroups = {
     { path: "/therapists/new", roles: ["admin", "super_admin"] },
     { path: "/billing", roles: ["admin", "super_admin"] },
     { path: "/monitoring", roles: ["admin", "super_admin"] },
+    { path: "/monitoringdashboard", roles: ["admin", "super_admin"], expectedPath: "/monitoring" },
     { path: "/reports", roles: ["admin", "super_admin"] },
     { path: "/settings", roles: ["admin", "super_admin"] },
+    {
+      path: "/settings/feature-flags",
+      roles: ["admin", "super_admin"],
+      expectedPathByRole: { admin: "/settings", super_admin: "/settings/feature-flags" },
+    },
+    {
+      path: "/settings/impersonation",
+      roles: ["admin", "super_admin"],
+      expectedPathByRole: { admin: "/settings", super_admin: "/settings/impersonation" },
+    },
+    { path: "/superadminfeatureflags", roles: ["admin", "super_admin"], expectedPath: "/settings" },
+    { path: "/superadminimpersonation", roles: ["admin", "super_admin"], expectedPath: "/settings" },
+    { path: "/super-admin/feature-flags", roles: ["super_admin"] },
+    { path: "/super-admin/impersonation", roles: ["super_admin"] },
+    { path: "/super-admin/prompts", roles: ["super_admin"] },
   ],
 } satisfies Record<string, readonly RouteScenario[]>;
 
@@ -141,13 +164,14 @@ export const installRouteDataStubs = (): void => {
   });
 };
 
-export const assertVisibleRoute = (path: string): void => {
+export const assertVisibleRoute = (path: string, expectedPath = path): void => {
   cy.visit(path);
   cy.wait("@runtimeConfig");
   cy.get("body").should("be.visible");
   cy.get('[data-testid="error-boundary"]').should("not.exist");
   cy.url().should("not.include", "/login");
   cy.url().should("not.include", "/unauthorized");
+  cy.location("pathname").should("eq", expectedPath);
 };
 
 export const assertBlockedRoute = (path: string): void => {
@@ -170,11 +194,11 @@ export const runRoleMatrix = (title: string, scenarios: readonly RouteScenario[]
           cy.login(roleEmail(role), password);
         });
 
-        scenarios.forEach(({ path, roles: allowed }) => {
+        scenarios.forEach(({ path, roles: allowed, expectedPath, expectedPathByRole }) => {
           const shouldAllow = allowed.includes(role);
           it(`${shouldAllow ? "allows" : "blocks"} ${path}`, () => {
             if (shouldAllow) {
-              assertVisibleRoute(path);
+              assertVisibleRoute(path, expectedPathByRole?.[role] ?? expectedPath);
             } else {
               assertBlockedRoute(path);
             }

--- a/docs/ai/2026-06-28-route-coverage-gaps-handoff.md
+++ b/docs/ai/2026-06-28-route-coverage-gaps-handoff.md
@@ -1,0 +1,45 @@
+# Route Coverage Gaps Handoff
+
+- chosen task: close Slice 2 route coverage gaps for React guard-layer launch checks
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- triggering paths:
+  - `src/pages/__tests__/AppNavigation.test.tsx`
+  - `src/pages/__tests__/PasswordRecovery.redirect.test.tsx`
+  - `src/pages/__tests__/Settings.test.tsx`
+  - `src/pages/Settings.tsx`
+  - `tests/edge/route-audit-policy.test.ts`
+  - `cypress/support/routeScenarios.ts`
+  - `scripts/route-audit.ts`
+- auth/routing boundary:
+  - super-admin route guards for `/super-admin/feature-flags`, `/super-admin/impersonation`, `/super-admin/prompts`
+  - settings deep links under `/settings/:tabId`
+  - legacy alias redirects for `/monitoringdashboard`, `/superadminfeatureflags`, `/superadminimpersonation`
+  - public `/auth/recovery` route and recovery callback sanitization
+- non-goals:
+  - no broad production guard refactor
+  - no Supabase schema, RLS, grants, or edge function changes
+  - no secret-backed Playwright credential changes
+- reviewer finding resolved:
+  - initial coverage blessed admin deep links to super-admin settings panels
+  - `Settings` now normalizes non-super-admin deep links for `/settings/feature-flags` and `/settings/impersonation` back to `/settings`
+  - unit and Cypress coverage now distinguish admin normalization from super-admin panel access
+- verification run:
+  - `npm ci` passed
+  - focused Vitest route suite passed: 6 files, 47 tests
+  - `npm run ci:check-focused` passed with DB-backed checks skipped because `SUPABASE_DB_URL` is not configured
+  - `npm run lint` passed
+  - `npm run typecheck` passed
+  - `npm run preview:build` passed with non-secret placeholder Supabase env
+  - `npm run test:routes -- --spec cypress/e2e/routes_public.cy.ts,cypress/e2e/routes_admin.cy.ts` passed: 64 tests
+  - after reviewer alias-matrix finding, `npm run test:routes -- --spec cypress/e2e/routes_admin.cy.ts` passed: 60 tests
+  - `npm run build` passed with non-secret placeholder Supabase env
+  - `npm run test:ci` passed: 334 files, 2060 tests
+  - `npm run ci:verify-coverage` passed
+  - `npm run test:routes:tier0` passed: 112 tests
+- blocked checks:
+  - `npm run ci:playwright` blocked locally at `playwright:preflight`; missing required protected credentials: `PW_SUPERADMIN_EMAIL` + `PW_SUPERADMIN_PASSWORD` or `PW_ADMIN_EMAIL` + `PW_ADMIN_PASSWORD`
+  - Linear issue linkage blocked because the Linear app requires reauthentication
+- reviewer status: no findings after alias expected-path fix
+- residual risk:
+  - local unit/Cypress coverage now exercises the requested routes and recovery behavior, but secret-backed Playwright auth/session smoke must run in CI or an environment with protected credentials

--- a/docs/ai/2026-06-28-route-coverage-gaps-handoff.md
+++ b/docs/ai/2026-06-28-route-coverage-gaps-handoff.md
@@ -40,6 +40,10 @@
 - blocked checks:
   - `npm run ci:playwright` blocked locally at `playwright:preflight`; missing required protected credentials: `PW_SUPERADMIN_EMAIL` + `PW_SUPERADMIN_PASSWORD` or `PW_ADMIN_EMAIL` + `PW_ADMIN_PASSWORD`
   - Linear issue linkage blocked because the Linear app requires reauthentication
+- live PR checks:
+  - PR #696 CI passed `change-scope`, `policy`, `lint-typecheck`, `unit-tests`, `build`, `tier0-browser`, `iehp-assessment-import-smoke`, Lighthouse, and Netlify checks
+  - PR #696 `auth-browser-smoke` failed twice after `playwright:auth` passed; both attempts timed out in existing `playwright:session-no-show` session lifecycle `book-session` after selecting an authorized therapist/client pair
 - reviewer status: no findings after alias expected-path fix
 - residual risk:
   - local unit/Cypress coverage now exercises the requested routes and recovery behavior, but secret-backed Playwright auth/session smoke must run in CI or an environment with protected credentials
+  - live CI has a persistent session-lifecycle booking timeout outside the route coverage diff that blocks merge until triaged or rerun successfully

--- a/scripts/route-audit.ts
+++ b/scripts/route-audit.ts
@@ -94,6 +94,7 @@ export const ROUTES: readonly RouteDefinition[] = [
   // Public routes
   { path: '/login', component: 'Login', roles: ['public'], permissions: [] },
   { path: '/signup', component: 'Signup', roles: ['public'], permissions: [] },
+  { path: '/auth/recovery', component: 'PasswordRecovery', roles: ['public'], permissions: [] },
   { path: '/unauthorized', component: 'Unauthorized', roles: ['public'], permissions: [] },
 
   // Protected routes

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -26,6 +26,8 @@ type Tab =
   | 'feature-flags'
   | 'impersonation';
 
+const SUPER_ADMIN_ONLY_TABS: readonly Tab[] = ['feature-flags', 'impersonation'];
+
 export function Settings() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -50,12 +52,26 @@ export function Settings() {
         'feature-flags',
         'impersonation',
       ];
-      if (allowed.includes(candidate)) return candidate;
+      if (allowed.includes(candidate)) {
+        if (SUPER_ADMIN_ONLY_TABS.includes(candidate) && !showSuperAdminTabs) {
+          return 'user';
+        }
+        return candidate;
+      }
     }
     return 'user';
-  }, [location.pathname]);
+  }, [location.pathname, showSuperAdminTabs]);
 
   const [activeTab, setActiveTab] = useState<Tab>(initialTab);
+
+  useEffect(() => {
+    const path = location.pathname.toLowerCase();
+    const match = path.match(/\/settings\/(.+)$/);
+    const candidate = match?.[1] as Tab | undefined;
+    if (candidate && SUPER_ADMIN_ONLY_TABS.includes(candidate) && !showSuperAdminTabs) {
+      navigate('/settings', { replace: true });
+    }
+  }, [location.pathname, navigate, showSuperAdminTabs]);
 
   useEffect(() => {
     setActiveTab(initialTab);

--- a/src/pages/__tests__/AppNavigation.test.tsx
+++ b/src/pages/__tests__/AppNavigation.test.tsx
@@ -61,6 +61,18 @@ vi.mock('../../pages/FamilyDashboard', () => ({
   FamilyDashboard: () => <div>FamilyDashboardPage</div>,
 }));
 
+vi.mock('../../pages/Login', () => ({
+  Login: () => <div>LoginPage</div>,
+}));
+
+vi.mock('../../pages/Signup', () => ({
+  Signup: () => <div>SignupPage</div>,
+}));
+
+vi.mock('../../pages/PasswordRecovery', () => ({
+  PasswordRecovery: () => <div>PasswordRecoveryPage</div>,
+}));
+
 vi.mock('../../pages/ClientOnboardingPage', () => ({
   ClientOnboardingPage: () => <div>ClientOnboardingPage</div>,
 }));
@@ -71,6 +83,22 @@ vi.mock('../../pages/ClientDetails', () => ({
 
 vi.mock('../../pages/TherapistOnboardingPage', () => ({
   TherapistOnboardingPage: () => <div>TherapistOnboardingPage</div>,
+}));
+
+vi.mock('../../pages/Settings', () => ({
+  Settings: () => <div>SettingsPage</div>,
+}));
+
+vi.mock('../../pages/SuperAdminFeatureFlags', () => ({
+  SuperAdminFeatureFlags: () => <div>SuperAdminFeatureFlagsPage</div>,
+}));
+
+vi.mock('../../pages/SuperAdminImpersonation', () => ({
+  SuperAdminImpersonation: () => <div>SuperAdminImpersonationPage</div>,
+}));
+
+vi.mock('../../pages/SuperAdminPrompts', () => ({
+  SuperAdminPrompts: () => <div>SuperAdminPromptsPage</div>,
 }));
 
 const renderApp = () => {
@@ -203,6 +231,83 @@ describe('App navigation landing', () => {
 
     await waitFor(() => {
       expect(window.location.pathname).toBe('/unauthorized');
+    });
+  });
+
+  it('renders password recovery as a public route outside the protected layout', async () => {
+    authRole = 'client';
+    window.history.pushState({}, '', '/auth/recovery?type=recovery#access_token=secret');
+    renderApp();
+
+    expect(await screen.findByText('PasswordRecoveryPage')).toBeInTheDocument();
+    expect(screen.queryByTestId('layout')).not.toBeInTheDocument();
+    expect(window.location.pathname).toBe('/auth/recovery');
+  });
+
+  it('allows admins and super admins to open settings tabs', async () => {
+    for (const role of ['admin', 'super_admin'] as const) {
+      authRole = role;
+      window.history.pushState({}, '', '/settings/organization');
+      const view = renderApp();
+
+      expect(await screen.findByText('SettingsPage')).toBeInTheDocument();
+      expect(window.location.pathname).toBe('/settings/organization');
+
+      view.unmount();
+    }
+  });
+
+  it('blocks non-admin roles from settings tabs', async () => {
+    for (const role of ['client', 'therapist'] as const) {
+      authRole = role;
+      window.history.pushState({}, '', '/settings/admin');
+      const view = renderApp();
+
+      await waitFor(() => {
+        expect(window.location.pathname).toBe('/unauthorized');
+      });
+
+      view.unmount();
+    }
+  });
+
+  it.each([
+    ['/super-admin/feature-flags', 'SuperAdminFeatureFlagsPage'],
+    ['/super-admin/impersonation', 'SuperAdminImpersonationPage'],
+    ['/super-admin/prompts', 'SuperAdminPromptsPage'],
+  ])('allows only super admins to render %s', async (path, pageText) => {
+    authRole = 'super_admin';
+    window.history.pushState({}, '', path);
+    const allowedView = renderApp();
+
+    expect(await screen.findByText(pageText)).toBeInTheDocument();
+    expect(window.location.pathname).toBe(path);
+    allowedView.unmount();
+
+    for (const blockedRole of ['client', 'therapist', 'admin'] as const) {
+      authRole = blockedRole;
+      window.history.pushState({}, '', path);
+      const blockedView = renderApp();
+
+      await waitFor(() => {
+        expect(window.location.pathname).toBe('/unauthorized');
+      });
+
+      blockedView.unmount();
+    }
+  });
+
+  it.each([
+    ['/monitoringdashboard', '/monitoring'],
+    ['/superadminfeatureflags', '/settings'],
+    ['/superadminimpersonation', '/settings'],
+  ])('keeps legacy alias %s inside the protected shell and redirects to %s', async (aliasPath, expectedPath) => {
+    authRole = 'admin';
+    window.history.pushState({}, '', aliasPath);
+    renderApp();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe(expectedPath);
     });
   });
 });

--- a/src/pages/__tests__/PasswordRecovery.redirect.test.tsx
+++ b/src/pages/__tests__/PasswordRecovery.redirect.test.tsx
@@ -236,4 +236,42 @@ describe('PasswordRecovery redirect guard', () => {
       expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
+
+  it('sanitizes mixed recovery query and hash callbacks without dropping safe parameters', async () => {
+    mockLocation.search = '?type=recovery&code=secret-code&next=settings';
+    mockLocation.hash = '#access_token=secret-access-token&refresh_token=secret-refresh-token&tab=security';
+
+    mockedUseAuth.mockReturnValue({
+      user: { id: 'user-1', email: 'user@example.com' } as never,
+      profile: null,
+      session: null,
+      loading: false,
+      profileLoading: false,
+      metadataRole: null,
+      effectiveRole: 'client',
+      roleMismatch: false,
+      authFlow: 'password_recovery',
+      signIn: vi.fn(),
+      signUp: vi.fn(),
+      signOut: vi.fn(),
+      resetPassword: vi.fn(),
+      updateProfile: vi.fn(),
+      hasRole: vi.fn().mockReturnValue(false),
+      hasAnyRole: vi.fn().mockReturnValue(false),
+      isAdmin: vi.fn().mockReturnValue(false),
+      isSuperAdmin: vi.fn().mockReturnValue(false),
+    });
+
+    renderWithProviders(<PasswordRecovery />, { auth: false });
+
+    expect(screen.getByText('Set a new password')).toBeInTheDocument();
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      window.history.state,
+      document.title,
+      '/auth/recovery?next=settings#tab=security'
+    );
+    await waitFor(() => {
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/pages/__tests__/Settings.test.tsx
+++ b/src/pages/__tests__/Settings.test.tsx
@@ -1,7 +1,21 @@
 import { describe, expect, it, afterEach, vi } from 'vitest';
+import { useLocation } from 'react-router-dom';
 import { renderWithProviders, screen } from '../../test/utils';
 import { Settings } from '../Settings';
 import * as authContext from '../../lib/authContext';
+
+vi.mock('../SuperAdminFeatureFlags', () => ({
+  SuperAdminFeatureFlags: () => <div>FeatureFlagsPanel</div>,
+}));
+
+vi.mock('../SuperAdminImpersonation', () => ({
+  SuperAdminImpersonation: () => <div>ImpersonationPanel</div>,
+}));
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="settings-location">{location.pathname}</div>;
+};
 
 describe('Settings', () => {
   const useAuthSpy = vi.spyOn(authContext, 'useAuth');
@@ -30,5 +44,55 @@ describe('Settings', () => {
 
     expect(screen.queryByRole('button', { name: /Feature Flags/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Impersonation/i })).not.toBeInTheDocument();
+  });
+
+  it('opens the feature flags tab from a settings deep link for super admins', () => {
+    useAuthSpy.mockReturnValue({
+      isSuperAdmin: () => true,
+    } as unknown as ReturnType<typeof authContext.useAuth>);
+
+    renderWithProviders(<Settings />, {
+      router: { initialEntries: ['/settings/feature-flags'] },
+    });
+
+    expect(screen.getByRole('button', { name: /Feature Flags/i })).toHaveClass('border-blue-500');
+    expect(screen.getByText('FeatureFlagsPanel')).toBeInTheDocument();
+  });
+
+  it('opens the impersonation tab from a settings deep link for super admins', () => {
+    useAuthSpy.mockReturnValue({
+      isSuperAdmin: () => true,
+    } as unknown as ReturnType<typeof authContext.useAuth>);
+
+    renderWithProviders(<Settings />, {
+      router: { initialEntries: ['/settings/impersonation'] },
+    });
+
+    expect(screen.getByRole('button', { name: /Impersonation/i })).toHaveClass('border-blue-500');
+    expect(screen.getByText('ImpersonationPanel')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['/settings/feature-flags', 'FeatureFlagsPanel'],
+    ['/settings/impersonation', 'ImpersonationPanel'],
+  ])('normalizes non-super-admin deep links from %s to personal settings', async (path, hiddenPanel) => {
+    useAuthSpy.mockReturnValue({
+      user: { id: 'admin-user-id', email: 'admin@example.com' },
+      isSuperAdmin: () => false,
+    } as unknown as ReturnType<typeof authContext.useAuth>);
+
+    renderWithProviders(
+      <>
+        <Settings />
+        <LocationProbe />
+      </>,
+      {
+        router: { initialEntries: [path] },
+      },
+    );
+
+    expect(await screen.findByTestId('settings-location')).toHaveTextContent('/settings');
+    expect(screen.getByRole('heading', { name: /Personal Settings/i })).toBeInTheDocument();
+    expect(screen.queryByText(hiddenPanel)).not.toBeInTheDocument();
   });
 });

--- a/tests/edge/route-audit-policy.test.ts
+++ b/tests/edge/route-audit-policy.test.ts
@@ -32,6 +32,7 @@ const parseAppRouteRoles = (source: string): Map<string, string[]> => {
   const routeMap = new Map<string, string[]>();
   routeMap.set('/login', ['public']);
   routeMap.set('/signup', ['public']);
+  routeMap.set('/auth/recovery', ['public']);
   routeMap.set('/unauthorized', ['public']);
   routeMap.set('/', normalizeRoles(['client', 'therapist', 'admin', 'super_admin']));
 


### PR DESCRIPTION
## Summary
- Add explicit React/AppNavigation and Cypress route-matrix coverage for super-admin routes, settings tab deep links, legacy aliases, and password recovery callbacks.
- Normalize non-super-admin deep links to super-admin-only settings tabs back to `/settings` so coverage does not bless hidden panel access.
- Add route-audit policy coverage for `/auth/recovery` and a handoff artifact with lane, verification, blocked checks, and residual risk.

## Route-task classification
- classification: high-risk human-reviewed
- lane: critical
- rationale: auth/routing boundary plus `src/pages/Settings.tsx` behavior change for role-sensitive settings tabs

## Verification
- `npm ci` passed
- focused Vitest route suite passed: 6 files, 47 tests
- `npm run ci:check-focused` passed; local DB-backed checks skipped because `SUPABASE_DB_URL` is not configured
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run preview:build` passed with non-secret placeholder Supabase env
- `npm run test:routes -- --spec cypress/e2e/routes_public.cy.ts,cypress/e2e/routes_admin.cy.ts` passed: 64 tests
- after reviewer alias-matrix finding, `npm run test:routes -- --spec cypress/e2e/routes_admin.cy.ts` passed: 60 tests
- `npm run build` passed with non-secret placeholder Supabase env
- `npm run test:ci` passed: 334 files, 2060 tests
- `npm run ci:verify-coverage` passed
- `npm run test:routes:tier0` passed: 112 tests
- commit hook reran `npm run ci:check-focused` successfully

## Blocked local checks
- `npm run ci:playwright` blocked locally at preflight: missing protected `PW_SUPERADMIN_EMAIL` + `PW_SUPERADMIN_PASSWORD` or `PW_ADMIN_EMAIL` + `PW_ADMIN_PASSWORD`.
- Linear issue linkage blocked because the Linear app requires reauthentication.

## Review
- tester coverage planning completed
- reviewer initial finding resolved
- reviewer recheck: no findings

## Risk
Critical lane due auth/routing behavior. Human review required before merge.