### PR TITLE
Repair supervision session note request FK advisor indexes

### DIFF
--- a/supabase/migrations/20260701135040_repair_supervision_session_note_request_fk_covering_indexes.sql
+++ b/supabase/migrations/20260701135040_repair_supervision_session_note_request_fk_covering_indexes.sql
@@ -1,0 +1,19 @@
+-- @migration-intent: Repair live Supabase performance advisor drift for unindexed foreign keys on public.supervision_session_note_requests.
+-- @migration-dependencies: 20260629233000_create_supervision_session_note_workflow.sql
+-- @migration-scope: Index-only; no table, RLS, grant, RPC, or data changes.
+-- @migration-rollback: drop index if exists public.supervision_session_note_requests_bt_therapist_id_idx; drop index if exists public.supervision_session_note_requests_client_id_idx; drop index if exists public.supervision_session_note_requests_requested_by_idx;
+
+begin;
+
+set search_path = public;
+
+create index if not exists supervision_session_note_requests_bt_therapist_id_idx
+  on public.supervision_session_note_requests (bt_therapist_id);
+
+create index if not exists supervision_session_note_requests_client_id_idx
+  on public.supervision_session_note_requests (client_id);
+
+create index if not exists supervision_session_note_requests_requested_by_idx
+  on public.supervision_session_note_requests (requested_by);
+
+commit;

--- a/tests/supervisionSessionNoteRequestIndexAdvisorMigration.test.ts
+++ b/tests/supervisionSessionNoteRequestIndexAdvisorMigration.test.ts
@@ -1,0 +1,38 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('supervision session note request advisor index migration', () => {
+  const migrationsDir = join(process.cwd(), 'supabase/migrations');
+  const migrationFile = '20260701135040_repair_supervision_session_note_request_fk_covering_indexes.sql';
+  const migrationSql = readFileSync(join(migrationsDir, migrationFile), 'utf-8');
+  const executableSql = migrationSql
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('--'))
+    .join('\n');
+
+  it('tracks exactly one hosted follow-up migration for the supervision request foreign-key advisor repair', () => {
+    const migrationFiles = readdirSync(migrationsDir).filter((fileName) =>
+      fileName.endsWith('_repair_supervision_session_note_request_fk_covering_indexes.sql'),
+    );
+
+    expect(migrationFiles).toEqual([migrationFile]);
+  });
+
+  it('covers the three advisor-reported foreign key columns', () => {
+    expect(migrationSql).toMatch(
+      /create index if not exists supervision_session_note_requests_bt_therapist_id_idx\s+on public\.supervision_session_note_requests \(bt_therapist_id\);/i,
+    );
+    expect(migrationSql).toMatch(
+      /create index if not exists supervision_session_note_requests_client_id_idx\s+on public\.supervision_session_note_requests \(client_id\);/i,
+    );
+    expect(migrationSql).toMatch(
+      /create index if not exists supervision_session_note_requests_requested_by_idx\s+on public\.supervision_session_note_requests \(requested_by\);/i,
+    );
+  });
+
+  it('stays limited to index-only DDL', () => {
+    expect(executableSql).not.toMatch(/\b(create|alter|drop)\s+(table|policy|function|trigger)\b/i);
+    expect(executableSql).not.toMatch(/\b(grant|revoke|insert|update|delete)\b/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add an index-only migration for `supervision_session_note_requests.bt_therapist_id`, `client_id`, and `requested_by`
- add a focused migration test proving the repair stays limited to the three advisor-reported foreign keys
- apply the same migration to live Supabase project `wnnjeqheqxxyrgsjmygy` and verify the three indexes exist

## Verification
- `npx vitest run tests/supervisionSessionNoteRequestIndexAdvisorMigration.test.ts` ✅
- `npm run ci:check-focused` ✅
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run validate:tenant` ✅
- `npm run build` ✅
- `npm run test:ci` ⚠️ blocked by existing env-dependent `src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts` failures requiring `VITE_SUPABASE_URL`; one earlier run also ended with a coverage `.tmp` ENOENT after suite execution
- `npm run verify:local` ⚠️ blocked for the same `test:ci` reason

## Live Supabase proof
- July 1, 2026 13:53 UTC: applied `repair_supervision_session_note_request_fk_covering_indexes` to `wnnjeqheqxxyrgsjmygy`
- Post-apply catalog query shows:
  - `supervision_session_note_requests_bt_therapist_id_idx`
  - `supervision_session_note_requests_client_id_idx`
  - `supervision_session_note_requests_requested_by_idx`
- Post-apply performance advisor no longer lists the three `supervision_session_note_requests` foreign-key warnings

## Tracking
- Linear: WIN-190
