### PR TITLE
Follow up admin role CORS and auth gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,13 @@ jobs:
         if: steps.browser_scope.outputs.auth_smoke_required == 'true'
         run: npm ci
 
+      - name: Provision auth smoke admin
+        if: steps.browser_scope.outputs.auth_smoke_required == 'true'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npx tsx scripts/provision-ci-smoke-admin.ts
+
       - name: Install Playwright browser
         if: steps.browser_scope.outputs.auth_smoke_required == 'true'
         run: npx playwright install --with-deps chromium
@@ -443,8 +450,51 @@ jobs:
           PW_BASE_URL: ${{ secrets.PW_BASE_URL }}
           PW_ADMIN_EMAIL: ${{ secrets.PW_ADMIN_EMAIL }}
           PW_ADMIN_PASSWORD: ${{ secrets.PW_ADMIN_PASSWORD }}
-          PW_SUPERADMIN_EMAIL: ${{ secrets.PW_SUPERADMIN_EMAIL }}
-          PW_SUPERADMIN_PASSWORD: ${{ secrets.PW_SUPERADMIN_PASSWORD }}
+          PW_THERAPIST_EMAIL: ${{ secrets.PW_THERAPIST_EMAIL }}
+          PW_THERAPIST_PASSWORD: ${{ secrets.PW_THERAPIST_PASSWORD }}
+          PW_SCHEDULE_EMAIL: ${{ secrets.PW_SCHEDULE_EMAIL }}
+          PW_SCHEDULE_PASSWORD: ${{ secrets.PW_SCHEDULE_PASSWORD }}
+          PW_FOREIGN_CLIENT_ID: ${{ secrets.PW_FOREIGN_CLIENT_ID }}
+          PW_FOREIGN_THERAPIST_ID: ${{ secrets.PW_FOREIGN_THERAPIST_ID }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY || secrets.SUPABASE_ANON_KEY }}
+        run: |
+          required=(
+            PW_BASE_URL
+            PW_THERAPIST_EMAIL
+            PW_THERAPIST_PASSWORD
+            PW_FOREIGN_CLIENT_ID
+            PW_FOREIGN_THERAPIST_ID
+            VITE_SUPABASE_URL
+            VITE_SUPABASE_ANON_KEY
+          )
+          missing=()
+          for key in "${required[@]}"; do
+            if [ -z "${!key}" ]; then
+              missing+=("$key")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+              echo "::warning::Missing auth smoke secrets on pull_request; skipping browser smoke gate: ${missing[*]}"
+              exit 0
+            fi
+            echo "Missing required secrets for auth browser smoke gate: ${missing[*]}"
+            exit 1
+          fi
+          export CI_SESSION_PARITY_REQUIRED=true
+          echo "Running auth browser smoke."
+          npm run playwright:auth
+
+      - name: Session browser smoke gate
+        if: steps.browser_scope.outputs.auth_smoke_required == 'true'
+        env:
+          PW_BASE_URL: ${{ secrets.PW_BASE_URL }}
+          PW_ADMIN_EMAIL: ${{ secrets.PW_ADMIN_EMAIL }}
+          PW_ADMIN_PASSWORD: ${{ secrets.PW_ADMIN_PASSWORD }}
           PW_THERAPIST_EMAIL: ${{ secrets.PW_THERAPIST_EMAIL }}
           PW_THERAPIST_PASSWORD: ${{ secrets.PW_THERAPIST_PASSWORD }}
           PW_SCHEDULE_EMAIL: ${{ secrets.PW_SCHEDULE_EMAIL }}
@@ -477,17 +527,15 @@ jobs:
 
           if [ "${#missing[@]}" -gt 0 ]; then
             if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-              echo "::warning::Missing auth smoke secrets on pull_request; skipping browser smoke gate: ${missing[*]}"
+              echo "::warning::Missing session smoke secrets on pull_request; skipping session browser smoke gate: ${missing[*]}"
               exit 0
             fi
-            echo "Missing required secrets for auth browser smoke gate: ${missing[*]}"
+            echo "Missing required secrets for session browser smoke gate: ${missing[*]}"
             exit 1
           fi
           export CI_SESSION_PARITY_REQUIRED=true
-          echo "Running non-AI sessions browser gates (preflight -> auth -> terminal:no-show -> terminal:completed -> blocked-close -> session-note-measurement-roundtrip)"
+          echo "Running non-AI session preflight."
           npm run playwright:preflight
-          echo "Preflight passed. Running auth smoke."
-          npm run playwright:auth
           echo "Running terminal flow regression: no-show"
           npm run playwright:session-no-show
           echo "Running terminal flow regression: completed"
@@ -496,6 +544,13 @@ jobs:
           npm run playwright:schedule-blocked-close
           echo "Running session note measurement roundtrip regression"
           npm run playwright:session-note-measurement-roundtrip
+
+      - name: Cleanup auth smoke admin
+        if: always() && steps.browser_scope.outputs.auth_smoke_required == 'true'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npx tsx scripts/provision-ci-smoke-admin.ts --cleanup
 
       - name: Record auth smoke evidence
         if: always()
@@ -530,14 +585,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Provision IEHP smoke admin
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npx tsx scripts/provision-ci-smoke-admin.ts
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
       - name: IEHP assessment import smoke gate
         env:
           PW_BASE_URL: ${{ secrets.PW_BASE_URL }}
-          PW_ADMIN_EMAIL: ${{ secrets.PW_SUPERADMIN_EMAIL || secrets.PW_ADMIN_EMAIL }}
-          PW_ADMIN_PASSWORD: ${{ secrets.PW_SUPERADMIN_PASSWORD || secrets.PW_ADMIN_PASSWORD }}
           PW_ASSESSMENT_CLIENT_ID: ${{ secrets.PW_ASSESSMENT_CLIENT_ID || secrets.W_ASSESSMENT_CLIENT_ID }}
           PW_ASSESSMENT_SAMPLE_FILE: ${{ secrets.PW_ASSESSMENT_SAMPLE_FILE }}
           VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -547,8 +606,8 @@ jobs:
         run: |
           required=(
             PW_BASE_URL
-            PW_ADMIN_EMAIL
-            PW_ADMIN_PASSWORD
+            PW_SUPERADMIN_EMAIL
+            PW_SUPERADMIN_PASSWORD
             PW_ASSESSMENT_CLIENT_ID
             PW_ASSESSMENT_SAMPLE_FILE
             VITE_SUPABASE_URL
@@ -567,6 +626,13 @@ jobs:
           fi
 
           npm run playwright:iehp-assessment-import-smoke
+
+      - name: Cleanup IEHP smoke admin
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npx tsx scripts/provision-ci-smoke-admin.ts --cleanup
 
       - name: Record IEHP import smoke evidence
         if: always()

--- a/scripts/playwright-iehp-assessment-import-smoke.ts
+++ b/scripts/playwright-iehp-assessment-import-smoke.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { chromium } from 'playwright';
 
 import { cleanupAssessmentImportArtifacts } from './lib/assessment-import-cleanup';
@@ -35,6 +36,14 @@ type AssessmentDraftsResponse = {
 
 const DEFAULT_BASE_URL = 'https://app.allincompassing.ai';
 const EXTRACTION_TIMEOUT_MS = 120_000;
+
+type SupabaseClientFactory = typeof createClient;
+type SmokeAuthResult = { accessToken: string };
+type CredentialCandidate = {
+  email?: string;
+  password?: string;
+  label: string;
+};
 
 const getRequiredEnv = (name: string): string => {
   const value = process.env[name]?.trim();
@@ -134,28 +143,91 @@ const fetchAssessmentDraftCounts = async (
   };
 };
 
-const selectConfiguredSmokeClient = async (
-  supabaseUrl: string,
-  supabaseAnonKey: string,
+const isInvalidCredentialsError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const candidate = error as { code?: unknown };
+  return candidate.code === 'invalid_credentials';
+};
+
+const signInSmokeUser = async (
+  supabase: ReturnType<SupabaseClientFactory>,
   email: string,
   password: string,
-): Promise<{ accessToken: string; clientId: string }> => {
-  const configuredClientId = getRequiredEnv('PW_ASSESSMENT_CLIENT_ID');
-  const supabase = createClient(supabaseUrl, supabaseAnonKey);
+): Promise<SmokeAuthResult> => {
   const { data: authData, error: authError } = await supabase.auth.signInWithPassword({ email, password });
   if (authError || !authData.session || !authData.user) {
     throw authError ?? new Error('Could not authenticate IEHP assessment import smoke user.');
   }
 
-  const { data: client, error } = await supabase.from('clients').select('id').eq('id', configuredClientId).maybeSingle();
-  if (error || !client) {
-    throw error ?? new Error('Configured PW_ASSESSMENT_CLIENT_ID is not accessible.');
-  }
-
   return {
     accessToken: authData.session.access_token,
-    clientId: client.id,
   };
+};
+
+export const selectConfiguredSmokeClient = async (
+  supabaseUrl: string,
+  supabaseAnonKey: string,
+  credentialCandidates: CredentialCandidate[],
+  options: {
+    clientFactory?: SupabaseClientFactory;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): Promise<{ accessToken: string; clientId: string; credentials: { email: string; password: string; label: string } }> => {
+  const env = options.env ?? process.env;
+  const configuredClientId = env.PW_ASSESSMENT_CLIENT_ID?.trim();
+  if (!configuredClientId) {
+    throw new Error('PW_ASSESSMENT_CLIENT_ID is required for IEHP assessment import smoke.');
+  }
+  const clientFactory = options.clientFactory ?? createClient;
+  const supabase = clientFactory(supabaseUrl, supabaseAnonKey);
+  const availableCredentials = credentialCandidates.filter((candidate) => candidate.email && candidate.password);
+
+  if (availableCredentials.length === 0) {
+    const labels = credentialCandidates.map((candidate) => candidate.label).join(' | ');
+    throw new Error(`Missing required credentials. Provide one of: ${labels}`);
+  }
+
+  for (const candidate of availableCredentials) {
+    const email = candidate.email!;
+    const password = candidate.password!;
+    try {
+      const authResult = await signInSmokeUser(supabase, email, password);
+      const { data: client, error } = await supabase
+        .from('clients')
+        .select('id')
+        .eq('id', configuredClientId)
+        .maybeSingle();
+
+      if (error) {
+        throw error;
+      }
+
+      if (!client) {
+        throw new Error(
+          `Configured PW_ASSESSMENT_CLIENT_ID is not accessible for authenticated credential: ${candidate.label}.`,
+        );
+      }
+
+      return {
+        accessToken: authResult.accessToken,
+        clientId: client.id,
+        credentials: {
+          email,
+          password,
+          label: candidate.label,
+        },
+      };
+    } catch (error) {
+      if (!isInvalidCredentialsError(error)) {
+        throw error;
+      }
+      console.warn(`IEHP assessment import smoke credential failed: ${candidate.label}. Trying next configured credential.`);
+    }
+  }
+
+  throw new Error('Could not authenticate any configured IEHP assessment import smoke credential.');
 };
 
 async function run() {
@@ -167,18 +239,18 @@ async function run() {
   const sampleFilePath = resolveIehpSmokeSampleFile({ cwd: process.cwd() });
   const sourceFileBuffer = readFileSync(sampleFilePath);
   const uploadFileName = buildIehpSmokeUploadFileName();
-  const credentials = preflightCredentials([
+  const credentialCandidates = [
     {
-      email: process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL,
-      password: process.env.PW_ADMIN_PASSWORD ?? process.env.PLAYWRIGHT_ADMIN_PASSWORD,
-      label: 'PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD',
+      email: process.env.PW_SUPERADMIN_EMAIL,
+      password: process.env.PW_SUPERADMIN_PASSWORD,
+      label: 'PW_SUPERADMIN_EMAIL + PW_SUPERADMIN_PASSWORD',
     },
-  ]);
-  const { accessToken, clientId } = await selectConfiguredSmokeClient(
+  ];
+  preflightCredentials(credentialCandidates);
+  const { accessToken, clientId, credentials } = await selectConfiguredSmokeClient(
     supabaseUrl,
     supabaseAnonKey,
-    credentials.email,
-    credentials.password,
+    credentialCandidates,
   );
 
   const browser = await chromium.launch({ headless: process.env.HEADLESS !== 'false' });
@@ -329,7 +401,12 @@ async function run() {
   }
 }
 
-run().catch((error) => {
-  console.error('Playwright IEHP assessment import smoke failed', error);
-  process.exit(1);
-});
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href && process.env.VITEST !== 'true';
+
+if (isDirectRun) {
+  run().catch((error) => {
+    console.error('Playwright IEHP assessment import smoke failed', error);
+    process.exit(1);
+  });
+}

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -43,6 +43,11 @@ interface BrowserFetchResult<TBody> {
   body: TBody | null;
 }
 
+interface BookingOccupiedRange {
+  start_time: string | null;
+  end_time: string | null;
+}
+
 const isTruthy = (value: string | undefined): boolean => /^(1|true|yes)$/i.test(value ?? "");
 /** UI wait + edge/RPC fallback can exceed 120s on cold paths. */
 const STEP_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_STEP_TIMEOUT_MS ?? "300000");
@@ -239,6 +244,93 @@ const createSessionViaServiceRole = async (params: {
   }
 
   throw new Error("Service-role session fallback insert failed: unable to find a non-overlapping slot.");
+};
+
+export const filterNonOverlappingBookingStarts = (
+  candidates: Date[],
+  durationMs: number,
+  occupiedRanges: BookingOccupiedRange[],
+): Date[] =>
+  candidates.filter((candidateStart) => {
+    const candidateEndMs = candidateStart.getTime() + durationMs;
+    return !occupiedRanges.some((range) => {
+      if (!range.start_time || !range.end_time) {
+        return false;
+      }
+      const occupiedStartMs = new Date(range.start_time).getTime();
+      const occupiedEndMs = new Date(range.end_time).getTime();
+      if (!Number.isFinite(occupiedStartMs) || !Number.isFinite(occupiedEndMs)) {
+        return false;
+      }
+      return occupiedStartMs < candidateEndMs && occupiedEndMs > candidateStart.getTime();
+    });
+  });
+
+export const buildBookingConflictWindowFilters = (params: {
+  therapistId: string;
+  clientId: string;
+  minStartIso: string;
+  maxEndIso: string;
+  nowIso: string;
+}): {
+  participantFilter: string;
+  minStartIso: string;
+  maxEndIso: string;
+  activeHoldExpiresAfterIso: string;
+} => ({
+  participantFilter: `therapist_id.eq.${params.therapistId},client_id.eq.${params.clientId}`,
+  minStartIso: params.minStartIso,
+  maxEndIso: params.maxEndIso,
+  activeHoldExpiresAfterIso: params.nowIso,
+});
+
+const fetchOccupiedBookingRanges = async (params: {
+  therapistId: string;
+  clientId: string;
+  minStartIso: string;
+  maxEndIso: string;
+}): Promise<BookingOccupiedRange[]> => {
+  const supabaseUrl = getEnv("VITE_SUPABASE_URL");
+  const serviceRole = getEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const adminClient = createClient(supabaseUrl, serviceRole, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  });
+  const conflictFilters = buildBookingConflictWindowFilters({
+    therapistId: params.therapistId,
+    clientId: params.clientId,
+    minStartIso: params.minStartIso,
+    maxEndIso: params.maxEndIso,
+    nowIso: new Date().toISOString(),
+  });
+  const windowFilters = (query: ReturnType<typeof adminClient.from>) =>
+    query
+      .select("start_time,end_time")
+      .or(conflictFilters.participantFilter)
+      .lt("start_time", conflictFilters.maxEndIso)
+      .gt("end_time", conflictFilters.minStartIso)
+      .limit(1000);
+
+  const { data: sessionRows, error: sessionError } = await windowFilters(adminClient.from("sessions")).neq(
+    "status",
+    "cancelled",
+  );
+  if (sessionError) {
+    throw new Error(`Unable to preflight lifecycle booking session conflicts: ${sessionError.message}`);
+  }
+
+  const { data: holdRows, error: holdError } = await windowFilters(adminClient.from("session_holds")).gt(
+    "expires_at",
+    conflictFilters.activeHoldExpiresAfterIso,
+  );
+  if (holdError) {
+    throw new Error(`Unable to preflight lifecycle booking hold conflicts: ${holdError.message}`);
+  }
+
+  return [...(sessionRows ?? []), ...(holdRows ?? [])];
 };
 
 const fetchAuthorizedTherapistClientPairs = async (): Promise<LifecycleTargetPair[]> => {
@@ -855,6 +947,7 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
   await openSessionModal(page);
 
   const candidateStarts = buildBookingCandidateStarts();
+  const bookingDurationMs = 60 * 60 * 1000;
   const excludedPairKeys = new Set<string>();
   let lastFailure: {
     selected: Awaited<ReturnType<typeof chooseSessionTargetsExcluding>>;
@@ -875,14 +968,41 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
       }
       throw error;
     }
+    const minStartIso = candidateStarts[0]?.toISOString();
+    const maxEndIso = candidateStarts.length > 0
+      ? new Date(candidateStarts[candidateStarts.length - 1].getTime() + bookingDurationMs).toISOString()
+      : "";
+    const occupiedRanges = minStartIso && maxEndIso
+      ? await fetchOccupiedBookingRanges({
+          therapistId: selected.therapistId,
+          clientId: selected.clientId,
+          minStartIso,
+          maxEndIso,
+        })
+      : [];
+    const availableCandidateStarts = filterNonOverlappingBookingStarts(
+      candidateStarts,
+      bookingDurationMs,
+      occupiedRanges,
+    );
+    if (availableCandidateStarts.length === 0) {
+      console.warn("[lifecycle] no conflict-free candidate starts for therapist-client pair; trying next pair", {
+        pairKey: selected.pairKey,
+        occupiedRangeCount: occupiedRanges.length,
+      });
+      await cleanupCreatedProgramGoal(selected);
+      excludedPairKeys.add(selected.pairKey);
+      continue;
+    }
+
     let finalStartIso = "";
     let finalEndIso = "";
     let payload: BrowserFetchResult<Record<string, unknown>> | null = null;
     let payloadBody: { success?: boolean; data?: { session?: { id?: string } }; code?: string } | null = null;
 
-    for (let attempt = 0; attempt < candidateStarts.length; attempt += 1) {
-      const attemptStart = candidateStarts[attempt];
-      const attemptEnd = new Date(attemptStart.getTime() + 60 * 60 * 1000);
+    for (let attempt = 0; attempt < availableCandidateStarts.length; attempt += 1) {
+      const attemptStart = availableCandidateStarts[attempt];
+      const attemptEnd = new Date(attemptStart.getTime() + bookingDurationMs);
       const startIso = attemptStart.toISOString();
       const endIso = attemptEnd.toISOString();
       finalStartIso = startIso;

--- a/scripts/provision-ci-smoke-admin.ts
+++ b/scripts/provision-ci-smoke-admin.ts
@@ -1,0 +1,269 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { appendFileSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+
+type RoleName = 'super_admin';
+
+const getEnv = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+};
+
+export const serializeError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (error && typeof error === 'object') {
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error);
+};
+
+export const getMissingProvisionSecrets = (env: NodeJS.ProcessEnv = process.env): string[] => (
+  ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'].filter((name) => !env[name]?.trim())
+);
+
+export const shouldSkipForSecretlessPullRequest = (env: NodeJS.ProcessEnv = process.env): boolean => (
+  env.GITHUB_EVENT_NAME === 'pull_request' && getMissingProvisionSecrets(env).length > 0
+);
+
+export const buildDefaultSmokeAdminEmail = (): string => {
+  const runId = process.env.GITHUB_RUN_ID?.trim() || String(Date.now());
+  const runAttempt = process.env.GITHUB_RUN_ATTEMPT?.trim() || '1';
+  const job = process.env.GITHUB_JOB?.trim() || 'local';
+  return `playwright.ci.${job}.${runId}.${runAttempt}@example.com`.toLowerCase();
+};
+
+export const assertDedicatedSmokeEmail = (email: string): void => {
+  if (!/^playwright\.ci\.[a-z0-9_.-]+@example\.com$/i.test(email)) {
+    throw new Error('Refusing to mutate non-dedicated CI smoke account email.');
+  }
+};
+
+const createPassword = (): string => `C1-${randomBytes(18).toString('base64url')}!Aa`;
+
+const createAdminClient = (): SupabaseClient =>
+  createClient(getEnv('SUPABASE_URL'), getEnv('SUPABASE_SERVICE_ROLE_KEY'), {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+const findUserByEmail = async (client: SupabaseClient, email: string) => {
+  const normalized = email.toLowerCase();
+  const perPage = 200;
+
+  for (let page = 1; page <= 10; page += 1) {
+    const { data, error } = await client.auth.admin.listUsers({ page, perPage });
+    if (error) {
+      throw error;
+    }
+
+    const user = data.users.find((candidate) => candidate.email?.toLowerCase() === normalized);
+    if (user) {
+      return user;
+    }
+
+    if (data.users.length < perPage) {
+      break;
+    }
+  }
+
+  return null;
+};
+
+const ensureRoleMapping = async (client: SupabaseClient, userId: string, email: string, role: RoleName): Promise<void> => {
+  const { data: roleRow, error: roleError } = await client
+    .from('roles')
+    .select('id')
+    .eq('name', role)
+    .maybeSingle();
+
+  if (roleError) {
+    throw roleError;
+  }
+  if (!roleRow?.id) {
+    throw new Error(`Role ${role} is not provisioned.`);
+  }
+
+  const { error: profileError } = await client.from('profiles').upsert(
+    {
+      id: userId,
+      email,
+      role,
+      is_active: true,
+      first_name: 'Playwright',
+      last_name: 'CI',
+      organization_id: null,
+    },
+    { onConflict: 'id' },
+  );
+
+  if (profileError) {
+    throw profileError;
+  }
+
+  const { error: userRoleError } = await client.from('user_roles').upsert(
+    {
+      user_id: userId,
+      role_id: roleRow.id,
+      is_active: true,
+    },
+    { onConflict: 'user_id,role_id' },
+  );
+
+  if (userRoleError) {
+    throw userRoleError;
+  }
+};
+
+export const writeGitHubEnv = (email: string, password: string): void => {
+  process.stdout.write(`::add-mask::${password}\n`);
+
+  const githubEnv = process.env.GITHUB_ENV?.trim();
+  if (!githubEnv) {
+    return;
+  }
+
+  appendFileSync(githubEnv, `PW_SUPERADMIN_EMAIL=${email}\n`, { encoding: 'utf8' });
+  appendFileSync(githubEnv, `PW_SUPERADMIN_PASSWORD=${password}\n`, { encoding: 'utf8' });
+};
+
+export const resolveCleanupSmokeAdminEmail = (): string => (
+  process.env.CI_SMOKE_ADMIN_EMAIL?.trim()
+  || process.env.PW_SUPERADMIN_EMAIL?.trim()
+  || buildDefaultSmokeAdminEmail()
+).toLowerCase();
+
+const provision = async (): Promise<void> => {
+  const email = (process.env.CI_SMOKE_ADMIN_EMAIL?.trim() || buildDefaultSmokeAdminEmail()).toLowerCase();
+  assertDedicatedSmokeEmail(email);
+
+  const password = createPassword();
+  const metadata = {
+    role: 'super_admin',
+    signup_role: 'super_admin',
+    is_admin: true,
+    is_super_admin: true,
+    organization_id: null,
+    organizationId: null,
+  };
+  const client = createAdminClient();
+  const existing = await findUserByEmail(client, email);
+
+  if (existing) {
+    const { error } = await client.auth.admin.updateUserById(existing.id, {
+      password,
+      email_confirm: true,
+      user_metadata: {
+        ...(existing.user_metadata ?? {}),
+        ...metadata,
+      },
+    });
+    if (error) {
+      throw error;
+    }
+    await ensureRoleMapping(client, existing.id, email, 'super_admin');
+    writeGitHubEnv(email, password);
+    console.log(JSON.stringify({ ok: true, action: 'updated', email, userId: existing.id }));
+    return;
+  }
+
+  const { data, error } = await client.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: metadata,
+  });
+
+  if (error) {
+    throw error;
+  }
+  if (!data.user) {
+    throw new Error('Supabase did not return a created smoke user.');
+  }
+
+  await ensureRoleMapping(client, data.user.id, email, 'super_admin');
+  writeGitHubEnv(email, password);
+  console.log(JSON.stringify({ ok: true, action: 'created', email, userId: data.user.id }));
+};
+
+const cleanup = async (): Promise<void> => {
+  const email = resolveCleanupSmokeAdminEmail();
+  if (!email) {
+    console.log(JSON.stringify({ ok: true, action: 'cleanup_skipped', reason: 'missing_email' }));
+    return;
+  }
+  assertDedicatedSmokeEmail(email);
+
+  const client = createAdminClient();
+  const user = await findUserByEmail(client, email);
+  if (!user) {
+    console.log(JSON.stringify({ ok: true, action: 'cleanup_skipped', email, reason: 'not_found' }));
+    return;
+  }
+
+  const { error: userRolesDeleteError } = await client.from('user_roles').delete().eq('user_id', user.id);
+  if (userRolesDeleteError) {
+    throw userRolesDeleteError;
+  }
+
+  const { error: profileDeleteError } = await client.from('profiles').delete().eq('id', user.id);
+  if (profileDeleteError) {
+    throw profileDeleteError;
+  }
+
+  const { error } = await client.auth.admin.deleteUser(user.id);
+  if (error) {
+    throw error;
+  }
+  console.log(JSON.stringify({ ok: true, action: 'deleted', email, userId: user.id }));
+};
+
+const main = async (): Promise<void> => {
+  const missingSecrets = getMissingProvisionSecrets();
+  if (missingSecrets.length > 0) {
+    if (shouldSkipForSecretlessPullRequest()) {
+      console.log(
+        JSON.stringify({
+          ok: true,
+          action: 'skipped',
+          reason: 'missing_pull_request_secrets',
+          missing: missingSecrets,
+        }),
+      );
+      return;
+    }
+    throw new Error(`Missing required Supabase admin secrets: ${missingSecrets.join(', ')}.`);
+  }
+
+  if (process.argv.includes('--cleanup')) {
+    await cleanup();
+    return;
+  }
+  await provision();
+};
+
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href && process.env.VITEST !== 'true';
+
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(
+      JSON.stringify({
+        ok: false,
+        error: serializeError(error),
+      }),
+    );
+    process.exit(1);
+  });
+}

--- a/supabase/functions/admin-users-roles/index.ts
+++ b/supabase/functions/admin-users-roles/index.ts
@@ -1,3 +1,5 @@
+import { corsHeadersForRequest } from "../_shared/cors.ts";
+
 interface RoleUpdateRequest { target_user_id?: string; role: 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin'; is_active?: boolean; }
 
 type AppRole = RoleUpdateRequest["role"];
@@ -24,35 +26,6 @@ const ROLE_RANK: Record<AppRole, number> = {
   therapist: 4,
   bt: 3,
   client: 1,
-};
-
-const STATIC_ALLOWED_ORIGINS = [
-  "https://app.allincompassing.ai",
-  "https://allincompassing.ai",
-  "https://www.allincompassing.ai",
-  "https://preview.allincompassing.ai",
-  "https://staging.allincompassing.ai",
-  "http://127.0.0.1:5173",
-  "http://127.0.0.1:4173",
-  "http://localhost:4173",
-  "http://localhost:3000",
-  "http://localhost:5173",
-] as const;
-
-const corsHeadersForPreflight = (req: Request): Record<string, string> => {
-  const requestOrigin = req.headers.get("origin");
-  const origin = requestOrigin && STATIC_ALLOWED_ORIGINS.includes(requestOrigin as typeof STATIC_ALLOWED_ORIGINS[number])
-    ? requestOrigin
-    : "https://app.allincompassing.ai";
-
-  return {
-    "Access-Control-Allow-Origin": origin,
-    "Access-Control-Allow-Methods": "PATCH, OPTIONS",
-    "Access-Control-Allow-Headers":
-      "Authorization, Content-Type, X-Client-Info, x-client-info, apikey, idempotency-key, x-request-id, x-correlation-id, x-agent-operation-id, x-supabase-authorization",
-    "Access-Control-Max-Age": "86400",
-    Vary: "Origin",
-  };
 };
 
 /**
@@ -166,20 +139,16 @@ async function runBestEffortAudit(work: () => Promise<void>): Promise<void> {
 }
 
 async function loadAdminRoleDeps() {
-  const [{ createRequestClient, supabaseAdmin }, { assertAdminOrSuperAdmin }] = await Promise.all([
-    import("../_shared/database.ts"),
-    import("../_shared/auth.ts"),
-  ]);
+  const { createRequestClient, supabaseAdmin } = await import("../_shared/database.ts");
 
-  return { createRequestClient, supabaseAdmin, assertAdminOrSuperAdmin };
+  return { createRequestClient, supabaseAdmin };
 }
 
 async function handleRoleUpdate(req: Request, userContext: any, corsHeaders: Record<string, string>, logApiAccess: any) {
   if (req.method !== 'PATCH') return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   try {
-    const { createRequestClient, supabaseAdmin, assertAdminOrSuperAdmin } = await loadAdminRoleDeps();
+    const { createRequestClient, supabaseAdmin } = await loadAdminRoleDeps();
     const adminClient = createRequestClient(req);
-    await assertAdminOrSuperAdmin(adminClient);
 
     const body = await req.json().catch(() => null) as RoleUpdateRequest | null;
     if (!body || typeof body !== "object") return new Response(JSON.stringify({ error: 'Valid role update request is required' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
@@ -271,11 +240,24 @@ async function handleRoleUpdate(req: Request, userContext: any, corsHeaders: Rec
 
 let protectedHandlerPromise: Promise<(req: Request) => Promise<Response>> | null = null;
 
+function withRequestCors(response: Response, req: Request): Response {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(corsHeadersForRequest(req))) {
+    headers.set(key, value);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 async function getProtectedHandler(): Promise<(req: Request) => Promise<Response>> {
   if (!protectedHandlerPromise) {
     protectedHandlerPromise = import("../_shared/auth-middleware.ts").then((auth) =>
       auth.createProtectedRoute(
-        (req: Request, userContext) => handleRoleUpdate(req, userContext, auth.corsHeaders, auth.logApiAccess),
+        (req: Request, userContext) => handleRoleUpdate(req, userContext, corsHeadersForRequest(req), auth.logApiAccess),
         auth.RouteOptions.superAdmin,
       )
     );
@@ -287,12 +269,13 @@ export async function handler(req: Request): Promise<Response> {
   if (req.method === "OPTIONS") {
     return new Response(null, {
       status: 204,
-      headers: corsHeadersForPreflight(req),
+      headers: corsHeadersForRequest(req),
     });
   }
 
   const protectedHandler = await getProtectedHandler();
-  return protectedHandler(req);
+  const response = await protectedHandler(req);
+  return withRequestCors(response, req);
 }
 
 if (typeof Deno !== "undefined" && typeof Deno.serve === "function") {

--- a/tests/admin-users-roles.access.spec.ts
+++ b/tests/admin-users-roles.access.spec.ts
@@ -52,6 +52,7 @@ let existingProfile: TestProfile & {
 let adminActionInserts: Array<Record<string, unknown>> = [];
 let userRolesUpsertPayload: Record<string, unknown> | null = null;
 let stallAuditUserLookup = false;
+let failLegacyRoleRpc = false;
 
 type AdminUserRecord = {
   id: string;
@@ -69,10 +70,13 @@ vi.mock('../supabase/functions/_shared/auth-middleware.ts', () => ({
     'Access-Control-Max-Age': '86400',
   },
   RouteOptions: {
-    superAdmin: {},
+    superAdmin: { allowedRoles: ['super_admin'] },
   },
   logApiAccess,
-  createProtectedRoute: (handler: (req: Request, userContext: TestUserContext) => Promise<Response>) => {
+  createProtectedRoute: (
+    handler: (req: Request, userContext: TestUserContext) => Promise<Response>,
+    options?: { allowedRoles?: TestRole[] },
+  ) => {
     return async (req: Request) => {
       const contextKey = req.headers.get('x-test-user') ?? 'default';
       const context = userContexts.get(contextKey);
@@ -80,6 +84,12 @@ vi.mock('../supabase/functions/_shared/auth-middleware.ts', () => ({
         return new Response(
           JSON.stringify({ error: 'Authentication required' }),
           { status: 401, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (options?.allowedRoles?.length && !options.allowedRoles.includes(context.profile.role)) {
+        return new Response(
+          JSON.stringify({ error: 'Insufficient permissions' }),
+          { status: 403, headers: { 'Content-Type': 'application/json' } },
         );
       }
       return handler(req, context);
@@ -170,6 +180,9 @@ vi.mock('../supabase/functions/_shared/database.ts', () => {
     createRequestClient: () => ({
       rpc: vi.fn(async (functionName: string) => {
         if (functionName === 'get_user_roles') {
+          if (failLegacyRoleRpc) {
+            return { data: null, error: { message: 'hosted RPC shape mismatch' } };
+          }
           return { data: [{ roles: rpcRoles }], error: null };
         }
         return { data: null, error: { message: `Unexpected RPC ${functionName}` } };
@@ -191,6 +204,8 @@ vi.mock('../supabase/functions/_shared/database.ts', () => {
 
 describe('admin-users-roles access control', () => {
   beforeEach(() => {
+    envValues.delete('CORS_ALLOWED_ORIGINS');
+    envValues.delete('API_ALLOWED_ORIGINS');
     userContexts.clear();
     logApiAccess.mockClear();
     rpcRoles = [];
@@ -210,6 +225,7 @@ describe('admin-users-roles access control', () => {
     adminUsers.clear();
     userRolesUpsertPayload = null;
     stallAuditUserLookup = false;
+    failLegacyRoleRpc = false;
   });
 
   it('allows a super admin to demote another admin user', async () => {
@@ -424,6 +440,183 @@ describe('admin-users-roles access control', () => {
     expect(latestUpdatePayload).toEqual({ role: 'admin_schedule' });
   });
 
+  it('uses the protected-route super-admin context instead of the legacy role RPC', async () => {
+    failLegacyRoleRpc = true;
+
+    const superAdminContext: TestUserContext = {
+      user: { id: 'super-admin-rpc-drift', email: 'super-rpc@example.com' },
+      profile: {
+        id: 'super-admin-rpc-drift-profile',
+        email: 'super-rpc@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    };
+
+    userContexts.set('super-rpc', superAdminContext);
+    adminUsers.set('super-admin-rpc-drift', {
+      id: 'super-admin-rpc-drift',
+      email: 'super-rpc@example.com',
+      user_metadata: { organization_id: 'org-123' },
+    });
+    adminUsers.set(existingProfile.id, {
+      id: existingProfile.id,
+      email: existingProfile.email,
+      user_metadata: { organization_id: 'org-999' },
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-users-roles/index.ts');
+
+    const response = await handler(
+      new Request('http://localhost/functions/v1/admin-users-roles', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+          'x-test-user': 'super-rpc',
+        },
+        body: JSON.stringify({
+          target_user_id: '11111111-1111-1111-1111-111111111111',
+          role: 'therapist',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(userRolesUpsertPayload).toMatchObject({
+      user_id: existingProfile.id,
+      role_id: 'rid-therapist',
+      granted_by: 'super-admin-rpc-drift',
+      is_active: true,
+    });
+    expect(latestUpdatePayload).toEqual({ role: 'therapist' });
+  });
+
+  it('uses request CORS headers on protected PATCH responses', async () => {
+    const previewOrigin = 'https://deploy-preview-725--velvety-cendol-dae4d6.netlify.app';
+
+    const superAdminContext: TestUserContext = {
+      user: { id: 'super-admin-cors', email: 'super-cors@example.com' },
+      profile: {
+        id: 'super-admin-cors-profile',
+        email: 'super-cors@example.com',
+        role: 'super_admin',
+        is_active: true,
+      },
+    };
+
+    userContexts.set('super-cors', superAdminContext);
+    adminUsers.set('super-admin-cors', {
+      id: 'super-admin-cors',
+      email: 'super-cors@example.com',
+      user_metadata: { organization_id: 'org-123' },
+    });
+    adminUsers.set(existingProfile.id, {
+      id: existingProfile.id,
+      email: existingProfile.email,
+      user_metadata: { organization_id: 'org-999' },
+    });
+
+    const { default: handler } = await import('../supabase/functions/admin-users-roles/index.ts');
+
+    const response = await handler(
+      new Request('http://localhost/functions/v1/admin-users-roles', {
+        method: 'PATCH',
+        headers: {
+          Origin: previewOrigin,
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+          'x-test-user': 'super-cors',
+        },
+        body: JSON.stringify({
+          target_user_id: '11111111-1111-1111-1111-111111111111',
+          role: 'therapist',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(previewOrigin);
+    expect(response.headers.get('Vary')).toBe('Origin');
+    expect(userRolesUpsertPayload).toMatchObject({
+      user_id: existingProfile.id,
+      role_id: 'rid-therapist',
+      granted_by: 'super-admin-cors',
+      is_active: true,
+    });
+  });
+
+  it('preserves middleware error responses while applying request CORS headers', async () => {
+    const previewOrigin = 'https://deploy-preview-725--velvety-cendol-dae4d6.netlify.app';
+    const { default: handler } = await import('../supabase/functions/admin-users-roles/index.ts');
+
+    const response = await handler(
+      new Request('http://localhost/functions/v1/admin-users-roles', {
+        method: 'PATCH',
+        headers: {
+          Origin: previewOrigin,
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+        },
+        body: JSON.stringify({
+          target_user_id: '11111111-1111-1111-1111-111111111111',
+          role: 'therapist',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(previewOrigin);
+    expect(response.headers.get('Vary')).toBe('Origin');
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    await expect(response.json()).resolves.toEqual({ error: 'Authentication required' });
+    expect(userRolesUpsertPayload).toBeNull();
+    expect(latestUpdatePayload).toBeNull();
+    expect(adminActionInserts).toEqual([]);
+  });
+
+  it('denies non-super-admin callers before role update side effects', async () => {
+    failLegacyRoleRpc = true;
+    const previewOrigin = 'https://deploy-preview-725--velvety-cendol-dae4d6.netlify.app';
+
+    const adminContext: TestUserContext = {
+      user: { id: 'admin-rpc-drift', email: 'admin-rpc@example.com' },
+      profile: {
+        id: 'admin-rpc-profile',
+        email: 'admin-rpc@example.com',
+        role: 'admin',
+        is_active: true,
+      },
+    };
+
+    userContexts.set('admin-rpc', adminContext);
+
+    const { default: handler } = await import('../supabase/functions/admin-users-roles/index.ts');
+
+    const response = await handler(
+      new Request('http://localhost/functions/v1/admin-users-roles', {
+        method: 'PATCH',
+        headers: {
+          Origin: previewOrigin,
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+          'x-test-user': 'admin-rpc',
+        },
+        body: JSON.stringify({
+          target_user_id: '11111111-1111-1111-1111-111111111111',
+          role: 'therapist',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(previewOrigin);
+    expect(userRolesUpsertPayload).toBeNull();
+    expect(latestUpdatePayload).toBeNull();
+    expect(adminActionInserts).toEqual([]);
+    expect(logApiAccess).not.toHaveBeenCalled();
+  });
+
   it('returns success when audit metadata lookup stalls after the role write', async () => {
     vi.useFakeTimers();
     try {
@@ -475,5 +668,42 @@ describe('admin-users-roles access control', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('preserves shared CORS origins on browser preflight', async () => {
+    envValues.set('CORS_ALLOWED_ORIGINS', 'https://custom-preview.example.com');
+
+    const { default: handler } = await import('../supabase/functions/admin-users-roles/index.ts');
+
+    const deployPreviewResponse = await handler(
+      new Request('http://localhost/functions/v1/admin-users-roles', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://deploy-preview-724--velvety-cendol-dae4d6.netlify.app',
+          'Access-Control-Request-Method': 'PATCH',
+        },
+      }),
+    );
+
+    expect(deployPreviewResponse.status).toBe(204);
+    expect(deployPreviewResponse.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://deploy-preview-724--velvety-cendol-dae4d6.netlify.app',
+    );
+    expect(deployPreviewResponse.headers.get('Access-Control-Allow-Methods')).toContain('PATCH');
+
+    const configuredOriginResponse = await handler(
+      new Request('http://localhost/functions/v1/admin-users-roles', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://custom-preview.example.com',
+          'Access-Control-Request-Method': 'PATCH',
+        },
+      }),
+    );
+
+    expect(configuredOriginResponse.status).toBe(204);
+    expect(configuredOriginResponse.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://custom-preview.example.com',
+    );
   });
 });

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { selectConfiguredSmokeClient } from '../../scripts/playwright-iehp-assessment-import-smoke';
+
+describe('selectConfiguredSmokeClient', () => {
+  it('falls back to the next configured credential when the first seed password drifted', async () => {
+    const signInWithPassword = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: { session: null, user: null },
+        error: { code: 'invalid_credentials', status: 400 },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          session: { access_token: 'admin-token' },
+          user: { id: 'admin-user' },
+        },
+        error: null,
+      });
+    const maybeSingle = vi.fn().mockResolvedValue({ data: { id: 'client-123' }, error: null });
+    const anonClient = {
+      auth: { signInWithPassword },
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({ maybeSingle })),
+        })),
+      })),
+    };
+    const clientFactory = vi.fn(() => anonClient);
+
+    const result = await selectConfiguredSmokeClient(
+      'https://example.supabase.co',
+      'anon-key',
+      [
+        {
+          email: 'superadmin@test.com',
+          password: 'drifted-secret',
+          label: 'PW_SUPERADMIN_EMAIL + PW_SUPERADMIN_PASSWORD',
+        },
+        {
+          email: 'admin@test.com',
+          password: 'valid-secret',
+          label: 'PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD',
+        },
+      ],
+      {
+        clientFactory: clientFactory as never,
+        env: {
+          PW_ASSESSMENT_CLIENT_ID: 'client-123',
+        } as NodeJS.ProcessEnv,
+      },
+    );
+
+    expect(result).toEqual({
+      accessToken: 'admin-token',
+      clientId: 'client-123',
+      credentials: {
+        email: 'admin@test.com',
+        password: 'valid-secret',
+        label: 'PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD',
+      },
+    });
+    expect(signInWithPassword).toHaveBeenNthCalledWith(1, {
+      email: 'superadmin@test.com',
+      password: 'drifted-secret',
+    });
+    expect(signInWithPassword).toHaveBeenNthCalledWith(2, {
+      email: 'admin@test.com',
+      password: 'valid-secret',
+    });
+  });
+
+  it('does not try the next credential for generic auth 400 errors', async () => {
+    const signInWithPassword = vi.fn().mockResolvedValue({
+      data: { session: null, user: null },
+      error: { code: 'bad_request', status: 400 },
+    });
+    const anonClient = {
+      auth: { signInWithPassword },
+      from: vi.fn(),
+    };
+    const clientFactory = vi.fn(() => anonClient);
+
+    await expect(
+      selectConfiguredSmokeClient(
+        'https://example.supabase.co',
+        'anon-key',
+        [
+          {
+            email: 'superadmin@test.com',
+            password: 'bad-request-secret',
+            label: 'PW_SUPERADMIN_EMAIL + PW_SUPERADMIN_PASSWORD',
+          },
+          {
+            email: 'admin@test.com',
+            password: 'valid-secret',
+            label: 'PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD',
+          },
+        ],
+        {
+          clientFactory: clientFactory as never,
+          env: {
+            PW_ASSESSMENT_CLIENT_ID: 'client-123',
+          } as NodeJS.ProcessEnv,
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'bad_request' });
+
+    expect(signInWithPassword).toHaveBeenCalledTimes(1);
+    expect(anonClient.from).not.toHaveBeenCalled();
+  });
+
+  it('fails immediately when an authenticated credential cannot access the configured client', async () => {
+    const signInWithPassword = vi.fn().mockResolvedValue({
+      data: {
+        session: { access_token: 'super-admin-token' },
+        user: { id: 'super-admin-user' },
+      },
+      error: null,
+    });
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+    const anonClient = {
+      auth: { signInWithPassword },
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({ maybeSingle })),
+        })),
+      })),
+    };
+    const clientFactory = vi.fn(() => anonClient);
+
+    await expect(
+      selectConfiguredSmokeClient(
+        'https://example.supabase.co',
+        'anon-key',
+        [
+          {
+            email: 'superadmin@test.com',
+            password: 'valid-but-wrong-client',
+            label: 'PW_SUPERADMIN_EMAIL + PW_SUPERADMIN_PASSWORD',
+          },
+          {
+            email: 'admin@test.com',
+            password: 'valid-secret',
+            label: 'PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD',
+          },
+        ],
+        {
+          clientFactory: clientFactory as never,
+          env: {
+            PW_ASSESSMENT_CLIENT_ID: 'client-123',
+          } as NodeJS.ProcessEnv,
+        },
+      ),
+    ).rejects.toThrow(
+      'Configured PW_ASSESSMENT_CLIENT_ID is not accessible for authenticated credential: PW_SUPERADMIN_EMAIL + PW_SUPERADMIN_PASSWORD.',
+    );
+
+    expect(signInWithPassword).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the CI IEHP smoke path dedicated to the generated super-admin account', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(path.join(root, '.github/workflows/ci.yml'), 'utf8');
+    const script = readFileSync(path.join(root, 'scripts/playwright-iehp-assessment-import-smoke.ts'), 'utf8');
+    const iehpJob = workflow.slice(
+      workflow.indexOf('iehp_assessment_import_smoke:'),
+      workflow.indexOf('ci_gate:'),
+    );
+    const candidateBlock = script.slice(
+      script.indexOf('const credentialCandidates = ['),
+      script.indexOf('preflightCredentials(credentialCandidates);'),
+    );
+
+    expect(iehpJob).toContain('PW_SUPERADMIN_EMAIL');
+    expect(iehpJob).toContain('PW_SUPERADMIN_PASSWORD');
+    expect(iehpJob).not.toMatch(/^\s+PW_ADMIN_EMAIL/m);
+    expect(iehpJob).not.toMatch(/^\s+PW_ADMIN_PASSWORD/m);
+    expect(candidateBlock).toContain('PW_SUPERADMIN_EMAIL');
+    expect(candidateBlock).not.toContain('PW_ADMIN_EMAIL');
+    expect(candidateBlock).not.toContain('PLAYWRIGHT_ADMIN_EMAIL');
+  });
+});

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   buildBookingCandidateStarts,
+  buildBookingConflictWindowFilters,
   cleanupBeforeNoResponseFailure,
+  filterNonOverlappingBookingStarts,
   isCreateSessionButtonReady,
 } from "../../scripts/playwright-session-lifecycle";
 
@@ -42,6 +44,71 @@ describe("playwright session lifecycle booking starts", () => {
     expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: null })).toBe(true);
     expect(isCreateSessionButtonReady({ disabled: "", ariaDisabled: null })).toBe(false);
     expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: "true" })).toBe(false);
+  });
+
+  it("filters booking starts that overlap occupied sessions or holds", () => {
+    const starts = [
+      new Date("2026-08-06T16:00:00.000Z"),
+      new Date("2026-08-06T18:00:00.000Z"),
+      new Date("2026-08-06T20:00:00.000Z"),
+    ];
+
+    const available = filterNonOverlappingBookingStarts(starts, 60 * 60 * 1000, [
+      {
+        start_time: "2026-08-06T16:30:00.000Z",
+        end_time: "2026-08-06T17:30:00.000Z",
+      },
+      {
+        start_time: "2026-08-06T19:00:00.000Z",
+        end_time: "2026-08-06T20:30:00.000Z",
+      },
+    ]);
+
+    expect(available.map((start) => start.toISOString())).toEqual(["2026-08-06T18:00:00.000Z"]);
+  });
+
+  it("keeps adjacent booking starts and ignores malformed occupied ranges", () => {
+    const starts = [
+      new Date("2026-08-06T16:00:00.000Z"),
+      new Date("2026-08-06T17:00:00.000Z"),
+    ];
+
+    const available = filterNonOverlappingBookingStarts(starts, 60 * 60 * 1000, [
+      {
+        start_time: "2026-08-06T15:00:00.000Z",
+        end_time: "2026-08-06T16:00:00.000Z",
+      },
+      {
+        start_time: "not-a-date",
+        end_time: "2026-08-06T17:30:00.000Z",
+      },
+      {
+        start_time: "2026-08-06T18:00:00.000Z",
+        end_time: "2026-08-06T19:00:00.000Z",
+      },
+    ]);
+
+    expect(available.map((start) => start.toISOString())).toEqual([
+      "2026-08-06T16:00:00.000Z",
+      "2026-08-06T17:00:00.000Z",
+    ]);
+  });
+
+  it("builds the hosted conflict preflight filters used for sessions and active holds", () => {
+    expect(
+      buildBookingConflictWindowFilters({
+        therapistId: "therapist-123",
+        clientId: "client-456",
+        minStartIso: "2026-08-06T16:00:00.000Z",
+        maxEndIso: "2026-08-20T21:00:00.000Z",
+        nowIso: "2026-07-04T22:00:00.000Z",
+      }),
+    ).toEqual({
+      participantFilter: "therapist_id.eq.therapist-123,client_id.eq.client-456",
+      minStartIso: "2026-08-06T16:00:00.000Z",
+      maxEndIso: "2026-08-20T21:00:00.000Z",
+      activeHoldExpiresAfterIso: "2026-07-04T22:00:00.000Z",
+    });
   });
 
   it("does not block the no-response failure when cleanup rejects", async () => {

--- a/tests/scripts/provision-ci-smoke-admin.test.ts
+++ b/tests/scripts/provision-ci-smoke-admin.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  assertDedicatedSmokeEmail,
+  buildDefaultSmokeAdminEmail,
+  getMissingProvisionSecrets,
+  resolveCleanupSmokeAdminEmail,
+  serializeError,
+  shouldSkipForSecretlessPullRequest,
+  writeGitHubEnv,
+} from '../../scripts/provision-ci-smoke-admin';
+
+describe('provision-ci-smoke-admin safeguards', () => {
+  it('accepts only dedicated CI smoke account addresses', () => {
+    expect(() => assertDedicatedSmokeEmail('playwright.ci.auth_browser_smoke.123.1@example.com')).not.toThrow();
+    expect(() => assertDedicatedSmokeEmail('playwright.ci.iehp-assessment-import-smoke.123.1@example.com')).not.toThrow();
+  });
+
+  it('refuses to mutate configured human or shared diagnostic accounts', () => {
+    expect(() => assertDedicatedSmokeEmail('superadmin@test.com')).toThrow(
+      'Refusing to mutate non-dedicated CI smoke account email.',
+    );
+    expect(() => assertDedicatedSmokeEmail('admin@example.com')).toThrow(
+      'Refusing to mutate non-dedicated CI smoke account email.',
+    );
+    expect(() => assertDedicatedSmokeEmail('playwright.ci.admin@allincompassing.ai')).toThrow(
+      'Refusing to mutate non-dedicated CI smoke account email.',
+    );
+  });
+
+  it('builds a deterministic dedicated address from GitHub job identity', () => {
+    const originalRunId = process.env.GITHUB_RUN_ID;
+    const originalRunAttempt = process.env.GITHUB_RUN_ATTEMPT;
+    const originalJob = process.env.GITHUB_JOB;
+    process.env.GITHUB_RUN_ID = '28720453572';
+    process.env.GITHUB_RUN_ATTEMPT = '2';
+    process.env.GITHUB_JOB = 'iehp_assessment_import_smoke';
+
+    try {
+      expect(buildDefaultSmokeAdminEmail()).toBe(
+        'playwright.ci.iehp_assessment_import_smoke.28720453572.2@example.com',
+      );
+    } finally {
+      if (originalRunId === undefined) {
+        delete process.env.GITHUB_RUN_ID;
+      } else {
+        process.env.GITHUB_RUN_ID = originalRunId;
+      }
+      if (originalRunAttempt === undefined) {
+        delete process.env.GITHUB_RUN_ATTEMPT;
+      } else {
+        process.env.GITHUB_RUN_ATTEMPT = originalRunAttempt;
+      }
+      if (originalJob === undefined) {
+        delete process.env.GITHUB_JOB;
+      } else {
+        process.env.GITHUB_JOB = originalJob;
+      }
+    }
+  });
+
+  it('uses the deterministic smoke address for cleanup when env export did not happen', () => {
+    const originalCiEmail = process.env.CI_SMOKE_ADMIN_EMAIL;
+    const originalSuperEmail = process.env.PW_SUPERADMIN_EMAIL;
+    const originalRunId = process.env.GITHUB_RUN_ID;
+    const originalRunAttempt = process.env.GITHUB_RUN_ATTEMPT;
+    const originalJob = process.env.GITHUB_JOB;
+    delete process.env.CI_SMOKE_ADMIN_EMAIL;
+    delete process.env.PW_SUPERADMIN_EMAIL;
+    process.env.GITHUB_RUN_ID = '28720453572';
+    process.env.GITHUB_RUN_ATTEMPT = '3';
+    process.env.GITHUB_JOB = 'auth_browser_smoke';
+
+    try {
+      expect(resolveCleanupSmokeAdminEmail()).toBe('playwright.ci.auth_browser_smoke.28720453572.3@example.com');
+    } finally {
+      if (originalCiEmail === undefined) {
+        delete process.env.CI_SMOKE_ADMIN_EMAIL;
+      } else {
+        process.env.CI_SMOKE_ADMIN_EMAIL = originalCiEmail;
+      }
+      if (originalSuperEmail === undefined) {
+        delete process.env.PW_SUPERADMIN_EMAIL;
+      } else {
+        process.env.PW_SUPERADMIN_EMAIL = originalSuperEmail;
+      }
+      if (originalRunId === undefined) {
+        delete process.env.GITHUB_RUN_ID;
+      } else {
+        process.env.GITHUB_RUN_ID = originalRunId;
+      }
+      if (originalRunAttempt === undefined) {
+        delete process.env.GITHUB_RUN_ATTEMPT;
+      } else {
+        process.env.GITHUB_RUN_ATTEMPT = originalRunAttempt;
+      }
+      if (originalJob === undefined) {
+        delete process.env.GITHUB_JOB;
+      } else {
+        process.env.GITHUB_JOB = originalJob;
+      }
+    }
+  });
+
+  it('masks the generated password before exporting it to GitHub env', () => {
+    const originalGitHubEnv = process.env.GITHUB_ENV;
+    const tmp = mkdtempSync(path.join(tmpdir(), 'smoke-admin-env-'));
+    const envPath = path.join(tmp, 'github-env');
+    process.env.GITHUB_ENV = envPath;
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      writeGitHubEnv('playwright.ci.auth.1.1@example.com', 'C1-generated-secret!Aa');
+      expect(writes.join('')).toContain('::add-mask::C1-generated-secret!Aa');
+      expect(readFileSync(envPath, 'utf8')).toContain('PW_SUPERADMIN_EMAIL=playwright.ci.auth.1.1@example.com');
+      expect(readFileSync(envPath, 'utf8')).toContain('PW_SUPERADMIN_PASSWORD=C1-generated-secret!Aa');
+    } finally {
+      process.stdout.write = originalWrite;
+      if (originalGitHubEnv === undefined) {
+        delete process.env.GITHUB_ENV;
+      } else {
+        process.env.GITHUB_ENV = originalGitHubEnv;
+      }
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps service-role credentials out of the auth login smoke step', () => {
+    const workflow = readFileSync(path.join(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+    const authStep = workflow.slice(
+      workflow.indexOf('- name: Auth browser smoke gate'),
+      workflow.indexOf('- name: Session browser smoke gate'),
+    );
+    const sessionStep = workflow.slice(
+      workflow.indexOf('- name: Session browser smoke gate'),
+      workflow.indexOf('- name: Cleanup auth smoke admin'),
+    );
+
+    expect(authStep).toContain('npm run playwright:auth');
+    expect(authStep).not.toContain('npm run playwright:preflight');
+    expect(authStep).not.toContain('SUPABASE_SECRET_KEY');
+    expect(authStep).not.toContain('SUPABASE_SERVICE_ROLE_KEY');
+    expect(sessionStep).toContain('npm run playwright:preflight');
+    expect(sessionStep).toContain('SUPABASE_SERVICE_ROLE_KEY');
+  });
+
+  it('preserves the secretless pull_request skip path for provisioning and cleanup', () => {
+    const pullRequestEnv = {
+      GITHUB_EVENT_NAME: 'pull_request',
+      SUPABASE_URL: '',
+      SUPABASE_SERVICE_ROLE_KEY: '',
+    } as NodeJS.ProcessEnv;
+    const pushEnv = {
+      GITHUB_EVENT_NAME: 'push',
+      SUPABASE_URL: '',
+      SUPABASE_SERVICE_ROLE_KEY: '',
+    } as NodeJS.ProcessEnv;
+
+    expect(getMissingProvisionSecrets(pullRequestEnv)).toEqual(['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY']);
+    expect(shouldSkipForSecretlessPullRequest(pullRequestEnv)).toBe(true);
+    expect(shouldSkipForSecretlessPullRequest(pushEnv)).toBe(false);
+  });
+
+  it('serializes Supabase error objects for CI diagnostics', () => {
+    expect(serializeError({ code: '23505', message: 'duplicate key value violates unique constraint' })).toBe(
+      '{"code":"23505","message":"duplicate key value violates unique constraint"}',
+    );
+  });
+
+  it('does not write hosted generated profile columns', () => {
+    const script = readFileSync(path.join(process.cwd(), 'scripts/provision-ci-smoke-admin.ts'), 'utf8');
+    const profilePayload = script.slice(
+      script.indexOf("const { error: profileError } = await client.from('profiles').upsert("),
+      script.indexOf("const { error: userRoleError } = await client.from('user_roles').upsert("),
+    );
+
+    expect(profilePayload).not.toContain('full_name');
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve shared/request-derived CORS origins for `admin-users-roles` OPTIONS preflight.
- Apply the same request-derived CORS headers to protected PATCH responses, including success, 403, and middleware-generated 401 responses.
- Keep role mutation authorization on the protected super-admin route and avoid the stale legacy RPC gate that caused hosted false denials.
- Add regression coverage for deploy-preview preflight/PATCH CORS behavior and protected failure response preservation.
- Fix the failed CI smoke jobs by provisioning a dedicated per-job CI super-admin account with a generated masked password, using it for auth/IEHP browser login, and cleaning it up with deterministic safeguards.
- Keep the IEHP smoke path dedicated to generated `PW_SUPERADMIN_*` only; no shared `PW_ADMIN_*` fallback and no service-role secret in the IEHP browser step.
- Split auth login smoke from service-role-backed session preflight/regressions so the auth login step does not receive service-role credentials.
- Stabilize the session lifecycle smoke by prefiltering candidate booking slots against existing sessions and active holds before driving the UI modal.

## Verification
- `npm run test -- tests/admin-users-roles.access.spec.ts tests/edge/auth-middleware.role-resolution.test.ts src/tests/security/edgeFunctionConfig.test.ts tests/edge/cors-policy.test.ts` passed: 4 files, 16 tests.
- `npm run test -- tests/scripts/playwright-session-lifecycle.test.ts tests/scripts/provision-ci-smoke-admin.test.ts tests/scripts/playwright-iehp-assessment-import-smoke.test.ts tests/ci/check-e2e-reliability-gates.test.ts` passed: 4 files, 27 tests.
- `npm run ci:check-focused` passed locally and in the commit hook; DB-backed checks skipped locally because no `SUPABASE_DB_URL`/`DATABASE_URL`; auth parity skipped because `CI_SUPABASE_AUTH_PARITY_REQUIRED` is disabled.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run test:ci` passed locally: 352 files, 2229 tests.
- `npm run build` passed locally.
- `npm run validate:tenant` passed locally.
- `npm run test:routes:tier0` passed locally: 212 Cypress route tests.
- GitHub CI passed on `b4100a35`: policy, lint-typecheck, unit-tests, auth-browser-smoke, iehp-assessment-import-smoke, build, tier0-browser, tenant-safety, Lighthouse CI, Netlify deploy preview, Supabase Preview, and ci-gate.

## Risk
- Critical/protected paths: `supabase/functions/admin-users-roles/**`, `.github/workflows/**`, and CI Playwright smoke scripts.
- Human review required before merge under repo policy.
- No migration, RLS, grant, or tenant-scope widening in this PR.
- CI provisioning refuses non-dedicated account emails, masks generated passwords, preserves secretless pull-request skip behavior, fails push runs with missing Supabase admin secrets, and cleanup fails visibly if role/profile/auth deletion fails.
