### PR TITLE
Repair manage_admin_users advisor surface

### DIFF
--- a/docs/ai/manage-admin-users-advisor-repair-2026-06-28.md
+++ b/docs/ai/manage-admin-users-advisor-repair-2026-06-28.md
@@ -1,0 +1,37 @@
+# manage_admin_users Advisor Repair
+
+- classification: high-risk human-reviewed
+- lane: critical
+- live project: wnnjeqheqxxyrgsjmygy
+- scope: Repair live-proven `public.manage_admin_users` overload/grant drift only.
+- non-goals: Do not change `get_admin_users`, `get_admin_users_paged`, `assign_admin_role`, app auth code, RLS policies, or unrelated SECURITY DEFINER functions.
+- live evidence before repair:
+  - `public.manage_admin_users(operation text, target_user_id uuid)` existed as `SECURITY DEFINER` with `proconfig = null` and `authenticated_execute = true`.
+  - `public.manage_admin_users(operation text, target_user_id text, caller_organization_id uuid)` existed with `authenticated_execute = true` and `app_admin_executor_execute = true`.
+  - `public.manage_admin_users(operation text, target_user_id text)` existed with pinned `search_path=public, auth` and `authenticated_execute = true`; this remains intentional because current UI/server callers use it.
+- intended boundary:
+  - Authenticated browser/admin callers may use the current two-argument `manage_admin_users(text,text)` RPC, which performs its own active admin/super-admin checks.
+  - The explicit-organization three-argument overload remains callable only by `service_role` and `app_admin_executor`.
+  - Obsolete overloads are removed so stale search-path/security-definer state cannot remain exposed.
+- live evidence after repair:
+  - `public.manage_admin_users(operation text, target_user_id text)` remains `SECURITY DEFINER`, `search_path=public, auth`, `authenticated_execute = true`, `anon_execute = false`.
+  - `public.manage_admin_users(operation text, target_user_id text, caller_organization_id uuid)` remains `SECURITY DEFINER`, `search_path=public, auth`, `authenticated_execute = false`, `service_role_execute = true`, `app_admin_executor_execute = true`.
+  - No `public.manage_admin_users(operation text, target_user_id uuid)` row remains.
+- post-apply verification query:
+  - `select n.nspname as schema, p.proname, pg_get_function_identity_arguments(p.oid) as args, p.prosecdef as security_definer, p.proconfig, p.proacl, has_function_privilege('anon', p.oid, 'execute') as anon_execute, has_function_privilege('authenticated', p.oid, 'execute') as authenticated_execute, has_function_privilege('service_role', p.oid, 'execute') as service_role_execute, has_function_privilege('app_admin_executor', p.oid, 'execute') as app_admin_executor_execute from pg_proc p join pg_namespace n on n.oid = p.pronamespace where n.nspname = 'public' and p.proname = 'manage_admin_users' order by args;`
+- post-apply verification output:
+  - `manage_admin_users(operation text, target_user_id text)`: `security_definer=true`, `proconfig={search_path=public, auth}`, `anon_execute=false`, `authenticated_execute=true`, `service_role_execute=true`, `app_admin_executor_execute=false`.
+  - `manage_admin_users(operation text, target_user_id text, caller_organization_id uuid)`: `security_definer=true`, `proconfig={search_path=public, auth}`, `anon_execute=false`, `authenticated_execute=false`, `service_role_execute=true`, `app_admin_executor_execute=true`.
+- rollback:
+  - Dropped obsolete overloads have no automatic rollback because they were the stale advisor surface; recreate them only from the specific historical migration if a caller is deliberately reintroduced.
+  - To reopen the current explicit-org overload to authenticated callers: `grant execute on function public.manage_admin_users(text, text, uuid) to authenticated;`
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run verify:local` when local prerequisites allow it
+- reviewer: required before PR-ready state.
+- residual risk: Live migration touches privileged RPC grants and must receive human review before merge.

--- a/supabase/migrations/20260628221116_repair_manage_admin_users_advisor_surface.sql
+++ b/supabase/migrations/20260628221116_repair_manage_admin_users_advisor_surface.sql
@@ -1,0 +1,34 @@
+-- @migration-intent: Repair live Supabase advisor drift for obsolete manage_admin_users overloads and executor-only admin RPC grants.
+-- @migration-dependencies: 20251021123000_consolidate_manage_admin_users.sql,20260310190000_auth_access_hardening.sql,20260506170000_super_admin_admin_management_authz.sql
+-- @migration-rollback: No rollback for dropped obsolete overloads; restore them only from the specific historical migration if a caller is deliberately reintroduced. To reopen the explicit-org overload to authenticated callers, run: grant execute on function public.manage_admin_users(text, text, uuid) to authenticated;
+
+begin;
+
+set search_path = public;
+
+-- Remove obsolete overloads that are no longer used by the app and can retain
+-- stale SECURITY DEFINER/search_path state in hosted projects.
+drop function if exists public.manage_admin_users(text, uuid);
+drop function if exists public.manage_admin_users(text, text, jsonb);
+drop function if exists public.manage_admin_users(text, text, jsonb, text);
+drop function if exists public.manage_admin_users(text, uuid, jsonb);
+drop function if exists public.manage_admin_users(text, uuid, uuid);
+
+-- Preserve the intended executor/service-role caller path for the explicit-org
+-- overload without leaving it exposed to generic authenticated callers.
+do $$
+begin
+  if to_regprocedure('public.manage_admin_users(text,text,uuid)') is not null then
+    revoke execute on function public.manage_admin_users(text, text, uuid) from public;
+    revoke execute on function public.manage_admin_users(text, text, uuid) from anon;
+    revoke execute on function public.manage_admin_users(text, text, uuid) from authenticated;
+    grant execute on function public.manage_admin_users(text, text, uuid) to service_role;
+
+    if exists (select 1 from pg_roles where rolname = 'app_admin_executor') then
+      grant execute on function public.manage_admin_users(text, text, uuid) to app_admin_executor;
+    end if;
+  end if;
+end
+$$;
+
+commit;

--- a/tests/admins/manage_admin_users_advisor_surface.spec.ts
+++ b/tests/admins/manage_admin_users_advisor_surface.spec.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const migrationSql = () =>
+  readFileSync(
+    join(process.cwd(), 'supabase/migrations/20260628221116_repair_manage_admin_users_advisor_surface.sql'),
+    'utf-8',
+  );
+
+describe('manage_admin_users advisor repair migration', () => {
+  it('drops obsolete overloads that can retain stale security-definer search_path state', () => {
+    const sql = migrationSql();
+
+    expect(sql).toMatch(/drop function if exists public\.manage_admin_users\(text,\s*uuid\)/i);
+    expect(sql).toMatch(/drop function if exists public\.manage_admin_users\(text,\s*text,\s*jsonb\)/i);
+    expect(sql).toMatch(/drop function if exists public\.manage_admin_users\(text,\s*text,\s*jsonb,\s*text\)/i);
+    expect(sql).toMatch(/drop function if exists public\.manage_admin_users\(text,\s*uuid,\s*jsonb\)/i);
+    expect(sql).toMatch(/drop function if exists public\.manage_admin_users\(text,\s*uuid,\s*uuid\)/i);
+  });
+
+  it('keeps the explicit-org overload on executor/service-role grants only', () => {
+    const sql = migrationSql();
+
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text,\s*text,\s*uuid\) from public/i);
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text,\s*text,\s*uuid\) from anon/i);
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text,\s*text,\s*uuid\) from authenticated/i);
+    expect(sql).toMatch(/grant execute on function public\.manage_admin_users\(text,\s*text,\s*uuid\) to service_role/i);
+    expect(sql).toMatch(/grant execute on function public\.manage_admin_users\(text,\s*text,\s*uuid\) to app_admin_executor/i);
+  });
+
+  it('guards grant repair so replay is safe when the explicit-org overload is absent', () => {
+    const sql = migrationSql();
+
+    expect(sql).toMatch(/if to_regprocedure\('public\.manage_admin_users\(text,text,uuid\)'\) is not null then/i);
+  });
+
+  it('does not revoke the current two-argument browser admin RPC surface', () => {
+    const sql = migrationSql();
+
+    expect(sql).not.toMatch(/revoke execute on function public\.manage_admin_users\(text,\s*text\) from authenticated/i);
+    expect(sql).not.toMatch(/drop function if exists public\.manage_admin_users\(text,\s*text\)/i);
+  });
+
+  it('documents a concrete rollback command for the only narrowed current overload', () => {
+    const sql = migrationSql();
+
+    expect(sql).toMatch(/grant execute on function public\.manage_admin_users\(text,\s*text,\s*uuid\) to authenticated/i);
+    expect(sql).toMatch(/No rollback for dropped obsolete overloads/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Drops obsolete `public.manage_admin_users` overloads that retained stale SECURITY DEFINER/search_path state in the live Supabase project.
- Narrows `public.manage_admin_users(text,text,uuid)` execution to `service_role` and `app_admin_executor`, preserving the current authenticated two-argument admin RPC caller.
- Adds a focused migration contract test and protected-change handoff evidence with live post-apply grant/search_path proof.

## Live Supabase Evidence
Project: `wnnjeqheqxxyrgsjmygy`

Pre-repair: `manage_admin_users(text,uuid)` existed with `proconfig = null` and `authenticated_execute = true`; `manage_admin_users(text,text,uuid)` had `authenticated_execute = true`.

Post-repair: only `manage_admin_users(text,text)` and `manage_admin_users(text,text,uuid)` remain. Both have `search_path=public, auth`; the two-argument overload remains `authenticated_execute=true`; the three-argument overload is `authenticated_execute=false`, `service_role_execute=true`, `app_admin_executor_execute=true`.

## Verification
- `npx vitest run tests/admins/manage_admin_users_advisor_surface.spec.ts tests/admins/manage_admin_users.log.spec.ts` passed (2 files, 9 tests)
- `npm run ci:check-focused` passed
- commit hook `npm run ci:check-focused` passed
- `npx eslint tests/admins/manage_admin_users_advisor_surface.spec.ts --max-warnings 0 --no-warn-ignored` passed
- `npm run typecheck` passed
- `npm run test:ci` passed (334 files, 2043 tests)
- `npm run validate:tenant` passed
- `npm run build` passed

## Blockers
- Draft PR because Linear reauthentication is required before creating/linking the mandatory high-risk issue.
- `npm run lint` currently fails because ESLint traverses unrelated `.worktrees/pr695-auth-book-timeout/**` checkout files; scoped lint for the new test passed.