### PR TITLE
WIN-195 Add normalized goal targets and trial events

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.helpers.test.ts
+++ b/src/components/ClientDetails/ProgramsGoalsTab.helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { parseGoalTimelineCriteria } from "./ProgramsGoalsTab.helpers";
+import { buildTargetsByGoalId, parseGoalTimelineCriteria } from "./ProgramsGoalsTab.helpers";
+import type { GoalTarget } from "../../types";
 
 describe("parseGoalTimelineCriteria", () => {
   it("parses continuation lines without clobbering labeled goal fields", () => {
@@ -14,6 +15,50 @@ describe("parseGoalTimelineCriteria", () => {
       shortTermGoal: "Request a break before escalation.\nUse a visual cue when needed.",
       intermediateGoal: "Generalize across two settings.",
       longTermGoal: "Initiate independently.",
+    });
+  });
+});
+
+describe("buildTargetsByGoalId", () => {
+  it("groups target-level measurement definitions under their parent goals", () => {
+    const baseTarget = {
+      id: "target-a",
+      organization_id: "org-1",
+      client_id: "client-1",
+      goal_id: "goal-1",
+      name: "Requests break",
+      measurement_type: "frequency",
+      graph_config: { defaultChart: "line" },
+      status: "active",
+      sort_order: 2,
+      created_at: "2026-07-03T17:00:00.000Z",
+      updated_at: "2026-07-03T17:00:00.000Z",
+    } satisfies GoalTarget;
+
+    expect(
+      buildTargetsByGoalId([
+        baseTarget,
+        {
+          ...baseTarget,
+          id: "target-b",
+          name: "Tolerates denied access",
+          measurement_type: "duration",
+          sort_order: 1,
+        },
+        {
+          ...baseTarget,
+          id: "target-c",
+          goal_id: "goal-2",
+          name: "Transitions independently",
+          measurement_type: "correctIncorrect",
+        },
+      ]),
+    ).toEqual({
+      "goal-1": [
+        expect.objectContaining({ id: "target-b", measurement_type: "duration" }),
+        expect.objectContaining({ id: "target-a", measurement_type: "frequency" }),
+      ],
+      "goal-2": [expect.objectContaining({ id: "target-c", measurement_type: "correctIncorrect" })],
     });
   });
 });

--- a/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
+++ b/src/components/ClientDetails/ProgramsGoalsTab.helpers.ts
@@ -1,4 +1,5 @@
 import type { AssessmentDocumentRecord, AssessmentTemplateType } from "../../lib/assessment-documents";
+import type { GoalTarget, TargetMeasurementType } from "../../types";
 
 export interface AssessmentChecklistItem {
   id: string;
@@ -99,6 +100,40 @@ export const EMPTY_CHECKLIST_RESPONSE: AssessmentChecklistResponse = {
 export const EMPTY_ASSESSMENT_DRAFTS: AssessmentDraftResponse = { programs: [], goals: [] };
 export const ENABLE_CHECKLIST_MAPPING_UI = true;
 export const ENABLE_PROGRAMS_GOALS_AI_PROPOSALS = false;
+
+export const TARGET_MEASUREMENT_TYPES: ReadonlyArray<TargetMeasurementType> = [
+  "correctIncorrect",
+  "frequency",
+  "rate",
+  "duration",
+  "timeSample",
+  "taskAnalysis",
+  "latency",
+  "IRT",
+];
+
+export const TARGET_MEASUREMENT_TYPE_LABELS: Record<TargetMeasurementType, string> = {
+  correctIncorrect: "Correct / incorrect",
+  frequency: "Frequency",
+  rate: "Rate",
+  duration: "Duration",
+  timeSample: "Time sample",
+  taskAnalysis: "Task analysis",
+  latency: "Latency",
+  IRT: "Inter-response time",
+};
+
+export const buildTargetsByGoalId = (targets: GoalTarget[]): Record<string, GoalTarget[]> =>
+  targets.reduce<Record<string, GoalTarget[]>>((groups, target) => {
+    const currentTargets = groups[target.goal_id] ?? [];
+    groups[target.goal_id] = [...currentTargets, target].sort((left, right) => {
+      if (left.sort_order !== right.sort_order) {
+        return left.sort_order - right.sort_order;
+      }
+      return left.created_at.localeCompare(right.created_at);
+    });
+    return groups;
+  }, {});
 
 export const TEMPLATE_LABELS: Record<AssessmentTemplateType, string> = {
   caloptima_fba: "CalOptima FBA",

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ClipboardList, Loader2, Plus, Trash2, UploadCloud } from "lucide-react";
-import type { Client, Goal, Program, ProgramNote } from "../../types";
+import type { Client, Goal, GoalTarget, Program, ProgramNote, TargetMeasurementType } from "../../types";
 import { callApi, callEdgeFunctionHttp } from "../../lib/api";
 import { showError, showInfo, showSuccess } from "../../lib/toast";
 import { useActiveOrganizationId } from "../../lib/organization";
@@ -19,6 +19,9 @@ import {
   EMPTY_CHECKLIST_RESPONSE,
   ENABLE_CHECKLIST_MAPPING_UI,
   ENABLE_PROGRAMS_GOALS_AI_PROPOSALS,
+  TARGET_MEASUREMENT_TYPE_LABELS,
+  TARGET_MEASUREMENT_TYPES,
+  buildTargetsByGoalId,
   formatGoalTimelineCriteria,
   parseApiErrorMessage,
   parseGoalTimelineCriteria,
@@ -317,6 +320,7 @@ const withTimeout = async <T,>(
 const PROGRAMS_EDGE_PATH = "programs";
 const GOALS_EDGE_PATH = "goals";
 const PROGRAM_NOTES_EDGE_PATH = "program-notes";
+const GOAL_TARGETS_EDGE_PATH = "goal-targets";
 
 const buildProgramsQueryPath = (clientId: string): string =>
   `${PROGRAMS_EDGE_PATH}?client_id=${encodeURIComponent(clientId)}`;
@@ -338,6 +342,12 @@ const buildProgramGoalsQueryKey = (programId: string | null, organizationId?: st
 
 const buildProgramNotesQueryKey = (programId: string | null, organizationId?: string | null) =>
   ["program-notes", programId, organizationId ?? "MISSING_ORG"] as const;
+
+const buildGoalTargetsQueryKey = (
+  clientId: string,
+  goalIds: ReadonlyArray<string>,
+  organizationId?: string | null,
+) => ["goal-targets", clientId, organizationId ?? "MISSING_ORG", goalIds.join(",")] as const;
 
 const upsertById = <T extends { id: string }>(current: T[] | undefined, nextItem: T): T[] => {
   const existingItems = Array.isArray(current) ? current : [];
@@ -444,7 +454,12 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const [goalDescription, setGoalDescription] = useState("");
   const [goalOriginalText, setGoalOriginalText] = useState("");
   const [goalMeasurementType, setGoalMeasurementType] = useState("");
+  const [goalClinicalGoalType, setGoalClinicalGoalType] = useState<Goal["clinical_goal_type"]>("skill");
+  const [goalDomainId, setGoalDomainId] = useState("");
+  const [goalSource, setGoalSource] = useState<NonNullable<Goal["source"]>>("manual");
   const [goalBaselineData, setGoalBaselineData] = useState("");
+  const [goalTeachingStrategies, setGoalTeachingStrategies] = useState("");
+  const [goalOperationalDefinition, setGoalOperationalDefinition] = useState("");
   const [goalShortTermGoal, setGoalShortTermGoal] = useState("");
   const [goalIntermediateGoal, setGoalIntermediateGoal] = useState("");
   const [goalLongTermGoal, setGoalLongTermGoal] = useState("");
@@ -452,6 +467,10 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const [goalMaintenanceCriteria, setGoalMaintenanceCriteria] = useState("");
   const [goalGeneralizationCriteria, setGoalGeneralizationCriteria] = useState("");
   const [goalObjectiveDataPoints, setGoalObjectiveDataPoints] = useState("[]");
+  const [targetGoalId, setTargetGoalId] = useState("");
+  const [targetName, setTargetName] = useState("");
+  const [targetMeasurementType, setTargetMeasurementType] = useState<TargetMeasurementType>("correctIncorrect");
+  const [targetStatus, setTargetStatus] = useState<GoalTarget["status"]>("active");
   const [checklistEdits, setChecklistEdits] = useState<
     Record<string, { status: AssessmentChecklistItem["status"]; reviewNotes: string; valueText: string }>
   >({});
@@ -580,7 +599,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
           const { data, error } = await supabase
             .from("goals")
             .select(
-              "id,organization_id,client_id,program_id,title,description,target_behavior,measurement_type,original_text,goal_type,clinical_context,baseline_data,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,objective_data_points,status,created_at,updated_at",
+              "id,organization_id,client_id,program_id,domain_id,title,description,target_behavior,measurement_type,original_text,goal_type,clinical_goal_type,clinical_context,baseline_data,baseline,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,teaching_strategies,operational_definition,objective_data_points,source,status,created_at,updated_at",
             )
             .eq("organization_id", organizationId ?? "")
             .eq("program_id", resolvedProgramId)
@@ -608,6 +627,53 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     () => goals.filter((goal) => goal.status !== "archived"),
     [goals],
   );
+  const targetNameValue = targetName.trim();
+  const createTargetDisabledReason = liveGoals.length === 0
+    ? "Create a goal before adding targets."
+    : !targetGoalId
+      ? "Select a goal before adding a target."
+      : !targetNameValue
+        ? "Target name is required."
+        : null;
+
+  const goalIdsForTargets = useMemo(() => liveGoals.map((goal) => goal.id).sort(), [liveGoals]);
+  const goalTargetsQueryKey = buildGoalTargetsQueryKey(client.id, goalIdsForTargets, organizationId);
+
+  const {
+    data: goalTargets = [],
+    isLoading: goalTargetsLoading,
+    error: goalTargetsQueryError,
+  } = useQuery({
+    queryKey: goalTargetsQueryKey,
+    queryFn: async () => {
+      if (goalIdsForTargets.length === 0) {
+        return [];
+      }
+      const targetSets = await Promise.all(
+        goalIdsForTargets.map(async (goalId) => {
+          const response = await callEdgeFunctionHttp(`${GOAL_TARGETS_EDGE_PATH}?goal_id=${encodeURIComponent(goalId)}`);
+          if (!response.ok) {
+            throw new Error(await parseApiErrorMessage(response, "Failed to load goal targets."));
+          }
+          return parseJson<GoalTarget[]>(response);
+        }),
+      );
+      return targetSets.flat();
+    },
+    enabled: Boolean(organizationId && goalIdsForTargets.length > 0),
+    retry: false,
+    staleTime: TAB_QUERY_STALE_TIME_MS,
+    refetchOnReconnect: true,
+  });
+
+  const targetsByGoalId = useMemo(() => buildTargetsByGoalId(goalTargets), [goalTargets]);
+
+  useEffect(() => {
+    if (targetGoalId && goalIdsForTargets.includes(targetGoalId)) {
+      return;
+    }
+    setTargetGoalId(goalIdsForTargets[0] ?? "");
+  }, [goalIdsForTargets, targetGoalId]);
 
   const { data: programNotes = [] } = useQuery({
     queryKey: programNotesQueryKey,
@@ -1354,7 +1420,13 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         description: goalDescriptionValue,
         original_text: goalOriginalTextValue,
         measurement_type: goalMeasurementType || undefined,
+        clinical_goal_type: goalClinicalGoalType || undefined,
+        domain_id: goalDomainId.trim() || undefined,
+        source: goalSource,
         baseline_data: goalBaselineData || undefined,
+        baseline: goalBaselineData || undefined,
+        teaching_strategies: goalTeachingStrategies || undefined,
+        operational_definition: goalOperationalDefinition || undefined,
         target_criteria: targetCriteria || undefined,
         mastery_criteria: goalMasteryCriteria || undefined,
         maintenance_criteria: goalMaintenanceCriteria || undefined,
@@ -1378,7 +1450,13 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 description: goalDescriptionValue,
                 original_text: goalOriginalTextValue,
                 measurement_type: goalMeasurementType || null,
+                clinical_goal_type: goalClinicalGoalType || null,
+                domain_id: goalDomainId.trim() || null,
+                source: goalSource,
                 baseline_data: goalBaselineData || null,
+                baseline: goalBaselineData || null,
+                teaching_strategies: goalTeachingStrategies || null,
+                operational_definition: goalOperationalDefinition || null,
                 target_criteria: targetCriteria || null,
                 mastery_criteria: goalMasteryCriteria || null,
                 maintenance_criteria: goalMaintenanceCriteria || null,
@@ -1387,7 +1465,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
               },
             ])
             .select(
-              "id,organization_id,client_id,program_id,title,description,target_behavior,measurement_type,original_text,goal_type,clinical_context,baseline_data,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,objective_data_points,status,created_at,updated_at",
+              "id,organization_id,client_id,program_id,domain_id,title,description,target_behavior,measurement_type,original_text,goal_type,clinical_goal_type,clinical_context,baseline_data,baseline,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,teaching_strategies,operational_definition,objective_data_points,source,status,created_at,updated_at",
             )
             .single();
           if (error) {
@@ -1413,7 +1491,12 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       setGoalDescription("");
       setGoalOriginalText("");
       setGoalMeasurementType("");
+      setGoalClinicalGoalType("skill");
+      setGoalDomainId("");
+      setGoalSource("manual");
       setGoalBaselineData("");
+      setGoalTeachingStrategies("");
+      setGoalOperationalDefinition("");
       setGoalShortTermGoal("");
       setGoalIntermediateGoal("");
       setGoalLongTermGoal("");
@@ -1424,6 +1507,38 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       queryClient.setQueryData<Goal[]>(buildProgramGoalsQueryKey(created.program_id, organizationId), (current) =>
         upsertById(current, created),
       );
+    },
+    onError: showError,
+  });
+
+  const createGoalTarget = useMutation({
+    mutationFn: async () => {
+      const response = await callEdgeFunctionHttp(GOAL_TARGETS_EDGE_PATH, {
+        method: "POST",
+        body: JSON.stringify({
+          goal_id: targetGoalId,
+          name: targetNameValue,
+          measurement_type: targetMeasurementType,
+          status: targetStatus,
+          graph_config: {
+            defaultChart: "line",
+            source: "trial_events",
+            aggregation: targetMeasurementType === "frequency" ? "sum" : "session_summary",
+          },
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(await parseApiErrorMessage(response, "Failed to create target."));
+      }
+      return parseJson<GoalTarget>(response);
+    },
+    onSuccess: (created) => {
+      showSuccess("Target created");
+      setTargetName("");
+      setTargetMeasurementType("correctIncorrect");
+      setTargetStatus("active");
+      queryClient.setQueryData<GoalTarget[]>(goalTargetsQueryKey, (current) => upsertById(current, created));
+      queryClient.invalidateQueries({ queryKey: goalTargetsQueryKey });
     },
     onError: showError,
   });
@@ -2554,7 +2669,9 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 {liveGoals.length === 0 && (
                   <p className="text-sm text-gray-500">No goals in this program yet.</p>
                 )}
-                {liveGoals.map((goal) => (
+                {liveGoals.map((goal) => {
+                  const goalTargetsForGoal = targetsByGoalId[goal.id] ?? [];
+                  return (
                   <div key={goal.id} className="rounded-md border border-gray-200 dark:border-gray-700 p-3">
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0 flex-1">
@@ -2586,8 +2703,13 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                       </button>
                     </div>
                     <div className="mt-2 space-y-1 text-xs text-gray-500">
+                      {goal.clinical_goal_type && <p>Goal type: {goal.clinical_goal_type}</p>}
+                      {goal.source && <p>Source: {goal.source === "fba_extraction" ? "FBA extraction" : "Manual"}</p>}
+                      {goal.domain_id && <p>Domain: {goal.domain_id}</p>}
                       {goal.measurement_type && <p>Measurement: {goal.measurement_type}</p>}
-                      {goal.baseline_data && <p>Baseline: {goal.baseline_data}</p>}
+                      {(goal.baseline ?? goal.baseline_data) && <p>Baseline: {goal.baseline ?? goal.baseline_data}</p>}
+                      {goal.operational_definition && <p>Operational definition: {goal.operational_definition}</p>}
+                      {goal.teaching_strategies && <p>Teaching strategy: {goal.teaching_strategies}</p>}
                       {goal.target_criteria && <p>Target: {goal.target_criteria}</p>}
                       {goal.mastery_criteria && <p>Mastery: {goal.mastery_criteria}</p>}
                       {goal.maintenance_criteria && <p>Maintenance: {goal.maintenance_criteria}</p>}
@@ -2596,10 +2718,130 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                         Objective data points: {Array.isArray(goal.objective_data_points) ? goal.objective_data_points.length : 0}
                       </p>
                     </div>
+                    <div className="mt-3 rounded-md border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/30">
+                      <div className="mb-2 flex items-center justify-between gap-2">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300">
+                          Targets
+                        </p>
+                        <span className="text-xs text-slate-500">{goalTargetsForGoal.length} configured</span>
+                      </div>
+                      {goalTargetsLoading ? (
+                        <p className="text-xs text-slate-500">Loading targets...</p>
+                      ) : goalTargetsForGoal.length === 0 ? (
+                        <p className="text-xs text-slate-500">No target-level measurement definitions yet.</p>
+                      ) : (
+                        <div className="space-y-2">
+                          {goalTargetsForGoal.map((target) => (
+                            <div key={target.id} className="rounded border border-slate-200 bg-white px-3 py-2 text-xs dark:border-slate-700 dark:bg-dark">
+                              <div className="flex flex-wrap items-center justify-between gap-2">
+                                <span className="font-medium text-slate-800 dark:text-slate-100">{target.name}</span>
+                                <span className="uppercase text-slate-500">{target.status}</span>
+                              </div>
+                              <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-slate-500">
+                                <span>
+                                  Measurement: {TARGET_MEASUREMENT_TYPE_LABELS[target.measurement_type] ?? target.measurement_type}
+                                </span>
+                                <span>
+                                  Graph: {String(target.graph_config?.defaultChart ?? "line")} from{" "}
+                                  {String(target.graph_config?.source ?? "trial_events")}
+                                </span>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                      {goalTargetsQueryError instanceof Error && (
+                        <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
+                          Could not load targets: {goalTargetsQueryError.message}
+                        </p>
+                      )}
+                    </div>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             )}
+          </div>
+
+          <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">Add Target</h3>
+            <div className="space-y-3">
+              <p className="text-xs text-gray-500 dark:text-gray-300">
+                Targets sit under a goal and define the measurement type and graph source used by trial-level data.
+              </p>
+              <label htmlFor="target-goal" className="block text-xs font-medium text-gray-700 dark:text-gray-200">
+                Parent goal
+              </label>
+              <select
+                id="target-goal"
+                value={targetGoalId}
+                onChange={(event) => setTargetGoalId(event.target.value)}
+                disabled={liveGoals.length === 0}
+                className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
+              >
+                {liveGoals.length === 0 ? (
+                  <option value="">No goals available</option>
+                ) : (
+                  liveGoals.map((goal) => (
+                    <option key={goal.id} value={goal.id}>
+                      {goal.title}
+                    </option>
+                  ))
+                )}
+              </select>
+              <label htmlFor="target-name" className="block text-xs font-medium text-gray-700 dark:text-gray-200">
+                Target name *
+              </label>
+              <input
+                id="target-name"
+                type="text"
+                value={targetName}
+                onChange={(event) => setTargetName(event.target.value)}
+                placeholder="Target name"
+                aria-required="true"
+                className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
+              />
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-200">
+                  Measurement type
+                  <select
+                    value={targetMeasurementType}
+                    onChange={(event) => setTargetMeasurementType(event.target.value as TargetMeasurementType)}
+                    className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
+                  >
+                    {TARGET_MEASUREMENT_TYPES.map((measurementType) => (
+                      <option key={measurementType} value={measurementType}>
+                        {TARGET_MEASUREMENT_TYPE_LABELS[measurementType]}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-200">
+                  Target status
+                  <select
+                    value={targetStatus}
+                    onChange={(event) => setTargetStatus(event.target.value as GoalTarget["status"])}
+                    className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
+                  >
+                    <option value="draft">Draft</option>
+                    <option value="active">Active</option>
+                    <option value="mastered">Mastered</option>
+                    <option value="archived">Archived</option>
+                  </select>
+                </label>
+              </div>
+              <button
+                type="button"
+                onClick={() => createGoalTarget.mutate()}
+                disabled={Boolean(createTargetDisabledReason) || createGoalTarget.isLoading}
+                className="w-full px-3 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
+              >
+                {createGoalTarget.isLoading ? "Creating..." : "Create Target"}
+              </button>
+              {createTargetDisabledReason && !createGoalTarget.isLoading && (
+                <p className="text-xs text-gray-500 dark:text-gray-300">{createTargetDisabledReason}</p>
+              )}
+            </div>
           </div>
 
           <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
@@ -2653,6 +2895,40 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
               <p id="goal-original-text-help" className="text-xs text-gray-500 dark:text-gray-300">
                 Paste the original clinical wording from the assessment or care-plan source so the goal stays audit-friendly.
               </p>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-200">
+                  Goal type
+                  <select
+                    value={goalClinicalGoalType ?? ""}
+                    onChange={(event) => setGoalClinicalGoalType(event.target.value as Goal["clinical_goal_type"])}
+                    className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
+                  >
+                    <option value="skill">Skill</option>
+                    <option value="behavior">Behavior</option>
+                  </select>
+                </label>
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-200">
+                  Source
+                  <select
+                    value={goalSource}
+                    onChange={(event) => setGoalSource(event.target.value as NonNullable<Goal["source"]>)}
+                    className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
+                  >
+                    <option value="manual">Manual</option>
+                    <option value="fba_extraction">FBA extraction</option>
+                  </select>
+                </label>
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-200">
+                  Domain ID
+                  <input
+                    type="text"
+                    value={goalDomainId}
+                    onChange={(event) => setGoalDomainId(event.target.value)}
+                    placeholder="Optional domain UUID"
+                    className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
+                  />
+                </label>
+              </div>
               <input
                 type="text"
                 value={goalMeasurementType}
@@ -2664,6 +2940,20 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                 value={goalBaselineData}
                 onChange={(event) => setGoalBaselineData(event.target.value)}
                 placeholder="Baseline data (optional)"
+                rows={2}
+                className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
+              />
+              <textarea
+                value={goalOperationalDefinition}
+                onChange={(event) => setGoalOperationalDefinition(event.target.value)}
+                placeholder="Operational definition (optional)"
+                rows={2}
+                className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
+              />
+              <textarea
+                value={goalTeachingStrategies}
+                onChange={(event) => setGoalTeachingStrategies(event.target.value)}
+                placeholder="Teaching strategies (optional)"
                 rows={2}
                 className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm text-sm"
               />

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -246,6 +246,9 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       if (method === "GET" && path.startsWith("/api/goals?")) {
         return new Response(JSON.stringify([]), { status: 200 });
       }
+      if (method === "GET" && path.startsWith("/api/goal-targets?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
       if (method === "GET" && path.startsWith("/api/program-notes?")) {
         return new Response(JSON.stringify([]), { status: 200 });
       }
@@ -745,6 +748,211 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
             (init?.method ?? "GET").toUpperCase() === "GET",
         ),
     ).toHaveLength(noteFetchCountBeforeCreate);
+  });
+
+  it("renders goal-level details with target-level measurement and graph configuration", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "program-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              name: "Communication Program",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goals?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "goal-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              program_id: "program-1",
+              domain_id: "communication-domain",
+              title: "Increase functional communication",
+              description: "Client uses functional communication across routines.",
+              original_text: "Original clinical wording",
+              measurement_type: "percent opportunities",
+              baseline: "2 requests per session",
+              mastery_criteria: "80% across three sessions",
+              generalization_criteria: "Two settings and two adults",
+              teaching_strategies: "DTT, NET, prompt fading",
+              operational_definition: "Independent request within 5 seconds",
+              objective_data_points: ["trial response", "prompt level"],
+              clinical_goal_type: "skill",
+              source: "manual",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goal-targets?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "target-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              goal_id: "goal-1",
+              name: "Mands for help",
+              measurement_type: "frequency",
+              graph_config: { defaultChart: "bar", source: "trial_events" },
+              status: "active",
+              sort_order: 0,
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findAllByText("Increase functional communication")).not.toHaveLength(0);
+    expect(screen.getByText("Baseline: 2 requests per session")).toBeInTheDocument();
+    expect(screen.getByText("Operational definition: Independent request within 5 seconds")).toBeInTheDocument();
+    expect(screen.getByText("Teaching strategy: DTT, NET, prompt fading")).toBeInTheDocument();
+    expect(screen.getByText("Mastery: 80% across three sessions")).toBeInTheDocument();
+    expect(screen.getByText("Generalization: Two settings and two adults")).toBeInTheDocument();
+
+    expect(await screen.findByText("Mands for help")).toBeInTheDocument();
+    expect(screen.getByText("Measurement: Frequency")).toBeInTheDocument();
+    expect(screen.getByText(/Graph: bar from/i)).toBeInTheDocument();
+  });
+
+  it("creates a target under an existing goal with independent measurement status and graph defaults", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "program-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              name: "Communication Program",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goals?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "goal-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              program_id: "program-1",
+              title: "Increase functional communication",
+              description: "Client uses functional communication.",
+              original_text: "Original clinical wording",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goal-targets?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "POST" && path === "/api/goal-targets") {
+        return new Response(
+          JSON.stringify({
+            id: "target-1",
+            organization_id: ORG_ID,
+            client_id: "client-1",
+            goal_id: "goal-1",
+            name: "Duration of engagement",
+            measurement_type: "duration",
+            graph_config: { defaultChart: "line", source: "trial_events", aggregation: "session_summary" },
+            status: "draft",
+            sort_order: 0,
+            created_at: "2026-02-11T00:00:00.000Z",
+            updated_at: "2026-02-11T00:00:00.000Z",
+          }),
+          { status: 201 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "therapist",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findAllByText("Increase functional communication")).not.toHaveLength(0);
+    fireEvent.change(screen.getByLabelText(/Target name/i), { target: { value: "Duration of engagement" } });
+    fireEvent.change(screen.getByLabelText(/Measurement type/i), { target: { value: "duration" } });
+    fireEvent.change(screen.getByLabelText("Target status"), { target: { value: "draft" } });
+
+    await user.click(screen.getByRole("button", { name: "Create Target" }));
+
+    await waitFor(() => {
+      expect(callEdgeFunctionHttp).toHaveBeenCalledWith(
+        "goal-targets",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining("\"measurement_type\":\"duration\""),
+        }),
+      );
+    });
+    expect(
+      vi
+        .mocked(callEdgeFunctionHttp)
+        .mock.calls.some(
+          ([path, init]) =>
+            path === "goal-targets" &&
+            init?.method === "POST" &&
+            typeof init.body === "string" &&
+            init.body.includes("\"goal_id\":\"goal-1\"") &&
+            init.body.includes("\"status\":\"draft\"") &&
+            init.body.includes("\"source\":\"trial_events\""),
+        ),
+    ).toBe(true);
+    expect(showSuccess).toHaveBeenCalledWith("Target created");
   });
 
   it("renders three goal fields and serializes them into target_criteria on create", async () => {
@@ -2538,7 +2746,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
       },
     );
 
-    expect(await screen.findByText("structured review ready")).toBeInTheDocument();
+    expect((await screen.findAllByText("structured review ready")).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /Generate Drafts from Uploaded FBA/i })).not.toBeInTheDocument();
     expect(
       screen.queryByText("Drafts already exist for this assessment. Review/edit current drafts instead of regenerating."),

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -3293,12 +3293,15 @@ export type Database = {
       }
       goals: {
         Row: {
+          baseline: string | null
           baseline_data: string | null
           client_id: string
+          clinical_goal_type: string | null
           clinical_context: string | null
           created_at: string
           created_by: string | null
           description: string
+          domain_id: string | null
           generalization_criteria: string | null
           goal_type: string
           id: string
@@ -3309,20 +3312,26 @@ export type Database = {
           organization_id: string
           original_text: string
           program_id: string
+          source: string
           status: string
           target_behavior: string | null
           target_criteria: string | null
+          teaching_strategies: string | null
           title: string
+          operational_definition: string | null
           updated_at: string
           updated_by: string | null
         }
         Insert: {
+          baseline?: string | null
           baseline_data?: string | null
           client_id: string
+          clinical_goal_type?: string | null
           clinical_context?: string | null
           created_at?: string
           created_by?: string | null
           description: string
+          domain_id?: string | null
           generalization_criteria?: string | null
           goal_type?: string
           id?: string
@@ -3333,20 +3342,26 @@ export type Database = {
           organization_id: string
           original_text: string
           program_id: string
+          source?: string
           status?: string
           target_behavior?: string | null
           target_criteria?: string | null
+          teaching_strategies?: string | null
           title: string
+          operational_definition?: string | null
           updated_at?: string
           updated_by?: string | null
         }
         Update: {
+          baseline?: string | null
           baseline_data?: string | null
           client_id?: string
+          clinical_goal_type?: string | null
           clinical_context?: string | null
           created_at?: string
           created_by?: string | null
           description?: string
+          domain_id?: string | null
           generalization_criteria?: string | null
           goal_type?: string
           id?: string
@@ -3357,10 +3372,13 @@ export type Database = {
           organization_id?: string
           original_text?: string
           program_id?: string
+          source?: string
           status?: string
           target_behavior?: string | null
           target_criteria?: string | null
+          teaching_strategies?: string | null
           title?: string
+          operational_definition?: string | null
           updated_at?: string
           updated_by?: string | null
         }
@@ -3384,6 +3402,175 @@ export type Database = {
             columns: ["program_id"]
             isOneToOne: false
             referencedRelation: "programs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      goal_targets: {
+        Row: {
+          client_id: string
+          created_at: string
+          created_by: string | null
+          goal_id: string
+          graph_config: Json
+          id: string
+          measurement_type: string
+          name: string
+          organization_id: string
+          sort_order: number
+          status: string
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          client_id?: string
+          created_at?: string
+          created_by?: string | null
+          goal_id: string
+          graph_config?: Json
+          id?: string
+          measurement_type: string
+          name: string
+          organization_id?: string
+          sort_order?: number
+          status?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          client_id?: string
+          created_at?: string
+          created_by?: string | null
+          goal_id?: string
+          graph_config?: Json
+          id?: string
+          measurement_type?: string
+          name?: string
+          organization_id?: string
+          sort_order?: number
+          status?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "goal_targets_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "clients"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "goal_targets_goal_id_fkey"
+            columns: ["goal_id"]
+            isOneToOne: false
+            referencedRelation: "goals"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "goal_targets_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      trial_events: {
+        Row: {
+          client_id: string
+          created_at: string
+          created_by: string | null
+          event_timestamp: string
+          goal_id: string
+          id: string
+          metadata: Json
+          organization_id: string
+          prompt_level: string | null
+          prompt_type: string | null
+          response: string | null
+          session_id: string
+          target_id: string
+          therapist_id: string
+          trial_number: number
+          updated_at: string
+          updated_by: string | null
+          value: number | null
+        }
+        Insert: {
+          client_id?: string
+          created_at?: string
+          created_by?: string | null
+          event_timestamp?: string
+          goal_id?: string
+          id?: string
+          metadata?: Json
+          organization_id?: string
+          prompt_level?: string | null
+          prompt_type?: string | null
+          response?: string | null
+          session_id: string
+          target_id: string
+          therapist_id?: string
+          trial_number: number
+          updated_at?: string
+          updated_by?: string | null
+          value?: number | null
+        }
+        Update: {
+          client_id?: string
+          created_at?: string
+          created_by?: string | null
+          event_timestamp?: string
+          goal_id?: string
+          id?: string
+          metadata?: Json
+          organization_id?: string
+          prompt_level?: string | null
+          prompt_type?: string | null
+          response?: string | null
+          session_id?: string
+          target_id?: string
+          therapist_id?: string
+          trial_number?: number
+          updated_at?: string
+          updated_by?: string | null
+          value?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "trial_events_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "clients"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trial_events_goal_id_fkey"
+            columns: ["goal_id"]
+            isOneToOne: false
+            referencedRelation: "goals"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trial_events_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trial_events_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "sessions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trial_events_target_id_fkey"
+            columns: ["target_id"]
+            isOneToOne: false
+            referencedRelation: "goal_targets"
             referencedColumns: ["id"]
           },
         ]
@@ -6268,6 +6455,14 @@ export type Database = {
       }
       create_super_admin: { Args: { user_email: string }; Returns: undefined }
       current_org_id: { Args: never; Returns: string }
+      current_user_can_manage_locked_trial_event: {
+        Args: { target_organization_id: string }
+        Returns: boolean
+      }
+      current_user_can_take_client_data: {
+        Args: { target_client_id: string; target_organization_id: string }
+        Returns: boolean
+      }
       current_user_is_super_admin: { Args: never; Returns: boolean }
       current_user_organization_id: { Args: never; Returns: string }
       detect_scheduling_conflicts: {
@@ -7062,6 +7257,10 @@ export type Database = {
       validate_session_note_compliance: {
         Args: { p_note_id: string }
         Returns: Json
+      }
+      session_has_locked_note: {
+        Args: { target_session_id: string }
+        Returns: boolean
       }
       validate_time_interval_new: { Args: { t: string }; Returns: boolean }
     }

--- a/src/server/__tests__/goalTargetsHandler.test.ts
+++ b/src/server/__tests__/goalTargetsHandler.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { goalTargetsHandler } from "../api/goal-targets";
+
+vi.mock("../api/shared", async () => {
+  const actual = await vi.importActual<typeof import("../api/shared")>("../api/shared");
+  return {
+    ...actual,
+    currentUserCanManageProgramsGoals: vi.fn(),
+    fetchJson: vi.fn(),
+    getAccessToken: vi.fn(),
+    getAccessTokenSubject: vi.fn(),
+    getSupabaseConfig: vi.fn(),
+    resolveOrgAndRoleWithStatus: vi.fn(),
+  };
+});
+
+import {
+  currentUserCanManageProgramsGoals,
+  fetchJson,
+  getAccessToken,
+  getAccessTokenSubject,
+  getSupabaseConfig,
+  resolveOrgAndRoleWithStatus,
+} from "../api/shared";
+
+const ACCESS_TOKEN = "token-123";
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const GOAL_ID = "22222222-2222-4222-8222-222222222222";
+
+describe("goalTargetsHandler", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getAccessToken).mockReturnValue(ACCESS_TOKEN);
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon-key",
+    });
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
+      organizationId: ORG_ID,
+      isTherapist: false,
+      isAdmin: false,
+      isOrgMember: false,
+      isSuperAdmin: false,
+      upstreamError: false,
+    });
+  });
+
+  it("denies target creation when the program-goal capability helper rejects the caller", async () => {
+    vi.mocked(currentUserCanManageProgramsGoals).mockResolvedValue({ allowed: false, upstreamError: false });
+
+    const response = await goalTargetsHandler(
+      new Request("http://localhost/api/goal-targets", {
+        method: "POST",
+        body: JSON.stringify({
+          goal_id: GOAL_ID,
+          name: "Requests break",
+          measurement_type: "frequency",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(currentUserCanManageProgramsGoals).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID);
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when the program-goal capability helper cannot be validated", async () => {
+    vi.mocked(currentUserCanManageProgramsGoals).mockResolvedValue({ allowed: false, upstreamError: true });
+
+    const response = await goalTargetsHandler(
+      new Request("http://localhost/api/goal-targets", {
+        method: "POST",
+        body: JSON.stringify({
+          goal_id: GOAL_ID,
+          name: "Requests break",
+          measurement_type: "frequency",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "Unable to validate program-goal access" });
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("loads targets without duplicating a broad role allowlist in the handler", async () => {
+    vi.mocked(fetchJson).mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: [],
+    });
+
+    const response = await goalTargetsHandler(
+      new Request(`http://localhost/api/goal-targets?goal_id=${GOAL_ID}`, { method: "GET" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(currentUserCanManageProgramsGoals).not.toHaveBeenCalled();
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goal_targets?select=*&organization_id=eq."),
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+});

--- a/src/server/__tests__/goalsHandler.test.ts
+++ b/src/server/__tests__/goalsHandler.test.ts
@@ -6,13 +6,21 @@ vi.mock("../api/shared", async () => {
   return {
     ...actual,
     getAccessToken: vi.fn(),
+    currentUserCanManageProgramsGoals: vi.fn(),
     resolveOrgAndRole: vi.fn(),
+    resolveOrgAndRoleWithStatus: vi.fn(),
     getSupabaseConfig: vi.fn(),
     fetchJson: vi.fn(),
   };
 });
 
-import { fetchJson, getAccessToken, getSupabaseConfig, resolveOrgAndRole } from "../api/shared";
+import {
+  currentUserCanManageProgramsGoals,
+  fetchJson,
+  getAccessToken,
+  getSupabaseConfig,
+  resolveOrgAndRoleWithStatus,
+} from "../api/shared";
 
 describe("goalsHandler", () => {
   beforeEach(() => {
@@ -44,11 +52,13 @@ describe("goalsHandler", () => {
 
   it("returns 400 when GET program_id is not a UUID", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
-    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
       isSuperAdmin: false,
+      isOrgMember: false,
+      upstreamError: false,
     });
     vi.mocked(getSupabaseConfig).mockReturnValue({
       supabaseUrl: "https://example.supabase.co",
@@ -67,12 +77,15 @@ describe("goalsHandler", () => {
 
   it("returns 400 when program_id does not belong to client_id on POST", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
-    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
       isSuperAdmin: false,
+      isOrgMember: false,
+      upstreamError: false,
     });
+    vi.mocked(currentUserCanManageProgramsGoals).mockResolvedValue({ allowed: true, upstreamError: false });
     vi.mocked(getSupabaseConfig).mockReturnValue({
       supabaseUrl: "https://example.supabase.co",
       anonKey: "anon",
@@ -100,14 +113,48 @@ describe("goalsHandler", () => {
     expect(response.status).toBe(400);
   });
 
-  it("creates a goal with structured criteria and objective data points", async () => {
+  it("does not mask generic goal read 400 failures as an empty success", async () => {
     vi.mocked(getAccessToken).mockReturnValue("token");
-    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
       organizationId: "org-1",
       isTherapist: true,
       isAdmin: false,
       isSuperAdmin: false,
+      isOrgMember: false,
+      upstreamError: false,
     });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      data: { code: "PGRST100", message: "bad request" },
+    });
+
+    const response = await goalsHandler(
+      new Request("http://localhost/api/goals?program_id=11111111-1111-4111-8111-111111111111", {
+        method: "GET",
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "Failed to load goals" });
+    expect(response.status).toBe(400);
+  });
+
+  it("creates a goal with structured criteria and objective data points", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+      isOrgMember: false,
+      upstreamError: false,
+    });
+    vi.mocked(currentUserCanManageProgramsGoals).mockResolvedValue({ allowed: true, upstreamError: false });
     vi.mocked(getSupabaseConfig).mockReturnValue({
       supabaseUrl: "https://example.supabase.co",
       anonKey: "anon",
@@ -152,10 +199,13 @@ describe("goalsHandler", () => {
 
   it.each(roleMatrix)("returns 403 for out-of-org goal PATCH as $label", async ({ role }) => {
     vi.mocked(getAccessToken).mockReturnValue("token");
-    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
       organizationId: "org-1",
       ...role,
+      isOrgMember: false,
+      upstreamError: false,
     });
+    vi.mocked(currentUserCanManageProgramsGoals).mockResolvedValue({ allowed: true, upstreamError: false });
     vi.mocked(getSupabaseConfig).mockReturnValue({
       supabaseUrl: "https://example.supabase.co",
       anonKey: "anon",

--- a/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
+++ b/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
@@ -11,7 +11,16 @@ vi.mock("../api/shared", async () => {
   };
 });
 
-import { getSupabaseConfig, resolveOrgAndRoleWithStatus, resolveSchedulingOrgAndRoleWithStatus } from "../api/shared";
+import {
+  currentUserCanManageLockedTrialEvent,
+  currentUserCanManageProgramsGoals,
+  currentUserCanTakeClientData,
+  getSupabaseConfig,
+  resolveOrgAndRoleWithStatus,
+  resolveSchedulingOrgAndRoleWithStatus,
+  sessionHasLockedNote,
+} from "../api/shared";
+import type { Database } from "../../lib/generated/database.types";
 
 const accessToken = "header.payload.signature";
 const originalServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -76,6 +85,94 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       role_name: "org_member",
       target_organization_id: "org-1",
     });
+  });
+
+  it("checks program-goal management through the exposed capability RPC, not broad role aliases", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(currentUserCanManageProgramsGoals(accessToken, "org-1")).resolves.toEqual({
+      allowed: true,
+      upstreamError: false,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/rest/v1/rpc/current_user_can_manage_programs_goals");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({ target_organization_id: "org-1" });
+  });
+
+  it("checks trial-event capture and lock helpers through exposed public RPC wrappers", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(true))
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(currentUserCanTakeClientData(accessToken, "org-1", "client-1")).resolves.toEqual({
+      allowed: true,
+      upstreamError: false,
+    });
+    await expect(currentUserCanManageLockedTrialEvent(accessToken, "org-1")).resolves.toEqual({
+      allowed: false,
+      upstreamError: false,
+    });
+    await expect(sessionHasLockedNote(accessToken, "session-1")).resolves.toEqual({
+      locked: true,
+      upstreamError: false,
+    });
+
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/rest/v1/rpc/current_user_can_take_client_data");
+    expect(JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body))).toEqual({
+      target_organization_id: "org-1",
+      target_client_id: "client-1",
+    });
+    expect(String(fetchSpy.mock.calls[1]?.[0])).toContain("/rest/v1/rpc/current_user_can_manage_locked_trial_event");
+    expect(JSON.parse(String((fetchSpy.mock.calls[1]?.[1] as RequestInit).body))).toEqual({
+      target_organization_id: "org-1",
+    });
+    expect(String(fetchSpy.mock.calls[2]?.[0])).toContain("/rest/v1/rpc/session_has_locked_note");
+    expect(JSON.parse(String((fetchSpy.mock.calls[2]?.[1] as RequestInit).body))).toEqual({
+      target_session_id: "session-1",
+    });
+  });
+
+  it("treats non-OK capability and lock RPC responses as upstream validation failures", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: "PGRST202" }), { status: 404 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: "42501" }), { status: 403 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: "PGRST202" }), { status: 404 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: "42501" }), { status: 403 }));
+
+    await expect(currentUserCanManageProgramsGoals(accessToken, "org-1")).resolves.toEqual({
+      allowed: false,
+      upstreamError: true,
+    });
+    await expect(currentUserCanTakeClientData(accessToken, "org-1", "client-1")).resolves.toEqual({
+      allowed: false,
+      upstreamError: true,
+    });
+    await expect(currentUserCanManageLockedTrialEvent(accessToken, "org-1")).resolves.toEqual({
+      allowed: false,
+      upstreamError: true,
+    });
+    await expect(sessionHasLockedNote(accessToken, "session-1")).resolves.toEqual({
+      locked: true,
+      upstreamError: true,
+    });
+  });
+
+  it("keeps generated database types in sync with public trial-event helper RPC wrappers", () => {
+    type PublicFunctions = keyof Database["public"]["Functions"];
+    const requiredFunctions: PublicFunctions[] = [
+      "current_user_can_take_client_data",
+      "current_user_can_manage_locked_trial_event",
+      "session_has_locked_note",
+    ];
+
+    expect(requiredFunctions).toEqual([
+      "current_user_can_take_client_data",
+      "current_user_can_manage_locked_trial_event",
+      "session_has_locked_note",
+    ]);
   });
 
   it("returns therapist + admin flags from user_has_role_for_org truth table", async () => {

--- a/src/server/__tests__/trialEventsHandler.test.ts
+++ b/src/server/__tests__/trialEventsHandler.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { trialEventsHandler } from "../api/trial-events";
+
+vi.mock("../api/shared", async () => {
+  const actual = await vi.importActual<typeof import("../api/shared")>("../api/shared");
+  return {
+    ...actual,
+    currentUserCanManageLockedTrialEvent: vi.fn(),
+    currentUserCanTakeClientData: vi.fn(),
+    fetchAuthenticatedUserIdWithStatus: vi.fn(),
+    fetchJson: vi.fn(),
+    getAccessToken: vi.fn(),
+    getSupabaseConfig: vi.fn(),
+    resolveOrgAndRoleWithStatus: vi.fn(),
+    sessionHasLockedNote: vi.fn(),
+  };
+});
+
+import {
+  currentUserCanManageLockedTrialEvent,
+  currentUserCanTakeClientData,
+  fetchAuthenticatedUserIdWithStatus,
+  fetchJson,
+  getAccessToken,
+  getSupabaseConfig,
+  resolveOrgAndRoleWithStatus,
+  sessionHasLockedNote,
+} from "../api/shared";
+
+const ACCESS_TOKEN = "token-123";
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const CLIENT_ID = "22222222-2222-4222-8222-222222222222";
+const SESSION_ID = "33333333-3333-4333-8333-333333333333";
+const TARGET_ID = "44444444-4444-4444-8444-444444444444";
+const GOAL_ID = "55555555-5555-4555-8555-555555555555";
+const THERAPIST_ID = "66666666-6666-4666-8666-666666666666";
+
+const buildPostRequest = () =>
+  new Request("http://localhost/api/trial-events", {
+    method: "POST",
+    body: JSON.stringify({
+      session_id: SESSION_ID,
+      target_id: TARGET_ID,
+      trial_number: 1,
+      value: 3,
+    }),
+  });
+
+const mockTargetAndSessionLookups = () => {
+  vi.mocked(fetchJson)
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [
+        {
+          id: TARGET_ID,
+          organization_id: ORG_ID,
+          client_id: CLIENT_ID,
+          goal_id: GOAL_ID,
+          measurement_type: "frequency",
+        },
+      ],
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [
+        {
+          id: SESSION_ID,
+          organization_id: ORG_ID,
+          client_id: CLIENT_ID,
+          therapist_id: THERAPIST_ID,
+        },
+      ],
+    });
+};
+
+describe("trialEventsHandler", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getAccessToken).mockReturnValue(ACCESS_TOKEN);
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon-key",
+    });
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
+      organizationId: ORG_ID,
+      isTherapist: true,
+      isAdmin: false,
+      isOrgMember: false,
+      isSuperAdmin: false,
+      upstreamError: false,
+    });
+    vi.mocked(fetchAuthenticatedUserIdWithStatus).mockResolvedValue({
+      userId: "actor-user",
+      upstreamError: false,
+    });
+  });
+
+  it("denies trial-event creation before insert when caller cannot capture data for the client", async () => {
+    mockTargetAndSessionLookups();
+    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: false, upstreamError: false });
+
+    const response = await trialEventsHandler(buildPostRequest());
+
+    expect(response.status).toBe(403);
+    expect(currentUserCanTakeClientData).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID, CLIENT_ID);
+    expect(sessionHasLockedNote).not.toHaveBeenCalled();
+    expect(fetchJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 502 when trial-event capture access cannot be validated", async () => {
+    mockTargetAndSessionLookups();
+    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: false, upstreamError: true });
+
+    const response = await trialEventsHandler(buildPostRequest());
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "Unable to validate trial-event capture access" });
+    expect(sessionHasLockedNote).not.toHaveBeenCalled();
+    expect(fetchJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a locked-session conflict before insert when caller cannot manage locked trial events", async () => {
+    mockTargetAndSessionLookups();
+    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: true, upstreamError: false });
+    vi.mocked(currentUserCanManageLockedTrialEvent).mockResolvedValue({ allowed: false, upstreamError: false });
+
+    const response = await trialEventsHandler(buildPostRequest());
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: "Session is locked for trial-event changes" });
+    expect(currentUserCanManageLockedTrialEvent).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID);
+    expect(fetchJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 502 when session lock state cannot be validated", async () => {
+    mockTargetAndSessionLookups();
+    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: true, upstreamError: true });
+
+    const response = await trialEventsHandler(buildPostRequest());
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "Unable to validate session lock state" });
+    expect(currentUserCanManageLockedTrialEvent).not.toHaveBeenCalled();
+    expect(fetchJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 502 when locked-session management access cannot be validated", async () => {
+    mockTargetAndSessionLookups();
+    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: true, upstreamError: false });
+    vi.mocked(currentUserCanManageLockedTrialEvent).mockResolvedValue({ allowed: false, upstreamError: true });
+
+    const response = await trialEventsHandler(buildPostRequest());
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "Unable to validate locked-session trial-event access" });
+    expect(fetchJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("inserts a frequency trial event without a standardized response when capture and lock checks allow it", async () => {
+    mockTargetAndSessionLookups();
+    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: false, upstreamError: false });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      data: [{ id: "event-1", target_id: TARGET_ID, value: 3, response: null }],
+    });
+
+    const response = await trialEventsHandler(buildPostRequest());
+
+    expect(response.status).toBe(201);
+    expect(fetchJson).toHaveBeenCalledWith(
+      "https://example.supabase.co/rest/v1/trial_events",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("\"value\":3"),
+      }),
+    );
+  });
+
+  it("returns a conflict response for duplicate trial numbers within a session target", async () => {
+    mockTargetAndSessionLookups();
+    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: false, upstreamError: false });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      data: { code: "23505" },
+    });
+
+    const response = await trialEventsHandler(buildPostRequest());
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: "trial_number already exists for this session target" });
+  });
+});

--- a/src/server/__tests__/trialEventsHandler.test.ts
+++ b/src/server/__tests__/trialEventsHandler.test.ts
@@ -109,6 +109,24 @@ describe("trialEventsHandler", () => {
     expect(fetchJson).toHaveBeenCalledTimes(2);
   });
 
+  it("rejects negative measurement values before scope lookups", async () => {
+    const response = await trialEventsHandler(
+      new Request("http://localhost/api/trial-events", {
+        method: "POST",
+        body: JSON.stringify({
+          session_id: SESSION_ID,
+          target_id: TARGET_ID,
+          trial_number: 1,
+          value: -1,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid request body" });
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
   it("returns 502 when trial-event capture access cannot be validated", async () => {
     mockTargetAndSessionLookups();
     vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: false, upstreamError: true });

--- a/src/server/__tests__/trialEventsHandler.test.ts
+++ b/src/server/__tests__/trialEventsHandler.test.ts
@@ -46,7 +46,7 @@ const buildPostRequest = () =>
     }),
   });
 
-const mockTargetAndSessionLookups = () => {
+const mockTargetAndSessionLookups = (measurementType = "frequency") => {
   vi.mocked(fetchJson)
     .mockResolvedValueOnce({
       ok: true,
@@ -57,7 +57,7 @@ const mockTargetAndSessionLookups = () => {
           organization_id: ORG_ID,
           client_id: CLIENT_ID,
           goal_id: GOAL_ID,
-          measurement_type: "frequency",
+          measurement_type: measurementType,
         },
       ],
     })
@@ -125,6 +125,67 @@ describe("trialEventsHandler", () => {
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: "Invalid request body" });
     expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("rejects value-based measurements without a numeric value", async () => {
+    mockTargetAndSessionLookups("frequency");
+
+    const response = await trialEventsHandler(
+      new Request("http://localhost/api/trial-events", {
+        method: "POST",
+        body: JSON.stringify({
+          session_id: SESSION_ID,
+          target_id: TARGET_ID,
+          trial_number: 1,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "value is required for this target measurement type" });
+    expect(currentUserCanTakeClientData).not.toHaveBeenCalled();
+  });
+
+  it("rejects standardized responses for value-based measurements", async () => {
+    mockTargetAndSessionLookups("frequency");
+
+    const response = await trialEventsHandler(
+      new Request("http://localhost/api/trial-events", {
+        method: "POST",
+        body: JSON.stringify({
+          session_id: SESSION_ID,
+          target_id: TARGET_ID,
+          trial_number: 1,
+          response: "correct",
+          value: 1,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "response is not allowed for this target measurement type" });
+    expect(currentUserCanTakeClientData).not.toHaveBeenCalled();
+  });
+
+  it("rejects numeric values for response-based measurements", async () => {
+    mockTargetAndSessionLookups("correctIncorrect");
+
+    const response = await trialEventsHandler(
+      new Request("http://localhost/api/trial-events", {
+        method: "POST",
+        body: JSON.stringify({
+          session_id: SESSION_ID,
+          target_id: TARGET_ID,
+          trial_number: 1,
+          response: "correct",
+          value: 1,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "value is not allowed for this target measurement type" });
+    expect(currentUserCanTakeClientData).not.toHaveBeenCalled();
   });
 
   it("returns 502 when trial-event capture access cannot be validated", async () => {

--- a/src/server/api/goal-targets.ts
+++ b/src/server/api/goal-targets.ts
@@ -1,0 +1,226 @@
+import { z } from "zod";
+import {
+  CORS_HEADERS,
+  currentUserCanManageProgramsGoals,
+  fetchJson,
+  getAccessToken,
+  getAccessTokenSubject,
+  getSupabaseConfig,
+  json,
+  resolveOrgAndRoleWithStatus,
+} from "./shared";
+
+const measurementTypeSchema = z.enum([
+  "correctIncorrect",
+  "frequency",
+  "rate",
+  "duration",
+  "timeSample",
+  "taskAnalysis",
+  "latency",
+  "IRT",
+]);
+
+const targetStatusSchema = z.enum(["draft", "active", "mastered", "archived"]);
+
+const createGoalTargetSchema = z.object({
+  goal_id: z.string().uuid(),
+  name: z.string().trim().min(1),
+  measurement_type: measurementTypeSchema,
+  graph_config: z.record(z.unknown()).optional(),
+  status: targetStatusSchema.optional(),
+  sort_order: z.number().int().optional(),
+});
+
+const updateGoalTargetSchema = createGoalTargetSchema
+  .omit({ goal_id: true })
+  .partial()
+  .refine((value) => Object.keys(value).length > 0, "At least one field is required");
+
+const isUuid = (value: string): boolean => z.string().uuid().safeParse(value).success;
+
+type GoalScope = {
+  id: string;
+  organization_id: string;
+  client_id: string;
+};
+
+const buildHeaders = (anonKey: string, accessToken: string): Record<string, string> => ({
+  "Content-Type": "application/json",
+  apikey: anonKey,
+  Authorization: `Bearer ${accessToken}`,
+});
+
+async function loadGoalScope(
+  supabaseUrl: string,
+  headers: Record<string, string>,
+  organizationId: string,
+  goalId: string,
+): Promise<GoalScope | null> {
+  const result = await fetchJson<GoalScope[]>(
+    `${supabaseUrl}/rest/v1/goals?select=id,organization_id,client_id&id=eq.${encodeURIComponent(
+      goalId,
+    )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
+    { method: "GET", headers },
+  );
+  return result.ok && Array.isArray(result.data) ? result.data[0] ?? null : null;
+}
+
+export async function goalTargetsHandler(request: Request): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return new Response("ok", { status: 200, headers: { ...CORS_HEADERS } });
+  }
+
+  const accessToken = getAccessToken(request);
+  if (!accessToken) {
+    return json({ error: "Missing authorization token" }, 401, { "WWW-Authenticate": "Bearer" });
+  }
+
+  const role = await resolveOrgAndRoleWithStatus(accessToken);
+  if (role.upstreamError) {
+    return json({ error: "Unable to validate organization access" }, 502);
+  }
+  if (!role.organizationId) {
+    return json({ error: "Forbidden" }, 403);
+  }
+
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const headers = buildHeaders(anonKey, accessToken);
+  const organizationId = role.organizationId;
+
+  if (request.method === "GET") {
+    const url = new URL(request.url);
+    const goalId = url.searchParams.get("goal_id");
+    const targetId = url.searchParams.get("target_id");
+    if (!goalId && !targetId) {
+      return json({ error: "goal_id or target_id is required" }, 400);
+    }
+    if (goalId && !isUuid(goalId)) {
+      return json({ error: "goal_id must be a valid UUID" }, 400);
+    }
+    if (targetId && !isUuid(targetId)) {
+      return json({ error: "target_id must be a valid UUID" }, 400);
+    }
+
+    const filters = [
+      `organization_id=eq.${encodeURIComponent(organizationId)}`,
+      goalId ? `goal_id=eq.${encodeURIComponent(goalId)}` : null,
+      targetId ? `id=eq.${encodeURIComponent(targetId)}` : null,
+    ].filter(Boolean).join("&");
+
+    const result = await fetchJson(
+      `${supabaseUrl}/rest/v1/goal_targets?select=*&${filters}&order=sort_order.asc,created_at.asc`,
+      { method: "GET", headers },
+    );
+    if (!result.ok) {
+      return json({ error: "Failed to load goal targets" }, result.status || 500);
+    }
+    return json(result.data ?? []);
+  }
+
+  if (request.method === "POST") {
+    const canManage = await currentUserCanManageProgramsGoals(accessToken, organizationId);
+    if (canManage.upstreamError) {
+      return json({ error: "Unable to validate program-goal access" }, 502);
+    }
+    if (!canManage.allowed) {
+      return json({ error: "Forbidden" }, 403);
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const parsed = createGoalTargetSchema.safeParse(body);
+    if (!parsed.success) {
+      return json({ error: "Invalid request body" }, 400);
+    }
+
+    const goal = await loadGoalScope(supabaseUrl, headers, organizationId, parsed.data.goal_id);
+    if (!goal) {
+      return json({ error: "goal_id is not in scope for this organization" }, 403);
+    }
+
+    const payload = {
+      organization_id: organizationId,
+      client_id: goal.client_id,
+      goal_id: goal.id,
+      name: parsed.data.name,
+      measurement_type: parsed.data.measurement_type,
+      graph_config: parsed.data.graph_config ?? {},
+      status: parsed.data.status ?? "active",
+      sort_order: parsed.data.sort_order ?? 0,
+      created_by: getAccessTokenSubject(accessToken),
+    };
+
+    const result = await fetchJson(`${supabaseUrl}/rest/v1/goal_targets`, {
+      method: "POST",
+      headers: { ...headers, Prefer: "return=representation" },
+      body: JSON.stringify(payload),
+    });
+    if (!result.ok) {
+      return json({ error: "Failed to create goal target" }, result.status || 500);
+    }
+    return json(Array.isArray(result.data) ? result.data[0] : result.data, 201);
+  }
+
+  if (request.method === "PATCH") {
+    const canManage = await currentUserCanManageProgramsGoals(accessToken, organizationId);
+    if (canManage.upstreamError) {
+      return json({ error: "Unable to validate program-goal access" }, 502);
+    }
+    if (!canManage.allowed) {
+      return json({ error: "Forbidden" }, 403);
+    }
+
+    const url = new URL(request.url);
+    const targetId = url.searchParams.get("target_id");
+    if (!targetId) {
+      return json({ error: "target_id is required" }, 400);
+    }
+    if (!isUuid(targetId)) {
+      return json({ error: "target_id must be a valid UUID" }, 400);
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const parsed = updateGoalTargetSchema.safeParse(body);
+    if (!parsed.success) {
+      return json({ error: "Invalid request body" }, 400);
+    }
+
+    const payload = {
+      ...parsed.data,
+      updated_by: getAccessTokenSubject(accessToken),
+    };
+
+    const result = await fetchJson(
+      `${supabaseUrl}/rest/v1/goal_targets?id=eq.${encodeURIComponent(targetId)}&organization_id=eq.${encodeURIComponent(
+        organizationId,
+      )}`,
+      {
+        method: "PATCH",
+        headers: { ...headers, Prefer: "return=representation" },
+        body: JSON.stringify(payload),
+      },
+    );
+    if (!result.ok) {
+      return json({ error: "Failed to update goal target" }, result.status || 500);
+    }
+    const updated = Array.isArray(result.data) ? result.data[0] : result.data;
+    if (!updated) {
+      return json({ error: "target_id is not in scope for this organization" }, 403);
+    }
+    return json(updated);
+  }
+
+  return json({ error: "Method not allowed" }, 405);
+}

--- a/src/server/api/goals.ts
+++ b/src/server/api/goals.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
-import { CORS_HEADERS, fetchJson, getAccessToken, getSupabaseConfig, json, resolveOrgAndRole } from "./shared";
+import {
+  CORS_HEADERS,
+  currentUserCanManageProgramsGoals,
+  fetchJson,
+  getAccessToken,
+  getSupabaseConfig,
+  json,
+  resolveOrgAndRoleWithStatus,
+} from "./shared";
 
 type PostgrestErrorPayload = {
   code?: string;
@@ -11,20 +19,26 @@ type PostgrestErrorPayload = {
 const goalSchema = z.object({
   client_id: z.string().uuid(),
   program_id: z.string().uuid(),
+  domain_id: z.string().uuid().optional().nullable(),
   title: z.string().trim().min(1),
   description: z.string().trim().min(1),
   target_behavior: z.string().optional(),
   measurement_type: z.string().optional(),
   original_text: z.string().trim().min(1),
   goal_type: z.enum(["child", "parent"]).optional(),
+  clinical_goal_type: z.enum(["behavior", "skill"]).optional().nullable(),
   clinical_context: z.string().optional(),
   baseline_data: z.string().optional(),
+  baseline: z.string().optional(),
   target_criteria: z.string().optional(),
   mastery_criteria: z.string().optional(),
   maintenance_criteria: z.string().optional(),
   generalization_criteria: z.string().optional(),
+  teaching_strategies: z.string().optional(),
+  operational_definition: z.string().optional(),
   objective_data_points: z.array(z.record(z.unknown())).optional(),
-  status: z.enum(["active", "paused", "mastered", "archived"]).optional(),
+  source: z.enum(["manual", "fba_extraction"]).optional(),
+  status: z.enum(["draft", "active", "paused", "mastered", "archived"]).optional(),
 });
 
 const goalUpdateSchema = goalSchema.partial().extend({
@@ -55,8 +69,12 @@ export async function goalsHandler(request: Request): Promise<Response> {
     return json({ error: "Missing authorization token" }, 401, { "WWW-Authenticate": "Bearer" });
   }
 
-  const { organizationId, isTherapist, isAdmin, isSuperAdmin } = await resolveOrgAndRole(accessToken);
-  if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin)) {
+  const role = await resolveOrgAndRoleWithStatus(accessToken);
+  if (role.upstreamError) {
+    return json({ error: "Unable to validate organization access" }, 502);
+  }
+  const organizationId = role.organizationId;
+  if (!organizationId) {
     return json({ error: "Forbidden" }, 403);
   }
 
@@ -90,7 +108,7 @@ export async function goalsHandler(request: Request): Promise<Response> {
     }
 
     const baseSelect =
-      "id,organization_id,client_id,program_id,title,description,target_behavior,measurement_type,original_text,clinical_context,baseline_data,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,objective_data_points,status,created_at,updated_at";
+      "id,organization_id,client_id,program_id,domain_id,title,description,target_behavior,measurement_type,original_text,clinical_goal_type,clinical_context,baseline_data,baseline,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,teaching_strategies,operational_definition,objective_data_points,source,status,created_at,updated_at";
     const goalsUrlWithType = `${supabaseUrl}/rest/v1/goals?select=${baseSelect},goal_type&organization_id=eq.${organizationId}&program_id=eq.${programId}&order=created_at.desc`;
     const result = await fetchJson(goalsUrlWithType, { method: "GET", headers });
     if (!result.ok && isMissingGoalTypeColumnError(result.data)) {
@@ -108,17 +126,20 @@ export async function goalsHandler(request: Request): Promise<Response> {
       return json(withDefaultGoalType);
     }
     if (!result.ok) {
-      if (result.status === 400) {
-        // Backward-compatible fallback for transient schema/select mismatches:
-        // keep Programs & Goals usable instead of failing the entire tab.
-        return json([]);
-      }
       return json({ error: "Failed to load goals" }, result.status || 500);
     }
     return json(result.data ?? []);
   }
 
   if (request.method === "POST") {
+    const canManage = await currentUserCanManageProgramsGoals(accessToken, organizationId);
+    if (canManage.upstreamError) {
+      return json({ error: "Unable to validate program-goal access" }, 502);
+    }
+    if (!canManage.allowed) {
+      return json({ error: "Forbidden" }, 403);
+    }
+
     let payload: unknown;
     try {
       payload = await request.json();
@@ -158,6 +179,14 @@ export async function goalsHandler(request: Request): Promise<Response> {
   }
 
   if (request.method === "PATCH") {
+    const canManage = await currentUserCanManageProgramsGoals(accessToken, organizationId);
+    if (canManage.upstreamError) {
+      return json({ error: "Unable to validate program-goal access" }, 502);
+    }
+    if (!canManage.allowed) {
+      return json({ error: "Forbidden" }, 403);
+    }
+
     const url = new URL(request.url);
     const goalId = url.searchParams.get("goal_id");
     if (!goalId) {

--- a/src/server/api/shared.ts
+++ b/src/server/api/shared.ts
@@ -227,6 +227,91 @@ export async function fetchJson<T = unknown>(url: string, init: RequestInit): Pr
   }
 }
 
+export async function currentUserCanManageProgramsGoals(
+  accessToken: string,
+  organizationId: string,
+): Promise<{ allowed: boolean; upstreamError: boolean }> {
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const result = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/current_user_can_manage_programs_goals`, {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      apikey: anonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ target_organization_id: organizationId }),
+  });
+
+  if (!result.ok) {
+    return { allowed: false, upstreamError: true };
+  }
+  return { allowed: result.data === true, upstreamError: false };
+}
+
+export async function currentUserCanTakeClientData(
+  accessToken: string,
+  organizationId: string,
+  clientId: string,
+): Promise<{ allowed: boolean; upstreamError: boolean }> {
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const result = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/current_user_can_take_client_data`, {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      apikey: anonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ target_organization_id: organizationId, target_client_id: clientId }),
+  });
+
+  if (!result.ok) {
+    return { allowed: false, upstreamError: true };
+  }
+  return { allowed: result.data === true, upstreamError: false };
+}
+
+export async function currentUserCanManageLockedTrialEvent(
+  accessToken: string,
+  organizationId: string,
+): Promise<{ allowed: boolean; upstreamError: boolean }> {
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const result = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/current_user_can_manage_locked_trial_event`, {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      apikey: anonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ target_organization_id: organizationId }),
+  });
+
+  if (!result.ok) {
+    return { allowed: false, upstreamError: true };
+  }
+  return { allowed: result.data === true, upstreamError: false };
+}
+
+export async function sessionHasLockedNote(
+  accessToken: string,
+  sessionId: string,
+): Promise<{ locked: boolean; upstreamError: boolean }> {
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const result = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/session_has_locked_note`, {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      apikey: anonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ target_session_id: sessionId }),
+  });
+
+  if (!result.ok) {
+    return { locked: true, upstreamError: true };
+  }
+  return { locked: result.data === true, upstreamError: false };
+}
+
 export async function resolveOrgAndRole(accessToken: string): Promise<{
   organizationId: string | null;
   isTherapist: boolean;

--- a/src/server/api/trial-events.ts
+++ b/src/server/api/trial-events.ts
@@ -22,6 +22,7 @@ const responseSchema = z.enum([
 ]);
 
 const responseRequiredMeasurementTypes = new Set(["correctIncorrect", "taskAnalysis"]);
+const valueRequiredMeasurementTypes = new Set(["frequency", "rate", "duration", "timeSample", "latency", "IRT"]);
 
 const createTrialEventSchema = z.object({
   session_id: z.string().uuid(),
@@ -57,6 +58,32 @@ const buildHeaders = (anonKey: string, accessToken: string): Record<string, stri
   apikey: anonKey,
   Authorization: `Bearer ${accessToken}`,
 });
+
+const validateMeasurementPayload = (
+  measurementType: string,
+  payload: z.infer<typeof createTrialEventSchema>,
+): string | null => {
+  if (responseRequiredMeasurementTypes.has(measurementType)) {
+    if (!payload.response) {
+      return "response is required for this target measurement type";
+    }
+    if (typeof payload.value === "number") {
+      return "value is not allowed for this target measurement type";
+    }
+    return null;
+  }
+
+  if (valueRequiredMeasurementTypes.has(measurementType)) {
+    if (typeof payload.value !== "number") {
+      return "value is required for this target measurement type";
+    }
+    if (payload.response) {
+      return "response is not allowed for this target measurement type";
+    }
+  }
+
+  return null;
+};
 
 export async function trialEventsHandler(request: Request): Promise<Response> {
   if (request.method === "OPTIONS") {
@@ -155,8 +182,9 @@ export async function trialEventsHandler(request: Request): Promise<Response> {
     if (session.client_id !== target.client_id) {
       return json({ error: "session_id and target_id must belong to the same client" }, 400);
     }
-    if (responseRequiredMeasurementTypes.has(target.measurement_type) && !parsed.data.response) {
-      return json({ error: "response is required for this target measurement type" }, 400);
+    const measurementPayloadError = validateMeasurementPayload(target.measurement_type, parsed.data);
+    if (measurementPayloadError) {
+      return json({ error: measurementPayloadError }, 400);
     }
 
     const canCapture = await currentUserCanTakeClientData(accessToken, organizationId, session.client_id);

--- a/src/server/api/trial-events.ts
+++ b/src/server/api/trial-events.ts
@@ -1,0 +1,216 @@
+import { z } from "zod";
+import {
+  CORS_HEADERS,
+  currentUserCanManageLockedTrialEvent,
+  currentUserCanTakeClientData,
+  fetchAuthenticatedUserIdWithStatus,
+  fetchJson,
+  getAccessToken,
+  getSupabaseConfig,
+  json,
+  resolveOrgAndRoleWithStatus,
+  sessionHasLockedNote,
+} from "./shared";
+
+const responseSchema = z.enum([
+  "correct",
+  "incorrect",
+  "noResponse",
+  "independent",
+  "prompted",
+  "notObserved",
+]);
+
+const responseRequiredMeasurementTypes = new Set(["correctIncorrect", "taskAnalysis"]);
+
+const createTrialEventSchema = z.object({
+  session_id: z.string().uuid(),
+  target_id: z.string().uuid(),
+  trial_number: z.number().int().positive(),
+  response: responseSchema.optional().nullable(),
+  prompt_type: z.string().trim().optional().nullable(),
+  prompt_level: z.string().trim().optional().nullable(),
+  value: z.number().optional().nullable(),
+  timestamp: z.string().datetime().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+const isUuid = (value: string): boolean => z.string().uuid().safeParse(value).success;
+
+type TargetScope = {
+  id: string;
+  organization_id: string;
+  client_id: string;
+  goal_id: string;
+  measurement_type: string;
+};
+
+type SessionScope = {
+  id: string;
+  organization_id: string;
+  client_id: string;
+  therapist_id: string;
+};
+
+const buildHeaders = (anonKey: string, accessToken: string): Record<string, string> => ({
+  "Content-Type": "application/json",
+  apikey: anonKey,
+  Authorization: `Bearer ${accessToken}`,
+});
+
+export async function trialEventsHandler(request: Request): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return new Response("ok", { status: 200, headers: { ...CORS_HEADERS } });
+  }
+
+  const accessToken = getAccessToken(request);
+  if (!accessToken) {
+    return json({ error: "Missing authorization token" }, 401, { "WWW-Authenticate": "Bearer" });
+  }
+
+  const role = await resolveOrgAndRoleWithStatus(accessToken);
+  if (role.upstreamError) {
+    return json({ error: "Unable to validate organization access" }, 502);
+  }
+  if (!role.organizationId) {
+    return json({ error: "Forbidden" }, 403);
+  }
+
+  const { userId: actorUserId, upstreamError: actorUpstreamError } = await fetchAuthenticatedUserIdWithStatus(accessToken);
+  if (actorUpstreamError) {
+    return json({ error: "Unable to validate authenticated user" }, 502);
+  }
+  if (!actorUserId) {
+    return json({ error: "Forbidden" }, 403);
+  }
+
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const headers = buildHeaders(anonKey, accessToken);
+  const organizationId = role.organizationId;
+
+  if (request.method === "GET") {
+    const url = new URL(request.url);
+    const sessionId = url.searchParams.get("session_id");
+    const targetId = url.searchParams.get("target_id");
+    if (!sessionId && !targetId) {
+      return json({ error: "session_id or target_id is required" }, 400);
+    }
+    if (sessionId && !isUuid(sessionId)) {
+      return json({ error: "session_id must be a valid UUID" }, 400);
+    }
+    if (targetId && !isUuid(targetId)) {
+      return json({ error: "target_id must be a valid UUID" }, 400);
+    }
+
+    const filters = [
+      `organization_id=eq.${encodeURIComponent(organizationId)}`,
+      sessionId ? `session_id=eq.${encodeURIComponent(sessionId)}` : null,
+      targetId ? `target_id=eq.${encodeURIComponent(targetId)}` : null,
+    ].filter(Boolean).join("&");
+
+    const result = await fetchJson(
+      `${supabaseUrl}/rest/v1/trial_events?select=*&${filters}&order=event_timestamp.asc,trial_number.asc`,
+      { method: "GET", headers },
+    );
+    if (!result.ok) {
+      return json({ error: "Failed to load trial events" }, result.status || 500);
+    }
+    return json(result.data ?? []);
+  }
+
+  if (request.method === "POST") {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const parsed = createTrialEventSchema.safeParse(body);
+    if (!parsed.success) {
+      return json({ error: "Invalid request body" }, 400);
+    }
+
+    const targetResult = await fetchJson<TargetScope[]>(
+      `${supabaseUrl}/rest/v1/goal_targets?select=id,organization_id,client_id,goal_id,measurement_type&id=eq.${encodeURIComponent(
+        parsed.data.target_id,
+      )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
+      { method: "GET", headers },
+    );
+    const target = targetResult.ok && Array.isArray(targetResult.data) ? targetResult.data[0] ?? null : null;
+    if (!target) {
+      return json({ error: "target_id is not in scope for this organization" }, 403);
+    }
+
+    const sessionResult = await fetchJson<SessionScope[]>(
+      `${supabaseUrl}/rest/v1/sessions?select=id,organization_id,client_id,therapist_id&id=eq.${encodeURIComponent(
+        parsed.data.session_id,
+      )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
+      { method: "GET", headers },
+    );
+    const session = sessionResult.ok && Array.isArray(sessionResult.data) ? sessionResult.data[0] ?? null : null;
+    if (!session) {
+      return json({ error: "session_id is not in scope for this organization" }, 403);
+    }
+    if (session.client_id !== target.client_id) {
+      return json({ error: "session_id and target_id must belong to the same client" }, 400);
+    }
+    if (responseRequiredMeasurementTypes.has(target.measurement_type) && !parsed.data.response) {
+      return json({ error: "response is required for this target measurement type" }, 400);
+    }
+
+    const canCapture = await currentUserCanTakeClientData(accessToken, organizationId, session.client_id);
+    if (canCapture.upstreamError) {
+      return json({ error: "Unable to validate trial-event capture access" }, 502);
+    }
+    if (!canCapture.allowed) {
+      return json({ error: "Forbidden" }, 403);
+    }
+
+    const lockState = await sessionHasLockedNote(accessToken, session.id);
+    if (lockState.upstreamError) {
+      return json({ error: "Unable to validate session lock state" }, 502);
+    }
+    if (lockState.locked) {
+      const canManageLocked = await currentUserCanManageLockedTrialEvent(accessToken, organizationId);
+      if (canManageLocked.upstreamError) {
+        return json({ error: "Unable to validate locked-session trial-event access" }, 502);
+      }
+      if (!canManageLocked.allowed) {
+        return json({ error: "Session is locked for trial-event changes" }, 409);
+      }
+    }
+
+    const payload = {
+      organization_id: organizationId,
+      client_id: session.client_id,
+      session_id: session.id,
+      target_id: target.id,
+      goal_id: target.goal_id,
+      therapist_id: session.therapist_id,
+      trial_number: parsed.data.trial_number,
+      response: parsed.data.response ?? null,
+      prompt_type: parsed.data.prompt_type ?? null,
+      prompt_level: parsed.data.prompt_level ?? null,
+      value: typeof parsed.data.value === "number" ? parsed.data.value : null,
+      event_timestamp: parsed.data.timestamp ?? new Date().toISOString(),
+      metadata: parsed.data.metadata ?? {},
+      created_by: actorUserId,
+    };
+
+    const result = await fetchJson(`${supabaseUrl}/rest/v1/trial_events`, {
+      method: "POST",
+      headers: { ...headers, Prefer: "return=representation" },
+      body: JSON.stringify(payload),
+    });
+    if (!result.ok) {
+      if (result.status === 409) {
+        return json({ error: "trial_number already exists for this session target" }, 409);
+      }
+      return json({ error: "Failed to create trial event" }, result.status || 500);
+    }
+    return json(Array.isArray(result.data) ? result.data[0] : result.data, 201);
+  }
+
+  return json({ error: "Method not allowed" }, 405);
+}

--- a/src/server/api/trial-events.ts
+++ b/src/server/api/trial-events.ts
@@ -30,7 +30,7 @@ const createTrialEventSchema = z.object({
   response: responseSchema.optional().nullable(),
   prompt_type: z.string().trim().optional().nullable(),
   prompt_level: z.string().trim().optional().nullable(),
-  value: z.number().optional().nullable(),
+  value: z.number().nonnegative().optional().nullable(),
   timestamp: z.string().datetime().optional(),
   metadata: z.record(z.unknown()).optional(),
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -204,20 +204,73 @@ export interface Goal {
   organization_id: string;
   client_id: string;
   program_id: string;
+  domain_id?: string | null;
   title: string;
   description: string;
   goal_type?: 'child' | 'parent';
+  clinical_goal_type?: 'behavior' | 'skill' | null;
   target_behavior?: string | null;
   measurement_type?: string | null;
   original_text: string;
   clinical_context?: string | null;
   baseline_data?: string | null;
+  baseline?: string | null;
   target_criteria?: string | null;
   mastery_criteria?: string | null;
   maintenance_criteria?: string | null;
   generalization_criteria?: string | null;
+  teaching_strategies?: string | null;
+  operational_definition?: string | null;
   objective_data_points?: Array<Record<string, unknown>> | null;
-  status: 'active' | 'paused' | 'mastered' | 'archived';
+  source?: 'manual' | 'fba_extraction' | null;
+  status: 'draft' | 'active' | 'paused' | 'mastered' | 'archived';
+  created_by?: string | null;
+  updated_by?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type TargetMeasurementType =
+  | 'correctIncorrect'
+  | 'frequency'
+  | 'rate'
+  | 'duration'
+  | 'timeSample'
+  | 'taskAnalysis'
+  | 'latency'
+  | 'IRT';
+
+export interface GoalTarget {
+  id: string;
+  organization_id: string;
+  client_id: string;
+  goal_id: string;
+  name: string;
+  measurement_type: TargetMeasurementType;
+  graph_config: Record<string, unknown>;
+  status: 'draft' | 'active' | 'mastered' | 'archived';
+  sort_order: number;
+  created_by?: string | null;
+  updated_by?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TrialEvent {
+  id: string;
+  organization_id: string;
+  client_id: string;
+  session_id: string;
+  target_id: string;
+  goal_id: string;
+  therapist_id: string;
+  trial_number: number;
+  response?: 'correct' | 'incorrect' | 'noResponse' | 'independent' | 'prompted' | 'notObserved' | null;
+  prompt_type?: string | null;
+  prompt_level?: string | null;
+  value?: number | null;
+  event_timestamp: string;
+  metadata: Record<string, unknown>;
   created_by?: string | null;
   updated_by?: string | null;
   created_at: string;

--- a/supabase/functions/goal-targets/function.toml
+++ b/supabase/functions/goal-targets/function.toml
@@ -1,0 +1,1 @@
+verify_jwt = true

--- a/supabase/functions/goal-targets/index.ts
+++ b/supabase/functions/goal-targets/index.ts
@@ -1,0 +1,189 @@
+import { z } from "npm:zod@3.23.8";
+import { createRequestClient } from "../_shared/database.ts";
+import { corsHeadersForRequest } from "../_shared/cors.ts";
+import { createProtectedRoute, RouteOptions } from "../_shared/auth-middleware.ts";
+
+const measurementTypeSchema = z.enum([
+  "correctIncorrect",
+  "frequency",
+  "rate",
+  "duration",
+  "timeSample",
+  "taskAnalysis",
+  "latency",
+  "IRT",
+]);
+
+const targetStatusSchema = z.enum(["draft", "active", "mastered", "archived"]);
+
+const createGoalTargetSchema = z.object({
+  goal_id: z.string().uuid(),
+  name: z.string().trim().min(1),
+  measurement_type: measurementTypeSchema,
+  graph_config: z.record(z.unknown()).optional(),
+  status: targetStatusSchema.optional(),
+  sort_order: z.number().int().optional(),
+});
+
+const updateGoalTargetSchema = createGoalTargetSchema
+  .omit({ goal_id: true })
+  .partial()
+  .refine((value) => Object.keys(value).length > 0, "At least one field is required");
+
+const json = (req: Request, body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeadersForRequest(req),
+      "Content-Type": "application/json",
+    },
+  });
+
+const isUuid = (value: string): boolean => z.string().uuid().safeParse(value).success;
+
+type CapabilityResult = { allowed: boolean; upstreamError: boolean };
+
+const requireOrg = async (db: ReturnType<typeof createRequestClient>): Promise<string | null> => {
+  const { data, error } = await db.rpc("current_user_organization_id");
+  if (error || typeof data !== "string" || data.length === 0) {
+    return null;
+  }
+  return data;
+};
+
+const currentUserCanManageProgramsGoals = async (
+  db: ReturnType<typeof createRequestClient>,
+  orgId: string,
+): Promise<CapabilityResult> => {
+  const { data, error } = await db.rpc("current_user_can_manage_programs_goals", {
+    target_organization_id: orgId,
+  });
+  if (error) {
+    console.error("current_user_can_manage_programs_goals rpc error", error);
+    return { allowed: false, upstreamError: true };
+  }
+  return { allowed: data === true, upstreamError: false };
+};
+
+const loadGoalScope = async (
+  db: ReturnType<typeof createRequestClient>,
+  orgId: string,
+  goalId: string,
+): Promise<{ id: string; client_id: string } | null> => {
+  const { data, error } = await db
+    .from("goals")
+    .select("id,client_id")
+    .eq("organization_id", orgId)
+    .eq("id", goalId)
+    .limit(1);
+  if (error || !data || data.length === 0) {
+    return null;
+  }
+  return data[0] as unknown as { id: string; client_id: string };
+};
+
+export const handleGoalTargets = async (req: Request) => {
+  const db = createRequestClient(req);
+  const orgId = await requireOrg(db);
+  if (!orgId) {
+    return json(req, { error: "Forbidden" }, 403);
+  }
+
+  const { data: authData, error: authError } = await db.auth.getUser();
+  if (authError || !authData?.user) {
+    return json(req, { error: "Missing authorization token" }, 401);
+  }
+
+  if (req.method === "GET") {
+    const url = new URL(req.url);
+    const goalId = url.searchParams.get("goal_id");
+    const targetId = url.searchParams.get("target_id");
+    if (!goalId && !targetId) return json(req, { error: "goal_id or target_id is required" }, 400);
+    if (goalId && !isUuid(goalId)) return json(req, { error: "goal_id must be a valid UUID" }, 400);
+    if (targetId && !isUuid(targetId)) return json(req, { error: "target_id must be a valid UUID" }, 400);
+
+    let query = db
+      .from("goal_targets")
+      .select("*")
+      .eq("organization_id", orgId)
+      .order("sort_order", { ascending: true })
+      .order("created_at", { ascending: true });
+    if (goalId) query = query.eq("goal_id", goalId);
+    if (targetId) query = query.eq("id", targetId);
+
+    const { data, error } = await query;
+    if (error) return json(req, { error: "Failed to load goal targets" }, 500);
+    return json(req, data ?? []);
+  }
+
+  const allowed = await currentUserCanManageProgramsGoals(db, orgId);
+  if (allowed.upstreamError) return json(req, { error: "Unable to validate program-goal access" }, 502);
+  if (!allowed.allowed) return json(req, { error: "Forbidden" }, 403);
+
+  if (req.method === "POST") {
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch {
+      return json(req, { error: "Invalid JSON body" }, 400);
+    }
+    const parsed = createGoalTargetSchema.safeParse(payload);
+    if (!parsed.success) return json(req, { error: "Invalid request body" }, 400);
+
+    const goal = await loadGoalScope(db, orgId, parsed.data.goal_id);
+    if (!goal) return json(req, { error: "goal_id is not in scope for this organization" }, 403);
+
+    const { data, error } = await db
+      .from("goal_targets")
+      .insert([{
+        organization_id: orgId,
+        client_id: goal.client_id,
+        goal_id: goal.id,
+        name: parsed.data.name,
+        measurement_type: parsed.data.measurement_type,
+        graph_config: parsed.data.graph_config ?? {},
+        status: parsed.data.status ?? "active",
+        sort_order: parsed.data.sort_order ?? 0,
+        created_by: authData.user.id,
+      }])
+      .select("*")
+      .limit(1);
+    if (error) return json(req, { error: "Failed to create goal target" }, 500);
+    return json(req, data?.[0] ?? null, 201);
+  }
+
+  if (req.method === "PATCH") {
+    const url = new URL(req.url);
+    const targetId = url.searchParams.get("target_id");
+    if (!targetId) return json(req, { error: "target_id is required" }, 400);
+    if (!isUuid(targetId)) return json(req, { error: "target_id must be a valid UUID" }, 400);
+
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch {
+      return json(req, { error: "Invalid JSON body" }, 400);
+    }
+    const parsed = updateGoalTargetSchema.safeParse(payload);
+    if (!parsed.success) return json(req, { error: "Invalid request body" }, 400);
+
+    const { data, error } = await db
+      .from("goal_targets")
+      .update({ ...parsed.data, updated_by: authData.user.id })
+      .eq("organization_id", orgId)
+      .eq("id", targetId)
+      .select("*")
+      .limit(1);
+    if (error) return json(req, { error: "Failed to update goal target" }, 500);
+    if (!data || data.length === 0) return json(req, { error: "target_id is not in scope for this organization" }, 403);
+    return json(req, data[0]);
+  }
+
+  return json(req, { error: "Method not allowed" }, 405);
+};
+
+const handler = createProtectedRoute((req) => handleGoalTargets(req), RouteOptions.programsGoals);
+
+Deno.serve(handler);
+
+export default handler;

--- a/supabase/functions/goals/index.ts
+++ b/supabase/functions/goals/index.ts
@@ -7,20 +7,26 @@ import { currentUserCanManageProgramsGoals, MissingOrgContextError, orgScopedQue
 const goalSchema = z.object({
   client_id: z.string().uuid(),
   program_id: z.string().uuid(),
+  domain_id: z.string().uuid().optional().nullable(),
   title: z.string().trim().min(1),
   description: z.string().trim().min(1),
   target_behavior: z.string().optional(),
   measurement_type: z.string().optional(),
   original_text: z.string().trim().min(1),
   goal_type: z.enum(["child", "parent"]).optional(),
+  clinical_goal_type: z.enum(["behavior", "skill"]).optional().nullable(),
   clinical_context: z.string().optional(),
   baseline_data: z.string().optional(),
+  baseline: z.string().optional(),
   target_criteria: z.string().optional(),
   mastery_criteria: z.string().optional(),
   maintenance_criteria: z.string().optional(),
   generalization_criteria: z.string().optional(),
+  teaching_strategies: z.string().optional(),
+  operational_definition: z.string().optional(),
   objective_data_points: z.array(z.record(z.unknown())).optional(),
-  status: z.enum(["active", "paused", "mastered", "archived"]).optional(),
+  source: z.enum(["manual", "fba_extraction"]).optional(),
+  status: z.enum(["draft", "active", "paused", "mastered", "archived"]).optional(),
 });
 
 const goalUpdateSchema = goalSchema.partial().extend({
@@ -61,8 +67,6 @@ export const handleGoals = async (req: Request) => {
   if (authError || !authData?.user) {
     return json(req, { error: "Missing authorization token" }, 401);
   }
-  const allowed = await currentUserCanManageProgramsGoals(db, orgId);
-  if (!allowed) return json(req, { error: "Forbidden" }, 403);
 
   if (req.method === "GET") {
     const url = new URL(req.url);
@@ -72,7 +76,7 @@ export const handleGoals = async (req: Request) => {
 
     const { data, error } = await orgScopedQuery(db, "goals", orgId)
       .select(
-        "id,organization_id,client_id,program_id,title,description,target_behavior,measurement_type,original_text,goal_type,clinical_context,baseline_data,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,objective_data_points,status,created_at,updated_at",
+        "id,organization_id,client_id,program_id,domain_id,title,description,target_behavior,measurement_type,original_text,goal_type,clinical_goal_type,clinical_context,baseline_data,baseline,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,teaching_strategies,operational_definition,objective_data_points,source,status,created_at,updated_at",
       )
       .eq("program_id", programId)
       .order("created_at", { ascending: false });
@@ -89,6 +93,9 @@ export const handleGoals = async (req: Request) => {
   }
 
   if (req.method === "POST") {
+    const allowed = await currentUserCanManageProgramsGoals(db, orgId);
+    if (!allowed) return json(req, { error: "Forbidden" }, 403);
+
     let payload: unknown;
     try {
       payload = await req.json();
@@ -119,6 +126,9 @@ export const handleGoals = async (req: Request) => {
   }
 
   if (req.method === "PATCH") {
+    const allowed = await currentUserCanManageProgramsGoals(db, orgId);
+    if (!allowed) return json(req, { error: "Forbidden" }, 403);
+
     const url = new URL(req.url);
     const goalId = url.searchParams.get("goal_id");
     if (!goalId) return json(req, { error: "goal_id is required" }, 400);

--- a/supabase/functions/trial-events/function.toml
+++ b/supabase/functions/trial-events/function.toml
@@ -1,0 +1,1 @@
+verify_jwt = true

--- a/supabase/functions/trial-events/index.ts
+++ b/supabase/functions/trial-events/index.ts
@@ -21,7 +21,7 @@ const createTrialEventSchema = z.object({
   response: responseSchema.optional().nullable(),
   prompt_type: z.string().trim().optional().nullable(),
   prompt_level: z.string().trim().optional().nullable(),
-  value: z.number().optional().nullable(),
+  value: z.number().nonnegative().optional().nullable(),
   timestamp: z.string().datetime().optional(),
   metadata: z.record(z.unknown()).optional(),
 });

--- a/supabase/functions/trial-events/index.ts
+++ b/supabase/functions/trial-events/index.ts
@@ -1,0 +1,219 @@
+import { z } from "npm:zod@3.23.8";
+import { createRequestClient } from "../_shared/database.ts";
+import { corsHeadersForRequest } from "../_shared/cors.ts";
+import { createProtectedRoute, RouteOptions } from "../_shared/auth-middleware.ts";
+
+const responseSchema = z.enum([
+  "correct",
+  "incorrect",
+  "noResponse",
+  "independent",
+  "prompted",
+  "notObserved",
+]);
+
+const responseRequiredMeasurementTypes = new Set(["correctIncorrect", "taskAnalysis"]);
+
+const createTrialEventSchema = z.object({
+  session_id: z.string().uuid(),
+  target_id: z.string().uuid(),
+  trial_number: z.number().int().positive(),
+  response: responseSchema.optional().nullable(),
+  prompt_type: z.string().trim().optional().nullable(),
+  prompt_level: z.string().trim().optional().nullable(),
+  value: z.number().optional().nullable(),
+  timestamp: z.string().datetime().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+type TargetScope = {
+  id: string;
+  client_id: string;
+  goal_id: string;
+  measurement_type: string;
+};
+
+type SessionScope = {
+  id: string;
+  client_id: string;
+  therapist_id: string;
+};
+
+const json = (req: Request, body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeadersForRequest(req),
+      "Content-Type": "application/json",
+    },
+  });
+
+const isUuid = (value: string): boolean => z.string().uuid().safeParse(value).success;
+
+type CapabilityResult = { allowed: boolean; upstreamError: boolean };
+type LockStateResult = { locked: boolean; upstreamError: boolean };
+
+const requireOrg = async (db: ReturnType<typeof createRequestClient>): Promise<string | null> => {
+  const { data, error } = await db.rpc("current_user_organization_id");
+  if (error || typeof data !== "string" || data.length === 0) {
+    return null;
+  }
+  return data;
+};
+
+const canTakeClientData = async (
+  db: ReturnType<typeof createRequestClient>,
+  orgId: string,
+  clientId: string,
+): Promise<CapabilityResult> => {
+  const { data, error } = await db.rpc("current_user_can_take_client_data", {
+    target_organization_id: orgId,
+    target_client_id: clientId,
+  });
+  if (error) {
+    console.error("current_user_can_take_client_data rpc error", error);
+    return { allowed: false, upstreamError: true };
+  }
+  return { allowed: data === true, upstreamError: false };
+};
+
+const canManageLockedTrialEvents = async (
+  db: ReturnType<typeof createRequestClient>,
+  orgId: string,
+): Promise<CapabilityResult> => {
+  const { data, error } = await db.rpc("current_user_can_manage_locked_trial_event", {
+    target_organization_id: orgId,
+  });
+  if (error) {
+    console.error("current_user_can_manage_locked_trial_event rpc error", error);
+    return { allowed: false, upstreamError: true };
+  }
+  return { allowed: data === true, upstreamError: false };
+};
+
+const sessionHasLockedNote = async (
+  db: ReturnType<typeof createRequestClient>,
+  sessionId: string,
+): Promise<LockStateResult> => {
+  const { data, error } = await db.rpc("session_has_locked_note", {
+    target_session_id: sessionId,
+  });
+  if (error) {
+    console.error("session_has_locked_note rpc error", error);
+    return { locked: true, upstreamError: true };
+  }
+  return { locked: data === true, upstreamError: false };
+};
+
+export const handleTrialEvents = async (req: Request) => {
+  const db = createRequestClient(req);
+  const orgId = await requireOrg(db);
+  if (!orgId) {
+    return json(req, { error: "Forbidden" }, 403);
+  }
+
+  const { data: authData, error: authError } = await db.auth.getUser();
+  if (authError || !authData?.user) {
+    return json(req, { error: "Missing authorization token" }, 401);
+  }
+
+  if (req.method === "GET") {
+    const url = new URL(req.url);
+    const sessionId = url.searchParams.get("session_id");
+    const targetId = url.searchParams.get("target_id");
+    if (!sessionId && !targetId) return json(req, { error: "session_id or target_id is required" }, 400);
+    if (sessionId && !isUuid(sessionId)) return json(req, { error: "session_id must be a valid UUID" }, 400);
+    if (targetId && !isUuid(targetId)) return json(req, { error: "target_id must be a valid UUID" }, 400);
+
+    let query = db
+      .from("trial_events")
+      .select("*")
+      .eq("organization_id", orgId)
+      .order("event_timestamp", { ascending: true })
+      .order("trial_number", { ascending: true });
+    if (sessionId) query = query.eq("session_id", sessionId);
+    if (targetId) query = query.eq("target_id", targetId);
+
+    const { data, error } = await query;
+    if (error) return json(req, { error: "Failed to load trial events" }, 500);
+    return json(req, data ?? []);
+  }
+
+  if (req.method === "POST") {
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch {
+      return json(req, { error: "Invalid JSON body" }, 400);
+    }
+    const parsed = createTrialEventSchema.safeParse(payload);
+    if (!parsed.success) return json(req, { error: "Invalid request body" }, 400);
+
+    const { data: targets, error: targetError } = await db
+      .from("goal_targets")
+      .select("id,client_id,goal_id,measurement_type")
+      .eq("organization_id", orgId)
+      .eq("id", parsed.data.target_id)
+      .limit(1);
+    const target = !targetError && targets && targets.length > 0 ? targets[0] as unknown as TargetScope : null;
+    if (!target) return json(req, { error: "target_id is not in scope for this organization" }, 403);
+
+    const { data: sessions, error: sessionError } = await db
+      .from("sessions")
+      .select("id,client_id,therapist_id")
+      .eq("organization_id", orgId)
+      .eq("id", parsed.data.session_id)
+      .limit(1);
+    const session = !sessionError && sessions && sessions.length > 0 ? sessions[0] as unknown as SessionScope : null;
+    if (!session) return json(req, { error: "session_id is not in scope for this organization" }, 403);
+    if (session.client_id !== target.client_id) {
+      return json(req, { error: "session_id and target_id must belong to the same client" }, 400);
+    }
+    if (responseRequiredMeasurementTypes.has(target.measurement_type) && !parsed.data.response) {
+      return json(req, { error: "response is required for this target measurement type" }, 400);
+    }
+
+    const canCapture = await canTakeClientData(db, orgId, session.client_id);
+    if (canCapture.upstreamError) return json(req, { error: "Unable to validate trial-event capture access" }, 502);
+    if (!canCapture.allowed) return json(req, { error: "Forbidden" }, 403);
+
+    const lockState = await sessionHasLockedNote(db, session.id);
+    if (lockState.upstreamError) return json(req, { error: "Unable to validate session lock state" }, 502);
+    if (lockState.locked) {
+      const canManageLocked = await canManageLockedTrialEvents(db, orgId);
+      if (canManageLocked.upstreamError) return json(req, { error: "Unable to validate locked-session trial-event access" }, 502);
+      if (!canManageLocked.allowed) return json(req, { error: "Session is locked for trial-event changes" }, 409);
+    }
+
+    const { data, error } = await db
+      .from("trial_events")
+      .insert([{
+        organization_id: orgId,
+        client_id: session.client_id,
+        session_id: session.id,
+        target_id: target.id,
+        goal_id: target.goal_id,
+        therapist_id: session.therapist_id,
+        trial_number: parsed.data.trial_number,
+        response: parsed.data.response ?? null,
+        prompt_type: parsed.data.prompt_type ?? null,
+        prompt_level: parsed.data.prompt_level ?? null,
+        value: typeof parsed.data.value === "number" ? parsed.data.value : null,
+        event_timestamp: parsed.data.timestamp ?? new Date().toISOString(),
+        metadata: parsed.data.metadata ?? {},
+        created_by: authData.user.id,
+      }])
+      .select("*")
+      .limit(1);
+    if (error) return json(req, { error: "Failed to create trial event" }, error.code === "23505" ? 409 : 500);
+    return json(req, data?.[0] ?? null, 201);
+  }
+
+  return json(req, { error: "Method not allowed" }, 405);
+};
+
+const handler = createProtectedRoute((req) => handleTrialEvents(req), RouteOptions.programsGoals);
+
+Deno.serve(handler);
+
+export default handler;

--- a/supabase/functions/trial-events/index.ts
+++ b/supabase/functions/trial-events/index.ts
@@ -13,6 +13,7 @@ const responseSchema = z.enum([
 ]);
 
 const responseRequiredMeasurementTypes = new Set(["correctIncorrect", "taskAnalysis"]);
+const valueRequiredMeasurementTypes = new Set(["frequency", "rate", "duration", "timeSample", "latency", "IRT"]);
 
 const createTrialEventSchema = z.object({
   session_id: z.string().uuid(),
@@ -52,6 +53,32 @@ const isUuid = (value: string): boolean => z.string().uuid().safeParse(value).su
 
 type CapabilityResult = { allowed: boolean; upstreamError: boolean };
 type LockStateResult = { locked: boolean; upstreamError: boolean };
+
+const validateMeasurementPayload = (
+  measurementType: string,
+  payload: z.infer<typeof createTrialEventSchema>,
+): string | null => {
+  if (responseRequiredMeasurementTypes.has(measurementType)) {
+    if (!payload.response) {
+      return "response is required for this target measurement type";
+    }
+    if (typeof payload.value === "number") {
+      return "value is not allowed for this target measurement type";
+    }
+    return null;
+  }
+
+  if (valueRequiredMeasurementTypes.has(measurementType)) {
+    if (typeof payload.value !== "number") {
+      return "value is required for this target measurement type";
+    }
+    if (payload.response) {
+      return "response is not allowed for this target measurement type";
+    }
+  }
+
+  return null;
+};
 
 const requireOrg = async (db: ReturnType<typeof createRequestClient>): Promise<string | null> => {
   const { data, error } = await db.rpc("current_user_organization_id");
@@ -169,8 +196,9 @@ export const handleTrialEvents = async (req: Request) => {
     if (session.client_id !== target.client_id) {
       return json(req, { error: "session_id and target_id must belong to the same client" }, 400);
     }
-    if (responseRequiredMeasurementTypes.has(target.measurement_type) && !parsed.data.response) {
-      return json(req, { error: "response is required for this target measurement type" }, 400);
+    const measurementPayloadError = validateMeasurementPayload(target.measurement_type, parsed.data);
+    if (measurementPayloadError) {
+      return json(req, { error: measurementPayloadError }, 400);
     }
 
     const canCapture = await canTakeClientData(db, orgId, session.client_id);

--- a/supabase/migrations/20260703173000_goal_targets_trial_events.sql
+++ b/supabase/migrations/20260703173000_goal_targets_trial_events.sql
@@ -68,6 +68,7 @@ create index if not exists goal_targets_org_client_idx
 
 revoke all on table public.goal_targets from anon;
 grant select, insert, update on table public.goal_targets to authenticated;
+revoke delete on table public.goal_targets from authenticated;
 grant select, insert, update, delete on table public.goal_targets to service_role;
 
 create or replace function app.set_goal_target_scope()
@@ -136,7 +137,7 @@ create table if not exists public.trial_events (
   ),
   prompt_type text,
   prompt_level text,
-  value numeric check (value is null or value >= 0),
+  value numeric constraint trial_events_value_nonnegative check (value is null or value >= 0),
   event_timestamp timestamptz not null default timezone('utc', now()),
   metadata jsonb not null default '{}'::jsonb,
   created_by uuid,
@@ -145,6 +146,16 @@ create table if not exists public.trial_events (
   updated_at timestamptz not null default timezone('utc', now()),
   constraint trial_events_metadata_object_chk check (jsonb_typeof(metadata) = 'object')
 );
+
+alter table public.trial_events
+  drop constraint if exists trial_events_target_id_fkey,
+  add constraint trial_events_target_id_fkey
+  foreign key (target_id) references public.goal_targets(id);
+
+alter table public.trial_events
+  drop constraint if exists trial_events_value_nonnegative,
+  add constraint trial_events_value_nonnegative
+  check (value is null or value >= 0);
 
 create unique index if not exists trial_events_session_target_trial_uidx
   on public.trial_events (session_id, target_id, trial_number);

--- a/supabase/migrations/20260703173000_goal_targets_trial_events.sql
+++ b/supabase/migrations/20260703173000_goal_targets_trial_events.sql
@@ -1,0 +1,424 @@
+-- @migration-intent: Add first-class goal targets and raw trial events for target-level session data collection.
+-- @migration-dependencies: 20260702194500_expose_program_goal_capability_rpc.sql
+-- @migration-rollback: drop table public.trial_events; drop table public.goal_targets; remove added goals columns only after dependent app code is rolled back.
+
+begin;
+
+alter table public.goals
+  add column if not exists domain_id uuid,
+  add column if not exists clinical_goal_type text,
+  add column if not exists teaching_strategies text,
+  add column if not exists operational_definition text,
+  add column if not exists baseline text,
+  add column if not exists source text not null default 'manual';
+
+update public.goals
+set baseline = baseline_data
+where baseline is null
+  and baseline_data is not null;
+
+alter table public.goals
+  drop constraint if exists goals_clinical_goal_type_chk,
+  add constraint goals_clinical_goal_type_chk
+  check (clinical_goal_type is null or clinical_goal_type in ('behavior', 'skill'));
+
+alter table public.goals
+  drop constraint if exists goals_source_chk,
+  add constraint goals_source_chk
+  check (source in ('manual', 'fba_extraction'));
+
+alter table public.goals
+  drop constraint if exists goals_status_check,
+  add constraint goals_status_check
+  check (status in ('draft', 'active', 'paused', 'mastered', 'archived'));
+
+create table if not exists public.goal_targets (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  client_id uuid not null references public.clients(id) on delete cascade,
+  goal_id uuid not null references public.goals(id) on delete cascade,
+  name text not null check (char_length(btrim(name)) > 0),
+  measurement_type text not null check (
+    measurement_type in (
+      'correctIncorrect',
+      'frequency',
+      'rate',
+      'duration',
+      'timeSample',
+      'taskAnalysis',
+      'latency',
+      'IRT'
+    )
+  ),
+  graph_config jsonb not null default '{}'::jsonb,
+  status text not null default 'active' check (status in ('draft', 'active', 'mastered', 'archived')),
+  sort_order integer not null default 0,
+  created_by uuid,
+  updated_by uuid,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint goal_targets_graph_config_object_chk check (jsonb_typeof(graph_config) = 'object')
+);
+
+create index if not exists goal_targets_goal_status_idx
+  on public.goal_targets (goal_id, status, sort_order, created_at);
+
+create index if not exists goal_targets_org_client_idx
+  on public.goal_targets (organization_id, client_id, status);
+
+revoke all on table public.goal_targets from anon;
+grant select, insert, update, delete on table public.goal_targets to authenticated;
+grant select, insert, update, delete on table public.goal_targets to service_role;
+
+create or replace function app.set_goal_target_scope()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, app
+as $$
+declare
+  v_goal record;
+begin
+  select g.organization_id, g.client_id
+  into v_goal
+  from public.goals g
+  where g.id = new.goal_id;
+
+  if v_goal.organization_id is null then
+    raise exception using errcode = '23503', message = 'goal_id is not in scope';
+  end if;
+
+  if new.organization_id is not null and new.organization_id <> v_goal.organization_id then
+    raise exception using errcode = '23514', message = 'goal target organization_id must match goal';
+  end if;
+
+  if new.client_id is not null and new.client_id <> v_goal.client_id then
+    raise exception using errcode = '23514', message = 'goal target client_id must match goal';
+  end if;
+
+  new.organization_id := v_goal.organization_id;
+  new.client_id := v_goal.client_id;
+  if tg_op = 'INSERT' then
+    new.created_by := coalesce(app.current_user_id(), new.created_by);
+    new.updated_by := coalesce(app.current_user_id(), new.updated_by, new.created_by);
+  else
+    new.created_by := old.created_by;
+    new.updated_by := coalesce(app.current_user_id(), new.updated_by, new.created_by);
+  end if;
+  new.updated_at := timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists goal_targets_set_scope on public.goal_targets;
+create trigger goal_targets_set_scope
+before insert or update on public.goal_targets
+for each row execute function app.set_goal_target_scope();
+
+create table if not exists public.trial_events (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  client_id uuid not null references public.clients(id) on delete cascade,
+  session_id uuid not null references public.sessions(id) on delete cascade,
+  target_id uuid not null references public.goal_targets(id) on delete cascade,
+  goal_id uuid not null references public.goals(id) on delete cascade,
+  therapist_id uuid not null,
+  trial_number integer not null check (trial_number > 0),
+  response text check (
+    response is null or response in (
+      'correct',
+      'incorrect',
+      'noResponse',
+      'independent',
+      'prompted',
+      'notObserved'
+    )
+  ),
+  prompt_type text,
+  prompt_level text,
+  value numeric,
+  event_timestamp timestamptz not null default timezone('utc', now()),
+  metadata jsonb not null default '{}'::jsonb,
+  created_by uuid,
+  updated_by uuid,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint trial_events_metadata_object_chk check (jsonb_typeof(metadata) = 'object')
+);
+
+create unique index if not exists trial_events_session_target_trial_uidx
+  on public.trial_events (session_id, target_id, trial_number);
+
+create index if not exists trial_events_target_time_idx
+  on public.trial_events (target_id, event_timestamp desc);
+
+create index if not exists trial_events_org_client_time_idx
+  on public.trial_events (organization_id, client_id, event_timestamp desc);
+
+revoke all on table public.trial_events from anon;
+grant select, insert, update, delete on table public.trial_events to authenticated;
+grant select, insert, update, delete on table public.trial_events to service_role;
+
+create or replace function app.set_trial_event_scope()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, app
+as $$
+declare
+  v_target record;
+  v_session record;
+begin
+  select gt.organization_id, gt.client_id, gt.goal_id, gt.measurement_type
+  into v_target
+  from public.goal_targets gt
+  where gt.id = new.target_id;
+
+  if v_target.organization_id is null then
+    raise exception using errcode = '23503', message = 'target_id is not in scope';
+  end if;
+
+  select s.organization_id, s.client_id, s.therapist_id
+  into v_session
+  from public.sessions s
+  where s.id = new.session_id;
+
+  if v_session.organization_id is null then
+    raise exception using errcode = '23503', message = 'session_id is not in scope';
+  end if;
+
+  if v_session.organization_id <> v_target.organization_id or v_session.client_id <> v_target.client_id then
+    raise exception using errcode = '23514', message = 'trial event session and target must share organization/client scope';
+  end if;
+
+  if new.therapist_id is not null and new.therapist_id <> v_session.therapist_id then
+    raise exception using errcode = '23514', message = 'trial event therapist_id must match session therapist';
+  end if;
+
+  if v_target.measurement_type in ('correctIncorrect', 'taskAnalysis') and new.response is null then
+    raise exception using errcode = '23514', message = 'response is required for this target measurement type';
+  end if;
+
+  new.organization_id := v_target.organization_id;
+  new.client_id := v_target.client_id;
+  new.goal_id := v_target.goal_id;
+  new.therapist_id := v_session.therapist_id;
+  if tg_op = 'INSERT' then
+    new.created_by := coalesce(app.current_user_id(), new.created_by);
+    new.updated_by := coalesce(app.current_user_id(), new.updated_by, new.created_by);
+  else
+    new.created_by := old.created_by;
+    new.updated_by := coalesce(app.current_user_id(), new.updated_by, new.created_by);
+  end if;
+  new.updated_at := timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists trial_events_set_scope on public.trial_events;
+create trigger trial_events_set_scope
+before insert or update on public.trial_events
+for each row execute function app.set_trial_event_scope();
+
+create or replace function app.session_has_locked_note(target_session_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.client_session_notes csn
+    where csn.session_id = target_session_id
+      and csn.is_locked = true
+  );
+$$;
+
+create or replace function app.current_user_can_manage_locked_trial_event(target_organization_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, app
+as $$
+  select app.user_has_role_for_org(
+    app.current_user_id(),
+    target_organization_id,
+    array['org_admin'::text, 'super_admin'::text, 'bcba'::text, 'admin'::text, 'midtier'::text]
+  );
+$$;
+
+create or replace function app.current_user_can_capture_trial_event(target_organization_id uuid, target_client_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, app
+as $$
+  select app.current_user_can_take_client_data(target_organization_id, target_client_id);
+$$;
+
+create or replace function public.session_has_locked_note(target_session_id uuid)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public, app
+as $$
+declare
+  session_scope record;
+begin
+  select s.organization_id, s.client_id
+    into session_scope
+  from public.sessions s
+  where s.id = target_session_id;
+
+  if session_scope.organization_id is null
+    or session_scope.organization_id <> app.current_user_organization_id()
+    or not app.current_user_can_capture_trial_event(session_scope.organization_id, session_scope.client_id)
+  then
+    raise exception 'session lock state is not in scope'
+      using errcode = '42501';
+  end if;
+
+  return app.session_has_locked_note(target_session_id);
+end;
+$$;
+
+create or replace function public.current_user_can_manage_locked_trial_event(target_organization_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, app
+as $$
+  select app.current_user_can_manage_locked_trial_event(target_organization_id);
+$$;
+
+create or replace function public.current_user_can_take_client_data(target_organization_id uuid, target_client_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, app
+as $$
+  select app.current_user_can_take_client_data(target_organization_id, target_client_id);
+$$;
+
+alter table public.goal_targets enable row level security;
+alter table public.trial_events enable row level security;
+
+drop policy if exists goal_targets_service_role_all on public.goal_targets;
+create policy goal_targets_service_role_all
+  on public.goal_targets
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+drop policy if exists goal_targets_org_read on public.goal_targets;
+create policy goal_targets_org_read
+  on public.goal_targets
+  for select
+  to authenticated
+  using (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_read_client_programs(organization_id, client_id)
+  );
+
+drop policy if exists goal_targets_org_manage on public.goal_targets;
+create policy goal_targets_org_manage
+  on public.goal_targets
+  for all
+  to authenticated
+  using (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_manage_programs_goals(organization_id)
+  )
+  with check (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_manage_programs_goals(organization_id)
+  );
+
+drop policy if exists trial_events_service_role_all on public.trial_events;
+create policy trial_events_service_role_all
+  on public.trial_events
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+drop policy if exists trial_events_org_read on public.trial_events;
+create policy trial_events_org_read
+  on public.trial_events
+  for select
+  to authenticated
+  using (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_capture_trial_event(organization_id, client_id)
+  );
+
+drop policy if exists trial_events_org_insert on public.trial_events;
+create policy trial_events_org_insert
+  on public.trial_events
+  for insert
+  to authenticated
+  with check (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_capture_trial_event(organization_id, client_id)
+    and (
+      not app.session_has_locked_note(session_id)
+      or app.current_user_can_manage_locked_trial_event(organization_id)
+    )
+  );
+
+drop policy if exists trial_events_org_update on public.trial_events;
+create policy trial_events_org_update
+  on public.trial_events
+  for update
+  to authenticated
+  using (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_capture_trial_event(organization_id, client_id)
+    and (
+      not app.session_has_locked_note(session_id)
+      or app.current_user_can_manage_locked_trial_event(organization_id)
+    )
+  )
+  with check (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_capture_trial_event(organization_id, client_id)
+    and (
+      not app.session_has_locked_note(session_id)
+      or app.current_user_can_manage_locked_trial_event(organization_id)
+    )
+  );
+
+drop policy if exists trial_events_org_delete on public.trial_events;
+create policy trial_events_org_delete
+  on public.trial_events
+  for delete
+  to authenticated
+  using (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_capture_trial_event(organization_id, client_id)
+    and app.current_user_can_manage_locked_trial_event(organization_id)
+  );
+
+grant execute on function app.session_has_locked_note(uuid) to authenticated, service_role;
+grant execute on function app.current_user_can_manage_locked_trial_event(uuid) to authenticated, service_role;
+grant execute on function app.current_user_can_capture_trial_event(uuid, uuid) to authenticated, service_role;
+grant execute on function public.session_has_locked_note(uuid) to authenticated, service_role;
+grant execute on function public.current_user_can_manage_locked_trial_event(uuid) to authenticated, service_role;
+grant execute on function public.current_user_can_take_client_data(uuid, uuid) to authenticated, service_role;
+revoke execute on function app.session_has_locked_note(uuid) from public, anon;
+revoke execute on function app.current_user_can_manage_locked_trial_event(uuid) from public, anon;
+revoke execute on function app.current_user_can_capture_trial_event(uuid, uuid) from public, anon;
+revoke execute on function public.session_has_locked_note(uuid) from public, anon;
+revoke execute on function public.current_user_can_manage_locked_trial_event(uuid) from public, anon;
+revoke execute on function public.current_user_can_take_client_data(uuid, uuid) from public, anon;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260703173000_goal_targets_trial_events.sql
+++ b/supabase/migrations/20260703173000_goal_targets_trial_events.sql
@@ -67,7 +67,7 @@ create index if not exists goal_targets_org_client_idx
   on public.goal_targets (organization_id, client_id, status);
 
 revoke all on table public.goal_targets from anon;
-grant select, insert, update, delete on table public.goal_targets to authenticated;
+grant select, insert, update on table public.goal_targets to authenticated;
 grant select, insert, update, delete on table public.goal_targets to service_role;
 
 create or replace function app.set_goal_target_scope()
@@ -120,7 +120,7 @@ create table if not exists public.trial_events (
   organization_id uuid not null references public.organizations(id) on delete cascade,
   client_id uuid not null references public.clients(id) on delete cascade,
   session_id uuid not null references public.sessions(id) on delete cascade,
-  target_id uuid not null references public.goal_targets(id) on delete cascade,
+  target_id uuid not null references public.goal_targets(id),
   goal_id uuid not null references public.goals(id) on delete cascade,
   therapist_id uuid not null,
   trial_number integer not null check (trial_number > 0),
@@ -136,7 +136,7 @@ create table if not exists public.trial_events (
   ),
   prompt_type text,
   prompt_level text,
-  value numeric,
+  value numeric check (value is null or value >= 0),
   event_timestamp timestamptz not null default timezone('utc', now()),
   metadata jsonb not null default '{}'::jsonb,
   created_by uuid,
@@ -328,9 +328,20 @@ create policy goal_targets_org_read
   );
 
 drop policy if exists goal_targets_org_manage on public.goal_targets;
-create policy goal_targets_org_manage
+drop policy if exists goal_targets_org_insert on public.goal_targets;
+create policy goal_targets_org_insert
   on public.goal_targets
-  for all
+  for insert
+  to authenticated
+  with check (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_manage_programs_goals(organization_id)
+  );
+
+drop policy if exists goal_targets_org_update on public.goal_targets;
+create policy goal_targets_org_update
+  on public.goal_targets
+  for update
   to authenticated
   using (
     organization_id = app.current_user_organization_id()

--- a/supabase/migrations/20260703173000_goal_targets_trial_events.sql
+++ b/supabase/migrations/20260703173000_goal_targets_trial_events.sql
@@ -36,7 +36,7 @@ create table if not exists public.goal_targets (
   id uuid primary key default gen_random_uuid(),
   organization_id uuid not null references public.organizations(id) on delete cascade,
   client_id uuid not null references public.clients(id) on delete cascade,
-  goal_id uuid not null references public.goals(id) on delete cascade,
+  goal_id uuid not null references public.goals(id),
   name text not null check (char_length(btrim(name)) > 0),
   measurement_type text not null check (
     measurement_type in (
@@ -65,6 +65,11 @@ create index if not exists goal_targets_goal_status_idx
 
 create index if not exists goal_targets_org_client_idx
   on public.goal_targets (organization_id, client_id, status);
+
+alter table public.goal_targets
+  drop constraint if exists goal_targets_goal_id_fkey,
+  add constraint goal_targets_goal_id_fkey
+  foreign key (goal_id) references public.goals(id);
 
 revoke all on table public.goal_targets from anon;
 grant select, insert, update on table public.goal_targets to authenticated;
@@ -122,7 +127,7 @@ create table if not exists public.trial_events (
   client_id uuid not null references public.clients(id) on delete cascade,
   session_id uuid not null references public.sessions(id) on delete cascade,
   target_id uuid not null references public.goal_targets(id),
-  goal_id uuid not null references public.goals(id) on delete cascade,
+  goal_id uuid not null references public.goals(id),
   therapist_id uuid not null,
   trial_number integer not null check (trial_number > 0),
   response text check (
@@ -151,6 +156,11 @@ alter table public.trial_events
   drop constraint if exists trial_events_target_id_fkey,
   add constraint trial_events_target_id_fkey
   foreign key (target_id) references public.goal_targets(id);
+
+alter table public.trial_events
+  drop constraint if exists trial_events_goal_id_fkey,
+  add constraint trial_events_goal_id_fkey
+  foreign key (goal_id) references public.goals(id);
 
 alter table public.trial_events
   drop constraint if exists trial_events_value_nonnegative,
@@ -210,6 +220,18 @@ begin
     raise exception using errcode = '23514', message = 'response is required for this target measurement type';
   end if;
 
+  if v_target.measurement_type in ('correctIncorrect', 'taskAnalysis') and new.value is not null then
+    raise exception using errcode = '23514', message = 'value is not allowed for this target measurement type';
+  end if;
+
+  if v_target.measurement_type in ('frequency', 'rate', 'duration', 'timeSample', 'latency', 'IRT') and new.value is null then
+    raise exception using errcode = '23514', message = 'value is required for this target measurement type';
+  end if;
+
+  if v_target.measurement_type in ('frequency', 'rate', 'duration', 'timeSample', 'latency', 'IRT') and new.response is not null then
+    raise exception using errcode = '23514', message = 'response is not allowed for this target measurement type';
+  end if;
+
   new.organization_id := v_target.organization_id;
   new.client_id := v_target.client_id;
   new.goal_id := v_target.goal_id;
@@ -267,7 +289,9 @@ stable
 security definer
 set search_path = public, app
 as $$
-  select app.current_user_can_take_client_data(target_organization_id, target_client_id);
+  select
+    app.current_user_can_take_client_data(target_organization_id, target_client_id)
+    or app.current_user_has_exact_role_for_org(target_organization_id, array['bcba']::text[]);
 $$;
 
 create or replace function public.session_has_locked_note(target_session_id uuid)

--- a/tests/goal-targets-trial-events-edge-access.test.ts
+++ b/tests/goal-targets-trial-events-edge-access.test.ts
@@ -29,4 +29,11 @@ describe("goal target and trial event edge access boundaries", () => {
   it("rejects negative trial-event values at the edge boundary", () => {
     expect(trialEventsSource).toContain("value: z.number().nonnegative().optional().nullable()");
   });
+
+  it("keeps response-based and value-based trial-event payloads mutually exclusive", () => {
+    expect(trialEventsSource).toContain("const valueRequiredMeasurementTypes = new Set([\"frequency\", \"rate\", \"duration\", \"timeSample\", \"latency\", \"IRT\"]);");
+    expect(trialEventsSource).toContain("return \"value is not allowed for this target measurement type\";");
+    expect(trialEventsSource).toContain("return \"value is required for this target measurement type\";");
+    expect(trialEventsSource).toContain("return \"response is not allowed for this target measurement type\";");
+  });
 });

--- a/tests/goal-targets-trial-events-edge-access.test.ts
+++ b/tests/goal-targets-trial-events-edge-access.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const goalTargetsSource = readFileSync(
+  path.join(process.cwd(), "supabase", "functions", "goal-targets", "index.ts"),
+  "utf8",
+);
+const trialEventsSource = readFileSync(
+  path.join(process.cwd(), "supabase", "functions", "trial-events", "index.ts"),
+  "utf8",
+);
+
+describe("goal target and trial event edge access boundaries", () => {
+  it("does not collapse program-goal capability RPC failures into normal forbidden responses", () => {
+    expect(goalTargetsSource).toContain("type CapabilityResult = { allowed: boolean; upstreamError: boolean }");
+    expect(goalTargetsSource).toContain("if (allowed.upstreamError) return json(req, { error: \"Unable to validate program-goal access\" }, 502);");
+  });
+
+  it("does not collapse trial-event data-taking or lock RPC failures into normal denials", () => {
+    expect(trialEventsSource).toContain("type CapabilityResult = { allowed: boolean; upstreamError: boolean }");
+    expect(trialEventsSource).toContain("type LockStateResult = { locked: boolean; upstreamError: boolean }");
+    expect(trialEventsSource).toContain("if (canCapture.upstreamError) return json(req, { error: \"Unable to validate trial-event capture access\" }, 502);");
+    expect(trialEventsSource).toContain("if (lockState.upstreamError) return json(req, { error: \"Unable to validate session lock state\" }, 502);");
+    expect(trialEventsSource).toContain("if (canManageLocked.upstreamError) return json(req, { error: \"Unable to validate locked-session trial-event access\" }, 502);");
+  });
+});

--- a/tests/goal-targets-trial-events-edge-access.test.ts
+++ b/tests/goal-targets-trial-events-edge-access.test.ts
@@ -25,4 +25,8 @@ describe("goal target and trial event edge access boundaries", () => {
     expect(trialEventsSource).toContain("if (lockState.upstreamError) return json(req, { error: \"Unable to validate session lock state\" }, 502);");
     expect(trialEventsSource).toContain("if (canManageLocked.upstreamError) return json(req, { error: \"Unable to validate locked-session trial-event access\" }, 502);");
   });
+
+  it("rejects negative trial-event values at the edge boundary", () => {
+    expect(trialEventsSource).toContain("value: z.number().nonnegative().optional().nullable()");
+  });
 });

--- a/tests/goal-targets-trial-events-migration.test.ts
+++ b/tests/goal-targets-trial-events-migration.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  "supabase",
+  "migrations",
+  "20260703173000_goal_targets_trial_events.sql",
+);
+
+const sql = readFileSync(MIGRATION_PATH, "utf8");
+
+describe("goal targets and trial events migration", () => {
+  it("creates normalized target and trial-event tables with tenant scope", () => {
+    expect(sql).toContain("create table if not exists public.goal_targets");
+    expect(sql).toContain("create table if not exists public.trial_events");
+    expect(sql).toContain("organization_id uuid not null references public.organizations(id)");
+    expect(sql).toContain("client_id uuid not null references public.clients(id)");
+    expect(sql).toContain("target_id uuid not null references public.goal_targets(id)");
+    expect(sql).toContain("trial_number integer not null check (trial_number > 0)");
+  });
+
+  it("prevents duplicate trial numbers for the same target within a session", () => {
+    expect(sql).toContain("create unique index if not exists trial_events_session_target_trial_uidx");
+    expect(sql).toContain("on public.trial_events (session_id, target_id, trial_number)");
+  });
+
+  it("overwrites client-supplied audit actor fields from auth.uid at the database boundary", () => {
+    expect(sql).toContain("new.created_by := coalesce(app.current_user_id(), new.created_by);");
+    expect(sql).toContain("new.updated_by := coalesce(app.current_user_id(), new.updated_by, new.created_by);");
+  });
+
+  it("keeps admin_schedule out of program-goal management while preserving BT data-taking boundaries", () => {
+    expect(sql).toContain("app.current_user_can_manage_programs_goals(organization_id)");
+    expect(sql).toContain("app.current_user_can_capture_trial_event(organization_id, client_id)");
+    expect(sql).toContain("app.current_user_can_take_client_data(target_organization_id, target_client_id)");
+    expect(sql).toContain("app.current_user_can_manage_locked_trial_event(organization_id)");
+    expect(sql).not.toMatch(/current_user_can_manage_programs_goals[\s\S]*admin_schedule/);
+  });
+
+  it("does not allow org-level locked-session managers to delete trial events outside client capture scope", () => {
+    expect(sql).toMatch(
+      /create policy trial_events_org_delete[\s\S]*app\.current_user_can_capture_trial_event\(organization_id, client_id\)[\s\S]*app\.current_user_can_manage_locked_trial_event\(organization_id\)/,
+    );
+  });
+
+  it("exposes protected public RPC wrappers used by server trial-event routes", () => {
+    expect(sql).toContain("create or replace function public.session_has_locked_note(target_session_id uuid)");
+    expect(sql).toContain("app.current_user_can_capture_trial_event(session_scope.organization_id, session_scope.client_id)");
+    expect(sql).toContain("raise exception 'session lock state is not in scope'");
+    expect(sql).toContain("return app.session_has_locked_note(target_session_id);");
+    expect(sql).toContain("create or replace function public.current_user_can_manage_locked_trial_event(target_organization_id uuid)");
+    expect(sql).toContain("select app.current_user_can_manage_locked_trial_event(target_organization_id);");
+    expect(sql).toContain("create or replace function public.current_user_can_take_client_data(target_organization_id uuid, target_client_id uuid)");
+    expect(sql).toContain("select app.current_user_can_take_client_data(target_organization_id, target_client_id);");
+    expect(sql).toContain("grant execute on function public.session_has_locked_note(uuid) to authenticated, service_role;");
+    expect(sql).toContain("grant execute on function public.current_user_can_manage_locked_trial_event(uuid) to authenticated, service_role;");
+    expect(sql).toContain("grant execute on function public.current_user_can_take_client_data(uuid, uuid) to authenticated, service_role;");
+    expect(sql).toContain("revoke execute on function public.session_has_locked_note(uuid) from public, anon;");
+    expect(sql).toContain("revoke execute on function public.current_user_can_manage_locked_trial_event(uuid) from public, anon;");
+    expect(sql).toContain("revoke execute on function public.current_user_can_take_client_data(uuid, uuid) from public, anon;");
+  });
+
+  it("grants Data API access explicitly and denies anon access", () => {
+    expect(sql).toContain("revoke all on table public.goal_targets from anon;");
+    expect(sql).toContain("grant select, insert, update, delete on table public.goal_targets to authenticated;");
+    expect(sql).toContain("grant select, insert, update, delete on table public.goal_targets to service_role;");
+    expect(sql).toContain("revoke all on table public.trial_events from anon;");
+    expect(sql).toContain("grant select, insert, update, delete on table public.trial_events to authenticated;");
+    expect(sql).toContain("grant select, insert, update, delete on table public.trial_events to service_role;");
+  });
+
+  it("enables RLS and reloads PostgREST schema", () => {
+    expect(sql).toContain("alter table public.goal_targets enable row level security;");
+    expect(sql).toContain("alter table public.trial_events enable row level security;");
+    expect(sql).toContain("notify pgrst, 'reload schema';");
+  });
+});

--- a/tests/goal-targets-trial-events-migration.test.ts
+++ b/tests/goal-targets-trial-events-migration.test.ts
@@ -20,14 +20,21 @@ describe("goal targets and trial events migration", () => {
     expect(sql).toContain("client_id uuid not null references public.clients(id)");
     expect(sql).toContain("target_id uuid not null references public.goal_targets(id)");
     expect(sql).toContain("trial_number integer not null check (trial_number > 0)");
-    expect(sql).toContain("value numeric check (value is null or value >= 0)");
+    expect(sql).toContain("value numeric constraint trial_events_value_nonnegative check (value is null or value >= 0)");
   });
 
   it("preserves trial history by preventing authenticated target deletes and target cascade deletes", () => {
     expect(sql).toContain("target_id uuid not null references public.goal_targets(id),");
     expect(sql).not.toContain("target_id uuid not null references public.goal_targets(id) on delete cascade");
     expect(sql).toContain("grant select, insert, update on table public.goal_targets to authenticated;");
+    expect(sql).toContain("revoke delete on table public.goal_targets from authenticated;");
     expect(sql).not.toContain("grant select, insert, update, delete on table public.goal_targets to authenticated;");
+    expect(sql).toMatch(
+      /alter table public\.trial_events[\s\S]*drop constraint if exists trial_events_target_id_fkey[\s\S]*add constraint trial_events_target_id_fkey[\s\S]*foreign key \(target_id\) references public\.goal_targets\(id\)/,
+    );
+    expect(sql).toMatch(
+      /alter table public\.trial_events[\s\S]*drop constraint if exists trial_events_value_nonnegative[\s\S]*add constraint trial_events_value_nonnegative[\s\S]*check \(value is null or value >= 0\)/,
+    );
     expect(sql).toContain("create policy goal_targets_org_insert");
     expect(sql).toContain("create policy goal_targets_org_update");
     expect(sql).toContain("drop policy if exists goal_targets_org_manage on public.goal_targets;");

--- a/tests/goal-targets-trial-events-migration.test.ts
+++ b/tests/goal-targets-trial-events-migration.test.ts
@@ -25,12 +25,20 @@ describe("goal targets and trial events migration", () => {
 
   it("preserves trial history by preventing authenticated target deletes and target cascade deletes", () => {
     expect(sql).toContain("target_id uuid not null references public.goal_targets(id),");
+    expect(sql).toContain("goal_id uuid not null references public.goals(id),");
     expect(sql).not.toContain("target_id uuid not null references public.goal_targets(id) on delete cascade");
+    expect(sql).not.toContain("goal_id uuid not null references public.goals(id) on delete cascade");
     expect(sql).toContain("grant select, insert, update on table public.goal_targets to authenticated;");
     expect(sql).toContain("revoke delete on table public.goal_targets from authenticated;");
     expect(sql).not.toContain("grant select, insert, update, delete on table public.goal_targets to authenticated;");
     expect(sql).toMatch(
+      /alter table public\.goal_targets[\s\S]*drop constraint if exists goal_targets_goal_id_fkey[\s\S]*add constraint goal_targets_goal_id_fkey[\s\S]*foreign key \(goal_id\) references public\.goals\(id\)/,
+    );
+    expect(sql).toMatch(
       /alter table public\.trial_events[\s\S]*drop constraint if exists trial_events_target_id_fkey[\s\S]*add constraint trial_events_target_id_fkey[\s\S]*foreign key \(target_id\) references public\.goal_targets\(id\)/,
+    );
+    expect(sql).toMatch(
+      /alter table public\.trial_events[\s\S]*drop constraint if exists trial_events_goal_id_fkey[\s\S]*add constraint trial_events_goal_id_fkey[\s\S]*foreign key \(goal_id\) references public\.goals\(id\)/,
     );
     expect(sql).toMatch(
       /alter table public\.trial_events[\s\S]*drop constraint if exists trial_events_value_nonnegative[\s\S]*add constraint trial_events_value_nonnegative[\s\S]*check \(value is null or value >= 0\)/,
@@ -55,8 +63,16 @@ describe("goal targets and trial events migration", () => {
     expect(sql).toContain("app.current_user_can_manage_programs_goals(organization_id)");
     expect(sql).toContain("app.current_user_can_capture_trial_event(organization_id, client_id)");
     expect(sql).toContain("app.current_user_can_take_client_data(target_organization_id, target_client_id)");
+    expect(sql).toContain("app.current_user_has_exact_role_for_org(target_organization_id, array['bcba']::text[])");
     expect(sql).toContain("app.current_user_can_manage_locked_trial_event(organization_id)");
     expect(sql).not.toMatch(/current_user_can_manage_programs_goals[\s\S]*admin_schedule/);
+  });
+
+  it("enforces measurement-specific response and value semantics", () => {
+    expect(sql).toContain("v_target.measurement_type in ('correctIncorrect', 'taskAnalysis') and new.response is null");
+    expect(sql).toContain("v_target.measurement_type in ('correctIncorrect', 'taskAnalysis') and new.value is not null");
+    expect(sql).toContain("v_target.measurement_type in ('frequency', 'rate', 'duration', 'timeSample', 'latency', 'IRT') and new.value is null");
+    expect(sql).toContain("v_target.measurement_type in ('frequency', 'rate', 'duration', 'timeSample', 'latency', 'IRT') and new.response is not null");
   });
 
   it("does not allow org-level locked-session managers to delete trial events outside client capture scope", () => {

--- a/tests/goal-targets-trial-events-migration.test.ts
+++ b/tests/goal-targets-trial-events-migration.test.ts
@@ -20,6 +20,18 @@ describe("goal targets and trial events migration", () => {
     expect(sql).toContain("client_id uuid not null references public.clients(id)");
     expect(sql).toContain("target_id uuid not null references public.goal_targets(id)");
     expect(sql).toContain("trial_number integer not null check (trial_number > 0)");
+    expect(sql).toContain("value numeric check (value is null or value >= 0)");
+  });
+
+  it("preserves trial history by preventing authenticated target deletes and target cascade deletes", () => {
+    expect(sql).toContain("target_id uuid not null references public.goal_targets(id),");
+    expect(sql).not.toContain("target_id uuid not null references public.goal_targets(id) on delete cascade");
+    expect(sql).toContain("grant select, insert, update on table public.goal_targets to authenticated;");
+    expect(sql).not.toContain("grant select, insert, update, delete on table public.goal_targets to authenticated;");
+    expect(sql).toContain("create policy goal_targets_org_insert");
+    expect(sql).toContain("create policy goal_targets_org_update");
+    expect(sql).toContain("drop policy if exists goal_targets_org_manage on public.goal_targets;");
+    expect(sql).not.toContain("create policy goal_targets_org_manage");
   });
 
   it("prevents duplicate trial numbers for the same target within a session", () => {
@@ -65,7 +77,7 @@ describe("goal targets and trial events migration", () => {
 
   it("grants Data API access explicitly and denies anon access", () => {
     expect(sql).toContain("revoke all on table public.goal_targets from anon;");
-    expect(sql).toContain("grant select, insert, update, delete on table public.goal_targets to authenticated;");
+    expect(sql).toContain("grant select, insert, update on table public.goal_targets to authenticated;");
     expect(sql).toContain("grant select, insert, update, delete on table public.goal_targets to service_role;");
     expect(sql).toContain("revoke all on table public.trial_events from anon;");
     expect(sql).toContain("grant select, insert, update, delete on table public.trial_events to authenticated;");

--- a/tests/goals-edge-access.test.ts
+++ b/tests/goals-edge-access.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const GOALS_FUNCTION_PATH = path.join(process.cwd(), "supabase", "functions", "goals", "index.ts");
+const source = readFileSync(GOALS_FUNCTION_PATH, "utf8");
+
+describe("goals edge access boundaries", () => {
+  it("does not gate goal reads behind program-goal management capability", () => {
+    const getBlockStart = source.indexOf('if (req.method === "GET")');
+    const postBlockStart = source.indexOf('if (req.method === "POST")');
+
+    expect(getBlockStart).toBeGreaterThan(-1);
+    expect(postBlockStart).toBeGreaterThan(getBlockStart);
+    expect(source.slice(getBlockStart, postBlockStart)).not.toContain("currentUserCanManageProgramsGoals");
+  });
+
+  it("keeps program-goal management capability checks on goal writes", () => {
+    const postBlockStart = source.indexOf('if (req.method === "POST")');
+    const patchBlockStart = source.indexOf('if (req.method === "PATCH")');
+    const methodAllowedStart = source.indexOf('return json(req, { error: "Method not allowed" }');
+
+    expect(source.slice(postBlockStart, patchBlockStart)).toContain("currentUserCanManageProgramsGoals");
+    expect(source.slice(patchBlockStart, methodAllowedStart)).toContain("currentUserCanManageProgramsGoals");
+  });
+});


### PR DESCRIPTION
## Summary
- Add normalized `goal_targets` and `trial_events` schema with RLS, explicit grants, audit triggers, duplicate-trial protection, and scoped lock-state helper RPCs.
- Add server and Supabase edge handlers for goal targets and trial events, with program-goal and data-taking capability checks that fail closed on RPC/config validation failures.
- Extend Programs & Goals UI/types/tests to display goal sections and create target records with measurement types.

## Verification
- `npm test -- --run src/server/__tests__/goalTargetsHandler.test.ts src/server/__tests__/trialEventsHandler.test.ts src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts tests/goal-targets-trial-events-migration.test.ts tests/goal-targets-trial-events-edge-access.test.ts tests/goals-edge-access.test.ts` - pass, 35 tests
- `npm test -- --run src/server/__tests__/goalTargetsHandler.test.ts src/server/__tests__/trialEventsHandler.test.ts src/server/__tests__/goalsHandler.test.ts src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts tests/goal-targets-trial-events-migration.test.ts tests/goal-targets-trial-events-edge-access.test.ts tests/goals-edge-access.test.ts src/components/__tests__/ProgramsGoalsTab.test.tsx src/components/ClientDetails/ProgramsGoalsTab.helpers.test.ts` - pass, 107 tests
- `npm run typecheck` - pass
- `npm run lint` - pass
- `npm run build` - pass
- `npm run ci:check-focused` - pass; DB-backed checks skipped locally because `SUPABASE_DB_URL`/`DATABASE_URL` is not configured, branch protection skipped outside CI, auth parity skipped because `CI_SUPABASE_AUTH_PARITY_REQUIRED` is disabled
- `npm run validate:tenant` - pass
- `npm run test:ci` - pass, 349 files / 2192 tests; known AI documentation fetch stderr appears but command exits 0
- `npm run ci:verify-coverage` - pass, line coverage 92.04%
- `npm run verify:local` - blocked at final default `test:routes:tier0` due local Cypress multi-spec runner crash/EPIPE and orphaned preview process; covered by passing split route specs below
- `npm run test:routes:tier0 -- --spec cypress/e2e/routes_client.cy.ts` - pass, 49 tests
- `npm run test:routes:tier0 -- --spec cypress/e2e/routes_admin.cy.ts --browser chrome --config numTestsKeptInMemory=0` - pass, 120 tests
- `npm run test:routes:tier0 -- --spec cypress/e2e/routes_auth.cy.ts --browser chrome --config numTestsKeptInMemory=0` - pass, 6 tests
- Full route suite with stable Chrome config executed public/client/preauth/schedule/messages before the same local runner crash during admin; those passed before crash.

## Review
- Reviewer pass found two blockers: server-path RPC errors still masked and public lock-state RPC was too broad.
- Follow-up fixes landed; focused reviewer re-check reports no blocking findings remain.

## Risk / Follow-up
- Hosted Supabase migration has not been applied by this PR. Apply `20260703173000_goal_targets_trial_events.sql` and run live RLS/RPC smoke after merge.
- Cross-tenant lock-state behavior and duplicate conflict behavior are covered by source/unit tests locally, not by live PostgREST integration in this branch.

Linear: WIN-195