### PR TITLE
Refresh dashboard supervision notes due list

### DIFF
--- a/src/lib/__tests__/supervision-session-notes.test.ts
+++ b/src/lib/__tests__/supervision-session-notes.test.ts
@@ -14,6 +14,7 @@ import {
   completeSupervisionSessionNote,
   fetchPendingSupervisionSessionNoteCount,
   fetchPendingSupervisionSessionNoteRequests,
+  reconcilePendingSupervisionSessionNoteRequests,
 } from '../supervision-session-notes';
 
 describe('supervision session note data access', () => {
@@ -79,7 +80,7 @@ describe('supervision session note data access', () => {
 
     const result = await fetchPendingSupervisionSessionNoteRequests('org-1');
 
-    expect(rpcMock).toHaveBeenCalledWith('reconcile_supervision_session_note_requests', {});
+    expect(rpcMock).not.toHaveBeenCalled();
     expect(fromMock).toHaveBeenCalledWith('supervision_session_note_requests');
     expect(fromMock).toHaveBeenCalledWith('session_note_templates');
     expect(result.template?.id).toBe('template-1');
@@ -91,6 +92,15 @@ describe('supervision session note data access', () => {
         btTherapistTitle: 'BT',
       }),
     ]);
+  });
+
+  it('reconciles pending supervision requests through a separate tenant-checked RPC', async () => {
+    rpcMock.mockResolvedValue({ data: 1, error: null });
+
+    await reconcilePendingSupervisionSessionNoteRequests('org-1');
+
+    expect(rpcMock).toHaveBeenCalledWith('reconcile_supervision_session_note_requests', {});
+    expect(fromMock).not.toHaveBeenCalled();
   });
 
   it('completes structured responses through the tenant-checked RPC', async () => {

--- a/src/lib/supervision-session-notes.ts
+++ b/src/lib/supervision-session-notes.ts
@@ -110,11 +110,6 @@ export const fetchPendingSupervisionSessionNoteRequests = async (
     throw new Error('Organization context is required to load supervision note requests.');
   }
 
-  const reconcileResult = await callRpc('reconcile_supervision_session_note_requests', {});
-  if (reconcileResult.error) {
-    throw reconcileResult.error;
-  }
-
   const [requestsResult, templateResult] = await Promise.all([
     fromTable('supervision_session_note_requests')
       .select(`
@@ -151,6 +146,19 @@ export const fetchPendingSupervisionSessionNoteRequests = async (
     requests: ((requestsResult.data ?? []) as RequestRow[]).map(mapRequestRow),
     template: normalizeTemplate((templateResult.data ?? null) as TemplateRow | null),
   };
+};
+
+export const reconcilePendingSupervisionSessionNoteRequests = async (
+  organizationId: string,
+): Promise<void> => {
+  if (!organizationId) {
+    throw new Error('Organization context is required to reconcile supervision note requests.');
+  }
+
+  const reconcileResult = await callRpc('reconcile_supervision_session_note_requests', {});
+  if (reconcileResult.error) {
+    throw reconcileResult.error;
+  }
 };
 
 export type CompleteSupervisionSessionNoteInput = {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import { showError, showSuccess } from '../lib/toast';
 import {
   completeSupervisionSessionNote,
   fetchPendingSupervisionSessionNoteRequests,
+  reconcilePendingSupervisionSessionNoteRequests,
   type PendingSupervisionSessionNoteRequest,
   type SupervisionSessionNoteTemplate,
   type SupervisionTemplateField,
@@ -771,12 +772,33 @@ const Dashboard = () => {
     refreshConfig: { isLiveRole: boolean; intervalMs: number };
   };
 
+  const supervisionRequestsQueryKey = useMemo(
+    () => ['supervision-session-note-requests', organizationId ?? 'MISSING_ORG'] as const,
+    [organizationId],
+  );
+
+  const supervisionReconcileQuery = useQuery({
+    queryKey: ['supervision-session-note-requests', 'reconcile', organizationId ?? 'MISSING_ORG'],
+    queryFn: () => reconcilePendingSupervisionSessionNoteRequests(organizationId!),
+    enabled: canViewStaffDashboard && Boolean(organizationId) && hasAccessToken && !authLoading,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+
   const supervisionQuery = useQuery({
-    queryKey: ['supervision-session-note-requests', organizationId ?? 'MISSING_ORG'],
+    queryKey: supervisionRequestsQueryKey,
     queryFn: () => fetchPendingSupervisionSessionNoteRequests(organizationId!),
     enabled: canViewStaffDashboard && Boolean(organizationId) && hasAccessToken && !authLoading,
     staleTime: 30_000,
+    refetchInterval: 30_000,
   });
+
+  useEffect(() => {
+    if (!supervisionReconcileQuery.isSuccess) {
+      return;
+    }
+    void queryClient.invalidateQueries({ queryKey: supervisionRequestsQueryKey });
+  }, [queryClient, supervisionReconcileQuery.isSuccess, supervisionRequestsQueryKey]);
 
   const completeSupervisionMutation = useMutation({
     mutationFn: async (input: {

--- a/src/pages/__tests__/Dashboard.dashboardQueryGate.test.tsx
+++ b/src/pages/__tests__/Dashboard.dashboardQueryGate.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React from "react";
 import { render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -8,6 +8,27 @@ let capturedDashboardEnabled: boolean | undefined;
 let capturedActorScope:
   | { userId?: string | null; effectiveRole?: string | null; organizationId?: string | null }
   | undefined;
+
+const mockFetchPendingSupervisionSessionNoteRequests = vi.hoisted(() => vi.fn());
+const mockReconcilePendingSupervisionSessionNoteRequests = vi.hoisted(() => vi.fn());
+const mockUseQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: mockUseQuery,
+  };
+});
+
+vi.mock("../../lib/supervision-session-notes", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/supervision-session-notes")>();
+  return {
+    ...actual,
+    fetchPendingSupervisionSessionNoteRequests: mockFetchPendingSupervisionSessionNoteRequests,
+    reconcilePendingSupervisionSessionNoteRequests: mockReconcilePendingSupervisionSessionNoteRequests,
+  };
+});
 
 vi.mock("../../lib/optimizedQueries", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/optimizedQueries")>();
@@ -69,7 +90,22 @@ describe("Dashboard staff dashboard query gate", () => {
   beforeEach(() => {
     capturedDashboardEnabled = undefined;
     capturedActorScope = undefined;
+    mockFetchPendingSupervisionSessionNoteRequests.mockReset();
+    mockFetchPendingSupervisionSessionNoteRequests.mockResolvedValue({ requests: [], template: null });
+    mockReconcilePendingSupervisionSessionNoteRequests.mockReset();
+    mockReconcilePendingSupervisionSessionNoteRequests.mockResolvedValue(undefined);
+    mockUseQuery.mockReset();
+    mockUseQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
     mockUseAuth.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("disables useDashboardData until auth loading completes and a bearer exists", () => {
@@ -137,5 +173,39 @@ describe("Dashboard staff dashboard query gate", () => {
       effectiveRole: "admin",
       organizationId: "org-9",
     });
+  });
+
+  it("polls only read-only supervision note requests on the notification cadence", () => {
+    mockUseAuth.mockReturnValue(
+      authStub({
+        user: { id: "user-7" },
+        profile: { organization_id: "org-9" },
+        effectiveRole: "admin",
+        session: { access_token: "valid-token" } as import("@supabase/supabase-js").Session,
+        loading: false,
+        isAdmin: () => true,
+        isSuperAdmin: () => false,
+      }),
+    );
+
+    renderDashboard();
+
+    const queryConfigs = mockUseQuery.mock.calls.map(([config]) => config);
+    const listQuery = queryConfigs.find((config) =>
+      JSON.stringify(config.queryKey) === JSON.stringify(["supervision-session-note-requests", "org-9"]),
+    );
+    const reconcileQuery = queryConfigs.find((config) =>
+      JSON.stringify(config.queryKey) === JSON.stringify(["supervision-session-note-requests", "reconcile", "org-9"]),
+    );
+
+    expect(listQuery).toEqual(expect.objectContaining({
+      refetchInterval: 30_000,
+      staleTime: 30_000,
+    }));
+    expect(reconcileQuery).toEqual(expect.objectContaining({
+      staleTime: 5 * 60_000,
+      refetchOnWindowFocus: false,
+    }));
+    expect(reconcileQuery).not.toHaveProperty("refetchInterval");
   });
 });


### PR DESCRIPTION
## Summary
- Confirmed hosted Supabase has a pending supervision request for the closed Amaya Martinez / Aaliyah Jones BT session; request creation is working.
- Updated the Dashboard supervision notes query to refetch every 30 seconds, matching the sidebar badge polling cadence so the list does not remain stale after session close.
- Added a focused Dashboard query-gate test asserting the supervision requests query uses the notification cadence.

## Hosted evidence
- Project: `wnnjeqheqxxyrgsjmygy`
- Pending request exists for org `5238e88b-6198-4862-80a2-dbe15bbeabdd`
- Request status: `pending`; session status: `completed`; client: Amaya Martinez; BT: Aaliyah Jones; therapist title: BT

## Verification
- `npm test -- src/pages/__tests__/Dashboard.noFallback.test.tsx src/pages/__tests__/Dashboard.dashboardQueryGate.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run verify:local`

## Local verification notes
`npm run verify:local` passed. Repo scripts skipped DB-backed/CI-only checks where local env vars are absent: branch protection outside CI, privileged function DB grant check without `SUPABASE_DB_URL`, auth parity with `CI_SUPABASE_AUTH_PARITY_REQUIRED` disabled, sensitive-table RLS overlap without DB URL, and Supabase preview drift without `SUPABASE_DB_URL`.