### PR TITLE
WIN-189 Preserve admin metadata overload

### DIFF
--- a/supabase/migrations/20260628221116_repair_manage_admin_users_advisor_surface.sql
+++ b/supabase/migrations/20260628221116_repair_manage_admin_users_advisor_surface.sql
@@ -1,6 +1,6 @@
 -- @migration-intent: Repair live Supabase advisor drift for obsolete manage_admin_users overloads and executor-only admin RPC grants.
 -- @migration-dependencies: 20251021123000_consolidate_manage_admin_users.sql,20260310190000_auth_access_hardening.sql,20260506170000_super_admin_admin_management_authz.sql
--- @migration-rollback: No rollback for dropped obsolete overloads; restore them only from the specific historical migration if a caller is deliberately reintroduced. To reopen the explicit-org overload to authenticated callers, run: grant execute on function public.manage_admin_users(text, text, uuid) to authenticated;
+-- @migration-rollback: No rollback for dropped obsolete overloads; restore them only from the specific historical migration if a caller is deliberately reintroduced. To reopen the explicit-org overload to authenticated callers, run: grant execute on function public.manage_admin_users(text, text, uuid) to authenticated; to remove the metadata compatibility wrapper after callers stop sending metadata, run: drop function public.manage_admin_users(text, text, jsonb);
 
 begin;
 
@@ -9,10 +9,32 @@ set search_path = public;
 -- Remove obsolete overloads that are no longer used by the app and can retain
 -- stale SECURITY DEFINER/search_path state in hosted projects.
 drop function if exists public.manage_admin_users(text, uuid);
-drop function if exists public.manage_admin_users(text, text, jsonb);
 drop function if exists public.manage_admin_users(text, text, jsonb, text);
 drop function if exists public.manage_admin_users(text, uuid, jsonb);
 drop function if exists public.manage_admin_users(text, uuid, uuid);
+
+-- src/server/rpc/admin.ts still sends a documented metadata argument for
+-- removeAdminUser. Keep that PostgREST signature available while delegating to
+-- the current two-argument implementation and replacing any stale definition.
+create or replace function public.manage_admin_users(
+  operation text,
+  target_user_id text,
+  metadata jsonb
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+begin
+  perform public.manage_admin_users(operation, target_user_id);
+end;
+$$;
+
+revoke execute on function public.manage_admin_users(text, text, jsonb) from public;
+revoke execute on function public.manage_admin_users(text, text, jsonb) from anon;
+revoke execute on function public.manage_admin_users(text, text, jsonb) from authenticated;
+grant execute on function public.manage_admin_users(text, text, jsonb) to service_role;
 
 -- Preserve the intended executor/service-role caller path for the explicit-org
 -- overload without leaving it exposed to generic authenticated callers.

--- a/tests/admins/manage_admin_users_advisor_surface.spec.ts
+++ b/tests/admins/manage_admin_users_advisor_surface.spec.ts
@@ -13,10 +13,21 @@ describe('manage_admin_users advisor repair migration', () => {
     const sql = migrationSql();
 
     expect(sql).toMatch(/drop function if exists public\.manage_admin_users\(text,\s*uuid\)/i);
-    expect(sql).toMatch(/drop function if exists public\.manage_admin_users\(text,\s*text,\s*jsonb\)/i);
     expect(sql).toMatch(/drop function if exists public\.manage_admin_users\(text,\s*text,\s*jsonb,\s*text\)/i);
     expect(sql).toMatch(/drop function if exists public\.manage_admin_users\(text,\s*uuid,\s*jsonb\)/i);
     expect(sql).toMatch(/drop function if exists public\.manage_admin_users\(text,\s*uuid,\s*uuid\)/i);
+  });
+
+  it('keeps a metadata overload for documented server removeAdminUser callers', () => {
+    const sql = migrationSql();
+
+    expect(sql).not.toMatch(/drop function if exists public\.manage_admin_users\(text,\s*text,\s*jsonb\)/i);
+    expect(sql).toMatch(/create or replace function public\.manage_admin_users\(\s*operation text,\s*target_user_id text,\s*metadata jsonb/i);
+    expect(sql).toMatch(/perform public\.manage_admin_users\(operation,\s*target_user_id\)/i);
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text,\s*text,\s*jsonb\) from public/i);
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text,\s*text,\s*jsonb\) from anon/i);
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text,\s*text,\s*jsonb\) from authenticated/i);
+    expect(sql).toMatch(/grant execute on function public\.manage_admin_users\(text,\s*text,\s*jsonb\) to service_role/i);
   });
 
   it('keeps the explicit-org overload on executor/service-role grants only', () => {


### PR DESCRIPTION
## Summary
- keep public.manage_admin_users(text,text,jsonb) available for documented removeAdminUser metadata payloads
- replace any stale metadata overload with a fixed-search_path wrapper that delegates to the current two-argument RPC
- keep metadata-overload execute narrowed to service_role and add a migration guard assertion

## Verification
- pass: npm test -- src/server/rpc/__tests__/admin.test.ts
- pass: direct SQL guard for preserving/recreating metadata overload and service_role grant
- pass: npm run ci:check-focused (DB-backed checks skipped locally because SUPABASE_DB_URL is not configured)
- pass: npm run validate:tenant
- pass: npm run typecheck
- pass: npm run build
- blocked locally: npm test -- tests/admins/manage_admin_users_advisor_surface.spec.ts in dependency-installed checkout fails before collection on html-encoding-sniffer/@exodus bytes ERR_REQUIRE_ESM; in clean worktree it cannot run until node_modules are installed
- blocked locally: npm run lint in original checkout walks unrelated .worktrees/pr695-auth-book-timeout lint failures outside this two-file diff

Linear: WIN-189