### PR TITLE
Finalize employee route landing matrix

### DIFF
--- a/cypress/support/routeScenarios.ts
+++ b/cypress/support/routeScenarios.ts
@@ -37,7 +37,20 @@ export const routeGroups = {
     { path: "/unauthorized", roles: ["public"] },
   ],
   client: [
-    { path: "/", roles: ["client", "bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
+    {
+      path: "/",
+      roles: ["client", "bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"],
+      expectedPathByRole: {
+        client: "/documentation",
+        bt: "/clients",
+        therapist: "/schedule",
+        midtier: "/schedule",
+        admin_schedule: "/",
+        admin: "/",
+        bcba: "/",
+        super_admin: "/",
+      },
+    },
     { path: "/clients", roles: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
     { path: "/clients/client-1", roles: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
     { path: "/documentation", roles: ["client", "bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,6 +104,10 @@ const DashboardLanding: React.FC = () => {
     return <Navigate to="/schedule" replace />;
   }
 
+  if (hasCapability('viewClients')) {
+    return <Navigate to="/clients" replace />;
+  }
+
   // Plain clients should land on family-safe docs, not the admin dashboard shell.
   return <Navigate to="/documentation" replace />;
 };

--- a/src/pages/__tests__/AppNavigation.test.tsx
+++ b/src/pages/__tests__/AppNavigation.test.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { App } from '../../App';
 
 type TestRole = 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin';
-type TestCapability = 'staffDashboard' | 'viewSchedule';
+type TestCapability = 'staffDashboard' | 'viewClients' | 'viewSchedule';
 
 let authRole: TestRole = 'client';
 let authIsGuardian = false;
@@ -27,6 +27,7 @@ vi.mock('../../lib/authContext', () => {
   const signOut = vi.fn();
   const capabilityRoles: Record<TestCapability, TestRole[]> = {
     staffDashboard: ['admin_schedule', 'admin', 'bcba', 'super_admin'],
+    viewClients: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
     viewSchedule: ['therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
   };
   return {
@@ -171,12 +172,34 @@ describe('App navigation landing', () => {
     });
   });
 
-  it('keeps admins on the dashboard', async () => {
-    authRole = 'admin';
+  it('redirects midtier users to schedule from dashboard landing', async () => {
+    authRole = 'midtier';
     window.history.pushState({}, '', '/');
     renderApp();
 
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/schedule');
+    });
+  });
+
+  it('redirects BT users to clients from dashboard landing', async () => {
+    authRole = 'bt';
+    window.history.pushState({}, '', '/');
+    renderApp();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/clients');
+    });
+  });
+
+  it.each(['admin_schedule', 'admin', 'bcba', 'super_admin'] as const)('keeps %s on the dashboard', async (role) => {
+    authRole = role;
+    window.history.pushState({}, '', '/');
+    const view = renderApp();
+
     expect(await screen.findByText('DashboardPage')).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/');
+    view.unmount();
   });
 
   it('does not log raw search/hash in route telemetry', async () => {
@@ -284,16 +307,18 @@ describe('App navigation landing', () => {
     ['/super-admin/feature-flags', 'SuperAdminFeatureFlagsPage'],
     ['/super-admin/impersonation', 'SuperAdminImpersonationPage'],
     ['/super-admin/prompts', 'SuperAdminPromptsPage'],
-  ])('allows only super admins to render %s', async (path, pageText) => {
-    authRole = 'super_admin';
-    window.history.pushState({}, '', path);
-    const allowedView = renderApp();
+  ])('allows BCBA and super admins to render %s', async (path, pageText) => {
+    for (const allowedRole of ['bcba', 'super_admin'] as const) {
+      authRole = allowedRole;
+      window.history.pushState({}, '', path);
+      const allowedView = renderApp();
 
-    expect(await screen.findByText(pageText)).toBeInTheDocument();
-    expect(window.location.pathname).toBe(path);
-    allowedView.unmount();
+      expect(await screen.findByText(pageText)).toBeInTheDocument();
+      expect(window.location.pathname).toBe(path);
+      allowedView.unmount();
+    }
 
-    for (const blockedRole of ['client', 'therapist', 'admin'] as const) {
+    for (const blockedRole of ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin'] as const) {
       authRole = blockedRole;
       window.history.pushState({}, '', path);
       const blockedView = renderApp();


### PR DESCRIPTION
## Summary
- Route BT users from the authenticated root landing page to `/clients` instead of falling through to documentation.
- Keep therapist and midtier root landings on `/schedule`, and admin_schedule/admin/bcba/super_admin on the dashboard.
- Add focused Vitest coverage and Cypress route-matrix expectations for the employee-role landing matrix and BCBA super-admin-equivalent routes.

## Route-task
- classification: high-risk human-reviewed
- lane: critical
- triggering paths: `src/App.tsx`, `src/pages/__tests__/AppNavigation.test.tsx`, `cypress/support/routeScenarios.ts`
- rationale: changes protected route/authz landing behavior for employee roles.

## Verification
- PASS: `npm test -- --run src/pages/__tests__/AppNavigation.test.tsx tests/edge/route-guards-parity.test.ts tests/edge/route-audit-policy.test.ts`
- PASS: `npm run ci:check-focused`
- PASS: `npm run lint`
- PASS: `npm run typecheck`
- PASS: `npm run test:ci`
- PASS: `npm run test:routes:tier0`
- PASS: `npm run build`
- BLOCKED locally: `npm run ci:playwright` timed out twice, once at 5 minutes and once at 15 minutes, with no terminal result. Required to run in CI or a provisioned local browser-auth environment.

## Reviewer/tester
- reviewer subagent: no auth/routing/capability regressions found; recommended additional focused unit coverage, which was added.
- tester subagent: confirmed critical-lane required checks and identified `ci:playwright` as the likely local blocker.

## Blocking Items Before Merge
- Critical-lane human review is required.
- Linear issue linkage is required by repo policy, but Linear connector lookup failed locally with expired token.
- Required CI/browser auth gate must pass or be explicitly accepted by a human reviewer.