### PR TITLE
Stabilize session lifecycle booking smoke

### DIFF
--- a/docs/ai/2026-06-28-route-coverage-gaps-handoff.md
+++ b/docs/ai/2026-06-28-route-coverage-gaps-handoff.md
@@ -47,3 +47,46 @@
 - residual risk:
   - local unit/Cypress coverage now exercises the requested routes and recovery behavior, but secret-backed Playwright auth/session smoke must run in CI or an environment with protected credentials
   - live CI has a persistent session-lifecycle booking timeout outside the route coverage diff that blocks merge until triaged or rerun successfully
+
+## Follow-up: auth-browser-smoke booking timeout
+
+- chosen task: triage `auth-browser-smoke` / `playwright:session-no-show` booking timeout
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- triggering paths:
+  - `scripts/playwright-session-lifecycle.ts`
+  - `tests/scripts/playwright-session-lifecycle.test.ts`
+- failing flow:
+  - PR #696 `auth-browser-smoke` passed `playwright:auth`
+  - `playwright:session-no-show` selected an authorized therapist/client pair with active program/goal
+  - `book-session` timed out after 300 seconds before creating a session
+- fix:
+  - keep the schedule modal booking attempt as the required signal
+  - wait for the `Create Session` button to become enabled before clicking it
+  - if the click does not emit `/api/book` or a visible blocking validation state within `PW_LIFECYCLE_UI_BOOK_RESPONSE_TIMEOUT_MS` (default 45000ms), fail fast with pair/time diagnostics instead of silently looping until the outer 300s timeout
+  - rejected an earlier direct `/api/book` fallback because reviewer found it would weaken the UI smoke and risk duplicate booking races
+  - PR #697 CI proved the no-show terminal flow now books and closes successfully; the completed terminal flow then exposed a dependent-select issue where client selection could clear the therapist select, leaving visible `Therapist is required` validation instead of submitting
+  - revised the harness to select client/therapist in a dependency-aware order, verify both selected values before using the pair, and include required-field validation in the blocking-state detector
+  - moved `/api/book` and blocking-validation waiters to start after the `Create Session` readiness wait, immediately before the click, so slow dependent-data loading does not consume the response/validation timeout before submit
+  - added best-effort, timeout-bounded cleanup of any seeded program/goal before the no-response fail-fast throw, preserving the original diagnostic if cleanup rejects or stalls
+- verification run:
+  - `npx vitest run --config vitest.config.ts tests/scripts/playwright-session-lifecycle.test.ts` passed: 1 file, 5 tests
+  - `npm run typecheck` passed
+  - `npm run lint` passed
+  - `npm run ci:check-focused` passed with expected local DB-backed skips
+  - `npm run build` passed with non-secret placeholder Supabase env
+  - `npm run test:ci` passed with non-secret placeholder Supabase env: 334 files, 2065 tests
+  - `npm run ci:verify-coverage` passed
+  - `npm run test:routes:tier0` passed: 112 tests
+- protected CI:
+  - PR #697 protected CI run `28339456372` failed before the dependent-select fix; `auth-browser-smoke` log showed no-show success and completed-flow booking failure at `Create Session clicked but no /api/book response or blocking validation appeared` with screenshot evidence showing `Therapist is required`
+  - PR #697 protected CI run `28339751797` passed after the dependent-select fix: `policy`, `lint-typecheck`, `unit-tests`, `auth-browser-smoke`, `iehp-assessment-import-smoke`, `build`, `tier0-browser`, and `ci-gate` all succeeded
+- locally blocked checks:
+  - `npm run ci:playwright` remains blocked locally at `playwright:preflight`; missing protected credentials, but the protected GitHub `auth-browser-smoke` gate passed on run `28339751797`
+- reviewer status:
+  - reviewer recheck found the cleanup-stall issue resolved after adding timeout-bounded cleanup and focused reject/stall regression tests
+  - reviewer requested the verification-count handoff correction; corrected in this update
+  - tester recheck found no additional session-flow-specific local checks; recommended coverage verification, which passed
+- residual risk:
+  - the dependency-aware select sequencing and required-field blocking branch are not directly unit-tested; protected `auth-browser-smoke` is the executable regression proof for that behavior
+  - critical-lane PR still requires human review/merge approval; Linear tracking could not be updated from this session because Linear auth returned `UNAUTHORIZED oauth_token_invalid_grant`

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -44,8 +44,10 @@ interface BrowserFetchResult<TBody> {
 }
 
 const isTruthy = (value: string | undefined): boolean => /^(1|true|yes)$/i.test(value ?? "");
-/** UI wait (90s) + edge/RPC fallback can exceed 120s on cold paths. */
+/** UI wait + edge/RPC fallback can exceed 120s on cold paths. */
 const STEP_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_STEP_TIMEOUT_MS ?? "300000");
+const UI_BOOK_RESPONSE_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_UI_BOOK_RESPONSE_TIMEOUT_MS ?? "45000");
+const CLEANUP_BEFORE_FAILURE_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_CLEANUP_BEFORE_FAILURE_TIMEOUT_MS ?? "5000");
 
 const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): Promise<T> => {
   console.log(`[lifecycle] start ${label}`);
@@ -498,6 +500,51 @@ const toDatetimeLocal = (date: Date): string => {
   return local.toISOString().slice(0, 16);
 };
 
+export const isCreateSessionButtonReady = ({
+  disabled,
+  ariaDisabled,
+}: {
+  disabled: string | null;
+  ariaDisabled: string | null;
+}): boolean => disabled === null && ariaDisabled !== "true";
+
+const expectCreateSessionButtonReady = async (
+  page: Page,
+  context: {
+    pairKey: string;
+    attempt: number;
+    startIso: string;
+  },
+): Promise<ReturnType<Page["getByRole"]>> => {
+  const createSessionButton = page.getByRole("button", { name: /Create Session/i });
+  await createSessionButton.waitFor({ state: "visible", timeout: 10_000 });
+
+  const deadline = Date.now() + 20_000;
+  let disabled: string | null = null;
+  let ariaDisabled: string | null = null;
+  while (Date.now() < deadline) {
+    disabled = await createSessionButton.getAttribute("disabled");
+    ariaDisabled = await createSessionButton.getAttribute("aria-disabled");
+    if (isCreateSessionButtonReady({ disabled, ariaDisabled })) {
+      return createSessionButton;
+    }
+    await page.waitForTimeout(250);
+  }
+
+  const visibleErrors = await page
+    .locator('[role="alert"], .text-red-600, .text-red-700, .text-destructive')
+    .evaluateAll((nodes) =>
+      nodes
+        .map((node) => node.textContent?.replace(/\s+/g, " ").trim())
+        .filter((text): text is string => Boolean(text))
+        .slice(0, 5),
+    )
+    .catch(() => []);
+  throw new Error(
+    `Create Session stayed disabled for lifecycle booking. pair=${context.pairKey} attempt=${context.attempt} startIso=${context.startIso} disabled=${disabled ?? "null"} ariaDisabled=${ariaDisabled ?? "null"} visibleErrors=${JSON.stringify(visibleErrors)}`,
+  );
+};
+
 export const buildBookingCandidateStarts = (
   terminalStatus = process.env.PW_LIFECYCLE_TERMINAL_STATUS,
 ): Date[] => {
@@ -663,6 +710,72 @@ const selectOptionWhenAvailable = async (
   return false;
 };
 
+export const cleanupBeforeNoResponseFailure = async (
+  cleanup: () => Promise<void>,
+  warn: (message: string, error?: unknown) => void = console.warn,
+  timeoutMs = CLEANUP_BEFORE_FAILURE_TIMEOUT_MS,
+): Promise<void> => {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const cleanupResult = Promise.resolve()
+    .then(cleanup)
+    .then(() => ({ kind: "ok" as const }))
+    .catch((error) => ({ kind: "error" as const, error }));
+  const timeoutResult = new Promise<{ kind: "timeout" }>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve({ kind: "timeout" }), Math.max(0, timeoutMs));
+    timeoutHandle.unref?.();
+  });
+
+  const result = await Promise.race([cleanupResult, timeoutResult]);
+  if (timeoutHandle) {
+    clearTimeout(timeoutHandle);
+  }
+  if (result.kind === "error") {
+    warn("[lifecycle] failed to clean up seeded program/goal before no-response failure", result.error);
+  } else if (result.kind === "timeout") {
+    warn(`[lifecycle] timed out cleaning up seeded program/goal before no-response failure (${timeoutMs}ms)`);
+  }
+};
+
+const selectTherapistClientPair = async (
+  page: Page,
+  therapistId: string,
+  clientId: string,
+): Promise<boolean> => {
+  const sequences: Array<Array<[string, string]>> = [
+    [
+      ["#client-select", clientId],
+      ["#therapist-select", therapistId],
+    ],
+    [
+      ["#therapist-select", therapistId],
+      ["#client-select", clientId],
+      ["#therapist-select", therapistId],
+    ],
+  ];
+
+  for (const sequence of sequences) {
+    let sequenceApplied = true;
+    for (const [selector, value] of sequence) {
+      sequenceApplied = (await selectOptionWhenAvailable(page, selector, value)) && sequenceApplied;
+      await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => undefined);
+      await page.waitForTimeout(250);
+    }
+    if (!sequenceApplied) {
+      continue;
+    }
+
+    const selectedValues = await page.evaluate(() => ({
+      therapistId: (document.querySelector("#therapist-select") as HTMLSelectElement | null)?.value ?? "",
+      clientId: (document.querySelector("#client-select") as HTMLSelectElement | null)?.value ?? "",
+    }));
+    if (selectedValues.therapistId === therapistId && selectedValues.clientId === clientId) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 const lifecyclePairKey = (therapistId: string, clientId: string): string => `${therapistId}:${clientId}`;
 
 async function chooseSessionTargetsExcluding(page: Page, excludedPairKeys: Set<string>): Promise<{
@@ -698,9 +811,12 @@ async function chooseSessionTargetsExcluding(page: Page, excludedPairKeys: Set<s
     if (excludedPairKeys.has(pairKey)) {
       continue;
     }
-    await page.selectOption("#therapist-select", therapistId);
     const seeded = await ensureProgramAndGoalForPair(therapistId, clientId);
-    await page.selectOption("#client-select", clientId);
+    const selectedPair = await selectTherapistClientPair(page, therapistId, clientId);
+    if (!selectedPair) {
+      await cleanupCreatedProgramGoal(seeded);
+      continue;
+    }
     const selectedProgram = await selectOptionWhenAvailable(page, "#program-select", seeded.programId);
     if (!selectedProgram) {
       await cleanupCreatedProgramGoal(seeded);
@@ -778,10 +894,15 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
       page.once("dialog", (dialog) => {
         void dialog.accept().catch(() => undefined);
       });
+      const createSessionButton = await expectCreateSessionButtonReady(page, {
+        pairKey: selected.pairKey,
+        attempt: attempt + 1,
+        startIso,
+      });
       const responsePromise = page
         .waitForResponse(
           (res) => res.url().includes("/api/book") && res.request().method() === "POST",
-          { timeout: 90_000 },
+          { timeout: UI_BOOK_RESPONSE_TIMEOUT_MS },
         )
         .then((response) => ({ kind: "response" as const, response }))
         .catch(() => null);
@@ -791,14 +912,21 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
           timeout: 2500,
         }),
         page.getByText(/No active programs found/i).first().waitFor({ state: "visible", timeout: 2500 }),
+        page
+          .getByText(/Therapist is required|Client is required|Program is required|Primary goal is required/i)
+          .first()
+          .waitFor({ state: "visible", timeout: 2500 }),
       ])
         .then(() => ({ kind: "blocked" as const }))
         .catch(() => new Promise<never>(() => undefined));
 
-      await page.getByRole("button", { name: /Create Session/i }).click();
+      await createSessionButton.click();
       const outcome = await Promise.race([responsePromise, blockedPromise]);
       if (!outcome) {
-        continue;
+        await cleanupBeforeNoResponseFailure(() => cleanupCreatedProgramGoal(selected));
+        throw new Error(
+          `Create Session clicked but no /api/book response or blocking validation appeared. pair=${selected.pairKey} attempt=${attempt + 1} startIso=${startIso}`,
+        );
       }
       if (outcome.kind === "blocked") {
         responsePromise.catch(() => undefined);

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { buildBookingCandidateStarts } from "../../scripts/playwright-session-lifecycle";
+import {
+  buildBookingCandidateStarts,
+  cleanupBeforeNoResponseFailure,
+  isCreateSessionButtonReady,
+} from "../../scripts/playwright-session-lifecycle";
 
 const originalGithubRunId = process.env.GITHUB_RUN_ID;
 const originalTerminalStatus = process.env.PW_LIFECYCLE_TERMINAL_STATUS;
@@ -32,5 +36,44 @@ describe("playwright session lifecycle booking starts", () => {
 
     expect(firstDayOffset).toBeGreaterThanOrEqual(21);
     expect(firstDayOffset).toBeLessThanOrEqual(41);
+  });
+
+  it("treats the Create Session button as ready only when enabled", () => {
+    expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: null })).toBe(true);
+    expect(isCreateSessionButtonReady({ disabled: "", ariaDisabled: null })).toBe(false);
+    expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: "true" })).toBe(false);
+  });
+
+  it("does not block the no-response failure when cleanup rejects", async () => {
+    const warnings: unknown[][] = [];
+
+    await expect(
+      cleanupBeforeNoResponseFailure(
+        () => Promise.reject(new Error("cleanup failed")),
+        (...args) => {
+          warnings.push(args);
+        },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(warnings).toHaveLength(1);
+    expect(String(warnings[0][0])).toContain("failed to clean up");
+  });
+
+  it("does not block the no-response failure when cleanup stalls", async () => {
+    const warnings: unknown[][] = [];
+
+    await expect(
+      cleanupBeforeNoResponseFailure(
+        () => new Promise<void>(() => undefined),
+        (...args) => {
+          warnings.push(args);
+        },
+        1,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(warnings).toHaveLength(1);
+    expect(String(warnings[0][0])).toContain("timed out");
   });
 });


### PR DESCRIPTION
## Summary
- keep the session lifecycle smoke on the Schedule modal UI booking path
- wait for the Create Session button to become enabled before clicking
- fail fast with pair/start diagnostics when no /api/book response or validation appears
- document the follow-up triage in the route coverage handoff

## Verification
- npx vitest run --config vitest.config.ts tests/scripts/playwright-session-lifecycle.test.ts
- npm run typecheck
- npm run lint
- npm run ci:check-focused
- npm run ci:verify-coverage
- VITE_SUPABASE_URL=https://test.supabase.co VITE_SUPABASE_ANON_KEY=anon-key npm run build
- npm run test:routes:tier0
- VITE_SUPABASE_URL=https://test.supabase.co VITE_SUPABASE_ANON_KEY=anon-key npm run test:ci

## Blocked locally
- npm run ci:playwright stops at playwright:preflight because protected Playwright credentials are not present in this shell: PW_SUPERADMIN_EMAIL/PW_SUPERADMIN_PASSWORD or PW_ADMIN_EMAIL/PW_ADMIN_PASSWORD

## Risk
- Critical lane/auth-session smoke harness change. This intentionally does not add a direct API fallback; it preserves the modal submit signal and only makes the existing UI path fail with useful diagnostics instead of hanging at the runner timeout.