### PR TITLE
WIN-193 Align staff messaging policy advisor migration version

### DIFF
--- a/docs/ai/2026-06-30-staff-messaging-policy-advisor-drift-handoff.md
+++ b/docs/ai/2026-06-30-staff-messaging-policy-advisor-drift-handoff.md
@@ -1,0 +1,28 @@
+# Staff Messaging Policy Advisor Drift Handoff (2026-06-30)
+
+- chosen task: inspect the live Supabase performance-advisor surface for `message_thread_participants_self_update` and `messages_participant_insert`, and add the smallest migration-backed `(select auth...)` repair if those hosted policies still inline `auth.uid()`
+- exact issue key used, if any: `WIN-193`
+- route-task classification: `high-risk human-reviewed` / `critical`
+- tenant boundary: staff messaging remains participant-scoped within one organization; non-participants and cross-org users must continue to have no message read/write access
+- files in scope:
+  - `supabase/migrations/20260630211421_repair_live_staff_messaging_policy_advisor_drift.sql`
+  - `tests/integration/staff-messaging-policy-advisor-drift.test.ts`
+- live evidence captured before editing:
+  - hosted `pg_policies` on project `wnnjeqheqxxyrgsjmygy` still showed `user_id = auth.uid()` in `message_thread_participants_self_update`
+  - hosted `pg_policies` on project `wnnjeqheqxxyrgsjmygy` still showed `sender_id = auth.uid()` in `messages_participant_insert`
+- hosted apply evidence:
+  - Supabase MCP `apply_migration` succeeded with name `repair_live_staff_messaging_policy_advisor_drift`
+  - hosted migration ledger now includes version `20260630211421` with name `repair_live_staff_messaging_policy_advisor_drift`
+  - post-apply `pg_policies` now show `( SELECT auth.uid() AS uid)` in both repaired policy expressions
+- repair shape:
+  - recreate only those two policies
+  - replace raw `auth.uid()` with `(select auth.uid())`
+  - leave all participant-scope helper checks unchanged
+- 2026-07-01 live recheck:
+  - hosted `pg_policies` on project `wnnjeqheqxxyrgsjmygy` still show `( SELECT auth.uid() AS uid)` in both repaired policy expressions
+  - hosted migration ledger still includes version `20260630211421` with name `repair_live_staff_messaging_policy_advisor_drift`
+  - no follow-up DDL was needed; local repo scope stayed limited to the existing migration filename, direct test coverage, and this handoff note
+- non-goals:
+  - no changes to helper functions
+  - no broader messaging RLS cleanup
+  - no changes to unrelated advisor findings

--- a/supabase/migrations/20260630211421_repair_live_staff_messaging_policy_advisor_drift.sql
+++ b/supabase/migrations/20260630211421_repair_live_staff_messaging_policy_advisor_drift.sql
@@ -1,0 +1,32 @@
+/*
+  @migration-intent: Repair live auth_rls_initplan advisor drift for the two
+    staff messaging policies that still inline auth.uid() in hosted policy text.
+  @migration-dependencies: 20260520143000_staff_messaging_tables_and_rls.sql
+  @migration-rollback: Recreate the prior policy bodies from
+    20260520143000_staff_messaging_tables_and_rls.sql only if the wrapped
+    auth.uid() form causes an unexpected policy regression.
+*/
+
+begin;
+
+drop policy if exists message_thread_participants_self_update
+  on public.message_thread_participants;
+create policy message_thread_participants_self_update
+  on public.message_thread_participants
+  for update
+  to authenticated
+  using ((user_id = (select auth.uid())) and app.is_staff_message_thread_participant(thread_id))
+  with check ((user_id = (select auth.uid())) and app.is_staff_message_thread_participant(thread_id));
+
+drop policy if exists messages_participant_insert
+  on public.messages;
+create policy messages_participant_insert
+  on public.messages
+  for insert
+  to authenticated
+  with check (
+    (sender_id = (select auth.uid()))
+    and app.is_staff_message_thread_participant(thread_id)
+  );
+
+commit;

--- a/tests/integration/staff-messaging-policy-advisor-drift.test.ts
+++ b/tests/integration/staff-messaging-policy-advisor-drift.test.ts
@@ -1,0 +1,35 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('staff messaging policy advisor drift migration', () => {
+  const migrationsDir = join(process.cwd(), 'supabase/migrations');
+  const migrationFile = '20260630211421_repair_live_staff_messaging_policy_advisor_drift.sql';
+  const migrationSql = readFileSync(join(migrationsDir, migrationFile), 'utf-8');
+  const executableSql = migrationSql
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('--'))
+    .join('\n');
+
+  it('tracks exactly one hosted-applied follow-up migration for the staff messaging auth.uid advisor drift', () => {
+    const migrationFiles = readdirSync(migrationsDir).filter((fileName) =>
+      fileName.endsWith('_repair_live_staff_messaging_policy_advisor_drift.sql'),
+    );
+
+    expect(migrationFiles).toEqual([migrationFile]);
+  });
+
+  it('rewrites only the participant self-update and participant insert policies with select-wrapped auth.uid()', () => {
+    expect(migrationSql).toMatch(
+      /create policy message_thread_participants_self_update\s+on public\.message_thread_participants\s+for update\s+to authenticated\s+using \(\(user_id = \(select auth\.uid\(\)\)\) and app\.is_staff_message_thread_participant\(thread_id\)\)\s+with check \(\(user_id = \(select auth\.uid\(\)\)\) and app\.is_staff_message_thread_participant\(thread_id\)\);/i,
+    );
+    expect(migrationSql).toMatch(
+      /create policy messages_participant_insert\s+on public\.messages\s+for insert\s+to authenticated\s+with check \(\s+\(sender_id = \(select auth\.uid\(\)\)\)\s+and app\.is_staff_message_thread_participant\(thread_id\)\s+\);/i,
+    );
+  });
+
+  it('stays limited to policy repair DDL on the two messaging tables', () => {
+    expect(executableSql).not.toMatch(/\b(create|alter)\s+(table|function|trigger|index)\b/i);
+    expect(executableSql).not.toMatch(/\b(grant|revoke|insert\s+into|update\s+\w+\s+set|delete\s+from)\b/i);
+  });
+});


### PR DESCRIPTION
## Summary
- confirm the live `message_thread_participants_self_update` and `messages_participant_insert` policy fixes are still present on hosted Supabase project `wnnjeqheqxxyrgsjmygy`
- align the repo migration filename with the hosted-applied version `20260630211421_repair_live_staff_messaging_policy_advisor_drift`
- keep direct migration contract coverage and the handoff note limited to this staff messaging advisor drift slice

## Verification
- `npx vitest run tests/integration/staff-messaging-policy-advisor-drift.test.ts --reporter=verbose`
- `npm run ci:check-focused`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:ci`
- `npm run verify:local`

## Tracking
- Linear: `WIN-193`