### PR TITLE
WIN-195 Add per-target trial-event graphs

### DIFF
--- a/reports/test-reliability-latest.json
+++ b/reports/test-reliability-latest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-15T14:09:09.248Z",
+  "generatedAt": "2026-07-04T00:28:57.993Z",
   "slo": {
     "suitePassRatePctTarget": 99.5,
     "rollingWindowDays": 14

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ClipboardList, Loader2, Plus, Trash2, UploadCloud } from "lucide-react";
-import type { Client, Goal, GoalTarget, Program, ProgramNote, TargetMeasurementType } from "../../types";
+import type { Client, Goal, GoalTarget, Program, ProgramNote, TargetMeasurementType, TrialEvent } from "../../types";
 import { callApi, callEdgeFunctionHttp } from "../../lib/api";
 import { showError, showInfo, showSuccess } from "../../lib/toast";
 import { useActiveOrganizationId } from "../../lib/organization";
@@ -54,6 +54,8 @@ const ACTIVE_ASSESSMENT_POLL_STATUSES: ReadonlySet<AssessmentDocumentRecord["sta
   "extracting",
   "extraction_running",
 ]);
+const TRIAL_EVENT_GRAPH_POINT_LIMIT = 6;
+const TRIAL_EVENTS_REQUEST_TIMEOUT_MS = 8_000;
 
 const detectAssessmentTemplateTypeFromFileName = (fileName: string): AssessmentTemplateType | null => {
   const normalized = fileName.toLowerCase();
@@ -178,6 +180,38 @@ const hasMeaningfulAdaptiveBlocks = (payload: Record<string, unknown>): boolean 
     );
   });
 };
+
+const responseGraphScores: Record<NonNullable<TrialEvent["response"]>, number> = {
+  correct: 1,
+  independent: 1,
+  prompted: 0.5,
+  incorrect: 0,
+  noResponse: 0,
+  notObserved: 0,
+};
+
+const formatTrialEventValue = (event: TrialEvent): string => {
+  if (typeof event.value === "number") {
+    return Number.isInteger(event.value) ? String(event.value) : event.value.toFixed(2);
+  }
+  return event.response ? event.response.replace(/([A-Z])/g, " $1").toLowerCase() : "not scored";
+};
+
+const trialEventGraphScore = (event: TrialEvent): number => {
+  if (typeof event.value === "number") {
+    return event.value;
+  }
+  return event.response ? responseGraphScores[event.response] ?? 0 : 0;
+};
+
+const sortTrialEvents = (events: TrialEvent[]): TrialEvent[] =>
+  [...events].sort((left, right) => {
+    const timestampComparison = left.event_timestamp.localeCompare(right.event_timestamp);
+    return timestampComparison === 0 ? left.trial_number - right.trial_number : timestampComparison;
+  });
+
+const latestTrialEventsForGraph = (events: TrialEvent[]): TrialEvent[] =>
+  events.slice(Math.max(0, events.length - TRIAL_EVENT_GRAPH_POINT_LIMIT));
 
 const hasLegacySignaturePayload = (payload: Record<string, unknown>): boolean => {
   const hasTransferSignatureFields = ["report_completed_date", "credentials", "agency"].some((key) =>
@@ -321,6 +355,7 @@ const PROGRAMS_EDGE_PATH = "programs";
 const GOALS_EDGE_PATH = "goals";
 const PROGRAM_NOTES_EDGE_PATH = "program-notes";
 const GOAL_TARGETS_EDGE_PATH = "goal-targets";
+const TRIAL_EVENTS_EDGE_PATH = "trial-events";
 
 const buildProgramsQueryPath = (clientId: string): string =>
   `${PROGRAMS_EDGE_PATH}?client_id=${encodeURIComponent(clientId)}`;
@@ -435,6 +470,83 @@ interface AssessmentPromoteResponse {
   promoted_program_count?: number;
   promoted_goal_count?: number;
   completion_mode?: "assessment_only" | "live_program_goals";
+}
+
+interface TargetTrialEventGraphProps {
+  clientId: string;
+  organizationId: string | null;
+  target: GoalTarget;
+}
+
+function TargetTrialEventGraph({ clientId, organizationId, target }: TargetTrialEventGraphProps) {
+  const {
+    data: trialEvents = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["trial-events", clientId, organizationId ?? "no-org", target.id] as const,
+    queryFn: async () => {
+      const response = await withTimeout(
+        callEdgeFunctionHttp(`${TRIAL_EVENTS_EDGE_PATH}?target_id=${encodeURIComponent(target.id)}`),
+        TRIAL_EVENTS_REQUEST_TIMEOUT_MS,
+        "Trial-event graph request timed out. Please retry.",
+      );
+      if (!response.ok) {
+        throw new Error(await parseApiErrorMessage(response, "Failed to load trial events."));
+      }
+      return sortTrialEvents(await parseJson<TrialEvent[]>(response));
+    },
+    enabled: Boolean(organizationId && target.id),
+    retry: false,
+    staleTime: TAB_QUERY_STALE_TIME_MS,
+    refetchOnReconnect: true,
+  });
+  const graphEvents = latestTrialEventsForGraph(trialEvents);
+  const maxGraphScore = Math.max(1, ...graphEvents.map(trialEventGraphScore));
+
+  return (
+    <div
+      className="mt-2 rounded border border-slate-100 bg-slate-50 p-2 dark:border-slate-700 dark:bg-slate-900/40"
+      aria-label={`Trial-event graph for ${target.name}`}
+    >
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <span className="font-medium text-slate-700 dark:text-slate-200">Target graph</span>
+        <span className="text-slate-500">
+          {trialEvents.length} trial{trialEvents.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      {error instanceof Error ? (
+        <p className="text-amber-700 dark:text-amber-300">
+          Could not load trial-level data: {error.message}
+        </p>
+      ) : isLoading ? (
+        <p className="text-slate-500">Loading trial-level data...</p>
+      ) : graphEvents.length === 0 ? (
+        <p className="text-slate-500">No trial-level data yet.</p>
+      ) : (
+        <div className="space-y-1">
+          {graphEvents.map((event) => {
+            const score = trialEventGraphScore(event);
+            const widthPercent = Math.max(8, Math.round((score / maxGraphScore) * 100));
+            return (
+              <div key={event.id} className="grid grid-cols-[5rem_1fr_5rem] items-center gap-2">
+                <span className="text-slate-500">Trial {event.trial_number}</span>
+                <div className="h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
+                  <div
+                    className="h-full rounded-full bg-blue-500"
+                    style={{ width: `${widthPercent}%` }}
+                  />
+                </div>
+                <span className="text-right text-slate-600 dark:text-slate-300">
+                  {formatTrialEventValue(event)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
@@ -667,7 +779,6 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   });
 
   const targetsByGoalId = useMemo(() => buildTargetsByGoalId(goalTargets), [goalTargets]);
-
   useEffect(() => {
     if (targetGoalId && goalIdsForTargets.includes(targetGoalId)) {
       return;
@@ -2746,6 +2857,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                                   {String(target.graph_config?.source ?? "trial_events")}
                                 </span>
                               </div>
+                              <TargetTrialEventGraph clientId={client.id} organizationId={organizationId} target={target} />
                             </div>
                           ))}
                         </div>

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -814,9 +814,66 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
               created_at: "2026-02-11T00:00:00.000Z",
               updated_at: "2026-02-11T00:00:00.000Z",
             },
+            {
+              id: "target-2",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              goal_id: "goal-1",
+              name: "Sustained engagement",
+              measurement_type: "duration",
+              graph_config: { defaultChart: "line", source: "trial_events" },
+              status: "draft",
+              sort_order: 1,
+              created_at: "2026-02-11T00:01:00.000Z",
+              updated_at: "2026-02-11T00:01:00.000Z",
+            },
           ]),
           { status: 200 },
         );
+      }
+      if (method === "GET" && path.startsWith("/api/trial-events?target_id=target-1")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "trial-event-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              session_id: "session-1",
+              target_id: "target-1",
+              goal_id: "goal-1",
+              therapist_id: "therapist-1",
+              trial_number: 1,
+              response: null,
+              value: 3,
+              event_timestamp: "2026-02-11T17:00:00.000Z",
+              metadata: {},
+              created_at: "2026-02-11T17:00:00.000Z",
+              updated_at: "2026-02-11T17:00:00.000Z",
+            },
+            {
+              id: "trial-event-2",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              session_id: "session-1",
+              target_id: "target-1",
+              goal_id: "goal-1",
+              therapist_id: "therapist-1",
+              trial_number: 2,
+              response: null,
+              value: 5,
+              event_timestamp: "2026-02-11T17:05:00.000Z",
+              metadata: {},
+              created_at: "2026-02-11T17:05:00.000Z",
+              updated_at: "2026-02-11T17:05:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/trial-events?target_id=target-2")) {
+        return new Promise<Response>(() => {
+          // Keep this target pending to prove one slow graph does not block sibling targets.
+        });
       }
       if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
       if (method === "GET" && path.startsWith("/api/assessment-documents?")) return new Response(JSON.stringify([]), { status: 200 });
@@ -845,6 +902,24 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(await screen.findByText("Mands for help")).toBeInTheDocument();
     expect(screen.getByText("Measurement: Frequency")).toBeInTheDocument();
     expect(screen.getByText(/Graph: bar from/i)).toBeInTheDocument();
+    const mandsGraph = await screen.findByLabelText("Trial-event graph for Mands for help");
+    expect(within(mandsGraph).getByText("2 trials")).toBeInTheDocument();
+    expect(within(mandsGraph).getByText("Trial 1")).toBeInTheDocument();
+    expect(within(mandsGraph).getByText("Trial 2")).toBeInTheDocument();
+    expect(within(mandsGraph).getByText("5")).toBeInTheDocument();
+
+    expect(await screen.findByText("Sustained engagement")).toBeInTheDocument();
+    const engagementGraph = await screen.findByLabelText("Trial-event graph for Sustained engagement");
+    expect(within(engagementGraph).getByText("Loading trial-level data...")).toBeInTheDocument();
+    expect(
+      await within(engagementGraph).findByText(
+        "Could not load trial-level data: Trial-event graph request timed out. Please retry.",
+        {},
+        { timeout: 10_000 },
+      ),
+    ).toBeInTheDocument();
+    expect(callEdgeFunctionHttp).toHaveBeenCalledWith("trial-events?target_id=target-1");
+    expect(callEdgeFunctionHttp).toHaveBeenCalledWith("trial-events?target_id=target-2");
   });
 
   it("creates a target under an existing goal with independent measurement status and graph defaults", async () => {

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -6461,6 +6461,10 @@ export type Database = {
       }
       create_super_admin: { Args: { user_email: string }; Returns: undefined }
       current_org_id: { Args: never; Returns: string }
+      current_user_can_capture_trial_event: {
+        Args: { target_client_id: string; target_organization_id: string }
+        Returns: boolean
+      }
       current_user_can_manage_locked_trial_event: {
         Args: { target_organization_id: string }
         Returns: boolean

--- a/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
+++ b/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
@@ -12,6 +12,7 @@ vi.mock("../api/shared", async () => {
 });
 
 import {
+  currentUserCanCaptureTrialEvent,
   currentUserCanManageLockedTrialEvent,
   currentUserCanManageProgramsGoals,
   currentUserCanTakeClientData,
@@ -104,10 +105,15 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
   it("checks trial-event capture and lock helpers through exposed public RPC wrappers", async () => {
     fetchSpy
       .mockResolvedValueOnce(jsonResponse(true))
+      .mockResolvedValueOnce(jsonResponse(true))
       .mockResolvedValueOnce(jsonResponse(false))
       .mockResolvedValueOnce(jsonResponse(true));
 
     await expect(currentUserCanTakeClientData(accessToken, "org-1", "client-1")).resolves.toEqual({
+      allowed: true,
+      upstreamError: false,
+    });
+    await expect(currentUserCanCaptureTrialEvent(accessToken, "org-1", "client-1")).resolves.toEqual({
       allowed: true,
       upstreamError: false,
     });
@@ -125,12 +131,17 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       target_organization_id: "org-1",
       target_client_id: "client-1",
     });
-    expect(String(fetchSpy.mock.calls[1]?.[0])).toContain("/rest/v1/rpc/current_user_can_manage_locked_trial_event");
+    expect(String(fetchSpy.mock.calls[1]?.[0])).toContain("/rest/v1/rpc/current_user_can_capture_trial_event");
     expect(JSON.parse(String((fetchSpy.mock.calls[1]?.[1] as RequestInit).body))).toEqual({
       target_organization_id: "org-1",
+      target_client_id: "client-1",
     });
-    expect(String(fetchSpy.mock.calls[2]?.[0])).toContain("/rest/v1/rpc/session_has_locked_note");
+    expect(String(fetchSpy.mock.calls[2]?.[0])).toContain("/rest/v1/rpc/current_user_can_manage_locked_trial_event");
     expect(JSON.parse(String((fetchSpy.mock.calls[2]?.[1] as RequestInit).body))).toEqual({
+      target_organization_id: "org-1",
+    });
+    expect(String(fetchSpy.mock.calls[3]?.[0])).toContain("/rest/v1/rpc/session_has_locked_note");
+    expect(JSON.parse(String((fetchSpy.mock.calls[3]?.[1] as RequestInit).body))).toEqual({
       target_session_id: "session-1",
     });
   });
@@ -140,6 +151,7 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       .mockResolvedValueOnce(new Response(JSON.stringify({ code: "PGRST202" }), { status: 404 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ code: "42501" }), { status: 403 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ code: "PGRST202" }), { status: 404 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: "PGRST202" }), { status: 404 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ code: "42501" }), { status: 403 }));
 
     await expect(currentUserCanManageProgramsGoals(accessToken, "org-1")).resolves.toEqual({
@@ -147,6 +159,10 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       upstreamError: true,
     });
     await expect(currentUserCanTakeClientData(accessToken, "org-1", "client-1")).resolves.toEqual({
+      allowed: false,
+      upstreamError: true,
+    });
+    await expect(currentUserCanCaptureTrialEvent(accessToken, "org-1", "client-1")).resolves.toEqual({
       allowed: false,
       upstreamError: true,
     });
@@ -163,12 +179,14 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
   it("keeps generated database types in sync with public trial-event helper RPC wrappers", () => {
     type PublicFunctions = keyof Database["public"]["Functions"];
     const requiredFunctions: PublicFunctions[] = [
+      "current_user_can_capture_trial_event",
       "current_user_can_take_client_data",
       "current_user_can_manage_locked_trial_event",
       "session_has_locked_note",
     ];
 
     expect(requiredFunctions).toEqual([
+      "current_user_can_capture_trial_event",
       "current_user_can_take_client_data",
       "current_user_can_manage_locked_trial_event",
       "session_has_locked_note",

--- a/src/server/__tests__/trialEventsHandler.test.ts
+++ b/src/server/__tests__/trialEventsHandler.test.ts
@@ -1,12 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { trialEventsHandler } from "../api/trial-events";
 
 vi.mock("../api/shared", async () => {
   const actual = await vi.importActual<typeof import("../api/shared")>("../api/shared");
   return {
     ...actual,
+    currentUserCanCaptureTrialEvent: vi.fn(),
     currentUserCanManageLockedTrialEvent: vi.fn(),
-    currentUserCanTakeClientData: vi.fn(),
     fetchAuthenticatedUserIdWithStatus: vi.fn(),
     fetchJson: vi.fn(),
     getAccessToken: vi.fn(),
@@ -17,8 +17,8 @@ vi.mock("../api/shared", async () => {
 });
 
 import {
+  currentUserCanCaptureTrialEvent,
   currentUserCanManageLockedTrialEvent,
-  currentUserCanTakeClientData,
   fetchAuthenticatedUserIdWithStatus,
   fetchJson,
   getAccessToken,
@@ -34,6 +34,8 @@ const SESSION_ID = "33333333-3333-4333-8333-333333333333";
 const TARGET_ID = "44444444-4444-4444-8444-444444444444";
 const GOAL_ID = "55555555-5555-4555-8555-555555555555";
 const THERAPIST_ID = "66666666-6666-4666-8666-666666666666";
+const SERVICE_ROLE_KEY = "service-role-key";
+const ORIGINAL_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 const buildPostRequest = () =>
   new Request("http://localhost/api/trial-events", {
@@ -44,6 +46,11 @@ const buildPostRequest = () =>
       trial_number: 1,
       value: 3,
     }),
+  });
+
+const buildGetRequest = (query = `target_id=${TARGET_ID}`) =>
+  new Request(`http://localhost/api/trial-events?${query}`, {
+    method: "GET",
   });
 
 const mockTargetAndSessionLookups = (measurementType = "frequency") => {
@@ -75,9 +82,41 @@ const mockTargetAndSessionLookups = (measurementType = "frequency") => {
     });
 };
 
+const mockTargetReadLookup = () => {
+  vi.mocked(fetchJson).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    data: [
+      {
+        id: TARGET_ID,
+        organization_id: ORG_ID,
+        client_id: CLIENT_ID,
+        goal_id: GOAL_ID,
+        measurement_type: "frequency",
+      },
+    ],
+  });
+};
+
+const mockSessionReadLookup = (clientId = CLIENT_ID) => {
+  vi.mocked(fetchJson).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    data: [
+      {
+        id: SESSION_ID,
+        organization_id: ORG_ID,
+        client_id: clientId,
+        therapist_id: THERAPIST_ID,
+      },
+    ],
+  });
+};
+
 describe("trialEventsHandler", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE_ROLE_KEY;
     vi.mocked(getAccessToken).mockReturnValue(ACCESS_TOKEN);
     vi.mocked(getSupabaseConfig).mockReturnValue({
       supabaseUrl: "https://example.supabase.co",
@@ -97,16 +136,137 @@ describe("trialEventsHandler", () => {
     });
   });
 
+  afterEach(() => {
+    if (typeof ORIGINAL_SERVICE_ROLE_KEY === "string") {
+      process.env.SUPABASE_SERVICE_ROLE_KEY = ORIGINAL_SERVICE_ROLE_KEY;
+    } else {
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    }
+  });
+
+  it("denies trial-event reads when caller cannot access the target client data", async () => {
+    mockTargetReadLookup();
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: false, upstreamError: false });
+
+    const response = await trialEventsHandler(buildGetRequest());
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+    expect(currentUserCanCaptureTrialEvent).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID, CLIENT_ID);
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 502 when trial-event read access cannot be validated", async () => {
+    mockTargetReadLookup();
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: false, upstreamError: true });
+
+    const response = await trialEventsHandler(buildGetRequest());
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "Unable to validate trial-event read access" });
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads target trial events only after target client access is allowed", async () => {
+    mockTargetReadLookup();
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [{ id: "event-1", target_id: TARGET_ID, value: 4, response: null }],
+    });
+
+    const response = await trialEventsHandler(buildGetRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([{ id: "event-1", target_id: TARGET_ID, value: 4, response: null }]);
+    expect(currentUserCanCaptureTrialEvent).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID, CLIENT_ID);
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/rest/v1/goal_targets?"),
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        }),
+      }),
+    );
+    expect(fetchJson).toHaveBeenLastCalledWith(
+      expect.stringContaining(`/rest/v1/trial_events?select=*&organization_id=eq.${ORG_ID}&target_id=eq.${TARGET_ID}`),
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          apikey: "anon-key",
+          Authorization: `Bearer ${ACCESS_TOKEN}`,
+        }),
+      }),
+    );
+  });
+
+  it("loads session trial events only after session client access is allowed", async () => {
+    mockSessionReadLookup();
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [{ id: "event-1", session_id: SESSION_ID, value: 2, response: null }],
+    });
+
+    const response = await trialEventsHandler(buildGetRequest(`session_id=${SESSION_ID}`));
+
+    expect(response.status).toBe(200);
+    expect(currentUserCanCaptureTrialEvent).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID, CLIENT_ID);
+    expect(fetchJson).toHaveBeenLastCalledWith(
+      expect.stringContaining(`/rest/v1/trial_events?select=*&organization_id=eq.${ORG_ID}&session_id=eq.${SESSION_ID}`),
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("rejects mixed session and target reads when they belong to different clients", async () => {
+    const otherClientId = "77777777-7777-4777-8777-777777777777";
+    mockTargetReadLookup();
+    mockSessionReadLookup(otherClientId);
+
+    const response = await trialEventsHandler(buildGetRequest(`session_id=${SESSION_ID}&target_id=${TARGET_ID}`));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "session_id and target_id must belong to the same client" });
+    expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
+  });
+
   it("denies trial-event creation before insert when caller cannot capture data for the client", async () => {
     mockTargetAndSessionLookups();
-    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: false, upstreamError: false });
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: false, upstreamError: false });
 
     const response = await trialEventsHandler(buildPostRequest());
 
     expect(response.status).toBe(403);
-    expect(currentUserCanTakeClientData).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID, CLIENT_ID);
+    expect(currentUserCanCaptureTrialEvent).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID, CLIENT_ID);
     expect(sessionHasLockedNote).not.toHaveBeenCalled();
     expect(fetchJson).toHaveBeenCalledTimes(2);
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/rest/v1/goal_targets?"),
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        }),
+      }),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/rest/v1/sessions?"),
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        }),
+      }),
+    );
   });
 
   it("rejects negative measurement values before scope lookups", async () => {
@@ -143,7 +303,7 @@ describe("trialEventsHandler", () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: "value is required for this target measurement type" });
-    expect(currentUserCanTakeClientData).not.toHaveBeenCalled();
+    expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
   });
 
   it("rejects standardized responses for value-based measurements", async () => {
@@ -164,7 +324,7 @@ describe("trialEventsHandler", () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: "response is not allowed for this target measurement type" });
-    expect(currentUserCanTakeClientData).not.toHaveBeenCalled();
+    expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
   });
 
   it("rejects numeric values for response-based measurements", async () => {
@@ -185,12 +345,12 @@ describe("trialEventsHandler", () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: "value is not allowed for this target measurement type" });
-    expect(currentUserCanTakeClientData).not.toHaveBeenCalled();
+    expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
   });
 
   it("returns 502 when trial-event capture access cannot be validated", async () => {
     mockTargetAndSessionLookups();
-    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: false, upstreamError: true });
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: false, upstreamError: true });
 
     const response = await trialEventsHandler(buildPostRequest());
 
@@ -202,7 +362,7 @@ describe("trialEventsHandler", () => {
 
   it("returns a locked-session conflict before insert when caller cannot manage locked trial events", async () => {
     mockTargetAndSessionLookups();
-    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
     vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: true, upstreamError: false });
     vi.mocked(currentUserCanManageLockedTrialEvent).mockResolvedValue({ allowed: false, upstreamError: false });
 
@@ -216,7 +376,7 @@ describe("trialEventsHandler", () => {
 
   it("returns 502 when session lock state cannot be validated", async () => {
     mockTargetAndSessionLookups();
-    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
     vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: true, upstreamError: true });
 
     const response = await trialEventsHandler(buildPostRequest());
@@ -229,7 +389,7 @@ describe("trialEventsHandler", () => {
 
   it("returns 502 when locked-session management access cannot be validated", async () => {
     mockTargetAndSessionLookups();
-    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
     vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: true, upstreamError: false });
     vi.mocked(currentUserCanManageLockedTrialEvent).mockResolvedValue({ allowed: false, upstreamError: true });
 
@@ -242,7 +402,7 @@ describe("trialEventsHandler", () => {
 
   it("inserts a frequency trial event without a standardized response when capture and lock checks allow it", async () => {
     mockTargetAndSessionLookups();
-    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
     vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: false, upstreamError: false });
     vi.mocked(fetchJson).mockResolvedValueOnce({
       ok: true,
@@ -264,7 +424,7 @@ describe("trialEventsHandler", () => {
 
   it("returns a conflict response for duplicate trial numbers within a session target", async () => {
     mockTargetAndSessionLookups();
-    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
     vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: false, upstreamError: false });
     vi.mocked(fetchJson).mockResolvedValueOnce({
       ok: false,

--- a/src/server/api/shared.ts
+++ b/src/server/api/shared.ts
@@ -270,6 +270,28 @@ export async function currentUserCanTakeClientData(
   return { allowed: result.data === true, upstreamError: false };
 }
 
+export async function currentUserCanCaptureTrialEvent(
+  accessToken: string,
+  organizationId: string,
+  clientId: string,
+): Promise<{ allowed: boolean; upstreamError: boolean }> {
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const result = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/current_user_can_capture_trial_event`, {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      apikey: anonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ target_organization_id: organizationId, target_client_id: clientId }),
+  });
+
+  if (!result.ok) {
+    return { allowed: false, upstreamError: true };
+  }
+  return { allowed: result.data === true, upstreamError: false };
+}
+
 export async function currentUserCanManageLockedTrialEvent(
   accessToken: string,
   organizationId: string,

--- a/src/server/api/trial-events.ts
+++ b/src/server/api/trial-events.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
+import { getOptionalServerEnv } from "../env";
 import {
   CORS_HEADERS,
+  currentUserCanCaptureTrialEvent,
   currentUserCanManageLockedTrialEvent,
-  currentUserCanTakeClientData,
   fetchAuthenticatedUserIdWithStatus,
   fetchJson,
   getAccessToken,
@@ -53,11 +54,27 @@ type SessionScope = {
   therapist_id: string;
 };
 
+type TrialEventReadScope = {
+  clientId: string;
+};
+
 const buildHeaders = (anonKey: string, accessToken: string): Record<string, string> => ({
   "Content-Type": "application/json",
   apikey: anonKey,
   Authorization: `Bearer ${accessToken}`,
 });
+
+const buildServiceRoleHeaders = (): Record<string, string> | null => {
+  const serviceRoleKey = getOptionalServerEnv("SUPABASE_SERVICE_ROLE_KEY")?.trim();
+  if (!serviceRoleKey) {
+    return null;
+  }
+  return {
+    "Content-Type": "application/json",
+    apikey: serviceRoleKey,
+    Authorization: `Bearer ${serviceRoleKey}`,
+  };
+};
 
 const validateMeasurementPayload = (
   measurementType: string,
@@ -83,6 +100,55 @@ const validateMeasurementPayload = (
   }
 
   return null;
+};
+
+const resolveTrialEventReadScope = async (
+  supabaseUrl: string,
+  headers: Record<string, string>,
+  organizationId: string,
+  sessionId: string | null,
+  targetId: string | null,
+): Promise<{ scope: TrialEventReadScope | null; response?: Response }> => {
+  let clientId: string | null = null;
+
+  if (targetId) {
+    const targetResult = await fetchJson<TargetScope[]>(
+      `${supabaseUrl}/rest/v1/goal_targets?select=id,organization_id,client_id,goal_id,measurement_type&id=eq.${encodeURIComponent(
+        targetId,
+      )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
+      { method: "GET", headers },
+    );
+    if (!targetResult.ok) {
+      return { scope: null, response: json({ error: "Unable to validate trial-event target access" }, targetResult.status || 500) };
+    }
+    const target = Array.isArray(targetResult.data) ? targetResult.data[0] ?? null : null;
+    if (!target) {
+      return { scope: null, response: json({ error: "target_id is not in scope for this organization" }, 403) };
+    }
+    clientId = target.client_id;
+  }
+
+  if (sessionId) {
+    const sessionResult = await fetchJson<SessionScope[]>(
+      `${supabaseUrl}/rest/v1/sessions?select=id,organization_id,client_id,therapist_id&id=eq.${encodeURIComponent(
+        sessionId,
+      )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
+      { method: "GET", headers },
+    );
+    if (!sessionResult.ok) {
+      return { scope: null, response: json({ error: "Unable to validate trial-event session access" }, sessionResult.status || 500) };
+    }
+    const session = Array.isArray(sessionResult.data) ? sessionResult.data[0] ?? null : null;
+    if (!session) {
+      return { scope: null, response: json({ error: "session_id is not in scope for this organization" }, 403) };
+    }
+    if (clientId && session.client_id !== clientId) {
+      return { scope: null, response: json({ error: "session_id and target_id must belong to the same client" }, 400) };
+    }
+    clientId = session.client_id;
+  }
+
+  return clientId ? { scope: { clientId } } : { scope: null, response: json({ error: "session_id or target_id is required" }, 400) };
 };
 
 export async function trialEventsHandler(request: Request): Promise<Response> {
@@ -113,6 +179,7 @@ export async function trialEventsHandler(request: Request): Promise<Response> {
 
   const { supabaseUrl, anonKey } = getSupabaseConfig();
   const headers = buildHeaders(anonKey, accessToken);
+  const serviceRoleHeaders = buildServiceRoleHeaders();
   const organizationId = role.organizationId;
 
   if (request.method === "GET") {
@@ -127,6 +194,22 @@ export async function trialEventsHandler(request: Request): Promise<Response> {
     }
     if (targetId && !isUuid(targetId)) {
       return json({ error: "target_id must be a valid UUID" }, 400);
+    }
+
+    if (!serviceRoleHeaders) {
+      return json({ error: "Unable to validate trial-event read scope" }, 502);
+    }
+
+    const readScope = await resolveTrialEventReadScope(supabaseUrl, serviceRoleHeaders, organizationId, sessionId, targetId);
+    if (!readScope.scope) {
+      return readScope.response ?? json({ error: "Forbidden" }, 403);
+    }
+    const canRead = await currentUserCanCaptureTrialEvent(accessToken, organizationId, readScope.scope.clientId);
+    if (canRead.upstreamError) {
+      return json({ error: "Unable to validate trial-event read access" }, 502);
+    }
+    if (!canRead.allowed) {
+      return json({ error: "Forbidden" }, 403);
     }
 
     const filters = [
@@ -157,13 +240,19 @@ export async function trialEventsHandler(request: Request): Promise<Response> {
     if (!parsed.success) {
       return json({ error: "Invalid request body" }, 400);
     }
+    if (!serviceRoleHeaders) {
+      return json({ error: "Unable to validate trial-event scope" }, 502);
+    }
 
     const targetResult = await fetchJson<TargetScope[]>(
       `${supabaseUrl}/rest/v1/goal_targets?select=id,organization_id,client_id,goal_id,measurement_type&id=eq.${encodeURIComponent(
         parsed.data.target_id,
       )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
-      { method: "GET", headers },
+      { method: "GET", headers: serviceRoleHeaders },
     );
+    if (!targetResult.ok) {
+      return json({ error: "Unable to validate trial-event target access" }, targetResult.status || 500);
+    }
     const target = targetResult.ok && Array.isArray(targetResult.data) ? targetResult.data[0] ?? null : null;
     if (!target) {
       return json({ error: "target_id is not in scope for this organization" }, 403);
@@ -173,8 +262,11 @@ export async function trialEventsHandler(request: Request): Promise<Response> {
       `${supabaseUrl}/rest/v1/sessions?select=id,organization_id,client_id,therapist_id&id=eq.${encodeURIComponent(
         parsed.data.session_id,
       )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
-      { method: "GET", headers },
+      { method: "GET", headers: serviceRoleHeaders },
     );
+    if (!sessionResult.ok) {
+      return json({ error: "Unable to validate trial-event session access" }, sessionResult.status || 500);
+    }
     const session = sessionResult.ok && Array.isArray(sessionResult.data) ? sessionResult.data[0] ?? null : null;
     if (!session) {
       return json({ error: "session_id is not in scope for this organization" }, 403);
@@ -187,7 +279,7 @@ export async function trialEventsHandler(request: Request): Promise<Response> {
       return json({ error: measurementPayloadError }, 400);
     }
 
-    const canCapture = await currentUserCanTakeClientData(accessToken, organizationId, session.client_id);
+    const canCapture = await currentUserCanCaptureTrialEvent(accessToken, organizationId, session.client_id);
     if (canCapture.upstreamError) {
       return json({ error: "Unable to validate trial-event capture access" }, 502);
     }

--- a/supabase/functions/admin-users-roles/index.ts
+++ b/supabase/functions/admin-users-roles/index.ts
@@ -31,8 +31,9 @@ const ROLE_RANK: Record<AppRole, number> = {
 /**
  * `profiles.role` is not authoritative: middleware and RLS use `user_roles` + helpers
  * (`current_user_is_super_admin`, `get_user_role_from_junction`). Authenticated clients
- * cannot mutate another user's `user_roles` rows (RLS), so apply junction changes with the
- * service role after this super-admin-only route has authorized the caller.
+ * cannot reliably mutate another user's `user_roles` or `profiles` rows across org scopes (RLS),
+ * so apply target-user changes with the service role after this super-admin-only route has
+ * authorized the caller.
  */
 async function syncCanonicalUserRoles(
   targetUserId: string,
@@ -141,7 +142,7 @@ export default createProtectedRoute(async (req: Request, userContext) => {
     const validRoles = CANONICAL_ROLE_NAMES;
     if (!role || !validRoles.includes(role)) return new Response(JSON.stringify({ error: 'Valid role is required', validRoles }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
-    const { data: existingUser } = await adminClient.from('profiles').select('id, email, role, is_active').eq('id', userId).single();
+    const { data: existingUser } = await supabaseAdmin.from('profiles').select('id, email, role, is_active').eq('id', userId).single();
     if (!existingUser) return new Response(JSON.stringify({ error: 'User not found' }), { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
     if (
@@ -158,7 +159,7 @@ export default createProtectedRoute(async (req: Request, userContext) => {
       return new Response(JSON.stringify({ error: junctionError }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
-    const { data: updatedUser, error: updateError } = await adminClient
+    const { data: updatedUser, error: updateError } = await supabaseAdmin
       .from('profiles').update(updateData).eq('id', userId)
       .select('id, email, role, first_name, last_name, full_name, is_active, updated_at').single();
 

--- a/supabase/functions/trial-events/index.ts
+++ b/supabase/functions/trial-events/index.ts
@@ -1,5 +1,5 @@
 import { z } from "npm:zod@3.23.8";
-import { createRequestClient } from "../_shared/database.ts";
+import { createRequestClient, supabaseAdmin } from "../_shared/database.ts";
 import { corsHeadersForRequest } from "../_shared/cors.ts";
 import { createProtectedRoute, RouteOptions } from "../_shared/auth-middleware.ts";
 
@@ -38,6 +38,10 @@ type SessionScope = {
   id: string;
   client_id: string;
   therapist_id: string;
+};
+
+type TrialEventReadScope = {
+  clientId: string;
 };
 
 const json = (req: Request, body: unknown, status = 200) =>
@@ -88,17 +92,17 @@ const requireOrg = async (db: ReturnType<typeof createRequestClient>): Promise<s
   return data;
 };
 
-const canTakeClientData = async (
+const canCaptureTrialEvent = async (
   db: ReturnType<typeof createRequestClient>,
   orgId: string,
   clientId: string,
 ): Promise<CapabilityResult> => {
-  const { data, error } = await db.rpc("current_user_can_take_client_data", {
+  const { data, error } = await db.rpc("current_user_can_capture_trial_event", {
     target_organization_id: orgId,
     target_client_id: clientId,
   });
   if (error) {
-    console.error("current_user_can_take_client_data rpc error", error);
+    console.error("current_user_can_capture_trial_event rpc error", error);
     return { allowed: false, upstreamError: true };
   }
   return { allowed: data === true, upstreamError: false };
@@ -132,8 +136,50 @@ const sessionHasLockedNote = async (
   return { locked: data === true, upstreamError: false };
 };
 
+const resolveTrialEventReadScope = async (
+  db: ReturnType<typeof createRequestClient>,
+  orgId: string,
+  req: Request,
+  sessionId: string | null,
+  targetId: string | null,
+): Promise<{ scope: TrialEventReadScope | null; response?: Response }> => {
+  let clientId: string | null = null;
+
+  if (targetId) {
+    const { data: targets, error: targetError } = await db
+      .from("goal_targets")
+      .select("id,client_id,goal_id,measurement_type")
+      .eq("organization_id", orgId)
+      .eq("id", targetId)
+      .limit(1);
+    const target = !targetError && targets && targets.length > 0 ? targets[0] as unknown as TargetScope : null;
+    if (targetError) return { scope: null, response: json(req, { error: "Unable to validate trial-event target access" }, 500) };
+    if (!target) return { scope: null, response: json(req, { error: "target_id is not in scope for this organization" }, 403) };
+    clientId = target.client_id;
+  }
+
+  if (sessionId) {
+    const { data: sessions, error: sessionError } = await db
+      .from("sessions")
+      .select("id,client_id,therapist_id")
+      .eq("organization_id", orgId)
+      .eq("id", sessionId)
+      .limit(1);
+    const session = !sessionError && sessions && sessions.length > 0 ? sessions[0] as unknown as SessionScope : null;
+    if (sessionError) return { scope: null, response: json(req, { error: "Unable to validate trial-event session access" }, 500) };
+    if (!session) return { scope: null, response: json(req, { error: "session_id is not in scope for this organization" }, 403) };
+    if (clientId && session.client_id !== clientId) {
+      return { scope: null, response: json(req, { error: "session_id and target_id must belong to the same client" }, 400) };
+    }
+    clientId = session.client_id;
+  }
+
+  return clientId ? { scope: { clientId } } : { scope: null, response: json(req, { error: "session_id or target_id is required" }, 400) };
+};
+
 export const handleTrialEvents = async (req: Request) => {
   const db = createRequestClient(req);
+  const scopeDb = supabaseAdmin;
   const orgId = await requireOrg(db);
   if (!orgId) {
     return json(req, { error: "Forbidden" }, 403);
@@ -151,6 +197,12 @@ export const handleTrialEvents = async (req: Request) => {
     if (!sessionId && !targetId) return json(req, { error: "session_id or target_id is required" }, 400);
     if (sessionId && !isUuid(sessionId)) return json(req, { error: "session_id must be a valid UUID" }, 400);
     if (targetId && !isUuid(targetId)) return json(req, { error: "target_id must be a valid UUID" }, 400);
+
+    const readScope = await resolveTrialEventReadScope(scopeDb, orgId, req, sessionId, targetId);
+    if (!readScope.scope) return readScope.response ?? json(req, { error: "Forbidden" }, 403);
+    const canRead = await canCaptureTrialEvent(db, orgId, readScope.scope.clientId);
+    if (canRead.upstreamError) return json(req, { error: "Unable to validate trial-event read access" }, 502);
+    if (!canRead.allowed) return json(req, { error: "Forbidden" }, 403);
 
     let query = db
       .from("trial_events")
@@ -176,7 +228,7 @@ export const handleTrialEvents = async (req: Request) => {
     const parsed = createTrialEventSchema.safeParse(payload);
     if (!parsed.success) return json(req, { error: "Invalid request body" }, 400);
 
-    const { data: targets, error: targetError } = await db
+    const { data: targets, error: targetError } = await scopeDb
       .from("goal_targets")
       .select("id,client_id,goal_id,measurement_type")
       .eq("organization_id", orgId)
@@ -185,7 +237,7 @@ export const handleTrialEvents = async (req: Request) => {
     const target = !targetError && targets && targets.length > 0 ? targets[0] as unknown as TargetScope : null;
     if (!target) return json(req, { error: "target_id is not in scope for this organization" }, 403);
 
-    const { data: sessions, error: sessionError } = await db
+    const { data: sessions, error: sessionError } = await scopeDb
       .from("sessions")
       .select("id,client_id,therapist_id")
       .eq("organization_id", orgId)
@@ -201,7 +253,7 @@ export const handleTrialEvents = async (req: Request) => {
       return json(req, { error: measurementPayloadError }, 400);
     }
 
-    const canCapture = await canTakeClientData(db, orgId, session.client_id);
+    const canCapture = await canCaptureTrialEvent(db, orgId, session.client_id);
     if (canCapture.upstreamError) return json(req, { error: "Unable to validate trial-event capture access" }, 502);
     if (!canCapture.allowed) return json(req, { error: "Forbidden" }, 403);
 

--- a/supabase/migrations/20260703173000_goal_targets_trial_events.sql
+++ b/supabase/migrations/20260703173000_goal_targets_trial_events.sql
@@ -593,6 +593,16 @@ as $$
   select app.current_user_can_manage_locked_trial_event(target_organization_id);
 $$;
 
+create or replace function public.current_user_can_capture_trial_event(target_organization_id uuid, target_client_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, app
+as $$
+  select app.current_user_can_capture_trial_event(target_organization_id, target_client_id);
+$$;
+
 create or replace function public.current_user_can_take_client_data(target_organization_id uuid, target_client_id uuid)
 returns boolean
 language sql
@@ -719,12 +729,14 @@ grant execute on function app.current_user_can_manage_locked_trial_event(uuid) t
 grant execute on function app.current_user_can_capture_trial_event(uuid, uuid) to authenticated, service_role;
 grant execute on function public.session_has_locked_note(uuid) to authenticated, service_role;
 grant execute on function public.current_user_can_manage_locked_trial_event(uuid) to authenticated, service_role;
+grant execute on function public.current_user_can_capture_trial_event(uuid, uuid) to authenticated, service_role;
 grant execute on function public.current_user_can_take_client_data(uuid, uuid) to authenticated, service_role;
 revoke execute on function app.session_has_locked_note(uuid) from public, anon;
 revoke execute on function app.current_user_can_manage_locked_trial_event(uuid) from public, anon;
 revoke execute on function app.current_user_can_capture_trial_event(uuid, uuid) from public, anon;
 revoke execute on function public.session_has_locked_note(uuid) from public, anon;
 revoke execute on function public.current_user_can_manage_locked_trial_event(uuid) from public, anon;
+revoke execute on function public.current_user_can_capture_trial_event(uuid, uuid) from public, anon;
 revoke execute on function public.current_user_can_take_client_data(uuid, uuid) from public, anon;
 
 notify pgrst, 'reload schema';

--- a/supabase/migrations/20260703195500_sync_user_profile_organization_scope.sql
+++ b/supabase/migrations/20260703195500_sync_user_profile_organization_scope.sql
@@ -87,16 +87,20 @@ begin
   with admin_profiles_to_backfill as (
     select
       p.id,
-      public.get_organization_id_from_metadata(u.raw_user_meta_data) as metadata_org_id
+      metadata_org.metadata_org_id
     from auth.users u
     join public.profiles p on p.id = u.id
     join public.user_roles ur on ur.user_id = u.id
     join public.roles r on r.id = ur.role_id
+    join lateral (
+      select public.get_organization_id_from_metadata(u.raw_user_meta_data) as metadata_org_id
+    ) metadata_org on true
+    join public.organizations o on o.id = metadata_org.metadata_org_id
     where r.name in ('admin', 'super_admin')
       and coalesce(ur.is_active, true) = true
       and (ur.expires_at is null or ur.expires_at > now())
       and p.organization_id is null
-      and public.get_organization_id_from_metadata(u.raw_user_meta_data) is not null
+      and metadata_org.metadata_org_id is not null
   )
   update public.profiles p
   set organization_id = b.metadata_org_id,

--- a/tests/admin-create-user.access.spec.ts
+++ b/tests/admin-create-user.access.spec.ts
@@ -322,4 +322,45 @@ describe('admin-create-user access control', () => {
       error: 'User created, but organization context is unavailable.',
     });
   });
+
+  it('fails closed when created admin profile verification has a non-immutability database error', async () => {
+    userContexts.set('super-profile-db-error', {
+      user: { id: 'super-user-id', email: 'super@example.com' },
+      profile: {
+        id: 'super-profile-id',
+        email: 'super@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    });
+    profilesMaybeSingleSpy.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST202', message: 'profile lookup failed' },
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-create-user/index.ts');
+
+    const response = await handler(new Request('http://localhost/functions/v1/admin-create-user', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-token',
+        'x-test-user': 'super-profile-db-error',
+      },
+      body: JSON.stringify({
+        email: 'new.admin@example.com',
+        password: 'StrongPass123!',
+        first_name: 'New',
+        last_name: 'Admin',
+        organization_id: '22222222-2222-2222-2222-222222222222',
+        reason: 'Coverage for profile verification database errors.',
+      }),
+    }));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'User created, but organization context is unavailable.',
+    });
+    expect(logApiAccess).toHaveBeenCalledWith('POST', '/admin/create-user', expect.anything(), 500);
+  });
 });

--- a/tests/admin-users-roles.access.spec.ts
+++ b/tests/admin-users-roles.access.spec.ts
@@ -155,6 +155,9 @@ vi.mock('../supabase/functions/_shared/database.ts', () => {
             }),
           };
         }
+        if (table === 'profiles') {
+          return createProfilesQuery();
+        }
         throw new Error(`Unexpected supabaseAdmin table: ${table}`);
       }),
     },
@@ -166,18 +169,15 @@ vi.mock('../supabase/functions/_shared/database.ts', () => {
         return { data: null, error: { message: `Unexpected RPC ${functionName}` } };
       }),
       from: vi.fn((table: string) => {
-        if (table !== 'profiles') {
-          if (table === 'admin_actions') {
-            return {
-              insert: vi.fn(async (payload: Record<string, unknown>) => {
-                adminActionInserts.push(payload);
-                return { error: null };
-              }),
-            };
-          }
-          throw new Error(`Unexpected table: ${table}`);
+        if (table === 'admin_actions') {
+          return {
+            insert: vi.fn(async (payload: Record<string, unknown>) => {
+              adminActionInserts.push(payload);
+              return { error: null };
+            }),
+          };
         }
-        return createProfilesQuery();
+        throw new Error(`Unexpected request-scoped table access: ${table}`);
       }),
     }),
   };

--- a/tests/admins/sync_user_profile.organization.spec.ts
+++ b/tests/admins/sync_user_profile.organization.spec.ts
@@ -3,11 +3,14 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 describe('sync_user_profile organization sync', () => {
-  it('persists organization_id from auth metadata under the profile guard bypass', () => {
-    const migrationSql = readFileSync(
+  const readMigrationSql = () =>
+    readFileSync(
       join(process.cwd(), 'supabase/migrations/20260703195500_sync_user_profile_organization_scope.sql'),
       'utf-8',
     );
+
+  it('persists organization_id from auth metadata under the profile guard bypass', () => {
+    const migrationSql = readMigrationSql();
 
     const syncFunctionMatch = migrationSql.match(
       /create or replace function public\.sync_user_profile\(\)[\s\S]*?end;\s*\$\$/i,
@@ -23,13 +26,22 @@ describe('sync_user_profile organization sync', () => {
   });
 
   it('backfills missing admin profile organizations from auth metadata', () => {
-    const migrationSql = readFileSync(
-      join(process.cwd(), 'supabase/migrations/20260703195500_sync_user_profile_organization_scope.sql'),
-      'utf-8',
-    );
+    const migrationSql = readMigrationSql();
 
     expect(migrationSql).toMatch(/where r\.name in \('admin', 'super_admin'\)/i);
     expect(migrationSql).toMatch(/p\.organization_id is null/i);
+    expect(migrationSql).toMatch(/join public\.organizations o on o\.id = metadata_org\.metadata_org_id/i);
     expect(migrationSql).toMatch(/set organization_id = b\.metadata_org_id/i);
+  });
+
+  it('skips orphaned metadata organizations instead of creating or assigning them', () => {
+    const migrationSql = readMigrationSql();
+
+    expect(migrationSql).toMatch(
+      /join lateral \(\s*select public\.get_organization_id_from_metadata\(u\.raw_user_meta_data\) as metadata_org_id\s*\) metadata_org on true/i,
+    );
+    expect(migrationSql).toMatch(/join public\.organizations o on o\.id = metadata_org\.metadata_org_id/i);
+    expect(migrationSql).not.toMatch(/\binsert\s+into\s+public\.organizations\b/i);
+    expect(migrationSql).not.toMatch(/\binsert\s+into\s+organizations\b/i);
   });
 });

--- a/tests/goal-targets-trial-events-edge-access.test.ts
+++ b/tests/goal-targets-trial-events-edge-access.test.ts
@@ -26,6 +26,16 @@ describe("goal target and trial event edge access boundaries", () => {
     expect(trialEventsSource).toContain("if (canManageLocked.upstreamError) return json(req, { error: \"Unable to validate locked-session trial-event access\" }, 502);");
   });
 
+  it("gates trial-event reads through the trial-event capture capability", () => {
+    expect(trialEventsSource).toContain("import { createRequestClient, supabaseAdmin }");
+    expect(trialEventsSource).toContain("const scopeDb = supabaseAdmin;");
+    expect(trialEventsSource).toContain("const readScope = await resolveTrialEventReadScope(scopeDb, orgId, req, sessionId, targetId);");
+    expect(trialEventsSource).toContain("const canRead = await canCaptureTrialEvent(db, orgId, readScope.scope.clientId);");
+    expect(trialEventsSource).toContain("current_user_can_capture_trial_event");
+    expect(trialEventsSource).toContain("if (canRead.upstreamError) return json(req, { error: \"Unable to validate trial-event read access\" }, 502);");
+    expect(trialEventsSource).toContain("if (!canRead.allowed) return json(req, { error: \"Forbidden\" }, 403);");
+  });
+
   it("rejects negative trial-event values at the edge boundary", () => {
     expect(trialEventsSource).toContain("value: z.number().nonnegative().optional().nullable()");
   });

--- a/tests/goal-targets-trial-events-migration.test.ts
+++ b/tests/goal-targets-trial-events-migration.test.ts
@@ -107,13 +107,17 @@ describe("goal targets and trial events migration", () => {
     expect(sql).toContain("return app.session_has_locked_note(target_session_id);");
     expect(sql).toContain("create or replace function public.current_user_can_manage_locked_trial_event(target_organization_id uuid)");
     expect(sql).toContain("select app.current_user_can_manage_locked_trial_event(target_organization_id);");
+    expect(sql).toContain("create or replace function public.current_user_can_capture_trial_event(target_organization_id uuid, target_client_id uuid)");
+    expect(sql).toContain("select app.current_user_can_capture_trial_event(target_organization_id, target_client_id);");
     expect(sql).toContain("create or replace function public.current_user_can_take_client_data(target_organization_id uuid, target_client_id uuid)");
     expect(sql).toContain("select app.current_user_can_take_client_data(target_organization_id, target_client_id);");
     expect(sql).toContain("grant execute on function public.session_has_locked_note(uuid) to authenticated, service_role;");
     expect(sql).toContain("grant execute on function public.current_user_can_manage_locked_trial_event(uuid) to authenticated, service_role;");
+    expect(sql).toContain("grant execute on function public.current_user_can_capture_trial_event(uuid, uuid) to authenticated, service_role;");
     expect(sql).toContain("grant execute on function public.current_user_can_take_client_data(uuid, uuid) to authenticated, service_role;");
     expect(sql).toContain("revoke execute on function public.session_has_locked_note(uuid) from public, anon;");
     expect(sql).toContain("revoke execute on function public.current_user_can_manage_locked_trial_event(uuid) from public, anon;");
+    expect(sql).toContain("revoke execute on function public.current_user_can_capture_trial_event(uuid, uuid) from public, anon;");
     expect(sql).toContain("revoke execute on function public.current_user_can_take_client_data(uuid, uuid) from public, anon;");
   });
 


### PR DESCRIPTION
## Summary
- Render a trial-event graph inside each goal target card, backed by per-target TrialEvent reads and bounded graph-fetch timeout handling.
- Gate trial-event reads through current_user_can_capture_trial_event in both server and edge handlers.
- Resolve parent target/session client scope with service-role scope lookups before applying user-scoped capability checks and trial_events RLS reads/writes.

## Verification
- npm test -- src/server/__tests__/trialEventsHandler.test.ts tests/goal-targets-trial-events-edge-access.test.ts src/components/__tests__/ProgramsGoalsTab.test.tsx
- npm run verify:local
- npm run validate:tenant
- reviewer subagent re-check: no findings

## Local caveats
- npm run ci:playwright aggregate timed out twice after 15 minutes with no captured shell output. Direct relevant smokes passed: npm run playwright:session-note-measurement-roundtrip and npm run playwright:session-capture-adhoc-upsert.
- Local policy checks skipped DB-backed live grant/drift checks because SUPABASE_DB_URL is not configured.

## Route-task
classification: high-risk human-reviewed
lane: critical
triggering paths: src/server/**, supabase/functions/**, protected trial-event data access