### PR TITLE
WIN-196 require profile org sync before admin create succeeds

### DIFF
--- a/supabase/functions/admin-create-user/index.ts
+++ b/supabase/functions/admin-create-user/index.ts
@@ -35,17 +35,6 @@ const normalizeUuid = (value: unknown) => {
   return normalized && /^[0-9a-fA-F-]{36}$/.test(normalized) ? normalized : null;
 };
 
-const isProfileOrgImmutableError = (error: unknown) => {
-  if (!error || typeof error !== "object") return false;
-  const maybeCode = "code" in error ? (error as { code?: unknown }).code : null;
-  const maybeMessage = "message" in error ? (error as { message?: unknown }).message : null;
-  return (
-    maybeCode === "42501" &&
-    typeof maybeMessage === "string" &&
-    maybeMessage.includes("organization_id is immutable for this role")
-  );
-};
-
 const parseOrganizationFromMetadata = (metadata: Record<string, unknown> | null | undefined) => {
   if (!metadata || typeof metadata !== "object") return null;
   const snake = metadata["organization_id"];
@@ -188,28 +177,21 @@ const handler = createProtectedRoute(
         return respond(500, { error: "User created, but assigning admin role failed." });
       }
 
-      // Auth metadata + user_roles are authoritative; this profile sync only supports
-      // older readers that still surface profiles.organization_id directly.
-      const { data: profileOrgUpdate, error: profileOrgError } = await supabaseAdmin
+      const { data: profileOrgState, error: profileOrgError } = await supabaseAdmin
         .from("profiles")
-        .update({ organization_id: resolvedOrganization })
-        .eq("id", createResult.data.user.id)
-        .is("organization_id", null)
         .select("id, organization_id")
+        .eq("id", createResult.data.user.id)
         .maybeSingle();
 
-      if (profileOrgError) {
-        const logMethod = isProfileOrgImmutableError(profileOrgError) ? console.warn : console.error;
-        logMethod("Admin profile organization sync skipped", {
+      if (profileOrgError || profileOrgState?.organization_id !== resolvedOrganization) {
+        console.error("Admin profile organization verification failed", {
           error: profileOrgError,
           userId: createResult.data.user.id,
           organizationId: resolvedOrganization,
+          profileOrganizationId: profileOrgState?.organization_id ?? null,
         });
-      } else if (profileOrgUpdate?.organization_id !== resolvedOrganization) {
-        console.warn("Admin profile organization sync was a no-op", {
-          userId: createResult.data.user.id,
-          organizationId: resolvedOrganization,
-        });
+        logApiAccess("POST", "/admin/create-user", userContext, 500);
+        return respond(500, { error: "User created, but organization context is unavailable." });
       }
 
       logApiAccess("POST", "/admin/create-user", userContext, 200);

--- a/supabase/migrations/20260703195500_sync_user_profile_organization_scope.sql
+++ b/supabase/migrations/20260703195500_sync_user_profile_organization_scope.sql
@@ -1,0 +1,115 @@
+-- @migration-intent: Persist organization_id from auth metadata during trusted auth/profile sync so regular admins get org context before admin creation returns success.
+-- @migration-dependencies: 20251205094500_profile_role_guard_fix.sql,20260506170000_super_admin_admin_management_authz.sql
+-- @migration-rollback: Re-run 20251205094500_profile_role_guard_fix.sql to restore the previous sync_user_profile definition; manually clear any unintended admin profile organization backfills if rollback is required.
+
+set search_path = public;
+
+begin;
+
+create or replace function public.sync_user_profile()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  user_role_type role_type;
+  user_org_id uuid;
+begin
+  select r.name::role_type
+  into user_role_type
+  from user_roles ur
+  join roles r on ur.role_id = r.id
+  where ur.user_id = NEW.id
+  order by
+    case r.name
+      when 'super_admin' then 4
+      when 'admin' then 3
+      when 'therapist' then 2
+      when 'client' then 1
+      else 0
+    end desc
+  limit 1;
+
+  if user_role_type is null then
+    user_role_type := 'client'::role_type;
+  end if;
+
+  user_org_id := public.get_organization_id_from_metadata(NEW.raw_user_meta_data);
+
+  perform set_config('app.bypass_profile_role_guard', 'on', true);
+
+  insert into profiles (
+    id,
+    email,
+    role,
+    organization_id,
+    first_name,
+    last_name,
+    phone,
+    is_active,
+    created_at,
+    updated_at
+  ) values (
+    NEW.id,
+    NEW.email,
+    user_role_type,
+    user_org_id,
+    NEW.raw_user_meta_data->>'first_name',
+    NEW.raw_user_meta_data->>'last_name',
+    NEW.raw_user_meta_data->>'phone',
+    true,
+    now(),
+    now()
+  )
+  on conflict (id) do update set
+    email = excluded.email,
+    role = user_role_type,
+    organization_id = coalesce(excluded.organization_id, profiles.organization_id),
+    first_name = coalesce(excluded.first_name, NEW.raw_user_meta_data->>'first_name'),
+    last_name = coalesce(excluded.last_name, NEW.raw_user_meta_data->>'last_name'),
+    phone = coalesce(excluded.phone, NEW.raw_user_meta_data->>'phone'),
+    updated_at = now();
+
+  perform set_config('app.bypass_profile_role_guard', 'off', true);
+  return NEW;
+exception
+  when others then
+    perform set_config('app.bypass_profile_role_guard', 'off', true);
+    raise;
+end;
+$$;
+
+do $$
+begin
+  perform set_config('app.bypass_profile_role_guard', 'on', true);
+
+  with admin_profiles_to_backfill as (
+    select
+      p.id,
+      public.get_organization_id_from_metadata(u.raw_user_meta_data) as metadata_org_id
+    from auth.users u
+    join public.profiles p on p.id = u.id
+    join public.user_roles ur on ur.user_id = u.id
+    join public.roles r on r.id = ur.role_id
+    where r.name in ('admin', 'super_admin')
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+      and p.organization_id is null
+      and public.get_organization_id_from_metadata(u.raw_user_meta_data) is not null
+  )
+  update public.profiles p
+  set organization_id = b.metadata_org_id,
+      updated_at = now()
+  from admin_profiles_to_backfill b
+  where p.id = b.id;
+
+  perform set_config('app.bypass_profile_role_guard', 'off', true);
+exception
+  when others then
+    perform set_config('app.bypass_profile_role_guard', 'off', true);
+    raise;
+end;
+$$;
+
+commit;

--- a/tests/admin-create-user.access.spec.ts
+++ b/tests/admin-create-user.access.spec.ts
@@ -21,10 +21,8 @@ const userContexts = new Map<string, TestUserContext>();
 const createUserSpy = vi.fn();
 const assignAdminRoleSpy = vi.fn();
 const getUserByIdSpy = vi.fn();
-const profilesUpdateSpy = vi.fn();
-const profilesEqSpy = vi.fn();
-const profilesIsSpy = vi.fn();
 const profilesSelectSpy = vi.fn();
+const profilesEqSpy = vi.fn();
 const profilesMaybeSingleSpy = vi.fn();
 
 vi.mock('../supabase/functions/_shared/auth-middleware.ts', () => ({
@@ -79,7 +77,7 @@ vi.mock('../supabase/functions/_shared/database.ts', () => ({
         throw new Error(`Unexpected table ${table}`);
       }
       return {
-        update: profilesUpdateSpy,
+        select: profilesSelectSpy,
       };
     },
   },
@@ -92,10 +90,8 @@ describe('admin-create-user access control', () => {
     createUserSpy.mockReset();
     assignAdminRoleSpy.mockReset();
     getUserByIdSpy.mockReset();
-    profilesUpdateSpy.mockReset();
-    profilesEqSpy.mockReset();
-    profilesIsSpy.mockReset();
     profilesSelectSpy.mockReset();
+    profilesEqSpy.mockReset();
     profilesMaybeSingleSpy.mockReset();
 
     createUserSpy.mockResolvedValue({
@@ -103,10 +99,8 @@ describe('admin-create-user access control', () => {
       error: null,
     });
     assignAdminRoleSpy.mockResolvedValue({ error: null });
-    profilesUpdateSpy.mockReturnValue({ eq: profilesEqSpy });
-    profilesEqSpy.mockReturnValue({ is: profilesIsSpy });
-    profilesIsSpy.mockReturnValue({ select: profilesSelectSpy });
-    profilesSelectSpy.mockReturnValue({ maybeSingle: profilesMaybeSingleSpy });
+    profilesSelectSpy.mockReturnValue({ eq: profilesEqSpy });
+    profilesEqSpy.mockReturnValue({ maybeSingle: profilesMaybeSingleSpy });
     profilesMaybeSingleSpy.mockResolvedValue({
       data: {
         id: 'new-admin-user-id',
@@ -159,12 +153,8 @@ describe('admin-create-user access control', () => {
       organization_id: '22222222-2222-2222-2222-222222222222',
       reason: 'Coverage for the selected organization.',
     });
-    expect(profilesUpdateSpy).toHaveBeenCalledWith({
-      organization_id: '22222222-2222-2222-2222-222222222222',
-    });
-    expect(profilesEqSpy).toHaveBeenCalledWith('id', 'new-admin-user-id');
-    expect(profilesIsSpy).toHaveBeenCalledWith('organization_id', null);
     expect(profilesSelectSpy).toHaveBeenCalledWith('id, organization_id');
+    expect(profilesEqSpy).toHaveBeenCalledWith('id', 'new-admin-user-id');
     expect(profilesMaybeSingleSpy).toHaveBeenCalled();
   }, 20_000);
 
@@ -211,7 +201,7 @@ describe('admin-create-user access control', () => {
     await expect(response.json()).resolves.toMatchObject({ error: 'Caller organization mismatch.' });
     expect(createUserSpy).not.toHaveBeenCalled();
     expect(assignAdminRoleSpy).not.toHaveBeenCalled();
-    expect(profilesUpdateSpy).not.toHaveBeenCalled();
+    expect(profilesSelectSpy).not.toHaveBeenCalled();
   });
 
   it('denies non-admin roles from creating admins', async () => {
@@ -247,11 +237,11 @@ describe('admin-create-user access control', () => {
     expect(response.status).toBe(403);
     expect(createUserSpy).not.toHaveBeenCalled();
     expect(assignAdminRoleSpy).not.toHaveBeenCalled();
-    expect(profilesUpdateSpy).not.toHaveBeenCalled();
+    expect(profilesSelectSpy).not.toHaveBeenCalled();
   });
 
-  it('continues when profile organization sync is rejected by the immutability guard', async () => {
-    userContexts.set('super-profile-org-immutable', {
+  it('fails when the created admin profile organization is still unavailable', async () => {
+    userContexts.set('super-profile-org-missing', {
       user: { id: 'super-user-id', email: 'super@example.com' },
       profile: {
         id: 'super-profile-id',
@@ -262,7 +252,7 @@ describe('admin-create-user access control', () => {
     });
     profilesMaybeSingleSpy.mockResolvedValue({
       data: null,
-      error: { code: '42501', message: 'organization_id is immutable for this role' },
+      error: null,
     });
 
     const { default: handler } = await import('../supabase/functions/admin-create-user/index.ts');
@@ -272,7 +262,7 @@ describe('admin-create-user access control', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer test-token',
-        'x-test-user': 'super-profile-org-immutable',
+        'x-test-user': 'super-profile-org-missing',
       },
       body: JSON.stringify({
         email: 'new.admin@example.com',
@@ -280,19 +270,18 @@ describe('admin-create-user access control', () => {
         first_name: 'New',
         last_name: 'Admin',
         organization_id: '22222222-2222-2222-2222-222222222222',
-        reason: 'Coverage for immutable profile organization guard.',
+        reason: 'Coverage for missing profile organization context.',
       }),
     }));
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(500);
     await expect(response.json()).resolves.toMatchObject({
-      user_id: 'new-admin-user-id',
-      organization_id: '22222222-2222-2222-2222-222222222222',
+      error: 'User created, but organization context is unavailable.',
     });
   });
 
-  it('continues when profile organization sync is a no-op', async () => {
-    userContexts.set('super-profile-org-noop', {
+  it('fails when the created admin profile organization resolves to the wrong organization', async () => {
+    userContexts.set('super-profile-org-mismatch', {
       user: { id: 'super-user-id', email: 'super@example.com' },
       profile: {
         id: 'super-profile-id',
@@ -301,7 +290,13 @@ describe('admin-create-user access control', () => {
         is_active: true,
       },
     });
-    profilesMaybeSingleSpy.mockResolvedValue({ data: null, error: null });
+    profilesMaybeSingleSpy.mockResolvedValue({
+      data: {
+        id: 'new-admin-user-id',
+        organization_id: '33333333-3333-3333-3333-333333333333',
+      },
+      error: null,
+    });
 
     const { default: handler } = await import('../supabase/functions/admin-create-user/index.ts');
 
@@ -310,7 +305,7 @@ describe('admin-create-user access control', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer test-token',
-        'x-test-user': 'super-profile-org-noop',
+        'x-test-user': 'super-profile-org-mismatch',
       },
       body: JSON.stringify({
         email: 'new.admin@example.com',
@@ -318,14 +313,13 @@ describe('admin-create-user access control', () => {
         first_name: 'New',
         last_name: 'Admin',
         organization_id: '22222222-2222-2222-2222-222222222222',
-        reason: 'Coverage for profile organization no-op.',
+        reason: 'Coverage for mismatched profile organization context.',
       }),
     }));
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(500);
     await expect(response.json()).resolves.toMatchObject({
-      user_id: 'new-admin-user-id',
-      organization_id: '22222222-2222-2222-2222-222222222222',
+      error: 'User created, but organization context is unavailable.',
     });
   });
 });

--- a/tests/admins/sync_user_profile.organization.spec.ts
+++ b/tests/admins/sync_user_profile.organization.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('sync_user_profile organization sync', () => {
+  it('persists organization_id from auth metadata under the profile guard bypass', () => {
+    const migrationSql = readFileSync(
+      join(process.cwd(), 'supabase/migrations/20260703195500_sync_user_profile_organization_scope.sql'),
+      'utf-8',
+    );
+
+    const syncFunctionMatch = migrationSql.match(
+      /create or replace function public\.sync_user_profile\(\)[\s\S]*?end;\s*\$\$/i,
+    );
+    expect(syncFunctionMatch, 'sync_user_profile should be redefined').toBeTruthy();
+
+    const syncFunctionSql = syncFunctionMatch?.[0] ?? '';
+
+    expect(syncFunctionSql).toMatch(/get_organization_id_from_metadata\(NEW\.raw_user_meta_data\)/i);
+    expect(syncFunctionSql).toMatch(/set_config\('app\.bypass_profile_role_guard', 'on', true\)/i);
+    expect(syncFunctionSql).toMatch(/insert into profiles[\s\S]*organization_id/i);
+    expect(syncFunctionSql).toMatch(/organization_id = coalesce\(excluded\.organization_id, profiles\.organization_id\)/i);
+  });
+
+  it('backfills missing admin profile organizations from auth metadata', () => {
+    const migrationSql = readFileSync(
+      join(process.cwd(), 'supabase/migrations/20260703195500_sync_user_profile_organization_scope.sql'),
+      'utf-8',
+    );
+
+    expect(migrationSql).toMatch(/where r\.name in \('admin', 'super_admin'\)/i);
+    expect(migrationSql).toMatch(/p\.organization_id is null/i);
+    expect(migrationSql).toMatch(/set organization_id = b\.metadata_org_id/i);
+  });
+});


### PR DESCRIPTION
## Summary
- fail `admin-create-user` unless the created profile resolves to the requested organization
- update `sync_user_profile()` to persist organization metadata into `profiles.organization_id` under the trusted bypass path
- add regression coverage for the failure/no-op admin-create path and the migration contract

## Verification
- npx vitest run tests/admin-create-user.access.spec.ts tests/admins/sync_user_profile.organization.spec.ts
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run validate:tenant
- npm run build
- npm run test:ci *(fails locally: unrelated existing `src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts` requires `VITE_SUPABASE_URL` in this worktree environment)*
