### PR TITLE
Lock BT session edits and allow goal-free scheduling

### DIFF
--- a/scripts/lib/playwright-inprogress-session-setup.ts
+++ b/scripts/lib/playwright-inprogress-session-setup.ts
@@ -501,6 +501,7 @@ const toDatetimeLocal = (date: Date): string => {
 };
 
 const VISIBLE_SCHEDULE_START_HOURS = [8, 10, 12, 14, 16] as const;
+export const BOOKING_ATTEMPTS_PER_TARGET_PAIR = 12;
 
 const addCalendarDays = (localDate: string, days: number): string => {
   const [year, month, day] = localDate.split("-").map(Number);
@@ -543,6 +544,19 @@ export const buildVisibleScheduleBookingBaseStart = (
     start = toZonedGridStart(addRenderedScheduleDays(localDate, 1, timeZone), visibleHour, timeZone);
   }
   return start;
+};
+
+export const buildInProgressSessionBookingBaseStart = (
+  now = new Date(),
+  seed = Number(process.env.GITHUB_RUN_ID ?? Date.now()),
+  timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
+): Date => {
+  const seedNumber = Number.isFinite(seed) ? Math.abs(Math.trunc(seed)) : 0;
+  const safeFutureDayOffset = 21 + (seedNumber % 21);
+  const visibleBase = buildVisibleScheduleBookingBaseStart(now, seed, timeZone);
+  const localDate = formatInTimeZone(visibleBase, timeZone, "yyyy-MM-dd");
+  const localHour = Number(formatInTimeZone(visibleBase, timeZone, "H"));
+  return toZonedGridStart(addRenderedScheduleDays(localDate, safeFutureDayOffset, timeZone), localHour, timeZone);
 };
 
 export const buildVisibleScheduleBookingAttemptStart = (
@@ -618,7 +632,7 @@ const selectOptionWhenAvailable = async (
 
 async function chooseSessionTargets(
   page: Page,
-  options?: { allowedTherapistIds?: Set<string> },
+  options?: { allowedTherapistIds?: Set<string>; excludedPairKeys?: Set<string> },
 ): Promise<{
   therapistId: string;
   clientId: string;
@@ -626,6 +640,7 @@ async function chooseSessionTargets(
   goalId: string;
   createdProgramId?: string;
   createdGoalId?: string;
+  pairKey: string;
 }> {
   const therapistValues = await waitForSelectOptions(page, "#therapist-select");
   const clientValues = await waitForSelectOptions(page, "#client-select");
@@ -648,6 +663,10 @@ async function chooseSessionTargets(
   });
 
   for (const { therapistId, clientId } of candidatePairs) {
+    const pairKey = `${therapistId}:${clientId}`;
+    if (options?.excludedPairKeys?.has(pairKey)) {
+      continue;
+    }
     if (
       options?.allowedTherapistIds &&
       options.allowedTherapistIds.size > 0 &&
@@ -673,6 +692,7 @@ async function chooseSessionTargets(
         goalId: seeded.goalId,
         createdProgramId: seeded.createdProgramId,
         createdGoalId: seeded.createdGoalId,
+        pairKey,
       };
     }
     await archiveCreatedProgramGoalFixtures(seeded);
@@ -711,95 +731,138 @@ export async function bookSession(
     }
   }
 
-  console.log("[in-progress-setup] book-session choose-targets");
-  const selected = await chooseSessionTargets(page, { allowedTherapistIds });
-  console.log("[in-progress-setup] book-session selected-target");
-
   const timeZone = await resolveBrowserScheduleTimeZone(page);
-  const start = buildVisibleScheduleBookingBaseStart(new Date(), undefined, timeZone);
-  let finalStartIso = "";
-  let finalEndIso = "";
-  let payload: BrowserFetchResult<Record<string, unknown>> | null = null;
-  let payloadBody: { success?: boolean; data?: { session?: { id?: string } } } | null = null;
+  const start = buildInProgressSessionBookingBaseStart(new Date(), undefined, timeZone);
+  const excludedPairKeys = new Set<string>();
+  let lastFailure: {
+    selected: Awaited<ReturnType<typeof chooseSessionTargets>>;
+    finalStartIso: string;
+    finalEndIso: string;
+    payload: BrowserFetchResult<Record<string, unknown>> | null;
+    payloadBody: { success?: boolean; data?: { session?: { id?: string } } } | null;
+  } | null = null;
 
-  for (let attempt = 0; attempt < 48; attempt += 1) {
-    const attemptStart = buildVisibleScheduleBookingAttemptStart(start, attempt, timeZone);
-    const attemptEnd = new Date(attemptStart.getTime() + 60 * 60 * 1000);
-    const startIso = attemptStart.toISOString();
-    const endIso = attemptEnd.toISOString();
-    finalStartIso = startIso;
-    finalEndIso = endIso;
-    const startOffsetMinutes = Math.round(getTimezoneOffset(timeZone, attemptStart) / 60000);
-    const endOffsetMinutes = Math.round(getTimezoneOffset(timeZone, attemptEnd) / 60000);
-
-    await page.locator("#start-time-input").fill(toDatetimeLocal(attemptStart));
-    await page.locator("#end-time-input").fill(toDatetimeLocal(attemptEnd));
-    console.log("[in-progress-setup] book-session attempt", {
-      attempt: attempt + 1,
-      startIso,
-    });
-
+  while (true) {
+    console.log("[in-progress-setup] book-session choose-targets");
+    let selected: Awaited<ReturnType<typeof chooseSessionTargets>>;
     try {
-      const bookResponse = await fetchWithTimeout(`${getEnv("PW_BASE_URL", "https://app.allincompassing.ai").replace(/\/$/, "")}/api/book`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-          "Idempotency-Key": `pw-inprogress-${Date.now()}`,
-        },
-        body: JSON.stringify({
-          session: {
-            therapist_id: selected.therapistId,
-            client_id: selected.clientId,
-            program_id: selected.programId,
-            goal_id: selected.goalId,
-            goal_ids: [selected.goalId],
-            start_time: startIso,
-            end_time: endIso,
-            status: "scheduled",
-          },
-          startTimeOffsetMinutes: startOffsetMinutes,
-          endTimeOffsetMinutes: endOffsetMinutes,
-          timeZone,
-          holdSeconds: 300,
-        }),
-      });
-      payload = {
-        status: bookResponse.status,
-        ok: bookResponse.ok,
-        body: (await bookResponse.json().catch(() => null)) as Record<string, unknown> | null,
-      };
+      selected = await chooseSessionTargets(page, { allowedTherapistIds, excludedPairKeys });
     } catch (error) {
-      payload = {
-        status: 0,
-        ok: false,
-        body: { error: error instanceof Error ? error.message : String(error) },
-      };
+      if (lastFailure) {
+        break;
+      }
+      throw error;
     }
+    console.log("[in-progress-setup] book-session selected-target", { pairKey: selected.pairKey });
 
-    payloadBody = payload.body as
-      | { success?: boolean; data?: { session?: { id?: string } } }
-      | null;
-    if (payload.ok && payloadBody?.success && payloadBody?.data?.session?.id) {
+    let finalStartIso = "";
+    let finalEndIso = "";
+    let payload: BrowserFetchResult<Record<string, unknown>> | null = null;
+    let payloadBody: { success?: boolean; data?: { session?: { id?: string } } } | null = null;
+
+    for (let attempt = 0; attempt < BOOKING_ATTEMPTS_PER_TARGET_PAIR; attempt += 1) {
+      const attemptStart = buildVisibleScheduleBookingAttemptStart(start, attempt, timeZone);
+      const attemptEnd = new Date(attemptStart.getTime() + 60 * 60 * 1000);
+      const startIso = attemptStart.toISOString();
+      const endIso = attemptEnd.toISOString();
+      finalStartIso = startIso;
+      finalEndIso = endIso;
+      const startOffsetMinutes = Math.round(getTimezoneOffset(timeZone, attemptStart) / 60000);
+      const endOffsetMinutes = Math.round(getTimezoneOffset(timeZone, attemptEnd) / 60000);
+
+      await page.locator("#start-time-input").fill(toDatetimeLocal(attemptStart));
+      await page.locator("#end-time-input").fill(toDatetimeLocal(attemptEnd));
+      console.log("[in-progress-setup] book-session attempt", {
+        pairKey: selected.pairKey,
+        attempt: attempt + 1,
+        startIso,
+      });
+
+      try {
+        const bookResponse = await fetchWithTimeout(`${getEnv("PW_BASE_URL", "https://app.allincompassing.ai").replace(/\/$/, "")}/api/book`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+            "Idempotency-Key": `pw-inprogress-${Date.now()}`,
+          },
+          body: JSON.stringify({
+            session: {
+              therapist_id: selected.therapistId,
+              client_id: selected.clientId,
+              program_id: selected.programId,
+              goal_id: selected.goalId,
+              goal_ids: [selected.goalId],
+              start_time: startIso,
+              end_time: endIso,
+              status: "scheduled",
+            },
+            startTimeOffsetMinutes: startOffsetMinutes,
+            endTimeOffsetMinutes: endOffsetMinutes,
+            timeZone,
+            holdSeconds: 300,
+          }),
+        });
+        payload = {
+          status: bookResponse.status,
+          ok: bookResponse.ok,
+          body: (await bookResponse.json().catch(() => null)) as Record<string, unknown> | null,
+        };
+      } catch (error) {
+        payload = {
+          status: 0,
+          ok: false,
+          body: { error: error instanceof Error ? error.message : String(error) },
+        };
+      }
+
+      payloadBody = payload.body as
+        | { success?: boolean; data?: { session?: { id?: string } } }
+        | null;
+      if (payload.ok && payloadBody?.success && payloadBody?.data?.session?.id) {
+        return {
+          sessionId: payloadBody.data!.session!.id as string,
+          therapistId: selected.therapistId,
+          clientId: selected.clientId,
+          programId: selected.programId,
+          goalId: selected.goalId,
+          startIso: finalStartIso,
+          endIso: finalEndIso,
+          createdProgramId: selected.createdProgramId,
+          createdGoalId: selected.createdGoalId,
+        };
+      }
+      if (payload.status === 0 || payload.status === 409 || [500, 502, 503, 504].includes(payload.status)) {
+        console.log("[in-progress-setup] book-session retryable-response", {
+          pairKey: selected.pairKey,
+          attempt: attempt + 1,
+          status: payload.status,
+        });
+        await new Promise((resolve) => setTimeout(resolve, BOOKING_RETRY_DELAY_MS));
+        continue;
+      }
       break;
     }
-    if (payload.status === 0 || payload.status === 409 || [500, 502, 503, 504].includes(payload.status)) {
-      console.log("[in-progress-setup] book-session retryable-response", {
-        attempt: attempt + 1,
-        status: payload.status,
+
+    lastFailure = { selected, finalStartIso, finalEndIso, payload, payloadBody };
+    if (payload?.status === 409) {
+      console.warn("[in-progress-setup] booking conflict exhausted candidate starts; trying next therapist-client pair", {
+        pairKey: selected.pairKey,
       });
-      await new Promise((resolve) => setTimeout(resolve, BOOKING_RETRY_DELAY_MS));
+      await archiveCreatedProgramGoalFixtures(selected);
+      excludedPairKeys.add(selected.pairKey);
       continue;
     }
     break;
   }
 
-  if (!payload || !payloadBody?.success || !payloadBody?.data?.session?.id) {
+  if (lastFailure) {
+    const { selected, finalStartIso, finalEndIso, payload, payloadBody } = lastFailure;
     const shouldFallbackToServiceRole =
       !strictMode &&
       finalStartIso.length > 0 &&
       finalEndIso.length > 0 &&
-      (payload?.status === 401 || payload?.status === 409);
+      payload?.status === 401;
     if (shouldFallbackToServiceRole) {
       let fallbackSessionId = "";
       try {
@@ -834,17 +897,7 @@ export async function bookSession(
     );
   }
 
-  return {
-    sessionId: payloadBody.data!.session!.id as string,
-    therapistId: selected.therapistId,
-    clientId: selected.clientId,
-    programId: selected.programId,
-    goalId: selected.goalId,
-    startIso: finalStartIso,
-    endIso: finalEndIso,
-    createdProgramId: selected.createdProgramId,
-    createdGoalId: selected.createdGoalId,
-  };
+  throw new Error("Booking did not succeed. No therapist-client pair was attempted.");
 }
 
 export async function startSession(_page: Page, token: string, ids: LifecycleIds, strictMode: boolean): Promise<void> {

--- a/src/components/AddSessionNoteModal.tsx
+++ b/src/components/AddSessionNoteModal.tsx
@@ -88,8 +88,9 @@ export function AddSessionNoteModal({
   isSaving = false,
   existingNote = null,
 }: AddSessionNoteModalProps) {
-  const { hasCapability } = useAuth();
+  const { effectiveRole, hasCapability } = useAuth();
   const canLockSessionNotes = hasCapability('lockSessionNotes');
+  const isBtDataOnly = effectiveRole === 'bt';
   const organizationId = useActiveOrganizationId();
   const isMinWidthSm = useMinWidthSm();
   const [date, setDate] = useState(new Date().toISOString().split('T')[0]);
@@ -273,6 +274,9 @@ export function AddSessionNoteModal({
   }, [goals, isSessionGoalsFetched, selectedSessionId, sessionGoalsData, sessions]);
 
   const toggleGoalSelection = (goalId: string) => {
+    if (isBtDataOnly) {
+      return;
+    }
     setSelectedGoalIds((prev) => {
       if (prev.includes(goalId)) {
         // Remove the per-goal note when the goal is deselected.
@@ -337,6 +341,9 @@ export function AddSessionNoteModal({
   };
 
   const updateGoalTargets = (goal: Goal, nextTargets: string[]) => {
+    if (isBtDataOnly) {
+      return;
+    }
     setGoalMeasurements((prev) => {
       const draftEntry = createDraftGoalMeasurementEntry(goal, prev[goal.id]);
       return {
@@ -373,11 +380,17 @@ export function AddSessionNoteModal({
   };
 
   const addGoalTarget = (goal: Goal) => {
+    if (isBtDataOnly) {
+      return;
+    }
     const currentTargets = getEditableGoalTargets(goal, goalMeasurements[goal.id]);
     updateGoalTargets(goal, [...currentTargets, '']);
   };
 
   const changeGoalTarget = (goal: Goal, targetIndex: number, nextValue: string) => {
+    if (isBtDataOnly) {
+      return;
+    }
     const currentTargets = getEditableGoalTargets(goal, goalMeasurements[goal.id]);
     const nextTargets = currentTargets.slice();
     nextTargets[targetIndex] = nextValue;
@@ -385,6 +398,9 @@ export function AddSessionNoteModal({
   };
 
   const removeGoalTarget = (goal: Goal, targetIndex: number) => {
+    if (isBtDataOnly) {
+      return;
+    }
     const currentTargets = getEditableGoalTargets(goal, goalMeasurements[goal.id]);
     const nextTargets = currentTargets.filter((_, index) => index !== targetIndex);
     updateGoalTargets(goal, nextTargets.length > 0 ? nextTargets : ['']);
@@ -634,6 +650,7 @@ export function AddSessionNoteModal({
                       <input
                         type="checkbox"
                         checked={isSelected}
+                        disabled={isBtDataOnly}
                         onChange={() => toggleGoalSelection(goal.id)}
                         className="mt-0.5 h-5 w-5 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                         aria-label={goal.title}
@@ -676,6 +693,7 @@ export function AddSessionNoteModal({
                             <button
                               type="button"
                               onClick={() => addGoalTarget(goal)}
+                              disabled={isBtDataOnly}
                               className="inline-flex items-center gap-1 rounded-md border border-indigo-200 bg-white px-2 py-1 text-[11px] font-semibold text-indigo-700 shadow-sm hover:bg-indigo-50 dark:border-indigo-800 dark:bg-dark dark:text-indigo-200 dark:hover:bg-indigo-950/40"
                             >
                               <Plus className="h-3.5 w-3.5" />
@@ -689,6 +707,7 @@ export function AddSessionNoteModal({
                                   id={`goal-target-${goal.id}-${targetIndex}`}
                                   aria-label={targetIndex === 0 ? 'Target' : `Target ${targetIndex + 1}`}
                                   value={targetValue}
+                                  disabled={isBtDataOnly}
                                   onChange={(e) => changeGoalTarget(goal, targetIndex, e.target.value)}
                                   rows={2}
                                   placeholder={goal.target_criteria?.trim() || `Record the target for "${goal.title}"…`}
@@ -698,6 +717,7 @@ export function AddSessionNoteModal({
                                   <button
                                     type="button"
                                     onClick={() => removeGoalTarget(goal, targetIndex)}
+                                    disabled={isBtDataOnly}
                                     aria-label={`Remove target ${targetIndex + 1}`}
                                     className="mt-1 shrink-0 rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-rose-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-rose-300"
                                   >
@@ -845,6 +865,7 @@ export function AddSessionNoteModal({
                     <input
                       type="checkbox"
                       checked={isSelected}
+                      disabled={isBtDataOnly}
                       onChange={() => toggleGoalSelection(goal.id)}
                       className="mt-0.5 h-5 w-5 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                       aria-label={goal.title}
@@ -884,6 +905,7 @@ export function AddSessionNoteModal({
                           <button
                             type="button"
                             onClick={() => addGoalTarget(goal)}
+                            disabled={isBtDataOnly}
                             className="inline-flex items-center gap-1 rounded-md border border-indigo-200 bg-white px-2 py-1 text-[11px] font-semibold text-indigo-700 shadow-sm hover:bg-indigo-50 dark:border-indigo-800 dark:bg-dark dark:text-indigo-200 dark:hover:bg-indigo-950/40"
                           >
                             <Plus className="h-3.5 w-3.5" />
@@ -897,6 +919,7 @@ export function AddSessionNoteModal({
                                 id={`goal-target-${goal.id}-${targetIndex}`}
                                 aria-label={targetIndex === 0 ? 'Target' : `Target ${targetIndex + 1}`}
                                 value={targetValue}
+                                disabled={isBtDataOnly}
                                 onChange={(e) => changeGoalTarget(goal, targetIndex, e.target.value)}
                                 rows={2}
                                 placeholder={goal.target_criteria?.trim() || `Record the target for "${goal.title}"…`}
@@ -906,6 +929,7 @@ export function AddSessionNoteModal({
                                 <button
                                   type="button"
                                   onClick={() => removeGoalTarget(goal, targetIndex)}
+                                  disabled={isBtDataOnly}
                                   aria-label={`Remove target ${targetIndex + 1}`}
                                   className="mt-1 shrink-0 rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-rose-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-rose-300"
                                 >
@@ -1061,6 +1085,7 @@ export function AddSessionNoteModal({
                 id="session-date"
                 type="date"
                 value={date}
+                disabled={isBtDataOnly}
                 onChange={(e) => setDate(e.target.value)}
                 className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
               />
@@ -1074,6 +1099,7 @@ export function AddSessionNoteModal({
               <select
                 id="service-code"
                 value={serviceCode}
+                disabled={isBtDataOnly}
                 onChange={(e) => setServiceCode(e.target.value)}
                 className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
               >
@@ -1100,6 +1126,7 @@ export function AddSessionNoteModal({
                 id="start-time"
                 type="time"
                 value={startTime}
+                disabled={isBtDataOnly}
                 onChange={(e) => setStartTime(e.target.value)}
                 className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
               />
@@ -1114,6 +1141,7 @@ export function AddSessionNoteModal({
                 id="end-time"
                 type="time"
                 value={endTime}
+                disabled={isBtDataOnly}
                 onChange={(e) => setEndTime(e.target.value)}
                 className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
               />
@@ -1127,6 +1155,7 @@ export function AddSessionNoteModal({
             <select
               id="therapist-select"
               value={therapistId}
+              disabled={isBtDataOnly}
               onChange={(e) => setTherapistId(e.target.value)}
               className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
             >

--- a/src/components/AddSessionNoteModal.tsx
+++ b/src/components/AddSessionNoteModal.tsx
@@ -1177,7 +1177,7 @@ export function AddSessionNoteModal({
               value={selectedSessionId}
               onChange={(e) => setSelectedSessionId(e.target.value)}
               className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
-              disabled={isLoadingSessions || !hasSessions}
+              disabled={isLoadingSessions || !hasSessions || isBtDataOnly}
             >
               <option value="">
                 {isLoadingSessions ? 'Loading sessions...' : hasSessions ? 'Select a session' : 'No sessions available'}

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -673,9 +673,16 @@ export function SessionModal({
     const activeProgramIdsSet = new Set(
       programs.filter((program) => program.status === 'active').map((program) => program.id)
     );
+    if (!session?.id) {
+      if (programId && !activeProgramIdsSet.has(programId)) {
+        setValue('program_id', '');
+      }
+      setSelectedProgramIds((current) => current.filter((id) => activeProgramIdsSet.has(id)));
+      return;
+    }
     const nextProgram = programs.find((program) => program.status === 'active');
     if (!programId || !activeProgramIdsSet.has(programId)) {
-      if (session?.id && programId && !activeProgramIdsSet.has(programId)) {
+      if (programId && !activeProgramIdsSet.has(programId)) {
         return;
       }
       if (nextProgram?.id) {
@@ -714,6 +721,12 @@ export function SessionModal({
       activeGoals;
     const activeGoalIdsSet = new Set(activeGoals.map((goal) => goal.id));
     if (session?.id && goalId && !activeGoalIdsSet.has(goalId)) {
+      return;
+    }
+    if (!session?.id) {
+      if (goalId && !activeGoalIdsSet.has(goalId)) {
+        setValue('goal_id', '');
+      }
       return;
     }
     if (!goalId || !activeGoalIdsSet.has(goalId)) {
@@ -2081,7 +2094,7 @@ export function SessionModal({
                 </label>
                 <select
                   id="program-select"
-                  {...register('program_id', { required: session ? false : 'Program is required' })}
+                  {...register('program_id')}
                   disabled={isProgramsFetching || !clientId}
                   onChange={(event) => {
                     const nextProgramId = event.target.value;
@@ -2137,7 +2150,7 @@ export function SessionModal({
                 </label>
                 <select
                   id="goal-select"
-                  {...register('goal_id', { required: session ? false : 'Primary goal is required' })}
+                  {...register('goal_id')}
                   disabled={isGoalsFetching || selectedProgramGoals.length === 0}
                   className="min-h-11 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                 >

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -422,6 +422,7 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
     expect(screen.getByLabelText(/start time/i)).toBeDisabled();
     expect(screen.getByLabelText(/end time/i)).toBeDisabled();
     expect(screen.getByLabelText(/^therapist$/i)).toBeDisabled();
+    expect(screen.getByLabelText(/link to session/i)).toBeDisabled();
     expect(screen.getByRole('checkbox', { name: /default goal/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /add target/i })).toBeDisabled();
     expect(screen.getByLabelText(/^target$/i)).toBeDisabled();

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -374,6 +374,67 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
     expect(screen.getByLabelText(/measurement note/i)).toBeInTheDocument();
   });
 
+  it('locks BT session metadata and goal structure while leaving data collection editable', async () => {
+    renderWithProviders(
+      <AddSessionNoteModal
+        {...defaultProps}
+        therapists={[mockTherapist] as any}
+        existingNote={{
+          id: 'note-1',
+          client_id: 'client-1',
+          date: '2026-03-31',
+          start_time: '10:00',
+          end_time: '11:00',
+          service_code: '97153',
+          therapist_id: 'therapist-1',
+          therapist_name: 'Test Therapist',
+          goals_addressed: ['Default Goal'],
+          goal_ids: ['goal-1'],
+          goal_notes: { 'goal-1': 'Existing goal note' },
+          goal_measurements: {
+            'goal-1': {
+              version: 1,
+              data: {
+                measurement_type: 'frequency',
+                metric_label: 'Count',
+                metric_unit: 'responses',
+                metric_value: 2,
+                opportunities: 4,
+                incorrect_trials: null,
+                prompt_level: 'Gestural',
+                note: 'Existing measurement note',
+                targets: ['Existing target'],
+                target: 'Existing target',
+                trial_prompt_note: null,
+              },
+            },
+          },
+          session_id: 'session-1',
+          narrative: 'Existing narrative',
+          is_locked: false,
+        }}
+      />,
+      { auth: { role: 'bt' } },
+    );
+
+    expect(await screen.findByLabelText(/session date/i)).toBeDisabled();
+    expect(screen.getByLabelText(/service code/i)).toBeDisabled();
+    expect(screen.getByLabelText(/start time/i)).toBeDisabled();
+    expect(screen.getByLabelText(/end time/i)).toBeDisabled();
+    expect(screen.getByLabelText(/^therapist$/i)).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: /default goal/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /add target/i })).toBeDisabled();
+    expect(screen.getByLabelText(/^target$/i)).toBeDisabled();
+
+    const note = screen.getByLabelText(/note for this goal/i);
+    fireEvent.change(note, { target: { value: 'BT observed accurate responding.' } });
+    expect(note).toHaveValue('BT observed accurate responding.');
+
+    const count = screen.getByLabelText(/count \(responses\)/i);
+    fireEvent.change(count, { target: { value: '5' } });
+    expect(count).toHaveValue(5);
+  });
+
   it('submits normalized goal_measurements when provided', async () => {
     const onSubmit = vi.fn();
 

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -169,10 +169,35 @@ describe('SessionModal', () => {
     await waitFor(() => {
       expect(screen.getByText(/Therapist is required/)).toBeInTheDocument();
       expect(screen.getByText(/Client is required/)).toBeInTheDocument();
-      expect(screen.getByText(/Program is required/)).toBeInTheDocument();
-      expect(screen.getByText(/Primary goal is required/)).toBeInTheDocument();
+      expect(screen.queryByText(/Program is required/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Primary goal is required/)).not.toBeInTheDocument();
     });
   });
+
+  it('creates scheduled sessions without selecting program or goal links', async () => {
+    renderWithProviders(<SessionModal {...defaultProps} />);
+
+    await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
+    await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
+    fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2025-03-18T10:00' } });
+    fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2025-03-18T11:00' } });
+
+    await userEvent.click(screen.getByRole('button', { name: /Create Session/i }));
+
+    await waitFor(() => {
+      expect(defaultProps.onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        therapist_id: 'test-therapist-1',
+        client_id: 'test-client-1',
+        start_time: '2025-03-18T14:00:00.000Z',
+        end_time: '2025-03-18T15:00:00.000Z',
+        status: 'scheduled',
+      }));
+    });
+    expect(defaultProps.onSubmit.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      program_id: '',
+      goal_id: '',
+    }));
+  }, 15000);
 
   it('calls onSubmit with form data when valid', async () => {
     renderWithProviders(<SessionModal {...defaultProps} />);
@@ -1335,10 +1360,13 @@ describe('SessionModal', () => {
     await userEvent.click(screen.getByRole('button', { name: /Create Session/i }));
 
     await waitFor(() => {
-      expect(onSubmit).not.toHaveBeenCalled();
-      expect(screen.getByText(/Program is required/i)).toBeInTheDocument();
-      expect(screen.getByText(/Primary goal is required/i)).toBeInTheDocument();
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        program_id: '',
+        goal_id: '',
+      }));
     });
+    expect(screen.queryByText(/Program is required/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Primary goal is required/i)).not.toBeInTheDocument();
   });
 
   it('shows saved state after successful update for edit sessions', async () => {

--- a/src/features/scheduling/domain/__tests__/booking.test.ts
+++ b/src/features/scheduling/domain/__tests__/booking.test.ts
@@ -28,6 +28,49 @@ describe("booking domain payload builder", () => {
     expect(payload.session.status).toBe("scheduled");
   });
 
+  it("allows scheduling payloads without clinical program or goal links", () => {
+    const payload = buildBookSessionApiPayload(
+      {
+        therapist_id: "11111111-1111-1111-1111-111111111111",
+        client_id: "22222222-2222-2222-2222-222222222222",
+        start_time: "2026-03-20T15:00:00.000Z",
+        end_time: "2026-03-20T16:00:00.000Z",
+      } as never,
+      {
+        startOffsetMinutes: -240,
+        endOffsetMinutes: -240,
+        timeZone: "America/New_York",
+      },
+    );
+
+    const parsed = bookSessionApiRequestBodySchema.safeParse(payload);
+    expect(parsed.success).toBe(true);
+    expect(payload.session.program_id).toBeUndefined();
+    expect(payload.session.goal_id).toBeUndefined();
+  });
+
+  it("strips blank clinical links from scheduling payloads", () => {
+    const payload = buildBookSessionApiPayload(
+      {
+        therapist_id: "11111111-1111-1111-1111-111111111111",
+        client_id: "22222222-2222-2222-2222-222222222222",
+        program_id: "",
+        goal_id: "",
+        start_time: "2026-03-20T15:00:00.000Z",
+        end_time: "2026-03-20T16:00:00.000Z",
+      } as never,
+      {
+        startOffsetMinutes: -240,
+        endOffsetMinutes: -240,
+        timeZone: "America/New_York",
+      },
+    );
+
+    expect(payload.session.program_id).toBeUndefined();
+    expect(payload.session.goal_id).toBeUndefined();
+    expect(bookSessionApiRequestBodySchema.safeParse(payload).success).toBe(true);
+  });
+
   it("computes booking time metadata for valid session times", () => {
     const metadata = buildBookingTimeMetadata(
       {

--- a/src/features/scheduling/domain/booking.ts
+++ b/src/features/scheduling/domain/booking.ts
@@ -66,6 +66,11 @@ export function buildBookSessionApiPayload(
   if (normalizedSession.notes === null) {
     delete normalizedSession.notes;
   }
+  for (const optionalClinicalKey of ["program_id", "goal_id"] as const) {
+    if (normalizedSession[optionalClinicalKey] === "") {
+      delete normalizedSession[optionalClinicalKey];
+    }
+  }
 
   return {
     session: normalizedSession,

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -5240,13 +5240,13 @@ export type Database = {
           created_by: string | null
           duration_minutes: number | null
           end_time: string
-          goal_id: string
+          goal_id: string | null
           has_transcription_consent: boolean
           id: string
           location_type: string | null
           notes: string | null
           organization_id: string
-          program_id: string
+          program_id: string | null
           rate_per_hour: number | null
           session_date: string | null
           session_type: string | null
@@ -5264,13 +5264,13 @@ export type Database = {
           created_by?: string | null
           duration_minutes?: number | null
           end_time: string
-          goal_id: string
+          goal_id?: string | null
           has_transcription_consent?: boolean
           id?: string
           location_type?: string | null
           notes?: string | null
           organization_id: string
-          program_id: string
+          program_id?: string | null
           rate_per_hour?: number | null
           session_date?: string | null
           session_type?: string | null
@@ -5288,13 +5288,13 @@ export type Database = {
           created_by?: string | null
           duration_minutes?: number | null
           end_time?: string
-          goal_id?: string
+          goal_id?: string | null
           has_transcription_consent?: boolean
           id?: string
           location_type?: string | null
           notes?: string | null
           organization_id?: string
-          program_id?: string
+          program_id?: string | null
           rate_per_hour?: number | null
           session_date?: string | null
           session_type?: string | null

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -993,8 +993,6 @@ export const Schedule = React.memo(() => {
       if (
         !newSession.therapist_id ||
         !newSession.client_id ||
-        !newSession.program_id ||
-        !newSession.goal_id ||
         !newSession.start_time ||
         !newSession.end_time
       ) {

--- a/src/scripts/__tests__/playwrightInprogressSessionSetup.test.ts
+++ b/src/scripts/__tests__/playwrightInprogressSessionSetup.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { formatInTimeZone } from "date-fns-tz";
 
 import {
+  BOOKING_ATTEMPTS_PER_TARGET_PAIR,
+  buildInProgressSessionBookingBaseStart,
   buildVisibleScheduleBookingAttemptStart,
   buildVisibleScheduleBookingBaseStart,
   resolveBrowserScheduleTimeZone,
@@ -62,6 +64,21 @@ describe("playwright in-progress session setup", () => {
       expect(isoWeekday).toBeGreaterThanOrEqual(1);
       expect(isoWeekday).toBeLessThanOrEqual(6);
     }
+  });
+
+  it("uses a bounded future booking window for hosted in-progress smoke setup", () => {
+    const timeZone = "America/Los_Angeles";
+    const now = new Date("2026-06-18T16:30:00.000Z");
+    const seed = 28_636_957_641;
+
+    const immediateBase = buildVisibleScheduleBookingBaseStart(now, seed, timeZone);
+    const smokeBase = buildInProgressSessionBookingBaseStart(now, seed, timeZone);
+    const dayDelta = Math.round((smokeBase.getTime() - immediateBase.getTime()) / (24 * 60 * 60 * 1000));
+
+    expect(dayDelta).toBeGreaterThanOrEqual(21);
+    expect(dayDelta).toBeLessThanOrEqual(50);
+    expect(formatInTimeZone(smokeBase, timeZone, "H")).toBe(formatInTimeZone(immediateBase, timeZone, "H"));
+    expect(BOOKING_ATTEMPTS_PER_TARGET_PAIR).toBeLessThan(48);
   });
 
   it("uses the browser timezone as the schedule grid timezone source", async () => {

--- a/src/server/__tests__/bookHandler.test.ts
+++ b/src/server/__tests__/bookHandler.test.ts
@@ -406,6 +406,52 @@ describe("bookHandler", () => {
     expect(bookSessionMock).not.toHaveBeenCalled();
   });
 
+  it("allows scheduling bookings without clinical program or goal links", async () => {
+    bookSessionMock.mockResolvedValueOnce({
+      session: {
+        id: "session-1",
+        client_id: "client-1",
+        therapist_id: "therapist-1",
+        program_id: null,
+        goal_id: null,
+        start_time: "2025-01-01T10:00:00Z",
+        end_time: "2025-01-01T11:00:00Z",
+        status: "scheduled",
+        notes: "",
+        created_at: "2025-01-01T09:00:00Z",
+        created_by: "user-1",
+        updated_at: "2025-01-01T09:00:00Z",
+        updated_by: "user-1",
+        duration_minutes: 60,
+      },
+      sessions: [],
+      hold: {
+        holdKey: "hold",
+        holdId: "1",
+        startTime: "2025-01-01T10:00:00Z",
+        endTime: "2025-01-01T11:00:00Z",
+        expiresAt: "2025-01-01T10:05:00Z",
+        holds: [],
+      },
+      cpt: { code: "97153", description: "Adaptive behavior treatment by protocol", modifiers: [], source: "fallback", durationMinutes: 60 },
+    });
+    const { program_id: _programId, goal_id: _goalId, ...sessionWithoutGoals } = validPayload.session;
+
+    const bookHandler = await importBookHandler();
+    const response = await bookHandler(createRequest({
+      ...validPayload,
+      session: sessionWithoutGoals,
+    }));
+
+    expect(response.status).toBe(200);
+    expect(bookSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      session: expect.not.objectContaining({
+        program_id: expect.anything(),
+        goal_id: expect.anything(),
+      }),
+    }));
+  });
+
   it("forbids org-member-equivalent therapist role from booking for a different therapist", async () => {
     server.use(
       http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/user_has_role_for_org`, async ({ request }) => {

--- a/src/server/api/book.ts
+++ b/src/server/api/book.ts
@@ -141,20 +141,29 @@ async function assertBookRequestScope(
   const encodedOrgId = encodeURIComponent(organizationId);
   const encodedTherapistId = encodeURIComponent(body.session.therapist_id);
   const encodedClientId = encodeURIComponent(body.session.client_id);
-  const encodedProgramId = encodeURIComponent(body.session.program_id);
-  const encodedGoalId = encodeURIComponent(body.session.goal_id);
+  const programId = typeof body.session.program_id === "string" ? body.session.program_id.trim() : "";
+  const goalId = typeof body.session.goal_id === "string" ? body.session.goal_id.trim() : "";
+  const hasClinicalGoalLink = programId.length > 0 && goalId.length > 0;
 
   const therapistUrl = `${supabaseUrl}/rest/v1/therapists?select=id&organization_id=eq.${encodedOrgId}&id=eq.${encodedTherapistId}`;
   const clientUrl = `${supabaseUrl}/rest/v1/clients?select=id&organization_id=eq.${encodedOrgId}&id=eq.${encodedClientId}`;
-  const programUrl = `${supabaseUrl}/rest/v1/programs?select=id,client_id&organization_id=eq.${encodedOrgId}&id=eq.${encodedProgramId}`;
-  const goalUrl = `${supabaseUrl}/rest/v1/goals?select=id,program_id&organization_id=eq.${encodedOrgId}&id=eq.${encodedGoalId}`;
 
   const queryEntities = async (headers: Record<string, string>) => {
     const [therapistResult, clientResult, programResult, goalResult] = await Promise.all([
       fetchJson<Array<{ id: string }>>(therapistUrl, { method: "GET", headers }),
       fetchJson<Array<{ id: string }>>(clientUrl, { method: "GET", headers }),
-      fetchJson<Array<{ id: string; client_id: string }>>(programUrl, { method: "GET", headers }),
-      fetchJson<Array<{ id: string; program_id: string }>>(goalUrl, { method: "GET", headers }),
+      hasClinicalGoalLink
+        ? fetchJson<Array<{ id: string; client_id: string }>>(
+            `${supabaseUrl}/rest/v1/programs?select=id,client_id&organization_id=eq.${encodedOrgId}&id=eq.${encodeURIComponent(programId)}`,
+            { method: "GET", headers },
+          )
+        : Promise.resolve({ ok: true, status: 200, data: [] }),
+      hasClinicalGoalLink
+        ? fetchJson<Array<{ id: string; program_id: string }>>(
+            `${supabaseUrl}/rest/v1/goals?select=id,program_id&organization_id=eq.${encodedOrgId}&id=eq.${encodeURIComponent(goalId)}`,
+            { method: "GET", headers },
+          )
+        : Promise.resolve({ ok: true, status: 200, data: [] }),
     ]);
     return {
       therapistResult,
@@ -186,11 +195,11 @@ async function assertBookRequestScope(
   const program = Array.isArray(programResult.data) ? programResult.data[0] : null;
   const goal = Array.isArray(goalResult.data) ? goalResult.data[0] : null;
 
-  if (!therapistExists || !clientExists || !program || !goal) {
+  if (!therapistExists || !clientExists || (hasClinicalGoalLink && (!program || !goal))) {
     return errorResponse(request, "not_found", "Booking entities not found", { status: 404 });
   }
 
-  if (program.client_id !== body.session.client_id || goal.program_id !== body.session.program_id) {
+  if (hasClinicalGoalLink && program && goal && (program.client_id !== body.session.client_id || goal.program_id !== programId)) {
     return errorResponse(request, "validation_error", "Invalid booking relationships", { status: 400 });
   }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -24,11 +24,13 @@ export interface BookingOverrides {
 
 export type RequiredSessionFields = Pick<
   Session,
-  "therapist_id" | "client_id" | "program_id" | "goal_id" | "start_time" | "end_time"
+  "therapist_id" | "client_id" | "start_time" | "end_time"
 >;
 
 export type BookableSession = RequiredSessionFields &
-  Partial<Omit<Session, keyof RequiredSessionFields>> & {
+  Partial<Omit<Session, keyof RequiredSessionFields | "program_id" | "goal_id">> & {
+    program_id?: string | null;
+    goal_id?: string | null;
     recurrence?: SessionRecurrence | null;
   };
 
@@ -94,8 +96,8 @@ const sessionSchema = z
   .object({
     therapist_id: nonEmptyString,
     client_id: nonEmptyString,
-    program_id: nonEmptyString,
-    goal_id: nonEmptyString,
+    program_id: nonEmptyString.nullable().optional(),
+    goal_id: nonEmptyString.nullable().optional(),
     start_time: isoDateTime,
     end_time: isoDateTime,
     id: nonEmptyString.optional(),
@@ -112,6 +114,16 @@ const sessionSchema = z
   })
   .passthrough()
   .superRefine((session, ctx) => {
+    const hasProgramId = typeof session.program_id === "string" && session.program_id.trim().length > 0;
+    const hasGoalId = typeof session.goal_id === "string" && session.goal_id.trim().length > 0;
+    if (hasProgramId !== hasGoalId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: hasProgramId ? ["goal_id"] : ["program_id"],
+        message: "program_id and goal_id must be provided together when clinical goals are attached",
+      });
+    }
+
     if (
       typeof session.rate_per_hour === "number" &&
       typeof session.total_cost === "number" &&

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -164,8 +164,8 @@ export interface Session {
   id: string;
   client_id: string;
   therapist_id: string;
-  program_id: string;
-  goal_id: string;
+  program_id: string | null;
+  goal_id: string | null;
   start_time: string;
   end_time: string;
   status: 'scheduled' | 'in_progress' | 'completed' | 'cancelled' | 'no-show';

--- a/supabase/functions/sessions-book/index.ts
+++ b/supabase/functions/sessions-book/index.ts
@@ -9,12 +9,22 @@ const sessionSchema = z.object({
   start_time: isoDateTime,
   end_time: isoDateTime,
   id: z.string().uuid().optional(),
-  program_id: z.string().uuid(),
-  goal_id: z.string().uuid(),
+  program_id: z.string().uuid().nullable().optional(),
+  goal_id: z.string().uuid().nullable().optional(),
   goal_ids: z.array(z.string().uuid()).optional(),
   status: z.string().optional(),
   recurrence: z.unknown().optional(),
-}).passthrough();
+}).passthrough().superRefine((session, ctx) => {
+  const hasProgramId = typeof session.program_id === "string" && session.program_id.trim().length > 0;
+  const hasGoalId = typeof session.goal_id === "string" && session.goal_id.trim().length > 0;
+  if (hasProgramId !== hasGoalId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: hasProgramId ? ["goal_id"] : ["program_id"],
+      message: "program_id and goal_id must be provided together when clinical goals are attached",
+    });
+  }
+});
 
 const requestSchema = z.object({
   session: sessionSchema,

--- a/supabase/migrations/20260703032815_allow_goal_free_session_confirmation.sql
+++ b/supabase/migrations/20260703032815_allow_goal_free_session_confirmation.sql
@@ -1,0 +1,244 @@
+-- @migration-intent: Allow scheduling confirmation to persist sessions without attached program/goal links.
+-- @migration-dependencies: 20260318150000_batch_confirm_financial_hardening.sql
+-- @migration-rollback: Restore NOT NULL on public.sessions.program_id/goal_id only after backfilling every goal-free session.
+-- @migration-rollback: Re-run 20260318150000_batch_confirm_financial_hardening.sql to restore required program/goal confirmation behavior.
+
+set search_path = public;
+
+alter table public.sessions
+  alter column program_id drop not null,
+  alter column goal_id drop not null;
+
+create or replace function public.confirm_session_hold(
+  p_hold_key uuid,
+  p_session jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_hold public.session_holds;
+  v_session public.sessions;
+  v_session_id uuid;
+  v_therapist_id uuid;
+  v_client_id uuid;
+  v_program_id uuid;
+  v_goal_id uuid;
+  v_start timestamptz;
+  v_end timestamptz;
+  v_status text;
+  v_notes text;
+  v_location text;
+  v_session_type text;
+  v_rate numeric;
+  v_total numeric;
+  v_raw_duration numeric;
+  v_duration integer;
+  v_expected_total numeric;
+  v_cpt_increment constant integer := 15;
+  v_org uuid;
+begin
+  delete from public.session_holds
+  where expires_at <= timezone('utc', now());
+
+  select *
+  into v_hold
+  from public.session_holds
+  where hold_key = p_hold_key
+  for update;
+
+  if not found then
+    return jsonb_build_object('success', false, 'error_code', 'HOLD_NOT_FOUND', 'error_message', 'Hold has expired or does not exist.');
+  end if;
+
+  v_org := v_hold.organization_id;
+
+  v_session_id := nullif(p_session->>'id', '')::uuid;
+  v_therapist_id := nullif(p_session->>'therapist_id', '')::uuid;
+  v_client_id := nullif(p_session->>'client_id', '')::uuid;
+  v_program_id := nullif(p_session->>'program_id', '')::uuid;
+  v_goal_id := nullif(p_session->>'goal_id', '')::uuid;
+  v_start := nullif(p_session->>'start_time', '')::timestamptz;
+  v_end := nullif(p_session->>'end_time', '')::timestamptz;
+  v_status := coalesce(nullif(p_session->>'status', ''), 'scheduled');
+  v_notes := nullif(p_session->>'notes', '');
+  v_location := nullif(p_session->>'location_type', '');
+  v_session_type := nullif(p_session->>'session_type', '');
+  v_rate := nullif(p_session->>'rate_per_hour', '')::numeric;
+  v_total := nullif(p_session->>'total_cost', '')::numeric;
+  v_raw_duration := coalesce(
+    nullif(p_session->>'duration_minutes', '')::numeric,
+    (extract(epoch from (v_end - v_start)) / 60)::numeric
+  );
+
+  v_duration := greatest(v_cpt_increment, (round(v_raw_duration / v_cpt_increment)::int) * v_cpt_increment);
+
+  if v_therapist_id is null or v_client_id is null or v_start is null or v_end is null then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'MISSING_FIELDS', 'error_message', 'Missing required session fields.');
+  end if;
+
+  if (v_program_id is null) <> (v_goal_id is null) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'MISSING_FIELDS', 'error_message', 'program_id and goal_id must be provided together when clinical goals are attached.');
+  end if;
+
+  if v_rate is not null and v_rate < 0 then
+    return jsonb_build_object('success', false, 'error_code', 'INVALID_FINANCIAL_VALUE', 'error_message', 'rate_per_hour cannot be negative.');
+  end if;
+
+  if v_total is not null and v_total < 0 then
+    return jsonb_build_object('success', false, 'error_code', 'INVALID_FINANCIAL_VALUE', 'error_message', 'total_cost cannot be negative.');
+  end if;
+
+  if v_total is not null and v_rate is not null and v_duration > 0 then
+    v_expected_total := round(((v_rate * v_duration)::numeric / 60), 2);
+    if abs(v_total - v_expected_total) > 0.05 then
+      return jsonb_build_object(
+        'success', false,
+        'error_code', 'INVALID_FINANCIAL_TOTAL',
+        'error_message', 'total_cost must align with rate_per_hour and duration_minutes.',
+        'expected_total_cost', v_expected_total
+      );
+    end if;
+  end if;
+
+  if v_hold.therapist_id <> v_therapist_id or v_hold.start_time <> v_start or v_hold.end_time <> v_end then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'HOLD_MISMATCH', 'error_message', 'Session details do not match the held slot.');
+  end if;
+
+  if v_hold.client_id <> v_client_id then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'CLIENT_MISMATCH', 'error_message', 'Client differs from the hold.');
+  end if;
+
+  if v_hold.expires_at <= timezone('utc', now()) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'HOLD_EXPIRED', 'error_message', 'Hold has expired.');
+  end if;
+
+  if not exists (
+    select 1
+    from public.therapists t
+    where t.id = v_therapist_id
+      and t.organization_id = v_org
+  ) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'FORBIDDEN', 'error_message', 'Therapist not in organization scope.');
+  end if;
+
+  if not exists (
+    select 1
+    from public.clients c
+    where c.id = v_client_id
+      and c.organization_id = v_org
+  ) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'FORBIDDEN', 'error_message', 'Client not in organization scope.');
+  end if;
+
+  if exists (
+    select 1
+    from public.sessions s
+    where s.organization_id = v_org
+      and s.therapist_id = v_therapist_id
+      and (v_session_id is null or s.id <> v_session_id)
+      and s.status <> 'cancelled'
+      and tstzrange(s.start_time, s.end_time, '[)') && tstzrange(v_start, v_end, '[)')
+  ) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'THERAPIST_CONFLICT', 'error_message', 'Therapist already has a session during this time.');
+  end if;
+
+  if exists (
+    select 1
+    from public.sessions s
+    where s.organization_id = v_org
+      and s.client_id = v_client_id
+      and (v_session_id is null or s.id <> v_session_id)
+      and s.status <> 'cancelled'
+      and tstzrange(s.start_time, s.end_time, '[)') && tstzrange(v_start, v_end, '[)')
+  ) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'CLIENT_CONFLICT', 'error_message', 'Client already has a session during this time.');
+  end if;
+
+  if v_session_id is null then
+    insert into public.sessions (
+      organization_id,
+      therapist_id,
+      client_id,
+      program_id,
+      goal_id,
+      start_time,
+      end_time,
+      status,
+      notes,
+      location_type,
+      session_type,
+      rate_per_hour,
+      total_cost,
+      duration_minutes
+    )
+    values (
+      v_org,
+      v_therapist_id,
+      v_client_id,
+      v_program_id,
+      v_goal_id,
+      v_start,
+      v_end,
+      v_status,
+      v_notes,
+      v_location,
+      v_session_type,
+      v_rate,
+      v_total,
+      v_duration
+    )
+    returning * into v_session;
+  else
+    update public.sessions
+    set
+      organization_id = v_org,
+      therapist_id = v_therapist_id,
+      client_id = v_client_id,
+      program_id = v_program_id,
+      goal_id = v_goal_id,
+      start_time = v_start,
+      end_time = v_end,
+      status = v_status,
+      notes = v_notes,
+      location_type = v_location,
+      session_type = v_session_type,
+      rate_per_hour = v_rate,
+      total_cost = v_total,
+      duration_minutes = v_duration
+    where id = v_session_id
+      and organization_id = v_org
+    returning * into v_session;
+
+    if not found then
+      return jsonb_build_object(
+        'success', false,
+        'error_code', 'SESSION_NOT_FOUND',
+        'error_message', 'Session not found in organization scope.'
+      );
+    end if;
+  end if;
+
+  delete from public.session_holds where id = v_hold.id;
+
+  return jsonb_build_object('success', true, 'session', row_to_json(v_session));
+end;
+$$;
+
+revoke execute on function public.confirm_session_hold(uuid, jsonb) from public;
+revoke execute on function public.confirm_session_hold(uuid, jsonb) from anon;
+revoke execute on function public.confirm_session_hold(uuid, jsonb) from authenticated;
+grant execute on function public.confirm_session_hold(uuid, jsonb) to service_role;
+
+notify pgrst, 'reload schema';

--- a/tests/edge/sessions-book.success-envelope.contract.test.ts
+++ b/tests/edge/sessions-book.success-envelope.contract.test.ts
@@ -148,6 +148,78 @@ describe('sessions-book success envelope vs bookSessionEnvelopeSchema', () => {
     expect(parsed.success, parsed.success ? '' : JSON.stringify(parsed.error.format())).toBe(true);
   });
 
+  it('forwards goal-free bookings to confirm without clinical links', async () => {
+    const sessionRow = {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      therapist_id: '11111111-1111-1111-1111-111111111111',
+      client_id: '22222222-2222-2222-2222-222222222222',
+      program_id: null,
+      goal_id: null,
+      start_time: '2026-03-30T05:00:00.000Z',
+      end_time: '2026-03-30T05:30:00.000Z',
+      status: 'scheduled',
+    };
+    const goalFreeSession = {
+      therapist_id: validSessionPayload.therapist_id,
+      client_id: validSessionPayload.client_id,
+      start_time: validSessionPayload.start_time,
+      end_time: validSessionPayload.end_time,
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              holdKey: 'hold-goal-free',
+              holdId: 'hold-id-goal-free',
+              expiresAt: '2026-03-30T05:05:00.000Z',
+              holds: [],
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              session: sessionRow,
+              sessions: [sessionRow],
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/functions/v1/sessions-book', {
+        method: 'POST',
+        headers: {
+          Origin: 'https://preview.example.com',
+          Authorization: 'Bearer token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...validRequestPayload,
+          session: goalFreeSession,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const confirmBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(confirmBody.session).not.toHaveProperty('program_id');
+    expect(confirmBody.session).not.toHaveProperty('goal_id');
+    expect(confirmBody.goal_ids).toEqual([]);
+  });
+
   it('returns 400 for invalid top-level session.start_time without calling hold or confirm', async () => {
     const handler = await loadHandler();
 

--- a/tests/integration/goal-free-session-confirmation-migration.test.ts
+++ b/tests/integration/goal-free-session-confirmation-migration.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  "supabase",
+  "migrations",
+  "20260703032815_allow_goal_free_session_confirmation.sql",
+);
+
+function readMigration(): string {
+  return fs.readFileSync(MIGRATION_PATH, "utf8").replace(/\r\n/g, "\n");
+}
+
+describe("goal-free session confirmation migration", () => {
+  it("makes sessions clinical links nullable for scheduling-only bookings", () => {
+    const sql = readMigration();
+
+    expect(sql).toContain("alter column program_id drop not null");
+    expect(sql).toContain("alter column goal_id drop not null");
+  });
+
+  it("keeps confirm_session_hold required fields limited to scheduling identity and time", () => {
+    const sql = readMigration();
+
+    expect(sql).toMatch(
+      /if v_therapist_id is null or v_client_id is null or v_start is null or v_end is null then/i,
+    );
+    expect(sql).not.toMatch(
+      /if v_therapist_id is null or v_client_id is null or v_program_id is null or v_goal_id is null or v_start is null or v_end is null then/i,
+    );
+  });
+
+  it("rejects half-linked clinical sessions instead of accepting inconsistent goal links", () => {
+    const sql = readMigration();
+
+    expect(sql).toMatch(/\(v_program_id is null\) <> \(v_goal_id is null\)/i);
+    expect(sql).toContain("program_id and goal_id must be provided together when clinical goals are attached.");
+  });
+
+  it("preserves service-role-only execute access for the security-definer confirmation RPC", () => {
+    const sql = readMigration();
+
+    expect(sql).toContain("revoke execute on function public.confirm_session_hold(uuid, jsonb) from public;");
+    expect(sql).toContain("revoke execute on function public.confirm_session_hold(uuid, jsonb) from anon;");
+    expect(sql).toContain("revoke execute on function public.confirm_session_hold(uuid, jsonb) from authenticated;");
+    expect(sql).toContain("grant execute on function public.confirm_session_hold(uuid, jsonb) to service_role;");
+  });
+});


### PR DESCRIPTION
## Summary
- allow schedule booking payloads to omit program/goal links while preserving paired validation when clinical links are provided
- stop create-mode session modal from auto-attaching the first active program/goal; manual program/goal selection still works
- lock BT session-note metadata and goal-structure controls while leaving per-goal notes and measurement data collection editable

## Verification
- npm test -- --run src/features/scheduling/domain/__tests__/booking.test.ts src/server/__tests__/bookHandler.test.ts src/components/__tests__/SessionModal.test.tsx src/components/__tests__/AddSessionNoteModal.test.tsx
- npm run typecheck
- npm run ci:check-focused
- npm run lint
- npm run build
- npm run test:ci
- npm run ci:verify-coverage
- npm run test:routes:tier0

## Blocked / Required CI Follow-up
- npm run ci:playwright timed out locally twice with no emitted runner output (3 min, then 6 min). This remains required in CI/human review for the critical session/booking path.
- Critical-lane Linear linkage was not created because no Linear team discovery/known team value was available in this session.

## Risk
- Protected-path change: booking API/schema and Supabase sessions-book wrapper now accept goal-free scheduled appointments. Session start/capture flows still require goal selection through their existing paths.