### PR TITLE
Allow midtier program-goal edge access

### DIFF
--- a/supabase/functions/_shared/org.ts
+++ b/supabase/functions/_shared/org.ts
@@ -118,6 +118,20 @@ export async function assertUserHasOrgRole(
   return data === true;
 }
 
+export async function currentUserCanManageProgramsGoals(
+  db: SupabaseClient,
+  orgId: string,
+): Promise<boolean> {
+  const { data, error } = await db.rpc("current_user_can_manage_programs_goals", {
+    target_organization_id: orgId,
+  });
+  if (error) {
+    console.error("currentUserCanManageProgramsGoals rpc error", error);
+    return false;
+  }
+  return data === true;
+}
+
 export async function withOrg<T>(
   db: SupabaseClient,
   handler: (orgId: string) => Promise<T>,

--- a/supabase/functions/goals/index.ts
+++ b/supabase/functions/goals/index.ts
@@ -2,7 +2,7 @@ import { z } from "npm:zod@3.23.8";
 import { createRequestClient } from "../_shared/database.ts";
 import { corsHeadersForRequest } from "../_shared/cors.ts";
 import { createProtectedRoute, RouteOptions } from "../_shared/auth-middleware.ts";
-import { assertUserHasOrgRole, MissingOrgContextError, orgScopedQuery, requireOrg } from "../_shared/org.ts";
+import { currentUserCanManageProgramsGoals, MissingOrgContextError, orgScopedQuery, requireOrg } from "../_shared/org.ts";
 
 const goalSchema = z.object({
   client_id: z.string().uuid(),
@@ -37,15 +37,6 @@ const json = (req: Request, body: unknown, status = 200) =>
     },
   });
 
-const hasAllowedRole = async (orgId: string, userId: string, db: ReturnType<typeof createRequestClient>) => {
-  const [isTherapist, isAdmin, isSuperAdmin] = await Promise.all([
-    assertUserHasOrgRole(db, orgId, "therapist", { targetTherapistId: userId }),
-    assertUserHasOrgRole(db, orgId, "admin"),
-    assertUserHasOrgRole(db, orgId, "super_admin"),
-  ]);
-  return isTherapist || isAdmin || isSuperAdmin;
-};
-
 const loadProgram = async (db: ReturnType<typeof createRequestClient>, orgId: string, programId: string) => {
   const { data, error } = await orgScopedQuery(db, "programs", orgId)
     .select("id,client_id")
@@ -70,8 +61,7 @@ export const handleGoals = async (req: Request) => {
   if (authError || !authData?.user) {
     return json(req, { error: "Missing authorization token" }, 401);
   }
-  const userId = authData.user.id;
-  const allowed = await hasAllowedRole(orgId, userId, db);
+  const allowed = await currentUserCanManageProgramsGoals(db, orgId);
   if (!allowed) return json(req, { error: "Forbidden" }, 403);
 
   if (req.method === "GET") {
@@ -174,7 +164,7 @@ export const handleGoals = async (req: Request) => {
   return json(req, { error: "Method not allowed" }, 405);
 };
 
-const handler = createProtectedRoute((req) => handleGoals(req), RouteOptions.therapist);
+const handler = createProtectedRoute((req) => handleGoals(req), RouteOptions.programsGoals);
 
 Deno.serve(handler);
 

--- a/supabase/functions/program-notes/index.ts
+++ b/supabase/functions/program-notes/index.ts
@@ -2,7 +2,7 @@ import { z } from "npm:zod@3.23.8";
 import { createRequestClient } from "../_shared/database.ts";
 import { corsHeadersForRequest } from "../_shared/cors.ts";
 import { createProtectedRoute, RouteOptions } from "../_shared/auth-middleware.ts";
-import { assertUserHasOrgRole, orgScopedQuery, requireOrg } from "../_shared/org.ts";
+import { currentUserCanManageProgramsGoals, orgScopedQuery, requireOrg } from "../_shared/org.ts";
 
 const noteSchema = z.object({
   program_id: z.string().uuid(),
@@ -19,15 +19,6 @@ const json = (req: Request, body: unknown, status = 200) =>
     },
   });
 
-const hasAllowedRole = async (orgId: string, userId: string, db: ReturnType<typeof createRequestClient>) => {
-  const [isTherapist, isAdmin, isSuperAdmin] = await Promise.all([
-    assertUserHasOrgRole(db, orgId, "therapist", { targetTherapistId: userId }),
-    assertUserHasOrgRole(db, orgId, "admin"),
-    assertUserHasOrgRole(db, orgId, "super_admin"),
-  ]);
-  return isTherapist || isAdmin || isSuperAdmin;
-};
-
 export const handleProgramNotes = async (req: Request) => {
   const db = createRequestClient(req);
   const orgId = await requireOrg(db);
@@ -36,7 +27,7 @@ export const handleProgramNotes = async (req: Request) => {
     return json(req, { error: "Missing authorization token" }, 401);
   }
   const userId = authData.user.id;
-  const allowed = await hasAllowedRole(orgId, userId, db);
+  const allowed = await currentUserCanManageProgramsGoals(db, orgId);
   if (!allowed) return json(req, { error: "Forbidden" }, 403);
 
   if (req.method === "GET") {
@@ -88,7 +79,7 @@ export const handleProgramNotes = async (req: Request) => {
   return json(req, { error: "Method not allowed" }, 405);
 };
 
-const handler = createProtectedRoute((req) => handleProgramNotes(req), RouteOptions.therapist);
+const handler = createProtectedRoute((req) => handleProgramNotes(req), RouteOptions.programsGoals);
 
 Deno.serve(handler);
 

--- a/supabase/functions/programs/index.ts
+++ b/supabase/functions/programs/index.ts
@@ -1,7 +1,7 @@
 import { z } from "npm:zod@3.23.8";
 import { createRequestClient } from "../_shared/database.ts";
 import { corsHeadersForRequest, createProtectedRoute, RouteOptions } from "../_shared/auth-middleware.ts";
-import { assertUserHasOrgRole, MissingOrgContextError, orgScopedQuery, requireOrg } from "../_shared/org.ts";
+import { currentUserCanManageProgramsGoals, MissingOrgContextError, orgScopedQuery, requireOrg } from "../_shared/org.ts";
 
 const programSchema = z.object({
   client_id: z.string().uuid(),
@@ -25,15 +25,6 @@ const json = (req: Request, body: unknown, status = 200) =>
     },
   });
 
-const hasAllowedRole = async (orgId: string, userId: string, db: ReturnType<typeof createRequestClient>) => {
-  const [isTherapist, isAdmin, isSuperAdmin] = await Promise.all([
-    assertUserHasOrgRole(db, orgId, "therapist", { targetTherapistId: userId }),
-    assertUserHasOrgRole(db, orgId, "admin"),
-    assertUserHasOrgRole(db, orgId, "super_admin"),
-  ]);
-  return isTherapist || isAdmin || isSuperAdmin;
-};
-
 export const handlePrograms = async (req: Request) => {
   const db = createRequestClient(req);
   let orgId: string;
@@ -49,9 +40,7 @@ export const handlePrograms = async (req: Request) => {
   if (authError || !authData?.user) {
     return json(req, { error: "Missing authorization token" }, 401);
   }
-  const userId = authData.user.id;
-
-  const allowed = await hasAllowedRole(orgId, userId, db);
+  const allowed = await currentUserCanManageProgramsGoals(db, orgId);
   if (!allowed) {
     return json(req, { error: "Forbidden" }, 403);
   }
@@ -137,7 +126,7 @@ export const handlePrograms = async (req: Request) => {
   return json(req, { error: "Method not allowed" }, 405);
 };
 
-const handler = createProtectedRoute((req) => handlePrograms(req), RouteOptions.therapist);
+const handler = createProtectedRoute((req) => handlePrograms(req), RouteOptions.programsGoals);
 
 Deno.serve(handler);
 

--- a/supabase/migrations/20260702194500_expose_program_goal_capability_rpc.sql
+++ b/supabase/migrations/20260702194500_expose_program_goal_capability_rpc.sql
@@ -1,0 +1,22 @@
+-- @migration-intent: Expose the program-goal capability helper through the public PostgREST schema for edge function RPC calls.
+-- @migration-dependencies: 20260701150000_employee_role_capability_matrix.sql
+-- @migration-rollback: DROP FUNCTION IF EXISTS public.current_user_can_manage_programs_goals(uuid); then reload PostgREST schema cache.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.current_user_can_manage_programs_goals(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT app.current_user_can_manage_programs_goals(target_organization_id);
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.current_user_can_manage_programs_goals(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.current_user_can_manage_programs_goals(uuid) TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/tests/edge/goals.parity.contract.test.ts
+++ b/tests/edge/goals.parity.contract.test.ts
@@ -10,7 +10,7 @@ stubDenoEnv((key) => envValues.get(key) ?? "");
 
 const createRequestClientMock = vi.fn();
 const requireOrgMock = vi.fn();
-const assertUserHasOrgRoleMock = vi.fn();
+const currentUserCanManageProgramsGoalsMock = vi.fn();
 const orgScopedQueryMock = vi.fn();
 
 class MissingOrgContextError extends Error {
@@ -27,7 +27,7 @@ async function loadGoalsModule() {
   }));
   vi.doMock("../../supabase/functions/_shared/org.ts", () => ({
     requireOrg: requireOrgMock,
-    assertUserHasOrgRole: assertUserHasOrgRoleMock,
+    currentUserCanManageProgramsGoals: currentUserCanManageProgramsGoalsMock,
     orgScopedQuery: orgScopedQueryMock,
     MissingOrgContextError,
   }));
@@ -41,7 +41,7 @@ function configureGoalsGetSuccessDb() {
     },
   });
   requireOrgMock.mockResolvedValue("org-1");
-  assertUserHasOrgRoleMock.mockImplementation(async (_db: unknown, _orgId: string, role: string) => role === "therapist");
+  currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
   orgScopedQueryMock.mockImplementation((_db: unknown, table: string) => {
     if (table !== "goals") {
       throw new Error(`Unexpected table lookup: ${table}`);
@@ -56,14 +56,14 @@ function configureGoalsGetSuccessDb() {
   });
 }
 
-const roleMatrix = [["therapist"], ["admin"], ["super_admin"]] as const;
+const roleMatrix = [["therapist"], ["midtier"], ["admin"], ["super_admin"]] as const;
 
 describe("goals route organization context parity", () => {
   beforeEach(() => {
     vi.resetModules();
     createRequestClientMock.mockReset();
     requireOrgMock.mockReset();
-    assertUserHasOrgRoleMock.mockReset();
+    currentUserCanManageProgramsGoalsMock.mockReset();
     orgScopedQueryMock.mockReset();
   });
 
@@ -154,18 +154,18 @@ describe("goals route out-of-org PATCH deny matrix parity", () => {
     vi.resetModules();
     createRequestClientMock.mockReset();
     requireOrgMock.mockReset();
-    assertUserHasOrgRoleMock.mockReset();
+    currentUserCanManageProgramsGoalsMock.mockReset();
     orgScopedQueryMock.mockReset();
   });
 
-  it.each(roleMatrix)("denies out-of-org PATCH goal_id for %s role", async (activeRole) => {
+  it.each(roleMatrix)("denies out-of-org PATCH goal_id when %s has program-goal capability", async () => {
     createRequestClientMock.mockReturnValue({
       auth: {
         getUser: vi.fn(async () => ({ data: { user: { id: "user-1" } }, error: null })),
       },
     });
     requireOrgMock.mockResolvedValue("org-1");
-    assertUserHasOrgRoleMock.mockImplementation(async (_db: unknown, _orgId: string, role: string) => role === activeRole);
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
     orgScopedQueryMock.mockImplementation((_db: unknown, table: string) => {
       if (table !== "goals") {
         throw new Error(`Unexpected table lookup: ${table}`);
@@ -202,7 +202,7 @@ describe("goals route org-scope deny matrix", () => {
     vi.resetModules();
     createRequestClientMock.mockReset();
     requireOrgMock.mockReset();
-    assertUserHasOrgRoleMock.mockReset();
+    currentUserCanManageProgramsGoalsMock.mockReset();
     orgScopedQueryMock.mockReset();
   });
 
@@ -214,14 +214,14 @@ describe("goals route org-scope deny matrix", () => {
     original_text: "Clinical text",
   });
 
-  it.each(roleMatrix)("denies out-of-org program_id on POST for %s role", async (activeRole) => {
+  it.each(roleMatrix)("denies out-of-org program_id on POST when %s has program-goal capability", async () => {
     createRequestClientMock.mockReturnValue({
       auth: {
         getUser: vi.fn(async () => ({ data: { user: { id: "user-1" } }, error: null })),
       },
     });
     requireOrgMock.mockResolvedValue("org-1");
-    assertUserHasOrgRoleMock.mockImplementation(async (_db: unknown, _orgId: string, role: string) => role === activeRole);
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
     const goalsInsert = vi.fn(() => {
       throw new Error("goals insert should not run when program is out of scope");
     });
@@ -252,5 +252,73 @@ describe("goals route org-scope deny matrix", () => {
 
     expect(response.status).toBe(403);
     expect(goalsInsert).not.toHaveBeenCalled();
+  });
+
+  it("allows midtier through the handler role gate when the capability helper allows program-goal management", async () => {
+    const insertMock = vi.fn(() => ({
+      select: vi.fn(() => ({
+        limit: vi.fn(async () => ({ data: [{ id: "goal-1" }], error: null })),
+      })),
+    }));
+    const db = {
+      auth: {
+        getUser: vi.fn(async () => ({ data: { user: { id: "midtier-1" } }, error: null })),
+      },
+    };
+    createRequestClientMock.mockReturnValue(db);
+    requireOrgMock.mockResolvedValue("org-1");
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
+    orgScopedQueryMock.mockImplementation((_db: unknown, table: string) => {
+      if (table === "programs") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              limit: vi.fn(async () => ({
+                data: [{ id: "program-1", client_id: "11111111-1111-4111-8111-111111111111" }],
+                error: null,
+              })),
+            })),
+          })),
+        };
+      }
+      if (table === "goals") {
+        return { insert: insertMock };
+      }
+      throw new Error(`Unexpected table lookup: ${table}`);
+    });
+    const module = await loadGoalsModule();
+
+    const response = await module.handleGoals(
+      new Request("https://edge.example.com/functions/v1/goals", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify(validGoalBody()),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(currentUserCanManageProgramsGoalsMock).toHaveBeenCalledWith(db, "org-1");
+  });
+
+  it.each([["admin_schedule"], ["bt"]])("denies %s when the capability helper rejects program-goal management", async () => {
+    createRequestClientMock.mockReturnValue({
+      auth: {
+        getUser: vi.fn(async () => ({ data: { user: { id: "denied-user-1" } }, error: null })),
+      },
+    });
+    requireOrgMock.mockResolvedValue("org-1");
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(false);
+    const module = await loadGoalsModule();
+
+    const response = await module.handleGoals(
+      new Request("https://edge.example.com/functions/v1/goals", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify(validGoalBody()),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(orgScopedQueryMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/edge/orgRoleRpc.parity.contract.test.ts
+++ b/tests/edge/orgRoleRpc.parity.contract.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
-import { assertUserHasOrgRole, resolveOrgId } from "../../supabase/functions/_shared/org.ts";
+import {
+  assertUserHasOrgRole,
+  currentUserCanManageProgramsGoals,
+  resolveOrgId,
+} from "../../supabase/functions/_shared/org.ts";
 
 describe("P05 edge org RPC payload parity (untargeted)", () => {
   it("resolveOrgId invokes current_user_organization_id", async () => {
@@ -18,5 +22,20 @@ describe("P05 edge org RPC payload parity (untargeted)", () => {
       role_name: "therapist",
       target_organization_id: "org-1",
     });
+  });
+
+  it("currentUserCanManageProgramsGoals invokes the program-goal capability RPC with org scope", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: true, error: null });
+    const db = { rpc } as any;
+    await expect(currentUserCanManageProgramsGoals(db, "org-1")).resolves.toBe(true);
+    expect(rpc).toHaveBeenCalledWith("current_user_can_manage_programs_goals", {
+      target_organization_id: "org-1",
+    });
+  });
+
+  it("currentUserCanManageProgramsGoals fails closed on RPC errors", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: { message: "permission denied" } });
+    const db = { rpc } as any;
+    await expect(currentUserCanManageProgramsGoals(db, "org-1")).resolves.toBe(false);
   });
 });

--- a/tests/edge/program-notes.cors.contract.test.ts
+++ b/tests/edge/program-notes.cors.contract.test.ts
@@ -10,7 +10,7 @@ stubDenoEnv((key) => envValues.get(key) ?? "");
 
 const createRequestClientMock = vi.fn();
 const requireOrgMock = vi.fn();
-const assertUserHasOrgRoleMock = vi.fn();
+const currentUserCanManageProgramsGoalsMock = vi.fn();
 const orgScopedQueryMock = vi.fn();
 
 async function loadProgramNotesModule() {
@@ -19,7 +19,7 @@ async function loadProgramNotesModule() {
   }));
   vi.doMock("../../supabase/functions/_shared/org.ts", () => ({
     requireOrg: requireOrgMock,
-    assertUserHasOrgRole: assertUserHasOrgRoleMock,
+    currentUserCanManageProgramsGoals: currentUserCanManageProgramsGoalsMock,
     orgScopedQuery: orgScopedQueryMock,
   }));
   return import("../../supabase/functions/program-notes/index.ts");
@@ -32,7 +32,7 @@ function configureProgramNotesGetSuccessDb() {
     },
   });
   requireOrgMock.mockResolvedValue("org-1");
-  assertUserHasOrgRoleMock.mockImplementation(async (_db: unknown, _orgId: string, role: string) => role === "therapist");
+  currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
   orgScopedQueryMock.mockImplementation((_db: unknown, table: string) => {
     if (table !== "program_notes") {
       throw new Error(`Unexpected table lookup: ${table}`);
@@ -52,7 +52,7 @@ describe("program-notes route CORS contract", () => {
     vi.resetModules();
     createRequestClientMock.mockReset();
     requireOrgMock.mockReset();
-    assertUserHasOrgRoleMock.mockReset();
+    currentUserCanManageProgramsGoalsMock.mockReset();
     orgScopedQueryMock.mockReset();
   });
 
@@ -92,5 +92,91 @@ describe("program-notes route CORS contract", () => {
     expect(response.status).toBe(204);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://preview.example.com");
     expect(response.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("allows midtier through the handler role gate when the capability helper allows program-goal management", async () => {
+    const insertMock = vi.fn(() => ({
+      select: vi.fn(() => ({
+        limit: vi.fn(async () => ({ data: [{ id: "note-1" }], error: null })),
+      })),
+    }));
+    const db = {
+      auth: {
+        getUser: vi.fn(async () => ({ data: { user: { id: "midtier-1" } }, error: null })),
+      },
+      from: vi.fn((table: string) => {
+        if (table !== "program_notes") {
+          throw new Error(`Unexpected table insert: ${table}`);
+        }
+        return { insert: insertMock };
+      }),
+    };
+    createRequestClientMock.mockReturnValue(db);
+    requireOrgMock.mockResolvedValue("org-1");
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
+    orgScopedQueryMock.mockImplementation((_db: unknown, table: string) => {
+      if (table === "programs") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              limit: vi.fn(async () => ({ data: [{ id: "program-1" }], error: null })),
+            })),
+          })),
+        };
+      }
+      if (table === "program_notes") {
+        return { insert: insertMock };
+      }
+      throw new Error(`Unexpected table lookup: ${table}`);
+    });
+    const module = await loadProgramNotesModule();
+
+    const response = await module.handleProgramNotes(
+      new Request("https://edge.example.com/functions/v1/program-notes", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          program_id: "11111111-1111-4111-8111-111111111111",
+          note_type: "other",
+          content: { text: "Midtier note" },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(currentUserCanManageProgramsGoalsMock).toHaveBeenCalledWith(db, "org-1");
+    expect(insertMock).toHaveBeenCalledWith([{
+      organization_id: "org-1",
+      program_id: "11111111-1111-4111-8111-111111111111",
+      note_type: "other",
+      content: { text: "Midtier note" },
+      author_id: "midtier-1",
+    }]);
+  });
+
+  it.each([["admin_schedule"], ["bt"]])("denies %s when the capability helper rejects program-goal management", async () => {
+    createRequestClientMock.mockReturnValue({
+      auth: {
+        getUser: vi.fn(async () => ({ data: { user: { id: "denied-user-1" } }, error: null })),
+      },
+    });
+    requireOrgMock.mockResolvedValue("org-1");
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(false);
+    const module = await loadProgramNotesModule();
+
+    const response = await module.handleProgramNotes(
+      new Request("https://edge.example.com/functions/v1/program-notes", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          program_id: "11111111-1111-4111-8111-111111111111",
+          note_type: "other",
+          content: { text: "Denied note" },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(orgScopedQueryMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/edge/programs.cors.contract.test.ts
+++ b/tests/edge/programs.cors.contract.test.ts
@@ -10,7 +10,7 @@ stubDenoEnv((key) => envValues.get(key) ?? '');
 
 const createRequestClientMock = vi.fn();
 const requireOrgMock = vi.fn();
-const assertUserHasOrgRoleMock = vi.fn();
+const currentUserCanManageProgramsGoalsMock = vi.fn();
 const orgScopedQueryMock = vi.fn();
 class MissingOrgContextError extends Error {
   status = 403;
@@ -26,7 +26,7 @@ async function loadProgramsModule() {
   }));
   vi.doMock('../../supabase/functions/_shared/org.ts', () => ({
     requireOrg: requireOrgMock,
-    assertUserHasOrgRole: assertUserHasOrgRoleMock,
+    currentUserCanManageProgramsGoals: currentUserCanManageProgramsGoalsMock,
     orgScopedQuery: orgScopedQueryMock,
     MissingOrgContextError,
   }));
@@ -40,7 +40,7 @@ function configureProgramsGetSuccessDb() {
     },
   });
   requireOrgMock.mockResolvedValue('org-1');
-  assertUserHasOrgRoleMock.mockImplementation(async (_db: unknown, _orgId: string, role: string) => role === 'therapist');
+  currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
   orgScopedQueryMock.mockReturnValue({
     select: vi.fn(() => ({
       eq: vi.fn(() => ({
@@ -55,7 +55,7 @@ describe('programs route CORS contract', () => {
     vi.resetModules();
     createRequestClientMock.mockReset();
     requireOrgMock.mockReset();
-    assertUserHasOrgRoleMock.mockReset();
+    currentUserCanManageProgramsGoalsMock.mockReset();
     orgScopedQueryMock.mockReset();
   });
 
@@ -232,24 +232,25 @@ describe('programs route org-scope deny matrix', () => {
     vi.resetModules();
     createRequestClientMock.mockReset();
     requireOrgMock.mockReset();
-    assertUserHasOrgRoleMock.mockReset();
+    currentUserCanManageProgramsGoalsMock.mockReset();
     orgScopedQueryMock.mockReset();
   });
 
   const roleMatrix = [
     ['therapist'],
+    ['midtier'],
     ['admin'],
     ['super_admin'],
   ] as const;
 
-  it.each(roleMatrix)('denies out-of-scope client_id on POST for %s role', async (activeRole) => {
+  it.each(roleMatrix)('denies out-of-scope client_id on POST when %s has program-goal capability', async () => {
     createRequestClientMock.mockReturnValue({
       auth: {
         getUser: vi.fn(async () => ({ data: { user: { id: 'user-1' } }, error: null })),
       },
     });
     requireOrgMock.mockResolvedValue('org-1');
-    assertUserHasOrgRoleMock.mockImplementation(async (_db: unknown, _orgId: string, role: string) => role === activeRole);
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
     orgScopedQueryMock.mockImplementation((_db: unknown, table: string) => {
       if (table !== 'clients') {
         throw new Error(`Unexpected table lookup: ${table}`);
@@ -281,14 +282,14 @@ describe('programs route org-scope deny matrix', () => {
     expect(response.status).toBe(403);
   });
 
-  it.each(roleMatrix)('denies out-of-org program_id on PATCH for %s role', async (activeRole) => {
+  it.each(roleMatrix)('denies out-of-org program_id on PATCH when %s has program-goal capability', async () => {
     createRequestClientMock.mockReturnValue({
       auth: {
         getUser: vi.fn(async () => ({ data: { user: { id: 'user-1' } }, error: null })),
       },
     });
     requireOrgMock.mockResolvedValue('org-1');
-    assertUserHasOrgRoleMock.mockImplementation(async (_db: unknown, _orgId: string, role: string) => role === activeRole);
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
     orgScopedQueryMock.mockImplementation((_db: unknown, table: string) => {
       if (table !== 'programs') {
         throw new Error(`Unexpected table lookup: ${table}`);
@@ -322,14 +323,14 @@ describe('programs route org-scope deny matrix', () => {
     expect(response.status).toBe(403);
   });
 
-  it.each(roleMatrix)('denies out-of-scope PATCH client_id for %s role', async (activeRole) => {
+  it.each(roleMatrix)('denies out-of-scope PATCH client_id when %s has program-goal capability', async () => {
     createRequestClientMock.mockReturnValue({
       auth: {
         getUser: vi.fn(async () => ({ data: { user: { id: 'user-1' } }, error: null })),
       },
     });
     requireOrgMock.mockResolvedValue('org-1');
-    assertUserHasOrgRoleMock.mockImplementation(async (_db: unknown, _orgId: string, role: string) => role === activeRole);
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
     orgScopedQueryMock.mockImplementation((_db: unknown, table: string) => {
       if (table !== 'clients') {
         throw new Error(`Unexpected table lookup: ${table}`);
@@ -359,5 +360,85 @@ describe('programs route org-scope deny matrix', () => {
     );
 
     expect(response.status).toBe(403);
+  });
+
+  it('allows midtier through the handler role gate when the capability helper allows program-goal management', async () => {
+    const insertMock = vi.fn(() => ({
+      select: vi.fn(() => ({
+        limit: vi.fn(async () => ({ data: [{ id: 'program-1' }], error: null })),
+      })),
+    }));
+    const db = {
+      auth: {
+        getUser: vi.fn(async () => ({ data: { user: { id: 'midtier-1' } }, error: null })),
+      },
+      from: vi.fn((table: string) => {
+        if (table !== 'programs') {
+          throw new Error(`Unexpected table insert: ${table}`);
+        }
+        return { insert: insertMock };
+      }),
+    };
+    createRequestClientMock.mockReturnValue(db);
+    requireOrgMock.mockResolvedValue('org-1');
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(true);
+    orgScopedQueryMock.mockImplementation((_db: unknown, table: string) => {
+      if (table !== 'clients') {
+        throw new Error(`Unexpected table lookup: ${table}`);
+      }
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            limit: vi.fn(async () => ({ data: [{ id: 'client-1' }], error: null })),
+          })),
+        })),
+      };
+    });
+    const module = await loadProgramsModule();
+
+    const response = await module.handlePrograms(
+      new Request('https://edge.example.com/functions/v1/programs', {
+        method: 'POST',
+        headers: {
+          Origin: 'https://preview.example.com',
+          Authorization: 'Bearer token',
+        },
+        body: JSON.stringify({
+          client_id: '11111111-1111-4111-8111-111111111111',
+          name: 'Midtier Program',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(currentUserCanManageProgramsGoalsMock).toHaveBeenCalledWith(db, 'org-1');
+  });
+
+  it.each([['admin_schedule'], ['bt']])('denies %s when the capability helper rejects program-goal management', async () => {
+    createRequestClientMock.mockReturnValue({
+      auth: {
+        getUser: vi.fn(async () => ({ data: { user: { id: 'denied-user-1' } }, error: null })),
+      },
+    });
+    requireOrgMock.mockResolvedValue('org-1');
+    currentUserCanManageProgramsGoalsMock.mockResolvedValue(false);
+    const module = await loadProgramsModule();
+
+    const response = await module.handlePrograms(
+      new Request('https://edge.example.com/functions/v1/programs', {
+        method: 'POST',
+        headers: {
+          Origin: 'https://preview.example.com',
+          Authorization: 'Bearer token',
+        },
+        body: JSON.stringify({
+          client_id: '11111111-1111-4111-8111-111111111111',
+          name: 'Denied Program',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(orgScopedQueryMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/employee-role-capability-matrix-migration.test.ts
+++ b/tests/employee-role-capability-matrix-migration.test.ts
@@ -9,9 +9,16 @@ const MIGRATION_PATH = path.join(
   'migrations',
   '20260701150000_employee_role_capability_matrix.sql',
 );
+const EXPOSE_PROGRAM_GOAL_RPC_MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260702194500_expose_program_goal_capability_rpc.sql',
+);
 const SMOKE_SQL_PATH = path.join(process.cwd(), 'tests', 'sql', 'employee_role_capability_smoke.sql');
 
 const sql = readFileSync(MIGRATION_PATH, 'utf8');
+const exposeProgramGoalRpcSql = readFileSync(EXPOSE_PROGRAM_GOAL_RPC_MIGRATION_PATH, 'utf8');
 const smokeSql = readFileSync(SMOKE_SQL_PATH, 'utf8');
 
 const extractFunction = (name: string): string => {
@@ -57,6 +64,20 @@ describe('employee role capability matrix migration', () => {
     expect(sql).toContain('CREATE POLICY authorizations_org_write');
     expect(sql).toContain('app.current_user_can_manage_staff_clients(organization_id)');
     expect(sql).toContain('app.current_user_can_manage_authorizations(organization_id)');
+  });
+
+  it('exposes the program-goal capability RPC through the public PostgREST schema only', () => {
+    expect(exposeProgramGoalRpcSql).toContain(
+      'CREATE OR REPLACE FUNCTION public.current_user_can_manage_programs_goals(target_organization_id uuid)',
+    );
+    expect(exposeProgramGoalRpcSql).toContain('SELECT app.current_user_can_manage_programs_goals(target_organization_id);');
+    expect(exposeProgramGoalRpcSql).toContain(
+      'REVOKE EXECUTE ON FUNCTION public.current_user_can_manage_programs_goals(uuid) FROM PUBLIC, anon;',
+    );
+    expect(exposeProgramGoalRpcSql).toContain(
+      'GRANT EXECUTE ON FUNCTION public.current_user_can_manage_programs_goals(uuid) TO authenticated, service_role;',
+    );
+    expect(exposeProgramGoalRpcSql).toContain("NOTIFY pgrst, 'reload schema';");
   });
 
   it('limits bt programs, goals, sessions, and data-taking paths to assigned clients', () => {


### PR DESCRIPTION
## Summary
- Wires programs, goals, and program-notes edge handlers to the existing `current_user_can_manage_programs_goals` capability RPC.
- Switches the handler wrapper to `RouteOptions.programsGoals` so midtier reaches the handler and the DB/RPC capability remains the final allow/deny source.
- Adds edge contract coverage for midtier allow, admin_schedule/BT deny through the capability helper, and the shared RPC payload/fail-closed behavior.

## Verification
- `npx vitest run tests/edge/programs.cors.contract.test.ts tests/edge/goals.parity.contract.test.ts tests/edge/program-notes.cors.contract.test.ts tests/edge/orgRoleRpc.parity.contract.test.ts tests/employee-role-capability-matrix-migration.test.ts` PASS
- `npm run ci:check-focused` PASS; local DB-backed grant/drift checks skipped because `SUPABASE_DB_URL`/`DATABASE_URL` is not configured
- `npm run lint` PASS
- `npm run typecheck` PASS
- `npm run test:ci` PASS, 343 files / 2140 tests
- `npm run validate:tenant` PASS
- `npm run build` PASS
- `npm run test:routes:tier0` PASS on rerun after avoiding concurrent `dist` writes; 212/212 Cypress checks
- `npm run ci:playwright` PASS; captured in `reports/ci-playwright-midtier-program-goal-edge-access.log`, exit 0, `PASS all Playwright smoke scripts`
- `npm run verify:local` PASS

## Risk
- Critical path: `supabase/functions/**` edge authorization and tenant-scoped data access.
- The edge handlers now fail closed if the capability RPC errors.
- Merge blocker per repo policy: critical work needs Linear linkage before merge; no issue key was provided in the review prompt.