### PR TITLE
Fix BCBA downgrade super admin grant cleanup

### DIFF
--- a/supabase/functions/admin-users-roles/index.ts
+++ b/supabase/functions/admin-users-roles/index.ts
@@ -19,12 +19,12 @@ const CANONICAL_ROLE_NAMES: AppRole[] = [
 
 const ROLE_RANK: Record<AppRole, number> = {
   super_admin: 8,
-  bcba: 8,
-  admin: 7,
-  admin_schedule: 6,
-  midtier: 5,
-  therapist: 4,
-  bt: 3,
+  bcba: 7,
+  admin: 6,
+  admin_schedule: 5,
+  midtier: 4,
+  therapist: 3,
+  bt: 2,
   client: 1,
 };
 

--- a/tests/admin-users-roles.access.spec.ts
+++ b/tests/admin-users-roles.access.spec.ts
@@ -51,6 +51,7 @@ let existingProfile: TestProfile & {
 };
 let adminActionInserts: Array<Record<string, unknown>> = [];
 let userRolesUpsertPayload: Record<string, unknown> | null = null;
+let deletedUserRoleFilters: Array<{ userId: string; roleIds: string[] }> = [];
 let stallAuditUserLookup = false;
 let failLegacyRoleRpc = false;
 let priorJunctionRole: TestRole = 'admin';
@@ -177,8 +178,12 @@ vi.mock('../supabase/functions/_shared/database.ts', () => {
         if (table === 'user_roles') {
           return {
             delete: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                in: vi.fn(async () => {
+              eq: vi.fn((column: string, value: string) => ({
+                in: vi.fn(async (...args: unknown[]) => {
+                  const roleIds = args.length === 2 ? args[1] : args[0];
+                  if (column === 'user_id' && Array.isArray(roleIds)) {
+                    deletedUserRoleFilters.push({ userId: value, roleIds });
+                  }
                   roleMutationEvents.push('delete-user-roles');
                   return { error: null };
                 }),
@@ -244,6 +249,7 @@ describe('admin-users-roles access control', () => {
     adminActionInserts = [];
     adminUsers.clear();
     userRolesUpsertPayload = null;
+    deletedUserRoleFilters = [];
     stallAuditUserLookup = false;
     failLegacyRoleRpc = false;
     priorJunctionRole = 'admin';
@@ -300,6 +306,12 @@ describe('admin-users-roles access control', () => {
       granted_by: 'super-admin-1',
       is_active: true,
     });
+    expect(deletedUserRoleFilters).toEqual([
+      {
+        userId: existingProfile.id,
+        roleIds: ['rid-super', 'rid-bcba', 'rid-admin', 'rid-admin-schedule', 'rid-midtier'],
+      },
+    ]);
     expect(latestUpdatePayload).toEqual({ role: 'therapist' });
     expect(logApiAccess).toHaveBeenCalledWith('PATCH', '/admin/users/11111111-1111-1111-1111-111111111111/roles', superAdminContext, 200);
     expect(adminActionInserts).toEqual([
@@ -366,8 +378,10 @@ describe('admin-users-roles access control', () => {
     });
   });
 
-  it('syncs user_roles when assigning bcba', async () => {
+  it('syncs user_roles and revokes stale super_admin when downgrading to bcba', async () => {
     rpcRoles = ['super_admin'];
+    existingProfile.role = 'super_admin';
+    priorJunctionRole = 'super_admin';
 
     const superAdminContext: TestUserContext = {
       user: { id: 'super-admin-3', email: 'super3@example.com' },
@@ -412,6 +426,13 @@ describe('admin-users-roles access control', () => {
       granted_by: 'super-admin-3',
       is_active: true,
     });
+    expect(deletedUserRoleFilters).toEqual([
+      {
+        userId: existingProfile.id,
+        roleIds: ['rid-super'],
+      },
+    ]);
+    expect(latestUpdatePayload).toEqual({ role: 'bcba' });
   });
 
   it('accepts a target user id in the request body for direct edge invokes', async () => {


### PR DESCRIPTION
## Summary
- align the admin-users-roles edge-function role rank so `super_admin` is above `bcba`
- keep downgrade cleanup target-scoped and revoke stale active `super_admin` grants when assigning BCBA
- tighten admin-users-roles regression coverage for role-id cleanup and target user filtering

## Route / Risk
- classification: high-risk human-reviewed
- lane: critical
- protected surface: `supabase/functions/admin-users-roles/index.ts` privileged role mutation path
- tenant boundary: role cleanup remains scoped to `targetUserId`; no cross-tenant or cross-user delete should occur

## Verification
- PASS `npm test -- --run tests/admin-users-roles.access.spec.ts`
- PASS `npm run lint`
- PASS `npm run typecheck`
- PASS `npm run ci:check-focused` (local DB/CI-only checks skipped because `SUPABASE_DB_URL`/CI branch protection are unavailable locally)
- PASS `npm run validate:tenant`
- PASS `npm run test:ci` (353 files, 2257 tests)
- PASS `npm run build`
- PASS `npm run ci:verify-coverage`
- PASS `npm run test:routes:tier0`
- PASS exact rerun of unrelated intermittent `ProgramsGoalsTab` test: `npm test -- --run src/components/__tests__/ProgramsGoalsTab.test.tsx -t "shows actionable IEHP preflight blockers from generation responses"`
- NOTE `npm run verify:local` failed once inside `test:ci` on the unrelated `ProgramsGoalsTab` generated DOCX button lookup; the exact failing test and the standalone full `test:ci` both passed afterward.

## Reviewer Notes
- Focused reviewer re-check found no blocking findings after the test captured `userId` and `roleIds` for delete assertions.
- The older DB resolver rank tie in historical migration SQL remains a possible follow-up, but this PR stays limited to the edge-function downgrade cleanup path from the P1 review.