### PR TITLE
WIN-195 Represent session appointment metadata

### DIFF
--- a/src/lib/__tests__/sessionHolds.test.ts
+++ b/src/lib/__tests__/sessionHolds.test.ts
@@ -349,6 +349,57 @@ describe("session holds API helpers", () => {
     });
   });
 
+  it("serializes appointment identity and session metadata in confirmation requests", async () => {
+    mockedCallEdge.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        data: {
+          session: {
+            id: "session-appointment",
+            appointment_id: "11111111-1111-4111-8111-111111111111",
+            therapist_id: "therapist",
+            client_id: "client",
+            start_time: "2025-01-01T00:00:00Z",
+            end_time: "2025-01-01T01:00:00Z",
+            status: "scheduled",
+            notes: null,
+            metadata: { source: "schedule-modal" },
+            created_at: "2025-01-01T00:00:00Z",
+            created_by: "user-1",
+            updated_at: "2025-01-01T00:00:00Z",
+            updated_by: "user-1",
+          },
+          roundedDurationMinutes: 60,
+        },
+      }),
+    );
+
+    await confirmSessionBooking({
+      holdKey: "hold-key",
+      session: {
+        appointment_id: "11111111-1111-4111-8111-111111111111",
+        appointmentId: "11111111-1111-4111-8111-111111111111",
+        therapist_id: "therapist",
+        client_id: "client",
+        start_time: "2025-01-01T00:00:00Z",
+        end_time: "2025-01-01T01:00:00Z",
+        metadata: { source: "schedule-modal", externalAppointmentId: "apt-123" },
+      },
+      startTimeOffsetMinutes: 0,
+      endTimeOffsetMinutes: 0,
+      timeZone: "UTC",
+      accessToken: ACCESS_TOKEN,
+    });
+
+    const edgeRequest = mockedCallEdge.mock.calls[0]?.[1];
+    const body = JSON.parse(String(edgeRequest?.body));
+    expect(body.session).toMatchObject({
+      appointment_id: "11111111-1111-4111-8111-111111111111",
+      appointmentId: "11111111-1111-4111-8111-111111111111",
+      metadata: { source: "schedule-modal", externalAppointmentId: "apt-123" },
+    });
+  });
+
   it("normalizes duration_minutes using roundedDurationMinutes when provided", async () => {
     mockedCallEdge.mockResolvedValueOnce(
       jsonResponse({

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -5422,6 +5422,7 @@ export type Database = {
       }
       sessions: {
         Row: {
+          appointment_id: string | null
           client_id: string
           created_at: string | null
           created_by: string | null
@@ -5431,6 +5432,7 @@ export type Database = {
           has_transcription_consent: boolean
           id: string
           location_type: string | null
+          metadata: Json
           notes: string | null
           organization_id: string
           program_id: string | null
@@ -5446,6 +5448,7 @@ export type Database = {
           updated_by: string | null
         }
         Insert: {
+          appointment_id?: string | null
           client_id: string
           created_at?: string | null
           created_by?: string | null
@@ -5455,6 +5458,7 @@ export type Database = {
           has_transcription_consent?: boolean
           id?: string
           location_type?: string | null
+          metadata?: Json
           notes?: string | null
           organization_id: string
           program_id?: string | null
@@ -5470,6 +5474,7 @@ export type Database = {
           updated_by?: string | null
         }
         Update: {
+          appointment_id?: string | null
           client_id?: string
           created_at?: string | null
           created_by?: string | null
@@ -5479,6 +5484,7 @@ export type Database = {
           has_transcription_consent?: boolean
           id?: string
           location_type?: string | null
+          metadata?: Json
           notes?: string | null
           organization_id?: string
           program_id?: string | null

--- a/src/server/__tests__/bookSession.test.ts
+++ b/src/server/__tests__/bookSession.test.ts
@@ -222,6 +222,72 @@ describe("bookSession", () => {
     );
   });
 
+  it("forwards appointment identity and session metadata to confirmation", async () => {
+    const bookSession = await importBookSession();
+    mockedRequestSessionHold.mockResolvedValueOnce({
+      holdKey: "hold-key",
+      holdId: "hold-id",
+      startTime: basePayload.session.start_time,
+      endTime: basePayload.session.end_time,
+      expiresAt: "2025-01-01T00:05:00Z",
+      holds: [
+        {
+          holdKey: "hold-key",
+          holdId: "hold-id",
+          startTime: basePayload.session.start_time,
+          endTime: basePayload.session.end_time,
+          expiresAt: "2025-01-01T00:05:00Z",
+        },
+      ],
+    });
+
+    const confirmedSession: Session = {
+      id: "session-with-appointment",
+      appointment_id: "11111111-1111-4111-8111-111111111111",
+      appointmentId: "11111111-1111-4111-8111-111111111111",
+      client_id: basePayload.session.client_id,
+      therapist_id: basePayload.session.therapist_id,
+      program_id: basePayload.session.program_id,
+      goal_id: basePayload.session.goal_id,
+      start_time: basePayload.session.start_time,
+      end_time: basePayload.session.end_time,
+      status: "scheduled",
+      notes: "",
+      metadata: { source: "schedule-modal", externalAppointmentId: "apt-123" },
+      created_at: "2025-01-01T09:00:00Z",
+      created_by: "user-1",
+      updated_at: "2025-01-01T09:00:00Z",
+      updated_by: "user-1",
+      duration_minutes: 60,
+    };
+
+    mockedConfirmSessionBooking.mockResolvedValueOnce({
+      session: confirmedSession,
+      sessions: [confirmedSession],
+      roundedDurationMinutes: confirmedSession.duration_minutes ?? null,
+    });
+
+    await bookSession({
+      ...basePayload,
+      session: {
+        ...basePayload.session,
+        appointment_id: "11111111-1111-4111-8111-111111111111",
+        appointmentId: "11111111-1111-4111-8111-111111111111",
+        metadata: { source: "schedule-modal", externalAppointmentId: "apt-123" },
+      },
+    });
+
+    expect(mockedConfirmSessionBooking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          appointment_id: "11111111-1111-4111-8111-111111111111",
+          appointmentId: "11111111-1111-4111-8111-111111111111",
+          metadata: { source: "schedule-modal", externalAppointmentId: "apt-123" },
+        }),
+      }),
+    );
+  });
+
   it("releases the hold when confirmation fails", async () => {
     const bookSession = await importBookSession();
     mockedRequestSessionHold.mockResolvedValueOnce({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -162,6 +162,8 @@ export interface Client {
 
 export interface Session {
   id: string;
+  appointment_id?: string | null;
+  appointmentId?: string | null;
   client_id: string;
   therapist_id: string;
   program_id: string | null;
@@ -170,6 +172,7 @@ export interface Session {
   end_time: string;
   status: 'scheduled' | 'in_progress' | 'completed' | 'cancelled' | 'no-show';
   notes: string;
+  metadata?: Record<string, unknown>;
   created_at: string;
   created_by: string | null;
   updated_at: string;

--- a/supabase/migrations/20260703173000_goal_targets_trial_events.sql
+++ b/supabase/migrations/20260703173000_goal_targets_trial_events.sql
@@ -12,6 +12,261 @@ alter table public.goals
   add column if not exists baseline text,
   add column if not exists source text not null default 'manual';
 
+alter table public.sessions
+  add column if not exists appointment_id uuid,
+  add column if not exists metadata jsonb not null default '{}'::jsonb;
+
+alter table public.sessions
+  drop constraint if exists sessions_metadata_object_chk,
+  add constraint sessions_metadata_object_chk
+  check (jsonb_typeof(metadata) = 'object');
+
+create index if not exists sessions_appointment_id_idx
+  on public.sessions (appointment_id)
+  where appointment_id is not null;
+
+create or replace function public.confirm_session_hold(
+  p_hold_key uuid,
+  p_session jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_hold public.session_holds;
+  v_session public.sessions;
+  v_session_id uuid;
+  v_appointment_id uuid;
+  v_therapist_id uuid;
+  v_client_id uuid;
+  v_program_id uuid;
+  v_goal_id uuid;
+  v_start timestamptz;
+  v_end timestamptz;
+  v_status text;
+  v_notes text;
+  v_location text;
+  v_session_type text;
+  v_rate numeric;
+  v_total numeric;
+  v_raw_duration numeric;
+  v_duration integer;
+  v_expected_total numeric;
+  v_metadata jsonb;
+  v_cpt_increment constant integer := 15;
+  v_org uuid;
+begin
+  delete from public.session_holds
+  where expires_at <= timezone('utc', now());
+
+  select *
+  into v_hold
+  from public.session_holds
+  where hold_key = p_hold_key
+  for update;
+
+  if not found then
+    return jsonb_build_object('success', false, 'error_code', 'HOLD_NOT_FOUND', 'error_message', 'Hold has expired or does not exist.');
+  end if;
+
+  v_org := v_hold.organization_id;
+
+  v_session_id := nullif(p_session->>'id', '')::uuid;
+  v_appointment_id := coalesce(nullif(p_session->>'appointment_id', '')::uuid, nullif(p_session->>'appointmentId', '')::uuid);
+  v_therapist_id := nullif(p_session->>'therapist_id', '')::uuid;
+  v_client_id := nullif(p_session->>'client_id', '')::uuid;
+  v_program_id := nullif(p_session->>'program_id', '')::uuid;
+  v_goal_id := nullif(p_session->>'goal_id', '')::uuid;
+  v_start := nullif(p_session->>'start_time', '')::timestamptz;
+  v_end := nullif(p_session->>'end_time', '')::timestamptz;
+  v_status := coalesce(nullif(p_session->>'status', ''), 'scheduled');
+  v_notes := nullif(p_session->>'notes', '');
+  v_location := nullif(p_session->>'location_type', '');
+  v_session_type := nullif(p_session->>'session_type', '');
+  v_rate := nullif(p_session->>'rate_per_hour', '')::numeric;
+  v_total := nullif(p_session->>'total_cost', '')::numeric;
+  v_metadata := coalesce(p_session->'metadata', '{}'::jsonb);
+  v_raw_duration := coalesce(
+    nullif(p_session->>'duration_minutes', '')::numeric,
+    (extract(epoch from (v_end - v_start)) / 60)::numeric
+  );
+
+  if jsonb_typeof(v_metadata) <> 'object' then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'INVALID_METADATA', 'error_message', 'Session metadata must be a JSON object.');
+  end if;
+
+  v_duration := greatest(v_cpt_increment, (round(v_raw_duration / v_cpt_increment)::int) * v_cpt_increment);
+
+  if v_therapist_id is null or v_client_id is null or v_start is null or v_end is null then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'MISSING_FIELDS', 'error_message', 'Missing required session fields.');
+  end if;
+
+  if (v_program_id is null) <> (v_goal_id is null) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'MISSING_FIELDS', 'error_message', 'program_id and goal_id must be provided together when clinical goals are attached.');
+  end if;
+
+  if v_rate is not null and v_rate < 0 then
+    return jsonb_build_object('success', false, 'error_code', 'INVALID_FINANCIAL_VALUE', 'error_message', 'rate_per_hour cannot be negative.');
+  end if;
+
+  if v_total is not null and v_total < 0 then
+    return jsonb_build_object('success', false, 'error_code', 'INVALID_FINANCIAL_VALUE', 'error_message', 'total_cost cannot be negative.');
+  end if;
+
+  if v_total is not null and v_rate is not null and v_duration > 0 then
+    v_expected_total := round(((v_rate * v_duration)::numeric / 60), 2);
+    if abs(v_total - v_expected_total) > 0.05 then
+      return jsonb_build_object(
+        'success', false,
+        'error_code', 'INVALID_FINANCIAL_TOTAL',
+        'error_message', 'total_cost must align with rate_per_hour and duration_minutes.',
+        'expected_total_cost', v_expected_total
+      );
+    end if;
+  end if;
+
+  if v_hold.therapist_id <> v_therapist_id or v_hold.start_time <> v_start or v_hold.end_time <> v_end then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'HOLD_MISMATCH', 'error_message', 'Session details do not match the held slot.');
+  end if;
+
+  if v_hold.client_id <> v_client_id then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'CLIENT_MISMATCH', 'error_message', 'Client differs from the hold.');
+  end if;
+
+  if v_hold.expires_at <= timezone('utc', now()) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'HOLD_EXPIRED', 'error_message', 'Hold has expired.');
+  end if;
+
+  if not exists (
+    select 1
+    from public.therapists t
+    where t.id = v_therapist_id
+      and t.organization_id = v_org
+  ) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'FORBIDDEN', 'error_message', 'Therapist not in organization scope.');
+  end if;
+
+  if not exists (
+    select 1
+    from public.clients c
+    where c.id = v_client_id
+      and c.organization_id = v_org
+  ) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'FORBIDDEN', 'error_message', 'Client not in organization scope.');
+  end if;
+
+  if exists (
+    select 1
+    from public.sessions s
+    where s.organization_id = v_org
+      and s.therapist_id = v_therapist_id
+      and (v_session_id is null or s.id <> v_session_id)
+      and s.status <> 'cancelled'
+      and tstzrange(s.start_time, s.end_time, '[)') && tstzrange(v_start, v_end, '[)')
+  ) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'THERAPIST_CONFLICT', 'error_message', 'Therapist already has a session during this time.');
+  end if;
+
+  if exists (
+    select 1
+    from public.sessions s
+    where s.organization_id = v_org
+      and s.client_id = v_client_id
+      and (v_session_id is null or s.id <> v_session_id)
+      and s.status <> 'cancelled'
+      and tstzrange(s.start_time, s.end_time, '[)') && tstzrange(v_start, v_end, '[)')
+  ) then
+    delete from public.session_holds where id = v_hold.id;
+    return jsonb_build_object('success', false, 'error_code', 'CLIENT_CONFLICT', 'error_message', 'Client already has a session during this time.');
+  end if;
+
+  if v_session_id is null then
+    insert into public.sessions (
+      appointment_id,
+      organization_id,
+      therapist_id,
+      client_id,
+      program_id,
+      goal_id,
+      start_time,
+      end_time,
+      status,
+      notes,
+      location_type,
+      session_type,
+      rate_per_hour,
+      total_cost,
+      duration_minutes,
+      metadata
+    )
+    values (
+      v_appointment_id,
+      v_org,
+      v_therapist_id,
+      v_client_id,
+      v_program_id,
+      v_goal_id,
+      v_start,
+      v_end,
+      v_status,
+      v_notes,
+      v_location,
+      v_session_type,
+      v_rate,
+      v_total,
+      v_duration,
+      v_metadata
+    )
+    returning * into v_session;
+  else
+    update public.sessions
+    set
+      appointment_id = v_appointment_id,
+      organization_id = v_org,
+      therapist_id = v_therapist_id,
+      client_id = v_client_id,
+      program_id = v_program_id,
+      goal_id = v_goal_id,
+      start_time = v_start,
+      end_time = v_end,
+      status = v_status,
+      notes = v_notes,
+      location_type = v_location,
+      session_type = v_session_type,
+      rate_per_hour = v_rate,
+      total_cost = v_total,
+      duration_minutes = v_duration,
+      metadata = v_metadata
+    where id = v_session_id
+      and organization_id = v_org
+    returning * into v_session;
+
+    if not found then
+      return jsonb_build_object(
+        'success', false,
+        'error_code', 'SESSION_NOT_FOUND',
+        'error_message', 'Session not found in organization scope.'
+      );
+    end if;
+  end if;
+
+  delete from public.session_holds where id = v_hold.id;
+
+  return jsonb_build_object('success', true, 'session', row_to_json(v_session));
+end;
+$$;
+
 update public.goals
 set baseline = baseline_data
 where baseline is null

--- a/supabase/migrations/20260703173000_goal_targets_trial_events.sql
+++ b/supabase/migrations/20260703173000_goal_targets_trial_events.sql
@@ -55,6 +55,8 @@ declare
   v_duration integer;
   v_expected_total numeric;
   v_metadata jsonb;
+  v_has_appointment_id boolean;
+  v_has_metadata boolean;
   v_cpt_increment constant integer := 15;
   v_org uuid;
 begin
@@ -74,6 +76,8 @@ begin
   v_org := v_hold.organization_id;
 
   v_session_id := nullif(p_session->>'id', '')::uuid;
+  v_has_appointment_id := (p_session ? 'appointment_id') or (p_session ? 'appointmentId');
+  v_has_metadata := p_session ? 'metadata';
   v_appointment_id := coalesce(nullif(p_session->>'appointment_id', '')::uuid, nullif(p_session->>'appointmentId', '')::uuid);
   v_therapist_id := nullif(p_session->>'therapist_id', '')::uuid;
   v_client_id := nullif(p_session->>'client_id', '')::uuid;
@@ -87,13 +91,16 @@ begin
   v_session_type := nullif(p_session->>'session_type', '');
   v_rate := nullif(p_session->>'rate_per_hour', '')::numeric;
   v_total := nullif(p_session->>'total_cost', '')::numeric;
-  v_metadata := coalesce(p_session->'metadata', '{}'::jsonb);
+  v_metadata := case
+    when v_has_metadata then p_session->'metadata'
+    else '{}'::jsonb
+  end;
   v_raw_duration := coalesce(
     nullif(p_session->>'duration_minutes', '')::numeric,
     (extract(epoch from (v_end - v_start)) / 60)::numeric
   );
 
-  if jsonb_typeof(v_metadata) <> 'object' then
+  if v_has_metadata and jsonb_typeof(v_metadata) <> 'object' then
     delete from public.session_holds where id = v_hold.id;
     return jsonb_build_object('success', false, 'error_code', 'INVALID_METADATA', 'error_message', 'Session metadata must be a JSON object.');
   end if;
@@ -232,7 +239,7 @@ begin
   else
     update public.sessions
     set
-      appointment_id = v_appointment_id,
+      appointment_id = case when v_has_appointment_id then v_appointment_id else appointment_id end,
       organization_id = v_org,
       therapist_id = v_therapist_id,
       client_id = v_client_id,
@@ -247,7 +254,7 @@ begin
       rate_per_hour = v_rate,
       total_cost = v_total,
       duration_minutes = v_duration,
-      metadata = v_metadata
+      metadata = case when v_has_metadata then v_metadata else metadata end
     where id = v_session_id
       and organization_id = v_org
     returning * into v_session;

--- a/tests/goal-targets-trial-events-migration.test.ts
+++ b/tests/goal-targets-trial-events-migration.test.ts
@@ -13,6 +13,23 @@ const MIGRATION_PATH = path.join(
 const sql = readFileSync(MIGRATION_PATH, "utf8");
 
 describe("goal targets and trial events migration", () => {
+  it("represents session appointment metadata used by trial-event capture", () => {
+    expect(sql).toContain("alter table public.sessions");
+    expect(sql).toContain("add column if not exists appointment_id uuid");
+    expect(sql).toContain("add column if not exists metadata jsonb not null default '{}'::jsonb");
+    expect(sql).toMatch(
+      /alter table public\.sessions[\s\S]*drop constraint if exists sessions_metadata_object_chk[\s\S]*add constraint sessions_metadata_object_chk[\s\S]*check \(jsonb_typeof\(metadata\) = 'object'\)/,
+    );
+    expect(sql).toMatch(
+      /create index if not exists sessions_appointment_id_idx[\s\S]*on public\.sessions \(appointment_id\)[\s\S]*where appointment_id is not null/,
+    );
+    expect(sql).toMatch(/v_appointment_id := coalesce\(nullif\(p_session->>'appointment_id', ''\)::uuid, nullif\(p_session->>'appointmentId', ''\)::uuid\)/);
+    expect(sql).toContain("v_metadata := coalesce(p_session->'metadata', '{}'::jsonb)");
+    expect(sql).toContain("return jsonb_build_object('success', false, 'error_code', 'INVALID_METADATA'");
+    expect(sql).toMatch(/insert into public\.sessions \([\s\S]*appointment_id[\s\S]*metadata[\s\S]*\)[\s\S]*values \([\s\S]*v_appointment_id[\s\S]*v_metadata/s);
+    expect(sql).toMatch(/update public\.sessions[\s\S]*appointment_id = v_appointment_id[\s\S]*metadata = v_metadata/s);
+  });
+
   it("creates normalized target and trial-event tables with tenant scope", () => {
     expect(sql).toContain("create table if not exists public.goal_targets");
     expect(sql).toContain("create table if not exists public.trial_events");

--- a/tests/goal-targets-trial-events-migration.test.ts
+++ b/tests/goal-targets-trial-events-migration.test.ts
@@ -23,11 +23,13 @@ describe("goal targets and trial events migration", () => {
     expect(sql).toMatch(
       /create index if not exists sessions_appointment_id_idx[\s\S]*on public\.sessions \(appointment_id\)[\s\S]*where appointment_id is not null/,
     );
+    expect(sql).toContain("v_has_appointment_id := (p_session ? 'appointment_id') or (p_session ? 'appointmentId')");
+    expect(sql).toContain("v_has_metadata := p_session ? 'metadata'");
     expect(sql).toMatch(/v_appointment_id := coalesce\(nullif\(p_session->>'appointment_id', ''\)::uuid, nullif\(p_session->>'appointmentId', ''\)::uuid\)/);
-    expect(sql).toContain("v_metadata := coalesce(p_session->'metadata', '{}'::jsonb)");
+    expect(sql).toMatch(/v_metadata := case[\s\S]*when v_has_metadata then p_session->'metadata'[\s\S]*else '\{\}'::jsonb[\s\S]*end/);
     expect(sql).toContain("return jsonb_build_object('success', false, 'error_code', 'INVALID_METADATA'");
     expect(sql).toMatch(/insert into public\.sessions \([\s\S]*appointment_id[\s\S]*metadata[\s\S]*\)[\s\S]*values \([\s\S]*v_appointment_id[\s\S]*v_metadata/s);
-    expect(sql).toMatch(/update public\.sessions[\s\S]*appointment_id = v_appointment_id[\s\S]*metadata = v_metadata/s);
+    expect(sql).toMatch(/update public\.sessions[\s\S]*appointment_id = case when v_has_appointment_id then v_appointment_id else appointment_id end[\s\S]*metadata = case when v_has_metadata then v_metadata else metadata end/s);
   });
 
   it("creates normalized target and trial-event tables with tenant scope", () => {


### PR DESCRIPTION
## Summary
- follow up after #717 to represent Session appointment identity and session metadata in the Goal/Target/TrialEvent data model
- add `sessions.appointment_id` and `sessions.metadata` with object validation and an appointment index
- preserve those fields through `confirm_session_hold` and cover runtime serialization through booking/session-hold tests

## Route / Risk
- Linear: WIN-195
- classification: high-risk human-reviewed
- lane: critical
- protected paths: `supabase/migrations/**`, `src/server/**`
- tenant boundary: no widened cross-tenant access; this only adds nullable appointment linkage and object metadata to existing session rows/RPC persistence

## Verification
- `npm run verify:local` passed on clean branch `codex/session-appointment-metadata`
  - includes `ci:check-focused`, `lint`, `typecheck`, `test:ci`, `ci:verify-coverage`, `build`, `test:routes:tier0`
  - tier-0 Cypress: 212 passing
- local DB-backed checks skipped by policy because `SUPABASE_DB_URL` / `DATABASE_URL` are not configured locally

## Review
- reviewer subagent re-check returned no findings after fixes for RPC persistence, non-null metadata typing, and runtime serialization coverage
