### PR TITLE
[codex] Add employee role capability matrix

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -19,9 +19,23 @@ declare global {
 }
 
 // Custom login command for route testing
-const roleFromEmail = (email: string): 'client' | 'therapist' | 'admin' | 'super_admin' => {
+type AppRole = 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin';
+
+const roleFromEmail = (email: string): AppRole => {
   if (email.includes('superadmin')) {
     return 'super_admin';
+  }
+  if (email.includes('admin_schedule')) {
+    return 'admin_schedule';
+  }
+  if (email.includes('midtier')) {
+    return 'midtier';
+  }
+  if (email.includes('bcba')) {
+    return 'bcba';
+  }
+  if (email.includes('bt')) {
+    return 'bt';
   }
   if (email.includes('therapist')) {
     return 'therapist';
@@ -32,7 +46,7 @@ const roleFromEmail = (email: string): 'client' | 'therapist' | 'admin' | 'super
   return 'client';
 };
 
-const buildSupabaseUser = (params: { id: string; email: string; role: 'client' | 'therapist' | 'admin' | 'super_admin'; nowIso: string }) => {
+const buildSupabaseUser = (params: { id: string; email: string; role: AppRole; nowIso: string }) => {
   const { id, email, role, nowIso } = params;
 
   return {

--- a/cypress/support/routeScenarios.ts
+++ b/cypress/support/routeScenarios.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-export type AppRole = "client" | "therapist" | "admin" | "super_admin";
+export type AppRole = "client" | "bt" | "therapist" | "midtier" | "admin_schedule" | "admin" | "bcba" | "super_admin";
 export type RouteScenario = {
   path: string;
   roles: readonly (AppRole | "public")[];
@@ -14,7 +14,16 @@ export const roleEmail = (role: AppRole): string => (
   role === "super_admin" ? "superadmin@test.com" : `${role}@test.com`
 );
 
-export const roles: readonly AppRole[] = ["client", "therapist", "admin", "super_admin"];
+export const roles: readonly AppRole[] = [
+  "client",
+  "bt",
+  "therapist",
+  "midtier",
+  "admin_schedule",
+  "admin",
+  "bcba",
+  "super_admin",
+];
 
 export const routeGroups = {
   public: [
@@ -28,45 +37,45 @@ export const routeGroups = {
     { path: "/unauthorized", roles: ["public"] },
   ],
   client: [
-    { path: "/", roles: ["client", "therapist", "admin", "super_admin"] },
-    { path: "/clients", roles: ["therapist", "admin", "super_admin"] },
-    { path: "/clients/client-1", roles: ["therapist", "admin", "super_admin"] },
-    { path: "/documentation", roles: ["client", "therapist", "admin", "super_admin"] },
-    { path: "/authorizations", roles: ["admin", "super_admin"] },
+    { path: "/", roles: ["client", "bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
+    { path: "/clients", roles: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
+    { path: "/clients/client-1", roles: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
+    { path: "/documentation", roles: ["client", "bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
+    { path: "/authorizations", roles: ["midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
     { path: "/family", roles: [] },
   ],
   schedule: [
-    { path: "/schedule", roles: ["therapist", "admin", "super_admin"] },
+    { path: "/schedule", roles: ["therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
   ],
   messages: [
-    { path: "/messages", roles: ["therapist", "admin", "super_admin"] },
-    { path: "/messages/new", roles: ["therapist", "admin", "super_admin"] },
-    { path: "/messages/thread-1", roles: ["therapist", "admin", "super_admin"] },
+    { path: "/messages", roles: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
+    { path: "/messages/new", roles: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
+    { path: "/messages/thread-1", roles: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
   ],
   admin: [
-    { path: "/therapists", roles: ["admin", "super_admin"] },
-    { path: "/therapists/therapist-1", roles: ["therapist", "admin", "super_admin"] },
-    { path: "/therapists/new", roles: ["admin", "super_admin"] },
-    { path: "/billing", roles: ["admin", "super_admin"] },
-    { path: "/monitoring", roles: ["admin", "super_admin"] },
-    { path: "/monitoringdashboard", roles: ["admin", "super_admin"], expectedPath: "/monitoring" },
-    { path: "/reports", roles: ["admin", "super_admin"] },
-    { path: "/settings", roles: ["admin", "super_admin"] },
+    { path: "/therapists", roles: ["admin_schedule", "admin", "bcba", "super_admin"] },
+    { path: "/therapists/therapist-1", roles: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
+    { path: "/therapists/new", roles: ["admin_schedule", "admin", "bcba", "super_admin"] },
+    { path: "/billing", roles: ["admin", "bcba", "super_admin"] },
+    { path: "/monitoring", roles: ["admin", "bcba", "super_admin"] },
+    { path: "/monitoringdashboard", roles: ["admin", "bcba", "super_admin"], expectedPath: "/monitoring" },
+    { path: "/reports", roles: ["admin", "bcba", "super_admin"] },
+    { path: "/settings", roles: ["admin", "bcba", "super_admin"] },
     {
       path: "/settings/feature-flags",
-      roles: ["admin", "super_admin"],
-      expectedPathByRole: { admin: "/settings", super_admin: "/settings/feature-flags" },
+      roles: ["admin", "bcba", "super_admin"],
+      expectedPathByRole: { admin: "/settings", bcba: "/settings/feature-flags", super_admin: "/settings/feature-flags" },
     },
     {
       path: "/settings/impersonation",
-      roles: ["admin", "super_admin"],
-      expectedPathByRole: { admin: "/settings", super_admin: "/settings/impersonation" },
+      roles: ["admin", "bcba", "super_admin"],
+      expectedPathByRole: { admin: "/settings", bcba: "/settings/impersonation", super_admin: "/settings/impersonation" },
     },
-    { path: "/superadminfeatureflags", roles: ["admin", "super_admin"], expectedPath: "/settings" },
-    { path: "/superadminimpersonation", roles: ["admin", "super_admin"], expectedPath: "/settings" },
-    { path: "/super-admin/feature-flags", roles: ["super_admin"] },
-    { path: "/super-admin/impersonation", roles: ["super_admin"] },
-    { path: "/super-admin/prompts", roles: ["super_admin"] },
+    { path: "/superadminfeatureflags", roles: ["admin", "bcba", "super_admin"], expectedPath: "/settings" },
+    { path: "/superadminimpersonation", roles: ["admin", "bcba", "super_admin"], expectedPath: "/settings" },
+    { path: "/super-admin/feature-flags", roles: ["bcba", "super_admin"] },
+    { path: "/super-admin/impersonation", roles: ["bcba", "super_admin"] },
+    { path: "/super-admin/prompts", roles: ["bcba", "super_admin"] },
   ],
 } satisfies Record<string, readonly RouteScenario[]>;
 

--- a/scripts/ci/check-e2e-reliability-gates.mjs
+++ b/scripts/ci/check-e2e-reliability-gates.mjs
@@ -158,9 +158,9 @@ const run = async () => {
     }
   }
 
-  const scheduleRoleContract = 'roles: ["therapist", "admin", "super_admin"]';
+  const scheduleRoleContract = 'roles: ["therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"]';
   if (!routeScenarios.includes(scheduleRoleContract)) {
-    errors.push("cypress/support/routeScenarios.ts must align /schedule role coverage to therapist/admin/super_admin.");
+    errors.push("cypress/support/routeScenarios.ts must align /schedule role coverage to therapist/midtier/admin_schedule/admin/bcba/super_admin.");
   }
   if (!combinedRouteSpecs.includes("runRoleMatrix")) {
     errors.push("split Cypress route specs must use runRoleMatrix for deterministic role coverage.");

--- a/scripts/route-audit.ts
+++ b/scripts/route-audit.ts
@@ -13,7 +13,7 @@ import {
   type PreviewServerHandle,
 } from './lib/preview-runtime';
 
-type Role = 'public' | 'client' | 'therapist' | 'admin' | 'super_admin';
+type Role = 'public' | 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin';
 
 type ApiCallRecord = {
   readonly url: string;
@@ -98,47 +98,47 @@ export const ROUTES: readonly RouteDefinition[] = [
   { path: '/unauthorized', component: 'Unauthorized', roles: ['public'], permissions: [] },
 
   // Protected routes
-  { path: '/', component: 'Dashboard', roles: ['client', 'therapist', 'admin', 'super_admin'], permissions: [] },
-  { path: '/schedule', component: 'Schedule', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
-  { path: '/clients', component: 'Clients', roles: ['therapist', 'admin', 'super_admin'], permissions: ['view_clients'] },
+  { path: '/', component: 'Dashboard', roles: ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/schedule', component: 'Schedule', roles: ['therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/clients', component: 'Clients', roles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: ['view_clients'] },
   {
     path: '/clients/:clientId',
     component: 'ClientDetails',
-    roles: ['therapist', 'admin', 'super_admin'],
+    roles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     permissions: ['view_clients'],
   },
-  { path: '/clients/new', component: 'ClientOnboarding', roles: ['admin', 'super_admin'], permissions: [] },
-  { path: '/therapists', component: 'Therapists', roles: ['admin', 'super_admin'], permissions: [] },
+  { path: '/clients/new', component: 'ClientOnboarding', roles: ['admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/therapists', component: 'Therapists', roles: ['admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
   {
     path: '/therapists/:therapistId',
     component: 'TherapistDetails',
-    roles: ['therapist', 'admin', 'super_admin'],
+    roles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     permissions: [],
   },
-  { path: '/therapists/new', component: 'TherapistOnboarding', roles: ['admin', 'super_admin'], permissions: [] },
-  { path: '/documentation', component: 'Documentation', roles: ['client', 'therapist', 'admin', 'super_admin'], permissions: [] },
-  { path: '/fill-docs', component: 'FillDocs', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
-  { path: '/authorizations', component: 'Authorizations', roles: ['admin', 'super_admin'], permissions: [] },
-  { path: '/messages', component: 'MessagesInbox', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
-  { path: '/messages/new', component: 'MessagesNew', roles: ['therapist', 'admin', 'super_admin'], permissions: [] },
+  { path: '/therapists/new', component: 'TherapistOnboarding', roles: ['admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/documentation', component: 'Documentation', roles: ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/fill-docs', component: 'FillDocs', roles: ['therapist', 'midtier', 'admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/authorizations', component: 'Authorizations', roles: ['midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/messages', component: 'MessagesInbox', roles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/messages/new', component: 'MessagesNew', roles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
   {
     path: '/messages/:threadId',
     component: 'MessageThread',
-    roles: ['therapist', 'admin', 'super_admin'],
+    roles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     permissions: [],
   },
-  { path: '/billing', component: 'Billing', roles: ['admin', 'super_admin'], permissions: [] },
-  { path: '/monitoring', component: 'MonitoringDashboard', roles: ['admin', 'super_admin'], permissions: [] },
-  { path: '/reports', component: 'Reports', roles: ['admin', 'super_admin'], permissions: [] },
+  { path: '/billing', component: 'Billing', roles: ['admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/monitoring', component: 'MonitoringDashboard', roles: ['admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/reports', component: 'Reports', roles: ['admin', 'bcba', 'super_admin'], permissions: [] },
   { path: '/family', component: 'FamilyDashboard', roles: ['client'], permissions: [] },
-  { path: '/settings', component: 'Settings', roles: ['admin', 'super_admin'], permissions: [] },
-  { path: '/settings/:tabId', component: 'Settings', roles: ['admin', 'super_admin'], permissions: [] },
-  { path: '/super-admin/feature-flags', component: 'SuperAdminFeatureFlags', roles: ['super_admin'], permissions: [] },
-  { path: '/super-admin/impersonation', component: 'SuperAdminImpersonation', roles: ['super_admin'], permissions: [] },
-  { path: '/super-admin/prompts', component: 'SuperAdminPrompts', roles: ['super_admin'], permissions: [] },
+  { path: '/settings', component: 'Settings', roles: ['admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/settings/:tabId', component: 'Settings', roles: ['admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/super-admin/feature-flags', component: 'SuperAdminFeatureFlags', roles: ['bcba', 'super_admin'], permissions: [] },
+  { path: '/super-admin/impersonation', component: 'SuperAdminImpersonation', roles: ['bcba', 'super_admin'], permissions: [] },
+  { path: '/super-admin/prompts', component: 'SuperAdminPrompts', roles: ['bcba', 'super_admin'], permissions: [] },
 ];
 
-const TEST_ROLES: readonly Role[] = ['client', 'therapist', 'admin', 'super_admin'];
+const TEST_ROLES: readonly Role[] = ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'];
 
 type ApiEndpointEntry = {
   readonly type: 'table' | 'function' | 'edge_function';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,7 @@ const LoadingSpinner = () => (
 );
 
 const DashboardLanding: React.FC = () => {
-  const { user, profile, loading, profileLoading, isGuardian, effectiveRole } = useAuth();
+  const { user, profile, loading, profileLoading, isGuardian, effectiveRole, hasCapability } = useAuth();
 
   if (loading || (user && profileLoading && !profile)) {
     return (
@@ -100,7 +100,7 @@ const DashboardLanding: React.FC = () => {
     return <Dashboard />;
   }
 
-  if (effectiveRole === 'therapist') {
+  if (hasCapability('viewSchedule')) {
     return <Navigate to="/schedule" replace />;
   }
 
@@ -173,49 +173,49 @@ function App() {
 
                     {/* Schedule - accessible to therapists and above */}
                     <Route path="schedule" element={
-                      <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                      <RoleGuard roles={['therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']}>
                         <Schedule />
                       </RoleGuard>
                     } />
 
                     {/* Clients - accessible to therapists and above */}
                     <Route path="clients" element={
-                      <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                      <RoleGuard roles={['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']}>
                         <Clients />
                       </RoleGuard>
                     } />
                     
                     {/* Client Onboarding - admin and super_admin only */}
                     <Route path="clients/new" element={
-                      <RoleGuard roles={['admin', 'super_admin']}>
+                      <RoleGuard roles={['admin_schedule', 'admin', 'bcba', 'super_admin']}>
                         <ClientOnboardingPage />
                       </RoleGuard>
                     } />
 
                     {/* Client Details - accessible to therapists and above */}
                     <Route path="clients/:clientId" element={
-                      <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                      <RoleGuard roles={['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']}>
                         <ClientDetails />
                       </RoleGuard>
                     } />
 
                     {/* Therapists - admin and super_admin only */}
                     <Route path="therapists" element={
-                      <RoleGuard roles={['admin', 'super_admin']}>
+                      <RoleGuard roles={['admin_schedule', 'admin', 'bcba', 'super_admin']}>
                         <Therapists />
                       </RoleGuard>
                     } />
 
                     {/* Therapist Details - accessible to admins and the therapist themselves */}
                     <Route path="therapists/:therapistId" element={
-                      <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                      <RoleGuard roles={['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']}>
                         <TherapistDetails />
                       </RoleGuard>
                     } />
 
                     {/* Therapist Onboarding - admin and super_admin only */}
                     <Route path="therapists/new" element={
-                      <RoleGuard roles={['admin', 'super_admin']}>
+                      <RoleGuard roles={['admin_schedule', 'admin', 'bcba', 'super_admin']}>
                         <TherapistOnboardingPage />
                       </RoleGuard>
                     } />
@@ -227,7 +227,7 @@ function App() {
                     <Route
                       path="fill-docs"
                       element={(
-                        <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                        <RoleGuard roles={['therapist', 'midtier', 'admin', 'bcba', 'super_admin']}>
                           <FillDocs />
                         </RoleGuard>
                       )}
@@ -235,7 +235,7 @@ function App() {
 
                     {/* Authorizations - accessible to admins and above */}
                     <Route path="authorizations" element={
-                      <RoleGuard roles={['admin', 'super_admin']}>
+                      <RoleGuard roles={['midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']}>
                         <Authorizations />
                       </RoleGuard>
                     } />
@@ -244,7 +244,7 @@ function App() {
                     <Route
                       path="messages"
                       element={(
-                        <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                        <RoleGuard roles={['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']}>
                           <MessagesInbox />
                         </RoleGuard>
                       )}
@@ -252,7 +252,7 @@ function App() {
                     <Route
                       path="messages/new"
                       element={(
-                        <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                        <RoleGuard roles={['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']}>
                           <MessagesNew />
                         </RoleGuard>
                       )}
@@ -260,7 +260,7 @@ function App() {
                     <Route
                       path="messages/:threadId"
                       element={(
-                        <RoleGuard roles={['therapist', 'admin', 'super_admin']}>
+                        <RoleGuard roles={['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']}>
                           <MessageThread />
                         </RoleGuard>
                       )}
@@ -268,14 +268,14 @@ function App() {
 
                     {/* Billing - admin and super_admin only */}
                     <Route path="billing" element={
-                      <RoleGuard roles={['admin', 'super_admin']}>
+                      <RoleGuard roles={['admin', 'bcba', 'super_admin']}>
                         <Billing />
                       </RoleGuard>
                     } />
 
                     {/* Monitoring Dashboard - admin and super_admin only */}
                     <Route path="monitoring" element={
-                      <RoleGuard roles={['admin', 'super_admin']}>
+                      <RoleGuard roles={['admin', 'bcba', 'super_admin']}>
                         <MonitoringDashboard />
                       </RoleGuard>
                     } />
@@ -286,7 +286,7 @@ function App() {
                     
                     {/* Reports - admin and super_admin only */}
                     <Route path="reports" element={
-                      <RoleGuard roles={['admin', 'super_admin']}>
+                      <RoleGuard roles={['admin', 'bcba', 'super_admin']}>
                         <Reports />
                       </RoleGuard>
                     } />
@@ -303,12 +303,12 @@ function App() {
 
                     {/* Settings - admin and super_admin only */}
                     <Route path="settings" element={
-                      <RoleGuard roles={['admin', 'super_admin']}>
+                      <RoleGuard roles={['admin', 'bcba', 'super_admin']}>
                         <Settings />
                       </RoleGuard>
                     } />
                     <Route path="settings/:tabId" element={
-                      <RoleGuard roles={['admin', 'super_admin']}>
+                      <RoleGuard roles={['admin', 'bcba', 'super_admin']}>
                         <Settings />
                       </RoleGuard>
                     } />
@@ -317,7 +317,7 @@ function App() {
                     <Route
                       path="super-admin/feature-flags"
                       element={
-                        <RoleGuard roles={['super_admin']}>
+                        <RoleGuard roles={['bcba', 'super_admin']}>
                           <SuperAdminFeatureFlags />
                         </RoleGuard>
                       }
@@ -325,7 +325,7 @@ function App() {
                     <Route
                       path="super-admin/impersonation"
                       element={
-                        <RoleGuard roles={['super_admin']}>
+                        <RoleGuard roles={['bcba', 'super_admin']}>
                           <SuperAdminImpersonation />
                         </RoleGuard>
                       }
@@ -333,7 +333,7 @@ function App() {
                     <Route
                       path="super-admin/prompts"
                       element={
-                        <RoleGuard roles={['super_admin']}>
+                        <RoleGuard roles={['bcba', 'super_admin']}>
                           <SuperAdminPrompts />
                         </RoleGuard>
                       }

--- a/src/components/AddSessionNoteModal.tsx
+++ b/src/components/AddSessionNoteModal.tsx
@@ -88,8 +88,8 @@ export function AddSessionNoteModal({
   isSaving = false,
   existingNote = null,
 }: AddSessionNoteModalProps) {
-  const { profile } = useAuth();
-  const canLockSessionNotes = profile?.role === 'admin' || profile?.role === 'super_admin';
+  const { hasCapability } = useAuth();
+  const canLockSessionNotes = hasCapability('lockSessionNotes');
   const organizationId = useActiveOrganizationId();
   const isMinWidthSm = useMinWidthSm();
   const [date, setDate] = useState(new Date().toISOString().split('T')[0]);

--- a/src/components/ClientDetails/ProfileTab.tsx
+++ b/src/components/ClientDetails/ProfileTab.tsx
@@ -14,6 +14,7 @@ import type { Note, Issue } from '../../types';
 import { useClientIssues, useClientNotes } from '../../lib/clients/hooks';
 import { useAuth } from '../../lib/authContext';
 import { useActiveOrganizationId } from '../../lib/organization';
+import type { AppRole } from '../../lib/roles';
 
 interface ProfileTabProps {
   client: {
@@ -31,7 +32,7 @@ interface ProfileTabProps {
     gender?: string;
     cin_number?: string;
   };
-  viewerRole?: 'client' | 'therapist' | 'admin' | 'super_admin';
+  viewerRole?: AppRole;
 }
 
 export function ProfileTab({ client, viewerRole }: ProfileTabProps) {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,8 +7,8 @@ import { preloadRouteModule } from '../lib/routeModulePrefetch';
 import { RouteLoadingSkeleton } from './RouteLoadingSkeleton';
 
 export function Layout() {
-  const { user, effectiveRole, profileLoading, hasAnyRole, isGuardian } = useAuth();
-  const invalidateIndexStaffQueries = !profileLoading && hasAnyRole(['therapist', 'admin', 'super_admin']);
+  const { user, effectiveRole, profileLoading, hasCapability, isGuardian } = useAuth();
+  const invalidateIndexStaffQueries = !profileLoading && hasCapability('viewClients');
   useRouteQueryRefetch({ invalidateIndexStaffQueries });
 
   useEffect(() => {

--- a/src/components/RoleGuard.tsx
+++ b/src/components/RoleGuard.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useRef } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../lib/authContext';
+import type { AppRole } from '../lib/roles';
 import { logger } from '../lib/logger/logger';
 import { RouteGuardPending } from './RouteGuardPending';
 
 interface RoleGuardProps {
   children: React.ReactNode;
-  roles: ('client' | 'therapist' | 'admin' | 'super_admin')[];
+  roles: AppRole[];
   fallback?: React.ReactNode;
   requireGuardian?: boolean;
 }
@@ -17,7 +18,7 @@ export const RoleGuard: React.FC<RoleGuardProps> = ({
   fallback,
   requireGuardian = false,
 }) => {
-  const { user, loading, profileLoading, hasAnyRole, profile, isGuardian, signOut } = useAuth();
+  const { user, loading, profileLoading, effectiveRole, profile, isGuardian, signOut } = useAuth();
   const location = useLocation();
   const inactiveSignOutRequestedRef = useRef(false);
 
@@ -61,12 +62,12 @@ export const RoleGuard: React.FC<RoleGuardProps> = ({
   }
 
   // Check if user has any of the required roles
-  if (!hasAnyRole(roles)) {
+  if (!roles.includes(effectiveRole)) {
     logger.warn('Route access denied', {
       context: {
         route: location.pathname,
         requiredRoles: roles,
-        userRole: profile?.role,
+        userRole: effectiveRole,
         userId: user.id,
       }
     });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
 } from '../lib/supervision-session-notes';
 import { useTheme } from '../lib/theme';
 import { preloadRouteModule } from '../lib/routeModulePrefetch';
+import type { AppRole } from '../lib/roles';
 // Theme is toggled directly via context; no hidden proxy button
 import { logger } from '../lib/logger/logger';
 
@@ -35,7 +36,7 @@ const ChatAssistantFallback = () => (
 );
 
 export function Sidebar() {
-  const { signOut, hasRole, hasAnyRole, user, profile, isGuardian, effectiveRole } = useAuth();
+  const { signOut, hasRole, user, profile, isGuardian, effectiveRole, hasCapability } = useAuth();
   const organizationId = useActiveOrganizationId();
   const { isDark, toggleTheme } = useTheme();
   const [isSigningOut, setIsSigningOut] = useState(false);
@@ -107,91 +108,91 @@ export function Sidebar() {
       icon: UserCircle2,
       label: 'Family',
       path: '/family',
-      roles: ['client'],
+      roles: ['client'] as AppRole[],
       requiresGuardian: true,
     },
     {
       icon: LayoutDashboard,
       label: 'Dashboard',
       path: '/',
-      roles: ['admin', 'super_admin'],
+      roles: ['admin_schedule', 'admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     { 
       icon: Calendar, 
       label: 'Schedule', 
       path: '/schedule',
-      roles: ['therapist', 'admin', 'super_admin'],
+      roles: ['therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     {
       icon: Mail,
       label: 'Messages',
       path: '/messages',
-      roles: ['therapist', 'admin', 'super_admin'],
+      roles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     {
       icon: Users,
       label: 'Clients',
       path: '/clients',
-      roles: ['therapist', 'admin', 'super_admin'],
+      roles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     {
       icon: UserCog,
       label: 'Therapists',
       path: '/therapists',
-      roles: ['admin', 'super_admin'],
+      roles: ['admin_schedule', 'admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     {
       icon: FileCheck,
       label: 'Authorizations',
       path: '/authorizations',
-      roles: ['admin', 'super_admin'],
+      roles: ['midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     { 
       icon: FileText, 
       label: 'Documentation', 
       path: '/documentation',
-      roles: ['client', 'admin', 'super_admin'], // therapist view excludes docs navigation
+      roles: ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     {
       icon: FileText,
       label: 'Fill Docs',
       path: '/fill-docs',
-      roles: ['admin', 'super_admin'],
+      roles: ['therapist', 'midtier', 'admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     {
       icon: CreditCard,
       label: 'Billing',
       path: '/billing',
-      roles: ['admin', 'super_admin'],
+      roles: ['admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     {
       icon: BarChart,
       label: 'Reports',
       path: '/reports',
-      roles: ['admin', 'super_admin'],
+      roles: ['admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     {
       icon: Activity,
       label: 'Monitoring',
       path: '/monitoring',
-      roles: ['admin', 'super_admin'],
+      roles: ['admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     {
       icon: Settings,
       label: 'Settings',
       path: '/settings',
-      roles: ['admin', 'super_admin'],
+      roles: ['admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
   ];
@@ -214,13 +215,9 @@ export function Sidebar() {
     </button>
   );
 
-  const canAccessChatAssistant = hasAnyRole([
-    'therapist',
-    'admin',
-    'super_admin'
-  ]);
-  const canAccessMessages = hasAnyRole(['therapist', 'admin', 'super_admin']);
-  const canViewSupervisionNotifications = hasAnyRole(['admin', 'super_admin']);
+  const canAccessChatAssistant = hasCapability('viewSchedule') || hasCapability('dataTaking');
+  const canAccessMessages = hasCapability('viewMessages');
+  const canViewSupervisionNotifications = hasCapability('staffDashboard');
 
   const { data: unreadMessagesData } = useQuery({
     queryKey: [MESSAGES_QUERY_KEY, 'inbox', organizationId, profile?.id],
@@ -324,7 +321,7 @@ export function Sidebar() {
               return null;
             }
             // Skip if roles are specified and user doesn't have any of them
-            if (roles.length > 0 && !roles.some(role => hasRole(role as 'client' | 'therapist' | 'admin' | 'super_admin'))) {
+            if (roles.length > 0 && !roles.includes(effectiveRole)) {
               return null;
             }
 

--- a/src/components/__tests__/LayoutSuspense.test.tsx
+++ b/src/components/__tests__/LayoutSuspense.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../lib/authContext', () => ({
     effectiveRole: 'admin',
     profileLoading: false,
     hasAnyRole: (roles: string[]) => roles.includes('admin'),
+    hasCapability: (capability: string) => capability === 'viewClients',
     isGuardian: false,
   }),
 }));

--- a/src/components/__tests__/RoleGuard.test.tsx
+++ b/src/components/__tests__/RoleGuard.test.tsx
@@ -9,6 +9,7 @@ type MockAuthValue = {
   readonly loading: boolean;
   readonly profileLoading?: boolean;
   readonly profile?: unknown;
+  readonly effectiveRole?: 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin';
   readonly isGuardian?: boolean;
   readonly signOut?: () => Promise<void> | void;
   readonly hasAnyRole?: (roles: readonly string[]) => boolean;
@@ -61,6 +62,7 @@ describe('RoleGuard route guard behaviour', () => {
       loading: false,
       profileLoading: false,
       profile: { role: 'client' },
+      effectiveRole: 'client',
       hasAnyRole: vi.fn().mockReturnValue(false),
     });
 
@@ -75,6 +77,7 @@ describe('RoleGuard route guard behaviour', () => {
       loading: false,
       profileLoading: false,
       profile: { role: 'admin' },
+      effectiveRole: 'admin',
       hasAnyRole: vi.fn().mockReturnValue(true),
     });
 
@@ -89,6 +92,7 @@ describe('RoleGuard route guard behaviour', () => {
       loading: false,
       profileLoading: true,
       profile: null,
+      effectiveRole: 'client',
       hasAnyRole: vi.fn().mockReturnValue(false),
     });
 
@@ -105,6 +109,7 @@ describe('RoleGuard route guard behaviour', () => {
       loading: false,
       profileLoading: false,
       profile: { role: 'client', is_active: true },
+      effectiveRole: 'client',
       isGuardian: false,
       signOut: vi.fn(),
       hasAnyRole: vi.fn().mockReturnValue(true),
@@ -136,6 +141,7 @@ describe('RoleGuard route guard behaviour', () => {
       loading: false,
       profileLoading: false,
       profile: { role: 'admin', is_active: false },
+      effectiveRole: 'admin',
       isGuardian: false,
       signOut,
       hasAnyRole: vi.fn().mockReturnValue(true),

--- a/src/components/__tests__/SidebarNavigation.test.tsx
+++ b/src/components/__tests__/SidebarNavigation.test.tsx
@@ -13,6 +13,16 @@ const mockPreloadRouteModule = vi.fn();
 const mockFetchMessageThreads = vi.fn();
 const mockFetchPendingSupervisionSessionNoteCount = vi.fn();
 
+const capabilityForRole = (role: string) => (capability: string) => {
+  const matrix: Record<string, string[]> = {
+    viewSchedule: ["therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"],
+    dataTaking: ["bt", "therapist", "midtier"],
+    viewMessages: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"],
+    staffDashboard: ["admin_schedule", "admin", "bcba", "super_admin"],
+  };
+  return matrix[capability]?.includes(role) ?? false;
+};
+
 vi.mock("../../lib/authContext", () => ({
   useAuth: () => mockUseAuth(),
 }));
@@ -82,6 +92,8 @@ describe("Sidebar navigation active styling", () => {
       isGuardian: false,
       hasAnyRole: vi.fn(() => true),
       effectiveRole: "therapist",
+      hasCapability: vi.fn(capabilityForRole("therapist")),
+      hasAnyCapability: vi.fn((capabilities: string[]) => capabilities.some(capabilityForRole("therapist"))),
     });
 
     mockUseTheme.mockReturnValue({
@@ -131,13 +143,16 @@ describe("Sidebar navigation active styling", () => {
       hasAnyRole: vi.fn((roles: ("client" | "therapist" | "admin" | "super_admin")[]) =>
         roles.some(role => hasRole(role))
       ),
+      effectiveRole: "therapist",
+      hasCapability: vi.fn(capabilityForRole("therapist")),
+      hasAnyCapability: vi.fn((capabilities: string[]) => capabilities.some(capabilityForRole("therapist"))),
     });
 
     renderSidebar(["/schedule"]);
 
     expect(screen.queryByRole("link", { name: /authorizations/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: /documentation/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: /fill docs/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /documentation/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /fill docs/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /schedule/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /messages/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /clients/i })).toBeInTheDocument();
@@ -164,6 +179,9 @@ describe("Sidebar navigation active styling", () => {
       hasAnyRole: vi.fn((roles: ("client" | "therapist" | "admin" | "super_admin")[]) =>
         roles.some(role => hasRole(role))
       ),
+      effectiveRole: "super_admin",
+      hasCapability: vi.fn(capabilityForRole("super_admin")),
+      hasAnyCapability: vi.fn((capabilities: string[]) => capabilities.some(capabilityForRole("super_admin"))),
     });
 
     renderSidebar(["/"]);
@@ -195,6 +213,9 @@ describe("Sidebar navigation active styling", () => {
       hasAnyRole: vi.fn((roles: ("client" | "therapist" | "admin" | "super_admin")[]) =>
         roles.some(role => hasRole(role))
       ),
+      effectiveRole: "client",
+      hasCapability: vi.fn(capabilityForRole("client")),
+      hasAnyCapability: vi.fn((capabilities: string[]) => capabilities.some(capabilityForRole("client"))),
     });
 
     renderSidebar(["/"]);
@@ -261,6 +282,9 @@ describe("Sidebar navigation active styling", () => {
       hasAnyRole: vi.fn((roles: ("client" | "therapist" | "admin" | "super_admin")[]) =>
         roles.some(role => hasRole(role))
       ),
+      effectiveRole: "client",
+      hasCapability: vi.fn(capabilityForRole("client")),
+      hasAnyCapability: vi.fn((capabilities: string[]) => capabilities.some(capabilityForRole("client"))),
     });
 
     renderSidebar(["/"]);
@@ -313,6 +337,8 @@ describe("Sidebar navigation active styling", () => {
         roles.some(role => hasRole(role))
       ),
       effectiveRole: "admin",
+      hasCapability: vi.fn(capabilityForRole("admin")),
+      hasAnyCapability: vi.fn((capabilities: string[]) => capabilities.some(capabilityForRole("admin"))),
     });
     mockFetchPendingSupervisionSessionNoteCount.mockResolvedValueOnce(4);
 
@@ -344,6 +370,8 @@ describe("Sidebar navigation active styling", () => {
         roles.some(role => hasRole(role))
       ),
       effectiveRole: "therapist",
+      hasCapability: vi.fn(capabilityForRole("therapist")),
+      hasAnyCapability: vi.fn((capabilities: string[]) => capabilities.some(capabilityForRole("therapist"))),
     });
 
     renderSidebar(["/schedule"]);

--- a/src/components/settings/AdminSettings.tsx
+++ b/src/components/settings/AdminSettings.tsx
@@ -94,7 +94,8 @@ export function AdminSettings() {
   const resetPasswordInputRef = useRef<HTMLInputElement>(null);
 
   const queryClient = useQueryClient();
-  const { user, effectiveRole } = useAuth();
+  const { user, hasCapability } = useAuth();
+  const isSuperAdmin = hasCapability('accessSuperAdminTools');
 
   const organizationId = useMemo(() => {
     const metadata = user?.user_metadata ?? {};
@@ -103,7 +104,6 @@ export function AdminSettings() {
     return snake || camel || null;
   }, [user]);
 
-  const isSuperAdmin = effectiveRole === 'super_admin';
   const canOpenAddAdminModal = isSuperAdmin || Boolean(organizationId);
 
   const activeOrganizationId = useMemo(() => {

--- a/src/components/settings/OrganizationSettings.tsx
+++ b/src/components/settings/OrganizationSettings.tsx
@@ -4,8 +4,8 @@ import { useAuth } from '../../lib/authContext';
 import { getDefaultOrganizationId } from '../../lib/runtimeConfig';
 
 export function OrganizationSettings() {
-  const { effectiveRole, profile } = useAuth();
-  const isSuperAdmin = effectiveRole === 'super_admin';
+  const { effectiveRole, profile, hasCapability } = useAuth();
+  const isSuperAdmin = hasCapability('accessSuperAdminTools');
   const isAdmin = effectiveRole === 'admin';
 
   const defaultOrganizationId = useMemo(() => {

--- a/src/components/settings/__tests__/AdminSettings.cta.test.tsx
+++ b/src/components/settings/__tests__/AdminSettings.cta.test.tsx
@@ -11,6 +11,7 @@ vi.mock('../../../lib/authContext', async () => {
     useAuth: () => ({
       user: { id: 'user-1', user_metadata: {} },
       profile: { role: 'admin' },
+      hasCapability: () => false,
     }),
   };
 });

--- a/src/components/settings/__tests__/AdminSettings.test.tsx
+++ b/src/components/settings/__tests__/AdminSettings.test.tsx
@@ -44,6 +44,9 @@ const originalFrom = supabase.from.bind(supabase);
 
 let confirmSpy: ReturnType<typeof vi.spyOn> | null = null;
 
+const hasAdminCapability = vi.fn((capability: string) => capability !== 'accessSuperAdminTools');
+const hasSuperAdminCapability = vi.fn(() => true);
+
 const mockAdminUser = {
   id: 'admin-id',
   user_id: 'user-123',
@@ -103,6 +106,8 @@ describe('AdminSettings logging', () => {
       updateProfile: vi.fn(),
       hasRole: vi.fn(() => true),
       hasAnyRole: vi.fn(() => true),
+      hasCapability: hasAdminCapability,
+      hasAnyCapability: vi.fn(() => true),
       isAdmin: vi.fn(() => true),
       isSuperAdmin: vi.fn(() => false)
     } as unknown as ReturnType<typeof useAuth>;
@@ -332,6 +337,8 @@ describe('Guardian approvals', () => {
       updateProfile: vi.fn(),
       hasRole: vi.fn(() => true),
       hasAnyRole: vi.fn(() => true),
+      hasCapability: hasAdminCapability,
+      hasAnyCapability: vi.fn(() => true),
       isAdmin: vi.fn(() => true),
       isSuperAdmin: vi.fn(() => false),
     } as unknown as ReturnType<typeof useAuth>;
@@ -518,6 +525,8 @@ describe('Admin therapist links', () => {
       updateProfile: vi.fn(),
       hasRole: vi.fn(() => true),
       hasAnyRole: vi.fn(() => true),
+      hasCapability: hasAdminCapability,
+      hasAnyCapability: vi.fn(() => true),
       isAdmin: vi.fn(() => true),
       isSuperAdmin: vi.fn(() => false),
     } as unknown as ReturnType<typeof useAuth>;
@@ -737,6 +746,8 @@ describe('AdminSettings super admin access', () => {
       updateProfile: vi.fn(),
       hasRole: vi.fn(() => true),
       hasAnyRole: vi.fn(() => true),
+      hasCapability: hasSuperAdminCapability,
+      hasAnyCapability: vi.fn(() => true),
       isAdmin: vi.fn(() => false),
       isSuperAdmin: vi.fn(() => true),
     } as unknown as ReturnType<typeof useAuth>;
@@ -939,6 +950,8 @@ describe('AdminSettings accessibility', () => {
       updateProfile: vi.fn(),
       hasRole: vi.fn(() => true),
       hasAnyRole: vi.fn(() => true),
+      hasCapability: hasAdminCapability,
+      hasAnyCapability: vi.fn(() => true),
       isAdmin: vi.fn(() => true),
       isSuperAdmin: vi.fn(() => false)
     } as unknown as ReturnType<typeof useAuth>;

--- a/src/components/settings/__tests__/OrganizationSettings.test.tsx
+++ b/src/components/settings/__tests__/OrganizationSettings.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../../../lib/authContext', async () => {
     useAuth: () => ({
       profile: { role: 'super_admin' },
       effectiveRole: 'super_admin',
+      hasCapability: () => true,
     }),
   };
 });

--- a/src/lib/aiGuardrails.ts
+++ b/src/lib/aiGuardrails.ts
@@ -1,6 +1,7 @@
 import { logger } from './logger/logger';
+import { APP_ROLES, ROLE_RANK, roleHasCapability, type AppRole } from './roles';
 
-export type AssistantRole = 'client' | 'therapist' | 'admin' | 'super_admin';
+export type AssistantRole = AppRole;
 
 export type AssistantTool =
   | 'schedule_session'
@@ -55,10 +56,12 @@ export class AssistantGuardrailError extends Error {
 const MAX_MESSAGE_LENGTH = 4000;
 const CONTROL_CHARACTERS = /[\p{C}]/gu;
 
-const ROLE_ORDER: AssistantRole[] = ['client', 'therapist', 'admin', 'super_admin'];
-
 const ROLE_BASE_TOOLS: Record<AssistantRole, AssistantTool[]> = {
   client: [],
+  bt: [
+    'start_session',
+    'get_monthly_session_count',
+  ],
   therapist: [
     'schedule_session',
     'cancel_sessions',
@@ -67,7 +70,30 @@ const ROLE_BASE_TOOLS: Record<AssistantRole, AssistantTool[]> = {
     'suggest_optimal_times',
     'get_monthly_session_count',
   ],
+  midtier: [
+    'schedule_session',
+    'cancel_sessions',
+    'start_session',
+    'predict_conflicts',
+    'suggest_optimal_times',
+    'get_monthly_session_count',
+  ],
+  admin_schedule: [
+    'schedule_session',
+    'cancel_sessions',
+    'predict_conflicts',
+    'suggest_optimal_times',
+    'get_monthly_session_count',
+  ],
   admin: [
+    'schedule_session',
+    'cancel_sessions',
+    'start_session',
+    'predict_conflicts',
+    'suggest_optimal_times',
+    'get_monthly_session_count',
+  ],
+  bcba: [
     'schedule_session',
     'cancel_sessions',
     'start_session',
@@ -155,20 +181,25 @@ export const getRoleAllowedTools = (role: AssistantRole): AssistantTool[] => {
     return roleToolCache.get(role) ?? [];
   }
 
-  const roleIndex = ROLE_ORDER.indexOf(role);
-  if (roleIndex === -1) {
+  if (!APP_ROLES.includes(role)) {
     roleToolCache.set(role, []);
     return [];
   }
 
   const allowed = new Set<AssistantTool>();
-  for (let index = 0; index <= roleIndex; index += 1) {
-    const inheritedRole = ROLE_ORDER[index];
+  const inheritedRoles = APP_ROLES.filter((candidateRole) => ROLE_RANK[candidateRole] <= ROLE_RANK[role]);
+  for (const inheritedRole of inheritedRoles) {
     const tools = ROLE_BASE_TOOLS[inheritedRole] ?? [];
     tools.forEach((tool) => allowed.add(tool));
   }
+  if (!roleHasCapability(role, 'viewSchedule')) {
+    allowed.delete('schedule_session');
+    allowed.delete('cancel_sessions');
+    allowed.delete('predict_conflicts');
+    allowed.delete('suggest_optimal_times');
+  }
 
-  const result = Array.from(allowed.values());
+  const result = (ROLE_BASE_TOOLS[role] ?? []).filter((tool) => allowed.has(tool));
   roleToolCache.set(role, result);
   return result;
 };

--- a/src/lib/authContext.tsx
+++ b/src/lib/authContext.tsx
@@ -6,6 +6,16 @@ import { logger } from './logger/logger';
 import { toError } from './logger/normalizeError';
 import { readStubAuthState, STUB_AUTH_STORAGE_KEY } from './authStubSession';
 import { getDefaultOrganizationId } from './runtimeConfig';
+import {
+  APP_ROLES,
+  ROLE_RANK,
+  normalizeRole,
+  roleHasCapability,
+  roleHasAnyCapability,
+  roleMeetsOrExceeds,
+  type AppCapability,
+  type AppRole,
+} from './roles';
 
 const normalizeOrgId = (value: unknown): string | null => {
   if (typeof value !== 'string') {
@@ -38,7 +48,7 @@ const resolveAuthFlowForEvent = (event: AuthChangeEvent): 'normal' | 'password_r
 export interface UserProfile {
   id: string;
   email: string;
-  role: 'client' | 'therapist' | 'admin' | 'super_admin';
+  role: AppRole;
   organization_id?: string | null;
   first_name?: string;
   last_name?: string;
@@ -57,29 +67,10 @@ type Role = UserProfile['role'];
 type RoleRow = { is_active?: unknown; expires_at?: unknown; roles?: { name?: unknown } | null };
 
 const toRole = (value: unknown): Role | null => {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const normalized = value
-    .trim()
-    .toLowerCase()
-    .replace(/[\s-]+/g, '_');
-
-  switch (normalized) {
-    case 'client':
-    case 'therapist':
-    case 'admin':
-      return normalized;
-    case 'super_admin':
-    case 'superadmin':
-      return 'super_admin';
-    default:
-      return null;
-  }
+  return normalizeRole(value);
 };
 
-const roleOrder: readonly Role[] = ['super_admin', 'admin', 'therapist', 'client'];
+const roleOrder: readonly Role[] = [...APP_ROLES].sort((left, right) => ROLE_RANK[right] - ROLE_RANK[left]);
 
 const roleRowIsActive = (isActive: unknown, expiresAt: unknown): boolean => {
   if (isActive === false) {
@@ -208,8 +199,10 @@ interface AuthContextType {
   signOut: () => Promise<void>;
   resetPassword: (email: string) => Promise<{ error: Error | null }>;
   updateProfile: (updates: Partial<UserProfile>) => Promise<{ error: Error | null }>;
-  hasRole: (role: 'client' | 'therapist' | 'admin' | 'super_admin') => boolean;
-  hasAnyRole: (roles: ('client' | 'therapist' | 'admin' | 'super_admin')[]) => boolean;
+  hasRole: (role: AppRole) => boolean;
+  hasAnyRole: (roles: AppRole[]) => boolean;
+  hasCapability: (capability: AppCapability) => boolean;
+  hasAnyCapability: (capabilities: AppCapability[]) => boolean;
   isAdmin: () => boolean;
   isSuperAdmin: () => boolean;
 }
@@ -257,17 +250,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const profileRole = profile?.role ?? null;
 
-  const rolePriority: Record<Role, number> = {
-    client: 1,
-    therapist: 2,
-    admin: 3,
-    super_admin: 4,
-  };
-
   const effectiveRole = useMemo<Role>(() => {
     if (profileRole && roleFromAssignments) {
       // Prefer the highest role granted by authoritative role assignments.
-      return rolePriority[roleFromAssignments] > rolePriority[profileRole] ? roleFromAssignments : profileRole;
+      return ROLE_RANK[roleFromAssignments] > ROLE_RANK[profileRole] ? roleFromAssignments : profileRole;
     }
     if (roleFromAssignments) return roleFromAssignments;
     if (profileRole) return profileRole;
@@ -941,31 +927,31 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return effectiveRole;
   }, [effectiveRole]);
 
-  const roleHierarchy: Record<Role, number> = {
-    super_admin: 4,
-    admin: 3,
-    therapist: 2,
-    client: 1,
-  } as const;
-
   const hasRole = useCallback((role: Role) => {
     const currentRole = resolveRoleForComparison();
-    return roleHierarchy[currentRole] >= roleHierarchy[role];
+    return roleMeetsOrExceeds(currentRole, role);
   }, [resolveRoleForComparison]);
 
   const hasAnyRole = useCallback((roles: Role[]) => {
     const currentRole = resolveRoleForComparison();
-    const userLevel = roleHierarchy[currentRole];
-    return roles.some((r) => userLevel >= roleHierarchy[r]);
+    return roles.some((r) => roleMeetsOrExceeds(currentRole, r));
   }, [resolveRoleForComparison]);
 
-  const isAdmin = useCallback(() => {
-    return effectiveRole === 'admin' || effectiveRole === 'super_admin';
+  const hasCapability = useCallback((capability: AppCapability) => {
+    return roleHasCapability(effectiveRole, capability);
   }, [effectiveRole]);
 
-  const isSuperAdmin = useCallback(() => {
-    return effectiveRole === 'super_admin';
+  const hasAnyCapability = useCallback((capabilities: AppCapability[]) => {
+    return roleHasAnyCapability(effectiveRole, capabilities);
   }, [effectiveRole]);
+
+  const isAdmin = useCallback(() => {
+    return hasCapability('staffDashboard');
+  }, [hasCapability]);
+
+  const isSuperAdmin = useCallback(() => {
+    return hasCapability('accessSuperAdminTools');
+  }, [hasCapability]);
 
   const value = {
     user,
@@ -985,6 +971,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     updateProfile,
     hasRole,
     hasAnyRole,
+    hasCapability,
+    hasAnyCapability,
     isAdmin,
     isSuperAdmin,
   };

--- a/src/lib/authStubSession.ts
+++ b/src/lib/authStubSession.ts
@@ -1,11 +1,12 @@
 import type { Session, User } from '@supabase/supabase-js';
 import type { UserProfile } from './authContext';
+import { APP_ROLES, normalizeRole, type AppRole } from './roles';
 
 export const STUB_AUTH_STORAGE_KEY = 'auth-storage';
 
-type Role = 'client' | 'therapist' | 'admin' | 'super_admin';
+type Role = AppRole;
 
-const VALID_ROLES = new Set<Role>(['client', 'therapist', 'admin', 'super_admin']);
+const VALID_ROLES = new Set<Role>(APP_ROLES);
 
 type StubPayload = {
   readonly user?: {
@@ -146,10 +147,11 @@ export interface StubAuthState {
 
 const normaliseRole = (payload: StubPayload): Role | null => {
   const role = toOptionalString(payload.user?.role) ?? toOptionalString(payload.role);
-  if (!role || !VALID_ROLES.has(role as Role)) {
+  const normalizedRole = normalizeRole(role);
+  if (!normalizedRole || !VALID_ROLES.has(normalizedRole)) {
     return null;
   }
-  return role as Role;
+  return normalizedRole;
 };
 
 const normaliseStubPayload = (payload: StubPayload, now: number): StubAuthState | null => {

--- a/src/lib/clients/fetchers.ts
+++ b/src/lib/clients/fetchers.ts
@@ -4,6 +4,7 @@ import { fetchLinkedClientIdsForTherapist } from './therapistClientScope';
 import type { Database } from '../generated/database.types';
 import { supabase } from '../supabase';
 import { CLIENT_DETAIL_SELECT, CLIENT_LIST_SELECT } from './select';
+import type { AppRole } from '../roles';
 
 export type ClientsSupabaseClient = SupabaseClient<Database>;
 
@@ -176,7 +177,7 @@ interface FetchClientsOptions {
   allowAll?: boolean;
 }
 
-type ClientRecordViewerRole = 'client' | 'therapist' | 'admin' | 'super_admin';
+type ClientRecordViewerRole = AppRole;
 
 interface FetchClientByIdForViewerOptions {
   readonly clientId: string;
@@ -318,7 +319,7 @@ export const fetchClientByIdForViewer = async ({
 
   const clientRef = overrideClient ?? supabase;
 
-  if (viewerRole !== 'therapist') {
+  if (viewerRole !== 'therapist' && viewerRole !== 'bt' && viewerRole !== 'midtier') {
     return fetchClientById(clientId, organizationId, clientRef);
   }
 

--- a/src/lib/dashboardAccess.ts
+++ b/src/lib/dashboardAccess.ts
@@ -1,11 +1,17 @@
 import type { UserProfile } from './authContext';
+import { roleHasCapability } from './roles';
 
-export const STAFF_DASHBOARD_ROLES: ReadonlyArray<UserProfile['role']> = ['admin', 'super_admin'];
+export const STAFF_DASHBOARD_ROLES: ReadonlyArray<UserProfile['role']> = [
+  'admin_schedule',
+  'admin',
+  'bcba',
+  'super_admin',
+];
 
 export const canAccessStaffDashboard = (role: UserProfile['role'] | null | undefined): boolean => {
   if (!role) {
     return false;
   }
-  return STAFF_DASHBOARD_ROLES.includes(role);
+  return roleHasCapability(role, 'staffDashboard');
 };
 

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -7052,10 +7052,14 @@ export type Database = {
     Enums: {
       role_type:
         | "client"
+        | "bt"
         | "therapist"
+        | "midtier"
+        | "admin_schedule"
         | "staff"
         | "supervisor"
         | "admin"
+        | "bcba"
         | "super_admin"
     }
     CompositeTypes: {
@@ -7192,10 +7196,14 @@ export const Constants = {
     Enums: {
       role_type: [
         "client",
+        "bt",
         "therapist",
+        "midtier",
+        "admin_schedule",
         "staff",
         "supervisor",
         "admin",
+        "bcba",
         "super_admin",
       ],
     },

--- a/src/lib/messages/fetchStaffRecipients.ts
+++ b/src/lib/messages/fetchStaffRecipients.ts
@@ -1,7 +1,7 @@
 import { supabase } from '../supabase';
 import type { StaffRecipient } from './types';
 
-const STAFF_ROLES = new Set(['therapist', 'admin', 'super_admin']);
+const STAFF_ROLES = new Set(['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']);
 
 type RpcStaffRow = {
   user_id: string;

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,0 +1,200 @@
+export type AppRole =
+  | 'client'
+  | 'bt'
+  | 'therapist'
+  | 'midtier'
+  | 'admin_schedule'
+  | 'admin'
+  | 'bcba'
+  | 'super_admin';
+
+export type AppCapability =
+  | 'accessSuperAdminTools'
+  | 'assignClientsToStaff'
+  | 'dataTaking'
+  | 'lockSessionNotes'
+  | 'manageAuthorizations'
+  | 'manageClients'
+  | 'manageProgramsGoals'
+  | 'manageStaff'
+  | 'staffDashboard'
+  | 'viewAuthorizations'
+  | 'viewBilling'
+  | 'viewClients'
+  | 'viewDocumentation'
+  | 'viewFillDocs'
+  | 'viewMessages'
+  | 'viewMonitoring'
+  | 'viewProgramsGoals'
+  | 'viewReports'
+  | 'viewSchedule'
+  | 'viewSessionTrends'
+  | 'viewSettings'
+  | 'viewStaff'
+  | 'viewStaffProfile';
+
+export const APP_ROLES: readonly AppRole[] = [
+  'client',
+  'bt',
+  'therapist',
+  'midtier',
+  'admin_schedule',
+  'admin',
+  'bcba',
+  'super_admin',
+];
+
+export const ROLE_LABELS: Record<AppRole, string> = {
+  client: 'Client',
+  bt: 'BT',
+  therapist: 'Therapist',
+  midtier: 'Midtier',
+  admin_schedule: 'Admin Schedule',
+  admin: 'Admin',
+  bcba: 'BCBA',
+  super_admin: 'Super Admin',
+};
+
+export const ROLE_RANK: Record<AppRole, number> = {
+  client: 1,
+  bt: 2,
+  therapist: 3,
+  midtier: 4,
+  admin_schedule: 5,
+  admin: 6,
+  bcba: 7,
+  super_admin: 7,
+};
+
+const allCapabilities: readonly AppCapability[] = [
+  'accessSuperAdminTools',
+  'assignClientsToStaff',
+  'dataTaking',
+  'lockSessionNotes',
+  'manageAuthorizations',
+  'manageClients',
+  'manageProgramsGoals',
+  'manageStaff',
+  'staffDashboard',
+  'viewAuthorizations',
+  'viewBilling',
+  'viewClients',
+  'viewDocumentation',
+  'viewFillDocs',
+  'viewMessages',
+  'viewMonitoring',
+  'viewProgramsGoals',
+  'viewReports',
+  'viewSchedule',
+  'viewSessionTrends',
+  'viewSettings',
+  'viewStaff',
+  'viewStaffProfile',
+];
+
+export const ROLE_CAPABILITIES: Record<AppRole, readonly AppCapability[]> = {
+  client: ['viewDocumentation'],
+  bt: [
+    'dataTaking',
+    'viewClients',
+    'viewDocumentation',
+    'viewMessages',
+    'viewProgramsGoals',
+    'viewStaffProfile',
+  ],
+  therapist: [
+    'dataTaking',
+    'viewClients',
+    'viewDocumentation',
+    'viewFillDocs',
+    'viewMessages',
+    'viewProgramsGoals',
+    'viewSchedule',
+    'viewStaffProfile',
+  ],
+  midtier: [
+    'dataTaking',
+    'manageAuthorizations',
+    'manageProgramsGoals',
+    'viewAuthorizations',
+    'viewClients',
+    'viewDocumentation',
+    'viewFillDocs',
+    'viewMessages',
+    'viewProgramsGoals',
+    'viewSchedule',
+    'viewStaffProfile',
+  ],
+  admin_schedule: [
+    'assignClientsToStaff',
+    'lockSessionNotes',
+    'manageAuthorizations',
+    'manageClients',
+    'manageStaff',
+    'staffDashboard',
+    'viewAuthorizations',
+    'viewClients',
+    'viewDocumentation',
+    'viewMessages',
+    'viewSchedule',
+    'viewStaff',
+    'viewStaffProfile',
+  ],
+  admin: [
+    'assignClientsToStaff',
+    'dataTaking',
+    'lockSessionNotes',
+    'manageAuthorizations',
+    'manageClients',
+    'manageProgramsGoals',
+    'manageStaff',
+    'staffDashboard',
+    'viewAuthorizations',
+    'viewBilling',
+    'viewClients',
+    'viewDocumentation',
+    'viewFillDocs',
+    'viewMessages',
+    'viewMonitoring',
+    'viewProgramsGoals',
+    'viewReports',
+    'viewSchedule',
+    'viewSessionTrends',
+    'viewSettings',
+    'viewStaff',
+    'viewStaffProfile',
+  ],
+  bcba: allCapabilities,
+  super_admin: allCapabilities,
+};
+
+export const normalizeRole = (value: unknown): AppRole | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  if (normalized === 'superadmin') {
+    return 'super_admin';
+  }
+
+  return APP_ROLES.includes(normalized as AppRole) ? normalized as AppRole : null;
+};
+
+export const roleHasCapability = (role: AppRole | null | undefined, capability: AppCapability): boolean => {
+  if (!role) {
+    return false;
+  }
+  return ROLE_CAPABILITIES[role]?.includes(capability) ?? false;
+};
+
+export const roleHasAnyCapability = (
+  role: AppRole | null | undefined,
+  capabilities: readonly AppCapability[],
+): boolean => capabilities.some((capability) => roleHasCapability(role, capability));
+
+export const rolesForCapability = (capability: AppCapability): AppRole[] =>
+  APP_ROLES.filter((role) => roleHasCapability(role, capability));
+
+export const roleMeetsOrExceeds = (role: AppRole, requiredRole: AppRole): boolean =>
+  ROLE_RANK[role] >= ROLE_RANK[requiredRole];

--- a/src/pages/Authorizations.tsx
+++ b/src/pages/Authorizations.tsx
@@ -55,7 +55,7 @@ export function Authorizations() {
   const queryClient = useQueryClient();
   const { effectiveRole, profile } = useAuth();
   const resolvedOrganizationId = useActiveOrganizationId();
-  const isTherapistViewer = effectiveRole === 'therapist';
+  const isTherapistViewer = effectiveRole === 'midtier';
 
   const { data: authorizations = [], isLoading } = useQuery({
     queryKey: ['authorizations'],

--- a/src/pages/ClientDetails.tsx
+++ b/src/pages/ClientDetails.tsx
@@ -34,7 +34,7 @@ export function ClientDetails() {
   const location = useLocation();
   const initialTab = useMemo<TabType>(() => parseTabFromSearch(location.search), [location.search]);
   const [activeTab, setActiveTab] = useState<TabType>(initialTab);
-  const { profile, effectiveRole, loading: authLoading, profileLoading } = useAuth();
+  const { profile, effectiveRole, loading: authLoading, profileLoading, hasCapability } = useAuth();
   const activeOrganizationId = useActiveOrganizationId();
 
   useEffect(() => {
@@ -57,10 +57,10 @@ export function ClientDetails() {
     enabled: Boolean(clientId && activeOrganizationId),
   });
 
-  const isTherapistViewer = effectiveRole === 'therapist';
+  const isTherapistViewer = effectiveRole === 'therapist' || effectiveRole === 'bt' || effectiveRole === 'midtier';
   const isClientViewer = effectiveRole === 'client';
-  const isAuthorizationAdminViewer = effectiveRole === 'admin' || effectiveRole === 'super_admin';
-  const canViewSessionTrends = effectiveRole === 'admin' || effectiveRole === 'super_admin';
+  const isAuthorizationAdminViewer = hasCapability('viewAuthorizations');
+  const canViewSessionTrends = hasCapability('viewSessionTrends');
   const viewingOwnClientRecord = Boolean(isClientViewer && client?.id === profile?.id);
   const canViewClientRecord = Boolean(
     client &&
@@ -167,9 +167,12 @@ export function ClientDetails() {
       if (tab.id === 'session-trends') {
         return canViewSessionTrends;
       }
+      if (tab.id === 'programs-goals') {
+        return hasCapability('viewProgramsGoals');
+      }
       return true;
     }),
-    [canViewSessionTrends, isAuthorizationAdminViewer, tabs],
+    [canViewSessionTrends, hasCapability, isAuthorizationAdminViewer, tabs],
   );
 
   useEffect(() => {

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -48,11 +48,12 @@ const Clients = () => {
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [archivedFilter, setArchivedFilter] = useState<'all' | 'active' | 'archived'>('active');
   const queryClient = useQueryClient();
-  const { isSuperAdmin, profile, effectiveRole } = useAuth();
+  const { isSuperAdmin, profile, effectiveRole, hasCapability } = useAuth();
   const navigate = useNavigate();
   const activeOrganizationId = useActiveOrganizationId();
   const isSuperAdminUser = isSuperAdmin();
-  const isTherapistViewer = effectiveRole === 'therapist';
+  const isTherapistViewer = effectiveRole === 'bt' || effectiveRole === 'therapist' || effectiveRole === 'midtier';
+  const canManageClients = hasCapability('manageClients');
   const resolvedOrganizationId = activeOrganizationId ?? null;
   const loadAllClients = isSuperAdminUser && !resolvedOrganizationId;
 
@@ -387,7 +388,7 @@ const Clients = () => {
       )}
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Clients</h1>
-        {!isTherapistViewer ? (
+        {canManageClients ? (
           <div className="flex space-x-3">
             <button
               onClick={() => setIsImportModalOpen(true)}
@@ -645,7 +646,7 @@ const Clients = () => {
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex items-center space-x-3">
-                        {client.deleted_at ? (
+                        {canManageClients && client.deleted_at ? (
                           <button
                             onClick={() => handleRestoreClient(client)}
                             className="text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-300"
@@ -655,7 +656,7 @@ const Clients = () => {
                           >
                             <ArchiveRestore aria-hidden="true" className="w-4 h-4" />
                           </button>
-                        ) : (
+                        ) : canManageClients ? (
                           <button
                             onClick={() => handleArchiveClient(client)}
                             className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
@@ -665,7 +666,7 @@ const Clients = () => {
                           >
                             <Archive aria-hidden="true" className="w-4 h-4" />
                           </button>
-                        )}
+                        ) : null}
                         {isSuperAdmin() && (
                           <button
                             onClick={() => handleDeleteClient(client)}

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -140,9 +140,9 @@ const ReportMetrics = React.memo(({
 ReportMetrics.displayName = 'ReportMetrics';
 
 const Reports = React.memo(() => {
-  const { hasAnyRole, effectiveRole } = useAuth();
+  const { hasCapability, effectiveRole } = useAuth();
   const [reportType, setReportType] = useState<ReportType>('sessions');
-  const canExportReports = hasAnyRole(['therapist', 'admin', 'super_admin']);
+  const canExportReports = hasCapability('viewReports');
 
   const [filters, setFilters] = useState<ReportFilters>({
     dateRange: 'current_month',

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -341,7 +341,7 @@ export const Schedule = React.memo(() => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   useCapturePendingScheduleEvent();
-  const { user, profile, effectiveRole } = useAuth();
+  const { user, profile, effectiveRole, hasCapability } = useAuth();
   const activeOrganizationId = useActiveOrganizationId();
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [view, setView] = useState<"day" | "week">("week");
@@ -920,7 +920,7 @@ export const Schedule = React.memo(() => {
   const weekForwardDisplayedWeekSignature = `${weekStart.toISOString()}|${weekEnd.toISOString()}`;
   const weekForwardHasScheduledSessions = weekForwardSourceSessions.length > 0;
   const weekForwardHasSelectedSourceSessions = weekForwardSelectedSourceSessions.length > 0;
-  const weekForwardRequiresOrgContext = effectiveRole === "super_admin" && !activeOrganizationId;
+  const weekForwardRequiresOrgContext = hasCapability("accessSuperAdminTools") && !activeOrganizationId;
   const weekForwardAvailableInCurrentView = view === "week";
   const weekForwardSourceSummary = `${format(weekStart, "MMM d")} - ${format(weekEnd, "MMM d, yyyy")}`;
   const weekForwardCanPreview =

--- a/src/pages/SuperAdminFeatureFlags.tsx
+++ b/src/pages/SuperAdminFeatureFlags.tsx
@@ -65,14 +65,14 @@ const humanizeKey = (value: string): string => {
 };
 
 export const SuperAdminFeatureFlags: React.FC = () => {
-  const { effectiveRole } = useAuth();
+  const { hasCapability } = useAuth();
   const queryClient = useQueryClient();
 
   const [newFlagKey, setNewFlagKey] = useState('');
   const [newFlagDescription, setNewFlagDescription] = useState('');
   const [newFlagDefaultEnabled, setNewFlagDefaultEnabled] = useState(false);
 
-  const isSuperAdmin = effectiveRole === 'super_admin';
+  const isSuperAdmin = hasCapability('accessSuperAdminTools');
   const defaultOrganizationId = useMemo(() => {
     try {
       return getDefaultOrganizationId();

--- a/src/pages/SuperAdminImpersonation.tsx
+++ b/src/pages/SuperAdminImpersonation.tsx
@@ -31,7 +31,7 @@ const resolveOrganizationId = (metadata: Record<string, unknown> | null | undefi
 };
 
 export const SuperAdminImpersonation: React.FC = () => {
-  const { user, effectiveRole } = useAuth();
+  const { user, hasCapability } = useAuth();
   const queryClient = useQueryClient();
   const [targetUserId, setTargetUserId] = useState('');
   const [targetUserEmail, setTargetUserEmail] = useState('');
@@ -61,7 +61,7 @@ export const SuperAdminImpersonation: React.FC = () => {
 
   const impersonationsQuery = useQuery({
     queryKey: ['impersonation-audit'],
-    enabled: effectiveRole === 'super_admin',
+    enabled: hasCapability('accessSuperAdminTools'),
     refetchInterval: 15000,
     queryFn: async () => {
       const { data, error } = await supabase
@@ -196,7 +196,7 @@ export const SuperAdminImpersonation: React.FC = () => {
     });
   }, [impersonationsQuery.data, now, revokeMutation]);
 
-  if (effectiveRole !== 'super_admin') {
+  if (!hasCapability('accessSuperAdminTools')) {
     return (
       <div className="p-8">
         <h1 className="text-2xl font-semibold text-slate-900">Super Admin Impersonation</h1>

--- a/src/pages/__tests__/AppNavigation.test.tsx
+++ b/src/pages/__tests__/AppNavigation.test.tsx
@@ -5,7 +5,10 @@ import { Outlet } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from '../../App';
 
-let authRole: 'client' | 'therapist' | 'admin' | 'super_admin' = 'client';
+type TestRole = 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin';
+type TestCapability = 'staffDashboard' | 'viewSchedule';
+
+let authRole: TestRole = 'client';
 let authIsGuardian = false;
 const { mockLoggerInfo } = vi.hoisted(() => ({
   mockLoggerInfo: vi.fn(),
@@ -22,6 +25,10 @@ vi.mock('../../lib/logger/logger', () => ({
 
 vi.mock('../../lib/authContext', () => {
   const signOut = vi.fn();
+  const capabilityRoles: Record<TestCapability, TestRole[]> = {
+    staffDashboard: ['admin_schedule', 'admin', 'bcba', 'super_admin'],
+    viewSchedule: ['therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
+  };
   return {
     useAuth: () => ({
       profile: { role: authRole, is_active: true },
@@ -30,8 +37,10 @@ vi.mock('../../lib/authContext', () => {
       profileLoading: false,
       isGuardian: authIsGuardian,
       effectiveRole: authRole,
-      hasRole: (role: 'client' | 'therapist' | 'admin' | 'super_admin') => authRole === role,
-      hasAnyRole: (roles: ('client' | 'therapist' | 'admin' | 'super_admin')[]) => roles.includes(authRole),
+      hasRole: (role: TestRole) => authRole === role,
+      hasAnyRole: (roles: TestRole[]) => roles.includes(authRole),
+      hasCapability: (capability: TestCapability) => capabilityRoles[capability]?.includes(authRole) ?? false,
+      hasAnyCapability: (capabilities: TestCapability[]) => capabilities.some((capability) => capabilityRoles[capability]?.includes(authRole)),
       signOut,
       signIn: vi.fn(),
       signUp: vi.fn(),

--- a/src/pages/__tests__/Authorizations.test.tsx
+++ b/src/pages/__tests__/Authorizations.test.tsx
@@ -146,15 +146,15 @@ describe('Authorizations page query scope', () => {
     ]);
   });
 
-  it('uses scoped client fetch and bounded therapist fetch for therapist role', async () => {
+  it('uses scoped client fetch and bounded therapist fetch for midtier role', async () => {
     const therapistUserId = 'therapist-user-uuid';
 
     useAuthMock.mockReturnValue({
       user: null,
-      effectiveRole: 'therapist',
+      effectiveRole: 'midtier',
       profile: baseProfile({
         id: therapistUserId,
-        role: 'therapist',
+        role: 'midtier',
         organization_id: 'org-therapist-1',
       }),
     });

--- a/src/pages/__tests__/Clients.test.tsx
+++ b/src/pages/__tests__/Clients.test.tsx
@@ -27,6 +27,8 @@ vi.mock('@tanstack/react-query', async () => {
 vi.mock('../../lib/authContext', () => ({
   useAuth: () => ({
     isSuperAdmin: isSuperAdminMock,
+    effectiveRole: isSuperAdminMock() ? 'super_admin' : 'admin',
+    hasCapability: () => true,
   }),
 }));
 

--- a/src/pages/__tests__/Schedule.event.test.tsx
+++ b/src/pages/__tests__/Schedule.event.test.tsx
@@ -47,6 +47,11 @@ function SearchProbe() {
   return <output data-testid="schedule-search">{location.search}</output>;
 }
 
+const getVisibleSessionModal = (): HTMLElement | undefined =>
+  screen
+    .queryAllByTestId("event-session-modal")
+    .find((element) => !element.closest('[style*="display: none"]'));
+
 describe("Schedule page event listener", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -80,10 +85,11 @@ describe("Schedule page event listener", () => {
 
     await waitFor(() => {
       window.dispatchEvent(new CustomEvent("openScheduleModal", { detail }));
-      expect(screen.getByText(/New Session/i)).toBeInTheDocument();
+      expect(getVisibleSessionModal()).toBeDefined();
     });
 
     // Modal should open with default start time populated
+    expect(getVisibleSessionModal()).toHaveTextContent(/New Session/i);
     const input = screen
       .getAllByLabelText(/Start Time/i)
       .find((element) => !element.closest('[style*="display: none"]')) as HTMLInputElement | undefined;
@@ -110,10 +116,11 @@ describe("Schedule page event listener", () => {
     );
     await screen.findByRole("heading", { name: /Schedule/i });
 
-    await waitFor(async () => {
-      expect(await screen.findByText(/New Session/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getVisibleSessionModal()).toBeDefined();
       expect(localStorage.getItem("pendingSchedule")).toBeNull();
     });
+    expect(getVisibleSessionModal()).toHaveTextContent(/New Session/i);
   });
 
   it("opens create modal when query params request URL-addressable schedule state", async () => {
@@ -134,7 +141,10 @@ describe("Schedule page event listener", () => {
     );
 
     await screen.findByRole("heading", { name: /Schedule/i });
-    expect(await screen.findByText(/New Session/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getVisibleSessionModal()).toBeDefined();
+    });
+    expect(getVisibleSessionModal()).toHaveTextContent(/New Session/i);
   });
 
   it("clears expired URL modal params without opening the modal", async () => {
@@ -179,7 +189,9 @@ describe("Schedule page event listener", () => {
     );
 
     await screen.findByRole("heading", { name: /Schedule/i });
-    await screen.findByText(/New Session/i);
+    await waitFor(() => {
+      expect(getVisibleSessionModal()).toBeDefined();
+    });
     await userEvent.click(screen.getByLabelText(/Close session modal/i));
     await waitFor(() => {
       expect(screen.getByTestId("schedule-search").textContent).toBe("");

--- a/src/pages/__tests__/SuperAdminFeatureFlags.test.tsx
+++ b/src/pages/__tests__/SuperAdminFeatureFlags.test.tsx
@@ -32,6 +32,7 @@ describe('SuperAdminFeatureFlags', () => {
     useAuthSpy.mockReturnValue({
       profile: { role: 'admin' },
       effectiveRole: 'admin',
+      hasCapability: () => false,
     } as unknown as ReturnType<typeof authContext.useAuth>);
 
     renderWithProviders(<SuperAdminFeatureFlags />);
@@ -43,6 +44,7 @@ describe('SuperAdminFeatureFlags', () => {
     useAuthSpy.mockReturnValue({
       profile: { role: 'super_admin' },
       effectiveRole: 'super_admin',
+      hasCapability: () => true,
     } as unknown as ReturnType<typeof authContext.useAuth>);
 
     invokeSpy.mockImplementation(async (_path: string, options?: { body?: Record<string, unknown> }) => {
@@ -143,6 +145,7 @@ describe('SuperAdminFeatureFlags', () => {
     useAuthSpy.mockReturnValue({
       profile: { role: 'super_admin' },
       effectiveRole: 'super_admin',
+      hasCapability: () => true,
     } as unknown as ReturnType<typeof authContext.useAuth>);
 
     invokeSpy.mockImplementation(async (_path: string, options?: { body?: Record<string, unknown> }) => {
@@ -199,6 +202,7 @@ describe('SuperAdminFeatureFlags', () => {
     useAuthSpy.mockReturnValue({
       profile: { role: 'super_admin' },
       effectiveRole: 'super_admin',
+      hasCapability: () => true,
     } as unknown as ReturnType<typeof authContext.useAuth>);
 
     invokeSpy.mockResolvedValueOnce({

--- a/src/pages/__tests__/SuperAdminImpersonation.test.tsx
+++ b/src/pages/__tests__/SuperAdminImpersonation.test.tsx
@@ -42,6 +42,7 @@ beforeEach(() => {
     user: { user_metadata: { organization_id: 'org-123' } },
     profile: { role: 'super_admin' },
     effectiveRole: 'super_admin',
+    hasCapability: () => true,
   } as unknown as ReturnType<typeof authContext.useAuth>);
 
   showSuccessSpy = vi.spyOn(toast, 'showSuccess').mockImplementation(() => undefined);
@@ -67,6 +68,7 @@ describe('SuperAdminImpersonation page', () => {
       user: { user_metadata: { organization_id: 'org-123' } },
       profile: { role: 'admin' },
       effectiveRole: 'admin',
+      hasCapability: () => false,
     } as unknown as ReturnType<typeof authContext.useAuth>);
 
     renderWithProviders(<SuperAdminImpersonation />);

--- a/src/pages/messages/MessagesNew.tsx
+++ b/src/pages/messages/MessagesNew.tsx
@@ -14,9 +14,9 @@ import { showError, showSuccess } from '../../lib/toast';
 
 export function MessagesNew() {
   const navigate = useNavigate();
-  const { profile, effectiveRole } = useAuth();
+  const { profile, hasCapability } = useAuth();
   const organizationId = useActiveOrganizationId();
-  const canCreateGroup = effectiveRole === 'admin' || effectiveRole === 'super_admin';
+  const canCreateGroup = hasCapability('staffDashboard');
   const [subject, setSubject] = useState('');
   const [threadType, setThreadType] = useState<MessageThreadType>('direct');
   const [selectedIds, setSelectedIds] = useState<string[]>([]);

--- a/src/pages/messages/__tests__/MessagesNew.test.tsx
+++ b/src/pages/messages/__tests__/MessagesNew.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../../../lib/authContext', () => ({
   useAuth: () => ({
     profile: { id: 'user-1' },
     effectiveRole: 'therapist',
+    hasCapability: () => false,
   }),
 }));
 

--- a/src/server/routes/__tests__/guards.test.ts
+++ b/src/server/routes/__tests__/guards.test.ts
@@ -81,26 +81,33 @@ describe('route guard access controls', () => {
     expect(requiresPermission('/family', 'guardian_access')).toBe(true);
   });
 
-  it('route guard enforces role hierarchy for therapist routes', () => {
+  it('route guard enforces explicit role access for staff routes', () => {
     expect(hasRoleAccess('/therapists', 'admin')).toBe(true);
+    expect(hasRoleAccess('/therapists', 'admin_schedule')).toBe(true);
     expect(hasRoleAccess('/therapists', 'therapist')).toBe(false);
+    expect(hasRoleAccess('/therapists', 'bcba')).toBe(true);
     expect(hasRoleAccess('/therapists/new', 'super_admin')).toBe(true);
   });
 
   it('restricts client onboarding to admin roles', () => {
     expect(hasRoleAccess('/clients/new', 'therapist')).toBe(false);
+    expect(hasRoleAccess('/clients/new', 'admin_schedule')).toBe(true);
     expect(hasRoleAccess('/clients/new', 'admin')).toBe(true);
     expect(hasRoleAccess('/clients/new', 'super_admin')).toBe(true);
   });
 
-  it('route guard allows elevated roles to inherit lower privileges', () => {
+  it('route guard allows only explicitly listed roles', () => {
+    expect(hasRoleAccess('/clients', 'bt')).toBe(true);
     expect(hasRoleAccess('/clients', 'super_admin')).toBe(true);
     expect(hasRoleAccess('/clients', 'client')).toBe(false);
   });
 
-  it('restricts schedule access to therapist roles and above', () => {
+  it('restricts schedule access to schedule-capable roles', () => {
     expect(hasRoleAccess('/schedule', 'client')).toBe(false);
+    expect(hasRoleAccess('/schedule', 'bt')).toBe(false);
     expect(hasRoleAccess('/schedule', 'therapist')).toBe(true);
+    expect(hasRoleAccess('/schedule', 'midtier')).toBe(true);
+    expect(hasRoleAccess('/schedule', 'admin_schedule')).toBe(true);
     expect(hasRoleAccess('/schedule', 'admin')).toBe(true);
   });
 

--- a/src/server/routes/guards.ts
+++ b/src/server/routes/guards.ts
@@ -1,4 +1,4 @@
-export type AppRole = 'client' | 'therapist' | 'admin' | 'super_admin';
+import type { AppRole } from '../../lib/roles';
 
 export type RouteGuardDefinition = {
   readonly path: string;
@@ -24,32 +24,32 @@ const createGuard = (definition: RouteGuardDefinition): GuardWithMatcher => ({
 const guardDefinitions: readonly GuardWithMatcher[] = [
   createGuard({
     path: '/',
-    allowedRoles: ['client', 'therapist', 'admin', 'super_admin'],
+    allowedRoles: ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.sessions: sessions_scoped_access'],
   }),
   createGuard({
     path: '/schedule',
-    allowedRoles: ['therapist', 'admin', 'super_admin'],
+    allowedRoles: ['therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.sessions: sessions_scoped_access'],
   }),
   createGuard({
     path: '/clients',
-    allowedRoles: ['therapist', 'admin', 'super_admin'],
+    allowedRoles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: ['view_clients'],
     supabasePolicies: ['public.clients: role_scoped_select'],
   }),
   // Static segment must precede `/clients/:clientId` or `new` is treated as a UUID-like id.
   createGuard({
     path: '/clients/new',
-    allowedRoles: ['admin', 'super_admin'],
+    allowedRoles: ['admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['app.set_client_archive_state: admin_super_admin_execute'],
   }),
   createGuard({
     path: '/clients/:clientId',
-    allowedRoles: ['therapist', 'admin', 'super_admin'],
+    allowedRoles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: ['view_clients'],
     supabasePolicies: [
       'public.clients: role_scoped_select',
@@ -58,56 +58,56 @@ const guardDefinitions: readonly GuardWithMatcher[] = [
   }),
   createGuard({
     path: '/therapists',
-    allowedRoles: ['admin', 'super_admin'],
+    allowedRoles: ['admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.therapists: role_scoped_select'],
   }),
   createGuard({
     path: '/therapists/:therapistId',
-    allowedRoles: ['therapist', 'admin', 'super_admin'],
+    allowedRoles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.therapists: role_scoped_select'],
   }),
   createGuard({
     path: '/therapists/new',
-    allowedRoles: ['admin', 'super_admin'],
+    allowedRoles: ['admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.therapists: role_scoped_select'],
   }),
   createGuard({
     path: '/documentation',
-    allowedRoles: ['client', 'therapist', 'admin', 'super_admin'],
+    allowedRoles: ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.profiles: role_scoped_select'],
   }),
   createGuard({
     path: '/fill-docs',
-    allowedRoles: ['therapist', 'admin', 'super_admin'],
+    allowedRoles: ['therapist', 'midtier', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.sessions: sessions_scoped_access'],
   }),
   createGuard({
     path: '/authorizations',
-    allowedRoles: ['admin', 'super_admin'],
+    allowedRoles: ['midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.authorizations: authorizations_org_read'],
   }),
   createGuard({
     path: '/messages',
-    allowedRoles: ['therapist', 'admin', 'super_admin'],
+    allowedRoles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.message_threads: participant_scoped_select'],
   }),
   // Static segment must precede `/messages/:threadId` or `new` is treated as a thread id.
   createGuard({
     path: '/messages/new',
-    allowedRoles: ['therapist', 'admin', 'super_admin'],
+    allowedRoles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.message_threads: participant_scoped_insert'],
   }),
   createGuard({
     path: '/messages/:threadId',
-    allowedRoles: ['therapist', 'admin', 'super_admin'],
+    allowedRoles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: [
       'public.message_threads: participant_scoped_select',
@@ -116,19 +116,19 @@ const guardDefinitions: readonly GuardWithMatcher[] = [
   }),
   createGuard({
     path: '/billing',
-    allowedRoles: ['admin', 'super_admin'],
+    allowedRoles: ['admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.billing_records: scoped_access'],
   }),
   createGuard({
     path: '/monitoring',
-    allowedRoles: ['admin', 'super_admin'],
+    allowedRoles: ['admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['app.get_session_metrics: admin_super_admin_execute'],
   }),
   createGuard({
     path: '/reports',
-    allowedRoles: ['admin', 'super_admin'],
+    allowedRoles: ['admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['supabase.functions.generate_report: admin_super_admin_execute'],
   }),
@@ -141,7 +141,7 @@ const guardDefinitions: readonly GuardWithMatcher[] = [
   }),
   createGuard({
     path: '/settings',
-    allowedRoles: ['admin', 'super_admin'],
+    allowedRoles: ['admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: [
       'supabase.functions.admin_users: admin_super_admin_execute',
@@ -150,7 +150,7 @@ const guardDefinitions: readonly GuardWithMatcher[] = [
   }),
   createGuard({
     path: '/settings/:tabId',
-    allowedRoles: ['admin', 'super_admin'],
+    allowedRoles: ['admin', 'bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: [
       'supabase.functions.admin_users: admin_super_admin_execute',
@@ -159,19 +159,19 @@ const guardDefinitions: readonly GuardWithMatcher[] = [
   }),
   createGuard({
     path: '/super-admin/feature-flags',
-    allowedRoles: ['super_admin'],
+    allowedRoles: ['bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.feature_flags: super_admin_manage'],
   }),
   createGuard({
     path: '/super-admin/impersonation',
-    allowedRoles: ['super_admin'],
+    allowedRoles: ['bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['supabase.functions.super-admin-impersonate: super_admin_execute'],
   }),
   createGuard({
     path: '/super-admin/prompts',
-    allowedRoles: ['super_admin'],
+    allowedRoles: ['bcba', 'super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.agent_prompt_tool_versions: admin_read'],
   }),
@@ -183,13 +183,6 @@ export const findGuardForPath = (pathname: string): RouteGuardDefinition | undef
   return guardDefinitions.find((guard) => guard.matcher.test(pathname));
 };
 
-const roleHierarchy: Record<AppRole, number> = {
-  client: 1,
-  therapist: 2,
-  admin: 3,
-  super_admin: 4,
-};
-
 export const hasRoleAccess = (pathname: string, role: AppRole): boolean => {
   const guard = findGuardForPath(pathname);
   if (!guard) {
@@ -198,11 +191,7 @@ export const hasRoleAccess = (pathname: string, role: AppRole): boolean => {
   if (guard.requiresGuardian) {
     return guard.allowedRoles.includes(role);
   }
-  if (guard.allowedRoles.includes(role)) {
-    return true;
-  }
-  const roleRank = roleHierarchy[role];
-  return guard.allowedRoles.some((allowed) => roleRank >= roleHierarchy[allowed]);
+  return guard.allowedRoles.includes(role);
 };
 
 export const requiresPermission = (pathname: string, permission: string): boolean => {

--- a/supabase/functions/_shared/auth-middleware.ts
+++ b/supabase/functions/_shared/auth-middleware.ts
@@ -27,8 +27,7 @@ const loadSupabaseModule = (): Promise<SupabaseModule> => {
   return supabaseModulePromise;
 };
 
-// Role hierarchy for authorization
-export type Role = 'client' | 'therapist' | 'admin' | 'super_admin';
+export type Role = 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin';
 
 export interface UserContext {
   user: {
@@ -220,24 +219,10 @@ export const authMiddlewareDeps = {
  * Check if user has required role
  */
 function hasRequiredRole(userRole: Role, allowedRoles: Role[]): boolean {
-  // Role hierarchy: super_admin > admin > therapist > client
-  const roleHierarchy: Record<Role, number> = {
-    'super_admin': 4,
-    'admin': 3,
-    'therapist': 2,
-    'client': 1,
-  };
-
-  const userLevel = roleHierarchy[userRole];
-  
-  // Check if user has exact role or higher level role
-  return allowedRoles.some(role => {
-    const requiredLevel = roleHierarchy[role];
-    return userLevel >= requiredLevel;
-  });
+  return allowedRoles.includes(userRole);
 }
 
-const roleOrder: ReadonlyArray<Role> = ['super_admin', 'admin', 'therapist', 'client'];
+const roleOrder: ReadonlyArray<Role> = ['super_admin', 'bcba', 'admin', 'admin_schedule', 'midtier', 'therapist', 'bt', 'client'];
 
 function parseRole(value: unknown): Role | null {
   if (typeof value !== 'string') {
@@ -245,7 +230,16 @@ function parseRole(value: unknown): Role | null {
   }
 
   const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, '_');
-  if (normalized === 'client' || normalized === 'therapist' || normalized === 'admin' || normalized === 'super_admin') {
+  if (
+    normalized === 'client'
+    || normalized === 'bt'
+    || normalized === 'therapist'
+    || normalized === 'midtier'
+    || normalized === 'admin_schedule'
+    || normalized === 'admin'
+    || normalized === 'bcba'
+    || normalized === 'super_admin'
+  ) {
     return normalized;
   }
 
@@ -320,6 +314,15 @@ async function resolveRoleForOrganization(
 
   if (
     await rpcBoolean(supabase, "user_has_role_for_org", {
+      role_name: "bcba",
+      target_organization_id: orgId,
+    })
+  ) {
+    return "bcba";
+  }
+
+  if (
+    await rpcBoolean(supabase, "user_has_role_for_org", {
       role_name: "org_super_admin",
       target_organization_id: orgId,
     })
@@ -347,11 +350,38 @@ async function resolveRoleForOrganization(
 
   if (
     await rpcBoolean(supabase, "user_has_role_for_org", {
+      role_name: "admin_schedule",
+      target_organization_id: orgId,
+    })
+  ) {
+    return "admin_schedule";
+  }
+
+  if (
+    await rpcBoolean(supabase, "user_has_role_for_org", {
+      role_name: "midtier",
+      target_organization_id: orgId,
+    })
+  ) {
+    return "midtier";
+  }
+
+  if (
+    await rpcBoolean(supabase, "user_has_role_for_org", {
       role_name: "therapist",
       target_organization_id: orgId,
     })
   ) {
     return "therapist";
+  }
+
+  if (
+    await rpcBoolean(supabase, "user_has_role_for_org", {
+      role_name: "bt",
+      target_organization_id: orgId,
+    })
+  ) {
+    return "bt";
   }
 
   if (
@@ -552,16 +582,16 @@ export function createPublicRoute(
 /**
  * Role-based route decorators
  */
-export const requireClient = (allowedRoles: Role[] = ['client']) => 
+export const requireClient = (allowedRoles: Role[] = ['client']) =>
   ({ allowedRoles });
 
-export const requireTherapist = (allowedRoles: Role[] = ['therapist']) => 
+export const requireTherapist = (allowedRoles: Role[] = ['therapist']) =>
   ({ allowedRoles });
 
-export const requireAdmin = (allowedRoles: Role[] = ['admin', 'super_admin']) => 
+export const requireAdmin = (allowedRoles: Role[] = ['admin', 'bcba', 'super_admin']) =>
   ({ allowedRoles });
 
-export const requireSuperAdmin = (allowedRoles: Role[] = ['super_admin']) => 
+export const requireSuperAdmin = (allowedRoles: Role[] = ['bcba', 'super_admin']) =>
   ({ allowedRoles });
 
 /**
@@ -570,10 +600,12 @@ export const requireSuperAdmin = (allowedRoles: Role[] = ['super_admin']) =>
 export const RouteOptions = {
   public: {},
   authenticated: { requireAuth: true },
-  client: { requireAuth: true, allowedRoles: ['client', 'therapist', 'admin', 'super_admin'] as Role[] },
-  therapist: { requireAuth: true, allowedRoles: ['therapist', 'admin', 'super_admin'] as Role[] },
-  admin: { requireAuth: true, allowedRoles: ['admin', 'super_admin'] as Role[] },
-  superAdmin: { requireAuth: true, allowedRoles: ['super_admin'] as Role[] },
+  client: { requireAuth: true, allowedRoles: ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'] as Role[] },
+  therapist: { requireAuth: true, allowedRoles: ['bt', 'therapist', 'midtier', 'admin', 'bcba', 'super_admin'] as Role[] },
+  staffAdmin: { requireAuth: true, allowedRoles: ['admin_schedule', 'admin', 'bcba', 'super_admin'] as Role[] },
+  admin: { requireAuth: true, allowedRoles: ['admin', 'bcba', 'super_admin'] as Role[] },
+  programsGoals: { requireAuth: true, allowedRoles: ['bt', 'therapist', 'midtier', 'admin', 'bcba', 'super_admin'] as Role[] },
+  superAdmin: { requireAuth: true, allowedRoles: ['bcba', 'super_admin'] as Role[] },
 };
 
 export const __TESTING__ = {

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -35,7 +35,7 @@ export async function assertAdminOrSuperAdmin(db: SupabaseClient) {
       })
     : [];
 
-  const hasAdminAccess = roles.some(role => role === "admin" || role === "super_admin");
+  const hasAdminAccess = roles.some(role => role === "admin" || role === "bcba" || role === "super_admin");
 
   if (!hasAdminAccess) throw new Response("Forbidden", { status: 403 });
 }

--- a/supabase/functions/admin-users-roles/index.ts
+++ b/supabase/functions/admin-users-roles/index.ts
@@ -2,16 +2,29 @@ import { createProtectedRoute, corsHeaders, logApiAccess, RouteOptions } from ".
 import { createRequestClient, supabaseAdmin } from "../_shared/database.ts";
 import { assertAdminOrSuperAdmin } from "../_shared/auth.ts";
 
-interface RoleUpdateRequest { role: 'client' | 'therapist' | 'admin' | 'super_admin'; is_active?: boolean; }
+interface RoleUpdateRequest { role: 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin'; is_active?: boolean; }
 
 type AppRole = RoleUpdateRequest["role"];
 
-const CANONICAL_ROLE_NAMES: AppRole[] = ["super_admin", "admin", "therapist", "client"];
+const CANONICAL_ROLE_NAMES: AppRole[] = [
+  "super_admin",
+  "bcba",
+  "admin",
+  "admin_schedule",
+  "midtier",
+  "therapist",
+  "bt",
+  "client",
+];
 
 const ROLE_RANK: Record<AppRole, number> = {
-  super_admin: 4,
-  admin: 3,
-  therapist: 2,
+  super_admin: 8,
+  bcba: 8,
+  admin: 7,
+  admin_schedule: 6,
+  midtier: 5,
+  therapist: 4,
+  bt: 3,
   client: 1,
 };
 
@@ -119,13 +132,17 @@ export default createProtectedRoute(async (req: Request, userContext) => {
     if (!uuidRegex.test(userId)) return new Response(JSON.stringify({ error: 'Invalid user ID format' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
     const { role, is_active }: RoleUpdateRequest = await req.json();
-    const validRoles = ['client', 'therapist', 'admin', 'super_admin'];
+    const validRoles = CANONICAL_ROLE_NAMES;
     if (!role || !validRoles.includes(role)) return new Response(JSON.stringify({ error: 'Valid role is required', validRoles }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
     const { data: existingUser } = await adminClient.from('profiles').select('id, email, role, is_active').eq('id', userId).single();
     if (!existingUser) return new Response(JSON.stringify({ error: 'User not found' }), { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
-    if (userId === userContext.user.id && userContext.profile.role === 'super_admin' && role !== 'super_admin') return new Response(JSON.stringify({ error: 'Cannot demote yourself from super_admin role' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    if (
+      userId === userContext.user.id
+      && (userContext.profile.role === 'super_admin' || userContext.profile.role === 'bcba')
+      && role !== userContext.profile.role
+    ) return new Response(JSON.stringify({ error: `Cannot demote yourself from ${userContext.profile.role} role` }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     if (userId === userContext.user.id && is_active === false) return new Response(JSON.stringify({ error: 'Cannot deactivate your own account' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
     const updateData: any = { role }; if (is_active !== undefined) updateData.is_active = is_active;

--- a/supabase/migrations/20260701150000_employee_role_capability_matrix.sql
+++ b/supabase/migrations/20260701150000_employee_role_capability_matrix.sql
@@ -1,0 +1,865 @@
+-- @migration-intent: Add employee role vocabulary for the capability matrix and keep role resolvers aligned.
+-- @migration-dependencies: 20260422153000_user_has_role_for_org_storage_role_aliases.sql
+-- @migration-rollback: Remove new role rows from public.roles after removing assignments; enum values cannot be dropped safely without rebuilding public.role_type.
+
+ALTER TYPE public.role_type ADD VALUE IF NOT EXISTS 'bt';
+ALTER TYPE public.role_type ADD VALUE IF NOT EXISTS 'midtier';
+ALTER TYPE public.role_type ADD VALUE IF NOT EXISTS 'admin_schedule';
+ALTER TYPE public.role_type ADD VALUE IF NOT EXISTS 'bcba';
+
+INSERT INTO public.roles (name, description)
+VALUES
+  ('bt', 'Behavior technician assigned-client access'),
+  ('midtier', 'Mid-tier clinician schedule, authorization, programs, and goals access'),
+  ('admin_schedule', 'Scheduling administrator staff, client, authorization, and assignment access'),
+  ('bcba', 'BCBA super-admin-equivalent access')
+ON CONFLICT (name) DO UPDATE
+SET description = EXCLUDED.description;
+
+CREATE OR REPLACE FUNCTION public.get_user_role_from_junction(p_user_id uuid)
+RETURNS public.role_type
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  user_role text;
+BEGIN
+  SELECT r.name INTO user_role
+  FROM public.user_roles ur
+  JOIN public.roles r ON ur.role_id = r.id
+  WHERE ur.user_id = p_user_id
+    AND COALESCE(ur.is_active, true) = true
+    AND (ur.expires_at IS NULL OR ur.expires_at > now())
+  ORDER BY
+    CASE r.name
+      WHEN 'super_admin' THEN 8
+      WHEN 'bcba' THEN 8
+      WHEN 'admin' THEN 7
+      WHEN 'admin_schedule' THEN 6
+      WHEN 'midtier' THEN 5
+      WHEN 'therapist' THEN 4
+      WHEN 'bt' THEN 3
+      WHEN 'client' THEN 1
+      ELSE 0
+    END DESC
+  LIMIT 1;
+
+  RETURN COALESCE(user_role::public.role_type, 'client'::public.role_type);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_is_super_admin()
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id uuid;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    WHERE ur.user_id = v_user_id
+      AND r.name IN ('super_admin', 'bcba')
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.current_user_is_super_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, app_auth
+AS $$
+  SELECT COALESCE(app.current_user_is_super_admin(), false);
+$$;
+
+CREATE OR REPLACE FUNCTION app.user_has_role_for_org(
+  role_name text,
+  target_organization_id uuid DEFAULT NULL,
+  target_therapist_id uuid DEFAULT NULL,
+  target_client_id uuid DEFAULT NULL,
+  target_session_id uuid DEFAULT NULL
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  caller_id uuid;
+  caller_org uuid;
+  resolved_org uuid;
+  resolved_client_id uuid := target_client_id;
+  normalized_role text;
+BEGIN
+  caller_id := auth.uid();
+  IF caller_id IS NULL OR role_name IS NULL OR btrim(role_name) = '' THEN
+    RETURN false;
+  END IF;
+
+  IF app.current_user_is_super_admin() THEN
+    RETURN true;
+  END IF;
+
+  caller_org := app.resolve_user_organization_id(caller_id);
+  IF caller_org IS NULL THEN
+    RETURN false;
+  END IF;
+
+  resolved_org := target_organization_id;
+
+  IF resolved_org IS NULL AND target_therapist_id IS NOT NULL THEN
+    SELECT t.organization_id
+    INTO resolved_org
+    FROM public.therapists t
+    WHERE t.id = target_therapist_id;
+  END IF;
+
+  IF resolved_org IS NULL AND target_session_id IS NOT NULL THEN
+    SELECT COALESCE(s.organization_id, t.organization_id), s.client_id
+    INTO resolved_org, resolved_client_id
+    FROM public.sessions s
+    LEFT JOIN public.therapists t ON t.id = s.therapist_id
+    WHERE s.id = target_session_id;
+  END IF;
+
+  IF resolved_org IS NULL AND target_client_id IS NOT NULL THEN
+    SELECT COALESCE(
+      c.organization_id,
+      (
+        SELECT COALESCE(s.organization_id, t.organization_id)
+        FROM public.sessions s
+        LEFT JOIN public.therapists t ON t.id = s.therapist_id
+        WHERE s.client_id = c.id
+        ORDER BY s.created_at DESC NULLS LAST
+        LIMIT 1
+      )
+    ), c.id
+    INTO resolved_org, resolved_client_id
+    FROM public.clients c
+    WHERE c.id = target_client_id;
+  END IF;
+
+  IF resolved_org IS NULL OR resolved_org <> caller_org THEN
+    RETURN false;
+  END IF;
+
+  IF role_name = 'client' THEN
+    IF resolved_client_id IS NOT NULL THEN
+      IF caller_id = resolved_client_id THEN
+        RETURN true;
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM public.client_guardians cg
+        WHERE cg.guardian_id = caller_id
+          AND cg.client_id = resolved_client_id
+          AND cg.organization_id = resolved_org
+          AND cg.deleted_at IS NULL
+      ) THEN
+        RETURN true;
+      END IF;
+    END IF;
+
+    RETURN false;
+  END IF;
+
+  normalized_role := lower(btrim(role_name));
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    WHERE ur.user_id = caller_id
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+      AND (
+        (normalized_role = 'admin' AND r.name IN ('admin', 'org_admin'))
+        OR (normalized_role = 'therapist' AND r.name IN ('therapist', 'org_member'))
+        OR (normalized_role = 'super_admin' AND r.name IN ('super_admin', 'org_super_admin', 'bcba'))
+        OR r.name = normalized_role
+      )
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_user_role_from_junction(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_is_super_admin() TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.current_user_is_super_admin() TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.user_has_role_for_org(text, uuid, uuid, uuid, uuid) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION app.user_has_role_for_org(
+  target_user_id uuid,
+  target_organization_id uuid,
+  allowed_roles text[]
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  resolved_org uuid;
+BEGIN
+  IF target_user_id IS NULL OR target_organization_id IS NULL OR allowed_roles IS NULL OR cardinality(allowed_roles) = 0 THEN
+    RETURN false;
+  END IF;
+
+  IF target_user_id <> app.current_user_id() AND NOT app.current_user_is_super_admin() THEN
+    RETURN false;
+  END IF;
+
+  IF app.current_user_is_super_admin() THEN
+    RETURN true;
+  END IF;
+
+  resolved_org := app.resolve_user_organization_id(target_user_id);
+  IF resolved_org IS NULL OR resolved_org <> target_organization_id THEN
+    RETURN false;
+  END IF;
+
+  RETURN EXISTS (
+    WITH allowed_input AS (
+      SELECT lower(btrim(unnest(allowed_roles))) AS role_name
+    ),
+    mapped_roles AS (
+      SELECT unnest(
+        CASE role_name
+          WHEN 'org_admin' THEN ARRAY['admin']::text[]
+          WHEN 'org_member' THEN ARRAY['therapist', 'client']::text[]
+          WHEN 'org_super_admin' THEN ARRAY['super_admin', 'bcba']::text[]
+          WHEN 'super_admin' THEN ARRAY['super_admin', 'bcba']::text[]
+          WHEN 'therapist' THEN ARRAY['therapist']::text[]
+          ELSE ARRAY[role_name]::text[]
+        END
+      ) AS role_name
+      FROM allowed_input
+    )
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    JOIN mapped_roles mr ON mr.role_name = r.name
+    WHERE ur.user_id = target_user_id
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION app.user_has_role_for_org(uuid, uuid, text[]) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION app.is_super_admin()
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    WHERE ur.user_id = v_user_id
+      AND r.name IN ('super_admin', 'bcba')
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_has_exact_role_for_org(
+  target_organization_id uuid,
+  allowed_roles text[]
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  caller_id uuid := auth.uid();
+  caller_org uuid;
+BEGIN
+  IF caller_id IS NULL OR target_organization_id IS NULL OR allowed_roles IS NULL OR cardinality(allowed_roles) = 0 THEN
+    RETURN false;
+  END IF;
+
+  IF app.current_user_is_super_admin() THEN
+    RETURN true;
+  END IF;
+
+  caller_org := app.resolve_user_organization_id(caller_id);
+  IF caller_org IS NULL OR caller_org <> target_organization_id THEN
+    RETURN false;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    WHERE ur.user_id = caller_id
+      AND r.name = ANY(allowed_roles)
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_has_assigned_client(
+  target_organization_id uuid,
+  target_client_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  caller_id uuid := auth.uid();
+  caller_therapist_id uuid;
+BEGIN
+  IF caller_id IS NULL OR target_organization_id IS NULL OR target_client_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF target_organization_id <> app.current_user_organization_id() THEN
+    RETURN false;
+  END IF;
+
+  caller_therapist_id := app.current_therapist_id();
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.clients c
+    WHERE c.id = target_client_id
+      AND c.organization_id = target_organization_id
+      AND (
+        c.therapist_id IS NOT DISTINCT FROM caller_id
+        OR c.therapist_id IS NOT DISTINCT FROM caller_therapist_id
+        OR EXISTS (
+          SELECT 1
+          FROM public.client_therapist_links ctl
+          WHERE ctl.client_id = c.id
+            AND ctl.organization_id = target_organization_id
+            AND (
+              ctl.therapist_id IS NOT DISTINCT FROM caller_id
+              OR ctl.therapist_id IS NOT DISTINCT FROM caller_therapist_id
+            )
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM public.sessions s
+          WHERE s.client_id = c.id
+            AND s.organization_id = target_organization_id
+            AND (
+              s.therapist_id IS NOT DISTINCT FROM caller_id
+              OR s.therapist_id IS NOT DISTINCT FROM caller_therapist_id
+            )
+        )
+      )
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_manage_staff_clients(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['admin', 'admin_schedule']::text[]);
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_manage_authorizations(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['admin', 'admin_schedule', 'midtier']::text[]);
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_manage_schedule(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['admin', 'admin_schedule', 'midtier', 'therapist']::text[]);
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_manage_programs_goals(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['admin', 'midtier', 'therapist']::text[]);
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_read_client_programs(
+  target_organization_id uuid,
+  target_client_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT
+    app.current_user_can_manage_programs_goals(target_organization_id)
+    OR (
+      app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['bt']::text[])
+      AND app.current_user_has_assigned_client(target_organization_id, target_client_id)
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_take_client_data(
+  target_organization_id uuid,
+  target_client_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT
+    app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['admin', 'midtier']::text[])
+    OR (
+      app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['therapist', 'bt']::text[])
+      AND app.current_user_has_assigned_client(target_organization_id, target_client_id)
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_read_authorization_row(
+  p_organization_id uuid,
+  p_client_id uuid,
+  p_provider_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+BEGIN
+  IF p_organization_id IS NULL OR p_client_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF p_organization_id IS DISTINCT FROM app.current_user_organization_id() THEN
+    RETURN false;
+  END IF;
+
+  IF app.current_user_can_manage_authorizations(p_organization_id) THEN
+    RETURN true;
+  END IF;
+
+  IF COALESCE(app.user_has_role('client'), false)
+     AND NOT COALESCE(app.user_has_role('therapist'), false)
+     AND app.user_has_role_for_org(app.current_user_id(), p_organization_id, ARRAY['org_member'::text]) THEN
+    RETURN true;
+  END IF;
+
+  IF COALESCE(app.user_has_role('therapist'), false) THEN
+    IF p_provider_id IS NOT DISTINCT FROM app.current_user_id() THEN
+      RETURN true;
+    END IF;
+
+    RETURN app.current_user_has_assigned_client(p_organization_id, p_client_id);
+  END IF;
+
+  IF p_provider_id IS NOT DISTINCT FROM app.current_user_id() THEN
+    RETURN true;
+  END IF;
+
+  RETURN false;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION app.is_super_admin() TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_has_exact_role_for_org(uuid, text[]) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_has_assigned_client(uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_manage_staff_clients(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_manage_authorizations(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_manage_schedule(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_manage_programs_goals(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_read_client_programs(uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_take_client_data(uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_read_authorization_row(uuid, uuid, uuid) TO authenticated, service_role;
+
+DROP POLICY IF EXISTS org_read_clients ON public.clients;
+CREATE POLICY org_read_clients
+ON public.clients
+FOR SELECT
+TO authenticated
+USING (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND (
+      app.current_user_has_exact_role_for_org(organization_id, ARRAY['admin', 'admin_schedule', 'therapist', 'midtier']::text[])
+      OR app.user_has_role_for_org('client'::text, organization_id, NULL::uuid, id)
+      OR (
+        app.current_user_has_exact_role_for_org(organization_id, ARRAY['bt']::text[])
+        AND app.current_user_has_assigned_client(organization_id, id)
+      )
+    )
+  )
+);
+
+DROP POLICY IF EXISTS org_write_clients ON public.clients;
+CREATE POLICY org_write_clients
+ON public.clients
+FOR ALL
+TO authenticated
+USING (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND app.current_user_can_manage_staff_clients(organization_id)
+  )
+)
+WITH CHECK (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND app.current_user_can_manage_staff_clients(organization_id)
+  )
+);
+
+DROP POLICY IF EXISTS therapists_admin_manage ON public.therapists;
+DROP POLICY IF EXISTS therapists_org_admin_manage ON public.therapists;
+DROP POLICY IF EXISTS therapists_org_staff_select ON public.therapists;
+DROP POLICY IF EXISTS therapists_org_staff_manage ON public.therapists;
+CREATE POLICY therapists_org_staff_select
+ON public.therapists
+FOR SELECT
+TO authenticated
+USING (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND app.current_user_has_exact_role_for_org(organization_id, ARRAY['admin', 'admin_schedule', 'therapist', 'midtier', 'bt']::text[])
+  )
+);
+
+CREATE POLICY therapists_org_staff_manage
+ON public.therapists
+FOR ALL
+TO authenticated
+USING (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND app.current_user_can_manage_staff_clients(organization_id)
+  )
+)
+WITH CHECK (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND app.current_user_can_manage_staff_clients(organization_id)
+  )
+);
+
+DROP POLICY IF EXISTS client_therapist_links_manage_scope ON public.client_therapist_links;
+CREATE POLICY client_therapist_links_manage_scope
+ON public.client_therapist_links
+FOR ALL
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_staff_clients(organization_id)
+)
+WITH CHECK (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_staff_clients(organization_id)
+);
+
+DROP POLICY IF EXISTS client_therapist_links_select_scope ON public.client_therapist_links;
+CREATE POLICY client_therapist_links_select_scope
+ON public.client_therapist_links
+FOR SELECT
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND (
+    app.current_user_can_manage_staff_clients(organization_id)
+    OR therapist_id = app.current_therapist_id()
+    OR app.can_access_client(client_id)
+  )
+);
+
+DROP POLICY IF EXISTS authorizations_org_write ON public.authorizations;
+CREATE POLICY authorizations_org_write
+ON public.authorizations
+FOR ALL
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND (
+    app.current_user_can_manage_authorizations(organization_id)
+    OR provider_id = app.current_user_id()
+  )
+)
+WITH CHECK (
+  organization_id = app.current_user_organization_id()
+  AND (
+    app.current_user_can_manage_authorizations(organization_id)
+    OR provider_id = app.current_user_id()
+  )
+);
+
+DROP POLICY IF EXISTS authorization_services_org_write ON public.authorization_services;
+CREATE POLICY authorization_services_org_write
+ON public.authorization_services
+FOR ALL
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND EXISTS (
+    SELECT 1
+    FROM public.authorizations a
+    WHERE a.id = authorization_services.authorization_id
+      AND a.organization_id = authorization_services.organization_id
+      AND (
+        app.current_user_can_manage_authorizations(a.organization_id)
+        OR a.provider_id = app.current_user_id()
+      )
+  )
+)
+WITH CHECK (
+  organization_id = app.current_user_organization_id()
+  AND EXISTS (
+    SELECT 1
+    FROM public.authorizations a
+    WHERE a.id = authorization_services.authorization_id
+      AND a.organization_id = authorization_services.organization_id
+      AND (
+        app.current_user_can_manage_authorizations(a.organization_id)
+        OR a.provider_id = app.current_user_id()
+      )
+  )
+);
+
+DROP POLICY IF EXISTS programs_org_manage ON public.programs;
+DROP POLICY IF EXISTS programs_org_read ON public.programs;
+CREATE POLICY programs_org_read
+ON public.programs
+FOR SELECT
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_read_client_programs(organization_id, client_id)
+);
+
+CREATE POLICY programs_org_manage
+ON public.programs
+FOR ALL
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_programs_goals(organization_id)
+)
+WITH CHECK (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_programs_goals(organization_id)
+);
+
+DROP POLICY IF EXISTS goals_org_manage ON public.goals;
+DROP POLICY IF EXISTS goals_org_read ON public.goals;
+CREATE POLICY goals_org_read
+ON public.goals
+FOR SELECT
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_read_client_programs(organization_id, client_id)
+);
+
+CREATE POLICY goals_org_manage
+ON public.goals
+FOR ALL
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_programs_goals(organization_id)
+)
+WITH CHECK (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_programs_goals(organization_id)
+);
+
+DROP POLICY IF EXISTS goal_data_points_org_manage ON public.goal_data_points;
+CREATE POLICY goal_data_points_org_manage
+ON public.goal_data_points
+FOR ALL
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_take_client_data(organization_id, client_id)
+)
+WITH CHECK (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_take_client_data(organization_id, client_id)
+);
+
+DROP POLICY IF EXISTS org_read_client_session_notes ON public.client_session_notes;
+CREATE POLICY org_read_client_session_notes
+ON public.client_session_notes
+FOR SELECT
+TO authenticated
+USING (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND app.current_user_can_take_client_data(organization_id, client_id)
+  )
+);
+
+DROP POLICY IF EXISTS org_write_client_session_notes ON public.client_session_notes;
+CREATE POLICY org_write_client_session_notes
+ON public.client_session_notes
+FOR ALL
+TO authenticated
+USING (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND app.current_user_can_take_client_data(organization_id, client_id)
+  )
+)
+WITH CHECK (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND app.current_user_can_take_client_data(organization_id, client_id)
+  )
+);
+
+DROP POLICY IF EXISTS org_read_sessions ON public.sessions;
+CREATE POLICY org_read_sessions
+ON public.sessions
+FOR SELECT
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND (
+    app.current_user_can_manage_schedule(organization_id)
+    OR (
+      app.current_user_has_exact_role_for_org(organization_id, ARRAY['bt']::text[])
+      AND app.current_user_has_assigned_client(organization_id, client_id)
+    )
+  )
+);
+
+DROP POLICY IF EXISTS org_write_sessions ON public.sessions;
+CREATE POLICY org_write_sessions
+ON public.sessions
+FOR ALL
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_schedule(organization_id)
+)
+WITH CHECK (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_schedule(organization_id)
+);
+
+DROP POLICY IF EXISTS session_goals_org_read ON public.session_goals;
+CREATE POLICY session_goals_org_read
+ON public.session_goals
+FOR SELECT
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_read_client_programs(organization_id, client_id)
+);
+
+DROP POLICY IF EXISTS session_goals_org_insert ON public.session_goals;
+CREATE POLICY session_goals_org_insert
+ON public.session_goals
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_programs_goals(organization_id)
+);
+
+DROP POLICY IF EXISTS session_goals_org_update ON public.session_goals;
+CREATE POLICY session_goals_org_update
+ON public.session_goals
+FOR UPDATE
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_programs_goals(organization_id)
+  AND EXISTS (
+    SELECT 1
+    FROM public.sessions s
+    WHERE s.id = session_goals.session_id
+      AND s.organization_id = session_goals.organization_id
+      AND s.status <> 'in_progress'::text
+  )
+)
+WITH CHECK (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_programs_goals(organization_id)
+  AND EXISTS (
+    SELECT 1
+    FROM public.sessions s
+    WHERE s.id = session_goals.session_id
+      AND s.organization_id = session_goals.organization_id
+      AND s.status <> 'in_progress'::text
+  )
+);
+
+DROP POLICY IF EXISTS session_goals_org_delete ON public.session_goals;
+CREATE POLICY session_goals_org_delete
+ON public.session_goals
+FOR DELETE
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_manage_programs_goals(organization_id)
+  AND EXISTS (
+    SELECT 1
+    FROM public.sessions s
+    WHERE s.id = session_goals.session_id
+      AND s.organization_id = session_goals.organization_id
+      AND s.status <> 'in_progress'::text
+  )
+);

--- a/tests/admin-users-roles.access.spec.ts
+++ b/tests/admin-users-roles.access.spec.ts
@@ -9,12 +9,16 @@ const envValues = new Map<string, string>([
 
 const CANONICAL_TEST_ROLES = [
   { id: 'rid-super', name: 'super_admin' },
+  { id: 'rid-bcba', name: 'bcba' },
   { id: 'rid-admin', name: 'admin' },
+  { id: 'rid-admin-schedule', name: 'admin_schedule' },
+  { id: 'rid-midtier', name: 'midtier' },
   { id: 'rid-therapist', name: 'therapist' },
+  { id: 'rid-bt', name: 'bt' },
   { id: 'rid-client', name: 'client' },
 ] as const;
 
-type TestRole = 'client' | 'therapist' | 'admin' | 'super_admin';
+type TestRole = 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin';
 
 type TestUser = {
   id: string;
@@ -309,6 +313,54 @@ describe('admin-users-roles access control', () => {
       user_id: existingProfile.id,
       role_id: 'rid-super',
       granted_by: 'super-admin-2',
+      is_active: true,
+    });
+  });
+
+  it('syncs user_roles when assigning bcba', async () => {
+    rpcRoles = ['super_admin'];
+
+    const superAdminContext: TestUserContext = {
+      user: { id: 'super-admin-3', email: 'super3@example.com' },
+      profile: {
+        id: 'super-admin-profile-3',
+        email: 'super3@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    };
+
+    userContexts.set('super3', superAdminContext);
+    adminUsers.set('super-admin-3', {
+      id: 'super-admin-3',
+      email: 'super3@example.com',
+      user_metadata: { organization_id: 'org-123' },
+    });
+    adminUsers.set(existingProfile.id, {
+      id: existingProfile.id,
+      email: existingProfile.email,
+      user_metadata: { organization_id: 'org-999' },
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-users-roles/index.ts');
+
+    const response = await handler(
+      new Request('http://localhost/functions/v1/admin/users/11111111-1111-1111-1111-111111111111/roles', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+          'x-test-user': 'super3',
+        },
+        body: JSON.stringify({ role: 'bcba' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(userRolesUpsertPayload).toMatchObject({
+      user_id: existingProfile.id,
+      role_id: 'rid-bcba',
+      granted_by: 'super-admin-3',
       is_active: true,
     });
   });

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -65,7 +65,7 @@ const createFixture = (
     root,
     "cypress/support/routeScenarios.ts",
     [
-      'roles: ["therapist", "admin", "super_admin"]',
+      'roles: ["therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"]',
       'cy.intercept("GET", "**/api/runtime-config").as("runtimeConfig");',
       'cy.wait("@runtimeConfig");',
     ].join("\n"),

--- a/tests/edge/route-audit-policy.test.ts
+++ b/tests/edge/route-audit-policy.test.ts
@@ -34,7 +34,7 @@ const parseAppRouteRoles = (source: string): Map<string, string[]> => {
   routeMap.set('/signup', ['public']);
   routeMap.set('/auth/recovery', ['public']);
   routeMap.set('/unauthorized', ['public']);
-  routeMap.set('/', normalizeRoles(['client', 'therapist', 'admin', 'super_admin']));
+  routeMap.set('/', normalizeRoles(['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']));
 
   const routeEntries: Array<{ readonly index: number; readonly path: string }> = [];
   const routePathRegex = /<Route\b[\s\S]*?path="([^"]+)"/g;
@@ -59,7 +59,7 @@ const parseAppRouteRoles = (source: string): Map<string, string[]> => {
     const rolesMatch = snippet.match(/RoleGuard[\s\S]*?roles=\{\[([^\]]+)\]\}/);
     const roles = rolesMatch
       ? parseRoleList(rolesMatch[1])
-      : normalizeRoles(['client', 'therapist', 'admin', 'super_admin']);
+      : normalizeRoles(['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']);
 
     routeMap.set(`/${entry.path.replace(/^\//, '')}`, roles);
   }

--- a/tests/edge/route-guards-parity.test.ts
+++ b/tests/edge/route-guards-parity.test.ts
@@ -25,7 +25,7 @@ type AppGuardExpectation = {
 const parseGuardedRoutesFromApp = (source: string): Map<string, AppGuardExpectation> => {
   const routeMap = new Map<string, AppGuardExpectation>();
   routeMap.set('/', {
-    roles: normalizeRoles(['client', 'therapist', 'admin', 'super_admin']),
+    roles: normalizeRoles(['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']),
     requiresGuardian: false,
   });
 
@@ -51,7 +51,7 @@ const parseGuardedRoutesFromApp = (source: string): Map<string, AppGuardExpectat
     const rolesMatch = snippet.match(/RoleGuard[\s\S]*?roles=\{\[([^\]]+)\]\}/);
     const roles = rolesMatch
       ? parseRoleList(rolesMatch[1])
-      : normalizeRoles(['client', 'therapist', 'admin', 'super_admin']);
+      : normalizeRoles(['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']);
     const requiresGuardian = snippet.includes('requireGuardian');
 
     routeMap.set(`/${entry.path.replace(/^\//, '')}`, { roles, requiresGuardian });

--- a/tests/employee-role-capability-matrix-migration.test.ts
+++ b/tests/employee-role-capability-matrix-migration.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260701150000_employee_role_capability_matrix.sql',
+);
+const SMOKE_SQL_PATH = path.join(process.cwd(), 'tests', 'sql', 'employee_role_capability_smoke.sql');
+
+const sql = readFileSync(MIGRATION_PATH, 'utf8');
+const smokeSql = readFileSync(SMOKE_SQL_PATH, 'utf8');
+
+const extractFunction = (name: string): string => {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`CREATE OR REPLACE FUNCTION ${escapedName}\\([\\s\\S]*?\\n\\$\\$;`, 'i');
+  const match = sql.match(pattern);
+  expect(match, `${name} function should exist`).not.toBeNull();
+  return match?.[0] ?? '';
+};
+
+describe('employee role capability matrix migration', () => {
+  it('keeps bt and midtier out of broad therapist/org_member helper aliases', () => {
+    expect(sql).toContain("(normalized_role = 'therapist' AND r.name IN ('therapist', 'org_member'))");
+    expect(sql).toContain("WHEN 'org_member' THEN ARRAY['therapist', 'client']::text[]");
+    expect(sql).toContain("WHEN 'therapist' THEN ARRAY['therapist']::text[]");
+    expect(sql).not.toContain(
+      "normalized_role = 'therapist' AND r.name IN ('therapist', 'org_member', 'midtier', 'bt')",
+    );
+    expect(sql).not.toContain("WHEN 'therapist' THEN ARRAY['therapist', 'midtier', 'bt']::text[]");
+  });
+
+  it('treats bcba as super-admin-equivalent in database helper paths', () => {
+    const currentUserSuperAdmin = extractFunction('app.current_user_is_super_admin');
+    const isSuperAdmin = extractFunction('app.is_super_admin');
+
+    expect(currentUserSuperAdmin).toContain("r.name IN ('super_admin', 'bcba')");
+    expect(isSuperAdmin).toContain("r.name IN ('super_admin', 'bcba')");
+  });
+
+  it('allows admin_schedule to manage staff, clients, assignments, and authorizations only through explicit helpers', () => {
+    const staffClientHelper = extractFunction('app.current_user_can_manage_staff_clients');
+    const authorizationHelper = extractFunction('app.current_user_can_manage_authorizations');
+    const programsGoalsHelper = extractFunction('app.current_user_can_manage_programs_goals');
+
+    expect(staffClientHelper).toContain("ARRAY['admin', 'admin_schedule']::text[]");
+    expect(authorizationHelper).toContain("ARRAY['admin', 'admin_schedule', 'midtier']::text[]");
+    expect(programsGoalsHelper).toContain("ARRAY['admin', 'midtier', 'therapist']::text[]");
+    expect(programsGoalsHelper).not.toContain('admin_schedule');
+
+    expect(sql).toContain('CREATE POLICY org_write_clients');
+    expect(sql).toContain('CREATE POLICY therapists_org_staff_manage');
+    expect(sql).toContain('CREATE POLICY client_therapist_links_manage_scope');
+    expect(sql).toContain('CREATE POLICY authorizations_org_write');
+    expect(sql).toContain('app.current_user_can_manage_staff_clients(organization_id)');
+    expect(sql).toContain('app.current_user_can_manage_authorizations(organization_id)');
+  });
+
+  it('limits bt programs, goals, sessions, and data-taking paths to assigned clients', () => {
+    const readProgramsHelper = extractFunction('app.current_user_can_read_client_programs');
+    const takeDataHelper = extractFunction('app.current_user_can_take_client_data');
+
+    expect(readProgramsHelper).toContain("ARRAY['bt']::text[]");
+    expect(readProgramsHelper).toContain(
+      'app.current_user_has_assigned_client(target_organization_id, target_client_id)',
+    );
+    expect(takeDataHelper).toContain("ARRAY['therapist', 'bt']::text[]");
+    expect(takeDataHelper).toContain(
+      'app.current_user_has_assigned_client(target_organization_id, target_client_id)',
+    );
+
+    expect(sql).toContain('CREATE POLICY programs_org_read');
+    expect(sql).toContain('CREATE POLICY goals_org_read');
+    expect(sql).toContain('CREATE POLICY org_read_sessions');
+    expect(sql).toContain('CREATE POLICY goal_data_points_org_manage');
+    expect(sql).toContain('CREATE POLICY org_write_client_session_notes');
+    expect(sql).toContain('app.current_user_can_read_client_programs(organization_id, client_id)');
+    expect(sql).toContain('app.current_user_can_take_client_data(organization_id, client_id)');
+    expect(sql).toContain('app.current_user_has_assigned_client(organization_id, id)');
+  });
+
+  it('keeps rewritten policies idempotent for repeated or partial local applies', () => {
+    expect(sql).toContain('DROP POLICY IF EXISTS therapists_org_staff_select ON public.therapists;');
+    expect(sql).toContain('DROP POLICY IF EXISTS therapists_org_staff_manage ON public.therapists;');
+    expect(sql).toContain('DROP POLICY IF EXISTS programs_org_read ON public.programs;');
+    expect(sql).toContain('DROP POLICY IF EXISTS goals_org_read ON public.goals;');
+  });
+
+  it('keeps the hosted employee-role smoke cleanup-bound and matrix-aligned', () => {
+    expect(smokeSql).toContain('set role authenticated');
+    expect(smokeSql).toContain('cleanup_no_synthetic_rows_remaining');
+    expect(smokeSql).toContain("remaining_rows=' || count(*)");
+    expect(smokeSql).toContain('admin_schedule_authorization_write_allowed');
+    expect(smokeSql).toContain('admin_schedule_assignment_write_allowed');
+    expect(smokeSql).toContain('midtier_schedule_write_allowed');
+    expect(smokeSql).toContain('bt_schedule_write_denied');
+    expect(smokeSql).toContain('bcba_super_admin_equivalence_helpers');
+  });
+});

--- a/tests/sql/employee_role_capability_smoke.sql
+++ b/tests/sql/employee_role_capability_smoke.sql
@@ -1,0 +1,553 @@
+-- Live employee-role capability smoke.
+--
+-- Intended use:
+--   Run against a hosted Supabase database through a privileged SQL channel.
+--   The script creates fixed synthetic rows, switches to authenticated for RLS
+--   probes, then deletes every synthetic row and returns pass/fail rows.
+--
+-- Safety boundaries:
+--   - Uses only 00000000-0000-4000-8000-* synthetic UUIDs.
+--   - Uses example.invalid emails and synthetic names only.
+--   - Leaves no synthetic rows when cleanup succeeds.
+--   - Does not create or alter schema, policies, grants, or functions.
+
+create temp table if not exists role_smoke_results (
+  probe text,
+  passed boolean,
+  detail text,
+  observed_role text default current_user
+) on commit drop;
+
+truncate table role_smoke_results;
+grant insert, select on role_smoke_results to authenticated;
+
+do $cleanup$
+begin
+  reset role;
+
+  delete from public.client_session_notes
+  where id in ('00000000-0000-4000-8000-000000000701');
+
+  delete from public.goal_data_points
+  where id in ('00000000-0000-4000-8000-000000000601', '00000000-0000-4000-8000-000000000602');
+
+  delete from public.sessions
+  where id in (
+    '00000000-0000-4000-8000-000000000501',
+    '00000000-0000-4000-8000-000000000502',
+    '00000000-0000-4000-8000-000000000503',
+    '00000000-0000-4000-8000-000000000504',
+    '00000000-0000-4000-8000-000000000505'
+  );
+
+  delete from public.authorization_services
+  where id in ('00000000-0000-4000-8000-000000000451');
+
+  delete from public.authorizations
+  where id in (
+    '00000000-0000-4000-8000-000000000401',
+    '00000000-0000-4000-8000-000000000402',
+    '00000000-0000-4000-8000-000000000403',
+    '00000000-0000-4000-8000-000000000404'
+  );
+
+  delete from public.goals
+  where id in (
+    '00000000-0000-4000-8000-000000000301',
+    '00000000-0000-4000-8000-000000000302',
+    '00000000-0000-4000-8000-000000000303',
+    '00000000-0000-4000-8000-000000000304'
+  );
+
+  delete from public.programs
+  where id in (
+    '00000000-0000-4000-8000-000000000201',
+    '00000000-0000-4000-8000-000000000202',
+    '00000000-0000-4000-8000-000000000203',
+    '00000000-0000-4000-8000-000000000204'
+  );
+
+  delete from public.client_therapist_links
+  where id in (
+    '00000000-0000-4000-8000-000000000901',
+    '00000000-0000-4000-8000-000000000902'
+  );
+
+  delete from public.clients
+  where id in (
+    '00000000-0000-4000-8000-000000000101',
+    '00000000-0000-4000-8000-000000000102',
+    '00000000-0000-4000-8000-000000000103',
+    '00000000-0000-4000-8000-000000000104',
+    '00000000-0000-4000-8000-000000000105',
+    '00000000-0000-4000-8000-000000000106'
+  );
+
+  delete from public.therapists
+  where id in (
+    '00000000-0000-4000-8000-000000000013',
+    '00000000-0000-4000-8000-000000000021',
+    '00000000-0000-4000-8000-000000000023'
+  );
+
+  delete from public.user_roles
+  where user_id in (
+    '00000000-0000-4000-8000-000000000011',
+    '00000000-0000-4000-8000-000000000012',
+    '00000000-0000-4000-8000-000000000013',
+    '00000000-0000-4000-8000-000000000014'
+  );
+
+  delete from public.profiles
+  where id in (
+    '00000000-0000-4000-8000-000000000011',
+    '00000000-0000-4000-8000-000000000012',
+    '00000000-0000-4000-8000-000000000013',
+    '00000000-0000-4000-8000-000000000014'
+  );
+
+  delete from auth.users
+  where id in (
+    '00000000-0000-4000-8000-000000000011',
+    '00000000-0000-4000-8000-000000000012',
+    '00000000-0000-4000-8000-000000000013',
+    '00000000-0000-4000-8000-000000000014'
+  );
+
+  delete from public.organizations
+  where id in (
+    '00000000-0000-4000-8000-000000000001',
+    '00000000-0000-4000-8000-000000000002'
+  );
+end
+$cleanup$;
+
+do $seed$
+begin
+  insert into public.organizations (id, name, slug, metadata)
+  values
+    (
+      '00000000-0000-4000-8000-000000000001',
+      'Codex Employee Role Smoke Org',
+      'codex-employee-role-smoke-org',
+      '{"tags":["codex-smoke"],"notes":"synthetic employee role smoke"}'::jsonb
+    ),
+    (
+      '00000000-0000-4000-8000-000000000002',
+      'Codex Employee Role Smoke Other Org',
+      'codex-employee-role-smoke-other-org',
+      '{"tags":["codex-smoke"],"notes":"synthetic employee role smoke"}'::jsonb
+    );
+
+  insert into auth.users (
+    instance_id,
+    id,
+    aud,
+    role,
+    email,
+    encrypted_password,
+    email_confirmed_at,
+    created_at,
+    updated_at,
+    raw_app_meta_data,
+    raw_user_meta_data
+  )
+  values
+    ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-000000000011', 'authenticated', 'authenticated', 'codex-smoke-20260701-admin-schedule@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb),
+    ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-000000000012', 'authenticated', 'authenticated', 'codex-smoke-20260701-midtier@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb),
+    ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-000000000013', 'authenticated', 'authenticated', 'codex-smoke-20260701-bt@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb),
+    ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-000000000014', 'authenticated', 'authenticated', 'codex-smoke-20260701-bcba@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb);
+
+  perform set_config('app.bypass_profile_role_guard', 'on', true);
+
+  update public.profiles p
+  set
+    role = v.role::public.role_type,
+    first_name = 'Codex',
+    last_name = v.last_name,
+    organization_id = '00000000-0000-4000-8000-000000000001'
+  from (
+    values
+      ('00000000-0000-4000-8000-000000000011'::uuid, 'admin_schedule', 'Admin Schedule'),
+      ('00000000-0000-4000-8000-000000000012'::uuid, 'midtier', 'Midtier'),
+      ('00000000-0000-4000-8000-000000000013'::uuid, 'bt', 'BT'),
+      ('00000000-0000-4000-8000-000000000014'::uuid, 'bcba', 'BCBA')
+  ) as v(id, role, last_name)
+  where p.id = v.id;
+
+  perform set_config('app.bypass_profile_role_guard', 'off', true);
+
+  insert into public.user_roles (user_id, role_id, is_active)
+  select v.user_id, r.id, true
+  from (
+    values
+      ('00000000-0000-4000-8000-000000000011'::uuid, 'admin_schedule'),
+      ('00000000-0000-4000-8000-000000000012'::uuid, 'midtier'),
+      ('00000000-0000-4000-8000-000000000013'::uuid, 'bt'),
+      ('00000000-0000-4000-8000-000000000014'::uuid, 'bcba')
+  ) as v(user_id, role_name)
+  join public.roles r on r.name = v.role_name;
+
+  insert into public.therapists (id, email, full_name, first_name, last_name, status, organization_id)
+  values
+    ('00000000-0000-4000-8000-000000000013', 'codex-smoke-bt@example.invalid', 'Codex BT Staff', 'Codex', 'BT', 'active', '00000000-0000-4000-8000-000000000001'),
+    ('00000000-0000-4000-8000-000000000021', 'codex-smoke-provider@example.invalid', 'Codex Provider', 'Codex', 'Provider', 'active', '00000000-0000-4000-8000-000000000001');
+
+  insert into public.clients (id, full_name, status, organization_id, therapist_id, created_by, updated_by)
+  values
+    ('00000000-0000-4000-8000-000000000101', 'Codex Assigned Client', 'active', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011'),
+    ('00000000-0000-4000-8000-000000000102', 'Codex Unassigned Client', 'active', '00000000-0000-4000-8000-000000000001', null, '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011'),
+    ('00000000-0000-4000-8000-000000000103', 'Codex Cross Org Client', 'active', '00000000-0000-4000-8000-000000000002', null, null, null);
+
+  insert into public.client_therapist_links (id, client_id, therapist_id, organization_id, created_by)
+  values ('00000000-0000-4000-8000-000000000901', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011');
+
+  insert into public.programs (id, organization_id, client_id, name, status, created_by, updated_by)
+  values
+    ('00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101', 'Codex Assigned Program', 'active', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000012'),
+    ('00000000-0000-4000-8000-000000000202', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000102', 'Codex Unassigned Program', 'active', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000012');
+
+  insert into public.goals (id, organization_id, client_id, program_id, title, description, original_text, status, created_by, updated_by)
+  values
+    ('00000000-0000-4000-8000-000000000301', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000201', 'Codex Assigned Goal', 'Synthetic', 'Synthetic', 'active', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000012'),
+    ('00000000-0000-4000-8000-000000000302', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000202', 'Codex Unassigned Goal', 'Synthetic', 'Synthetic', 'active', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000012');
+
+  insert into public.sessions (id, client_id, therapist_id, start_time, end_time, status, has_transcription_consent, organization_id, created_by, updated_by, session_date, program_id, goal_id)
+  values
+    ('00000000-0000-4000-8000-000000000501', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000013', now() + interval '7 days', now() + interval '7 days 1 hour', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 7, '00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000301'),
+    ('00000000-0000-4000-8000-000000000502', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000021', now() + interval '8 days', now() + interval '8 days 1 hour', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 8, '00000000-0000-4000-8000-000000000202', '00000000-0000-4000-8000-000000000302');
+
+  insert into public.authorizations (id, authorization_number, client_id, provider_id, diagnosis_code, start_date, end_date, status, organization_id, created_by)
+  values
+    ('00000000-0000-4000-8000-000000000401', 'CODEX-SMOKE-AUTH-ASSIGNED', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000021', 'F84.0', current_date, current_date + 30, 'approved', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011'),
+    ('00000000-0000-4000-8000-000000000402', 'CODEX-SMOKE-AUTH-UNASSIGNED', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000021', 'F84.0', current_date, current_date + 30, 'approved', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011');
+
+  insert into role_smoke_results
+  values ('seed_synthetic_assignments', true, 'seeded synthetic role assignments and fixtures', current_user);
+exception
+  when others then
+    perform set_config('app.bypass_profile_role_guard', 'off', true);
+    insert into role_smoke_results
+    values ('seed_synthetic_assignments', false, sqlstate || ': ' || sqlerrm, current_user);
+end
+$seed$;
+
+set role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-000000000011', true);
+do $admin_schedule$
+begin
+  insert into role_smoke_results
+  values (
+    'admin_schedule_helpers',
+    app.current_user_can_manage_staff_clients('00000000-0000-4000-8000-000000000001')
+      and app.current_user_can_manage_authorizations('00000000-0000-4000-8000-000000000001')
+      and app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
+      and not app.current_user_can_manage_programs_goals('00000000-0000-4000-8000-000000000001'),
+    'staff=' || app.current_user_can_manage_staff_clients('00000000-0000-4000-8000-000000000001')
+      || ', authz=' || app.current_user_can_manage_authorizations('00000000-0000-4000-8000-000000000001')
+      || ', schedule=' || app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
+      || ', programs=' || app.current_user_can_manage_programs_goals('00000000-0000-4000-8000-000000000001'),
+    current_user
+  );
+
+  begin
+    insert into public.clients (id, full_name, status, organization_id, created_by, updated_by)
+    values ('00000000-0000-4000-8000-000000000104', 'Codex Admin Schedule Created Client', 'active', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011');
+    insert into role_smoke_results values ('admin_schedule_client_write_allowed', true, 'insert clients succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('admin_schedule_client_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.therapists (id, email, full_name, first_name, last_name, status, organization_id)
+    values ('00000000-0000-4000-8000-000000000023', 'codex-smoke-admin-created-staff@example.invalid', 'Codex Admin Created Staff', 'Codex', 'Admin Staff', 'active', '00000000-0000-4000-8000-000000000001');
+    insert into role_smoke_results values ('admin_schedule_staff_write_allowed', true, 'insert therapists succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('admin_schedule_staff_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.client_therapist_links (id, client_id, therapist_id, organization_id, created_by)
+    values ('00000000-0000-4000-8000-000000000902', '00000000-0000-4000-8000-000000000104', '00000000-0000-4000-8000-000000000023', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011');
+    insert into role_smoke_results values ('admin_schedule_assignment_write_allowed', true, 'insert client_therapist_links succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('admin_schedule_assignment_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.authorizations (id, authorization_number, client_id, provider_id, diagnosis_code, start_date, end_date, status, organization_id, created_by)
+    values ('00000000-0000-4000-8000-000000000403', 'CODEX-SMOKE-AUTH-ADMIN-SCHEDULE', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000021', 'F84.0', current_date, current_date + 30, 'approved', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011');
+    insert into role_smoke_results values ('admin_schedule_authorization_write_allowed', true, 'insert authorizations succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('admin_schedule_authorization_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.sessions (id, client_id, therapist_id, start_time, end_time, status, has_transcription_consent, organization_id, created_by, updated_by, session_date, program_id, goal_id)
+    values ('00000000-0000-4000-8000-000000000503', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000013', now() + interval '9 days', now() + interval '9 days 1 hour', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 9, '00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000301');
+    insert into role_smoke_results values ('admin_schedule_schedule_write_allowed', true, 'insert sessions succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('admin_schedule_schedule_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.programs (id, organization_id, client_id, name, status, created_by, updated_by)
+    values ('00000000-0000-4000-8000-000000000204', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101', 'Codex Admin Schedule Denied Program', 'active', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011');
+    insert into role_smoke_results values ('admin_schedule_program_write_denied', false, 'unexpected insert programs succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('admin_schedule_program_write_denied', sqlstate = '42501', sqlstate || ': ' || sqlerrm, current_user);
+  end;
+end
+$admin_schedule$;
+
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-000000000012', true);
+do $midtier$
+begin
+  insert into role_smoke_results
+  values (
+    'midtier_helpers',
+    not app.current_user_can_manage_staff_clients('00000000-0000-4000-8000-000000000001')
+      and app.current_user_can_manage_authorizations('00000000-0000-4000-8000-000000000001')
+      and app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
+      and app.current_user_can_manage_programs_goals('00000000-0000-4000-8000-000000000001'),
+    'staff=' || app.current_user_can_manage_staff_clients('00000000-0000-4000-8000-000000000001')
+      || ', authz=' || app.current_user_can_manage_authorizations('00000000-0000-4000-8000-000000000001')
+      || ', schedule=' || app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
+      || ', programs=' || app.current_user_can_manage_programs_goals('00000000-0000-4000-8000-000000000001'),
+    current_user
+  );
+
+  begin
+    insert into public.clients (id, full_name, status, organization_id, created_by, updated_by)
+    values ('00000000-0000-4000-8000-000000000105', 'Codex Midtier Denied Client', 'active', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000012');
+    insert into role_smoke_results values ('midtier_client_write_denied', false, 'unexpected insert clients succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('midtier_client_write_denied', sqlstate = '42501', sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.programs (id, organization_id, client_id, name, status, created_by, updated_by)
+    values ('00000000-0000-4000-8000-000000000204', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101', 'Codex Midtier Program', 'active', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000012');
+    insert into role_smoke_results values ('midtier_program_write_allowed', true, 'insert programs succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('midtier_program_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.goals (id, organization_id, client_id, program_id, title, description, original_text, status, created_by, updated_by)
+    values ('00000000-0000-4000-8000-000000000304', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000204', 'Codex Midtier Goal', 'Synthetic', 'Synthetic', 'active', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000012');
+    insert into role_smoke_results values ('midtier_goal_write_allowed', true, 'insert goals succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('midtier_goal_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.sessions (id, client_id, therapist_id, start_time, end_time, status, has_transcription_consent, organization_id, created_by, updated_by, session_date, program_id, goal_id)
+    values ('00000000-0000-4000-8000-000000000504', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000013', now() + interval '10 days', now() + interval '10 days 1 hour', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000012', current_date + 10, '00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000301');
+    insert into role_smoke_results values ('midtier_schedule_write_allowed', true, 'insert sessions succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('midtier_schedule_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.authorizations (id, authorization_number, client_id, provider_id, diagnosis_code, start_date, end_date, status, organization_id, created_by)
+    values ('00000000-0000-4000-8000-000000000404', 'CODEX-SMOKE-AUTH-MIDTIER', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000021', 'F84.0', current_date, current_date + 30, 'approved', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000012');
+    insert into role_smoke_results values ('midtier_authorization_write_allowed', true, 'insert authorizations succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('midtier_authorization_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+end
+$midtier$;
+
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-000000000013', true);
+do $bt$
+declare
+  assigned_count int;
+  unassigned_count int;
+  cross_org_count int;
+begin
+  insert into role_smoke_results
+  values (
+    'bt_helpers',
+    not app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
+      and app.current_user_can_take_client_data('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101')
+      and not app.current_user_can_take_client_data('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000102'),
+    'schedule=' || app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
+      || ', take_assigned=' || app.current_user_can_take_client_data('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101')
+      || ', take_unassigned=' || app.current_user_can_take_client_data('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000102'),
+    current_user
+  );
+
+  select count(*) into assigned_count from public.clients where id = '00000000-0000-4000-8000-000000000101';
+  select count(*) into unassigned_count from public.clients where id = '00000000-0000-4000-8000-000000000102';
+  select count(*) into cross_org_count from public.clients where id = '00000000-0000-4000-8000-000000000103';
+  insert into role_smoke_results
+  values ('bt_assigned_client_read_only', assigned_count = 1 and unassigned_count = 0 and cross_org_count = 0, 'assigned=' || assigned_count || ', unassigned=' || unassigned_count || ', cross_org=' || cross_org_count, current_user);
+
+  begin
+    insert into public.goal_data_points (id, organization_id, client_id, goal_id, session_id, source, metric_name, metric_value, created_by)
+    values ('00000000-0000-4000-8000-000000000601', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000301', '00000000-0000-4000-8000-000000000501', 'manual', 'codex_smoke', 1, '00000000-0000-4000-8000-000000000013');
+    insert into role_smoke_results values ('bt_assigned_goal_data_write_allowed', true, 'insert assigned goal_data_points succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('bt_assigned_goal_data_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.sessions (id, client_id, therapist_id, start_time, end_time, status, has_transcription_consent, organization_id, created_by, updated_by, session_date, program_id, goal_id)
+    values ('00000000-0000-4000-8000-000000000505', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000013', now() + interval '11 days', now() + interval '11 days 1 hour', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000013', current_date + 11, '00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000301');
+    insert into role_smoke_results values ('bt_schedule_write_denied', false, 'unexpected insert sessions succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('bt_schedule_write_denied', sqlstate = '42501', sqlstate || ': ' || sqlerrm, current_user);
+  end;
+end
+$bt$;
+
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-000000000014', true);
+do $bcba$
+begin
+  insert into role_smoke_results
+  values (
+    'bcba_super_admin_equivalence_helpers',
+    app.current_user_is_super_admin()
+      and app.current_user_can_manage_staff_clients('00000000-0000-4000-8000-000000000001')
+      and app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
+      and app.current_user_can_manage_programs_goals('00000000-0000-4000-8000-000000000001'),
+    'super=' || app.current_user_is_super_admin()
+      || ', staff=' || app.current_user_can_manage_staff_clients('00000000-0000-4000-8000-000000000001')
+      || ', schedule=' || app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
+      || ', programs=' || app.current_user_can_manage_programs_goals('00000000-0000-4000-8000-000000000001'),
+    current_user
+  );
+
+  begin
+    insert into public.clients (id, full_name, status, organization_id, created_by, updated_by)
+    values ('00000000-0000-4000-8000-000000000106', 'Codex BCBA Created Client', 'active', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000014', '00000000-0000-4000-8000-000000000014');
+    insert into role_smoke_results values ('bcba_client_write_allowed', true, 'insert clients succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('bcba_client_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+end
+$bcba$;
+
+reset role;
+
+do $final_cleanup$
+begin
+  delete from public.client_session_notes
+  where id in ('00000000-0000-4000-8000-000000000701');
+
+  delete from public.goal_data_points
+  where id in ('00000000-0000-4000-8000-000000000601', '00000000-0000-4000-8000-000000000602');
+
+  delete from public.sessions
+  where id in (
+    '00000000-0000-4000-8000-000000000501',
+    '00000000-0000-4000-8000-000000000502',
+    '00000000-0000-4000-8000-000000000503',
+    '00000000-0000-4000-8000-000000000504',
+    '00000000-0000-4000-8000-000000000505'
+  );
+
+  delete from public.authorization_services
+  where id in ('00000000-0000-4000-8000-000000000451');
+
+  delete from public.authorizations
+  where id in (
+    '00000000-0000-4000-8000-000000000401',
+    '00000000-0000-4000-8000-000000000402',
+    '00000000-0000-4000-8000-000000000403',
+    '00000000-0000-4000-8000-000000000404'
+  );
+
+  delete from public.goals
+  where id in (
+    '00000000-0000-4000-8000-000000000301',
+    '00000000-0000-4000-8000-000000000302',
+    '00000000-0000-4000-8000-000000000303',
+    '00000000-0000-4000-8000-000000000304'
+  );
+
+  delete from public.programs
+  where id in (
+    '00000000-0000-4000-8000-000000000201',
+    '00000000-0000-4000-8000-000000000202',
+    '00000000-0000-4000-8000-000000000203',
+    '00000000-0000-4000-8000-000000000204'
+  );
+
+  delete from public.client_therapist_links
+  where id in (
+    '00000000-0000-4000-8000-000000000901',
+    '00000000-0000-4000-8000-000000000902'
+  );
+
+  delete from public.clients
+  where id in (
+    '00000000-0000-4000-8000-000000000101',
+    '00000000-0000-4000-8000-000000000102',
+    '00000000-0000-4000-8000-000000000103',
+    '00000000-0000-4000-8000-000000000104',
+    '00000000-0000-4000-8000-000000000105',
+    '00000000-0000-4000-8000-000000000106'
+  );
+
+  delete from public.therapists
+  where id in (
+    '00000000-0000-4000-8000-000000000013',
+    '00000000-0000-4000-8000-000000000021',
+    '00000000-0000-4000-8000-000000000023'
+  );
+
+  delete from public.user_roles
+  where user_id in (
+    '00000000-0000-4000-8000-000000000011',
+    '00000000-0000-4000-8000-000000000012',
+    '00000000-0000-4000-8000-000000000013',
+    '00000000-0000-4000-8000-000000000014'
+  );
+
+  delete from public.profiles
+  where id in (
+    '00000000-0000-4000-8000-000000000011',
+    '00000000-0000-4000-8000-000000000012',
+    '00000000-0000-4000-8000-000000000013',
+    '00000000-0000-4000-8000-000000000014'
+  );
+
+  delete from auth.users
+  where id in (
+    '00000000-0000-4000-8000-000000000011',
+    '00000000-0000-4000-8000-000000000012',
+    '00000000-0000-4000-8000-000000000013',
+    '00000000-0000-4000-8000-000000000014'
+  );
+
+  delete from public.organizations
+  where id in (
+    '00000000-0000-4000-8000-000000000001',
+    '00000000-0000-4000-8000-000000000002'
+  );
+end
+$final_cleanup$;
+
+insert into role_smoke_results (probe, passed, detail)
+select 'cleanup_no_synthetic_rows_remaining', count(*) = 0, 'remaining_rows=' || count(*)
+from (
+  select id from public.organizations where id in ('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000002')
+  union all select id from auth.users where id in ('00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000014')
+  union all select id from public.profiles where id in ('00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000014')
+  union all select id from public.user_roles where user_id in ('00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000014')
+  union all select id from public.clients where id in ('00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000103', '00000000-0000-4000-8000-000000000104', '00000000-0000-4000-8000-000000000105', '00000000-0000-4000-8000-000000000106')
+  union all select id from public.therapists where id in ('00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000021', '00000000-0000-4000-8000-000000000023')
+  union all select id from public.programs where id in ('00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000202', '00000000-0000-4000-8000-000000000203', '00000000-0000-4000-8000-000000000204')
+  union all select id from public.goals where id in ('00000000-0000-4000-8000-000000000301', '00000000-0000-4000-8000-000000000302', '00000000-0000-4000-8000-000000000303', '00000000-0000-4000-8000-000000000304')
+  union all select id from public.sessions where id in ('00000000-0000-4000-8000-000000000501', '00000000-0000-4000-8000-000000000502', '00000000-0000-4000-8000-000000000503', '00000000-0000-4000-8000-000000000504', '00000000-0000-4000-8000-000000000505')
+  union all select id from public.authorizations where id in ('00000000-0000-4000-8000-000000000401', '00000000-0000-4000-8000-000000000402', '00000000-0000-4000-8000-000000000403', '00000000-0000-4000-8000-000000000404')
+  union all select id from public.goal_data_points where id in ('00000000-0000-4000-8000-000000000601', '00000000-0000-4000-8000-000000000602')
+) residue;
+
+select probe, passed, detail, observed_role
+from role_smoke_results
+order by probe;


### PR DESCRIPTION
## Summary
- Add the employee role capability matrix for `admin_schedule`, `midtier`, `bt`, and `bcba`, keeping `bcba` aligned with super-admin level access for now.
- Centralize frontend/server role capability checks and update route, sidebar, settings, messages, client, authorization, reports, schedule, and AI guardrail access behavior.
- Add Supabase migration/RLS/RPC allowlists plus reusable SQL smoke validation for employee-role read/write behavior.
- Extend route, edge, CI policy, admin-role, and migration contract coverage for the new employee roles.

## Verification
- `npm run verify:local` passed.
- `npm run ci:playwright` passed all 10 hosted Playwright smoke scripts.
- `npm run validate:tenant` passed.
- `git diff --check` passed.
- Hosted Supabase smoke previously passed for admin_schedule, midtier, bt, and bcba role-helper/RLS probes with cleanup confirming no synthetic rows remained.

## Risk / Review Notes
- Critical protected-path change: touches auth/routing, Supabase migration/RLS/RPC grants, edge function auth middleware, and tenant-sensitive role access.
- Human review is required before merge.
- Local DB-backed policy checks were skipped where `SUPABASE_DB_URL` was not configured; CI/protected environment should provide final DB grant/drift/parity validation.
- Linear issue is not linked in this PR body.
