### PR TITLE
Add super admin employee role editor

### DIFF
--- a/src/components/settings/AdminSettings.tsx
+++ b/src/components/settings/AdminSettings.tsx
@@ -1,14 +1,25 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Plus, Trash2, Shield, Mail, Calendar, Key, Users, Link2, CheckCircle2, Building2 } from 'lucide-react';
-import { supabase } from '../../lib/supabase';
+import { Plus, Trash2, Shield, Mail, Calendar, Key, Users, Link2, CheckCircle2, Building2, UserCog } from 'lucide-react';
+import { callEdge, supabase } from '../../lib/supabase';
 import { showSuccess, showError } from '../../lib/toast';
 import { logger } from '../../lib/logger/logger';
 import { useAuth } from '../../lib/authContext';
 import { Modal } from '../common/Modal';
 import type { PostgrestError } from '@supabase/supabase-js';
+import { ROLE_LABELS, type AppRole } from '../../lib/roles';
 
 const ADMIN_USER_FETCH_LIMIT = 200;
+const EMPLOYEE_USER_FETCH_LIMIT = 200;
+const EMPLOYEE_ROLE_OPTIONS = [
+  'bt',
+  'therapist',
+  'midtier',
+  'admin_schedule',
+  'admin',
+  'bcba',
+  'super_admin',
+] as const satisfies readonly AppRole[];
 
 interface AdminUser {
   id: string;
@@ -22,6 +33,20 @@ interface AdminUser {
     organization_id?: string;
     organizationId?: string;
   } | null;
+}
+
+interface EmployeeUser {
+  id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  full_name: string | null;
+  title: string | null;
+  role: AppRole;
+  is_active: boolean | null;
+  organization_id: string | null;
+  created_at: string | null;
+  last_login_at: string | null;
 }
 
 interface AdminFormData {
@@ -160,6 +185,38 @@ export function AdminSettings() {
       return (data as AdminUser[] | null) ?? [];
     },
     enabled: isSuperAdmin || Boolean(organizationId),
+    retry: false,
+  });
+
+  const {
+    data: employeeUsers = [],
+    isLoading: isEmployeeUsersLoading,
+    error: employeeUsersError,
+  } = useQuery<EmployeeUser[], Error>({
+    queryKey: ['employee-users', selectedOrganizationId],
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc('get_employee_users_paged', {
+        p_organization_id: activeOrganizationId ?? null,
+        p_limit: EMPLOYEE_USER_FETCH_LIMIT,
+        p_offset: 0,
+      });
+
+      if (error) {
+        const rpcError = error as PostgrestError & { status?: number };
+        const mappedError = new Error(
+          rpcError.code === '42501'
+            ? 'Only super administrators can view employee users.'
+            : error.message || 'Failed to load employee users.'
+        );
+        (mappedError as Error & { status?: number }).status = rpcError.code === '42501' ? 403 : 500;
+        throw mappedError;
+      }
+
+      return ((data as EmployeeUser[] | null) ?? []).filter((employee) =>
+        EMPLOYEE_ROLE_OPTIONS.includes(employee.role)
+      );
+    },
+    enabled: isSuperAdmin,
     retry: false,
   });
 
@@ -373,6 +430,14 @@ export function AdminSettings() {
 
     showError(organizationOptionsError);
   }, [organizationOptionsError]);
+
+  useEffect(() => {
+    if (!employeeUsersError) {
+      return;
+    }
+
+    showError(employeeUsersError);
+  }, [employeeUsersError]);
 
   useEffect(() => {
     if (!therapistOptionsError) {
@@ -623,6 +688,36 @@ export function AdminSettings() {
     },
   });
 
+  const updateEmployeeRoleMutation = useMutation({
+    mutationFn: async ({ userId, role }: { userId: string; role: AppRole }) => {
+      const response = await callEdge(`admin-users-roles/admin/users/${userId}/roles`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ role }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null) as { error?: unknown } | null;
+        const message = typeof payload?.error === 'string'
+          ? payload.error
+          : `Failed to update employee role (${response.status})`;
+        throw new Error(message);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['employee-users', selectedOrganizationId] });
+      queryClient.invalidateQueries({
+        queryKey: ['admins', isSuperAdmin ? selectedOrganizationId : organizationId],
+      });
+      showSuccess('Employee role updated successfully');
+    },
+    onError: (error) => {
+      showError(error);
+    },
+  });
+
   const resetForm = () => {
     setFormData({
       email: '',
@@ -680,6 +775,22 @@ export function AdminSettings() {
     }
 
     unlinkAdminTherapistMutation.mutate({ userId, therapistId });
+  };
+
+  const handleEmployeeRoleChange = (employee: EmployeeUser, nextRole: AppRole) => {
+    if (employee.role === nextRole) {
+      return;
+    }
+
+    const displayName = employee.full_name || [employee.first_name, employee.last_name].filter(Boolean).join(' ') || employee.email;
+    const shouldUpdate = window.confirm(
+      `Change ${displayName}'s role from ${ROLE_LABELS[employee.role]} to ${ROLE_LABELS[nextRole]}?`
+    );
+    if (!shouldUpdate) {
+      return;
+    }
+
+    updateEmployeeRoleMutation.mutate({ userId: employee.id, role: nextRole });
   };
 
   const getMetadataValue = (entry: GuardianQueueEntry, key: string) => {
@@ -811,6 +922,88 @@ export function AdminSettings() {
             )}
           </div>
         </div>
+      )}
+
+      {isSuperAdmin && (
+        <section className="rounded-lg border border-blue-100 bg-white p-4 shadow-sm dark:border-blue-900/40 dark:bg-dark-lighter">
+          <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h3 className="flex items-center gap-2 text-base font-semibold text-gray-900 dark:text-white">
+                <UserCog className="h-5 w-5 text-blue-600 dark:text-blue-300" />
+                Employee Role Access
+              </h3>
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Super admins can update employee app roles. Client roles are intentionally excluded from this editor.
+              </p>
+            </div>
+            <span className="rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-200">
+              {activeOrganizationId ? 'Organization scoped' : 'All organizations'}
+            </span>
+          </div>
+
+          {isEmployeeUsersLoading ? (
+            <div className="py-4 text-sm text-gray-500 dark:text-gray-400">Loading employee users…</div>
+          ) : employeeUsers.length === 0 ? (
+            <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600 dark:border-gray-700 dark:bg-dark dark:text-gray-300">
+              No employee users found.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
+                <thead>
+                  <tr>
+                    <th scope="col" className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Employee</th>
+                    <th scope="col" className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Organization</th>
+                    <th scope="col" className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Role</th>
+                    <th scope="col" className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Status</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                  {employeeUsers.map((employee) => {
+                    const displayName = employee.full_name
+                      || [employee.first_name, employee.last_name].filter(Boolean).join(' ')
+                      || employee.email;
+                    return (
+                      <tr key={employee.id}>
+                        <td className="px-3 py-3">
+                          <div className="font-medium text-gray-900 dark:text-gray-100">{displayName}</div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400">{employee.email}</div>
+                        </td>
+                        <td className="px-3 py-3 text-gray-600 dark:text-gray-300">
+                          {employee.organization_id ?? 'No organization'}
+                        </td>
+                        <td className="px-3 py-3">
+                          <select
+                            aria-label={`Role for ${employee.email}`}
+                            className="rounded-md border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-dark dark:text-gray-100"
+                            value={employee.role}
+                            disabled={updateEmployeeRoleMutation.isPending}
+                            onChange={(event) => handleEmployeeRoleChange(employee, event.target.value as AppRole)}
+                          >
+                            {EMPLOYEE_ROLE_OPTIONS.map((role) => (
+                              <option key={role} value={role}>
+                                {ROLE_LABELS[role]}
+                              </option>
+                            ))}
+                          </select>
+                        </td>
+                        <td className="px-3 py-3">
+                          <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${
+                            employee.is_active === false
+                              ? 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200'
+                              : 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-200'
+                          }`}>
+                            {employee.is_active === false ? 'Inactive' : 'Active'}
+                          </span>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
       )}
 
       {isLoading || (isSuperAdmin && isOrganizationOptionsLoading) ? (

--- a/src/components/settings/__tests__/AdminSettings.test.tsx
+++ b/src/components/settings/__tests__/AdminSettings.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderWithProviders, screen, waitFor, userEvent, within } from '../../../test/utils';
 import { AdminSettings } from '../AdminSettings';
 import { supabase } from '../../../lib/supabase';
+import * as supabaseModule from '../../../lib/supabase';
 import { logger } from '../../../lib/logger/logger';
 import { useAuth } from '../../../lib/authContext';
 import { showError, showSuccess } from '../../../lib/toast';
@@ -64,6 +65,20 @@ const mockTherapist = {
   id: 'therapist-1',
   full_name: 'Therapist One',
   email: 'therapist@example.com',
+};
+
+const mockEmployeeUser = {
+  id: '22222222-2222-2222-2222-222222222222',
+  email: 'midtier@example.com',
+  first_name: 'Mira',
+  last_name: 'Midtier',
+  full_name: 'Mira Midtier',
+  title: 'Clinical Supervisor',
+  role: 'midtier',
+  is_active: true,
+  organization_id: '11111111-1111-1111-1111-111111111111',
+  created_at: new Date('2025-02-01T00:00:00Z').toISOString(),
+  last_login_at: null,
 };
 
 const buildTherapistQuery = (data = [mockTherapist], error: Error | null = null) => {
@@ -729,6 +744,7 @@ describe('Admin therapist links', () => {
 describe('AdminSettings super admin access', () => {
   let fromSpy: ReturnType<typeof vi.spyOn> | null = null;
   let invokeSpy: ReturnType<typeof vi.spyOn> | null = null;
+  let callEdgeSpy: ReturnType<typeof vi.spyOn> | null = null;
 
   beforeEach(() => {
     const authStub = {
@@ -760,6 +776,9 @@ describe('AdminSettings super admin access', () => {
     rpcMock.mockImplementation(async (functionName: string, params?: Record<string, unknown>) => {
       if (functionName === 'get_admin_users_paged') {
         return { data: [mockAdminUser], error: null };
+      }
+      if (functionName === 'get_employee_users_paged') {
+        return { data: [mockEmployeeUser], error: null };
       }
       if (functionName === 'get_admin_therapist_links') {
         return { data: [], error: null };
@@ -802,6 +821,9 @@ describe('AdminSettings super admin access', () => {
     invokeSpy = vi
       .spyOn(supabase.functions, 'invoke')
       .mockResolvedValue({ data: null, error: null });
+    callEdgeSpy = vi
+      .spyOn(supabaseModule, 'callEdge')
+      .mockResolvedValue(new Response(JSON.stringify({ message: 'ok' }), { status: 200 }));
   });
 
   afterEach(() => {
@@ -810,6 +832,8 @@ describe('AdminSettings super admin access', () => {
     fromSpy = null;
     invokeSpy?.mockRestore();
     invokeSpy = null;
+    callEdgeSpy?.mockRestore();
+    callEdgeSpy = null;
     confirmSpy?.mockRestore();
     confirmSpy = null;
   });
@@ -824,7 +848,7 @@ describe('AdminSettings super admin access', () => {
     expect(initialAdminCalls[0]?.[1]).toMatchObject({ organization_id: null });
 
     await screen.findByText('Ada Admin');
-    await screen.findByText('11111111-1111-1111-1111-111111111111');
+    expect(screen.getAllByText('11111111-1111-1111-1111-111111111111').length).toBeGreaterThan(0);
 
     await userEvent.selectOptions(filterSelect, 'org-1');
 
@@ -832,6 +856,26 @@ describe('AdminSettings super admin access', () => {
       const adminCalls = rpcMock.mock.calls.filter(([fnName]) => fnName === 'get_admin_users_paged');
       expect(adminCalls.some(([, params]) => params && (params as Record<string, unknown>).organization_id === 'org-1')).toBe(true);
     });
+  });
+
+  it('allows super admins to update employee roles through the role editor', async () => {
+    renderWithProviders(<AdminSettings />);
+
+    const roleSelect = await screen.findByLabelText('Role for midtier@example.com');
+    expect(roleSelect).toHaveValue('midtier');
+
+    await userEvent.selectOptions(roleSelect, 'admin_schedule');
+
+    await waitFor(() => {
+      expect(callEdgeSpy).toHaveBeenCalledWith(
+        'admin-users-roles/admin/users/22222222-2222-2222-2222-222222222222/roles',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ role: 'admin_schedule' }),
+        }),
+      );
+    });
+    expect(showSuccess).toHaveBeenCalledWith('Employee role updated successfully');
   });
 
   it('keeps therapist link RPCs disabled for All organizations until a concrete org is selected', async () => {

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -6343,6 +6343,22 @@ export type Database = {
           isSetofReturn: true
         }
       }
+      get_employee_users_paged: {
+        Args: { p_organization_id?: string; p_limit?: number; p_offset?: number }
+        Returns: {
+          created_at: string | null
+          email: string | null
+          first_name: string | null
+          full_name: string | null
+          id: string | null
+          is_active: boolean | null
+          last_login_at: string | null
+          last_name: string | null
+          organization_id: string | null
+          role: Database["public"]["Enums"]["role_type"] | null
+          title: string | null
+        }[]
+      }
       get_admin_linkable_therapists: {
         Args: { p_organization_id: string }
         Returns: {

--- a/supabase/functions/admin-users-roles/index.ts
+++ b/supabase/functions/admin-users-roles/index.ts
@@ -2,7 +2,7 @@ import { createProtectedRoute, corsHeaders, logApiAccess, RouteOptions } from ".
 import { createRequestClient, supabaseAdmin } from "../_shared/database.ts";
 import { assertAdminOrSuperAdmin } from "../_shared/auth.ts";
 
-interface RoleUpdateRequest { role: 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin'; is_active?: boolean; }
+interface RoleUpdateRequest { target_user_id?: string; role: 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin'; is_active?: boolean; }
 
 type AppRole = RoleUpdateRequest["role"];
 
@@ -121,17 +121,23 @@ export default createProtectedRoute(async (req: Request, userContext) => {
     const adminClient = createRequestClient(req);
     await assertAdminOrSuperAdmin(adminClient);
 
+    const body = await req.json().catch(() => null) as RoleUpdateRequest | null;
+    if (!body || typeof body !== "object") return new Response(JSON.stringify({ error: 'Valid role update request is required' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+
     const url = new URL(req.url);
     const pathSegments = url.pathname.split('/');
     const userIdIndex = pathSegments.findIndex(segment => segment === 'users') + 1;
-    const userId = pathSegments[userIdIndex];
+    const pathUserId = userIdIndex > 0 ? pathSegments[userIdIndex] : "";
+    const bodyUserId = typeof body.target_user_id === "string" ? body.target_user_id.trim() : "";
+    const userId = pathUserId || bodyUserId;
 
     if (!userId) return new Response(JSON.stringify({ error: 'User ID is required' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    if (pathUserId && bodyUserId && pathUserId !== bodyUserId) return new Response(JSON.stringify({ error: 'Target user ID mismatch' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (!uuidRegex.test(userId)) return new Response(JSON.stringify({ error: 'Invalid user ID format' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
-    const { role, is_active }: RoleUpdateRequest = await req.json();
+    const { role, is_active } = body;
     const validRoles = CANONICAL_ROLE_NAMES;
     if (!role || !validRoles.includes(role)) return new Response(JSON.stringify({ error: 'Valid role is required', validRoles }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 

--- a/supabase/migrations/20260702120000_super_admin_employee_role_listing.sql
+++ b/supabase/migrations/20260702120000_super_admin_employee_role_listing.sql
@@ -31,9 +31,7 @@ SET search_path = public, app, pg_temp
 AS $$
 DECLARE
   current_user_id uuid := auth.uid();
-  is_super_admin boolean := public.current_user_is_super_admin()
-    OR app.user_has_role('super_admin')
-    OR app.user_has_role('bcba');
+  is_super_admin boolean := public.current_user_is_super_admin();
   limit_value integer := GREATEST(p_limit, 1);
   offset_value integer := GREATEST(p_offset, 0);
 BEGIN
@@ -53,13 +51,34 @@ BEGIN
     p.last_name,
     p.full_name,
     p.title,
-    p.role,
+    effective_role.role,
     p.is_active,
     p.organization_id,
     p.created_at,
     p.last_login_at
   FROM public.profiles p
-  WHERE p.role <> 'client'::public.role_type
+  JOIN LATERAL (
+    SELECT r.name::public.role_type AS role
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    WHERE ur.user_id = p.id
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+      AND r.name IN ('bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin')
+    ORDER BY
+      CASE r.name
+        WHEN 'super_admin' THEN 8
+        WHEN 'bcba' THEN 8
+        WHEN 'admin' THEN 7
+        WHEN 'admin_schedule' THEN 6
+        WHEN 'midtier' THEN 5
+        WHEN 'therapist' THEN 4
+        WHEN 'bt' THEN 3
+        ELSE 0
+      END DESC
+    LIMIT 1
+  ) effective_role ON true
+  WHERE effective_role.role <> 'client'::public.role_type
     AND (p_organization_id IS NULL OR p.organization_id = p_organization_id)
   ORDER BY
     p.last_name ASC NULLS LAST,

--- a/supabase/migrations/20260702120000_super_admin_employee_role_listing.sql
+++ b/supabase/migrations/20260702120000_super_admin_employee_role_listing.sql
@@ -1,0 +1,75 @@
+/*
+  @migration-intent: Add a super-admin-only employee user listing RPC for controlled role management UI.
+  @migration-dependencies: 20260202124000_forward_fix_admin_users_paged_super_admin_return.sql
+  @migration-rollback: DROP FUNCTION IF EXISTS public.get_employee_users_paged(uuid, integer, integer);
+*/
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_employee_users_paged(
+  p_organization_id uuid DEFAULT NULL,
+  p_limit integer DEFAULT 100,
+  p_offset integer DEFAULT 0
+)
+RETURNS TABLE (
+  id uuid,
+  email text,
+  first_name text,
+  last_name text,
+  full_name text,
+  title text,
+  role public.role_type,
+  is_active boolean,
+  organization_id uuid,
+  created_at timestamptz,
+  last_login_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+STABLE
+SET search_path = public, app, pg_temp
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  is_super_admin boolean := public.current_user_is_super_admin()
+    OR app.user_has_role('super_admin')
+    OR app.user_has_role('bcba');
+  limit_value integer := GREATEST(p_limit, 1);
+  offset_value integer := GREATEST(p_offset, 0);
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '28000', MESSAGE = 'Authentication required';
+  END IF;
+
+  IF NOT is_super_admin THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Only super administrators can view employee users';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.email,
+    p.first_name,
+    p.last_name,
+    p.full_name,
+    p.title,
+    p.role,
+    p.is_active,
+    p.organization_id,
+    p.created_at,
+    p.last_login_at
+  FROM public.profiles p
+  WHERE p.role <> 'client'::public.role_type
+    AND (p_organization_id IS NULL OR p.organization_id = p_organization_id)
+  ORDER BY
+    p.last_name ASC NULLS LAST,
+    p.first_name ASC NULLS LAST,
+    p.email ASC
+  LIMIT limit_value
+  OFFSET offset_value;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO authenticated;
+
+COMMIT;

--- a/tests/admin-users-roles.access.spec.ts
+++ b/tests/admin-users-roles.access.spec.ts
@@ -364,4 +364,56 @@ describe('admin-users-roles access control', () => {
       is_active: true,
     });
   });
+
+  it('accepts a target user id in the request body for direct edge invokes', async () => {
+    rpcRoles = ['super_admin'];
+
+    const superAdminContext: TestUserContext = {
+      user: { id: 'super-admin-4', email: 'super4@example.com' },
+      profile: {
+        id: 'super-admin-profile-4',
+        email: 'super4@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    };
+
+    userContexts.set('super4', superAdminContext);
+    adminUsers.set('super-admin-4', {
+      id: 'super-admin-4',
+      email: 'super4@example.com',
+      user_metadata: { organization_id: 'org-123' },
+    });
+    adminUsers.set(existingProfile.id, {
+      id: existingProfile.id,
+      email: existingProfile.email,
+      user_metadata: { organization_id: 'org-999' },
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-users-roles/index.ts');
+
+    const response = await handler(
+      new Request('http://localhost/functions/v1/admin-users-roles', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+          'x-test-user': 'super4',
+        },
+        body: JSON.stringify({
+          target_user_id: '11111111-1111-1111-1111-111111111111',
+          role: 'admin_schedule',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(userRolesUpsertPayload).toMatchObject({
+      user_id: existingProfile.id,
+      role_id: 'rid-admin-schedule',
+      granted_by: 'super-admin-4',
+      is_active: true,
+    });
+    expect(latestUpdatePayload).toEqual({ role: 'admin_schedule' });
+  });
 });

--- a/tests/employee-role-capability-matrix-migration.test.ts
+++ b/tests/employee-role-capability-matrix-migration.test.ts
@@ -15,10 +15,17 @@ const EXPOSE_PROGRAM_GOAL_RPC_MIGRATION_PATH = path.join(
   'migrations',
   '20260702194500_expose_program_goal_capability_rpc.sql',
 );
+const EMPLOYEE_ROLE_LISTING_MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260702120000_super_admin_employee_role_listing.sql',
+);
 const SMOKE_SQL_PATH = path.join(process.cwd(), 'tests', 'sql', 'employee_role_capability_smoke.sql');
 
 const sql = readFileSync(MIGRATION_PATH, 'utf8');
 const exposeProgramGoalRpcSql = readFileSync(EXPOSE_PROGRAM_GOAL_RPC_MIGRATION_PATH, 'utf8');
+const employeeRoleListingSql = readFileSync(EMPLOYEE_ROLE_LISTING_MIGRATION_PATH, 'utf8');
 const smokeSql = readFileSync(SMOKE_SQL_PATH, 'utf8');
 
 const extractFunction = (name: string): string => {
@@ -119,5 +126,17 @@ describe('employee role capability matrix migration', () => {
     expect(smokeSql).toContain('midtier_schedule_write_allowed');
     expect(smokeSql).toContain('bt_schedule_write_denied');
     expect(smokeSql).toContain('bcba_super_admin_equivalence_helpers');
+  });
+
+  it('lists editable employee roles from active unexpired junction grants only', () => {
+    expect(employeeRoleListingSql).toContain('is_super_admin boolean := public.current_user_is_super_admin();');
+    expect(employeeRoleListingSql).not.toContain("app.user_has_role('super_admin')");
+    expect(employeeRoleListingSql).not.toContain("app.user_has_role('bcba')");
+    expect(employeeRoleListingSql).toContain('FROM public.user_roles ur');
+    expect(employeeRoleListingSql).toContain('JOIN public.roles r ON r.id = ur.role_id');
+    expect(employeeRoleListingSql).toContain('COALESCE(ur.is_active, true) = true');
+    expect(employeeRoleListingSql).toContain('(ur.expires_at IS NULL OR ur.expires_at > now())');
+    expect(employeeRoleListingSql).toContain('effective_role.role');
+    expect(employeeRoleListingSql).not.toContain('WHERE p.role <>');
   });
 });


### PR DESCRIPTION
## Summary
- Adds a super-admin employee role editor to Admin Settings, excluding client roles from the editor.
- Adds `public.get_employee_users_paged(...)` as a super-admin/BCBA-only employee profile listing RPC for the UI.
- Reuses the existing `admin-users-roles` protected edge function for writes, with a body `target_user_id` fallback while preserving path-based PATCH support.

## Route Task
- classification: high-risk human-reviewed
- lane: critical
- triggering paths: `supabase/migrations/**`, `supabase/functions/**`, role-management UI in `src/components/settings/**`
- risk: role assignment, RPC exposure, tenant/org-scoped employee reads, protected edge write path

## Verification Card
- change type: UI/component, edge integration, database/RPC/tenant isolation, authz role handling
- required checks: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, targeted tests, `npm run test:ci`, `npm run validate:tenant`, `npm run build`, `npm run test:routes:tier0`, `npm run ci:playwright`, `npm run verify:local`
- executed checks:
  - `npm run ci:check-focused`: passed
  - `npm run lint`: passed
  - `npm run typecheck`: passed
  - `npm run test -- src/components/settings/__tests__/AdminSettings.test.tsx tests/admin-users-roles.access.spec.ts`: passed
  - `npm run test:ci`: passed
  - `npm run validate:tenant`: passed
  - `npm run build`: passed
  - `npm run test:routes:tier0`: passed
  - `npm run verify:local`: passed
- blocked checks:
  - `npm run ci:playwright`: timed out locally twice, once after ~7 minutes and once after ~15 minutes without a completed result. Needs CI or a stable local Playwright environment.
- result: pass-with-blocked-checks
- residual risk: hosted migration/RPC behavior and auth-session browser path still need CI/hosted validation; Linear linkage is blocked by expired Linear token.

## PR Hygiene
- branch-ready: yes, `codex/super-admin-edit-employee-roles`
- single-purpose: yes
- unrelated changes: none
- generated artifact drift: none; `reports/test-reliability-latest.json` was restored after test runs
- protected-path drift: expected and routed as critical
- reviewer: human review required for critical authz/tenant-scope changes
- Linear: blocked, connector returned `token_expired`