### PR TITLE
Add downloadable multi-target session trends chart

### DIFF
--- a/src/components/ClientDetails/ClientSessionTrendsTab.tsx
+++ b/src/components/ClientDetails/ClientSessionTrendsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   Chart as ChartJS,
@@ -10,8 +10,8 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { BarChart3, Inbox, Loader2 } from 'lucide-react';
-import type { ChartData, ChartOptions } from 'chart.js';
+import { BarChart3, Download, Inbox, Loader2 } from 'lucide-react';
+import type { Chart as ChartInstance, ChartData, ChartOptions, PointStyle } from 'chart.js';
 import type { Goal } from '../../types';
 import { fetchClientSessionNotes } from '../../lib/session-notes';
 import { useActiveOrganizationId } from '../../lib/organization';
@@ -51,13 +51,39 @@ const todayDate = (): string => toLocalDateInputValue(new Date());
 const formatPercent = (value: number): string =>
   Number.isInteger(value) ? `${value}%` : `${value.toFixed(1)}%`;
 
+const targetSeriesColors = [
+  '#2563eb',
+  '#a855f7',
+  '#84cc16',
+  '#f97316',
+  '#14b8a6',
+  '#ef4444',
+  '#0891b2',
+  '#db2777',
+  '#65a30d',
+  '#7c3aed',
+];
+
+const targetPointStyles: PointStyle[] = [
+  'circle',
+  'rectRot',
+  'triangle',
+  'rect',
+  'star',
+  'crossRot',
+  'cross',
+  'dash',
+  'line',
+  'rectRounded',
+];
+
 export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) {
   const organizationId = useActiveOrganizationId();
   const [displayPeriod, setDisplayPeriod] = useState<SessionTrendDisplayPeriod>('month');
   const [startDate, setStartDate] = useState(defaultStartDate);
   const [endDate, setEndDate] = useState(todayDate);
   const [selectedGoalId, setSelectedGoalId] = useState<string | null>(null);
-  const [selectedTargetKey, setSelectedTargetKey] = useState<string | null>(null);
+  const chartRef = useRef<ChartInstance<'line', Array<number | null>, string> | undefined>(undefined);
 
   const {
     data: sessionNotes = [],
@@ -123,10 +149,9 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
 
   const trendModel = useMemo(() => buildSessionTrendModel(sessionNotes, goals, {
     selectedGoalId,
-    selectedTargetKey,
     displayPeriod,
     dateRange: { startDate, endDate },
-  }), [displayPeriod, endDate, goals, selectedGoalId, selectedTargetKey, sessionNotes, startDate]);
+  }), [displayPeriod, endDate, goals, selectedGoalId, sessionNotes, startDate]);
 
   useEffect(() => {
     if (trendModel.selectedGoalId !== selectedGoalId) {
@@ -134,30 +159,79 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
     }
   }, [selectedGoalId, trendModel.selectedGoalId]);
 
-  useEffect(() => {
-    if (trendModel.selectedTargetKey !== selectedTargetKey) {
-      setSelectedTargetKey(trendModel.selectedTargetKey);
-    }
-  }, [selectedTargetKey, trendModel.selectedTargetKey]);
-
   const isLoading = isLoadingSessionNotes || isLoadingGoals;
   const error = sessionNotesError ?? goalsError;
 
-  const chartData = useMemo<ChartData<'line'>>(() => ({
-    labels: trendModel.buckets.map((bucket) => bucket.label),
-    datasets: [
-      {
-        label: 'Median trial performance',
-        data: trendModel.buckets.map((bucket) => bucket.median),
-        borderColor: '#2563eb',
-        backgroundColor: 'rgba(37, 99, 235, 0.15)',
-        pointBackgroundColor: '#2563eb',
+  const targetSeries = useMemo(() => trendModel.targetOptions.map((target, index) => {
+    const model = buildSessionTrendModel(sessionNotes, goals, {
+      selectedGoalId: trendModel.selectedGoalId,
+      selectedTargetKey: target.key,
+      displayPeriod,
+      dateRange: { startDate, endDate },
+    });
+
+    return {
+      target,
+      buckets: model.buckets,
+      evidence: model.includedEvidence,
+      color: targetSeriesColors[(index + Math.floor(index / targetPointStyles.length)) % targetSeriesColors.length],
+      pointStyle: targetPointStyles[index % targetPointStyles.length],
+    };
+  }).filter((series) => series.buckets.length > 0), [
+    displayPeriod,
+    endDate,
+    goals,
+    sessionNotes,
+    startDate,
+    trendModel.selectedGoalId,
+    trendModel.targetOptions,
+  ]);
+
+  const chartBuckets = useMemo(() => {
+    const bucketsByKey = new Map<string, string>();
+    targetSeries.forEach((series) => {
+      series.buckets.forEach((bucket) => {
+        bucketsByKey.set(bucket.bucketKey, bucket.label);
+      });
+    });
+
+    return Array.from(bucketsByKey.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, label]) => ({ key, label }));
+  }, [targetSeries]);
+
+  const chartEvidence = useMemo(() => targetSeries.flatMap((series) => series.evidence), [targetSeries]);
+
+  const chartData = useMemo<ChartData<'line', Array<number | null>, string>>(() => ({
+    labels: chartBuckets.map((bucket) => bucket.label),
+    datasets: targetSeries.map((series) => {
+      const bucketsByKey = new Map(series.buckets.map((bucket) => [bucket.bucketKey, bucket]));
+      return {
+        label: series.target.label,
+        data: chartBuckets.map((bucket) => bucketsByKey.get(bucket.key)?.median ?? null),
+        borderColor: series.color,
+        backgroundColor: `${series.color}26`,
+        pointBackgroundColor: series.color,
         pointBorderColor: '#ffffff',
         pointRadius: 4,
+        pointStyle: series.pointStyle,
+        spanGaps: true,
         tension: 0.25,
-      },
-    ],
-  }), [trendModel.buckets]);
+      };
+    }),
+  }), [chartBuckets, targetSeries]);
+
+  const handleDownloadGraph = () => {
+    const imageUrl = chartRef.current?.toBase64Image('image/png', 1);
+    if (!imageUrl) {
+      return;
+    }
+
+    const anchor = document.createElement('a');
+    anchor.href = imageUrl;
+    anchor.download = `session-trends-${client.id}-${todayDate()}.png`;
+    anchor.click();
+  };
 
   const chartOptions = useMemo<ChartOptions<'line'>>(() => ({
     responsive: true,
@@ -171,7 +245,9 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
         callbacks: {
           label: (context) => ` Median: ${formatPercent(Number(context.parsed.y ?? 0))}`,
           afterLabel: (context) => {
-            const bucket = trendModel.buckets[context.dataIndex];
+            const series = targetSeries[context.datasetIndex];
+            const bucketKey = chartBuckets[context.dataIndex]?.key;
+            const bucket = series?.buckets.find((entry) => entry.bucketKey === bucketKey);
             return bucket ? `Sessions: ${bucket.sampleSize}` : '';
           },
         },
@@ -196,9 +272,9 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
         },
       },
     },
-  }), [displayPeriod, trendModel.buckets]);
+  }), [chartBuckets, displayPeriod, targetSeries]);
 
-  const recentEvidence = trendModel.includedEvidence
+  const recentEvidence = chartEvidence
     .slice()
     .sort((left, right) => right.sessionDate.localeCompare(left.sessionDate))
     .slice(0, 10);
@@ -235,7 +311,6 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
             value={selectedGoalId ?? ''}
             onChange={(event) => {
               setSelectedGoalId(event.target.value || null);
-              setSelectedTargetKey(null);
             }}
             className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-dark dark:text-white"
             disabled={trendModel.goalOptions.length === 0}
@@ -252,23 +327,14 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
           </select>
         </label>
 
-        <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-          Target
-          <select
-            value={selectedTargetKey ?? ''}
-            onChange={(event) => setSelectedTargetKey(event.target.value || null)}
-            className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-dark dark:text-white"
-            disabled={trendModel.targetOptions.length === 0}
-          >
-            {trendModel.targetOptions.length === 0 ? (
-              <option value="">No target data</option>
-            ) : (
-              trendModel.targetOptions.map((target) => (
-                <option key={target.key} value={target.key}>{target.label}</option>
-              ))
-            )}
-          </select>
-        </label>
+        <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          Targets
+          <div className="mt-1 flex min-h-10 items-center rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-700 dark:border-gray-700 dark:bg-dark dark:text-gray-200">
+            {trendModel.targetOptions.length === 0
+              ? 'No target data'
+              : `${trendModel.targetOptions.length} separate target series`}
+          </div>
+        </div>
 
         <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
           Display
@@ -314,7 +380,7 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
         <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-100">
           {error instanceof Error ? error.message : 'Session trends failed to load.'}
         </div>
-      ) : trendModel.buckets.length === 0 ? (
+      ) : chartBuckets.length === 0 ? (
         <div className="rounded-md border border-dashed border-gray-300 p-8 text-center dark:border-gray-700">
           <Inbox className="mx-auto h-10 w-10 text-gray-400" />
           <h3 className="mt-3 text-sm font-semibold text-gray-900 dark:text-white">No graphable trial data</h3>
@@ -325,19 +391,29 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
       ) : (
         <>
           <div className="rounded-md border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-dark-lighter">
+            <div className="mb-3 flex justify-end">
+              <button
+                type="button"
+                onClick={handleDownloadGraph}
+                className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-700 dark:bg-dark dark:text-gray-200 dark:hover:bg-gray-800"
+              >
+                <Download className="mr-2 h-4 w-4" />
+                Download graph
+              </button>
+            </div>
             <div className="h-80">
-              <Line options={chartOptions} data={chartData} />
+              <Line ref={chartRef} options={chartOptions} data={chartData} />
             </div>
           </div>
 
           <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
             <div className="rounded-md border border-gray-200 p-4 dark:border-gray-700">
               <div className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Buckets</div>
-              <div className="mt-1 text-2xl font-semibold text-gray-900 dark:text-white">{trendModel.buckets.length}</div>
+              <div className="mt-1 text-2xl font-semibold text-gray-900 dark:text-white">{chartBuckets.length}</div>
             </div>
             <div className="rounded-md border border-gray-200 p-4 dark:border-gray-700">
               <div className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Included session points</div>
-              <div className="mt-1 text-2xl font-semibold text-gray-900 dark:text-white">{trendModel.includedEvidence.length}</div>
+              <div className="mt-1 text-2xl font-semibold text-gray-900 dark:text-white">{chartEvidence.length}</div>
             </div>
             <div className="rounded-md border border-gray-200 p-4 dark:border-gray-700">
               <div className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Excluded sessions</div>

--- a/src/components/__tests__/ClientSessionTrendsTab.test.tsx
+++ b/src/components/__tests__/ClientSessionTrendsTab.test.tsx
@@ -1,16 +1,25 @@
+import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '../../test/utils';
+import { fireEvent, screen, waitFor } from '../../test/utils';
 import { renderWithProviders } from '../../test/utils';
 import { ClientSessionTrendsTab } from '../ClientDetails/ClientSessionTrendsTab';
 import { fetchClientSessionNotes } from '../../lib/session-notes';
 import { supabase } from '../../lib/supabase';
 
 vi.mock('react-chartjs-2', () => ({
-  Line: ({ data }: { data: { labels: string[]; datasets: Array<{ data: number[] }> } }) => (
-    <div data-testid="session-trends-chart">
-      {data.labels.join(',')}:{data.datasets[0]?.data.join(',')}
-    </div>
-  ),
+  Line: React.forwardRef(({ data }: { data: { labels: string[]; datasets: Array<{ label: string; data: number[]; pointStyle?: string; borderColor?: string }> } }, ref) => {
+    if (ref && typeof ref !== 'function') {
+      ref.current = {
+        toBase64Image: vi.fn(() => 'data:image/png;base64,chart-image'),
+      };
+    }
+
+    return (
+      <div data-testid="session-trends-chart">
+        {data.labels.join(',')}:{data.datasets.map((dataset) => `${dataset.label}:${dataset.pointStyle}:${dataset.data.join('|')}:${dataset.borderColor}`).join(';')}
+      </div>
+    );
+  }),
 }));
 
 vi.mock('../../lib/session-notes', async () => {
@@ -47,6 +56,39 @@ const createGoalsBuilder = () => {
   return builder;
 };
 
+const createSessionNote = (
+  id: string,
+  date: string,
+  targetTrials: Array<{ target: string; metric_value: number; opportunities: number }>,
+) => ({
+  id,
+  date,
+  start_time: '09:00:00',
+  end_time: '10:00:00',
+  service_code: '97153',
+  therapist_name: 'Test Therapist',
+  therapist_id: 'therapist-1',
+  goals_addressed: ['Emergency scenarios'],
+  goal_ids: ['goal-1'],
+  goal_notes: null,
+  goal_measurements: {
+    'goal-1': {
+      version: 1,
+      data: {
+        measurement_type: 'percent accuracy',
+        targets: targetTrials.map((trial) => trial.target),
+        target_trials: targetTrials,
+      },
+    },
+  },
+  session_id: `session-${id}`,
+  narrative: 'Session note',
+  is_locked: false,
+  client_id: 'client-1',
+  authorization_id: 'auth-1',
+  organization_id: '5238e88b-6198-4862-80a2-dbe15bbeabdd',
+});
+
 describe('ClientSessionTrendsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -71,6 +113,7 @@ describe('ClientSessionTrendsTab', () => {
               targets: ['lost in community'],
               target_trials: [
                 { target: 'lost in community', metric_value: 8, opportunities: 10 },
+                { target: 'cross street safely', metric_value: 5, opportunities: 10 },
               ],
             },
           },
@@ -101,6 +144,7 @@ describe('ClientSessionTrendsTab', () => {
               targets: ['lost in community'],
               target_trials: [
                 { target: 'lost in community', metric_value: 10, opportunities: 10 },
+                { target: 'cross street safely', metric_value: 4, opportunities: 10 },
               ],
             },
           },
@@ -126,7 +170,7 @@ describe('ClientSessionTrendsTab', () => {
       auth: { role: 'admin', userId: 'admin-user-id' },
     });
 
-    await waitFor(() => expect(screen.getByTestId('session-trends-chart')).toHaveTextContent('Jun 2025:90'));
+    await waitFor(() => expect(screen.getByTestId('session-trends-chart')).toHaveTextContent('Jun 2025:lost in community'));
     expect(fetchClientSessionNotes).toHaveBeenCalledWith('client-1', '5238e88b-6198-4862-80a2-dbe15bbeabdd', {
       limit: null,
       startDate: '2024-12-01',
@@ -134,10 +178,104 @@ describe('ClientSessionTrendsTab', () => {
     });
     expect(screen.getByRole('heading', { name: /Session Trends/i })).toBeInTheDocument();
     expect(screen.getByLabelText('Goal')).toHaveTextContent('Safety: Emergency scenarios');
-    expect(screen.getByLabelText('Target')).toHaveTextContent('lost in community');
+    expect(screen.getByText('2 separate target series')).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Day' })).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
     expect(screen.getAllByText(/80%|100%/).length).toBeGreaterThan(0);
+  });
+
+  it('renders each target as a separate chart series with distinct point symbols', async () => {
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    const chart = await screen.findByTestId('session-trends-chart');
+
+    expect(chart).toHaveTextContent('lost in community:circle:90');
+    expect(chart).toHaveTextContent('cross street safely:rectRot:45');
+  });
+
+  it('keeps target point symbols distinct beyond six target series', async () => {
+    vi.mocked(fetchClientSessionNotes).mockResolvedValue([
+      createSessionNote(
+        'many-targets',
+        '2025-06-15',
+        Array.from({ length: 7 }, (_, index) => ({
+          target: `target ${index + 1}`,
+          metric_value: index + 1,
+          opportunities: 10,
+        })),
+      ),
+    ]);
+
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    const chart = await screen.findByTestId('session-trends-chart');
+
+    expect(chart).toHaveTextContent('target 1:circle:10');
+    expect(chart).toHaveTextContent('target 2:rectRot:20');
+    expect(chart).toHaveTextContent('target 3:triangle:30');
+    expect(chart).toHaveTextContent('target 4:rect:40');
+    expect(chart).toHaveTextContent('target 5:star:50');
+    expect(chart).toHaveTextContent('target 6:crossRot:60');
+    expect(chart).toHaveTextContent('target 7:cross:70');
+  });
+
+  it('keeps marker and color pairs distinct across the full target encoding cycle', async () => {
+    vi.mocked(fetchClientSessionNotes).mockResolvedValue([
+      createSessionNote(
+        'many-encoded-targets',
+        '2025-06-15',
+        Array.from({ length: 100 }, (_, index) => ({
+          target: `target ${index + 1}`,
+          metric_value: index + 1,
+          opportunities: 100,
+        })),
+      ),
+    ]);
+
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    const chart = await screen.findByTestId('session-trends-chart');
+    const encodings = (chart.textContent ?? '')
+      .split(';')
+      .map((entry) => {
+        const parts = entry.split(':');
+        return `${parts.at(-3)}:${parts.at(-1)}`;
+      });
+
+    expect(chart).toHaveTextContent('target 1:circle:1:#2563eb');
+    expect(chart).toHaveTextContent('target 11:circle:11:#a855f7');
+    expect(new Set(encodings).size).toBe(100);
+  });
+
+  it('exposes a download button for the rendered trend graph', async () => {
+    const originalCreateElement = document.createElement.bind(document);
+    const click = vi.fn();
+    const anchor = originalCreateElement('a');
+    anchor.click = click;
+    const createElement = vi.spyOn(document, 'createElement').mockImplementation((tagName, options) => {
+      if (tagName === 'a') {
+        return anchor;
+      }
+      return originalCreateElement(tagName, options);
+    });
+
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: /Download graph/i }));
+
+    expect(anchor.getAttribute('href')).toBe('data:image/png;base64,chart-image');
+    expect(anchor.getAttribute('download')).toMatch(/^session-trends-client-1-\d{4}-\d{2}-\d{2}\.png$/);
+    expect(click).toHaveBeenCalled();
+
+    createElement.mockRestore();
   });
 
   it('uses a stable month-start default range on month-end dates', async () => {


### PR DESCRIPTION
## Summary
- Add a Download graph button that exports the rendered Session Trends Chart.js canvas as a PNG.
- Render every target under the selected goal as its own line dataset with distinct colors and point symbols.
- Decouple marker/color wrapping so combined visual encodings stay unique across the full 100-pair cycle.
- Expand component tests to cover multi-target datasets, more than six target marker uniqueness, 100 unique marker/color pairs, and the download path.

## Verification
- PASS: npm run lint
- PASS: npm run typecheck
- PASS: bundled Node direct Vitest: node_modules/vitest/vitest.mjs run --config vitest.config.ts src/components/__tests__/ClientSessionTrendsTab.test.tsx --reporter=verbose (7 tests)
- PASS: npm run build
- PASS: npm run ci:check-focused (via commit hook; DB-backed checks skipped for missing SUPABASE_DB_URL/DATABASE_URL)
- NOTE: npm test wrapper on this machine uses system Node v20.17.0 and can fail before collection because html-encoding-sniffer requires @exodus/bytes via CommonJS; bundled Node v24.14.0 runs the targeted component test successfully.

## Risk
- UI-only change in src/components/**; no auth, server/API, Supabase, runtime config, deploy config, schema, or CI paths touched.