### PR TITLE
Align admin-users-roles JWT config

### DIFF
--- a/src/tests/security/edgeFunctionConfig.test.ts
+++ b/src/tests/security/edgeFunctionConfig.test.ts
@@ -12,9 +12,6 @@ describe('edge function config', () => {
       'auth-signup',
       // Token-based automation endpoints (no JWT required)
       'admin-actions-retention',
-      // Browser PATCH preflight must reach the function CORS handler; the route
-      // still enforces super-admin authorization in createProtectedRoute.
-      'admin-users-roles',
     ]);
 
     const functionsRoot = join(process.cwd(), 'supabase', 'functions');

--- a/supabase/functions/admin-users-roles/function.toml
+++ b/supabase/functions/admin-users-roles/function.toml
@@ -1,1 +1,1 @@
-verify_jwt = false
+verify_jwt = true


### PR DESCRIPTION
## Summary
- align `admin-users-roles/function.toml` with production `verify_jwt=true`
- remove the stale `admin-users-roles` no-JWT exception from the edge function config guard

## Route / Risk
- classification: high-risk human-reviewed
- lane: critical
- protected path: `supabase/functions/admin-users-roles/function.toml`
- tenant boundary: no tenant data path changes; this keeps gateway JWT verification enabled for the super-admin role update function

## Verification
- Supabase metadata read: production `admin-users-roles` version 29 reports `verify_jwt=true`
- `npx vitest run src/tests/security/edgeFunctionConfig.test.ts`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci`
- `npm run ci:verify-coverage`
- `npm run build`
- `npm run validate:tenant`
- `npm run test:routes:tier0`
- `npm run verify:local`

## Blocked / Residual
- `npm run ci:playwright` failed after preflight because hosted auth smoke credentials for `superadmin@test.com` were rejected as invalid email/password.
- Linear issue creation was attempted but the connector returned only `Argument Validation Error`; no Linear key could be linked from this environment.
- Human review is required before merge because this touches `supabase/functions/**`.