### PR TITLE
WIN-196 tolerate legacy profile org sync guard in admin-create-user

### DIFF
--- a/supabase/functions/admin-create-user/index.ts
+++ b/supabase/functions/admin-create-user/index.ts
@@ -35,6 +35,17 @@ const normalizeUuid = (value: unknown) => {
   return normalized && /^[0-9a-fA-F-]{36}$/.test(normalized) ? normalized : null;
 };
 
+const isProfileOrgImmutableError = (error: unknown) => {
+  if (!error || typeof error !== "object") return false;
+  const maybeCode = "code" in error ? (error as { code?: unknown }).code : null;
+  const maybeMessage = "message" in error ? (error as { message?: unknown }).message : null;
+  return (
+    maybeCode === "42501" &&
+    typeof maybeMessage === "string" &&
+    maybeMessage.includes("organization_id is immutable for this role")
+  );
+};
+
 const parseOrganizationFromMetadata = (metadata: Record<string, unknown> | null | undefined) => {
   if (!metadata || typeof metadata !== "object") return null;
   const snake = metadata["organization_id"];
@@ -177,18 +188,28 @@ const handler = createProtectedRoute(
         return respond(500, { error: "User created, but assigning admin role failed." });
       }
 
+      // Auth metadata + user_roles are authoritative; this profile sync only supports
+      // older readers that still surface profiles.organization_id directly.
       const { data: profileOrgUpdate, error: profileOrgError } = await supabaseAdmin
         .from("profiles")
         .update({ organization_id: resolvedOrganization })
         .eq("id", createResult.data.user.id)
         .is("organization_id", null)
         .select("id, organization_id")
-        .single();
+        .maybeSingle();
 
-      if (profileOrgError || profileOrgUpdate?.organization_id !== resolvedOrganization) {
-        console.error("Admin profile organization assignment failed", { error: profileOrgError });
-        logApiAccess("POST", "/admin/create-user", userContext, 500);
-        return respond(500, { error: "User created, but assigning organization failed." });
+      if (profileOrgError) {
+        const logMethod = isProfileOrgImmutableError(profileOrgError) ? console.warn : console.error;
+        logMethod("Admin profile organization sync skipped", {
+          error: profileOrgError,
+          userId: createResult.data.user.id,
+          organizationId: resolvedOrganization,
+        });
+      } else if (profileOrgUpdate?.organization_id !== resolvedOrganization) {
+        console.warn("Admin profile organization sync was a no-op", {
+          userId: createResult.data.user.id,
+          organizationId: resolvedOrganization,
+        });
       }
 
       logApiAccess("POST", "/admin/create-user", userContext, 200);

--- a/tests/admin-create-user.access.spec.ts
+++ b/tests/admin-create-user.access.spec.ts
@@ -25,7 +25,7 @@ const profilesUpdateSpy = vi.fn();
 const profilesEqSpy = vi.fn();
 const profilesIsSpy = vi.fn();
 const profilesSelectSpy = vi.fn();
-const profilesSingleSpy = vi.fn();
+const profilesMaybeSingleSpy = vi.fn();
 
 vi.mock('../supabase/functions/_shared/auth-middleware.ts', () => ({
   corsHeaders: {
@@ -96,7 +96,7 @@ describe('admin-create-user access control', () => {
     profilesEqSpy.mockReset();
     profilesIsSpy.mockReset();
     profilesSelectSpy.mockReset();
-    profilesSingleSpy.mockReset();
+    profilesMaybeSingleSpy.mockReset();
 
     createUserSpy.mockResolvedValue({
       data: { user: { id: 'new-admin-user-id' } },
@@ -106,8 +106,8 @@ describe('admin-create-user access control', () => {
     profilesUpdateSpy.mockReturnValue({ eq: profilesEqSpy });
     profilesEqSpy.mockReturnValue({ is: profilesIsSpy });
     profilesIsSpy.mockReturnValue({ select: profilesSelectSpy });
-    profilesSelectSpy.mockReturnValue({ single: profilesSingleSpy });
-    profilesSingleSpy.mockResolvedValue({
+    profilesSelectSpy.mockReturnValue({ maybeSingle: profilesMaybeSingleSpy });
+    profilesMaybeSingleSpy.mockResolvedValue({
       data: {
         id: 'new-admin-user-id',
         organization_id: '22222222-2222-2222-2222-222222222222',
@@ -165,7 +165,7 @@ describe('admin-create-user access control', () => {
     expect(profilesEqSpy).toHaveBeenCalledWith('id', 'new-admin-user-id');
     expect(profilesIsSpy).toHaveBeenCalledWith('organization_id', null);
     expect(profilesSelectSpy).toHaveBeenCalledWith('id, organization_id');
-    expect(profilesSingleSpy).toHaveBeenCalled();
+    expect(profilesMaybeSingleSpy).toHaveBeenCalled();
   }, 20_000);
 
   it('denies a regular admin from creating an admin in a different organization', async () => {
@@ -250,8 +250,8 @@ describe('admin-create-user access control', () => {
     expect(profilesUpdateSpy).not.toHaveBeenCalled();
   });
 
-  it('returns an error when the created admin profile organization cannot be assigned', async () => {
-    userContexts.set('super-profile-org-failure', {
+  it('continues when profile organization sync is rejected by the immutability guard', async () => {
+    userContexts.set('super-profile-org-immutable', {
       user: { id: 'super-user-id', email: 'super@example.com' },
       profile: {
         id: 'super-profile-id',
@@ -260,9 +260,9 @@ describe('admin-create-user access control', () => {
         is_active: true,
       },
     });
-    profilesSingleSpy.mockResolvedValue({
+    profilesMaybeSingleSpy.mockResolvedValue({
       data: null,
-      error: { message: 'profile update failed' },
+      error: { code: '42501', message: 'organization_id is immutable for this role' },
     });
 
     const { default: handler } = await import('../supabase/functions/admin-create-user/index.ts');
@@ -272,7 +272,7 @@ describe('admin-create-user access control', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer test-token',
-        'x-test-user': 'super-profile-org-failure',
+        'x-test-user': 'super-profile-org-immutable',
       },
       body: JSON.stringify({
         email: 'new.admin@example.com',
@@ -280,17 +280,18 @@ describe('admin-create-user access control', () => {
         first_name: 'New',
         last_name: 'Admin',
         organization_id: '22222222-2222-2222-2222-222222222222',
-        reason: 'Coverage for profile organization failure.',
+        reason: 'Coverage for immutable profile organization guard.',
       }),
     }));
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      error: 'User created, but assigning organization failed.',
+      user_id: 'new-admin-user-id',
+      organization_id: '22222222-2222-2222-2222-222222222222',
     });
   });
 
-  it('returns an error when assigning the profile organization updates no rows', async () => {
+  it('continues when profile organization sync is a no-op', async () => {
     userContexts.set('super-profile-org-noop', {
       user: { id: 'super-user-id', email: 'super@example.com' },
       profile: {
@@ -300,7 +301,7 @@ describe('admin-create-user access control', () => {
         is_active: true,
       },
     });
-    profilesSingleSpy.mockResolvedValue({ data: null, error: null });
+    profilesMaybeSingleSpy.mockResolvedValue({ data: null, error: null });
 
     const { default: handler } = await import('../supabase/functions/admin-create-user/index.ts');
 
@@ -321,9 +322,10 @@ describe('admin-create-user access control', () => {
       }),
     }));
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      error: 'User created, but assigning organization failed.',
+      user_id: 'new-admin-user-id',
+      organization_id: '22222222-2222-2222-2222-222222222222',
     });
   });
 });


### PR DESCRIPTION
## Summary
- keep `auth.users` metadata and `user_roles` as the authoritative admin/org source in `admin-create-user`
- treat legacy `profiles.organization_id` sync as best-effort so immutable-guard rejections and no-op updates no longer return a false `500`
- update the focused edge-function access test to cover the live immutability-guard failure and no-op profile sync path

## Root cause
Live Supabase logs on July 3, 2026 showed the Auth user was created successfully, but the edge function still returned `500` because its follow-up `profiles.organization_id` update hit `organization_id is immutable for this role`.

## Verification
- `npx vitest run tests/admin-create-user.access.spec.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`

## Blocked / failed checks
- `npm run test:routes:tier0` failed locally with Cypress `EPIPE: broken pipe`
- `npm run test:ci` timed out locally with unrelated AI documentation network failures (`fetch failed` / `ECONNREFUSED`)
- `npm run ci:playwright` not run locally in this slice
- `npm run verify:local` not run because it would inherit the blocked gates above

## Tracking
- Linear: WIN-196
