### PR TITLE
Fix employee role update timeout

### DIFF
--- a/supabase/functions/admin-users-roles/index.ts
+++ b/supabase/functions/admin-users-roles/index.ts
@@ -6,6 +6,8 @@ interface RoleUpdateRequest { target_user_id?: string; role: 'client' | 'bt' | '
 
 type AppRole = RoleUpdateRequest["role"];
 
+const ADMIN_ROLE_AUDIT_TIMEOUT_MS = 2_500;
+
 const CANONICAL_ROLE_NAMES: AppRole[] = [
   "super_admin",
   "bcba",
@@ -116,6 +118,27 @@ async function syncCanonicalUserRoles(
   return null;
 }
 
+async function runBestEffortAudit(work: () => Promise<void>): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const audit = work().catch((error) => {
+    console.error("Failed to enrich admin action metadata:", error);
+  });
+
+  try {
+    await Promise.race([
+      audit,
+      new Promise<void>((resolve) => {
+        timeoutId = setTimeout(() => {
+          console.error("Admin role audit enrichment timed out");
+          resolve();
+        }, ADMIN_ROLE_AUDIT_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
 export default createProtectedRoute(async (req: Request, userContext) => {
   if (req.method !== 'PATCH') return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   try {
@@ -168,7 +191,7 @@ export default createProtectedRoute(async (req: Request, userContext) => {
       return new Response(JSON.stringify({ error: 'Failed to update user role' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
-    try {
+    await runBestEffortAudit(async () => {
       const [actorResponse, targetResponse] = await Promise.all([
         supabaseAdmin.auth.admin.getUserById(userContext.user.id),
         supabaseAdmin.auth.admin.getUserById(userId),
@@ -198,9 +221,7 @@ export default createProtectedRoute(async (req: Request, userContext) => {
       if (actionLogError) {
         console.error('Failed to record admin action:', actionLogError);
       }
-    } catch (logError) {
-      console.error('Failed to enrich admin action metadata:', logError);
-    }
+    });
 
     logApiAccess('PATCH', `/admin/users/${userId}/roles`, userContext, 200);
 

--- a/tests/admin-users-roles.access.spec.ts
+++ b/tests/admin-users-roles.access.spec.ts
@@ -51,6 +51,7 @@ let existingProfile: TestProfile & {
 };
 let adminActionInserts: Array<Record<string, unknown>> = [];
 let userRolesUpsertPayload: Record<string, unknown> | null = null;
+let stallAuditUserLookup = false;
 
 type AdminUserRecord = {
   id: string;
@@ -125,10 +126,15 @@ vi.mock('../supabase/functions/_shared/database.ts', () => {
     supabaseAdmin: {
       auth: {
         admin: {
-          getUserById: vi.fn(async (userId: string) => ({
-            data: { user: adminUsers.get(userId) ?? null },
-            error: null,
-          })),
+          getUserById: vi.fn(async (userId: string) => {
+            if (stallAuditUserLookup) {
+              return await new Promise(() => {});
+            }
+            return {
+              data: { user: adminUsers.get(userId) ?? null },
+              error: null,
+            };
+          }),
         },
       },
       from: vi.fn((table: string) => {
@@ -203,6 +209,7 @@ describe('admin-users-roles access control', () => {
     adminActionInserts = [];
     adminUsers.clear();
     userRolesUpsertPayload = null;
+    stallAuditUserLookup = false;
   });
 
   it('allows a super admin to demote another admin user', async () => {
@@ -415,5 +422,58 @@ describe('admin-users-roles access control', () => {
       is_active: true,
     });
     expect(latestUpdatePayload).toEqual({ role: 'admin_schedule' });
+  });
+
+  it('returns success when audit metadata lookup stalls after the role write', async () => {
+    vi.useFakeTimers();
+    try {
+      rpcRoles = ['super_admin'];
+      stallAuditUserLookup = true;
+
+      const superAdminContext: TestUserContext = {
+        user: { id: 'super-admin-5', email: 'super5@example.com' },
+        profile: {
+          id: 'super-admin-profile-5',
+          email: 'super5@example.com',
+          role: 'super_admin',
+          is_active: true,
+        },
+      };
+
+      userContexts.set('super5', superAdminContext);
+
+      const { default: handler } = await import('../supabase/functions/admin-users-roles/index.ts');
+      const responsePromise = handler(
+        new Request('http://localhost/functions/v1/admin-users-roles', {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer test-token',
+            'x-test-user': 'super5',
+          },
+          body: JSON.stringify({
+            target_user_id: '11111111-1111-1111-1111-111111111111',
+            role: 'therapist',
+          }),
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      const response = await responsePromise;
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.user.role).toBe('therapist');
+      expect(userRolesUpsertPayload).toMatchObject({
+        user_id: existingProfile.id,
+        role_id: 'rid-therapist',
+        granted_by: 'super-admin-5',
+        is_active: true,
+      });
+      expect(latestUpdatePayload).toEqual({ role: 'therapist' });
+      expect(adminActionInserts).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- bound best-effort admin role audit enrichment so stalled Supabase Auth metadata lookups cannot hold the employee role PATCH response open
- kept authorization, user_roles sync, profile update, and audit insert semantics unchanged
- added a regression test proving role/profile writes still return 200 when audit metadata lookup stalls

## Verification
- npm test -- tests/admin-users-roles.access.spec.ts
- npm test -- src/components/settings/__tests__/AdminSettings.test.tsx tests/admin-users-roles.access.spec.ts
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run validate:tenant
- npm run build
- npm run test:routes:tier0
- npm run ci:verify-coverage

## Blocked / skipped
- npm run ci:playwright timed out locally after 5 minutes with no completed result; keep as CI/protected-browser gate.
- DB-backed policy/drift checks inside ci:check-focused skipped locally because SUPABASE_DB_URL/DATABASE_URL is not configured.

## Risk
Critical-lane protected Supabase function change. Human review required by repo policy. The change intentionally affects only post-write best-effort audit timing; it does not broaden role permissions or tenant scope.