### PR TITLE
WIN-195 Track deployed trial capture RPC wrapper

### DIFF
--- a/supabase/migrations/20260704024435_goal_targets_trial_events_capture_rpc_wrapper.sql
+++ b/supabase/migrations/20260704024435_goal_targets_trial_events_capture_rpc_wrapper.sql
@@ -1,0 +1,22 @@
+-- @migration-intent: Expose the trial-event capture authorization RPC in the public PostgREST namespace.
+-- @migration-dependencies: 20260703173000_goal_targets_trial_events.sql
+-- @migration-rollback: drop function public.current_user_can_capture_trial_event(uuid, uuid);
+
+begin;
+
+create or replace function public.current_user_can_capture_trial_event(target_organization_id uuid, target_client_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, app
+as $$
+  select app.current_user_can_capture_trial_event(target_organization_id, target_client_id);
+$$;
+
+grant execute on function public.current_user_can_capture_trial_event(uuid, uuid) to authenticated, service_role;
+revoke execute on function public.current_user_can_capture_trial_event(uuid, uuid) from public, anon;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260704024435_goal_targets_trial_events_capture_rpc_wrapper.sql
+++ b/supabase/migrations/20260704024435_goal_targets_trial_events_capture_rpc_wrapper.sql
@@ -1,6 +1,6 @@
 -- @migration-intent: Expose the trial-event capture authorization RPC in the public PostgREST namespace.
 -- @migration-dependencies: 20260703173000_goal_targets_trial_events.sql
--- @migration-rollback: drop function public.current_user_can_capture_trial_event(uuid, uuid);
+-- @migration-rollback: Preserve this wrapper when replaying from repo migrations because 20260703173000 already creates it; only drop it in the legacy hosted chain after confirming no earlier applied migration created or depends on the public wrapper.
 
 begin;
 


### PR DESCRIPTION
## Summary
- add the repo migration record for the hosted Supabase migration `20260704024435_goal_targets_trial_events_capture_rpc_wrapper`
- keeps repo migration history aligned with the wrapper already applied through the Supabase plugin on project `wnnjeqheqxxyrgsjmygy`
- exposes `public.current_user_can_capture_trial_event(uuid, uuid)` with authenticated/service_role execute and anon/public revoked

## Verification
- `npm test -- tests/goal-targets-trial-events-migration.test.ts`
- `npm run ci:check-focused`

## Risk
- Protected Supabase migration surface. Hosted migration has already been applied and verified; this PR records the same SQL in source control to prevent migration drift.