### PR TITLE
WIN-194 Fix employee role editor save hang

### DIFF
--- a/src/components/settings/AdminSettings.tsx
+++ b/src/components/settings/AdminSettings.tsx
@@ -11,6 +11,7 @@ import { ROLE_LABELS, type AppRole } from '../../lib/roles';
 
 const ADMIN_USER_FETCH_LIMIT = 200;
 const EMPLOYEE_USER_FETCH_LIMIT = 200;
+const EMPLOYEE_ROLE_UPDATE_TIMEOUT_MS = 20_000;
 const EMPLOYEE_ROLE_OPTIONS = [
   'bt',
   'therapist',
@@ -690,13 +691,29 @@ export function AdminSettings() {
 
   const updateEmployeeRoleMutation = useMutation({
     mutationFn: async ({ userId, role }: { userId: string; role: AppRole }) => {
-      const response = await callEdge(`admin-users-roles/admin/users/${userId}/roles`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ role }),
-      });
+      const controller = new AbortController();
+      const timeoutId = globalThis.setTimeout(() => {
+        controller.abort();
+      }, EMPLOYEE_ROLE_UPDATE_TIMEOUT_MS);
+
+      let response: Response;
+      try {
+        response = await callEdge('admin-users-roles', {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          signal: controller.signal,
+          body: JSON.stringify({ target_user_id: userId, role }),
+        });
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          throw new Error('Timed out updating employee role. Please retry.');
+        }
+        throw error;
+      } finally {
+        globalThis.clearTimeout(timeoutId);
+      }
 
       if (!response.ok) {
         const payload = await response.json().catch(() => null) as { error?: unknown } | null;
@@ -963,6 +980,10 @@ export function AdminSettings() {
                     const displayName = employee.full_name
                       || [employee.first_name, employee.last_name].filter(Boolean).join(' ')
                       || employee.email;
+                    const isRoleUpdatePending =
+                      updateEmployeeRoleMutation.isPending
+                      && updateEmployeeRoleMutation.variables?.userId === employee.id;
+
                     return (
                       <tr key={employee.id}>
                         <td className="px-3 py-3">
@@ -975,9 +996,10 @@ export function AdminSettings() {
                         <td className="px-3 py-3">
                           <select
                             aria-label={`Role for ${employee.email}`}
+                            aria-busy={isRoleUpdatePending ? 'true' : undefined}
                             className="rounded-md border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-dark dark:text-gray-100"
                             value={employee.role}
-                            disabled={updateEmployeeRoleMutation.isPending}
+                            disabled={isRoleUpdatePending}
                             onChange={(event) => handleEmployeeRoleChange(employee, event.target.value as AppRole)}
                           >
                             {EMPLOYEE_ROLE_OPTIONS.map((role) => (
@@ -986,6 +1008,11 @@ export function AdminSettings() {
                               </option>
                             ))}
                           </select>
+                          {isRoleUpdatePending && (
+                            <div className="mt-1 text-xs text-blue-600 dark:text-blue-300" role="status">
+                              Saving role…
+                            </div>
+                          )}
                         </td>
                         <td className="px-3 py-3">
                           <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${

--- a/src/components/settings/__tests__/AdminSettings.test.tsx
+++ b/src/components/settings/__tests__/AdminSettings.test.tsx
@@ -868,14 +868,41 @@ describe('AdminSettings super admin access', () => {
 
     await waitFor(() => {
       expect(callEdgeSpy).toHaveBeenCalledWith(
-        'admin-users-roles/admin/users/22222222-2222-2222-2222-222222222222/roles',
+        'admin-users-roles',
         expect.objectContaining({
           method: 'PATCH',
-          body: JSON.stringify({ role: 'admin_schedule' }),
+          body: JSON.stringify({
+            target_user_id: '22222222-2222-2222-2222-222222222222',
+            role: 'admin_schedule',
+          }),
+          signal: expect.any(AbortSignal),
         }),
       );
     });
     expect(showSuccess).toHaveBeenCalledWith('Employee role updated successfully');
+  });
+
+  it('shows row-level saving feedback while an employee role update is pending', async () => {
+    callEdgeSpy?.mockReturnValue(new Promise<Response>(() => {}));
+    renderWithProviders(<AdminSettings />);
+
+    const roleSelect = await screen.findByLabelText('Role for midtier@example.com');
+    await userEvent.selectOptions(roleSelect, 'admin_schedule');
+
+    await waitFor(() => {
+      expect(callEdgeSpy).toHaveBeenCalledWith(
+        'admin-users-roles',
+        expect.objectContaining({
+          body: JSON.stringify({
+            target_user_id: '22222222-2222-2222-2222-222222222222',
+            role: 'admin_schedule',
+          }),
+        }),
+      );
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Saving role');
+    expect(roleSelect).toBeDisabled();
   });
 
   it('keeps therapist link RPCs disabled for All organizations until a concrete org is selected', async () => {


### PR DESCRIPTION
## Summary
- Route employee role saves through the canonical `admin-users-roles` edge function with `target_user_id` in the request body.
- Add a 20s abort timeout and row-level `Saving role…` feedback so a pending save does not look like a frozen table.
- Add regression coverage for the canonical edge payload and pending row state.

## Verification
- `npm test -- --run src/components/settings/__tests__/AdminSettings.test.tsx`
- `npm test -- --run tests/admin-users-roles.access.spec.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:ci`
- `npm run validate:tenant`
- `npm run test:routes:tier0`
- `npm run verify:local`
- `npm run playwright:preflight`
- `npm run playwright:auth`

## Caveat
- `npm run ci:playwright` was attempted twice locally and timed out without output; the timed-out run was traced to the longer session lifecycle sequence and its child processes were cleaned up. Treat full CI Playwright as required CI/human-review evidence.

## Risk
- Protected role-management behavior; review should focus on edge routing compatibility, authz fail-closed behavior, and whether the 20s timeout is acceptable for production UX.