### PR TITLE
Add goal domain foundation for FBA drafts

### DIFF
--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -732,10 +732,13 @@ export type Database = {
         Row: {
           accept_state: string
           assessment_document_id: string
+          baseline: string | null
           baseline_data: string | null
           client_id: string
+          clinical_goal_type: string | null
           created_at: string
           description: string
+          domain_id: string | null
           draft_program_id: string | null
           evidence_refs: Json
           generalization_criteria: string | null
@@ -755,16 +758,21 @@ export type Database = {
           reviewed_by: string | null
           target_behavior: string | null
           target_criteria: string | null
+          teaching_strategies: string | null
           title: string
+          operational_definition: string | null
           updated_at: string
         }
         Insert: {
           accept_state?: string
           assessment_document_id: string
+          baseline?: string | null
           baseline_data?: string | null
           client_id: string
+          clinical_goal_type?: string | null
           created_at?: string
           description: string
+          domain_id?: string | null
           draft_program_id?: string | null
           evidence_refs?: Json
           generalization_criteria?: string | null
@@ -784,16 +792,21 @@ export type Database = {
           reviewed_by?: string | null
           target_behavior?: string | null
           target_criteria?: string | null
+          teaching_strategies?: string | null
           title: string
+          operational_definition?: string | null
           updated_at?: string
         }
         Update: {
           accept_state?: string
           assessment_document_id?: string
+          baseline?: string | null
           baseline_data?: string | null
           client_id?: string
+          clinical_goal_type?: string | null
           created_at?: string
           description?: string
+          domain_id?: string | null
           draft_program_id?: string | null
           evidence_refs?: Json
           generalization_criteria?: string | null
@@ -813,7 +826,9 @@ export type Database = {
           reviewed_by?: string | null
           target_behavior?: string | null
           target_criteria?: string | null
+          teaching_strategies?: string | null
           title?: string
+          operational_definition?: string | null
           updated_at?: string
         }
         Relationships: [
@@ -830,6 +845,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "clients"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assessment_draft_goals_domain_id_fkey"
+            columns: ["domain_id", "organization_id"]
+            isOneToOne: false
+            referencedRelation: "goal_domains"
+            referencedColumns: ["id", "organization_id"]
           },
           {
             foreignKeyName: "assessment_draft_goals_draft_program_id_fkey"
@@ -3291,6 +3313,50 @@ export type Database = {
           },
         ]
       }
+      goal_domains: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          description: string | null
+          id: string
+          name: string
+          organization_id: string
+          status: string
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          organization_id: string
+          status?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          organization_id?: string
+          status?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "goal_domains_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       goals: {
         Row: {
           baseline: string | null
@@ -3389,6 +3455,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "clients"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "goals_domain_id_fkey"
+            columns: ["domain_id", "organization_id"]
+            isOneToOne: false
+            referencedRelation: "goal_domains"
+            referencedColumns: ["id", "organization_id"]
           },
           {
             foreignKeyName: "goals_organization_id_fkey"

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -33,13 +33,17 @@ const buildTypedGoals = (
     description: `Child goal description ${index + 1}`,
     original_text: `Child goal original text ${index + 1}`,
     goal_type: "child",
+    clinical_goal_type: "skill",
     target_behavior: "Functional communication response",
     measurement_type: "Frequency",
     baseline_data: "Baseline noted",
+    baseline: "Baseline noted",
     target_criteria: "Target criteria noted",
     mastery_criteria: "Mastery criteria noted",
     maintenance_criteria: "Maintenance criteria noted",
     generalization_criteria: "Generalization criteria noted",
+    teaching_strategies: "Modeling and least-to-most prompting",
+    operational_definition: "Independent functional communication response",
     objective_data_points: ["Point A", "Point B"],
     rationale: "Goal rationale",
     evidence_refs: [{ section_key: "assessment_summary", source_span: "Child evidence snippet" }],
@@ -51,13 +55,17 @@ const buildTypedGoals = (
     description: `Parent goal description ${index + 1}`,
     original_text: `Parent goal original text ${index + 1}`,
     goal_type: "parent",
+    clinical_goal_type: "skill",
     target_behavior: "Caregiver implementation fidelity",
     measurement_type: "Percent fidelity",
     baseline_data: "Baseline noted",
+    baseline: "Baseline noted",
     target_criteria: "Target criteria noted",
     mastery_criteria: "Mastery criteria noted",
     maintenance_criteria: "Maintenance criteria noted",
     generalization_criteria: "Generalization criteria noted",
+    teaching_strategies: "Behavior skills training",
+    operational_definition: "Caregiver completes intervention steps as written",
     objective_data_points: ["Point A", "Point B"],
     rationale: "Goal rationale",
     evidence_refs: [{ section_key: "parent_training", source_span: "Parent evidence snippet" }],
@@ -133,13 +141,17 @@ describe("assessmentDraftsHandler", () => {
               description: "Description A",
               original_text: "Original A",
               goal_type: "child",
+              clinical_goal_type: "skill",
               target_behavior: "Functional communication",
               measurement_type: "Frequency",
               baseline_data: "Baseline text",
+              baseline: "Baseline narrative",
               target_criteria: "Target text",
               mastery_criteria: "80% across 2 sessions",
               maintenance_criteria: "80% across 2 maintenance checks",
               generalization_criteria: "Across home and clinic",
+              teaching_strategies: "Modeling and prompting",
+              operational_definition: "Independent request for help",
               objective_data_points: ["Identify 4 emotions", "Track prompts used"],
               rationale: "Goal rationale",
               evidence_refs: [{ section_key: "goals_treatment_planning", source_span: "Evidence snippet" }],
@@ -203,6 +215,10 @@ describe("assessmentDraftsHandler", () => {
     const goalPayload = JSON.parse((goalCreateCall?.[1] as RequestInit).body as string) as Array<Record<string, unknown>>;
     expect(goalPayload[0]?.mastery_criteria).toBe("80% across 2 sessions");
     expect(goalPayload[0]?.goal_type).toBe("child");
+    expect(goalPayload[0]?.clinical_goal_type).toBe("skill");
+    expect(goalPayload[0]?.baseline).toBe("Baseline narrative");
+    expect(goalPayload[0]?.teaching_strategies).toBe("Modeling and prompting");
+    expect(goalPayload[0]?.operational_definition).toBe("Independent request for help");
     expect(Array.isArray(goalPayload[0]?.objective_data_points)).toBe(true);
     expect(Array.isArray(goalPayload[0]?.evidence_refs)).toBe(true);
     expect(Array.isArray(goalPayload[0]?.review_flags)).toBe(true);
@@ -431,6 +447,10 @@ describe("assessmentDraftsHandler", () => {
     expect(goalPayload[3]?.title).toBe("Transition Goal (2024)");
     expect(goalPayload[4]?.title).toBe("Transition Goal (2024) (2)");
     expect(goalPayload[0]?.mastery_criteria).toBe("Mastery criteria noted");
+    expect(goalPayload[0]?.clinical_goal_type).toBe("skill");
+    expect(goalPayload[0]?.baseline).toBe("Baseline noted");
+    expect(goalPayload[0]?.teaching_strategies).toBe("Modeling and least-to-most prompting");
+    expect(goalPayload[0]?.operational_definition).toBe("Independent functional communication response");
     expect(goalPayload[0]?.evidence_refs).toEqual([
       { section_key: "goals_treatment_planning", source_span: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS#0" },
     ]);
@@ -1249,6 +1269,93 @@ describe("assessmentDraftsHandler", () => {
       expect.stringContaining("/rest/v1/assessment_review_events"),
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("updates structured draft goal fields after validating domain scope", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [
+          {
+            id: "draft-goal-1",
+            assessment_document_id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            accept_state: "pending",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "22222222-2222-4222-8222-222222222222" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "draft-goal-1", title: "Edited Goal" }],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 201, data: null });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          draft_type: "goal",
+          id: "11111111-1111-1111-1111-111111111111",
+          accept_state: "edited",
+          title: "Edited Goal",
+          domain_id: "22222222-2222-4222-8222-222222222222",
+          clinical_goal_type: "behavior",
+          baseline: "Baseline narrative",
+          teaching_strategies: "DRA and prompting",
+          operational_definition: "Aggression includes hitting or kicking.",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goal_domains?select=id&id=in.(22222222-2222-4222-8222-222222222222)&organization_id=eq.org-1"),
+      expect.objectContaining({ method: "GET" }),
+    );
+    const updateCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(
+        ([url, init]) =>
+          typeof url === "string" &&
+          url.includes("/rest/v1/assessment_draft_goals?id=eq.draft-goal-1") &&
+          init?.method === "PATCH",
+      );
+    expect(updateCall).toBeTruthy();
+    expect(JSON.parse(String((updateCall?.[1] as RequestInit).body))).toMatchObject({
+      accept_state: "edited",
+      title: "Edited Goal",
+      domain_id: "22222222-2222-4222-8222-222222222222",
+      clinical_goal_type: "behavior",
+      baseline: "Baseline narrative",
+      teaching_strategies: "DRA and prompting",
+      operational_definition: "Aggression includes hitting or kicking.",
+    });
   });
 
   it("blocks draft goal updates when the parent assessment is already promoted", async () => {

--- a/src/server/__tests__/assessmentDraftsHandler.test.ts
+++ b/src/server/__tests__/assessmentDraftsHandler.test.ts
@@ -362,6 +362,13 @@ describe("assessmentDraftsHandler", () => {
       }
       if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?")) {
         const structuredGoals = buildStructuredGoalSections();
+        structuredGoals[0] = {
+          ...structuredGoals[0],
+          payload: {
+            ...(structuredGoals[0]?.payload as Record<string, unknown>),
+            domain_id: "33333333-3333-4333-8333-333333333333",
+          },
+        };
         structuredGoals[1] = {
           ...structuredGoals[1],
           payload: {
@@ -395,6 +402,9 @@ describe("assessmentDraftsHandler", () => {
           status: 200,
           data: structuredGoals,
         };
+      }
+      if (method === "GET" && url.includes("/rest/v1/goal_domains?")) {
+        return { ok: true, status: 200, data: [{ id: "33333333-3333-4333-8333-333333333333" }] };
       }
       if (method === "POST" && url.includes("/rest/v1/assessment_draft_programs")) {
         return { ok: true, status: 201, data: [{ id: "draft-program-2", name: "Communication Program" }] };
@@ -447,6 +457,7 @@ describe("assessmentDraftsHandler", () => {
     expect(goalPayload[3]?.title).toBe("Transition Goal (2024)");
     expect(goalPayload[4]?.title).toBe("Transition Goal (2024) (2)");
     expect(goalPayload[0]?.mastery_criteria).toBe("Mastery criteria noted");
+    expect(goalPayload[0]?.domain_id).toBe("33333333-3333-4333-8333-333333333333");
     expect(goalPayload[0]?.clinical_goal_type).toBe("skill");
     expect(goalPayload[0]?.baseline).toBe("Baseline noted");
     expect(goalPayload[0]?.teaching_strategies).toBe("Modeling and least-to-most prompting");
@@ -454,6 +465,10 @@ describe("assessmentDraftsHandler", () => {
     expect(goalPayload[0]?.evidence_refs).toEqual([
       { section_key: "goals_treatment_planning", source_span: "CALOPTIMA_FBA_SKILL_ACQUISITION_GOALS#0" },
     ]);
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goal_domains?select=id&id=in.(33333333-3333-4333-8333-333333333333)&organization_id=eq.org-1"),
+      expect.objectContaining({ method: "GET" }),
+    );
     const liveProgramWrite = vi
       .mocked(fetchJson)
       .mock.calls.find(([url]) => typeof url === "string" && url.includes("/rest/v1/programs"));
@@ -462,6 +477,79 @@ describe("assessmentDraftsHandler", () => {
       .mock.calls.find(([url]) => typeof url === "string" && url.includes("/rest/v1/goals"));
     expect(liveProgramWrite).toBeUndefined();
     expect(liveGoalWrite).toBeUndefined();
+  });
+
+  it("rejects deterministic structured draft domains outside the organization before writing draft rows", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "extracted" }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?select=id")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?select=id")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?")) {
+        const structuredGoals = buildStructuredGoalSections();
+        structuredGoals[0] = {
+          ...structuredGoals[0],
+          payload: {
+            ...(structuredGoals[0]?.payload as Record<string, unknown>),
+            domain_id: "44444444-4444-4444-8444-444444444444",
+          },
+        };
+        return { ok: true, status: 200, data: structuredGoals };
+      }
+      if (method === "GET" && url.includes("/rest/v1/goal_domains?")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      return { ok: true, status: 200, data: null };
+    });
+
+    const response = await assessmentDraftsHandler(
+      new Request("http://localhost/api/assessment-drafts", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          assessment_document_id: "11111111-1111-1111-1111-111111111111",
+          auto_generate: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Goal domain not found in organization scope" });
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goal_domains?select=id&id=in.(44444444-4444-4444-8444-444444444444)&organization_id=eq.org-1"),
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_draft_programs"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_draft_goals"),
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
   it("blocks IEHP deterministic draft auto-generation at the drafts API", async () => {

--- a/src/server/__tests__/assessmentPromoteHandler.test.ts
+++ b/src/server/__tests__/assessmentPromoteHandler.test.ts
@@ -24,6 +24,15 @@ const buildAcceptedGoals = (
     description: `Child goal description ${index + 1} with enough detail.`,
     original_text: `Child goal original text ${index + 1} with enough detail for validation.`,
     goal_type: "child",
+    clinical_goal_type: "skill",
+    baseline_data: "Baseline noted",
+    baseline: "Baseline narrative",
+    target_criteria: "Target criteria noted",
+    mastery_criteria: "Mastery criteria noted",
+    maintenance_criteria: "Maintenance criteria noted",
+    generalization_criteria: "Generalization criteria noted",
+    teaching_strategies: "Modeling and least-to-most prompting",
+    operational_definition: "Independent functional communication response",
     objective_data_points: index === 0
       ? [{ metric_name: "baseline", metric_value: 2, metric_unit: "responses" }, "Legacy manual objective note"]
       : [],
@@ -35,6 +44,15 @@ const buildAcceptedGoals = (
     description: `Parent goal description ${index + 1} with enough detail.`,
     original_text: `Parent goal original text ${index + 1} with enough detail for validation.`,
     goal_type: "parent",
+    clinical_goal_type: "skill",
+    baseline_data: "Baseline noted",
+    baseline: "Baseline narrative",
+    target_criteria: "Target criteria noted",
+    mastery_criteria: "Mastery criteria noted",
+    maintenance_criteria: "Maintenance criteria noted",
+    generalization_criteria: "Generalization criteria noted",
+    teaching_strategies: "Behavior skills training",
+    operational_definition: "Caregiver completes intervention steps as written",
     objective_data_points: [],
     accept_state: "accepted",
   })),
@@ -133,6 +151,93 @@ describe("assessmentPromoteHandler", () => {
         created_goal_count: 0,
       },
     });
+  });
+
+  it("rejects out-of-scope IEHP structured goal domains before creating live records", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status,template_type")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "doc-1",
+            organization_id: "org-1",
+            client_id: "client-1",
+            status: "extracted",
+            template_type: "iehp_fba",
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_checklist_items?select=id,placeholder_key,label,value_text,value_json&")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_structured_sections?select=id,field_key,section_index,payload&")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: "structured-goal-1",
+            field_key: "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS",
+            section_index: 0,
+            payload: {
+              program_name: "Behavior Treatment",
+              title: "Decrease aggression",
+              description: "Decrease aggression with enough clinical detail.",
+              raw_text: "When denied access, aggression occurs.",
+              original_text: "When denied access, aggression occurs.",
+              target_behavior: "Aggression",
+              measurement_type: "frequency",
+              baseline_data: "3 incidents per hour",
+              target_criteria: "Fewer than 1 incident per week",
+              mastery_criteria: "80% reduction across 4 weeks",
+              domain_id: "22222222-2222-4222-8222-222222222222",
+            },
+          }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/goal_domains?")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Goal domain not found in organization scope" });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/programs"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goals"),
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
   it("blocks IEHP assessment publish until all required review rows are approved", async () => {
@@ -956,6 +1061,12 @@ describe("assessmentPromoteHandler", () => {
         body: expect.stringContaining('"status":"active"'),
       }),
     );
+    const createGoalsCall = vi
+      .mocked(fetchJson)
+      .mock.calls.find(([url, init]) => typeof url === "string" && url.includes("/rest/v1/goals") && init?.method === "POST");
+    expect(createGoalsCall).toBeTruthy();
+    const createGoalsPayload = JSON.parse(String((createGoalsCall?.[1] as RequestInit).body)) as Array<Record<string, unknown>>;
+    expect(createGoalsPayload.every((goal) => goal.source === "fba_extraction")).toBe(true);
     const reviewEventCall = vi
       .mocked(fetchJson)
       .mock.calls.find(([url, init]) => typeof url === "string" && url.includes("/rest/v1/assessment_review_events") && init?.method === "POST");
@@ -1238,6 +1349,18 @@ describe("assessmentPromoteHandler", () => {
     expect(createGoalsCall).toBeTruthy();
     const createGoalsPayload = JSON.parse((createGoalsCall?.[1] as RequestInit).body as string) as Array<Record<string, unknown>>;
     expect(createGoalsPayload[0]?.goal_type).toBe("child");
+    expect(createGoalsPayload[0]).toMatchObject({
+      clinical_goal_type: "skill",
+      baseline_data: "Baseline noted",
+      baseline: "Baseline narrative",
+      target_criteria: "Target criteria noted",
+      mastery_criteria: "Mastery criteria noted",
+      maintenance_criteria: "Maintenance criteria noted",
+      generalization_criteria: "Generalization criteria noted",
+      teaching_strategies: "Modeling and least-to-most prompting",
+      operational_definition: "Independent functional communication response",
+    });
+    expect(createGoalsPayload[0]).not.toHaveProperty("source");
     expect(createGoalsPayload.filter((goal) => goal.goal_type === "child")).toHaveLength(20);
     expect(createGoalsPayload.filter((goal) => goal.goal_type === "parent")).toHaveLength(6);
     expect(createGoalsPayload.slice(0, 13).every((goal) => goal.program_id === "prod-program-1")).toBe(true);
@@ -1269,6 +1392,68 @@ describe("assessmentPromoteHandler", () => {
     expect(JSON.parse(String((documentPatchCalls.at(-1)?.[1] as RequestInit | undefined)?.body))).toMatchObject({
       status: "approved",
     });
+  });
+
+  it("rejects out-of-scope draft goal domains before locking the assessment", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(getAccessTokenSubject).mockReturnValue("user-1");
+    vi.mocked(resolveOrgAndRole).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+    });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson).mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/rest/v1/assessment_documents?select=id,organization_id,client_id,status")) {
+        return { ok: true, status: 200, data: [{ id: "doc-1", organization_id: "org-1", client_id: "client-1", status: "drafted" }] };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_programs?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{ id: "draft-program-1", name: "Draft Program 1", description: "x", accept_state: "accepted" }],
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/assessment_draft_goals?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: buildAcceptedGoals({ childCount: 1, parentCount: 0 }).map((goal) => ({
+            ...goal,
+            draft_program_id: "draft-program-1",
+            domain_id: "22222222-2222-4222-8222-222222222222",
+          })),
+        };
+      }
+      if (method === "GET" && url.includes("/rest/v1/goal_domains?")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      return { ok: false, status: 500, data: null };
+    });
+
+    const response = await assessmentPromoteHandler(
+      new Request("http://localhost/api/assessment-promote", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ assessment_document_id: "11111111-1111-1111-1111-111111111111" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Goal domain not found in organization scope" });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/assessment_documents?id=eq.doc-1&status=eq.drafted"),
+      expect.objectContaining({ method: "PATCH" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/programs"),
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
   it("blocks promotion when accepted goals contain duplicate titles", async () => {

--- a/src/server/__tests__/goalsHandler.test.ts
+++ b/src/server/__tests__/goalsHandler.test.ts
@@ -197,6 +197,60 @@ describe("goalsHandler", () => {
     expect(Array.isArray(createPayload.objective_data_points)).toBe(true);
   });
 
+  it("rejects creating a goal with a domain outside the organization scope", async () => {
+    vi.mocked(getAccessToken).mockReturnValue("token");
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: true,
+      isAdmin: false,
+      isSuperAdmin: false,
+      isOrgMember: false,
+      upstreamError: false,
+    });
+    vi.mocked(currentUserCanManageProgramsGoals).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(getSupabaseConfig).mockReturnValue({
+      supabaseUrl: "https://example.supabase.co",
+      anonKey: "anon",
+    });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: "program-1", client_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [],
+      });
+
+    const response = await goalsHandler(
+      new Request("http://localhost/api/goals", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({
+          client_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          program_id: "11111111-1111-1111-1111-111111111111",
+          domain_id: "22222222-2222-4222-8222-222222222222",
+          title: "Goal A",
+          description: "Description",
+          original_text: "Original clinical language",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "domain_id is not in scope for this organization" });
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goal_domains?select=id&id=eq.22222222-2222-4222-8222-222222222222&organization_id=eq.org-1&limit=1"),
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/rest/v1/goals"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it.each(roleMatrix)("returns 403 for out-of-org goal PATCH as $label", async ({ role }) => {
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -30,13 +30,18 @@ const draftGoalSchema = z.object({
   description: z.string().trim().min(1),
   original_text: z.string().trim().min(1),
   goal_type: z.enum(["child", "parent"]),
+  domain_id: z.string().uuid().nullable().optional(),
+  clinical_goal_type: z.enum(["behavior", "skill"]).nullable().optional(),
   target_behavior: z.string().trim().min(1),
   measurement_type: z.string().trim().min(1),
   baseline_data: z.string().trim().min(1),
+  baseline: z.string().trim().nullable().optional(),
   target_criteria: z.string().trim().min(1),
   mastery_criteria: z.string().trim().min(1),
   maintenance_criteria: z.string().trim().min(1),
   generalization_criteria: z.string().trim().min(1),
+  teaching_strategies: z.string().trim().nullable().optional(),
+  operational_definition: z.string().trim().nullable().optional(),
   objective_data_points: z.array(z.string().trim().min(1)).min(1),
   rationale: z.string().trim().min(1),
   evidence_refs: z.array(evidenceRefSchema).min(1),
@@ -77,13 +82,18 @@ const draftUpdateSchema = z.object({
   title: z.string().trim().optional(),
   original_text: z.string().trim().optional(),
   goal_type: z.enum(["child", "parent"]).optional(),
+  domain_id: z.string().uuid().nullable().optional(),
+  clinical_goal_type: z.enum(["behavior", "skill"]).nullable().optional(),
   target_behavior: z.string().trim().optional(),
   measurement_type: z.string().trim().optional(),
   baseline_data: z.string().trim().optional(),
+  baseline: z.string().trim().nullable().optional(),
   target_criteria: z.string().trim().optional(),
   mastery_criteria: z.string().trim().optional(),
   maintenance_criteria: z.string().trim().optional(),
   generalization_criteria: z.string().trim().optional(),
+  teaching_strategies: z.string().trim().nullable().optional(),
+  operational_definition: z.string().trim().nullable().optional(),
   objective_data_points: z.array(z.record(z.unknown())).optional(),
   program_name: z.string().trim().optional(),
   evidence_refs: z.array(evidenceRefSchema).optional(),
@@ -114,6 +124,17 @@ const DRAFT_PARENT_GOAL_FIELD_KEYS = new Set([
 
 const resolveProgramNameFromGoalSection = (fieldKey: string, payload: Record<string, unknown>, isParentGoal: boolean): string => {
   return getPayloadString(payload, ["program_name", "program", "domain"], isParentGoal ? "Parent Training" : "Behavior Treatment");
+};
+
+const resolveClinicalGoalTypeFromGoalSection = (fieldKey: string, payload: Record<string, unknown>): "behavior" | "skill" => {
+  const explicit = getPayloadString(payload, ["clinical_goal_type", "goal_category", "category", "type"]).toLowerCase();
+  if (explicit.includes("behavior") || explicit === "bx") {
+    return "behavior";
+  }
+  if (explicit.includes("skill")) {
+    return "skill";
+  }
+  return fieldKey === "CALOPTIMA_FBA_TARGET_REPLACEMENT_GOALS" ? "behavior" : "skill";
 };
 
 interface AssessmentDraftProgramRow {
@@ -179,13 +200,18 @@ export interface GeneratedDraftPayload {
     description: string;
     original_text: string;
     goal_type: "child" | "parent";
+    domain_id?: string | null;
+    clinical_goal_type?: "behavior" | "skill" | null;
     target_behavior: string;
     measurement_type: string;
     baseline_data: string;
+    baseline?: string | null;
     target_criteria: string;
     mastery_criteria: string;
     maintenance_criteria: string;
     generalization_criteria: string;
+    teaching_strategies?: string | null;
+    operational_definition?: string | null;
     objective_data_points: Array<Record<string, unknown>>;
     rationale: string;
     evidence_refs: Array<{ section_key: string; source_span: string }>;
@@ -324,13 +350,17 @@ export const buildDeterministicDraftPayload = (
       description,
       original_text: originalText,
       goal_type: isParentGoal ? ("parent" as const) : ("child" as const),
+      clinical_goal_type: resolveClinicalGoalTypeFromGoalSection(section.field_key, payload),
       target_behavior: getPayloadString(payload, ["target_behavior", "behavior", "skill"], title),
       measurement_type: getPayloadString(payload, ["measurement_type", "measure", "data_collection"], "frequency"),
       baseline_data: getPayloadString(payload, ["baseline_data", "baseline"], "Baseline pending staff review"),
+      baseline: getPayloadString(payload, ["baseline", "baseline_data"], "Baseline pending staff review"),
       target_criteria: getPayloadString(payload, ["target_criteria", "criteria", "objective"], description),
       mastery_criteria: getPayloadString(payload, ["mastery_criteria", "mastery"], "Mastery criteria pending staff review"),
       maintenance_criteria: getPayloadString(payload, ["maintenance_criteria", "maintenance"], "Maintenance criteria pending staff review"),
       generalization_criteria: getPayloadString(payload, ["generalization_criteria", "generalization"], "Generalization criteria pending staff review"),
+      teaching_strategies: getPayloadString(payload, ["teaching_strategies", "teaching_strategy", "intervention_strategies"]),
+      operational_definition: getPayloadString(payload, ["operational_definition", "definition"]),
       objective_data_points: getPayloadRows(payload, ["objective_data_points", "measurement_rows", "data_points"]),
       rationale: getPayloadString(payload, ["rationale"], "Derived deterministically from approved CalOptima structured section."),
       evidence_refs: [
@@ -400,6 +430,35 @@ const draftsAlreadyExistForDocument = async (args: {
   return hasPrograms || hasGoals;
 };
 
+const assertGoalDomainsInOrg = async (args: {
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  organizationId: string;
+  domainIds: Array<string | null | undefined>;
+  signal?: AbortSignal;
+}): Promise<{ ok: true } | { ok: false; status: number; error: string }> => {
+  const uniqueDomainIds = Array.from(new Set(args.domainIds.filter((id): id is string => Boolean(id))));
+  if (uniqueDomainIds.length === 0) {
+    return { ok: true };
+  }
+
+  const lookup = await fetchJson<Array<{ id: string }>>(
+    `${args.supabaseUrl}/rest/v1/goal_domains?select=id&id=in.(${uniqueDomainIds.map((id) => encodeURIComponent(id)).join(",")})&organization_id=eq.${encodeURIComponent(
+      args.organizationId,
+    )}`,
+    { method: "GET", headers: args.headers, signal: args.signal },
+  );
+  if (!lookup.ok || !Array.isArray(lookup.data)) {
+    return { ok: false, status: lookup.status || 500, error: "Failed to validate goal domain scope" };
+  }
+  const scopedDomainIds = new Set(lookup.data.map((row) => row.id));
+  const outOfScopeDomainId = uniqueDomainIds.find((id) => !scopedDomainIds.has(id));
+  if (outOfScopeDomainId) {
+    return { ok: false, status: 409, error: "Goal domain not found in organization scope" };
+  }
+  return { ok: true };
+};
+
 export const persistDraftRows = async (args: {
   supabaseUrl: string;
   headers: Record<string, string>;
@@ -412,6 +471,17 @@ export const persistDraftRows = async (args: {
   signal?: AbortSignal;
 }) => {
   const { supabaseUrl, headers, organizationId, actorId, document, assessmentDocumentId, payload, extractedAt, signal } = args;
+  const domainScope = await assertGoalDomainsInOrg({
+    supabaseUrl,
+    headers,
+    organizationId,
+    domainIds: payload.goals.map((goal) => goal.domain_id),
+    signal,
+  });
+  if (!domainScope.ok) {
+    return domainScope;
+  }
+
   const createProgramPayload = payload.programs.map((program) => ({
     assessment_document_id: assessmentDocumentId,
     organization_id: organizationId,
@@ -473,13 +543,18 @@ export const persistDraftRows = async (args: {
     description: goal.description,
     original_text: goal.original_text,
     goal_type: goal.goal_type,
+    domain_id: goal.domain_id ?? null,
+    clinical_goal_type: goal.clinical_goal_type ?? null,
     target_behavior: goal.target_behavior,
     measurement_type: goal.measurement_type,
     baseline_data: goal.baseline_data,
+    baseline: goal.baseline ?? goal.baseline_data,
     target_criteria: goal.target_criteria,
     mastery_criteria: goal.mastery_criteria,
     maintenance_criteria: goal.maintenance_criteria,
     generalization_criteria: goal.generalization_criteria,
+    teaching_strategies: goal.teaching_strategies ?? null,
+    operational_definition: goal.operational_definition ?? null,
     objective_data_points: goal.objective_data_points,
     rationale: goal.rationale,
     evidence_refs: goal.evidence_refs,
@@ -880,6 +955,23 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
     if (parsed.data.goal_type !== undefined) {
       updatePayload.goal_type = parsed.data.goal_type;
     }
+    if (parsed.data.domain_id !== undefined) {
+      if (parsed.data.domain_id) {
+        const domainScope = await assertGoalDomainsInOrg({
+          supabaseUrl,
+          headers,
+          organizationId,
+          domainIds: [parsed.data.domain_id],
+        });
+        if (!domainScope.ok) {
+          return json({ error: domainScope.error }, domainScope.status);
+        }
+      }
+      updatePayload.domain_id = parsed.data.domain_id;
+    }
+    if (parsed.data.clinical_goal_type !== undefined) {
+      updatePayload.clinical_goal_type = parsed.data.clinical_goal_type;
+    }
     if (parsed.data.target_behavior !== undefined) {
       updatePayload.target_behavior = parsed.data.target_behavior;
     }
@@ -888,6 +980,9 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
     }
     if (parsed.data.baseline_data !== undefined) {
       updatePayload.baseline_data = parsed.data.baseline_data;
+    }
+    if (parsed.data.baseline !== undefined) {
+      updatePayload.baseline = parsed.data.baseline;
     }
     if (parsed.data.target_criteria !== undefined) {
       updatePayload.target_criteria = parsed.data.target_criteria;
@@ -900,6 +995,12 @@ export async function assessmentDraftsHandler(request: Request): Promise<Respons
     }
     if (parsed.data.generalization_criteria !== undefined) {
       updatePayload.generalization_criteria = parsed.data.generalization_criteria;
+    }
+    if (parsed.data.teaching_strategies !== undefined) {
+      updatePayload.teaching_strategies = parsed.data.teaching_strategies;
+    }
+    if (parsed.data.operational_definition !== undefined) {
+      updatePayload.operational_definition = parsed.data.operational_definition;
     }
     if (parsed.data.objective_data_points !== undefined) {
       updatePayload.objective_data_points = parsed.data.objective_data_points;

--- a/src/server/api/assessment-drafts.ts
+++ b/src/server/api/assessment-drafts.ts
@@ -259,6 +259,11 @@ const getPayloadString = (payload: Record<string, unknown>, keys: string[], fall
   return fallback;
 };
 
+const getPayloadUuid = (payload: Record<string, unknown>, keys: string[]): string | null => {
+  const value = getPayloadString(payload, keys);
+  return value && isUuid(value) ? value : null;
+};
+
 const getPayloadRows = (payload: Record<string, unknown>, keys: string[]): Array<Record<string, unknown>> => {
   for (const key of keys) {
     const value = payload[key];
@@ -350,6 +355,7 @@ export const buildDeterministicDraftPayload = (
       description,
       original_text: originalText,
       goal_type: isParentGoal ? ("parent" as const) : ("child" as const),
+      domain_id: getPayloadUuid(payload, ["domain_id", "domainId"]),
       clinical_goal_type: resolveClinicalGoalTypeFromGoalSection(section.field_key, payload),
       target_behavior: getPayloadString(payload, ["target_behavior", "behavior", "skill"], title),
       measurement_type: getPayloadString(payload, ["measurement_type", "measure", "data_collection"], "frequency"),

--- a/src/server/api/assessment-promote.ts
+++ b/src/server/api/assessment-promote.ts
@@ -61,13 +61,18 @@ interface IehpLiveGoalCandidate {
   description: string;
   originalText: string;
   goalType: "child" | "parent";
+  domainId: string | null;
+  clinicalGoalType: "behavior" | "skill" | null;
   targetBehavior: string | null;
   measurementType: string | null;
   baselineData: string | null;
+  baseline: string | null;
   targetCriteria: string | null;
   masteryCriteria: string | null;
   maintenanceCriteria: string | null;
   generalizationCriteria: string | null;
+  teachingStrategies: string | null;
+  operationalDefinition: string | null;
   objectiveDataPoints: Array<Record<string, unknown> | string>;
 }
 
@@ -85,13 +90,18 @@ interface DraftGoalRow {
   description: string;
   original_text: string;
   goal_type: "child" | "parent";
+  domain_id: string | null;
+  clinical_goal_type: "behavior" | "skill" | null;
   target_behavior: string | null;
   measurement_type: string | null;
   baseline_data: string | null;
+  baseline: string | null;
   target_criteria: string | null;
   mastery_criteria: string | null;
   maintenance_criteria: string | null;
   generalization_criteria: string | null;
+  teaching_strategies: string | null;
+  operational_definition: string | null;
   objective_data_points: Array<Record<string, unknown> | string> | null;
   accept_state: "pending" | "accepted" | "rejected" | "edited";
 }
@@ -102,6 +112,42 @@ const isMinGoalQuality = (goal: DraftGoalRow): boolean =>
   goal.title.trim().length >= 3 && goal.description.trim().length >= 10 && goal.original_text.trim().length >= 10;
 
 const buildInFilter = (ids: string[]): string => `in.(${ids.map((id) => encodeURIComponent(id)).join(",")})`;
+
+const toUuidOrNull = (value: unknown): string | null => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return z.string().uuid().safeParse(trimmed).success ? trimmed : null;
+};
+
+const assertGoalDomainsInOrg = async (args: {
+  supabaseUrl: string;
+  headers: Record<string, string>;
+  organizationId: string;
+  domainIds: Array<string | null | undefined>;
+}): Promise<{ ok: true } | { ok: false; status: number; error: string }> => {
+  const uniqueDomainIds = Array.from(new Set(args.domainIds.filter((id): id is string => Boolean(id))));
+  if (uniqueDomainIds.length === 0) {
+    return { ok: true };
+  }
+
+  const lookup = await fetchJson<Array<{ id: string }>>(
+    `${args.supabaseUrl}/rest/v1/goal_domains?select=id&id=${buildInFilter(uniqueDomainIds)}&organization_id=eq.${encodeURIComponent(
+      args.organizationId,
+    )}`,
+    { method: "GET", headers: args.headers },
+  );
+  if (!lookup.ok || !Array.isArray(lookup.data)) {
+    return { ok: false, status: lookup.status || 500, error: "Failed to validate goal domain scope" };
+  }
+  const scopedDomainIds = new Set(lookup.data.map((row) => row.id));
+  const outOfScopeDomainId = uniqueDomainIds.find((id) => !scopedDomainIds.has(id));
+  if (outOfScopeDomainId) {
+    return { ok: false, status: 409, error: "Goal domain not found in organization scope" };
+  }
+  return { ok: true };
+};
 
 const toNumberOrNull = (value: unknown): number | null => {
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -212,6 +258,25 @@ const hasDefaultRequiredStructuredValue = (payload: Record<string, unknown>): bo
 const normalizeIehpGoalType = (value: unknown): "child" | "parent" =>
   typeof value === "string" && value.trim().toLowerCase() === "parent" ? "parent" : "child";
 
+const normalizeClinicalGoalType = (value: unknown, fieldKey?: string): "behavior" | "skill" | null => {
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized.includes("behavior") || normalized === "bx") {
+      return "behavior";
+    }
+    if (normalized.includes("skill")) {
+      return "skill";
+    }
+  }
+  if (fieldKey === "IEHP_FBA_TARGET_BEHAVIOR_INTERVENTION_BLOCKS") {
+    return "behavior";
+  }
+  if (fieldKey === "IEHP_FBA_SKILL_AND_SCHOOL_GOAL_BLOCKS") {
+    return "skill";
+  }
+  return null;
+};
+
 const toIehpGoalCandidate = (row: AssessmentRequiredStructuredReviewRow): IehpLiveGoalCandidate | null => {
   if (!IEHP_GOAL_SECTION_KEYS.has(row.field_key) || !row.payload || typeof row.payload !== "object") {
     return null;
@@ -230,13 +295,18 @@ const toIehpGoalCandidate = (row: AssessmentRequiredStructuredReviewRow): IehpLi
     description,
     originalText: rawText,
     goalType: normalizeIehpGoalType(payload.goal_type),
+    domainId: toUuidOrNull(payload.domain_id),
+    clinicalGoalType: normalizeClinicalGoalType(payload.clinical_goal_type ?? payload.goal_category ?? payload.category, row.field_key),
     targetBehavior: toStringOrNull(payload.target_behavior),
     measurementType: toStringOrNull(payload.measurement_type),
     baselineData: toStringOrNull(payload.baseline_data),
+    baseline: toStringOrNull(payload.baseline) ?? toStringOrNull(payload.baseline_data),
     targetCriteria: toStringOrNull(payload.target_criteria),
     masteryCriteria: toStringOrNull(payload.mastery_criteria),
     maintenanceCriteria: toStringOrNull(payload.maintenance_criteria),
     generalizationCriteria: toStringOrNull(payload.generalization_criteria),
+    teachingStrategies: toStringOrNull(payload.teaching_strategies) ?? toStringOrNull(payload.teaching_strategy),
+    operationalDefinition: toStringOrNull(payload.operational_definition) ?? toStringOrNull(payload.definition),
     objectiveDataPoints: Array.isArray(payload.objective_data_points)
       ? payload.objective_data_points.filter((point): point is Record<string, unknown> | string =>
         (typeof point === "string" && point.trim().length > 0) ||
@@ -468,6 +538,15 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     const now = new Date().toISOString();
     const actorId = getAccessTokenSubject(accessToken);
     const iehpLiveGoals = buildIehpLiveGoalCandidates(approvedStructuredRows);
+    const iehpDomainScope = await assertGoalDomainsInOrg({
+      supabaseUrl,
+      headers,
+      organizationId,
+      domainIds: iehpLiveGoals.map((goal) => goal.domainId),
+    });
+    if (!iehpDomainScope.ok) {
+      return json({ error: iehpDomainScope.error }, iehpDomainScope.status);
+    }
     const iehpProgramNames = Array.from(new Set(iehpLiveGoals.map((goal) => goal.programName)));
     const createdIehpProgramIds: string[] = [];
     const createdIehpProgramIdByName = new Map<string, string>();
@@ -599,14 +678,20 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
       description: goal.description,
       original_text: goal.originalText,
       goal_type: goal.goalType,
+      domain_id: goal.domainId,
+      clinical_goal_type: goal.clinicalGoalType,
       target_behavior: goal.targetBehavior,
       measurement_type: goal.measurementType,
       baseline_data: goal.baselineData,
+      baseline: goal.baseline,
       target_criteria: goal.targetCriteria,
       mastery_criteria: goal.masteryCriteria,
       maintenance_criteria: goal.maintenanceCriteria,
       generalization_criteria: goal.generalizationCriteria,
+      teaching_strategies: goal.teachingStrategies,
+      operational_definition: goal.operationalDefinition,
       objective_data_points: goal.objectiveDataPoints,
+      source: "fba_extraction",
       status: "active",
     }));
 
@@ -703,7 +788,7 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
       { method: "GET", headers },
     ),
     fetchJson<DraftGoalRow[]>(
-      `${supabaseUrl}/rest/v1/assessment_draft_goals?select=id,draft_program_id,title,description,original_text,goal_type,target_behavior,measurement_type,baseline_data,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,objective_data_points,accept_state&organization_id=eq.${encodeURIComponent(
+      `${supabaseUrl}/rest/v1/assessment_draft_goals?select=id,draft_program_id,title,description,original_text,goal_type,domain_id,clinical_goal_type,target_behavior,measurement_type,baseline_data,baseline,target_criteria,mastery_criteria,maintenance_criteria,generalization_criteria,teaching_strategies,operational_definition,objective_data_points,accept_state&organization_id=eq.${encodeURIComponent(
         organizationId,
       )}&assessment_document_id=eq.${encodeURIComponent(parsed.data.assessment_document_id)}&order=created_at.asc`,
       { method: "GET", headers },
@@ -774,6 +859,16 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
   const acceptedGoalsWithoutProgramLink = acceptedGoals.filter((goal) => !goal.draft_program_id);
   if (acceptedPrograms.length > 1 && acceptedGoalsWithoutProgramLink.length > 0) {
     return json({ error: "Accepted goals must keep their draft program link when promoting multiple programs." }, 409);
+  }
+
+  const domainScope = await assertGoalDomainsInOrg({
+    supabaseUrl,
+    headers,
+    organizationId,
+    domainIds: acceptedGoals.map((goal) => goal.domain_id),
+  });
+  if (!domainScope.ok) {
+    return json({ error: domainScope.error }, domainScope.status);
   }
 
   const actorId = getAccessTokenSubject(accessToken);
@@ -891,13 +986,18 @@ export async function assessmentPromoteHandler(request: Request): Promise<Respon
     description: goal.description,
     original_text: goal.original_text,
     goal_type: goal.goal_type,
+    domain_id: goal.domain_id,
+    clinical_goal_type: goal.clinical_goal_type,
     target_behavior: goal.target_behavior,
     measurement_type: goal.measurement_type,
     baseline_data: goal.baseline_data,
+    baseline: goal.baseline ?? goal.baseline_data,
     target_criteria: goal.target_criteria,
     mastery_criteria: goal.mastery_criteria,
     maintenance_criteria: goal.maintenance_criteria,
     generalization_criteria: goal.generalization_criteria,
+    teaching_strategies: goal.teaching_strategies,
+    operational_definition: goal.operational_definition,
     objective_data_points: goal.objective_data_points ?? [],
     status: "active",
   }));

--- a/src/server/api/goals.ts
+++ b/src/server/api/goals.ts
@@ -97,6 +97,18 @@ export async function goalsHandler(request: Request): Promise<Response> {
     return lookupResult.data[0] ?? null;
   };
 
+  const loadDomain = async (domainId: string): Promise<{ id: string } | null> => {
+    const domainLookupUrl = `${supabaseUrl}/rest/v1/goal_domains?select=id&id=eq.${domainId}&organization_id=eq.${organizationId}&limit=1`;
+    const lookupResult = await fetchJson<Array<{ id: string }>>(domainLookupUrl, {
+      method: "GET",
+      headers,
+    });
+    if (!lookupResult.ok || !Array.isArray(lookupResult.data) || lookupResult.data.length === 0) {
+      return null;
+    }
+    return lookupResult.data[0] ?? null;
+  };
+
   if (request.method === "GET") {
     const url = new URL(request.url);
     const programId = url.searchParams.get("program_id");
@@ -157,6 +169,12 @@ export async function goalsHandler(request: Request): Promise<Response> {
     }
     if (program.client_id !== parsed.data.client_id) {
       return json({ error: "program_id does not belong to client_id" }, 400);
+    }
+    if (parsed.data.domain_id) {
+      const domain = await loadDomain(parsed.data.domain_id);
+      if (!domain) {
+        return json({ error: "domain_id is not in scope for this organization" }, 403);
+      }
     }
 
     const createPayload = {
@@ -230,6 +248,12 @@ export async function goalsHandler(request: Request): Promise<Response> {
       }
       if (program.client_id !== effectiveClientId) {
         return json({ error: "program_id does not belong to client_id" }, 400);
+      }
+    }
+    if (parsed.data.domain_id) {
+      const domain = await loadDomain(parsed.data.domain_id);
+      if (!domain) {
+        return json({ error: "domain_id is not in scope for this organization" }, 403);
       }
     }
 

--- a/supabase/migrations/20260706143000_goal_domains_and_structured_draft_goals.sql
+++ b/supabase/migrations/20260706143000_goal_domains_and_structured_draft_goals.sql
@@ -1,0 +1,108 @@
+-- @migration-intent: Add org-scoped goal domains and preserve structured clinical draft fields through FBA promotion.
+-- @migration-dependencies: 20260703173000_goal_targets_trial_events.sql
+-- @migration-rollback: alter table public.goals drop constraint if exists goals_domain_id_fkey; alter table public.assessment_draft_goals drop column if exists domain_id, drop column if exists clinical_goal_type, drop column if exists teaching_strategies, drop column if exists operational_definition, drop column if exists baseline; drop table if exists public.goal_domains;
+
+begin;
+
+create table if not exists public.goal_domains (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  name text not null check (char_length(btrim(name)) > 0),
+  description text,
+  status text not null default 'active' check (status in ('active', 'archived')),
+  created_by uuid,
+  updated_by uuid,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create unique index if not exists goal_domains_org_name_uidx
+  on public.goal_domains (organization_id, lower(btrim(name)))
+  where status = 'active';
+
+alter table public.goal_domains
+  drop constraint if exists goal_domains_id_organization_id_key,
+  add constraint goal_domains_id_organization_id_key unique (id, organization_id);
+
+create index if not exists goal_domains_org_status_idx
+  on public.goal_domains (organization_id, status, name);
+
+drop trigger if exists goal_domains_set_updated_at on public.goal_domains;
+create trigger goal_domains_set_updated_at
+before update on public.goal_domains
+for each row
+execute function public.set_updated_at();
+
+alter table public.assessment_draft_goals
+  add column if not exists domain_id uuid references public.goal_domains(id),
+  add column if not exists clinical_goal_type text,
+  add column if not exists teaching_strategies text,
+  add column if not exists operational_definition text,
+  add column if not exists baseline text;
+
+update public.assessment_draft_goals
+set baseline = baseline_data
+where baseline is null
+  and baseline_data is not null;
+
+alter table public.assessment_draft_goals
+  drop constraint if exists assessment_draft_goals_clinical_goal_type_chk,
+  add constraint assessment_draft_goals_clinical_goal_type_chk
+  check (clinical_goal_type is null or clinical_goal_type in ('behavior', 'skill'));
+
+alter table public.goals
+  drop constraint if exists goals_domain_id_fkey,
+  add constraint goals_domain_id_fkey
+  foreign key (domain_id, organization_id) references public.goal_domains(id, organization_id);
+
+alter table public.assessment_draft_goals
+  drop constraint if exists assessment_draft_goals_domain_id_fkey,
+  add constraint assessment_draft_goals_domain_id_fkey
+  foreign key (domain_id, organization_id) references public.goal_domains(id, organization_id);
+
+alter table public.goal_domains enable row level security;
+
+revoke all on table public.goal_domains from anon;
+grant select, insert, update on table public.goal_domains to authenticated;
+grant select, insert, update, delete on table public.goal_domains to service_role;
+
+drop policy if exists goal_domains_service_role_all on public.goal_domains;
+create policy goal_domains_service_role_all
+  on public.goal_domains
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+drop policy if exists goal_domains_org_read on public.goal_domains;
+create policy goal_domains_org_read
+  on public.goal_domains
+  for select
+  to authenticated
+  using (organization_id = app.current_user_organization_id());
+
+drop policy if exists goal_domains_org_insert on public.goal_domains;
+create policy goal_domains_org_insert
+  on public.goal_domains
+  for insert
+  to authenticated
+  with check (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_manage_programs_goals(organization_id)
+  );
+
+drop policy if exists goal_domains_org_update on public.goal_domains;
+create policy goal_domains_org_update
+  on public.goal_domains
+  for update
+  to authenticated
+  using (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_manage_programs_goals(organization_id)
+  )
+  with check (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_manage_programs_goals(organization_id)
+  );
+
+commit;

--- a/supabase/migrations/20260706143000_goal_domains_and_structured_draft_goals.sql
+++ b/supabase/migrations/20260706143000_goal_domains_and_structured_draft_goals.sql
@@ -45,6 +45,42 @@ set baseline = baseline_data
 where baseline is null
   and baseline_data is not null;
 
+create temporary table legacy_goal_domain_backfill on commit drop as
+select
+  legacy_domains.organization_id,
+  legacy_domains.domain_id as legacy_domain_id,
+  case
+    when row_number() over (partition by legacy_domains.domain_id order by legacy_domains.organization_id) = 1
+      then legacy_domains.domain_id
+    else gen_random_uuid()
+  end as backfilled_domain_id
+from (
+  select distinct goals.organization_id, goals.domain_id
+  from public.goals
+  where goals.domain_id is not null
+    and goals.organization_id is not null
+) legacy_domains;
+
+insert into public.goal_domains (id, organization_id, name, description)
+select
+  backfilled_domain_id,
+  organization_id,
+  'Legacy domain ' || legacy_domain_id::text,
+  case
+    when backfilled_domain_id = legacy_domain_id
+      then 'Backfilled from goals.domain_id before goal domain catalog enforcement.'
+    else 'Backfilled from a duplicate legacy goals.domain_id before goal domain catalog enforcement.'
+  end
+from legacy_goal_domain_backfill
+on conflict (id) do nothing;
+
+update public.goals
+set domain_id = legacy_goal_domain_backfill.backfilled_domain_id
+from legacy_goal_domain_backfill
+where goals.organization_id = legacy_goal_domain_backfill.organization_id
+  and goals.domain_id = legacy_goal_domain_backfill.legacy_domain_id
+  and goals.domain_id is distinct from legacy_goal_domain_backfill.backfilled_domain_id;
+
 alter table public.assessment_draft_goals
   drop constraint if exists assessment_draft_goals_clinical_goal_type_chk,
   add constraint assessment_draft_goals_clinical_goal_type_chk

--- a/tests/integration/goal-domains-migration.contract.test.ts
+++ b/tests/integration/goal-domains-migration.contract.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("goal domains migration contract", () => {
+  const migrationPath = join(
+    process.cwd(),
+    "supabase",
+    "migrations",
+    "20260706143000_goal_domains_and_structured_draft_goals.sql",
+  );
+  const sql = readFileSync(migrationPath, "utf8").replace(/\s+/g, " ");
+
+  it("enforces goal domain tenant scope at the database boundary", () => {
+    expect(sql).toContain("add constraint goal_domains_id_organization_id_key unique (id, organization_id)");
+    expect(sql).toContain(
+      "add constraint goals_domain_id_fkey foreign key (domain_id, organization_id) references public.goal_domains(id, organization_id)",
+    );
+    expect(sql).toContain(
+      "add constraint assessment_draft_goals_domain_id_fkey foreign key (domain_id, organization_id) references public.goal_domains(id, organization_id)",
+    );
+  });
+});

--- a/tests/integration/goal-domains-migration.contract.test.ts
+++ b/tests/integration/goal-domains-migration.contract.test.ts
@@ -12,6 +12,16 @@ describe("goal domains migration contract", () => {
   const sql = readFileSync(migrationPath, "utf8").replace(/\s+/g, " ");
 
   it("enforces goal domain tenant scope at the database boundary", () => {
+    expect(sql).toContain("create temporary table legacy_goal_domain_backfill");
+    expect(sql).toContain("row_number() over (partition by legacy_domains.domain_id order by legacy_domains.organization_id) = 1");
+    expect(sql).toContain("else gen_random_uuid()");
+    expect(sql).toContain("update public.goals set domain_id = legacy_goal_domain_backfill.backfilled_domain_id");
+    expect(sql.indexOf("insert into public.goal_domains (id, organization_id, name, description)")).toBeLessThan(
+      sql.indexOf("add constraint goals_domain_id_fkey"),
+    );
+    expect(sql.indexOf("update public.goals set domain_id = legacy_goal_domain_backfill.backfilled_domain_id")).toBeLessThan(
+      sql.indexOf("add constraint goals_domain_id_fkey"),
+    );
     expect(sql).toContain("add constraint goal_domains_id_organization_id_key unique (id, organization_id)");
     expect(sql).toContain(
       "add constraint goals_domain_id_fkey foreign key (domain_id, organization_id) references public.goal_domains(id, organization_id)",


### PR DESCRIPTION
## Summary
- Add org-scoped `goal_domains` with RLS and composite `(domain_id, organization_id)` foreign keys for live and draft goals.
- Extend FBA assessment draft goals with structured clinical fields: domain, behavior/skill type, baseline, teaching strategies, operational definition, and criteria fields.
- Preserve structured draft fields through draft create/update and promotion while keeping normal draft promotion provenance defaulted and IEHP structured promotion as `fba_extraction`.

## Tracking
- Linear: WIN-198

## Verification
- `npx vitest run src/server/__tests__/assessmentDraftsHandler.test.ts src/server/__tests__/assessmentPromoteHandler.test.ts src/server/__tests__/goalsHandler.test.ts tests/integration/goal-domains-migration.contract.test.ts`
- `npm run ci:check-focused` (DB-backed checks skipped locally because `SUPABASE_DB_URL` is not configured)
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run test:ci` (354 files / 2262 tests passed)
- `npm run build`
- `npm run ci:verify-coverage`
- `npm run test:routes:tier0`

## Notes
- `npm run verify:local` timed out locally at the Cypress portion under the 5-minute command timeout, so the remaining component commands were run separately and passed.
- Migration was statically validated locally, but not applied to hosted Supabase from this branch.

## Risk
Critical/protected path: `supabase/migrations/**` and tenant-sensitive server API writes. Human review required before merge.