### PR TITLE
Add previous role values to admin role audit logs

### DIFF
--- a/supabase/functions/admin-users-roles/index.ts
+++ b/supabase/functions/admin-users-roles/index.ts
@@ -218,7 +218,9 @@ async function handleRoleUpdate(req: Request, userContext: any, corsHeaders: Rec
           organization_id: organizationId,
           action_type: 'role_update',
           action_details: {
+            old_role: existingUser.role,
             new_role: role,
+            old_is_active: existingUser.is_active,
             is_active: updateData.is_active ?? existingUser.is_active,
           },
         });

--- a/tests/admin-users-roles.access.spec.ts
+++ b/tests/admin-users-roles.access.spec.ts
@@ -285,7 +285,9 @@ describe('admin-users-roles access control', () => {
         organization_id: 'org-999',
         action_type: 'role_update',
         action_details: {
+          old_role: 'admin',
           new_role: 'therapist',
+          old_is_active: true,
           is_active: true,
         },
       },


### PR DESCRIPTION
## Summary
- add `old_role` and `old_is_active` to `admin_actions.action_details` for admin role updates
- update the focused Edge Function access-control test expectation

## Route Task
- classification: high-risk human-reviewed
- lane: critical
- triggering paths: `supabase/functions/admin-users-roles/index.ts`, `tests/admin-users-roles.access.spec.ts`
- risk rationale: protected Edge Function audit payload for privileged role mutation path

## Verification Card
- change type: server/API/edge integration; database/audit payload; tenant-sensitive privileged role path
- required checks: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npx vitest run tests/admin-users-roles.access.spec.ts --reporter=verbose`, `npm run test:ci`, `npm run validate:tenant`, `npm run ci:verify-coverage`, `npm run build`, `npm run test:routes:tier0`
- executed checks:
  - `npx vitest run tests/admin-users-roles.access.spec.ts --reporter=verbose` - pass
  - `npm run ci:check-focused` - pass
  - `npm run lint` - pass
  - `npm run typecheck` - pass
  - `npm run test:ci` - pass
  - `npm run validate:tenant` - pass
  - `npm run build` - pass
  - `npm run ci:verify-coverage` - pass
  - `npm run test:routes:tier0` - pass
- blocked checks: none
- residual risk: audit enrichment is best-effort by existing design; this change does not alter authz, CORS, role mutation order, or schema.

## PR Hygiene
- branch-ready: yes (`codex/admin-role-audit-old-role`)
- single-purpose: yes
- unrelated changes: none
- generated artifact drift: none
- protected-path drift: expected protected Edge Function path; lane is critical
- Linear: not linked; no issue key was provided for this P2 follow-up