### PR TITLE
WIN-194 Harden employee role listing RPC grants

### DIFF
--- a/supabase/migrations/20260702222500_restrict_employee_users_paged_execute_grants.sql
+++ b/supabase/migrations/20260702222500_restrict_employee_users_paged_execute_grants.sql
@@ -1,0 +1,12 @@
+-- @migration-intent: Restrict employee listing RPC execution to authenticated callers only.
+-- @migration-dependencies: 20260702120000_super_admin_employee_role_listing.sql
+-- @migration-rollback: GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO authenticated;
+
+BEGIN;
+
+REVOKE EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260702222500_restrict_employee_users_paged_execute_grants.sql
+++ b/supabase/migrations/20260702222500_restrict_employee_users_paged_execute_grants.sql
@@ -1,6 +1,8 @@
 -- @migration-intent: Restrict employee listing RPC execution to authenticated callers only.
 -- @migration-dependencies: 20260702120000_super_admin_employee_role_listing.sql
--- @migration-rollback: GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO authenticated;
+-- @migration-rollback: GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO PUBLIC, anon;
+-- @migration-rollback: REVOKE EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) FROM service_role;
+-- @migration-rollback: NOTIFY pgrst, 'reload schema';
 
 BEGIN;
 

--- a/tests/employee-role-capability-matrix-migration.test.ts
+++ b/tests/employee-role-capability-matrix-migration.test.ts
@@ -155,9 +155,15 @@ describe('employee role capability matrix migration', () => {
       'GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO authenticated, service_role;',
     );
     expect(employeeRoleListingGrantsSql).toContain(
+      '-- @migration-rollback: GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO PUBLIC, anon;',
+    );
+    expect(employeeRoleListingGrantsSql).toContain(
+      '-- @migration-rollback: REVOKE EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) FROM service_role;',
+    );
+    expect(employeeRoleListingGrantsSql).toContain("-- @migration-rollback: NOTIFY pgrst, 'reload schema';");
+    expect(employeeRoleListingGrantsSql).not.toContain(
       '-- @migration-rollback: GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO authenticated;',
     );
-    expect(employeeRoleListingGrantsSql).not.toContain('TO anon;');
     expect(employeeRoleListingGrantsSql).toContain("NOTIFY pgrst, 'reload schema';");
   });
 });

--- a/tests/employee-role-capability-matrix-migration.test.ts
+++ b/tests/employee-role-capability-matrix-migration.test.ts
@@ -21,11 +21,18 @@ const EMPLOYEE_ROLE_LISTING_MIGRATION_PATH = path.join(
   'migrations',
   '20260702120000_super_admin_employee_role_listing.sql',
 );
+const EMPLOYEE_ROLE_LISTING_GRANTS_MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260702222500_restrict_employee_users_paged_execute_grants.sql',
+);
 const SMOKE_SQL_PATH = path.join(process.cwd(), 'tests', 'sql', 'employee_role_capability_smoke.sql');
 
 const sql = readFileSync(MIGRATION_PATH, 'utf8');
 const exposeProgramGoalRpcSql = readFileSync(EXPOSE_PROGRAM_GOAL_RPC_MIGRATION_PATH, 'utf8');
 const employeeRoleListingSql = readFileSync(EMPLOYEE_ROLE_LISTING_MIGRATION_PATH, 'utf8');
+const employeeRoleListingGrantsSql = readFileSync(EMPLOYEE_ROLE_LISTING_GRANTS_MIGRATION_PATH, 'utf8');
 const smokeSql = readFileSync(SMOKE_SQL_PATH, 'utf8');
 
 const extractFunction = (name: string): string => {
@@ -138,5 +145,19 @@ describe('employee role capability matrix migration', () => {
     expect(employeeRoleListingSql).toContain('(ur.expires_at IS NULL OR ur.expires_at > now())');
     expect(employeeRoleListingSql).toContain('effective_role.role');
     expect(employeeRoleListingSql).not.toContain('WHERE p.role <>');
+  });
+
+  it('restricts employee listing RPC execution to authenticated callers', () => {
+    expect(employeeRoleListingGrantsSql).toContain(
+      'REVOKE EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) FROM PUBLIC, anon;',
+    );
+    expect(employeeRoleListingGrantsSql).toContain(
+      'GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO authenticated, service_role;',
+    );
+    expect(employeeRoleListingGrantsSql).toContain(
+      '-- @migration-rollback: GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO authenticated;',
+    );
+    expect(employeeRoleListingGrantsSql).not.toContain('TO anon;');
+    expect(employeeRoleListingGrantsSql).toContain("NOTIFY pgrst, 'reload schema';");
   });
 });


### PR DESCRIPTION
## Summary
- restrict `public.get_employee_users_paged(uuid, integer, integer)` execute grants to `authenticated` and `service_role`
- add migration-contract coverage for the employee listing RPC grants, schema reload, and rollback metadata
- link critical protected-path tracking to WIN-194

## Hosted Supabase evidence
- Supabase plugin migration apply succeeded on project `wnnjeqheqxxyrgsjmygy`
- hosted grant query shows `get_employee_users_paged` and `current_user_can_manage_programs_goals` grants limited to `{authenticated, postgres, service_role}`
- hosted role smoke passed 21/21 probes for `admin_schedule`, `midtier`, `bt`, and `bcba`; smoke residue count was 0

## Verification
- `npm test -- --run tests/employee-role-capability-matrix-migration.test.ts`
- focused role/edge tests: passed
- UI/route component tests: passed
- `npm run test:routes:tier0`: passed
- `npm run audit:routes`: passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run validate:tenant`: passed
- `npm run build`: passed
- `npm run test:ci`: passed
- `npm run ci:verify-coverage`: passed
- `npm run ci:check-focused`: passed, with expected local DB/protected-system skips
- `npm run ci:playwright`: passed all 10 hosted smoke scripts when run with sufficient outer timeout

## Review notes
- Reviewer finding on rollback metadata was fixed before this ready-for-review handoff.
- PR remains protected-path/critical because it touches `supabase/migrations/**`; human review is required before merge.

Linear: WIN-194