### PR TITLE
Harden BCBA and BT session access

### DIFF
--- a/cypress/support/routeScenarios.ts
+++ b/cypress/support/routeScenarios.ts
@@ -77,18 +77,18 @@ export const routeGroups = {
     {
       path: "/settings/feature-flags",
       roles: ["admin", "bcba", "super_admin"],
-      expectedPathByRole: { admin: "/settings", bcba: "/settings/feature-flags", super_admin: "/settings/feature-flags" },
+      expectedPathByRole: { admin: "/settings", bcba: "/settings", super_admin: "/settings/feature-flags" },
     },
     {
       path: "/settings/impersonation",
       roles: ["admin", "bcba", "super_admin"],
-      expectedPathByRole: { admin: "/settings", bcba: "/settings/impersonation", super_admin: "/settings/impersonation" },
+      expectedPathByRole: { admin: "/settings", bcba: "/settings", super_admin: "/settings/impersonation" },
     },
     { path: "/superadminfeatureflags", roles: ["admin", "bcba", "super_admin"], expectedPath: "/settings" },
     { path: "/superadminimpersonation", roles: ["admin", "bcba", "super_admin"], expectedPath: "/settings" },
-    { path: "/super-admin/feature-flags", roles: ["bcba", "super_admin"] },
-    { path: "/super-admin/impersonation", roles: ["bcba", "super_admin"] },
-    { path: "/super-admin/prompts", roles: ["bcba", "super_admin"] },
+    { path: "/super-admin/feature-flags", roles: ["super_admin"] },
+    { path: "/super-admin/impersonation", roles: ["super_admin"] },
+    { path: "/super-admin/prompts", roles: ["super_admin"] },
   ],
 } satisfies Record<string, readonly RouteScenario[]>;
 

--- a/scripts/route-audit.ts
+++ b/scripts/route-audit.ts
@@ -133,9 +133,9 @@ export const ROUTES: readonly RouteDefinition[] = [
   { path: '/family', component: 'FamilyDashboard', roles: ['client'], permissions: [] },
   { path: '/settings', component: 'Settings', roles: ['admin', 'bcba', 'super_admin'], permissions: [] },
   { path: '/settings/:tabId', component: 'Settings', roles: ['admin', 'bcba', 'super_admin'], permissions: [] },
-  { path: '/super-admin/feature-flags', component: 'SuperAdminFeatureFlags', roles: ['bcba', 'super_admin'], permissions: [] },
-  { path: '/super-admin/impersonation', component: 'SuperAdminImpersonation', roles: ['bcba', 'super_admin'], permissions: [] },
-  { path: '/super-admin/prompts', component: 'SuperAdminPrompts', roles: ['bcba', 'super_admin'], permissions: [] },
+  { path: '/super-admin/feature-flags', component: 'SuperAdminFeatureFlags', roles: ['super_admin'], permissions: [] },
+  { path: '/super-admin/impersonation', component: 'SuperAdminImpersonation', roles: ['super_admin'], permissions: [] },
+  { path: '/super-admin/prompts', component: 'SuperAdminPrompts', roles: ['super_admin'], permissions: [] },
 ];
 
 const TEST_ROLES: readonly Role[] = ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -321,7 +321,7 @@ function App() {
                     <Route
                       path="super-admin/feature-flags"
                       element={
-                        <RoleGuard roles={['bcba', 'super_admin']}>
+                        <RoleGuard roles={['super_admin']}>
                           <SuperAdminFeatureFlags />
                         </RoleGuard>
                       }
@@ -329,7 +329,7 @@ function App() {
                     <Route
                       path="super-admin/impersonation"
                       element={
-                        <RoleGuard roles={['bcba', 'super_admin']}>
+                        <RoleGuard roles={['super_admin']}>
                           <SuperAdminImpersonation />
                         </RoleGuard>
                       }
@@ -337,7 +337,7 @@ function App() {
                     <Route
                       path="super-admin/prompts"
                       element={
-                        <RoleGuard roles={['bcba', 'super_admin']}>
+                        <RoleGuard roles={['super_admin']}>
                           <SuperAdminPrompts />
                         </RoleGuard>
                       }

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -233,6 +233,7 @@ interface SessionModalProps {
   retryActionLabel?: string | null;
   onRetryAction?: (() => void) | undefined;
   onSessionStarted?: () => void | Promise<void>;
+  dataCollectionOnly?: boolean;
 }
 
 export function SessionModal({
@@ -253,6 +254,7 @@ export function SessionModal({
   retryActionLabel,
   onRetryAction,
   onSessionStarted,
+  dataCollectionOnly = false,
 }: SessionModalProps) {
   const [isPlanSummaryExpanded, setIsPlanSummaryExpanded] = useState(false);
   const [selectedProgramIds, setSelectedProgramIds] = useState<string[]>(() =>
@@ -278,6 +280,7 @@ export function SessionModal({
   const conflictDescriptionId = 'session-modal-conflicts-description';
   const conflictHeadingId = 'session-modal-conflicts-heading';
   const queryClient = useQueryClient();
+  const isDataCollectionOnly = Boolean(dataCollectionOnly && session?.id);
 
   const resolvedTimeZone = useMemo(() => resolveSchedulingTimeZone(timeZone), [timeZone]);
 
@@ -902,15 +905,21 @@ export function SessionModal({
 
   const toggleProgramSelection = useCallback(
     (targetProgramId: string) => {
+      if (isDataCollectionOnly) {
+        return;
+      }
       const nextProgramIds = selectedProgramSet.has(targetProgramId)
         ? selectedProgramIds.filter((id) => id !== targetProgramId)
         : [...selectedProgramIds, targetProgramId];
       updateProgramSelection(nextProgramIds);
     },
-    [selectedProgramIds, selectedProgramSet, updateProgramSelection],
+    [isDataCollectionOnly, selectedProgramIds, selectedProgramSet, updateProgramSelection],
   );
 
   const toggleGoalSelection = (targetId: string) => {
+    if (isDataCollectionOnly) {
+      return;
+    }
     const nextGoalIds = Array.isArray(goalIds) ? [...goalIds] : [];
     if (nextGoalIds.includes(targetId)) {
       if (targetId === goalId) {
@@ -1098,7 +1107,7 @@ export function SessionModal({
     data: SessionModalFormValues,
     options?: { captureMergeGoalIds?: string[] },
   ) => {
-    if (conflicts.length > 0) {
+    if (!isDataCollectionOnly && conflicts.length > 0) {
       if (!window.confirm('There are scheduling conflicts. Do you want to proceed anyway?')) {
         return;
       }
@@ -1107,14 +1116,14 @@ export function SessionModal({
       Boolean(session?.id) &&
       !hasStartedSession &&
       data.status === 'scheduled';
-    if (isSavingUnstartedScheduledSession && hasProgramValue && !hasProgramOptionForValue) {
+    if (!isDataCollectionOnly && isSavingUnstartedScheduledSession && hasProgramValue && !hasProgramOptionForValue) {
       setError('program_id', {
         type: 'validate',
         message: 'Select an active program before saving this scheduled session.',
       });
       return;
     }
-    if (isSavingUnstartedScheduledSession && hasGoalValue && !hasGoalOptionForValue) {
+    if (!isDataCollectionOnly && isSavingUnstartedScheduledSession && hasGoalValue && !hasGoalOptionForValue) {
       setError('goal_id', {
         type: 'validate',
         message: 'Select an active primary goal before saving this scheduled session.',
@@ -1300,6 +1309,20 @@ export function SessionModal({
           }
         }
       }
+      const lockedSessionFields: Partial<Session> = isDataCollectionOnly && session
+        ? {
+            id: session.id,
+            therapist_id: session.therapist_id,
+            client_id: session.client_id,
+            program_id: session.program_id,
+            goal_id: session.goal_id,
+            goal_ids: session.goal_ids ?? [],
+            start_time: session.start_time,
+            end_time: session.end_time,
+            status: session.status,
+            notes: session.notes ?? '',
+          }
+        : {};
       const transformed: SessionModalSubmitData = {
         ...working,
         ...(session?.id ? { id: session.id } : {}),
@@ -1323,6 +1346,7 @@ export function SessionModal({
         // If a timezone prop is provided, normalize to UTC for consumers expecting Z times
         start_time: timeZone ? toUtcSessionIsoString(working.start_time, resolvedTimeZone) : working.start_time,
         end_time: timeZone ? toUtcSessionIsoString(working.end_time, resolvedTimeZone) : working.end_time,
+        ...lockedSessionFields,
       };
       await onSubmit(transformed);
       if (trialEventsForSubmit.length > 0 && session?.id) {
@@ -1407,6 +1431,9 @@ export function SessionModal({
   }, [isDirty, isSubmitting, onClose]);
 
   const handleStartSession = async () => {
+    if (isDataCollectionOnly) {
+      return;
+    }
     if (!session?.id) {
       return;
     }
@@ -1434,6 +1461,9 @@ export function SessionModal({
   };
 
   const handleCloseSession = () => {
+    if (isDataCollectionOnly) {
+      return;
+    }
     setValue('status', 'completed', { shouldDirty: true });
     void handleSubmit(async (formData) => {
       await handleFormSubmit({
@@ -2158,7 +2188,9 @@ export function SessionModal({
               >
                 <p className="font-medium">Session in progress</p>
                 <p className="mt-1">
-                  You can adjust program and goals while active; save to keep the plan in sync with the schedule.
+                  {isDataCollectionOnly
+                    ? 'Session details are read-only. Save progress to sync data collection.'
+                    : 'You can adjust program and goals while active; save to keep the plan in sync with the schedule.'}
                 </p>
               </div>
             )}
@@ -2227,6 +2259,7 @@ export function SessionModal({
                 <select
                   id="therapist-select"
                   {...register('therapist_id', { required: 'Therapist is required' })}
+                  disabled={isDataCollectionOnly}
                   className="min-h-11 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                 >
                   <option value="">Select a therapist</option>
@@ -2251,6 +2284,7 @@ export function SessionModal({
                 <select
                   id="client-select"
                   {...register('client_id', { required: 'Client is required' })}
+                  disabled={isDataCollectionOnly}
                   className="min-h-11 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                 >
                   <option value="">Select a client</option>
@@ -2372,8 +2406,11 @@ export function SessionModal({
                 <select
                   id="program-select"
                   {...register('program_id')}
-                  disabled={isProgramsFetching || !clientId}
+                  disabled={isDataCollectionOnly || isProgramsFetching || !clientId}
                   onChange={(event) => {
+                    if (isDataCollectionOnly) {
+                      return;
+                    }
                     const nextProgramId = event.target.value;
                     setValue('program_id', nextProgramId, { shouldDirty: true, shouldTouch: true });
                     if (!nextProgramId) {
@@ -2428,7 +2465,7 @@ export function SessionModal({
                 <select
                   id="goal-select"
                   {...register('goal_id')}
-                  disabled={isGoalsFetching || selectedProgramGoals.length === 0}
+                  disabled={isDataCollectionOnly || isGoalsFetching || selectedProgramGoals.length === 0}
                   className="min-h-11 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                 >
                   <option value="">Select a goal</option>
@@ -2521,12 +2558,13 @@ export function SessionModal({
                           key={`mobile-program-${program.id}`}
                           className="flex min-w-0 items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
                         >
-                          <input
-                            type="checkbox"
-                            checked={selectedProgramSet.has(program.id)}
-                            onChange={() => toggleProgramSelection(program.id)}
-                            className="h-5 w-5 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                          />
+                        <input
+                          type="checkbox"
+                          checked={selectedProgramSet.has(program.id)}
+                          onChange={() => toggleProgramSelection(program.id)}
+                          disabled={isDataCollectionOnly}
+                          className="h-5 w-5 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        />
                           <span className="min-w-0 flex-1 truncate">{program.name}</span>
                           <span className="shrink-0 text-[11px] text-gray-500 dark:text-gray-400">
                             {groupedGoals.length} goals
@@ -2577,6 +2615,7 @@ export function SessionModal({
                                   type="checkbox"
                                   checked={Array.isArray(goalIds) && goalIds.includes(goal.id)}
                                   onChange={() => toggleGoalSelection(goal.id)}
+                                  disabled={isDataCollectionOnly}
                                   className="h-5 w-5 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                                 />
                                 <span className="min-w-0 flex-1 truncate">{goal.title}</span>
@@ -2626,6 +2665,7 @@ export function SessionModal({
                                   type="checkbox"
                                   checked={Array.isArray(goalIds) && goalIds.includes(goal.id)}
                                   onChange={() => toggleGoalSelection(goal.id)}
+                                  disabled={isDataCollectionOnly}
                                   className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                                 />
                                 <span className="truncate">{goal.title}</span>
@@ -2680,6 +2720,7 @@ export function SessionModal({
                     type="datetime-local"
                     id="start-time-input"
                     {...register('start_time', { required: 'Start time is required' })}
+                    disabled={isDataCollectionOnly}
                     className="min-h-11 w-full rounded-md border-gray-300 bg-white pl-10 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                     onChange={(e) => handleTimeChange(e, 'start_time')}
                     step="900" // 15 minutes in seconds
@@ -2703,6 +2744,7 @@ export function SessionModal({
                     type="datetime-local"
                     id="end-time-input"
                     {...register('end_time', { required: 'End time is required' })}
+                    disabled={isDataCollectionOnly}
                     className="min-h-11 w-full rounded-md border-gray-300 bg-white pl-10 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
                     onChange={(e) => handleTimeChange(e, 'end_time')}
                     step="900" // 15 minutes in seconds
@@ -2733,6 +2775,7 @@ export function SessionModal({
               <select
                 id="status-select"
                 {...register('status')}
+                disabled={isDataCollectionOnly}
                 className="min-h-11 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
               >
                 <option value="scheduled">Scheduled</option>
@@ -2762,6 +2805,7 @@ export function SessionModal({
               <textarea
                 id="notes-input"
                 {...register('notes')}
+                disabled={isDataCollectionOnly}
                 rows={3}
                 className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-dark shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:text-gray-200"
                 placeholder="Add any session notes here..."
@@ -3475,7 +3519,7 @@ export function SessionModal({
               >
                 Cancel
               </button>
-              {session?.id && session.status === 'scheduled' && !hasStartedSession ? (
+              {session?.id && session.status === 'scheduled' && !hasStartedSession && !isDataCollectionOnly ? (
                 <button
                   type="button"
                   onClick={handleStartSession}
@@ -3485,7 +3529,7 @@ export function SessionModal({
                   Start Session
                 </button>
               ) : null}
-              {session?.id && isInProgressSession ? (
+              {session?.id && isInProgressSession && !isDataCollectionOnly ? (
                 <button
                   type="button"
                   onClick={handleCloseSession}

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1318,6 +1318,51 @@ describe('SessionModal', () => {
       const select = screen.getByRole('combobox', { name: /Status/i }) as HTMLSelectElement;
       expect(select.value).toBe('in_progress');
     });
+
+    it('locks session metadata while allowing data-only save in edit mode', async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      const lockedSession: Session = {
+        ...editSession,
+        status: 'in_progress',
+        notes: 'Original schedule note',
+        started_at: '2026-03-31T10:05:00.000Z',
+      };
+
+      renderWithProviders(
+        <SessionModal
+          {...defaultProps}
+          onSubmit={onSubmit}
+          session={lockedSession}
+          dataCollectionOnly
+        />
+      );
+
+      expect(screen.getByRole('combobox', { name: /Therapist/i })).toBeDisabled();
+      expect(screen.getByRole('combobox', { name: /Client/i })).toBeDisabled();
+      expect(screen.getByRole('combobox', { name: /Program/i })).toBeDisabled();
+      expect(screen.getByRole('combobox', { name: /Primary Goal/i })).toBeDisabled();
+      expect(screen.getByRole('combobox', { name: /Status/i })).toBeDisabled();
+      expect(screen.getByLabelText(/Start Time/i)).toBeDisabled();
+      expect(screen.getByLabelText(/End Time/i)).toBeDisabled();
+      expect(screen.getByLabelText(/Schedule Notes/i)).toBeDisabled();
+      expect(screen.queryByRole('button', { name: /^Close Session$/i })).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+          id: 'session-edit',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-31T10:00:00.000Z',
+          end_time: '2026-03-31T11:00:00.000Z',
+          status: 'in_progress',
+          notes: 'Original schedule note',
+        }));
+      });
+    });
   });
 
   it('does not preselect inactive published programs or paused goals for a new session', async () => {

--- a/src/lib/__tests__/roles.test.ts
+++ b/src/lib/__tests__/roles.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { roleHasCapability, roleMeetsOrExceeds, rolesForCapability } from '../roles';
+
+describe('role capability matrix', () => {
+  it('keeps super-admin tooling exclusive to super_admin', () => {
+    expect(rolesForCapability('accessSuperAdminTools')).toEqual(['super_admin']);
+    expect(roleHasCapability('bcba', 'accessSuperAdminTools')).toBe(false);
+    expect(roleMeetsOrExceeds('bcba', 'super_admin')).toBe(false);
+    expect(roleMeetsOrExceeds('super_admin', 'bcba')).toBe(true);
+  });
+
+  it('defines BCBA as clinical and operational admin without super-admin bypass', () => {
+    expect(roleHasCapability('bcba', 'manageProgramsGoals')).toBe(true);
+    expect(roleHasCapability('bcba', 'manageStaff')).toBe(true);
+    expect(roleHasCapability('bcba', 'manageAuthorizations')).toBe(true);
+    expect(roleHasCapability('bcba', 'dataTaking')).toBe(true);
+    expect(roleHasCapability('bcba', 'viewSettings')).toBe(true);
+  });
+
+  it('keeps admin_schedule and BT scoped to their exact capabilities', () => {
+    expect(roleHasCapability('admin_schedule', 'manageClients')).toBe(true);
+    expect(roleHasCapability('admin_schedule', 'manageProgramsGoals')).toBe(false);
+    expect(roleHasCapability('admin_schedule', 'viewBilling')).toBe(false);
+    expect(roleHasCapability('admin_schedule', 'dataTaking')).toBe(false);
+
+    expect(roleHasCapability('bt', 'dataTaking')).toBe(true);
+    expect(roleHasCapability('bt', 'viewClients')).toBe(true);
+    expect(roleHasCapability('bt', 'viewSchedule')).toBe(false);
+    expect(roleHasCapability('bt', 'manageClients')).toBe(false);
+    expect(roleHasCapability('bt', 'manageProgramsGoals')).toBe(false);
+  });
+});

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -63,7 +63,7 @@ export const ROLE_RANK: Record<AppRole, number> = {
   admin_schedule: 5,
   admin: 6,
   bcba: 7,
-  super_admin: 7,
+  super_admin: 8,
 };
 
 const allCapabilities: readonly AppCapability[] = [
@@ -164,7 +164,30 @@ export const ROLE_CAPABILITIES: Record<AppRole, readonly AppCapability[]> = {
     'viewStaff',
     'viewStaffProfile',
   ],
-  bcba: allCapabilities,
+  bcba: [
+    'assignClientsToStaff',
+    'dataTaking',
+    'lockSessionNotes',
+    'manageAuthorizations',
+    'manageClients',
+    'manageProgramsGoals',
+    'manageStaff',
+    'staffDashboard',
+    'viewAuthorizations',
+    'viewBilling',
+    'viewClients',
+    'viewDocumentation',
+    'viewFillDocs',
+    'viewMessages',
+    'viewMonitoring',
+    'viewProgramsGoals',
+    'viewReports',
+    'viewSchedule',
+    'viewSessionTrends',
+    'viewSettings',
+    'viewStaff',
+    'viewStaffProfile',
+  ],
   super_admin: allCapabilities,
 };
 

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1531,6 +1531,12 @@ export const Schedule = React.memo(() => {
         selectedSession: effectiveSelectedSession,
         data: sessionPayload,
       });
+      const isBtDataCollectionOnlySession = effectiveRole === "bt" && Boolean(effectiveSelectedSession?.id);
+
+      if (isBtDataCollectionOnlySession && decision.kind !== "edit-update") {
+        showError("BT users can only save data collection for existing sessions.");
+        return;
+      }
 
       switch (decision.kind) {
         case "edit-cancel": {
@@ -1652,6 +1658,10 @@ export const Schedule = React.memo(() => {
           return;
         }
         case "edit-update": {
+          if (isBtDataCollectionOnlySession && !clinicalNoteDraft) {
+            showError("No data collection changes to save.");
+            return;
+          }
           if (effectiveSelectedSession && clinicalNoteDraft) {
             if (!activeOrganizationId) {
               throw new Error("Organization context is required to save session capture.");
@@ -1689,6 +1699,19 @@ export const Schedule = React.memo(() => {
               ...(mergeCaptureIds?.length ? { captureMergeGoalIds: mergeCaptureIds } : {}),
               ...(clinicalNoteDraft.trialEvents.length ? { trialEvents: clinicalNoteDraft.trialEvents } : {}),
             });
+            if (isBtDataCollectionOnlySession) {
+              invalidateSessionNoteCachesAfterSessionWrite(queryClient, {
+                sessionId: effectiveSelectedSession.id,
+                clientId: effectiveSelectedSession.client_id,
+                organizationId: activeOrganizationId,
+              });
+              showSuccess("Session data collection saved");
+              applyScheduleResetBranch(
+                { kind: "update-success" },
+                scheduleResetSetters,
+              );
+              return;
+            }
           }
           await updateSessionMutation.mutateAsync(sessionPayload);
           return;
@@ -1717,6 +1740,8 @@ export const Schedule = React.memo(() => {
       updateSessionMutation,
       createSessionMutation,
       displayData.sessions,
+      effectiveRole,
+      queryClient,
     ],
   );
 
@@ -1852,6 +1877,7 @@ export const Schedule = React.memo(() => {
         clients={visibleClients}
         existingSessions={displayData.sessions}
         timeZone={userTimeZone}
+        dataCollectionOnly={effectiveRole === "bt" && Boolean(selectedSession?.id)}
         defaultTherapistId={selectedTherapist}
         defaultClientId={selectedClient}
         retryHint={retryHint}

--- a/src/pages/__tests__/AppNavigation.test.tsx
+++ b/src/pages/__tests__/AppNavigation.test.tsx
@@ -307,8 +307,8 @@ describe('App navigation landing', () => {
     ['/super-admin/feature-flags', 'SuperAdminFeatureFlagsPage'],
     ['/super-admin/impersonation', 'SuperAdminImpersonationPage'],
     ['/super-admin/prompts', 'SuperAdminPromptsPage'],
-  ])('allows BCBA and super admins to render %s', async (path, pageText) => {
-    for (const allowedRole of ['bcba', 'super_admin'] as const) {
+  ])('allows only super admins to render %s', async (path, pageText) => {
+    for (const allowedRole of ['super_admin'] as const) {
       authRole = allowedRole;
       window.history.pushState({}, '', path);
       const allowedView = renderApp();
@@ -318,7 +318,7 @@ describe('App navigation landing', () => {
       allowedView.unmount();
     }
 
-    for (const blockedRole of ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin'] as const) {
+    for (const blockedRole of ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba'] as const) {
       authRole = blockedRole;
       window.history.pushState({}, '', path);
       const blockedView = renderApp();

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -103,17 +103,20 @@ vi.mock("../../components/SessionModal", () => ({
     onSubmit,
     session,
     retryHint,
+    dataCollectionOnly,
   }: {
     isOpen: boolean;
     onClose: () => void;
     onSubmit: (data: Record<string, unknown>) => unknown;
     session?: { id: string };
     retryHint?: string | null;
+    dataCollectionOnly?: boolean;
   }) =>
     isOpen ? (
       <div data-testid="session-modal">
         <div data-testid="modal-mode">{session ? "edit" : "create"}</div>
         <div data-testid="retry-hint">{retryHint ?? ""}</div>
+        <div data-testid="data-collection-only">{dataCollectionOnly ? "true" : "false"}</div>
         <button
           aria-label="submit-create"
           onClick={() => {
@@ -546,6 +549,35 @@ describe("Schedule orchestration integration hardening", () => {
       }],
     }));
     expect(bookSessionViaApiMock.mock.calls[0][1]).toBeUndefined();
+    expect(showErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("BT live capture persistence saves data collection without updating appointment metadata", async () => {
+    scheduleFixtures.sessions[0].status = "in_progress";
+
+    renderWithProviders(<Schedule />, {
+      auth: { role: "bt", organizationId: "org-1" },
+    });
+    await screen.findByRole("heading", { name: /Schedule/i });
+
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+    expect(screen.getByTestId("modal-mode")).toHaveTextContent("edit");
+    expect(screen.getByTestId("data-collection-only")).toHaveTextContent("true");
+    fireEvent.click(screen.getByLabelText("submit-capture-persist"));
+
+    await waitFor(() => {
+      expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1);
+    });
+    expect(bookSessionViaApiMock).not.toHaveBeenCalled();
+    expect(invalidateSessionNoteCachesAfterSessionWriteMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        sessionId: "session-1",
+        clientId: "client-1",
+      }),
+    );
+    expect(showSuccessMock).toHaveBeenCalledWith("Session data collection saved");
     expect(showErrorMock).not.toHaveBeenCalled();
   });
 

--- a/src/server/routes/__tests__/guards.test.ts
+++ b/src/server/routes/__tests__/guards.test.ts
@@ -117,4 +117,16 @@ describe('route guard access controls', () => {
     expect(hasRoleAccess('/family', 'admin')).toBe(false);
     expect(hasRoleAccess('/family', 'super_admin')).toBe(false);
   });
+
+  it('restricts super-admin tool routes to super admins only', () => {
+    for (const path of [
+      '/super-admin/feature-flags',
+      '/super-admin/impersonation',
+      '/super-admin/prompts',
+    ]) {
+      expect(hasRoleAccess(path, 'super_admin')).toBe(true);
+      expect(hasRoleAccess(path, 'bcba')).toBe(false);
+      expect(hasRoleAccess(path, 'admin')).toBe(false);
+    }
+  });
 });

--- a/src/server/routes/guards.ts
+++ b/src/server/routes/guards.ts
@@ -159,19 +159,19 @@ const guardDefinitions: readonly GuardWithMatcher[] = [
   }),
   createGuard({
     path: '/super-admin/feature-flags',
-    allowedRoles: ['bcba', 'super_admin'],
+    allowedRoles: ['super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.feature_flags: super_admin_manage'],
   }),
   createGuard({
     path: '/super-admin/impersonation',
-    allowedRoles: ['bcba', 'super_admin'],
+    allowedRoles: ['super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['supabase.functions.super-admin-impersonate: super_admin_execute'],
   }),
   createGuard({
     path: '/super-admin/prompts',
-    allowedRoles: ['bcba', 'super_admin'],
+    allowedRoles: ['super_admin'],
     requiredPermissions: [],
     supabasePolicies: ['public.agent_prompt_tool_versions: admin_read'],
   }),

--- a/supabase/migrations/20260706023600_bcba_exact_capability_matrix.sql
+++ b/supabase/migrations/20260706023600_bcba_exact_capability_matrix.sql
@@ -1,0 +1,349 @@
+-- @migration-intent: Make BCBA an exact clinical/admin role instead of a super-admin-equivalent bypass.
+-- @migration-dependencies: 20260701150000_employee_role_capability_matrix.sql
+-- @migration-rollback: Re-apply 20260701150000_employee_role_capability_matrix.sql helper definitions if BCBA must temporarily regain super-admin-equivalent access.
+
+BEGIN;
+
+UPDATE public.roles
+SET description = 'BCBA clinical and operational admin access'
+WHERE name = 'bcba';
+
+CREATE OR REPLACE FUNCTION app.current_user_is_super_admin()
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id uuid;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    WHERE ur.user_id = v_user_id
+      AND r.name = 'super_admin'
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.current_user_is_super_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, app_auth
+AS $$
+  SELECT COALESCE(app.current_user_is_super_admin(), false);
+$$;
+
+CREATE OR REPLACE FUNCTION app.is_super_admin()
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    WHERE ur.user_id = v_user_id
+      AND r.name = 'super_admin'
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.user_has_role_for_org(
+  role_name text,
+  target_organization_id uuid DEFAULT NULL,
+  target_therapist_id uuid DEFAULT NULL,
+  target_client_id uuid DEFAULT NULL,
+  target_session_id uuid DEFAULT NULL
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  caller_id uuid;
+  caller_org uuid;
+  resolved_org uuid;
+  resolved_client_id uuid := target_client_id;
+  normalized_role text;
+BEGIN
+  caller_id := auth.uid();
+  IF caller_id IS NULL OR role_name IS NULL OR btrim(role_name) = '' THEN
+    RETURN false;
+  END IF;
+
+  IF app.current_user_is_super_admin() THEN
+    RETURN true;
+  END IF;
+
+  caller_org := app.resolve_user_organization_id(caller_id);
+  IF caller_org IS NULL THEN
+    RETURN false;
+  END IF;
+
+  resolved_org := target_organization_id;
+
+  IF resolved_org IS NULL AND target_therapist_id IS NOT NULL THEN
+    SELECT t.organization_id
+    INTO resolved_org
+    FROM public.therapists t
+    WHERE t.id = target_therapist_id;
+  END IF;
+
+  IF resolved_org IS NULL AND target_session_id IS NOT NULL THEN
+    SELECT COALESCE(s.organization_id, t.organization_id), s.client_id
+    INTO resolved_org, resolved_client_id
+    FROM public.sessions s
+    LEFT JOIN public.therapists t ON t.id = s.therapist_id
+    WHERE s.id = target_session_id;
+  END IF;
+
+  IF resolved_org IS NULL AND target_client_id IS NOT NULL THEN
+    SELECT COALESCE(
+      c.organization_id,
+      (
+        SELECT COALESCE(s.organization_id, t.organization_id)
+        FROM public.sessions s
+        LEFT JOIN public.therapists t ON t.id = s.therapist_id
+        WHERE s.client_id = c.id
+        ORDER BY s.created_at DESC NULLS LAST
+        LIMIT 1
+      )
+    ), c.id
+    INTO resolved_org, resolved_client_id
+    FROM public.clients c
+    WHERE c.id = target_client_id;
+  END IF;
+
+  IF resolved_org IS NULL OR resolved_org <> caller_org THEN
+    RETURN false;
+  END IF;
+
+  IF role_name = 'client' THEN
+    IF resolved_client_id IS NOT NULL THEN
+      IF caller_id = resolved_client_id THEN
+        RETURN true;
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM public.client_guardians cg
+        WHERE cg.guardian_id = caller_id
+          AND cg.client_id = resolved_client_id
+          AND cg.organization_id = resolved_org
+          AND cg.deleted_at IS NULL
+      ) THEN
+        RETURN true;
+      END IF;
+    END IF;
+
+    RETURN false;
+  END IF;
+
+  normalized_role := lower(btrim(role_name));
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    WHERE ur.user_id = caller_id
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+      AND (
+        (normalized_role = 'admin' AND r.name IN ('admin', 'org_admin'))
+        OR (normalized_role = 'therapist' AND r.name IN ('therapist', 'org_member'))
+        OR (normalized_role = 'super_admin' AND r.name IN ('super_admin', 'org_super_admin'))
+        OR r.name = normalized_role
+      )
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.user_has_role_for_org(
+  target_user_id uuid,
+  target_organization_id uuid,
+  allowed_roles text[]
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  resolved_org uuid;
+BEGIN
+  IF target_user_id IS NULL OR target_organization_id IS NULL OR allowed_roles IS NULL OR cardinality(allowed_roles) = 0 THEN
+    RETURN false;
+  END IF;
+
+  IF target_user_id <> app.current_user_id() AND NOT app.current_user_is_super_admin() THEN
+    RETURN false;
+  END IF;
+
+  IF app.current_user_is_super_admin() THEN
+    RETURN true;
+  END IF;
+
+  resolved_org := app.resolve_user_organization_id(target_user_id);
+  IF resolved_org IS NULL OR resolved_org <> target_organization_id THEN
+    RETURN false;
+  END IF;
+
+  RETURN EXISTS (
+    WITH allowed_input AS (
+      SELECT lower(btrim(unnest(allowed_roles))) AS role_name
+    ),
+    mapped_roles AS (
+      SELECT unnest(
+        CASE role_name
+          WHEN 'org_admin' THEN ARRAY['admin']::text[]
+          WHEN 'org_member' THEN ARRAY['therapist', 'client']::text[]
+          WHEN 'org_super_admin' THEN ARRAY['super_admin']::text[]
+          WHEN 'super_admin' THEN ARRAY['super_admin']::text[]
+          WHEN 'therapist' THEN ARRAY['therapist']::text[]
+          ELSE ARRAY[role_name]::text[]
+        END
+      ) AS role_name
+      FROM allowed_input
+    )
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    JOIN mapped_roles mr ON mr.role_name = r.name
+    WHERE ur.user_id = target_user_id
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_manage_staff_clients(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['admin', 'admin_schedule', 'bcba']::text[]);
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_manage_authorizations(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['admin', 'admin_schedule', 'midtier', 'bcba']::text[]);
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_manage_schedule(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['admin', 'admin_schedule', 'midtier', 'therapist', 'bcba']::text[]);
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_manage_programs_goals(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['admin', 'midtier', 'therapist', 'bcba']::text[]);
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_take_client_data(
+  target_organization_id uuid,
+  target_client_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT
+    app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['admin', 'midtier', 'bcba']::text[])
+    OR (
+      app.current_user_has_exact_role_for_org(target_organization_id, ARRAY['therapist', 'bt']::text[])
+      AND app.current_user_has_assigned_client(target_organization_id, target_client_id)
+    );
+$$;
+
+DROP POLICY IF EXISTS org_read_clients ON public.clients;
+CREATE POLICY org_read_clients
+ON public.clients
+FOR SELECT
+TO authenticated
+USING (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND (
+      app.current_user_has_exact_role_for_org(organization_id, ARRAY['admin', 'admin_schedule', 'therapist', 'midtier', 'bcba']::text[])
+      OR app.user_has_role_for_org('client'::text, organization_id, NULL::uuid, id)
+      OR (
+        app.current_user_has_exact_role_for_org(organization_id, ARRAY['bt']::text[])
+        AND app.current_user_has_assigned_client(organization_id, id)
+      )
+    )
+  )
+);
+
+DROP POLICY IF EXISTS therapists_org_staff_select ON public.therapists;
+CREATE POLICY therapists_org_staff_select
+ON public.therapists
+FOR SELECT
+TO authenticated
+USING (
+  app.current_user_is_super_admin()
+  OR (
+    organization_id = app.current_user_organization_id()
+    AND app.current_user_has_exact_role_for_org(organization_id, ARRAY['admin', 'admin_schedule', 'therapist', 'midtier', 'bt', 'bcba']::text[])
+  )
+);
+
+GRANT EXECUTE ON FUNCTION app.current_user_is_super_admin() TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.current_user_is_super_admin() TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.is_super_admin() TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.user_has_role_for_org(text, uuid, uuid, uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.user_has_role_for_org(uuid, uuid, text[]) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_manage_staff_clients(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_manage_authorizations(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_manage_schedule(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_manage_programs_goals(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_take_client_data(uuid, uuid) TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/tests/employee-role-capability-matrix-migration.test.ts
+++ b/tests/employee-role-capability-matrix-migration.test.ts
@@ -27,21 +27,31 @@ const EMPLOYEE_ROLE_LISTING_GRANTS_MIGRATION_PATH = path.join(
   'migrations',
   '20260702222500_restrict_employee_users_paged_execute_grants.sql',
 );
+const BCBA_EXACT_CAPABILITY_MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260706023600_bcba_exact_capability_matrix.sql',
+);
 const SMOKE_SQL_PATH = path.join(process.cwd(), 'tests', 'sql', 'employee_role_capability_smoke.sql');
 
 const sql = readFileSync(MIGRATION_PATH, 'utf8');
 const exposeProgramGoalRpcSql = readFileSync(EXPOSE_PROGRAM_GOAL_RPC_MIGRATION_PATH, 'utf8');
 const employeeRoleListingSql = readFileSync(EMPLOYEE_ROLE_LISTING_MIGRATION_PATH, 'utf8');
 const employeeRoleListingGrantsSql = readFileSync(EMPLOYEE_ROLE_LISTING_GRANTS_MIGRATION_PATH, 'utf8');
+const bcbaExactCapabilitySql = readFileSync(BCBA_EXACT_CAPABILITY_MIGRATION_PATH, 'utf8');
 const smokeSql = readFileSync(SMOKE_SQL_PATH, 'utf8');
 
-const extractFunction = (name: string): string => {
+const extractFunctionFrom = (sourceSql: string, name: string): string => {
   const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const pattern = new RegExp(`CREATE OR REPLACE FUNCTION ${escapedName}\\([\\s\\S]*?\\n\\$\\$;`, 'i');
-  const match = sql.match(pattern);
+  const match = sourceSql.match(pattern);
   expect(match, `${name} function should exist`).not.toBeNull();
   return match?.[0] ?? '';
 };
+
+const extractFunction = (name: string): string => extractFunctionFrom(sql, name);
+const extractBcbaExactFunction = (name: string): string => extractFunctionFrom(bcbaExactCapabilitySql, name);
 
 describe('employee role capability matrix migration', () => {
   it('keeps bt and midtier out of broad therapist/org_member helper aliases', () => {
@@ -54,12 +64,41 @@ describe('employee role capability matrix migration', () => {
     expect(sql).not.toContain("WHEN 'therapist' THEN ARRAY['therapist', 'midtier', 'bt']::text[]");
   });
 
-  it('treats bcba as super-admin-equivalent in database helper paths', () => {
-    const currentUserSuperAdmin = extractFunction('app.current_user_is_super_admin');
-    const isSuperAdmin = extractFunction('app.is_super_admin');
+  it('removes BCBA from super-admin helper paths in the exact-capability follow-up', () => {
+    const currentUserSuperAdmin = extractBcbaExactFunction('app.current_user_is_super_admin');
+    const isSuperAdmin = extractBcbaExactFunction('app.is_super_admin');
+    const roleForOrg = extractBcbaExactFunction('app.user_has_role_for_org');
 
-    expect(currentUserSuperAdmin).toContain("r.name IN ('super_admin', 'bcba')");
-    expect(isSuperAdmin).toContain("r.name IN ('super_admin', 'bcba')");
+    expect(currentUserSuperAdmin).toContain("r.name = 'super_admin'");
+    expect(isSuperAdmin).toContain("r.name = 'super_admin'");
+    expect(currentUserSuperAdmin).not.toContain("'bcba'");
+    expect(isSuperAdmin).not.toContain("'bcba'");
+    expect(roleForOrg).toContain("r.name IN ('super_admin', 'org_super_admin')");
+    expect(roleForOrg).not.toContain("r.name IN ('super_admin', 'org_super_admin', 'bcba')");
+  });
+
+  it('keeps BCBA operational access explicit in the exact-capability follow-up', () => {
+    expect(extractBcbaExactFunction('app.current_user_can_manage_staff_clients')).toContain(
+      "ARRAY['admin', 'admin_schedule', 'bcba']::text[]",
+    );
+    expect(extractBcbaExactFunction('app.current_user_can_manage_authorizations')).toContain(
+      "ARRAY['admin', 'admin_schedule', 'midtier', 'bcba']::text[]",
+    );
+    expect(extractBcbaExactFunction('app.current_user_can_manage_schedule')).toContain(
+      "ARRAY['admin', 'admin_schedule', 'midtier', 'therapist', 'bcba']::text[]",
+    );
+    expect(extractBcbaExactFunction('app.current_user_can_manage_programs_goals')).toContain(
+      "ARRAY['admin', 'midtier', 'therapist', 'bcba']::text[]",
+    );
+    expect(extractBcbaExactFunction('app.current_user_can_take_client_data')).toContain(
+      "ARRAY['admin', 'midtier', 'bcba']::text[]",
+    );
+    expect(bcbaExactCapabilitySql).toContain(
+      "ARRAY['admin', 'admin_schedule', 'therapist', 'midtier', 'bcba']::text[]",
+    );
+    expect(bcbaExactCapabilitySql).toContain(
+      "ARRAY['admin', 'admin_schedule', 'therapist', 'midtier', 'bt', 'bcba']::text[]",
+    );
   });
 
   it('allows admin_schedule to manage staff, clients, assignments, and authorizations only through explicit helpers', () => {
@@ -132,7 +171,8 @@ describe('employee role capability matrix migration', () => {
     expect(smokeSql).toContain('admin_schedule_assignment_write_allowed');
     expect(smokeSql).toContain('midtier_schedule_write_allowed');
     expect(smokeSql).toContain('bt_schedule_write_denied');
-    expect(smokeSql).toContain('bcba_super_admin_equivalence_helpers');
+    expect(smokeSql).toContain('bcba_exact_capability_helpers');
+    expect(smokeSql).toContain('not app.current_user_is_super_admin()');
   });
 
   it('lists editable employee roles from active unexpired junction grants only', () => {

--- a/tests/sql/employee_role_capability_smoke.sql
+++ b/tests/sql/employee_role_capability_smoke.sql
@@ -409,8 +409,8 @@ do $bcba$
 begin
   insert into role_smoke_results
   values (
-    'bcba_super_admin_equivalence_helpers',
-    app.current_user_is_super_admin()
+    'bcba_exact_capability_helpers',
+    not app.current_user_is_super_admin()
       and app.current_user_can_manage_staff_clients('00000000-0000-4000-8000-000000000001')
       and app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
       and app.current_user_can_manage_programs_goals('00000000-0000-4000-8000-000000000001'),


### PR DESCRIPTION
## Summary
- define BCBA as an exact clinical/admin role instead of super-admin-equivalent, and restrict super-admin tooling routes/guards to `super_admin`
- lock BT Schedule session edits to data collection only, including disabled appointment metadata controls and a Schedule submit guard that skips appointment metadata mutation
- add a follow-up Supabase migration to remove BCBA from super-admin helper paths while preserving explicit BCBA operational helper access

## Tracking
- Linear: WIN-197
- Lane: critical / human-reviewed

## Verification
- `npm test -- --run src/components/__tests__/SessionModal.test.tsx src/server/routes/__tests__/guards.test.ts src/lib/__tests__/roles.test.ts src/pages/__tests__/AppNavigation.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx tests/employee-role-capability-matrix-migration.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run ci:check-focused`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:routes:tier0`
- `npm run test:ci`
- `npm run ci:verify-coverage`
- `npm run verify:local`

## Blocked / not clean locally
- `npm run ci:playwright` blocked on hosted credential drift: preflight passed, then `playwright:auth` failed for `superadmin@test.com` with `Invalid email or password`.

## Risk notes
- Protected surfaces touched: route guards, role/capability matrix, Schedule session edit path, Supabase migration/RLS helpers, route audit policy.
- Human review required before merge.