### PR TITLE
Persist Schedule capture as trial events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,16 +534,9 @@ jobs:
             exit 1
           fi
           export CI_SESSION_PARITY_REQUIRED=true
-          echo "Running non-AI session preflight."
-          npm run playwright:preflight
-          echo "Running terminal flow regression: no-show"
-          npm run playwright:session-no-show
-          echo "Running terminal flow regression: completed"
-          npm run playwright:session-complete
-          echo "Running blocked-close notes-required regression"
-          npm run playwright:schedule-blocked-close
-          echo "Running session note measurement roundtrip regression"
-          npm run playwright:session-note-measurement-roundtrip
+          export PW_CI_CHILD_TIMEOUT_MS=480000
+          echo "Running non-AI session browser smoke suite."
+          npm run ci:playwright:session-smoke
 
       - name: Cleanup auth smoke admin
         if: always() && steps.browser_scope.outputs.auth_smoke_required == 'true'

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "playwright:session-note-measurement-roundtrip": "tsx scripts/playwright-session-note-measurement-roundtrip.ts",
     "playwright:session-capture-adhoc-upsert": "tsx scripts/playwright-session-capture-adhoc-upsert.ts",
     "ci:playwright": "tsx scripts/playwright-ci-runner.ts playwright:preflight playwright:auth playwright:schedule-conflict playwright:therapist-onboarding playwright:therapist-authorization playwright:session-no-show playwright:session-complete playwright:schedule-blocked-close playwright:session-note-measurement-roundtrip playwright:session-capture-adhoc-upsert",
+    "ci:playwright:session-smoke": "tsx scripts/playwright-ci-runner.ts playwright:preflight playwright:session-no-show playwright:session-complete playwright:schedule-blocked-close playwright:session-note-measurement-roundtrip",
     "contract:runtime-config": "node scripts/contracts/check-runtime-config.mjs",
     "bolt:dev": "vite --host 0.0.0.0",
     "bolt:build": "tsc && vite build --mode production",

--- a/scripts/ci/check-e2e-reliability-gates.mjs
+++ b/scripts/ci/check-e2e-reliability-gates.mjs
@@ -48,7 +48,9 @@ const childIndex = (children, scriptName) => children.indexOf(scriptName);
 const ciPlaywrightRunnerHasChild = (runner, scriptName) => childIndex(runner.children, scriptName) !== -1;
 
 const ciWorkflowRunsPlaywrightScript = (workflow, scriptName) =>
-  workflow.includes(`npm run ${scriptName}`) || workflow.includes("npm run ci:playwright");
+  workflow.includes(`npm run ${scriptName}`) ||
+  workflow.includes("npm run ci:playwright") ||
+  workflow.includes("npm run ci:playwright:session-smoke");
 
 const workflowJobTimeoutMinutes = (workflow) => {
   const match = workflow.match(/^\s+timeout-minutes:\s*(\d+)\s*$/m);
@@ -102,11 +104,53 @@ const run = async () => {
   const scripts = packageJson?.scripts ?? {};
   const ciPlaywright = String(scripts["ci:playwright"] ?? "");
   const ciPlaywrightRunner = parseCiPlaywrightRunner(ciPlaywright);
+  const ciPlaywrightSessionSmoke = String(scripts["ci:playwright:session-smoke"] ?? "");
+  const ciPlaywrightSessionSmokeRunner = parseCiPlaywrightRunner(ciPlaywrightSessionSmoke);
   if (ciPlaywrightRunner.runnerIndex < 0 || ciPlaywrightRunner.runnerCommand !== "tsx") {
     errors.push("package.json script ci:playwright must invoke scripts/playwright-ci-runner.ts through tsx.");
   }
   if (ciPlaywrightRunner.tokens.includes("&&") || ciPlaywrightRunner.tokens.includes("npm")) {
     errors.push("package.json script ci:playwright must use the attributed runner, not an npm shell chain.");
+  }
+  if (ciPlaywrightSessionSmokeRunner.runnerIndex < 0 || ciPlaywrightSessionSmokeRunner.runnerCommand !== "tsx") {
+    errors.push("package.json script ci:playwright:session-smoke must invoke scripts/playwright-ci-runner.ts through tsx.");
+  }
+  if (
+    ciPlaywrightSessionSmokeRunner.tokens.includes("&&") ||
+    ciPlaywrightSessionSmokeRunner.tokens.includes("npm")
+  ) {
+    errors.push("package.json script ci:playwright:session-smoke must use the attributed runner, not an npm shell chain.");
+  }
+  if (ciPlaywrightSessionSmokeRunner.children[0] !== "playwright:preflight") {
+    errors.push("package.json script ci:playwright:session-smoke runner arguments must start with playwright:preflight.");
+  }
+  for (const scriptName of [
+    "playwright:session-no-show",
+    "playwright:session-complete",
+    "playwright:schedule-blocked-close",
+    "playwright:session-note-measurement-roundtrip",
+  ]) {
+    if (childIndex(ciPlaywrightSessionSmokeRunner.children, scriptName) === -1) {
+      errors.push(`package.json script ci:playwright:session-smoke runner arguments must include ${scriptName}.`);
+    }
+  }
+  if (
+    childIndex(ciPlaywrightSessionSmokeRunner.children, "playwright:session-no-show") !== -1 &&
+    childIndex(ciPlaywrightSessionSmokeRunner.children, "playwright:session-complete") !== -1 &&
+    childIndex(ciPlaywrightSessionSmokeRunner.children, "playwright:session-complete") <
+      childIndex(ciPlaywrightSessionSmokeRunner.children, "playwright:session-no-show")
+  ) {
+    errors.push("package.json script ci:playwright:session-smoke must run playwright:session-no-show before playwright:session-complete.");
+  }
+  if (
+    childIndex(ciPlaywrightSessionSmokeRunner.children, "playwright:schedule-blocked-close") !== -1 &&
+    childIndex(ciPlaywrightSessionSmokeRunner.children, "playwright:session-note-measurement-roundtrip") !== -1 &&
+    childIndex(ciPlaywrightSessionSmokeRunner.children, "playwright:session-note-measurement-roundtrip") <
+      childIndex(ciPlaywrightSessionSmokeRunner.children, "playwright:schedule-blocked-close")
+  ) {
+    errors.push(
+      "package.json script ci:playwright:session-smoke must run playwright:schedule-blocked-close before playwright:session-note-measurement-roundtrip.",
+    );
   }
   if (ciPlaywrightRunner.runnerIndex !== 1 || ciPlaywrightRunner.tokens[0] !== "tsx") {
     errors.push("package.json script ci:playwright must start with tsx scripts/playwright-ci-runner.ts.");

--- a/scripts/playwright-ci-runner.ts
+++ b/scripts/playwright-ci-runner.ts
@@ -54,6 +54,15 @@ const terminateChild = (child: ChildProcess, signal: NodeJS.Signals = "SIGTERM")
     return;
   }
 
+  if (child.pid) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // Fall back to the direct child if process-group signaling is unavailable.
+    }
+  }
+
   child.kill(signal);
 };
 
@@ -70,6 +79,7 @@ const runScript = (scriptName: string, index: number, total: number): Promise<Ru
     );
 
     const child = spawn(npmCommand, ["run", scriptName], {
+      detached: process.platform !== "win32",
       stdio: "inherit",
       shell: useShell,
       windowsHide: true,

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -53,6 +53,7 @@ const isTruthy = (value: string | undefined): boolean => /^(1|true|yes)$/i.test(
 const STEP_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_STEP_TIMEOUT_MS ?? "300000");
 const UI_BOOK_RESPONSE_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_UI_BOOK_RESPONSE_TIMEOUT_MS ?? "45000");
 const CLEANUP_BEFORE_FAILURE_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_CLEANUP_BEFORE_FAILURE_TIMEOUT_MS ?? "5000");
+const MAX_LIFECYCLE_PAIR_ATTEMPTS = Number(process.env.PW_LIFECYCLE_MAX_PAIR_ATTEMPTS ?? "3");
 
 const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): Promise<T> => {
   console.log(`[lifecycle] start ${label}`);
@@ -600,6 +601,26 @@ export const isCreateSessionButtonReady = ({
   ariaDisabled: string | null;
 }): boolean => disabled === null && ariaDisabled !== "true";
 
+export const shouldTryNextLifecyclePairAfterAttempts = ({
+  attemptedStartCount,
+  blockedAttemptCount,
+  payloadStatus,
+}: {
+  attemptedStartCount: number;
+  blockedAttemptCount: number;
+  payloadStatus: number | null;
+}): boolean =>
+  payloadStatus === 409 ||
+  (attemptedStartCount > 0 && blockedAttemptCount >= attemptedStartCount);
+
+export const hasReachedLifecyclePairAttemptLimit = ({
+  attemptedPairCount,
+  maxPairAttempts = MAX_LIFECYCLE_PAIR_ATTEMPTS,
+}: {
+  attemptedPairCount: number;
+  maxPairAttempts?: number;
+}): boolean => attemptedPairCount >= Math.max(1, maxPairAttempts);
+
 const expectCreateSessionButtonReady = async (
   page: Page,
   context: {
@@ -958,6 +979,9 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
   } | null = null;
 
   while (true) {
+    if (hasReachedLifecyclePairAttemptLimit({ attemptedPairCount: excludedPairKeys.size })) {
+      break;
+    }
     await ensureSessionModalOpen(page);
     let selected: Awaited<ReturnType<typeof chooseSessionTargetsExcluding>>;
     try {
@@ -999,6 +1023,7 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
     let finalEndIso = "";
     let payload: BrowserFetchResult<Record<string, unknown>> | null = null;
     let payloadBody: { success?: boolean; data?: { session?: { id?: string } }; code?: string } | null = null;
+    let blockedAttemptCount = 0;
 
     for (let attempt = 0; attempt < availableCandidateStarts.length; attempt += 1) {
       const attemptStart = availableCandidateStarts[attempt];
@@ -1049,6 +1074,7 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
         );
       }
       if (outcome.kind === "blocked") {
+        blockedAttemptCount += 1;
         responsePromise.catch(() => undefined);
         continue;
       }
@@ -1087,9 +1113,18 @@ async function bookSession(page: Page, token: string, strictMode: boolean): Prom
     }
 
     lastFailure = { selected, finalStartIso, finalEndIso, payload, payloadBody };
-    if (payload?.status === 409) {
-      console.warn("[lifecycle] booking conflict exhausted candidate starts; trying next therapist-client pair", {
+    if (
+      shouldTryNextLifecyclePairAfterAttempts({
+        attemptedStartCount: availableCandidateStarts.length,
+        blockedAttemptCount,
+        payloadStatus: payload?.status ?? null,
+      })
+    ) {
+      console.warn("[lifecycle] booking attempts exhausted for therapist-client pair; trying next pair", {
         pairKey: selected.pairKey,
+        blockedAttemptCount,
+        attemptedStartCount: availableCandidateStarts.length,
+        payloadStatus: payload?.status ?? null,
       });
       await cleanupCreatedProgramGoal(selected);
       excludedPairKeys.add(selected.pairKey);

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useForm } from 'react-hook-form';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { format, parseISO } from 'date-fns';
 import {
   X,
@@ -17,7 +17,10 @@ import {
 } from 'lucide-react';
 import type {
   Session,
+  GoalTarget,
+  SessionCaptureTrialEventInput,
   SessionGoalMeasurementEntry,
+  TrialEvent,
   Therapist,
   Client,
   Goal,
@@ -79,7 +82,11 @@ export interface SessionModalClinicalNotesPayload {
   session_note_persist_requested?: boolean;
   /** When set, POST /api/session-notes/upsert merges only these goal keys from this payload (server-authoritative). */
   session_note_capture_merge_goal_ids?: string[];
+  /** Raw trial-level events generated from configured goal targets during Schedule capture. */
+  session_note_trial_events?: SessionCaptureTrialEventInput[];
 }
+
+const responseRequiredMeasurementTypes = new Set(['correctIncorrect', 'taskAnalysis']);
 
 export type SessionModalSubmitData = Partial<Session> & SessionModalClinicalNotesPayload;
 
@@ -255,6 +262,7 @@ export function SessionModal({
   const [conflicts, setConflicts] = useState<Conflict[]>([]);
   const [alternativeTimes, setAlternativeTimes] = useState<AlternativeTime[]>([]);
   const [isLoadingAlternatives, setIsLoadingAlternatives] = useState(false);
+  const [pendingTrialEvents, setPendingTrialEvents] = useState<SessionCaptureTrialEventInput[]>([]);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const sessionCaptureSectionRef = useRef<HTMLElement | null>(null);
@@ -269,6 +277,7 @@ export function SessionModal({
   const retryHintHeadingId = 'session-modal-retry-heading';
   const conflictDescriptionId = 'session-modal-conflicts-description';
   const conflictHeadingId = 'session-modal-conflicts-heading';
+  const queryClient = useQueryClient();
 
   const resolvedTimeZone = useMemo(() => resolveSchedulingTimeZone(timeZone), [timeZone]);
 
@@ -424,6 +433,52 @@ export function SessionModal({
       return (data ?? []) as Goal[];
     },
     enabled: Boolean(clientId && activeOrganizationId),
+  });
+
+  const { data: goalTargets = [] } = useQuery({
+    queryKey: ['client-goal-targets', clientId, activeOrganizationId ?? 'MISSING_ORG'],
+    queryFn: async () => {
+      if (!clientId || !activeOrganizationId) {
+        return [];
+      }
+      const { data, error } = await supabase
+        .from('goal_targets')
+        .select('id, organization_id, client_id, goal_id, name, measurement_type, graph_config, status, sort_order, created_by, updated_by, created_at, updated_at')
+        .eq('client_id', clientId)
+        .eq('organization_id', activeOrganizationId)
+        .neq('status', 'archived')
+        .order('sort_order', { ascending: true });
+      if (error) {
+        throw error;
+      }
+      return (data ?? []) as GoalTarget[];
+    },
+    enabled: Boolean(clientId && activeOrganizationId),
+  });
+
+  const sessionTrialEventsQueryKey = useMemo(
+    () => ['session-trial-events', session?.id, activeOrganizationId ?? 'MISSING_ORG'] as const,
+    [activeOrganizationId, session?.id],
+  );
+
+  const { data: existingTrialEvents = [] } = useQuery({
+    queryKey: sessionTrialEventsQueryKey,
+    queryFn: async () => {
+      if (!session?.id || !activeOrganizationId) {
+        return [];
+      }
+      const { data, error } = await supabase
+        .from('trial_events')
+        .select('*')
+        .eq('session_id', session.id)
+        .eq('organization_id', activeOrganizationId)
+        .order('trial_number', { ascending: true });
+      if (error) {
+        throw error;
+      }
+      return (data ?? []) as TrialEvent[];
+    },
+    enabled: Boolean(session?.id && activeOrganizationId),
   });
 
   const captureBillingRelaxed = isSessionCaptureBillingGateRelaxed();
@@ -609,6 +664,10 @@ export function SessionModal({
     setSelectedProgramIds([]);
     setMobileProgramsExpanded(false);
   }, [clientId, setValue]);
+
+  useEffect(() => {
+    setPendingTrialEvents([]);
+  }, [session?.id, clientId]);
 
   useEffect(() => {
     if (!sessionDetails) {
@@ -1111,6 +1170,26 @@ export function SessionModal({
           working.session_note_goals_addressed?.[index]?.trim() ?? null,
         ]),
       );
+      const mergeGoalIds = options?.captureMergeGoalIds?.filter((id) => id.trim().length > 0) ?? [];
+      const isPartialCaptureSave = mergeGoalIds.length > 0;
+      const trialEventsForSubmit = pendingTrialEvents.filter((event) => {
+        if (!isPartialCaptureSave) {
+          return true;
+        }
+        const target = goalTargetsById.get(event.target_id);
+        return Boolean(target && mergeGoalIds.includes(target.goal_id));
+      });
+      const rawTrialBackedGoalIds = new Set(
+        [...existingTrialEvents, ...trialEventsForSubmit]
+          .map((event) => goalTargetsById.get(event.target_id)?.goal_id)
+          .filter((id): id is string => Boolean(id))
+          .filter((id) => !isPartialCaptureSave || mergeGoalIds.includes(id)),
+      );
+      const submittedTrialGoalIds = new Set(
+        trialEventsForSubmit
+          .map((event) => goalTargetsById.get(event.target_id)?.goal_id)
+          .filter((id): id is string => Boolean(id)),
+      );
       const normalizedGoalMeasurementMap = Object.fromEntries(
         mergedGoalIds
           .map((goalEntryId) => {
@@ -1123,7 +1202,26 @@ export function SessionModal({
               goal,
               goalEntryId,
             );
-            return entry ? [goalEntryId, entry] : null;
+            if (!entry) {
+              return null;
+            }
+            if (!rawTrialBackedGoalIds.has(goalEntryId)) {
+              return [goalEntryId, entry];
+            }
+            const rawEventBackedEntry: SessionGoalMeasurementEntry = {
+              version: entry.version,
+              data: {
+                ...entry.data,
+                metric_value: null,
+                incorrect_trials: null,
+                opportunities: null,
+                target_trials: null,
+                trial_prompt_note: null,
+              },
+            };
+            return hasMeaningfulGoalMeasurementEntry(rawEventBackedEntry)
+              ? [goalEntryId, rawEventBackedEntry]
+              : null;
           })
           .filter((entry): entry is [string, SessionGoalMeasurementEntry] => Boolean(entry)),
       );
@@ -1141,8 +1239,6 @@ export function SessionModal({
       ) {
         resolvedServiceCode = SESSION_CAPTURE_RELAXED_FALLBACK_SERVICE_CODE;
       }
-      const mergeGoalIds = options?.captureMergeGoalIds?.filter((id) => id.trim().length > 0) ?? [];
-      const isPartialCaptureSave = mergeGoalIds.length > 0;
       const hasCaptureInputFromSubmit = isPartialCaptureSave
         ? mergeGoalIds.some((goalKey) => {
             const noteText = (working.session_note_goal_notes?.[goalKey] ?? '').trim();
@@ -1157,7 +1253,7 @@ export function SessionModal({
                 goalKey,
               ),
             );
-          })
+          }) || submittedTrialGoalIds.size > 0
         : Object.values(working.session_note_goal_notes ?? {}).some(
             (value) => typeof value === 'string' && value.trim().length > 0,
           ) ||
@@ -1169,7 +1265,8 @@ export function SessionModal({
                 goalKey,
               ),
             ),
-          );
+          ) ||
+          submittedTrialGoalIds.size > 0;
       const goalIdsRequiringNotes = isPartialCaptureSave
         ? mergedGoalIds.filter((id) => mergeGoalIds.includes(id))
         : mergedGoalIds;
@@ -1219,14 +1316,68 @@ export function SessionModal({
         session_note_authorization_id: resolvedAuthorizationId,
         session_note_service_code: resolvedServiceCode,
         session_note_persist_requested:
-          isPartialCaptureSave || hasDirtySessionCaptureFields || isInProgressSession,
+          isPartialCaptureSave || hasDirtySessionCaptureFields || isInProgressSession || trialEventsForSubmit.length > 0,
         ...(isPartialCaptureSave ? { session_note_capture_merge_goal_ids: mergeGoalIds } : {}),
+        ...(trialEventsForSubmit.length > 0 ? { session_note_trial_events: trialEventsForSubmit } : {}),
         goal_ids: sessionGoalIds,
         // If a timezone prop is provided, normalize to UTC for consumers expecting Z times
         start_time: timeZone ? toUtcSessionIsoString(working.start_time, resolvedTimeZone) : working.start_time,
         end_time: timeZone ? toUtcSessionIsoString(working.end_time, resolvedTimeZone) : working.end_time,
       };
       await onSubmit(transformed);
+      if (trialEventsForSubmit.length > 0 && session?.id) {
+        const submittedAt = new Date().toISOString();
+        queryClient.setQueryData<TrialEvent[]>(sessionTrialEventsQueryKey, (current = []) => {
+          const existingKeys = new Set(
+            current.map((event) => `${event.session_id}:${event.target_id}:${event.trial_number}`),
+          );
+          const appended = trialEventsForSubmit
+            .map((event): TrialEvent | null => {
+              const target = goalTargetsById.get(event.target_id);
+              if (!target) {
+                return null;
+              }
+              return {
+                id: `pending-${session.id}-${event.target_id}-${event.trial_number}`,
+                organization_id: activeOrganizationId ?? target.organization_id,
+                client_id: target.client_id,
+                session_id: session.id,
+                target_id: event.target_id,
+                goal_id: target.goal_id,
+                therapist_id: working.therapist_id ?? session.therapist_id,
+                trial_number: event.trial_number,
+                response: event.response ?? null,
+                prompt_type: event.prompt_type ?? null,
+                prompt_level: event.prompt_level ?? null,
+                value: typeof event.value === 'number' ? event.value : null,
+                event_timestamp: event.timestamp ?? submittedAt,
+                metadata: event.metadata ?? {},
+                created_by: null,
+                updated_by: null,
+                created_at: submittedAt,
+                updated_at: submittedAt,
+              };
+            })
+            .filter((event): event is TrialEvent => Boolean(event))
+            .filter((event) => {
+              const key = `${event.session_id}:${event.target_id}:${event.trial_number}`;
+              if (existingKeys.has(key)) {
+                return false;
+              }
+              existingKeys.add(key);
+              return true;
+            });
+          return [...current, ...appended];
+        });
+        void queryClient.invalidateQueries({ queryKey: sessionTrialEventsQueryKey });
+      }
+      setPendingTrialEvents((current) =>
+        trialEventsForSubmit.length > 0
+          ? current.filter((event) => !trialEventsForSubmit.some((saved) => (
+              saved.target_id === event.target_id && saved.trial_number === event.trial_number
+            )))
+          : current,
+      );
       reset(getValues());
       setSaveState('saved');
     } catch (error) {
@@ -1401,8 +1552,126 @@ export function SessionModal({
     return sessionCaptureBxGoalIds;
   }, [sessionCaptureBxGoalIds, sessionCaptureSkillGoalIds, sessionCaptureTab]);
 
+  const goalTargetsByGoalId = useMemo(() => {
+    const grouped = new Map<string, GoalTarget[]>();
+    goalTargets.forEach((target) => {
+      const list = grouped.get(target.goal_id) ?? [];
+      list.push(target);
+      grouped.set(target.goal_id, list);
+    });
+    return grouped;
+  }, [goalTargets]);
+
+  const goalTargetsById = useMemo(
+    () => new Map(goalTargets.map((target) => [target.id, target])),
+    [goalTargets],
+  );
+
+  const resolveConfiguredGoalTarget = useCallback(
+    (goalId: string, targetValue: string): GoalTarget | null => {
+      if (isAdhocSessionTargetId(goalId)) {
+        return null;
+      }
+      const trimmedTarget = targetValue.trim();
+      if (!trimmedTarget) {
+        return null;
+      }
+      return goalTargetsByGoalId
+        .get(goalId)
+        ?.find((target) => target.name.trim() === trimmedTarget) ?? null;
+    },
+    [goalTargetsByGoalId],
+  );
+
+  const getRawTrialCount = useCallback(
+    (
+      targetId: string,
+      measurementType: string,
+      field: 'metric_value' | 'incorrect_trials',
+      scope: 'all' | 'pending' = 'all',
+    ) => {
+      const sourceEvents = scope === 'pending'
+        ? pendingTrialEvents
+        : [...existingTrialEvents, ...pendingTrialEvents];
+      return sourceEvents.filter((event) => {
+        if (event.target_id !== targetId) {
+          return false;
+        }
+        if (responseRequiredMeasurementTypes.has(measurementType)) {
+          return field === 'metric_value'
+            ? event.response === 'correct'
+            : event.response === 'incorrect' || event.response === 'noResponse';
+        }
+        return field === 'metric_value'
+          ? typeof event.value === 'number' && event.value > 0
+          : event.value === 0;
+      }).length;
+    },
+    [existingTrialEvents, pendingTrialEvents],
+  );
+
+  const getNextRawTrialNumber = useCallback(
+    (targetId: string): number => {
+      const maxTrialNumber = [...existingTrialEvents, ...pendingTrialEvents]
+        .filter((event) => event.target_id === targetId)
+        .reduce((max, event) => Math.max(max, Number(event.trial_number) || 0), 0);
+      return maxTrialNumber + 1;
+    },
+    [existingTrialEvents, pendingTrialEvents],
+  );
+
   const bumpTrialCount = useCallback(
-    (goalId: string, targetIndex: number, field: 'metric_value' | 'incorrect_trials', delta: number) => {
+    (
+      goalId: string,
+      targetIndex: number,
+      field: 'metric_value' | 'incorrect_trials',
+      delta: number,
+      configuredTarget?: GoalTarget | null,
+    ) => {
+      if (configuredTarget) {
+        if (delta > 0) {
+          const startTrialNumber = getNextRawTrialNumber(configuredTarget.id);
+          const newEvents = Array.from({ length: delta }, (_, index): SessionCaptureTrialEventInput => {
+            const trialNumber = startTrialNumber + index;
+            const usesResponse = responseRequiredMeasurementTypes.has(configuredTarget.measurement_type);
+            return {
+              target_id: configuredTarget.id,
+              trial_number: trialNumber,
+              ...(usesResponse
+                ? { response: field === 'metric_value' ? 'correct' : 'incorrect' }
+                : { value: field === 'metric_value' ? 1 : 0 }),
+              metadata: { source: 'schedule_capture', goal_id: goalId, target_index: targetIndex },
+            };
+          });
+          setPendingTrialEvents((current) => [...current, ...newEvents]);
+        } else if (delta < 0) {
+          const removeCount = Math.abs(delta);
+          setPendingTrialEvents((current) => {
+            let remainingToRemove = removeCount;
+            const next = current.slice();
+            for (let index = next.length - 1; index >= 0 && remainingToRemove > 0; index -= 1) {
+              const event = next[index];
+              if (event.target_id !== configuredTarget.id) {
+                continue;
+              }
+              const matchesField = responseRequiredMeasurementTypes.has(configuredTarget.measurement_type)
+                ? (field === 'metric_value'
+                    ? event.response === 'correct'
+                    : event.response === 'incorrect' || event.response === 'noResponse')
+                : (field === 'metric_value'
+                    ? typeof event.value === 'number' && event.value > 0
+                    : event.value === 0);
+              if (!matchesField) {
+                continue;
+              }
+              next.splice(index, 1);
+              remainingToRemove -= 1;
+            }
+            return next;
+          });
+        }
+        return;
+      }
       const path = `session_note_goal_measurements.${goalId}.data.target_trials.${targetIndex}.${field}` as const;
       const raw = getValues(path);
       const cur =
@@ -1414,7 +1683,7 @@ export function SessionModal({
       const safe = Number.isFinite(cur) ? cur : 0;
       setValue(path, Math.max(0, safe + delta), { shouldDirty: true, shouldTouch: true });
     },
-    [getValues, setValue],
+    [getNextRawTrialNumber, getValues, setValue],
   );
 
   const updateGoalTargets = useCallback(
@@ -2727,12 +2996,21 @@ export function SessionModal({
                           const visibleSessionTargetItems = isAdhocTarget || planGoalHasNoConfiguredTarget
                             ? sessionTargets.map((targetValue, sourceIndex) => ({ targetValue, sourceIndex }))
                             : (selectedPlanTargets.length > 0 ? selectedPlanTargets : [{ targetValue: '', sourceIndex: 0 }]);
+                          const getDisplayedTargetTrialValue = (
+                            item: { targetValue: string; sourceIndex: number },
+                            field: 'metric_value' | 'incorrect_trials',
+                          ) => {
+                            const configuredTarget = resolveConfiguredGoalTarget(selectedGoalId, item.targetValue);
+                            return configuredTarget
+                              ? getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, field)
+                              : getTargetTrialValue(item.sourceIndex, field);
+                          };
                           const correctDisplay = visibleSessionTargetItems.reduce(
-                            (sum, item) => sum + getTargetTrialValue(item.sourceIndex, 'metric_value'),
+                            (sum, item) => sum + getDisplayedTargetTrialValue(item, 'metric_value'),
                             0,
                           );
                           const incorrectDisplay = visibleSessionTargetItems.reduce(
-                            (sum, item) => sum + getTargetTrialValue(item.sourceIndex, 'incorrect_trials'),
+                            (sum, item) => sum + getDisplayedTargetTrialValue(item, 'incorrect_trials'),
                             0,
                           );
                           const captureDetailsOpen =
@@ -2909,8 +3187,19 @@ export function SessionModal({
                                       `${targetTrialsFieldBaseKey}.${sourceIndex}.trial_prompt_note` as const;
                                     const targetTrialTargetFieldKey =
                                       `${targetTrialsFieldBaseKey}.${sourceIndex}.target` as const;
-                                    const targetCorrectDisplay = getTargetTrialValue(sourceIndex, 'metric_value');
-                                    const targetIncorrectDisplay = getTargetTrialValue(sourceIndex, 'incorrect_trials');
+                                    const configuredTarget = resolveConfiguredGoalTarget(selectedGoalId, targetValue);
+                                    const targetCorrectDisplay = configuredTarget
+                                      ? getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'metric_value')
+                                      : getTargetTrialValue(sourceIndex, 'metric_value');
+                                    const targetIncorrectDisplay = configuredTarget
+                                      ? getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'incorrect_trials')
+                                      : getTargetTrialValue(sourceIndex, 'incorrect_trials');
+                                    const pendingCorrectDisplay = configuredTarget
+                                      ? getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'metric_value', 'pending')
+                                      : targetCorrectDisplay;
+                                    const pendingIncorrectDisplay = configuredTarget
+                                      ? getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'incorrect_trials', 'pending')
+                                      : targetIncorrectDisplay;
                                     const shouldRenderTargetTrialFields =
                                       isAdhocTarget ||
                                       planGoalHasNoConfiguredTarget ||
@@ -2991,7 +3280,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Increase correct trials for target ${targetIndex + 1}`}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white shadow-sm hover:bg-emerald-700"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', 1)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', 1, configuredTarget)}
                                               >
                                                 +
                                               </button>
@@ -3001,8 +3290,9 @@ export function SessionModal({
                                               <button
                                                 type="button"
                                                 aria-label={`Decrease correct trials for target ${targetIndex + 1}`}
+                                                disabled={pendingCorrectDisplay < 1}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full border border-emerald-700 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-200"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -1)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -1, configuredTarget)}
                                               >
                                                 −
                                               </button>
@@ -3010,16 +3300,16 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Add 5 correct trials for target ${targetIndex + 1}`}
                                                 className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', 5)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', 5, configuredTarget)}
                                               >
                                                 +5
                                               </button>
                                               <button
                                                 type="button"
                                                 aria-label={`Subtract 5 correct trials for target ${targetIndex + 1}`}
-                                                disabled={targetCorrectDisplay < 5}
+                                                disabled={pendingCorrectDisplay < 5}
                                                 className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -5)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -5, configuredTarget)}
                                               >
                                                 −5
                                               </button>
@@ -3030,7 +3320,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Increase incorrect or no-response trials for target ${targetIndex + 1}`}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full bg-rose-600 text-lg font-bold text-white shadow-sm hover:bg-rose-700"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', 1)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', 1, configuredTarget)}
                                               >
                                                 +
                                               </button>
@@ -3040,8 +3330,9 @@ export function SessionModal({
                                               <button
                                                 type="button"
                                                 aria-label={`Decrease incorrect trials for target ${targetIndex + 1}`}
+                                                disabled={pendingIncorrectDisplay < 1}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full border border-rose-700 text-rose-700 hover:bg-rose-50 dark:border-rose-400 dark:text-rose-200"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -1)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -1, configuredTarget)}
                                               >
                                                 −
                                               </button>
@@ -3049,16 +3340,16 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Add 5 incorrect or no-response trials for target ${targetIndex + 1}`}
                                                 className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', 5)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', 5, configuredTarget)}
                                               >
                                                 +5
                                               </button>
                                               <button
                                                 type="button"
                                                 aria-label={`Subtract 5 incorrect trials for target ${targetIndex + 1}`}
-                                                disabled={targetIncorrectDisplay < 5}
+                                                disabled={pendingIncorrectDisplay < 5}
                                                 className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -5)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -5, configuredTarget)}
                                               >
                                                 −5
                                               </button>

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -1629,6 +1629,12 @@ export function SessionModal({
       configuredTarget?: GoalTarget | null,
     ) => {
       if (configuredTarget) {
+        const dirtyPath =
+          `session_note_goal_measurements.${goalId}.data.target_trials.${targetIndex}.${field}` as const;
+        const nextDisplayedCount = Math.max(
+          0,
+          getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, field) + delta,
+        );
         if (delta > 0) {
           const startTrialNumber = getNextRawTrialNumber(configuredTarget.id);
           const newEvents = Array.from({ length: delta }, (_, index): SessionCaptureTrialEventInput => {
@@ -1644,6 +1650,7 @@ export function SessionModal({
             };
           });
           setPendingTrialEvents((current) => [...current, ...newEvents]);
+          setValue(dirtyPath, nextDisplayedCount, { shouldDirty: true, shouldTouch: true });
         } else if (delta < 0) {
           const removeCount = Math.abs(delta);
           setPendingTrialEvents((current) => {
@@ -1669,6 +1676,7 @@ export function SessionModal({
             }
             return next;
           });
+          setValue(dirtyPath, nextDisplayedCount, { shouldDirty: true, shouldTouch: true });
         }
         return;
       }
@@ -1683,7 +1691,7 @@ export function SessionModal({
       const safe = Number.isFinite(cur) ? cur : 0;
       setValue(path, Math.max(0, safe + delta), { shouldDirty: true, shouldTouch: true });
     },
-    [getNextRawTrialNumber, getValues, setValue],
+    [getNextRawTrialNumber, getRawTrialCount, getValues, setValue],
   );
 
   const updateGoalTargets = useCallback(

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1857,10 +1857,16 @@ describe('SessionModal', () => {
     );
 
     await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 1/i }));
+    expect(screen.getByTestId('session-modal-save-state')).toHaveTextContent('Unsaved changes.');
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await userEvent.click(screen.getByRole('button', { name: /^Cancel$/i }));
+    expect(confirmSpy).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+
     fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
       target: { value: 'Observed steady progress' },
     });
-    await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 1/i }));
     await userEvent.click(screen.getByRole('button', { name: /Increase incorrect or no-response trials for target 1/i }));
     await userEvent.click(screen.getByRole('button', { name: /Save skills/i }));
 

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../../lib/session-note-linked-fetch', () => ({
 type SupabaseQueryChain = {
   select: () => SupabaseQueryChain;
   eq: () => SupabaseQueryChain;
+  neq: () => SupabaseQueryChain;
   order: () => Promise<{ data: unknown[]; error: null }>;
   maybeSingle: () => Promise<{ data: unknown; error: null }>;
   limit: () => Promise<{ data: unknown[]; error: null }>;
@@ -87,6 +88,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -474,6 +476,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -571,6 +574,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -632,6 +636,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -686,10 +691,12 @@ describe('SessionModal', () => {
 
   it('submits completed status when Close Session is clicked', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     renderWithProviders(
       <SessionModal
         {...defaultProps}
         onSubmit={onSubmit}
+        existingSessions={[]}
         session={{
           id: 'session-close-action',
           therapist_id: 'test-therapist-1',
@@ -709,13 +716,16 @@ describe('SessionModal', () => {
       />
     );
 
-    await userEvent.click(screen.getByRole('button', { name: /^Close Session$/i }));
+    const closeSessionButton = screen.getByRole('button', { name: /^Close Session$/i });
+    await waitFor(() => expect(closeSessionButton).not.toBeDisabled());
+    await userEvent.click(closeSessionButton);
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
         status: 'completed',
       }));
     });
+    confirmSpy.mockRestore();
   });
 
   it('closes an in-progress historical session even when stored program and goal are no longer active', async () => {
@@ -723,6 +733,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -794,6 +805,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -901,6 +913,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -970,6 +983,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -1043,6 +1057,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -1109,6 +1124,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -1167,6 +1183,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -1308,6 +1325,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -1638,6 +1656,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -1736,12 +1755,285 @@ describe('SessionModal', () => {
     });
   }, 15000);
 
+  it('submits configured plan target trials as raw trial events', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const targetId = '88888888-8888-4888-8888-888888888888';
+    const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals);
+      }
+      if (table === 'authorizations') {
+        return buildChain([
+          {
+            id: 'auth-1',
+            authorization_number: 'AUTH-001',
+            services: [{ service_code: '97153' }],
+          },
+        ]);
+      }
+      if (table === 'goal_targets') {
+        return buildChain([
+          {
+            id: targetId,
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            goal_id: 'goal-1',
+            name: 'Match peer greeting in 4/5 trials',
+            measurement_type: 'correctIncorrect',
+            graph_config: {},
+            status: 'active',
+            sort_order: 0,
+            created_by: null,
+            updated_by: null,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        ]);
+      }
+      if (table === 'trial_events') {
+        return buildChain([
+          {
+            id: 'trial-existing',
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            session_id: 'session-raw-trials',
+            target_id: targetId,
+            goal_id: 'goal-1',
+            therapist_id: 'test-therapist-1',
+            trial_number: 2,
+            response: 'correct',
+            prompt_type: null,
+            prompt_level: null,
+            value: null,
+            event_timestamp: '2026-03-01T10:05:00.000Z',
+            metadata: {},
+            created_by: null,
+            updated_by: null,
+            created_at: '2026-03-01T10:05:00.000Z',
+            updated_at: '2026-03-01T10:05:00.000Z',
+          },
+        ]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        existingSessions={[]}
+        session={{
+          id: 'session-raw-trials',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
+    fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
+      target: { value: 'Observed steady progress' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 1/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Increase incorrect or no-response trials for target 1/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Save skills/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        session_note_trial_events: [
+          expect.objectContaining({
+            target_id: targetId,
+            trial_number: 3,
+            response: 'correct',
+            metadata: expect.objectContaining({ source: 'schedule_capture', goal_id: 'goal-1' }),
+          }),
+          expect.objectContaining({
+            target_id: targetId,
+            trial_number: 4,
+            response: 'incorrect',
+          }),
+        ],
+      }));
+    });
+    const submitted = onSubmit.mock.calls[0]?.[0] as {
+      session_note_goal_measurements?: Record<string, SessionGoalMeasurementEntry>;
+    };
+    expect(submitted.session_note_goal_measurements?.['goal-1']?.data.target_trials).toBeNull();
+    expect(submitted.session_note_goal_measurements?.['goal-1']?.data.metric_value).toBeNull();
+    expect(submitted.session_note_goal_measurements?.['goal-1']?.data.incorrect_trials).toBeNull();
+  }, 15000);
+
+  it('keeps aggregate counts nulled when reopening a raw-trial-backed target without new trial clicks', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const targetId = '88888888-8888-4888-8888-888888888889';
+    const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals);
+      }
+      if (table === 'authorizations') {
+        return buildChain([
+          {
+            id: 'auth-1',
+            authorization_number: 'AUTH-001',
+            services: [{ service_code: '97153' }],
+          },
+        ]);
+      }
+      if (table === 'goal_targets') {
+        return buildChain([
+          {
+            id: targetId,
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            goal_id: 'goal-1',
+            name: 'Match peer greeting in 4/5 trials',
+            measurement_type: 'correctIncorrect',
+            graph_config: {},
+            status: 'active',
+            sort_order: 0,
+            created_by: null,
+            updated_by: null,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        ]);
+      }
+      if (table === 'trial_events') {
+        return buildChain([
+          {
+            id: 'trial-existing-correct',
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            session_id: 'session-raw-trials-reopen',
+            target_id: targetId,
+            goal_id: 'goal-1',
+            therapist_id: 'test-therapist-1',
+            trial_number: 1,
+            response: 'correct',
+            prompt_type: null,
+            prompt_level: null,
+            value: null,
+            event_timestamp: '2026-03-01T10:05:00.000Z',
+            metadata: {},
+            created_by: null,
+            updated_by: null,
+            created_at: '2026-03-01T10:05:00.000Z',
+            updated_at: '2026-03-01T10:05:00.000Z',
+          },
+          {
+            id: 'trial-existing-incorrect',
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            session_id: 'session-raw-trials-reopen',
+            target_id: targetId,
+            goal_id: 'goal-1',
+            therapist_id: 'test-therapist-1',
+            trial_number: 2,
+            response: 'incorrect',
+            prompt_type: null,
+            prompt_level: null,
+            value: null,
+            event_timestamp: '2026-03-01T10:06:00.000Z',
+            metadata: {},
+            created_by: null,
+            updated_by: null,
+            created_at: '2026-03-01T10:06:00.000Z',
+            updated_at: '2026-03-01T10:06:00.000Z',
+          },
+        ]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        existingSessions={[]}
+        session={{
+          id: 'session-raw-trials-reopen',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
+    fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
+      target: { value: 'Reopened note update' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /Save skills/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const submitted = onSubmit.mock.calls[0]?.[0] as {
+      session_note_goal_measurements?: Record<string, SessionGoalMeasurementEntry>;
+      session_note_trial_events?: unknown[];
+    };
+    expect(submitted.session_note_trial_events).toBeUndefined();
+    expect(submitted.session_note_goal_measurements?.['goal-1']?.data.target_trials).toBeNull();
+    expect(submitted.session_note_goal_measurements?.['goal-1']?.data.metric_value).toBeNull();
+    expect(submitted.session_note_goal_measurements?.['goal-1']?.data.incorrect_trials).toBeNull();
+  }, 15000);
+
   it('shows trial controls for live plan goals without a configured target', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const buildChain = (rows: unknown[]) => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -1874,6 +2166,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -1987,6 +2280,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2113,6 +2407,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2202,6 +2497,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2355,6 +2651,7 @@ describe('SessionModal', () => {
         const chain: SupabaseQueryChain = {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
           order: vi.fn(async () => ({ data: mockPrograms, error: null })),
           maybeSingle: vi.fn(async () => ({ data: null, error: null })),
           limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2365,6 +2662,7 @@ describe('SessionModal', () => {
         const chain: SupabaseQueryChain = {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
           order: vi.fn(async () => ({ data: mockGoals, error: null })),
           maybeSingle: vi.fn(async () => ({ data: null, error: null })),
           limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2375,6 +2673,7 @@ describe('SessionModal', () => {
         const chain: SupabaseQueryChain = {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
           order: vi.fn(async () => ({
             data: [{ id: 'auth-1', authorization_number: 'AUTH-001', services: [{ service_code: '97153' }] }],
             error: null,
@@ -2387,6 +2686,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: [], error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2514,6 +2814,7 @@ describe('SessionModal', () => {
         const chain: SupabaseQueryChain = {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
           order: vi.fn(async () => ({ data: mockPrograms, error: null })),
           maybeSingle: vi.fn(async () => ({ data: null, error: null })),
           limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2524,6 +2825,7 @@ describe('SessionModal', () => {
         const chain: SupabaseQueryChain = {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
           order: vi.fn(async () => ({ data: mockGoals, error: null })),
           maybeSingle: vi.fn(async () => ({ data: null, error: null })),
           limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2534,6 +2836,7 @@ describe('SessionModal', () => {
         const chain: SupabaseQueryChain = {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
           order: vi.fn(async () => ({
             data: [{ id: 'auth-1', authorization_number: 'AUTH-001', services: [{ service_code: '97153' }] }],
             error: null,
@@ -2546,6 +2849,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: [], error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2680,6 +2984,7 @@ describe('SessionModal', () => {
         const chain: SupabaseQueryChain = {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
           order: vi.fn(async () => ({ data: mockPrograms, error: null })),
           maybeSingle: vi.fn(async () => ({ data: null, error: null })),
           limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2690,6 +2995,7 @@ describe('SessionModal', () => {
         const chain: SupabaseQueryChain = {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
           order: vi.fn(async () => ({ data: mockGoals, error: null })),
           maybeSingle: vi.fn(async () => ({ data: null, error: null })),
           limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2700,6 +3006,7 @@ describe('SessionModal', () => {
         const chain: SupabaseQueryChain = {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
           order: vi.fn(async () => ({
             data: [{ id: 'auth-1', authorization_number: 'AUTH-001', services: [{ service_code: '97153' }] }],
             error: null,
@@ -2712,6 +3019,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: [], error: null })),
         maybeSingle: vi.fn(async () => ({ data: null, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),
@@ -2779,6 +3087,7 @@ describe('SessionModal', () => {
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
         order: vi.fn(async () => ({ data: rows, error: null })),
         maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
         limit: vi.fn(async () => ({ data: [], error: null })),

--- a/src/lib/__tests__/session-notes.test.ts
+++ b/src/lib/__tests__/session-notes.test.ts
@@ -497,6 +497,42 @@ describe('session note write helpers', () => {
     expect(callApiMock).not.toHaveBeenCalled();
   });
 
+  it('upsertClientSessionNoteForSession forwards explicit trial events to the API', async () => {
+    await upsertClientSessionNoteForSession({
+      sessionId: '77777777-7777-4777-8777-777777777777',
+      clientId: '11111111-1111-4111-8111-111111111111',
+      authorizationId: '22222222-2222-4222-8222-222222222222',
+      therapistId: '33333333-3333-4333-8333-333333333333',
+      organizationId: 'org-1',
+      actorUserId: 'user-1',
+      serviceCode: '97153',
+      sessionDate: '2025-06-01',
+      startTime: '09:00',
+      endTime: '10:00',
+      goalsAddressed: ['Goal A'],
+      goalIds: ['44444444-4444-4444-8444-444444444444'],
+      goalMeasurements: null,
+      goalNotes: { '44444444-4444-4444-8444-444444444444': 'Progress captured' },
+      narrative: 'Narrative text',
+      trialEvents: [{
+        target_id: '88888888-8888-4888-8888-888888888888',
+        trial_number: 1,
+        response: 'correct',
+        prompt_level: 'independent',
+        metadata: { source: 'schedule_capture' },
+      }],
+    });
+
+    const payload = JSON.parse(callApiMock.mock.calls[0][1].body) as Record<string, unknown>;
+    expect(payload.trialEvents).toEqual([{
+      target_id: '88888888-8888-4888-8888-888888888888',
+      trial_number: 1,
+      response: 'correct',
+      prompt_level: 'independent',
+      metadata: { source: 'schedule_capture' },
+    }]);
+  });
+
   it('throws server error message when API request fails', async () => {
     callApiMock.mockResolvedValueOnce({
       ok: false,

--- a/src/lib/session-notes.ts
+++ b/src/lib/session-notes.ts
@@ -1,5 +1,5 @@
 import type { PostgrestError } from '@supabase/supabase-js';
-import type { SessionGoalMeasurementEntry, SessionNote } from '../types';
+import type { SessionCaptureTrialEventInput, SessionGoalMeasurementEntry, SessionNote } from '../types';
 import type { Database } from './generated/database.types';
 import { normalizeGoalMeasurementEntry } from './goal-measurements';
 import { callApi } from './api';
@@ -256,6 +256,7 @@ export interface UpsertClientSessionNoteForSessionInput {
   readonly goalNotes: Record<string, string>;
   readonly narrative: string;
   readonly captureMergeGoalIds?: string[];
+  readonly trialEvents?: SessionCaptureTrialEventInput[];
 }
 
 export interface UpdateClientSessionNoteInput {
@@ -297,6 +298,7 @@ export interface SessionNoteUpsertApiPayload {
   readonly isLocked: boolean;
   /** Server merges only these goal keys from the request into the existing session note. */
   readonly captureMergeGoalIds?: string[];
+  readonly trialEvents?: SessionCaptureTrialEventInput[];
 }
 
 /**
@@ -400,6 +402,7 @@ export const upsertClientSessionNoteForSession = async (
     narrative: payload.narrative,
     isLocked: false,
     ...(payload.captureMergeGoalIds?.length ? { captureMergeGoalIds: payload.captureMergeGoalIds } : {}),
+    ...(payload.trialEvents?.length ? { trialEvents: payload.trialEvents } : {}),
   });
 };
 

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -131,6 +131,7 @@ const stripClinicalNoteFields = (data: ScheduleSubmitData): Partial<Session> => 
     session_note_service_code: _sessionNoteServiceCode,
     session_note_persist_requested: _sessionNotePersistRequested,
     session_note_capture_merge_goal_ids: _sessionNoteCaptureMergeGoalIds,
+    session_note_trial_events: _sessionNoteTrialEvents,
     ...sessionPayload
   } = data;
   return sessionPayload;
@@ -147,6 +148,7 @@ const buildClinicalNoteDraft = (
   goalsAddressed: string[];
   authorizationId: string;
   serviceCode: string;
+  trialEvents: NonNullable<SessionModalClinicalNotesPayload["session_note_trial_events"]>;
 } | null => {
   if (data.session_note_persist_requested !== true) {
     return null;
@@ -165,6 +167,7 @@ const buildClinicalNoteDraft = (
     data.session_note_goal_measurements && typeof data.session_note_goal_measurements === "object"
       ? (data.session_note_goal_measurements as Record<string, SessionGoalMeasurementEntry>)
       : {};
+  const trialEvents = Array.isArray(data.session_note_trial_events) ? data.session_note_trial_events : [];
   const rawGoalLabels = Array.isArray(data.session_note_goals_addressed) ? data.session_note_goals_addressed : [];
   const goalsAddressed = goalIds.map((goalId, index) => {
     const label = (rawGoalLabels[index] ?? "").trim();
@@ -189,7 +192,7 @@ const buildClinicalNoteDraft = (
         const raw = data.session_note_goal_measurements?.[id];
         return hasMeaningfulGoalMeasurementEntry(
           normalizeGoalMeasurementEntry(raw, undefined, { fallbackMetricUnit: null }),
-        );
+        ) || trialEvents.some((event) => typeof event.target_id === "string");
       });
     if (!scopeHasContent) {
       return null;
@@ -197,7 +200,8 @@ const buildClinicalNoteDraft = (
   } else if (
     narrative.length === 0 &&
     Object.keys(goalNotes).length === 0 &&
-    Object.keys(goalMeasurements).length === 0
+    Object.keys(goalMeasurements).length === 0 &&
+    trialEvents.length === 0
   ) {
     return null;
   }
@@ -209,6 +213,7 @@ const buildClinicalNoteDraft = (
     goalsAddressed,
     authorizationId,
     serviceCode,
+    trialEvents,
   };
 };
 
@@ -1682,6 +1687,7 @@ export const Schedule = React.memo(() => {
               goalNotes: clinicalNoteDraft.goalNotes,
               narrative: clinicalNoteDraft.narrative,
               ...(mergeCaptureIds?.length ? { captureMergeGoalIds: mergeCaptureIds } : {}),
+              ...(clinicalNoteDraft.trialEvents.length ? { trialEvents: clinicalNoteDraft.trialEvents } : {}),
             });
           }
           await updateSessionMutation.mutateAsync(sessionPayload);

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -192,6 +192,12 @@ vi.mock("../../components/SessionModal", () => ({
               session_note_authorization_id: "auth-1",
               session_note_service_code: "97153",
               session_note_persist_requested: true,
+              session_note_trial_events: [{
+                target_id: "88888888-8888-4888-8888-888888888888",
+                trial_number: 1,
+                response: "correct",
+                metadata: { source: "schedule_capture" },
+              }],
               session_note_capture_merge_goal_ids: [
                 "goal-1",
                 "adhoc-skill-550e8400-e29b-41d4-a716-446655440000",
@@ -532,6 +538,12 @@ describe("Schedule orchestration integration hardening", () => {
       goalNotes: expect.objectContaining({
         "adhoc-skill-550e8400-e29b-41d4-a716-446655440000": "Adhoc note",
       }),
+      trialEvents: [{
+        target_id: "88888888-8888-4888-8888-888888888888",
+        trial_number: 1,
+        response: "correct",
+        metadata: { source: "schedule_capture" },
+      }],
     }));
     expect(bookSessionViaApiMock.mock.calls[0][1]).toBeUndefined();
     expect(showErrorMock).not.toHaveBeenCalled();

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -8,12 +8,14 @@ vi.mock("../api/shared", async () => {
     getAccessToken: vi.fn(),
     resolveOrgAndRoleWithStatus: vi.fn(),
     fetchAuthenticatedUserIdWithStatus: vi.fn(),
+    currentUserCanCaptureTrialEvent: vi.fn(),
     getSupabaseConfig: vi.fn(),
     fetchJson: vi.fn(),
   };
 });
 
 import {
+  currentUserCanCaptureTrialEvent,
   fetchAuthenticatedUserIdWithStatus,
   fetchJson,
   getAccessToken,
@@ -26,6 +28,7 @@ const BASE_URL = "https://example.supabase.co";
 const HEADERS = { Authorization: `Bearer ${ACCESS_TOKEN}` };
 
 const basePayload = {
+  sessionId: "77777777-7777-4777-8777-777777777777",
   clientId: "11111111-1111-4111-8111-111111111111",
   authorizationId: "22222222-2222-4222-8222-222222222222",
   therapistId: "33333333-3333-4333-8333-333333333333",
@@ -47,6 +50,8 @@ const basePayload = {
   narrative: "  Session narrative  ",
   isLocked: false,
 };
+
+const targetId = "88888888-8888-4888-8888-888888888888";
 
 const buildSessionNoteRow = (id: string) => ({
   id,
@@ -102,6 +107,10 @@ describe("sessionNotesUpsertHandler", () => {
     });
     vi.mocked(fetchAuthenticatedUserIdWithStatus).mockResolvedValue({
       userId: "actor-1",
+      upstreamError: false,
+    });
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({
+      allowed: true,
       upstreamError: false,
     });
     vi.mocked(getSupabaseConfig).mockReturnValue({
@@ -184,6 +193,458 @@ describe("sessionNotesUpsertHandler", () => {
     expect(response.status).toBe(200);
     expect(payload.id).toBe("note-created");
     expect(payload.goal_notes).toEqual({ "44444444-4444-4444-8444-444444444444": "covered" });
+  });
+
+  it("persists explicit raw trial events before saving the session note", async () => {
+    const fetchJsonMock = vi.mocked(fetchJson);
+    let trialEventsPostCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        return { ok: true, status: 201, data: [{ id: "note-with-events" }] };
+      }
+      if (requestUrl.includes("/rest/v1/goal_targets?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: targetId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            goal_id: basePayload.goalIds[0],
+            measurement_type: "correctIncorrect",
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/sessions?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.sessionId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            therapist_id: basePayload.therapistId,
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "GET") {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "POST") {
+        trialEventsPostCount += 1;
+        const parsedBody = JSON.parse(String(init.body)) as Array<Record<string, unknown>>;
+        expect(requestUrl).toContain("on_conflict=session_id%2Ctarget_id%2Ctrial_number");
+        expect(init.headers).toEqual(expect.objectContaining({
+          Prefer: "return=minimal,resolution=merge-duplicates",
+        }));
+        expect(parsedBody).toEqual([
+          expect.objectContaining({
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            session_id: basePayload.sessionId,
+            target_id: targetId,
+            goal_id: basePayload.goalIds[0],
+            therapist_id: basePayload.therapistId,
+            trial_number: 1,
+            response: "correct",
+            prompt_level: "independent",
+            value: null,
+            created_by: "actor-1",
+          }),
+          expect.objectContaining({
+            trial_number: 2,
+            response: "incorrect",
+            prompt_level: "gestural",
+          }),
+        ]);
+        return { ok: true, status: 201, data: [] };
+      }
+      if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes("id=eq.note-with-events")) {
+        return { ok: true, status: 200, data: [buildSessionNoteRow("note-with-events")] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          trialEvents: [
+            {
+              target_id: targetId,
+              trial_number: 1,
+              response: "correct",
+              prompt_level: "independent",
+              metadata: { source: "schedule_capture" },
+            },
+            {
+              target_id: targetId,
+              trial_number: 2,
+              response: "incorrect",
+              prompt_level: "gestural",
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(trialEventsPostCount).toBe(1);
+  });
+
+  it("rejects raw trial events outside the saved goal scope", async () => {
+    const fetchJsonMock = vi.mocked(fetchJson);
+    let noteWriteCount = 0;
+    let trialEventsPostCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/sessions?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.sessionId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            therapist_id: basePayload.therapistId,
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/goal_targets?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: targetId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            goal_id: "55555555-5555-4555-8555-555555555555",
+            measurement_type: "correctIncorrect",
+          }],
+        };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        noteWriteCount += 1;
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "POST") {
+        trialEventsPostCount += 1;
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          trialEvents: [{
+            target_id: targetId,
+            trial_number: 1,
+            response: "correct",
+          }],
+        }),
+      }),
+    );
+    const body = await response.json() as { error?: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Trial-event target is outside the saved goal scope.");
+    expect(noteWriteCount).toBe(0);
+    expect(trialEventsPostCount).toBe(0);
+  });
+
+  it("rolls back raw trial events when session note creation fails", async () => {
+    const fetchJsonMock = vi.mocked(fetchJson);
+    let trialEventsPostCount = 0;
+    let trialEventsDeleteCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/goal_targets?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: targetId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            goal_id: basePayload.goalIds[0],
+            measurement_type: "correctIncorrect",
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/sessions?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.sessionId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            therapist_id: basePayload.therapistId,
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "GET") {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "POST") {
+        trialEventsPostCount += 1;
+        return { ok: true, status: 201, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "DELETE") {
+        trialEventsDeleteCount += 1;
+        expect(requestUrl).toContain(`organization_id=eq.org-1`);
+        expect(requestUrl).toContain(`session_id=eq.${basePayload.sessionId}`);
+        expect(requestUrl).toContain(`target_id.eq.${targetId}`);
+        expect(requestUrl).toContain("trial_number.eq.1");
+        expect(init.headers).toEqual(expect.objectContaining({ Prefer: "return=minimal" }));
+        return { ok: true, status: 204, data: null };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        return { ok: false, status: 500, data: { message: "note write failed" } };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          trialEvents: [{
+            target_id: targetId,
+            trial_number: 1,
+            response: "correct",
+          }],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(trialEventsPostCount).toBe(1);
+    expect(trialEventsDeleteCount).toBe(1);
+  });
+
+  it("does not roll back preexisting raw trial events when session note creation fails after an upsert conflict", async () => {
+    const fetchJsonMock = vi.mocked(fetchJson);
+    let trialEventsPostCount = 0;
+    let trialEventsDeleteCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/goal_targets?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: targetId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            goal_id: basePayload.goalIds[0],
+            measurement_type: "correctIncorrect",
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/sessions?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.sessionId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            therapist_id: basePayload.therapistId,
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "GET") {
+        expect(requestUrl).toContain(`session_id=eq.${basePayload.sessionId}`);
+        expect(requestUrl).toContain(`target_id=in.(${targetId})`);
+        expect(requestUrl).toContain("trial_number=in.(1)");
+        return { ok: true, status: 200, data: [{ target_id: targetId, trial_number: 1 }] };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "POST") {
+        trialEventsPostCount += 1;
+        return { ok: true, status: 201, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "DELETE") {
+        trialEventsDeleteCount += 1;
+        return { ok: true, status: 204, data: null };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        return { ok: false, status: 500, data: { message: "note write failed" } };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          trialEvents: [{
+            target_id: targetId,
+            trial_number: 1,
+            response: "correct",
+          }],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(trialEventsPostCount).toBe(1);
+    expect(trialEventsDeleteCount).toBe(0);
+  });
+
+  it("rejects raw trial events before saving a note when capture access is denied", async () => {
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({
+      allowed: false,
+      upstreamError: false,
+    });
+    const fetchJsonMock = vi.mocked(fetchJson);
+    let noteWriteCount = 0;
+    let trialEventsPostCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/sessions?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.sessionId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            therapist_id: basePayload.therapistId,
+          }],
+        };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        noteWriteCount += 1;
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "POST") {
+        trialEventsPostCount += 1;
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          trialEvents: [{
+            target_id: targetId,
+            trial_number: 1,
+            response: "correct",
+          }],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(noteWriteCount).toBe(0);
+    expect(trialEventsPostCount).toBe(0);
+    expect(currentUserCanCaptureTrialEvent).toHaveBeenCalledWith(
+      ACCESS_TOKEN,
+      "org-1",
+      basePayload.clientId,
+    );
   });
 
   it("merges goal_ids from goal_notes keys omitted in goalIds and pads goals_addressed", async () => {

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -26,6 +26,7 @@ import {
 const ACCESS_TOKEN = "token-123";
 const BASE_URL = "https://example.supabase.co";
 const HEADERS = { Authorization: `Bearer ${ACCESS_TOKEN}` };
+const ORIGINAL_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 const basePayload = {
   sessionId: "77777777-7777-4777-8777-777777777777",
@@ -117,6 +118,15 @@ describe("sessionNotesUpsertHandler", () => {
       supabaseUrl: BASE_URL,
       anonKey: "anon-key",
     });
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+  });
+
+  afterEach(() => {
+    if (typeof ORIGINAL_SERVICE_ROLE_KEY === "string") {
+      process.env.SUPABASE_SERVICE_ROLE_KEY = ORIGINAL_SERVICE_ROLE_KEY;
+    } else {
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    }
   });
 
   it("creates a session note with normalized goal notes and measurements", async () => {
@@ -252,9 +262,9 @@ describe("sessionNotesUpsertHandler", () => {
       if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "POST") {
         trialEventsPostCount += 1;
         const parsedBody = JSON.parse(String(init.body)) as Array<Record<string, unknown>>;
-        expect(requestUrl).toContain("on_conflict=session_id%2Ctarget_id%2Ctrial_number");
+        expect(requestUrl).toBe(`${BASE_URL}/rest/v1/trial_events`);
         expect(init.headers).toEqual(expect.objectContaining({
-          Prefer: "return=minimal,resolution=merge-duplicates",
+          Prefer: "return=minimal",
         }));
         expect(parsedBody).toEqual([
           expect.objectContaining({
@@ -455,7 +465,11 @@ describe("sessionNotesUpsertHandler", () => {
         expect(requestUrl).toContain(`session_id=eq.${basePayload.sessionId}`);
         expect(requestUrl).toContain(`target_id.eq.${targetId}`);
         expect(requestUrl).toContain("trial_number.eq.1");
-        expect(init.headers).toEqual(expect.objectContaining({ Prefer: "return=minimal" }));
+        expect(init.headers).toEqual(expect.objectContaining({
+          apikey: "service-role-key",
+          Authorization: "Bearer service-role-key",
+          Prefer: "return=minimal",
+        }));
         return { ok: true, status: 204, data: null };
       }
       if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
@@ -484,10 +498,11 @@ describe("sessionNotesUpsertHandler", () => {
     expect(trialEventsDeleteCount).toBe(1);
   });
 
-  it("does not roll back preexisting raw trial events when session note creation fails after an upsert conflict", async () => {
+  it("rejects preexisting raw trial event keys before writing trial events", async () => {
     const fetchJsonMock = vi.mocked(fetchJson);
     let trialEventsPostCount = 0;
     let trialEventsDeleteCount = 0;
+    let noteWriteCount = 0;
     fetchJsonMock.mockImplementation(async (url, init) => {
       const requestUrl = String(url);
       if (requestUrl.includes("/rest/v1/authorizations?")) {
@@ -548,6 +563,7 @@ describe("sessionNotesUpsertHandler", () => {
         return { ok: true, status: 204, data: null };
       }
       if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        noteWriteCount += 1;
         return { ok: false, status: 500, data: { message: "note write failed" } };
       }
       throw new Error(`Unexpected request: ${requestUrl}`);
@@ -568,9 +584,108 @@ describe("sessionNotesUpsertHandler", () => {
       }),
     );
 
-    expect(response.status).toBe(500);
-    expect(trialEventsPostCount).toBe(1);
+    const body = await response.json() as { error?: string };
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe("Trial event already exists for this session target and trial number.");
+    expect(noteWriteCount).toBe(0);
+    expect(trialEventsPostCount).toBe(0);
     expect(trialEventsDeleteCount).toBe(0);
+  });
+
+  it("rejects duplicate raw trial event keys in the same request before writing trial events", async () => {
+    const fetchJsonMock = vi.mocked(fetchJson);
+    let trialEventsReadCount = 0;
+    let trialEventsPostCount = 0;
+    let noteWriteCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/goal_targets?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: targetId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            goal_id: basePayload.goalIds[0],
+            measurement_type: "correctIncorrect",
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/sessions?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.sessionId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            therapist_id: basePayload.therapistId,
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "GET") {
+        trialEventsReadCount += 1;
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "POST") {
+        trialEventsPostCount += 1;
+        return { ok: true, status: 201, data: [] };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        noteWriteCount += 1;
+        return { ok: true, status: 201, data: [{ id: "note-duplicate-request" }] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          trialEvents: [
+            {
+              target_id: targetId,
+              trial_number: 1,
+              response: "correct",
+            },
+            {
+              target_id: targetId,
+              trial_number: 1,
+              response: "incorrect",
+            },
+          ],
+        }),
+      }),
+    );
+    const body = await response.json() as { error?: string };
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe("Duplicate trial event submitted for this session target and trial number.");
+    expect(trialEventsReadCount).toBe(0);
+    expect(trialEventsPostCount).toBe(0);
+    expect(noteWriteCount).toBe(0);
   });
 
   it("rejects raw trial events before saving a note when capture access is denied", async () => {

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { SessionGoalMeasurementEntry, SessionNote } from "../../types";
 import { mergeUniqueGoalIds, normalizeGoalMeasurementEntry } from "../../lib/goal-measurements";
 import { isAdhocSessionTargetId, isValidSessionNoteGoalKey } from "../../lib/session-adhoc-targets";
+import { getOptionalServerEnv } from "../env";
 import {
   corsHeadersForRequest,
   currentUserCanCaptureTrialEvent,
@@ -132,6 +133,18 @@ type SessionScope = {
 
 const responseRequiredMeasurementTypes = new Set(["correctIncorrect", "taskAnalysis"]);
 const valueRequiredMeasurementTypes = new Set(["frequency", "rate", "duration", "timeSample", "latency", "IRT"]);
+
+const buildServiceRoleHeaders = (): Record<string, string> | null => {
+  const serviceRoleKey = getOptionalServerEnv("SUPABASE_SERVICE_ROLE_KEY")?.trim();
+  if (!serviceRoleKey) {
+    return null;
+  }
+  return {
+    "Content-Type": "application/json",
+    apikey: serviceRoleKey,
+    Authorization: `Bearer ${serviceRoleKey}`,
+  };
+};
 
 const normalizeTime = (value: string): string => {
   if (!value) {
@@ -680,14 +693,11 @@ const writeSessionTrialEventRows = async (args: {
     return null;
   }
 
-  const writeResult = await fetchJson(
-    `${args.supabaseUrl}/rest/v1/trial_events?on_conflict=session_id%2Ctarget_id%2Ctrial_number`,
-    {
-      method: "POST",
-      headers: { ...args.headers, Prefer: "return=minimal,resolution=merge-duplicates" },
-      body: JSON.stringify(args.rows),
-    },
-  );
+  const writeResult = await fetchJson(`${args.supabaseUrl}/rest/v1/trial_events`, {
+    method: "POST",
+    headers: { ...args.headers, Prefer: "return=minimal" },
+    body: JSON.stringify(args.rows),
+  });
   if (!writeResult.ok) {
     return errorResponse(args.request, "upstream_error", "Unable to save trial events", {
       status: writeResult.status || 502,
@@ -699,6 +709,18 @@ const writeSessionTrialEventRows = async (args: {
 
 const trialEventRowKey = (row: { target_id: unknown; trial_number: unknown }): string =>
   `${String(row.target_id ?? "")}:${String(row.trial_number ?? "")}`;
+
+const findDuplicateTrialEventRowKey = (rows: readonly Record<string, unknown>[]): string | null => {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const key = trialEventRowKey(row);
+    if (seen.has(key)) {
+      return key;
+    }
+    seen.add(key);
+  }
+  return null;
+};
 
 const fetchExistingSessionTrialEventKeys = async (args: {
   request: Request;
@@ -970,6 +992,12 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
   if (trialEventBuild.response) {
     return trialEventBuild.response;
   }
+  const duplicateTrialEventRowKey = findDuplicateTrialEventRowKey(trialEventBuild.rows);
+  if (duplicateTrialEventRowKey) {
+    return errorResponse(request, "conflict", "Duplicate trial event submitted for this session target and trial number.", {
+      status: 409,
+    });
+  }
 
   const writePayload = {
     authorization_id: payload.authorizationId,
@@ -1001,9 +1029,15 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
   if (existingTrialEventKeyBuild.response) {
     return existingTrialEventKeyBuild.response;
   }
-  const rollbackTrialEventRows = trialEventBuild.rows.filter(
-    (row) => !existingTrialEventKeyBuild.keys.has(trialEventRowKey(row)),
-  );
+  if (existingTrialEventKeyBuild.keys.size > 0) {
+    return errorResponse(request, "conflict", "Trial event already exists for this session target and trial number.", {
+      status: 409,
+    });
+  }
+  const rollbackHeaders = trialEventBuild.rows.length > 0 ? buildServiceRoleHeaders() : null;
+  if (trialEventBuild.rows.length > 0 && !rollbackHeaders) {
+    return errorResponse(request, "upstream_error", "Trial event rollback is not configured", { status: 500 });
+  }
 
   const trialEventError = await writeSessionTrialEventRows({
     request,
@@ -1044,7 +1078,12 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
       }
     }
     if (!insertResult.ok || !insertResult.data || insertResult.data.length === 0) {
-      await rollbackSessionTrialEventRows({ supabaseUrl, headers, organizationId, rows: rollbackTrialEventRows });
+      await rollbackSessionTrialEventRows({
+        supabaseUrl,
+        headers: rollbackHeaders ?? headers,
+        organizationId,
+        rows: trialEventBuild.rows,
+      });
       return errorResponse(request, "upstream_error", "Unable to create session note", {
         status: insertResult.status || 502,
       });
@@ -1072,7 +1111,12 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
       }
     }
     if (!updateResult.ok || !updateResult.data || updateResult.data.length === 0) {
-      await rollbackSessionTrialEventRows({ supabaseUrl, headers, organizationId, rows: rollbackTrialEventRows });
+      await rollbackSessionTrialEventRows({
+        supabaseUrl,
+        headers: rollbackHeaders ?? headers,
+        organizationId,
+        rows: trialEventBuild.rows,
+      });
       return errorResponse(request, "upstream_error", "Unable to update session note", {
         status: updateResult.status || 502,
       });
@@ -1081,7 +1125,12 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
 
   const savedRow = await fetchSessionNoteById(supabaseUrl, headers, organizationId, noteId);
   if (!savedRow) {
-    await rollbackSessionTrialEventRows({ supabaseUrl, headers, organizationId, rows: rollbackTrialEventRows });
+    await rollbackSessionTrialEventRows({
+      supabaseUrl,
+      headers: rollbackHeaders ?? headers,
+      organizationId,
+      rows: trialEventBuild.rows,
+    });
     return errorResponse(request, "upstream_error", "Unable to load saved session note", { status: 502 });
   }
 

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -4,6 +4,7 @@ import { mergeUniqueGoalIds, normalizeGoalMeasurementEntry } from "../../lib/goa
 import { isAdhocSessionTargetId, isValidSessionNoteGoalKey } from "../../lib/session-adhoc-targets";
 import {
   corsHeadersForRequest,
+  currentUserCanCaptureTrialEvent,
   errorResponse,
   fetchAuthenticatedUserIdWithStatus,
   fetchJson,
@@ -89,7 +90,48 @@ const upsertSchema = z.object({
     .array(z.string().min(1).refine((id) => isValidSessionNoteGoalKey(id)))
     .max(200)
     .optional(),
+  trialEvents: z
+    .array(z.object({
+      target_id: z.string().uuid(),
+      trial_number: z.number().int().positive(),
+      response: z.enum([
+        "correct",
+        "incorrect",
+        "noResponse",
+        "independent",
+        "prompted",
+        "notObserved",
+      ]).optional().nullable(),
+      prompt_type: z.string().trim().optional().nullable(),
+      prompt_level: z.string().trim().optional().nullable(),
+      value: z.number().nonnegative().optional().nullable(),
+      timestamp: z.string().datetime().optional(),
+      metadata: z.record(z.unknown()).optional(),
+    }))
+    .max(500)
+    .optional()
+    .default([]),
 });
+
+type SessionCaptureTrialEventInput = z.infer<typeof upsertSchema>["trialEvents"][number];
+
+type GoalTargetScope = {
+  id: string;
+  organization_id: string;
+  client_id: string;
+  goal_id: string;
+  measurement_type: string;
+};
+
+type SessionScope = {
+  id: string;
+  organization_id: string;
+  client_id: string;
+  therapist_id: string;
+};
+
+const responseRequiredMeasurementTypes = new Set(["correctIncorrect", "taskAnalysis"]);
+const valueRequiredMeasurementTypes = new Set(["frequency", "rate", "duration", "timeSample", "latency", "IRT"]);
 
 const normalizeTime = (value: string): string => {
   if (!value) {
@@ -447,6 +489,303 @@ const fetchSessionNoteById = async (
   return null;
 };
 
+const validateTrialEventMeasurementPayload = (
+  measurementType: string,
+  event: SessionCaptureTrialEventInput,
+): string | null => {
+  if (responseRequiredMeasurementTypes.has(measurementType)) {
+    if (!event.response) {
+      return "response is required for this target measurement type";
+    }
+    if (typeof event.value === "number") {
+      return "value is not allowed for this target measurement type";
+    }
+    return null;
+  }
+
+  if (valueRequiredMeasurementTypes.has(measurementType)) {
+    if (typeof event.value !== "number") {
+      return "value is required for this target measurement type";
+    }
+    if (event.response) {
+      return "response is not allowed for this target measurement type";
+    }
+  }
+
+  return null;
+};
+
+const buildSessionTrialEventRows = async (args: {
+  request: Request;
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  organizationId: string;
+  accessToken: string;
+  clientId: string;
+  sessionId: string | null | undefined;
+  therapistId: string;
+  actorUserId: string;
+  goalIds: readonly string[];
+  captureMergeGoalIds: readonly string[];
+  trialEvents: readonly SessionCaptureTrialEventInput[];
+}): Promise<{ rows: Array<Record<string, unknown>>; response: Response | null }> => {
+  if (args.trialEvents.length === 0) {
+    return { rows: [], response: null };
+  }
+
+  if (!args.sessionId) {
+    return {
+      rows: [],
+      response: errorResponse(args.request, "validation_error", "sessionId is required when saving trial events."),
+    };
+  }
+
+  const sessionUrl =
+    `${args.supabaseUrl}/rest/v1/sessions?select=id,organization_id,client_id,therapist_id` +
+    `&id=eq.${encodeURIComponent(args.sessionId)}` +
+    `&organization_id=eq.${encodeURIComponent(args.organizationId)}&limit=1`;
+  const sessionResult = await fetchJson<SessionScope[]>(sessionUrl, {
+    method: "GET",
+    headers: args.headers,
+  });
+  if (!sessionResult.ok) {
+    return {
+      rows: [],
+      response: errorResponse(args.request, "upstream_error", "Unable to validate trial-event session access", {
+        status: sessionResult.status || 502,
+      }),
+    };
+  }
+  const session = Array.isArray(sessionResult.data) ? sessionResult.data[0] ?? null : null;
+  if (!session) {
+    return {
+      rows: [],
+      response: errorResponse(args.request, "forbidden", "sessionId is not in scope for this organization.", { status: 403 }),
+    };
+  }
+  if (session.client_id !== args.clientId) {
+    return {
+      rows: [],
+      response: errorResponse(args.request, "validation_error", "Session does not match the selected client."),
+    };
+  }
+  if (session.therapist_id !== args.therapistId) {
+    return {
+      rows: [],
+      response: errorResponse(args.request, "validation_error", "Session does not match the selected therapist."),
+    };
+  }
+
+  const canCapture = await currentUserCanCaptureTrialEvent(args.accessToken, args.organizationId, session.client_id);
+  if (canCapture.upstreamError) {
+    return {
+      rows: [],
+      response: errorResponse(args.request, "upstream_error", "Unable to validate trial-event capture access", {
+        status: 502,
+      }),
+    };
+  }
+  if (!canCapture.allowed) {
+    return {
+      rows: [],
+      response: errorResponse(args.request, "forbidden", "Forbidden", { status: 403 }),
+    };
+  }
+
+  const targetIds = Array.from(new Set(args.trialEvents.map((event) => event.target_id)));
+  const targetFilter = targetIds.map((id) => encodeURIComponent(id)).join(",");
+  const targetUrl =
+    `${args.supabaseUrl}/rest/v1/goal_targets?select=id,organization_id,client_id,goal_id,measurement_type` +
+    `&id=in.(${targetFilter})` +
+    `&organization_id=eq.${encodeURIComponent(args.organizationId)}`;
+  const targetResult = await fetchJson<GoalTargetScope[]>(targetUrl, {
+    method: "GET",
+    headers: args.headers,
+  });
+  if (!targetResult.ok) {
+    return {
+      rows: [],
+      response: errorResponse(args.request, "upstream_error", "Unable to validate trial-event target access", {
+        status: targetResult.status || 502,
+      }),
+    };
+  }
+
+  const targetsById = new Map(
+    (Array.isArray(targetResult.data) ? targetResult.data : []).map((target) => [target.id, target]),
+  );
+  const submittedGoalIds = new Set(args.goalIds.filter((id) => id.trim().length > 0));
+  const scopedCaptureGoalIds = new Set(args.captureMergeGoalIds.filter((id) => id.trim().length > 0));
+  const allowedRawTrialGoalIds = scopedCaptureGoalIds.size > 0 ? scopedCaptureGoalIds : submittedGoalIds;
+  for (const event of args.trialEvents) {
+    const target = targetsById.get(event.target_id);
+    if (!target) {
+      return {
+        rows: [],
+        response: errorResponse(args.request, "forbidden", "target_id is not in scope for this organization.", { status: 403 }),
+      };
+    }
+    if (target.client_id !== args.clientId || target.client_id !== session.client_id) {
+      return {
+        rows: [],
+        response: errorResponse(args.request, "validation_error", "Trial-event target does not match the selected client."),
+      };
+    }
+    if (!allowedRawTrialGoalIds.has(target.goal_id)) {
+      return {
+        rows: [],
+        response: errorResponse(args.request, "validation_error", "Trial-event target is outside the saved goal scope."),
+      };
+    }
+    const measurementPayloadError = validateTrialEventMeasurementPayload(target.measurement_type, event);
+    if (measurementPayloadError) {
+      return {
+        rows: [],
+        response: errorResponse(args.request, "validation_error", measurementPayloadError),
+      };
+    }
+  }
+
+  const now = new Date().toISOString();
+  const rows = args.trialEvents.map((event) => {
+    const target = targetsById.get(event.target_id);
+    return {
+      organization_id: args.organizationId,
+      client_id: session.client_id,
+      session_id: session.id,
+      target_id: event.target_id,
+      goal_id: target?.goal_id ?? null,
+      therapist_id: session.therapist_id,
+      trial_number: event.trial_number,
+      response: event.response ?? null,
+      prompt_type: event.prompt_type ?? null,
+      prompt_level: event.prompt_level ?? null,
+      value: typeof event.value === "number" ? event.value : null,
+      event_timestamp: event.timestamp ?? now,
+      metadata: event.metadata ?? {},
+      created_by: args.actorUserId,
+    };
+  });
+
+  return { rows, response: null };
+};
+
+const writeSessionTrialEventRows = async (args: {
+  request: Request;
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  rows: readonly Record<string, unknown>[];
+}): Promise<Response | null> => {
+  if (args.rows.length === 0) {
+    return null;
+  }
+
+  const writeResult = await fetchJson(
+    `${args.supabaseUrl}/rest/v1/trial_events?on_conflict=session_id%2Ctarget_id%2Ctrial_number`,
+    {
+      method: "POST",
+      headers: { ...args.headers, Prefer: "return=minimal,resolution=merge-duplicates" },
+      body: JSON.stringify(args.rows),
+    },
+  );
+  if (!writeResult.ok) {
+    return errorResponse(args.request, "upstream_error", "Unable to save trial events", {
+      status: writeResult.status || 502,
+    });
+  }
+
+  return null;
+};
+
+const trialEventRowKey = (row: { target_id: unknown; trial_number: unknown }): string =>
+  `${String(row.target_id ?? "")}:${String(row.trial_number ?? "")}`;
+
+const fetchExistingSessionTrialEventKeys = async (args: {
+  request: Request;
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  organizationId: string;
+  rows: readonly Record<string, unknown>[];
+}): Promise<{ keys: Set<string>; response: Response | null }> => {
+  if (args.rows.length === 0) {
+    return { keys: new Set(), response: null };
+  }
+
+  const sessionId = String(args.rows[0]?.session_id ?? "");
+  const targetIds = Array.from(new Set(args.rows.map((row) => String(row.target_id ?? "")).filter(Boolean)));
+  const trialNumbers = Array.from(new Set(args.rows.map((row) => Number(row.trial_number)).filter(Number.isFinite)));
+  if (!sessionId || targetIds.length === 0 || trialNumbers.length === 0) {
+    return { keys: new Set(), response: null };
+  }
+
+  const result = await fetchJson<Array<{ target_id: string; trial_number: number }>>(
+    `${args.supabaseUrl}/rest/v1/trial_events?select=target_id,trial_number` +
+      `&organization_id=eq.${encodeURIComponent(args.organizationId)}` +
+      `&session_id=eq.${encodeURIComponent(sessionId)}` +
+      `&target_id=in.(${targetIds.map(encodeURIComponent).join(",")})` +
+      `&trial_number=in.(${trialNumbers.map((value) => encodeURIComponent(String(value))).join(",")})`,
+    {
+      method: "GET",
+      headers: args.headers,
+    },
+  );
+  if (!result.ok) {
+    return {
+      keys: new Set(),
+      response: errorResponse(args.request, "upstream_error", "Unable to validate existing trial events", {
+        status: result.status || 502,
+      }),
+    };
+  }
+
+  return {
+    keys: new Set((result.data ?? []).map((row) => trialEventRowKey(row))),
+    response: null,
+  };
+};
+
+const rollbackSessionTrialEventRows = async (args: {
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  organizationId: string;
+  rows: readonly Record<string, unknown>[];
+}): Promise<void> => {
+  if (args.rows.length === 0) {
+    return;
+  }
+
+  const sessionId = String(args.rows[0]?.session_id ?? "");
+  if (!sessionId) {
+    return;
+  }
+
+  const predicates = args.rows
+    .map((row) => {
+      const targetId = String(row.target_id ?? "");
+      const trialNumber = Number(row.trial_number);
+      if (!targetId || !Number.isFinite(trialNumber)) {
+        return null;
+      }
+      return `and(target_id.eq.${encodeURIComponent(targetId)},trial_number.eq.${encodeURIComponent(String(trialNumber))})`;
+    })
+    .filter((predicate): predicate is string => Boolean(predicate));
+
+  if (predicates.length === 0) {
+    return;
+  }
+
+  await fetchJson(
+    `${args.supabaseUrl}/rest/v1/trial_events` +
+      `?organization_id=eq.${encodeURIComponent(args.organizationId)}` +
+      `&session_id=eq.${encodeURIComponent(sessionId)}` +
+      `&or=(${predicates.join(",")})`,
+    {
+      method: "DELETE",
+      headers: { ...args.headers, Prefer: "return=minimal" },
+    },
+  );
+};
+
 export async function sessionNotesUpsertHandler(request: Request): Promise<Response> {
   if (isDisallowedOriginRequest(request)) {
     return errorResponse(request, "forbidden", "Origin not allowed", { status: 403 });
@@ -614,6 +953,24 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
     goalMeasurements: normalizedGoalMeasurements,
   });
 
+  const trialEventBuild = await buildSessionTrialEventRows({
+    request,
+    supabaseUrl,
+    headers,
+    organizationId,
+    accessToken,
+    clientId: payload.clientId,
+    sessionId: payload.sessionId,
+    therapistId: payload.therapistId,
+    actorUserId,
+    goalIds: alignedGoals.goalIds,
+    captureMergeGoalIds: mergeGoalIds,
+    trialEvents: payload.trialEvents,
+  });
+  if (trialEventBuild.response) {
+    return trialEventBuild.response;
+  }
+
   const writePayload = {
     authorization_id: payload.authorizationId,
     client_id: payload.clientId,
@@ -633,6 +990,30 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
     signed_at: payload.isLocked ? new Date().toISOString() : null,
     session_id: payload.sessionId ?? null,
   };
+
+  const existingTrialEventKeyBuild = await fetchExistingSessionTrialEventKeys({
+    request,
+    supabaseUrl,
+    headers,
+    organizationId,
+    rows: trialEventBuild.rows,
+  });
+  if (existingTrialEventKeyBuild.response) {
+    return existingTrialEventKeyBuild.response;
+  }
+  const rollbackTrialEventRows = trialEventBuild.rows.filter(
+    (row) => !existingTrialEventKeyBuild.keys.has(trialEventRowKey(row)),
+  );
+
+  const trialEventError = await writeSessionTrialEventRows({
+    request,
+    supabaseUrl,
+    headers,
+    rows: trialEventBuild.rows,
+  });
+  if (trialEventError) {
+    return trialEventError;
+  }
 
   let noteId = existingNote?.id ?? null;
   if (!noteId) {
@@ -663,6 +1044,7 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
       }
     }
     if (!insertResult.ok || !insertResult.data || insertResult.data.length === 0) {
+      await rollbackSessionTrialEventRows({ supabaseUrl, headers, organizationId, rows: rollbackTrialEventRows });
       return errorResponse(request, "upstream_error", "Unable to create session note", {
         status: insertResult.status || 502,
       });
@@ -690,6 +1072,7 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
       }
     }
     if (!updateResult.ok || !updateResult.data || updateResult.data.length === 0) {
+      await rollbackSessionTrialEventRows({ supabaseUrl, headers, organizationId, rows: rollbackTrialEventRows });
       return errorResponse(request, "upstream_error", "Unable to update session note", {
         status: updateResult.status || 502,
       });
@@ -698,6 +1081,7 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
 
   const savedRow = await fetchSessionNoteById(supabaseUrl, headers, organizationId, noteId);
   if (!savedRow) {
+    await rollbackSessionTrialEventRows({ supabaseUrl, headers, organizationId, rows: rollbackTrialEventRows });
     return errorResponse(request, "upstream_error", "Unable to load saved session note", { status: 502 });
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -280,6 +280,17 @@ export interface TrialEvent {
   updated_at: string;
 }
 
+export interface SessionCaptureTrialEventInput {
+  target_id: string;
+  trial_number: number;
+  response?: TrialEvent['response'];
+  prompt_type?: string | null;
+  prompt_level?: string | null;
+  value?: number | null;
+  timestamp?: string;
+  metadata?: Record<string, unknown>;
+}
+
 export interface ProgramNote {
   id: string;
   organization_id: string;

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -18,6 +18,13 @@ const runnerChildren = [
   "playwright:session-note-measurement-roundtrip",
   "playwright:session-capture-adhoc-upsert",
 ];
+const sessionSmokeRunnerChildren = [
+  "playwright:preflight",
+  "playwright:session-no-show",
+  "playwright:session-complete",
+  "playwright:schedule-blocked-close",
+  "playwright:session-note-measurement-roundtrip",
+];
 
 const write = (root: string, relativePath: string, content: string) => {
   const target = path.join(root, relativePath);
@@ -57,6 +64,7 @@ const createFixture = (
     JSON.stringify({
       scripts: {
         "ci:playwright": ciPlaywright,
+        "ci:playwright:session-smoke": `tsx scripts/playwright-ci-runner.ts ${sessionSmokeRunnerChildren.join(" ")}`,
         "playwright:preflight": "tsx scripts/playwright-preflight.ts",
       },
     }),
@@ -168,6 +176,18 @@ describe("check-e2e-reliability-gates", () => {
     const fixtureRoot = createFixture(
       `tsx scripts/playwright-ci-runner.ts ${runnerChildren.join(" ")}`,
       ["npm run ci:playwright"],
+    );
+
+    const result = spawnSync("node", [gatePath], { cwd: fixtureRoot, encoding: "utf8" });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("E2E reliability gate check passed.");
+  });
+
+  test("accepts workflow aggregate session smoke runner semantics", () => {
+    const fixtureRoot = createFixture(
+      `tsx scripts/playwright-ci-runner.ts ${runnerChildren.join(" ")}`,
+      ["npm run ci:playwright:session-smoke"],
     );
 
     const result = spawnSync("node", [gatePath], { cwd: fixtureRoot, encoding: "utf8" });

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -5,7 +5,9 @@ import {
   buildBookingConflictWindowFilters,
   cleanupBeforeNoResponseFailure,
   filterNonOverlappingBookingStarts,
+  hasReachedLifecyclePairAttemptLimit,
   isCreateSessionButtonReady,
+  shouldTryNextLifecyclePairAfterAttempts,
 } from "../../scripts/playwright-session-lifecycle";
 
 const originalGithubRunId = process.env.GITHUB_RUN_ID;
@@ -109,6 +111,30 @@ describe("playwright session lifecycle booking starts", () => {
       maxEndIso: "2026-08-20T21:00:00.000Z",
       activeHoldExpiresAfterIso: "2026-07-04T22:00:00.000Z",
     });
+  });
+
+  it("tries the next lifecycle target pair when every available start was blocked in the UI", () => {
+    expect(
+      shouldTryNextLifecyclePairAfterAttempts({
+        attemptedStartCount: 3,
+        blockedAttemptCount: 3,
+        payloadStatus: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldTryNextLifecyclePairAfterAttempts({
+        attemptedStartCount: 3,
+        blockedAttemptCount: 2,
+        payloadStatus: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("bounds hosted lifecycle target pair attempts", () => {
+    expect(hasReachedLifecyclePairAttemptLimit({ attemptedPairCount: 2, maxPairAttempts: 3 })).toBe(false);
+    expect(hasReachedLifecyclePairAttemptLimit({ attemptedPairCount: 3, maxPairAttempts: 3 })).toBe(true);
+    expect(hasReachedLifecyclePairAttemptLimit({ attemptedPairCount: 1, maxPairAttempts: 0 })).toBe(true);
   });
 
   it("does not block the no-response failure when cleanup rejects", async () => {

--- a/tests/scripts/provision-ci-smoke-admin.test.ts
+++ b/tests/scripts/provision-ci-smoke-admin.test.ts
@@ -138,6 +138,9 @@ describe('provision-ci-smoke-admin safeguards', () => {
 
   it('keeps service-role credentials out of the auth login smoke step', () => {
     const workflow = readFileSync(path.join(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+    const packageJson = JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
     const authStep = workflow.slice(
       workflow.indexOf('- name: Auth browser smoke gate'),
       workflow.indexOf('- name: Session browser smoke gate'),
@@ -151,7 +154,8 @@ describe('provision-ci-smoke-admin safeguards', () => {
     expect(authStep).not.toContain('npm run playwright:preflight');
     expect(authStep).not.toContain('SUPABASE_SECRET_KEY');
     expect(authStep).not.toContain('SUPABASE_SERVICE_ROLE_KEY');
-    expect(sessionStep).toContain('npm run playwright:preflight');
+    expect(sessionStep).toContain('npm run ci:playwright:session-smoke');
+    expect(packageJson.scripts?.['ci:playwright:session-smoke']).toContain('playwright:preflight');
     expect(sessionStep).toContain('SUPABASE_SERVICE_ROLE_KEY');
   });
 


### PR DESCRIPTION
## Summary
- Store configured Schedule capture trials as raw `trial_events` tied to `goal_targets.id` through the session-note upsert path.
- Keep configured raw-trial-backed goals from resaving aggregate `target_trials` counts, including reopened sessions with existing raw rows.
- Add server-side org/client/session/therapist/goal-scope validation and rollback only newly written raw rows if note persistence fails.

Linear: WIN-195

## Route / Risk
- classification: `high-risk human-reviewed`
- lane: `critical`
- triggering paths: `src/server/api/session-notes-upsert.ts`, tenant-scoped clinical writes, Schedule session capture

## Verification
Passed locally:
- `npm test -- src/server/__tests__/sessionNotesUpsertHandler.test.ts src/lib/__tests__/session-notes.test.ts src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci` (352 files, 2245 tests)
- `npm run ci:verify-coverage`
- `npm run build`
- `npm run validate:tenant`
- `npm run ci:check-focused`
- `npm run test:routes:tier0` (7 specs, 212 tests)

Blocked locally:
- `npm run ci:playwright` preflight passes, then `playwright:auth` fails for `superadmin@test.com` with `Invalid email or password`. Latest screenshot: `artifacts/latest/playwright-auth-smoke-failure-1783276211693.png`.

Notes:
- `npm run verify:local` visibly completed its child gates through Tier-0 routes but the wrapper command hit the local 5-minute timeout before process exit, so the child gates were rerun individually above with clean exit codes.
- `ci:check-focused` skipped DB-backed drift/grant checks locally because `SUPABASE_DB_URL`/`DATABASE_URL` is not configured.

## Reviewer
- Internal reviewer initially found rollback/data-scope/edit-cycle issues.
- Follow-up review reported no remaining findings for goal-scope enforcement, reopened raw-trial aggregate cleanup, or rollback conflict data-loss concern.

## Residual Risk
- Human review required before merge because this is critical protected-path work.
- Hosted Playwright auth/session smoke needs valid credentials or CI secret-backed confirmation.