### PR TITLE
WIN-192: fix CalOptima inline extraction parity

### DIFF
--- a/docs/ai/WIN-192-caloptima-inline-extraction-parity-handoff.md
+++ b/docs/ai/WIN-192-caloptima-inline-extraction-parity-handoff.md
@@ -1,0 +1,109 @@
+# WIN-192 CalOptima Inline Extraction Parity Handoff
+
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: the slice changes a protected Supabase edge function used by the CalOptima upload route and affects persisted extraction values
+- triggering paths:
+  - `supabase/functions/**`
+
+## Scope
+
+- task intent: repair hosted CalOptima upload extraction drift where adjacent inline labels collapse into the wrong scalar fields, then re-prove deployed extraction parity
+- files touched:
+  - `supabase/functions/extract-assessment-fields/index.ts`
+  - `supabase/functions/extract-assessment-fields/index.test.ts`
+- non-goals:
+  - no route/UI behavior changes
+  - no schema, RLS, grant, or migration changes
+  - no broader CalOptima mapping refactor
+- single-purpose diff: yes
+
+## Tenant Boundary
+
+- read/write boundary: extraction remains scoped to the existing uploaded assessment document for the current tenant/client context
+- guarantee preserved: this slice changes scalar parsing only; it does not widen org access, bypass auth, or introduce cross-tenant reads/writes
+- high-risk surface: `supabase/functions/extract-assessment-fields/index.ts`
+
+## Required Agents
+
+- required sequence:
+  - `specification-engineer`
+  - `software-architect`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+  - `security-engineer`
+- agents used:
+  - none
+- reviewer: blocked
+
+## Verification Card
+
+- change type:
+  - `server/API/edge integration`
+  - `database/RLS/migrations/tenant isolation`
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run verify:local`
+  - `deno test --node-modules-dir=auto --allow-read --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts --filter "adjacent CalOptima inline labels aligned to source values"`
+  - `deno test --node-modules-dir=auto --allow-read --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts`
+- executed checks:
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass via `npm run verify:local`
+  - `npm run typecheck`: pass
+  - `npm run test:ci`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+  - `npm run verify:local`: pass
+  - `deno test --node-modules-dir=auto --allow-read --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts --filter "adjacent CalOptima inline labels aligned to source values"`: pass after reproducing the failure pre-fix
+  - `deno test --node-modules-dir=auto --allow-read --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts`: pass
+- blocked checks:
+  - hosted production re-verification on fixed code -> blocked until PR merge and deploy
+- result: pass-with-blocked-checks
+- residual risk: local verification is clean, but current production still runs the pre-fix extractor until this branch is merged and deployed
+
+## Hosted Evidence
+
+- current hosted route status: operational
+- current hosted parity status before this fix: failed for retained CalOptima docs because several scalar fields were misaligned with uploaded source text
+- mismatched hosted examples observed during audit:
+  - `CALOPTIMA_FBA_CONTACT_PHONE = "Emma Jean Burgess"`
+  - `CALOPTIMA_FBA_SERVICE_INITIATION_DATE = "D ate services started with your agency"`
+  - `CALOPTIMA_FBA_DATE_ABA_FIRST_BEGAN = "D ate when ABA services started for this member"`
+  - `CALOPTIMA_FBA_IEP_DATE = "Did the ABA provider participate in the IEP/equivalent meeting(s)?"`
+  - `CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES = "(Full Name & credential)"`
+  - `CALOPTIMA_FBA_DIAGNOSES_ICD = "(including physical, mental health and medical diagnoses)"`
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes (`WIN-192`)
+- unrelated changes:
+  - `src/pages/__tests__/Schedule.event.test.tsx`
+  - `docs/ai/2026-06-30-staff-messaging-policy-advisor-drift-handoff.md`
+  - `supabase/migrations/20260630235958_repair_live_staff_messaging_policy_advisor_drift.sql`
+  - `tests/integration/staff-messaging-policy-advisor-drift.test.ts`
+- generated artifact drift: none in the intended diff
+- protected-path drift:
+  - `supabase/functions/extract-assessment-fields/index.ts`
+  - `supabase/functions/extract-assessment-fields/index.test.ts`
+- change summary: present
+- verification summary: present
+- pr-ready: no
+- pr handoff: missing push/PR/live-check evidence
+- required follow-up:
+  - stage only the extractor files plus this handoff
+  - push the branch and open a PR linked to `WIN-192`
+  - obtain protected-path human review
+  - merge/deploy, then rerun hosted CalOptima upload proof and row-level extraction audit
+
+## Handoff Summary
+
+This slice fixes a real hosted CalOptima extraction regression in the protected `extract-assessment-fields` edge function. The new coverage reproduces adjacent inline-label drift and the implementation adds narrow CalOptima-specific scalar parsing so guardian/phone, PCP, medications, service dates, IEP date, and diagnosis fields stay aligned to the uploaded source text. Local critical-lane verification passed, but production proof is still pending merge and deploy because the hosted site currently runs the old extractor.

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -1825,3 +1825,38 @@ Deno.test("mergeDeterministicFieldWithStructuredSummary keeps empty-only placeho
   });
   expect(merged.review_notes).toContain("empty template placeholder");
 });
+
+Deno.test("mergeDeterministicFieldWithStructuredSummary keeps real scalar values when structured payloads share the same key", () => {
+  const merged = __TESTING__.mergeDeterministicFieldWithStructuredSummary(
+    {
+      placeholder_key: "CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES",
+      value_text: "F84.0 Autism",
+      value_json: null,
+      confidence: 0.92,
+      mode: "AUTO",
+      status: "drafted",
+      source_span: { method: "caloptima_inline_pair" },
+      review_notes: "Deterministic scalar extracted from diagnostic table.",
+    },
+    {
+      count: 1,
+      firstPayload: {
+        field_key: "CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES",
+        section_key: "diagnostic_behavior_analysis",
+        rows: [{ code: "F84.0", description: "Autism" }],
+      },
+    },
+  );
+
+  expect(merged.value_text).toBe("F84.0 Autism");
+  expect(merged.value_json).toBeNull();
+  expect(merged.source_span).toMatchObject({
+    method: "caloptima_inline_pair",
+    structured_summary_count: 1,
+    structured_summary_payload: {
+      field_key: "CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES",
+      section_key: "diagnostic_behavior_analysis",
+    },
+  });
+  expect(merged.review_notes).toContain("Matching structured section payloads were also extracted");
+});

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -1278,6 +1278,92 @@ Deno.test("deterministicValueForRow extracts CalOptima filled-report scalars wit
   expect(byKey.get("CALOPTIMA_FBA_REPORT_COMPLETED_DATE")?.value_text).toBe("7/21/2025");
 });
 
+Deno.test("deterministicValueForRow keeps adjacent CalOptima inline labels aligned to source values", () => {
+  const rows = [
+    {
+      section: "identification_admin",
+      label: "Guardian Name",
+      placeholder_key: "CALOPTIMA_FBA_GUARDIAN_NAME",
+      required: true,
+      mode: "AUTO" as const,
+    },
+    {
+      section: "identification_admin",
+      label: "Phone (guardian/member)",
+      placeholder_key: "CALOPTIMA_FBA_CONTACT_PHONE",
+      required: true,
+      mode: "AUTO" as const,
+      extraction_aliases: ["Phone"],
+    },
+    {
+      section: "identification_admin",
+      label: "Primary Care Provider",
+      placeholder_key: "CALOPTIMA_FBA_PCP",
+      required: true,
+      mode: "ASSISTED" as const,
+    },
+    {
+      section: "identification_admin",
+      label: "Current Medications/Dosage",
+      placeholder_key: "CALOPTIMA_FBA_MEDICATIONS",
+      required: true,
+      mode: "ASSISTED" as const,
+    },
+    {
+      section: "identification_admin",
+      label: "Service Initiation Date",
+      placeholder_key: "CALOPTIMA_FBA_SERVICE_INITIATION_DATE",
+      required: true,
+      mode: "AUTO" as const,
+    },
+    {
+      section: "identification_admin",
+      label: "Date ABA first began",
+      placeholder_key: "CALOPTIMA_FBA_DATE_ABA_FIRST_BEGAN",
+      required: true,
+      mode: "ASSISTED" as const,
+    },
+    {
+      section: "background_school_history",
+      label: "Date of current IEP/equivalent",
+      placeholder_key: "CALOPTIMA_FBA_IEP_DATE",
+      required: true,
+      mode: "ASSISTED" as const,
+      extraction_aliases: ["Date of the current IEP/equivalent"],
+    },
+    {
+      section: "identification_admin",
+      label: "Diagnoses/with ICD Code",
+      placeholder_key: "CALOPTIMA_FBA_DIAGNOSES_ICD",
+      required: true,
+      mode: "AUTO" as const,
+    },
+    {
+      section: "diagnostic_behavior_analysis",
+      label: "Current diagnosis code(s)",
+      placeholder_key: "CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES",
+      required: true,
+      mode: "AUTO" as const,
+    },
+  ];
+
+  const byKey = new Map(rows.map((row) => [
+    row.placeholder_key,
+    __TESTING__.deterministicValueForRow(row, calOptimaRedactedStyleExcerpt, undefined, rows),
+  ]));
+
+  expect(byKey.get("CALOPTIMA_FBA_GUARDIAN_NAME")?.value_text).toBe("Sample Guardian");
+  expect(byKey.get("CALOPTIMA_FBA_CONTACT_PHONE")?.value_text).toBe("555-123-4567");
+  expect(byKey.get("CALOPTIMA_FBA_PCP")?.value_text).toBe("Dr. Sample Provider");
+  expect(byKey.get("CALOPTIMA_FBA_MEDICATIONS")?.value_text).toBe("N/A");
+  expect(byKey.get("CALOPTIMA_FBA_SERVICE_INITIATION_DATE")?.status).toBe("not_started");
+  expect(byKey.get("CALOPTIMA_FBA_SERVICE_INITIATION_DATE")?.value_text).toBeNull();
+  expect(byKey.get("CALOPTIMA_FBA_DATE_ABA_FIRST_BEGAN")?.value_text).toBe("7/1/2025");
+  expect(byKey.get("CALOPTIMA_FBA_IEP_DATE")?.value_text).toBe("6/1/2025");
+  expect(byKey.get("CALOPTIMA_FBA_DIAGNOSES_ICD")?.value_text).toBe("Autism F84.0");
+  expect(byKey.get("CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES")?.value_text).toBe("Autism Spectrum Disorder F84.0");
+});
+
 Deno.test("deterministicValueForRow preserves title-case parent involvement answer when agreement question is missing", () => {
   const value = __TESTING__.deterministicValueForRow(
     {

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -134,6 +134,19 @@ const calOptimaRedactedStyleExcerpt = `
   ** By signing, I attest that I have read, reviewed, and approved this proposed treatment plan.
 `;
 
+const calOptimaHostedPreviewStyleExcerpt = `
+  CalOptima Health Functional Behavior Assessment / Initial Treatment Plan
+  Diagnoses/with ICD Code: Autism F 84.0
+  Guardian Name: Phone: XXXX 123456789
+  Primary Care Provider: Known Allergies: Dr. Mostoufi Sayed 714-550-0110 N/A
+  Current Medications/Dosage: Dietary Restrictions: N/A N/A
+  Service Initiation Date Date ABA first began 7/1/2025 NA
+  Date of the current IEP/equivalent Pending
+  IX. DIAGNOSTIC INFORMATION
+  Current diagnosis code Diagnosis description Date of diagnosis/report Diagnosed by (Full Name & credential) F84.0 Autism 6 Doe Jhon CIN# 12345678A
+  X. FUNCTIONAL ASSESSMENT
+`;
+
 const iehpCompleteTemplateStyleExcerpt = `
   Header: Inland Empire Health Plan Functional Behavioral Assessment Report
   Page 1 of 30
@@ -1356,12 +1369,97 @@ Deno.test("deterministicValueForRow keeps adjacent CalOptima inline labels align
   expect(byKey.get("CALOPTIMA_FBA_CONTACT_PHONE")?.value_text).toBe("555-123-4567");
   expect(byKey.get("CALOPTIMA_FBA_PCP")?.value_text).toBe("Dr. Sample Provider");
   expect(byKey.get("CALOPTIMA_FBA_MEDICATIONS")?.value_text).toBe("N/A");
-  expect(byKey.get("CALOPTIMA_FBA_SERVICE_INITIATION_DATE")?.status).toBe("not_started");
-  expect(byKey.get("CALOPTIMA_FBA_SERVICE_INITIATION_DATE")?.value_text).toBeNull();
-  expect(byKey.get("CALOPTIMA_FBA_DATE_ABA_FIRST_BEGAN")?.value_text).toBe("7/1/2025");
+  expect(byKey.get("CALOPTIMA_FBA_SERVICE_INITIATION_DATE")?.value_text).toBe("7/1/2025");
+  expect(byKey.get("CALOPTIMA_FBA_DATE_ABA_FIRST_BEGAN")?.value_text).toBe("N/A");
   expect(byKey.get("CALOPTIMA_FBA_IEP_DATE")?.value_text).toBe("6/1/2025");
   expect(byKey.get("CALOPTIMA_FBA_DIAGNOSES_ICD")?.value_text).toBe("Autism F84.0");
   expect(byKey.get("CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES")?.value_text).toBe("Autism Spectrum Disorder F84.0");
+});
+
+Deno.test("deterministicValueForRow matches hosted CalOptima preview inline scalars from the uploaded PDF layout", () => {
+  const rows = [
+    {
+      section: "identification_admin",
+      label: "Guardian Name",
+      placeholder_key: "CALOPTIMA_FBA_GUARDIAN_NAME",
+      required: true,
+      mode: "AUTO" as const,
+    },
+    {
+      section: "identification_admin",
+      label: "Phone (guardian/member)",
+      placeholder_key: "CALOPTIMA_FBA_CONTACT_PHONE",
+      required: true,
+      mode: "AUTO" as const,
+      extraction_aliases: ["Phone"],
+    },
+    {
+      section: "identification_admin",
+      label: "Primary Care Provider",
+      placeholder_key: "CALOPTIMA_FBA_PCP",
+      required: true,
+      mode: "ASSISTED" as const,
+    },
+    {
+      section: "identification_admin",
+      label: "Current Medications/Dosage",
+      placeholder_key: "CALOPTIMA_FBA_MEDICATIONS",
+      required: true,
+      mode: "ASSISTED" as const,
+    },
+    {
+      section: "identification_admin",
+      label: "Service Initiation Date",
+      placeholder_key: "CALOPTIMA_FBA_SERVICE_INITIATION_DATE",
+      required: true,
+      mode: "AUTO" as const,
+    },
+    {
+      section: "identification_admin",
+      label: "Date ABA first began",
+      placeholder_key: "CALOPTIMA_FBA_DATE_ABA_FIRST_BEGAN",
+      required: true,
+      mode: "ASSISTED" as const,
+    },
+    {
+      section: "background_school_history",
+      label: "Date of current IEP/equivalent",
+      placeholder_key: "CALOPTIMA_FBA_IEP_DATE",
+      required: true,
+      mode: "ASSISTED" as const,
+      extraction_aliases: ["Date of the current IEP/equivalent"],
+    },
+    {
+      section: "identification_admin",
+      label: "Diagnoses/with ICD Code",
+      placeholder_key: "CALOPTIMA_FBA_DIAGNOSES_ICD",
+      required: true,
+      mode: "AUTO" as const,
+    },
+    {
+      section: "diagnostic_behavior_analysis",
+      label: "Current diagnosis code(s)",
+      placeholder_key: "CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES",
+      required: true,
+      mode: "AUTO" as const,
+    },
+  ];
+
+  const byKey = new Map(rows.map((row) => [
+    row.placeholder_key,
+    __TESTING__.deterministicValueForRow(row, calOptimaHostedPreviewStyleExcerpt, undefined, rows),
+  ]));
+
+  expect(byKey.get("CALOPTIMA_FBA_GUARDIAN_NAME")?.status).toBe("not_started");
+  expect(byKey.get("CALOPTIMA_FBA_GUARDIAN_NAME")?.value_text).toBeNull();
+  expect(byKey.get("CALOPTIMA_FBA_CONTACT_PHONE")?.value_text).toBe("XXXX 123456789");
+  expect(byKey.get("CALOPTIMA_FBA_PCP")?.value_text).toBe("Dr. Mostoufi Sayed");
+  expect(byKey.get("CALOPTIMA_FBA_MEDICATIONS")?.value_text).toBe("N/A");
+  expect(byKey.get("CALOPTIMA_FBA_SERVICE_INITIATION_DATE")?.value_text).toBe("7/1/2025");
+  expect(byKey.get("CALOPTIMA_FBA_DATE_ABA_FIRST_BEGAN")?.value_text).toBe("N/A");
+  expect(byKey.get("CALOPTIMA_FBA_IEP_DATE")?.value_text).toBe("Pending");
+  expect(byKey.get("CALOPTIMA_FBA_DIAGNOSES_ICD")?.value_text).toBe("Autism F 84.0");
+  expect(byKey.get("CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES")?.value_text).toBe("F84.0 Autism");
 });
 
 Deno.test("deterministicValueForRow preserves title-case parent involvement answer when agreement question is missing", () => {

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -2818,6 +2818,19 @@ const mergeDeterministicFieldWithStructuredSummary = (
     };
   }
 
+  if (hasExistingDeterministicValue(field)) {
+    return {
+      ...field,
+      source_span: {
+        ...(field.source_span ?? {}),
+        structured_summary_count: structuredSummary.count,
+        structured_summary_payload: structuredSummary.firstPayload,
+      },
+      review_notes:
+        `${field.review_notes ?? "Deterministic checklist value retained."} Matching structured section payloads were also extracted; review the structured section details before approval.`,
+    };
+  }
+
   return {
     ...field,
     value_text: `${structuredSummary.count} structured section${structuredSummary.count === 1 ? "" : "s"} extracted`,

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -1874,6 +1874,9 @@ const CALOPTIMA_NO_VALUE_MARKERS = [
 const looksLikeNoValueMarker = (value: string): boolean =>
   CALOPTIMA_NO_VALUE_MARKERS.includes(normalizeExtractedValue(value).toLowerCase() as typeof CALOPTIMA_NO_VALUE_MARKERS[number]);
 
+const CALOPTIMA_PHONE_PATTERN =
+  /((?:\(\d{3}\)\s*\d{3}[-\s]?\d{4})|(?:\d{3}[-\s]?\d{3}[-\s]?\d{4})|(?:X{3,}\s*\d{3,})|(?:\d{7,}))/i;
+
 const extractCaloptimaInlineGuardianAndPhone = (text: string): { guardianName: string | null; contactPhone: string | null } => {
   const compact = compactDocumentText(text);
   const match = compact.match(
@@ -1885,7 +1888,7 @@ const extractCaloptimaInlineGuardianAndPhone = (text: string): { guardianName: s
   }
 
   const phoneMatch = combined.match(
-    /((?:\(\d{3}\)\s*\d{3}[-\s]?\d{4})|(?:\d{3}[-\s]?\d{3}[-\s]?\d{4})|(?:X{3,}\s*\d{3,})|(?:\d{7,}))/i,
+    CALOPTIMA_PHONE_PATTERN,
   );
   const contactPhone = phoneMatch?.[1] ? normalizeExtractedValue(phoneMatch[1]) : null;
   const guardianCandidate = phoneMatch
@@ -1905,20 +1908,33 @@ const extractCaloptimaInlinePcpAndAllergies = (text: string): { pcp: string | nu
     return { pcp: null, allergies: null };
   }
 
-  const parts = combined.split(/\s{1,}/).filter(Boolean);
-  if (parts.length === 0) {
-    return { pcp: null, allergies: null };
-  }
-  const trailingMarker = parts[parts.length - 1] ?? "";
-  if (looksLikeNoValueMarker(trailingMarker)) {
-    const pcp = normalizeExtractedValue(parts.slice(0, -1).join(" "));
+  const phoneMatch = combined.match(CALOPTIMA_PHONE_PATTERN);
+  const trailingPhoneIndex = phoneMatch ? (phoneMatch.index ?? 0) + phoneMatch[0].length : -1;
+  const nameCandidate = phoneMatch
+    ? normalizeExtractedValue(combined.slice(0, phoneMatch.index ?? 0))
+    : combined;
+  const trailingValue = phoneMatch
+    ? normalizeExtractedValue(combined.slice(trailingPhoneIndex))
+    : "";
+  if (nameCandidate && trailingValue && looksLikeNoValueMarker(trailingValue)) {
     return {
-      pcp: pcp || null,
-      allergies: normalizeExtractedValue(trailingMarker),
+      pcp: nameCandidate,
+      allergies: trailingValue,
     };
   }
 
-  return { pcp: combined, allergies: null };
+  if (phoneMatch && nameCandidate) {
+    return { pcp: nameCandidate, allergies: null };
+  }
+
+  const parts = combined.split(/\s{1,}/).filter(Boolean);
+  const trailingMarker = parts[parts.length - 1] ?? "";
+  if (parts.length > 1 && looksLikeNoValueMarker(trailingMarker)) {
+    const pcp = normalizeExtractedValue(parts.slice(0, -1).join(" "));
+    return { pcp: pcp || null, allergies: normalizeExtractedValue(trailingMarker) };
+  }
+
+  return { pcp: nameCandidate || combined, allergies: null };
 };
 
 const extractCaloptimaInlineMedicationsAndDietary = (
@@ -1959,17 +1975,31 @@ const extractCaloptimaServiceDatePair = (
     return { serviceInitiationDate: null, dateAbaFirstBegan: null };
   }
 
-  const dateMatches = [...combined.matchAll(/\b\d{1,2}\/\d{1,2}\/\d{2,4}\b/g)].map((value) =>
-    normalizeExtractedValue(value[0] ?? "")
-  );
-  if (dateMatches.length >= 2) {
+  const orderedValues = combined
+    .split(/\s+/)
+    .map((value) => normalizeExtractedValue(value))
+    .filter((value) => value.length > 0)
+    .filter((value) => /\b\d{1,2}\/\d{1,2}\/\d{2,4}\b/.test(value) || looksLikeNoValueMarker(value));
+
+  const normalizeDateLikeValue = (value: string | undefined): string | null => {
+    if (!value) return null;
+    if (looksLikeNoValueMarker(value)) {
+      return "N/A";
+    }
+    return normalizeExtractedValue(value);
+  };
+
+  if (orderedValues.length >= 2) {
     return {
-      serviceInitiationDate: dateMatches[0] ?? null,
-      dateAbaFirstBegan: dateMatches[1] ?? null,
+      serviceInitiationDate: normalizeDateLikeValue(orderedValues[0]),
+      dateAbaFirstBegan: normalizeDateLikeValue(orderedValues[1]),
     };
   }
-  if (dateMatches.length === 1) {
-    return { serviceInitiationDate: null, dateAbaFirstBegan: dateMatches[0] ?? null };
+  if (orderedValues.length === 1) {
+    return {
+      serviceInitiationDate: normalizeDateLikeValue(orderedValues[0]),
+      dateAbaFirstBegan: null,
+    };
   }
 
   return { serviceInitiationDate: null, dateAbaFirstBegan: null };
@@ -1997,6 +2027,15 @@ const extractCaloptimaCurrentDiagnosisCodes = (text: string): string | null => {
   const compact = compactDocumentText(text);
   const section = extractSectionText(text, [/IX\.\s+DIAGNOSTIC\s+INFORMATION/i], [/X\.\s+FUNCTIONAL\s+ASSESSMENT/i]);
   const sectionCompact = compactDocumentText(section ?? compact);
+  const tableMatch = sectionCompact.match(
+    /Current\s+diagnosis\s+code\s+Diagnosis\s+description\s+Date\s+of\s+diagnosis\/report\s+Diagnosed\s+by\s+\(Full\s+Name\s*&\s*credential\)\s+([A-Z]\d{1,2}(?:\.\d+)?)\s+(.+?)(?=\s+(?:Pending|N\/A|\d{1,2}(?:\/\d{1,2}\/\d{2,4})?|\d{1,2})\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+\s+CIN#|\s+X\.\s+FUNCTIONAL\s+ASSESSMENT|$)/i,
+  );
+  if (tableMatch?.[1] && tableMatch[2]) {
+    const code = normalizeExtractedValue(tableMatch[1]);
+    const description = normalizeExtractedValue(tableMatch[2]);
+    const value = normalizeExtractedValue(`${code} ${description}`);
+    return value || null;
+  }
   const match = sectionCompact.match(
     /Current\s+diagnosis(?:\s+is)?\s+(.+?)(?=\.?\s+X\.\s+FUNCTIONAL\s+ASSESSMENT|$)/i,
   );

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -1863,11 +1863,187 @@ const extractSignatureScalarByKey = (key: string, text: string): string | null =
   return null;
 };
 
+const CALOPTIMA_NO_VALUE_MARKERS = [
+  "n/a",
+  "na",
+  "none",
+  "unknown",
+  "nkda",
+] as const;
+
+const looksLikeNoValueMarker = (value: string): boolean =>
+  CALOPTIMA_NO_VALUE_MARKERS.includes(normalizeExtractedValue(value).toLowerCase() as typeof CALOPTIMA_NO_VALUE_MARKERS[number]);
+
+const extractCaloptimaInlineGuardianAndPhone = (text: string): { guardianName: string | null; contactPhone: string | null } => {
+  const compact = compactDocumentText(text);
+  const match = compact.match(
+    /Guardian\s+Name\s*:?\s*Phone\s*:?\s*(.+?)(?=\s+Primary\s+Care\s+Provider\b|$)/i,
+  );
+  const combined = normalizeExtractedValue(match?.[1] ?? "");
+  if (!combined) {
+    return { guardianName: null, contactPhone: null };
+  }
+
+  const phoneMatch = combined.match(
+    /((?:\(\d{3}\)\s*\d{3}[-\s]?\d{4})|(?:\d{3}[-\s]?\d{3}[-\s]?\d{4})|(?:X{3,}\s*\d{3,})|(?:\d{7,}))/i,
+  );
+  const contactPhone = phoneMatch?.[1] ? normalizeExtractedValue(phoneMatch[1]) : null;
+  const guardianCandidate = phoneMatch
+    ? normalizeExtractedValue(combined.slice(0, phoneMatch.index ?? 0))
+    : combined;
+  const guardianName = guardianCandidate && !looksLikeNoValueMarker(guardianCandidate) ? guardianCandidate : null;
+  return { guardianName, contactPhone };
+};
+
+const extractCaloptimaInlinePcpAndAllergies = (text: string): { pcp: string | null; allergies: string | null } => {
+  const compact = compactDocumentText(text);
+  const match = compact.match(
+    /Primary\s+Care\s+Provider\s*:?\s*Known\s+Allergies\s*:?\s*(.+?)(?=\s+Current\s+Medications\/Dosage\b|$)/i,
+  );
+  const combined = normalizeExtractedValue(match?.[1] ?? "");
+  if (!combined) {
+    return { pcp: null, allergies: null };
+  }
+
+  const parts = combined.split(/\s{1,}/).filter(Boolean);
+  if (parts.length === 0) {
+    return { pcp: null, allergies: null };
+  }
+  const trailingMarker = parts[parts.length - 1] ?? "";
+  if (looksLikeNoValueMarker(trailingMarker)) {
+    const pcp = normalizeExtractedValue(parts.slice(0, -1).join(" "));
+    return {
+      pcp: pcp || null,
+      allergies: normalizeExtractedValue(trailingMarker),
+    };
+  }
+
+  return { pcp: combined, allergies: null };
+};
+
+const extractCaloptimaInlineMedicationsAndDietary = (
+  text: string,
+): { medications: string | null; dietaryRestrictions: string | null } => {
+  const compact = compactDocumentText(text);
+  const match = compact.match(
+    /Current\s+Medications\/Dosage\s*:?\s*Dietary\s+Restrictions\s*:?\s*(.+?)(?=\s+LMHP\b|\s+Contact\s+Number\b|$)/i,
+  );
+  const combined = normalizeExtractedValue(match?.[1] ?? "");
+  if (!combined) {
+    return { medications: null, dietaryRestrictions: null };
+  }
+
+  const tokens = combined.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    return { medications: null, dietaryRestrictions: null };
+  }
+  if (tokens.length >= 2 && looksLikeNoValueMarker(tokens[0])) {
+    return {
+      medications: normalizeExtractedValue(tokens[0]),
+      dietaryRestrictions: normalizeExtractedValue(tokens.slice(1).join(" ")) || null,
+    };
+  }
+
+  return { medications: combined, dietaryRestrictions: null };
+};
+
+const extractCaloptimaServiceDatePair = (
+  text: string,
+): { serviceInitiationDate: string | null; dateAbaFirstBegan: string | null } => {
+  const compact = compactDocumentText(text);
+  const match = compact.match(
+    /Service\s+Initiation\s+Date\s+Date\s+ABA\s+first\s+began\s+(.+?)(?=\s+Prior\s+Applied\s+Behavioral\s+Health\s+Agencies\b|$)/i,
+  );
+  const combined = normalizeExtractedValue(match?.[1] ?? "");
+  if (!combined) {
+    return { serviceInitiationDate: null, dateAbaFirstBegan: null };
+  }
+
+  const dateMatches = [...combined.matchAll(/\b\d{1,2}\/\d{1,2}\/\d{2,4}\b/g)].map((value) =>
+    normalizeExtractedValue(value[0] ?? "")
+  );
+  if (dateMatches.length >= 2) {
+    return {
+      serviceInitiationDate: dateMatches[0] ?? null,
+      dateAbaFirstBegan: dateMatches[1] ?? null,
+    };
+  }
+  if (dateMatches.length === 1) {
+    return { serviceInitiationDate: null, dateAbaFirstBegan: dateMatches[0] ?? null };
+  }
+
+  return { serviceInitiationDate: null, dateAbaFirstBegan: null };
+};
+
+const extractCaloptimaIepDate = (text: string): string | null => {
+  const compact = compactDocumentText(text);
+  const match = compact.match(
+    /Date\s+of\s+the?\s*current\s+IEP\/equivalent\s+(.+?)(?=\s+Individualized\s+Educational\s+Plan\s+\(IEP\/equivalent\)\s+Information\b|\s+PREVIOUS\s+INTERVENTIONS\b|\s+Did\s+the\s+ABA\s+provider\b|$)/i,
+  );
+  const dateMatch = normalizeExtractedValue(match?.[1] ?? "").match(/\b\d{1,2}\/\d{1,2}\/\d{2,4}\b/);
+  return dateMatch?.[0] ? normalizeExtractedValue(dateMatch[0]) : null;
+};
+
+const extractCaloptimaDiagnosesIcd = (text: string): string | null => {
+  const compact = compactDocumentText(text);
+  const match = compact.match(
+    /Diagnoses\/with\s+ICD\s+Code\s*:?\s*(.+?)(?=\s+Guardian\s+Name\b|\s+IX\.\s+DIAGNOSTIC\s+INFORMATION\b|$)/i,
+  );
+  const value = normalizeExtractedValue(match?.[1] ?? "");
+  return value || null;
+};
+
+const extractCaloptimaCurrentDiagnosisCodes = (text: string): string | null => {
+  const compact = compactDocumentText(text);
+  const section = extractSectionText(text, [/IX\.\s+DIAGNOSTIC\s+INFORMATION/i], [/X\.\s+FUNCTIONAL\s+ASSESSMENT/i]);
+  const sectionCompact = compactDocumentText(section ?? compact);
+  const match = sectionCompact.match(
+    /Current\s+diagnosis(?:\s+is)?\s+(.+?)(?=\.?\s+X\.\s+FUNCTIONAL\s+ASSESSMENT|$)/i,
+  );
+  const value = normalizeExtractedValue(match?.[1] ?? "");
+  return value || null;
+};
+
+const extractCaloptimaInlineScalarByKey = (key: string, text: string): string | null => {
+  if (key === "CALOPTIMA_FBA_GUARDIAN_NAME") {
+    return extractCaloptimaInlineGuardianAndPhone(text).guardianName;
+  }
+  if (key === "CALOPTIMA_FBA_CONTACT_PHONE") {
+    return extractCaloptimaInlineGuardianAndPhone(text).contactPhone;
+  }
+  if (key === "CALOPTIMA_FBA_PCP") {
+    return extractCaloptimaInlinePcpAndAllergies(text).pcp;
+  }
+  if (key === "CALOPTIMA_FBA_MEDICATIONS") {
+    return extractCaloptimaInlineMedicationsAndDietary(text).medications;
+  }
+  if (key === "CALOPTIMA_FBA_SERVICE_INITIATION_DATE") {
+    return extractCaloptimaServiceDatePair(text).serviceInitiationDate;
+  }
+  if (key === "CALOPTIMA_FBA_DATE_ABA_FIRST_BEGAN") {
+    return extractCaloptimaServiceDatePair(text).dateAbaFirstBegan;
+  }
+  if (key === "CALOPTIMA_FBA_IEP_DATE") {
+    return extractCaloptimaIepDate(text);
+  }
+  if (key === "CALOPTIMA_FBA_DIAGNOSES_ICD") {
+    return extractCaloptimaDiagnosesIcd(text);
+  }
+  if (key === "CALOPTIMA_FBA_CURRENT_DIAGNOSIS_CODES") {
+    return extractCaloptimaCurrentDiagnosisCodes(text);
+  }
+  return null;
+};
+
 const extractSpecialScalarByKey = (
   row: z.infer<typeof checklistRowSchema>,
   text: string,
 ): ExtractedFieldResult | null => {
   const key = row.placeholder_key;
+  const calOptimaInline = extractCaloptimaInlineScalarByKey(key, text);
+  if (calOptimaInline) {
+    return makeAutoField(row, calOptimaInline, { method: "caloptima_inline_pair", key }, text);
+  }
   const checkbox = extractCheckboxScalarByKey(key, text);
   if (checkbox) {
     return makeAutoField(row, checkbox, { method: "checkbox_yes_no", key }, text);


### PR DESCRIPTION
## Summary
- fix CalOptima inline scalar extraction when adjacent labels collapse together in hosted upload text
- add regression coverage for guardian/phone, PCP, medications, service dates, IEP date, and diagnosis fields
- record the critical-lane handoff and verification summary for WIN-192

## Problem
Hosted CalOptima uploads were reaching drafted status, but retained extraction rows showed several scalar values misaligned with the uploaded source text. The bug was in `supabase/functions/extract-assessment-fields` when inline label/value pairs were compacted together.

## Verification
- deno test --node-modules-dir=auto --allow-read --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts --filter "adjacent CalOptima inline labels aligned to source values"
- deno test --node-modules-dir=auto --allow-read --allow-env=WS_NO_BUFFER_UTIL --allow-net=0.0.0.0:8000 supabase/functions/extract-assessment-fields/index.test.ts
- npm run ci:check-focused
- npm run typecheck
- npm run test:ci
- npm run validate:tenant
- npm run build
- npm run verify:local

## Remaining blocker
Production parity still needs to be re-proved after this PR is merged and deployed, because current hosted evidence was gathered against the pre-fix extractor.

Refs: WIN-192