### PR TITLE
Complete session data collection capture

### DIFF
--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -87,6 +87,38 @@ export interface SessionModalClinicalNotesPayload {
 }
 
 const responseRequiredMeasurementTypes = new Set(['correctIncorrect', 'taskAnalysis']);
+const valueRequiredMeasurementTypes = new Set(['frequency', 'rate', 'duration', 'timeSample', 'latency', 'IRT']);
+
+const valueMeasurementMeta: Record<string, { label: string; unit: string; step: number }> = {
+  frequency: { label: 'Frequency', unit: 'count', step: 1 },
+  rate: { label: 'Rate', unit: 'per hour', step: 0.1 },
+  duration: { label: 'Duration', unit: 'minutes', step: 0.1 },
+  timeSample: { label: 'Time sample', unit: 'intervals', step: 1 },
+  latency: { label: 'Latency', unit: 'seconds', step: 0.1 },
+  IRT: { label: 'IRT', unit: 'seconds', step: 0.1 },
+};
+
+const responseOptionsByMeasurementType: Record<string, Array<{ response: NonNullable<TrialEvent['response']>; label: string }>> = {
+  correctIncorrect: [
+    { response: 'correct', label: 'Correct' },
+    { response: 'incorrect', label: 'Incorrect' },
+    { response: 'noResponse', label: 'No response' },
+  ],
+  taskAnalysis: [
+    { response: 'independent', label: 'Independent' },
+    { response: 'prompted', label: 'Prompted' },
+    { response: 'incorrect', label: 'Incorrect' },
+    { response: 'noResponse', label: 'No response' },
+  ],
+};
+
+const getValueMeasurementMeta = (measurementType: string) =>
+  valueRequiredMeasurementTypes.has(measurementType)
+    ? valueMeasurementMeta[measurementType] ?? { label: 'Value', unit: 'value', step: 0.1 }
+    : null;
+
+const isPositiveResponse = (response: TrialEvent['response']): boolean =>
+  response === 'correct' || response === 'independent' || response === 'prompted';
 
 export type SessionModalSubmitData = Partial<Session> & SessionModalClinicalNotesPayload;
 
@@ -265,6 +297,7 @@ export function SessionModal({
   const [alternativeTimes, setAlternativeTimes] = useState<AlternativeTime[]>([]);
   const [isLoadingAlternatives, setIsLoadingAlternatives] = useState(false);
   const [pendingTrialEvents, setPendingTrialEvents] = useState<SessionCaptureTrialEventInput[]>([]);
+  const [pendingNumericTrialValues, setPendingNumericTrialValues] = useState<Record<string, string>>({});
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const sessionCaptureSectionRef = useRef<HTMLElement | null>(null);
@@ -627,15 +660,18 @@ export function SessionModal({
       hasNestedDirtyEntries(dirtyFields.session_note_goal_ids) ||
       hasNestedDirtyEntries(dirtyFields.session_note_goals_addressed) ||
       hasNestedDirtyEntries(dirtyFields.session_note_goal_notes) ||
-      hasNestedDirtyEntries(dirtyFields.session_note_goal_measurements),
+      hasNestedDirtyEntries(dirtyFields.session_note_goal_measurements) ||
+      Object.values(pendingNumericTrialValues).some((value) => value.trim().length > 0),
     [
       dirtyFields.session_note_goal_ids,
       dirtyFields.session_note_goals_addressed,
       dirtyFields.session_note_goal_measurements,
       dirtyFields.session_note_goal_notes,
       dirtyFields.session_note_narrative,
+      pendingNumericTrialValues,
     ],
   );
+  const hasUnsavedSessionChanges = isDirty || hasDirtySessionCaptureFields;
 
   useEffect(() => {
     if (session?.therapist_id) {
@@ -670,6 +706,7 @@ export function SessionModal({
 
   useEffect(() => {
     setPendingTrialEvents([]);
+    setPendingNumericTrialValues({});
   }, [session?.id, clientId]);
 
   useEffect(() => {
@@ -1225,7 +1262,7 @@ export function SessionModal({
                 incorrect_trials: null,
                 opportunities: null,
                 target_trials: null,
-                trial_prompt_note: null,
+                trial_prompt_note: entry.data.trial_prompt_note,
               },
             };
             return hasMeaningfulGoalMeasurementEntry(rawEventBackedEntry)
@@ -1418,7 +1455,7 @@ export function SessionModal({
     if (isSubmitting) {
       return;
     }
-    if (!isDirty) {
+    if (!hasUnsavedSessionChanges) {
       onClose();
       return;
     }
@@ -1428,7 +1465,7 @@ export function SessionModal({
     if (shouldDiscard) {
       onClose();
     }
-  }, [isDirty, isSubmitting, onClose]);
+  }, [hasUnsavedSessionChanges, isSubmitting, onClose]);
 
   const handleStartSession = async () => {
     if (isDataCollectionOnly) {
@@ -1629,13 +1666,31 @@ export function SessionModal({
         }
         if (responseRequiredMeasurementTypes.has(measurementType)) {
           return field === 'metric_value'
-            ? event.response === 'correct'
+            ? isPositiveResponse(event.response)
             : event.response === 'incorrect' || event.response === 'noResponse';
         }
         return field === 'metric_value'
           ? typeof event.value === 'number' && event.value > 0
           : event.value === 0;
       }).length;
+    },
+    [existingTrialEvents, pendingTrialEvents],
+  );
+
+  const getRawTrialNumericSummary = useCallback(
+    (targetId: string, scope: 'all' | 'pending' = 'all') => {
+      const sourceEvents = scope === 'pending'
+        ? pendingTrialEvents
+        : [...existingTrialEvents, ...pendingTrialEvents];
+      return sourceEvents
+        .filter((event) => event.target_id === targetId && typeof event.value === 'number')
+        .reduce(
+          (summary, event) => ({
+            count: summary.count + 1,
+            total: summary.total + (typeof event.value === 'number' ? event.value : 0),
+          }),
+          { count: 0, total: 0 },
+        );
     },
     [existingTrialEvents, pendingTrialEvents],
   );
@@ -1693,7 +1748,7 @@ export function SessionModal({
               }
               const matchesField = responseRequiredMeasurementTypes.has(configuredTarget.measurement_type)
                 ? (field === 'metric_value'
-                    ? event.response === 'correct'
+                    ? isPositiveResponse(event.response)
                     : event.response === 'incorrect' || event.response === 'noResponse')
                 : (field === 'metric_value'
                     ? typeof event.value === 'number' && event.value > 0
@@ -1722,6 +1777,66 @@ export function SessionModal({
       setValue(path, Math.max(0, safe + delta), { shouldDirty: true, shouldTouch: true });
     },
     [getNextRawTrialNumber, getRawTrialCount, getValues, setValue],
+  );
+
+  const recordResponseTrial = useCallback(
+    (
+      goalId: string,
+      targetIndex: number,
+      configuredTarget: GoalTarget,
+      response: NonNullable<TrialEvent['response']>,
+    ) => {
+      const field = isPositiveResponse(response) ? 'metric_value' : 'incorrect_trials';
+      const dirtyPath =
+        `session_note_goal_measurements.${goalId}.data.target_trials.${targetIndex}.${field}` as const;
+      const nextDisplayedCount = getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, field) + 1;
+      const newEvent: SessionCaptureTrialEventInput = {
+        target_id: configuredTarget.id,
+        trial_number: getNextRawTrialNumber(configuredTarget.id),
+        response,
+        metadata: { source: 'schedule_capture', goal_id: goalId, target_index: targetIndex },
+      };
+      setPendingTrialEvents((current) => [...current, newEvent]);
+      setValue(dirtyPath, nextDisplayedCount, { shouldDirty: true, shouldTouch: true });
+    },
+    [getNextRawTrialNumber, getRawTrialCount, setValue],
+  );
+
+  const recordNumericTrial = useCallback(
+    (goalId: string, targetIndex: number, configuredTarget: GoalTarget, rawValue: string) => {
+      if (rawValue.trim().length === 0) {
+        showError('Enter a non-negative value before adding the trial.');
+        return;
+      }
+      const value = Number(rawValue);
+      if (!Number.isFinite(value) || value < 0) {
+        showError('Enter a non-negative value before adding the trial.');
+        return;
+      }
+      const metricValuePath =
+        `session_note_goal_measurements.${goalId}.data.target_trials.${targetIndex}.metric_value` as const;
+      const opportunitiesPath =
+        `session_note_goal_measurements.${goalId}.data.target_trials.${targetIndex}.opportunities` as const;
+      const currentSummary = getRawTrialNumericSummary(configuredTarget.id);
+      const nextSummary = {
+        count: currentSummary.count + 1,
+        total: currentSummary.total + value,
+      };
+      const newEvent: SessionCaptureTrialEventInput = {
+        target_id: configuredTarget.id,
+        trial_number: getNextRawTrialNumber(configuredTarget.id),
+        value,
+        metadata: { source: 'schedule_capture', goal_id: goalId, target_index: targetIndex },
+      };
+      setPendingTrialEvents((current) => [...current, newEvent]);
+      setValue(metricValuePath, nextSummary.total, { shouldDirty: true, shouldTouch: true });
+      setValue(opportunitiesPath, nextSummary.count, { shouldDirty: true, shouldTouch: true });
+      setPendingNumericTrialValues((current) => ({
+        ...current,
+        [configuredTarget.id]: '',
+      }));
+    },
+    [getNextRawTrialNumber, getRawTrialNumericSummary, setValue],
   );
 
   const updateGoalTargets = useCallback(
@@ -1864,11 +1979,11 @@ export function SessionModal({
     if (saveState === 'error') {
       return { tone: 'error' as const, text: 'Unable to save session details. Try again.' };
     }
-    if (isDirty) {
+    if (hasUnsavedSessionChanges) {
       return { tone: 'warning' as const, text: 'Unsaved changes.' };
     }
     return null;
-  }, [isDirty, isSubmitting, saveState]);
+  }, [hasUnsavedSessionChanges, isSubmitting, saveState]);
   const dialogDescriptionIds = [
     dialogDescriptionId,
     ...(retryHint ? [retryHintDescriptionId] : []),
@@ -1953,7 +2068,7 @@ export function SessionModal({
   }, [isOpen, handleAttemptClose]);
 
   useEffect(() => {
-    if (!isOpen || !isDirty || isSubmitting) {
+    if (!isOpen || !hasUnsavedSessionChanges || isSubmitting) {
       return;
     }
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -1964,13 +2079,13 @@ export function SessionModal({
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [isOpen, isDirty, isSubmitting]);
+  }, [isOpen, hasUnsavedSessionChanges, isSubmitting]);
 
   useEffect(() => {
-    if (!isDirty && saveState === 'error') {
+    if (!hasUnsavedSessionChanges && saveState === 'error') {
       setSaveState('idle');
     }
-  }, [isDirty, saveState]);
+  }, [hasUnsavedSessionChanges, saveState]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -1979,7 +2094,7 @@ export function SessionModal({
   }, [isOpen, session?.id]);
 
   useEffect(() => {
-    if (!linkedSessionNote || !session?.id || isDirty) {
+    if (!linkedSessionNote || !session?.id || hasUnsavedSessionChanges) {
       return;
     }
     const linkedMeasurements = (linkedSessionNote.goal_measurements as Record<string, unknown> | null) ?? {};
@@ -2008,7 +2123,7 @@ export function SessionModal({
     setValue('session_note_goals_addressed', linkedSessionNote.goals_addressed ?? []);
     setValue('session_note_authorization_id', linkedSessionNote.authorization_id ?? '');
     setValue('session_note_service_code', linkedSessionNote.service_code ?? '');
-  }, [goalsById, linkedSessionNote, session?.id, setValue, isDirty]);
+  }, [goalsById, linkedSessionNote, session?.id, setValue, hasUnsavedSessionChanges]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -3240,17 +3355,40 @@ export function SessionModal({
                                     const targetTrialTargetFieldKey =
                                       `${targetTrialsFieldBaseKey}.${sourceIndex}.target` as const;
                                     const configuredTarget = resolveConfiguredGoalTarget(selectedGoalId, targetValue);
+                                    const valueCaptureMeta = configuredTarget
+                                      ? getValueMeasurementMeta(configuredTarget.measurement_type)
+                                      : null;
+                                    const responseCaptureOptions = configuredTarget
+                                      ? responseOptionsByMeasurementType[configuredTarget.measurement_type] ?? []
+                                      : [];
+                                    const numericInputValue = configuredTarget
+                                      ? pendingNumericTrialValues[configuredTarget.id] ?? ''
+                                      : '';
+                                    const numericSummary = configuredTarget && valueCaptureMeta
+                                      ? getRawTrialNumericSummary(configuredTarget.id)
+                                      : { count: 0, total: 0 };
+                                    const pendingNumericSummary = configuredTarget && valueCaptureMeta
+                                      ? getRawTrialNumericSummary(configuredTarget.id, 'pending')
+                                      : { count: 0, total: 0 };
                                     const targetCorrectDisplay = configuredTarget
-                                      ? getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'metric_value')
+                                      ? (valueCaptureMeta
+                                          ? numericSummary.total
+                                          : getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'metric_value'))
                                       : getTargetTrialValue(sourceIndex, 'metric_value');
                                     const targetIncorrectDisplay = configuredTarget
-                                      ? getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'incorrect_trials')
+                                      ? (valueCaptureMeta
+                                          ? 0
+                                          : getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'incorrect_trials'))
                                       : getTargetTrialValue(sourceIndex, 'incorrect_trials');
                                     const pendingCorrectDisplay = configuredTarget
-                                      ? getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'metric_value', 'pending')
+                                      ? (valueCaptureMeta
+                                          ? pendingNumericSummary.total
+                                          : getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'metric_value', 'pending'))
                                       : targetCorrectDisplay;
                                     const pendingIncorrectDisplay = configuredTarget
-                                      ? getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'incorrect_trials', 'pending')
+                                      ? (valueCaptureMeta
+                                          ? 0
+                                          : getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'incorrect_trials', 'pending'))
                                       : targetIncorrectDisplay;
                                     const shouldRenderTargetTrialFields =
                                       isAdhocTarget ||
@@ -3322,10 +3460,77 @@ export function SessionModal({
                                           <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-200">
                                             Trials for target {targetIndex + 1}
                                           </p>
-                                          <p className="mt-1 text-[11px] text-indigo-700/90 dark:text-indigo-200/80">
-                                            + correct or achieved · − incorrect or no response.
-                                          </p>
-                                          <div className="mt-3 flex flex-wrap items-center gap-3">
+                                          {valueCaptureMeta && configuredTarget ? (
+                                            <div className="mt-3">
+                                              <label
+                                                htmlFor={`numeric-trial-${selectedGoalId}-${targetIndex}`}
+                                                className="block text-xs font-medium text-gray-700 dark:text-gray-300"
+                                              >
+                                                {valueCaptureMeta.label} value for target {targetIndex + 1} ({valueCaptureMeta.unit})
+                                              </label>
+                                              <div className="mt-1 flex flex-wrap items-center gap-2">
+                                                <input
+                                                  id={`numeric-trial-${selectedGoalId}-${targetIndex}`}
+                                                  type="number"
+                                                  min={0}
+                                                  step={valueCaptureMeta.step}
+                                                  value={numericInputValue}
+                                                  onChange={(event) =>
+                                                    setPendingNumericTrialValues((current) => ({
+                                                      ...current,
+                                                      [configuredTarget.id]: event.target.value,
+                                                    }))
+                                                  }
+                                                  className="min-h-10 w-32 rounded-md border-gray-300 bg-white px-3 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                                />
+                                                <button
+                                                  type="button"
+                                                  aria-label={`Add ${valueCaptureMeta.label.toLowerCase()} trial for target ${targetIndex + 1}`}
+                                                  className="rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold text-white shadow-sm hover:bg-indigo-700"
+                                                  onClick={() => recordNumericTrial(selectedGoalId, sourceIndex, configuredTarget, numericInputValue)}
+                                                >
+                                                  Add trial
+                                                </button>
+                                                <span className="text-xs tabular-nums text-gray-600 dark:text-gray-300">
+                                                  {numericSummary.count} trials · total {numericSummary.total}
+                                                </span>
+                                              </div>
+                                            </div>
+                                          ) : (
+                                            <>
+                                              <p className="mt-1 text-[11px] text-indigo-700/90 dark:text-indigo-200/80">
+                                                + correct or achieved · − incorrect or no response.
+                                              </p>
+                                              {configuredTarget && responseCaptureOptions.length > 0 ? (
+                                                <div className="mt-3 flex flex-wrap items-center gap-2">
+                                                  {responseCaptureOptions.map((option) => (
+                                                    <button
+                                                      key={option.response}
+                                                      type="button"
+                                                      aria-label={
+                                                        option.response === 'correct'
+                                                          ? `Increase correct trials for target ${targetIndex + 1}`
+                                                          : option.response === 'incorrect'
+                                                            ? `Increase incorrect or no-response trials for target ${targetIndex + 1}`
+                                                            : `Record ${option.label.toLowerCase()} response for target ${targetIndex + 1}`
+                                                      }
+                                                      className={[
+                                                        'rounded-md px-3 py-2 text-xs font-semibold shadow-sm',
+                                                        isPositiveResponse(option.response)
+                                                          ? 'bg-emerald-600 text-white hover:bg-emerald-700'
+                                                          : 'bg-rose-600 text-white hover:bg-rose-700',
+                                                      ].join(' ')}
+                                                      onClick={() => recordResponseTrial(selectedGoalId, sourceIndex, configuredTarget, option.response)}
+                                                    >
+                                                      {option.label}
+                                                    </button>
+                                                  ))}
+                                                  <span className="text-xs tabular-nums text-gray-600 dark:text-gray-300">
+                                                    +{targetCorrectDisplay} · −{targetIncorrectDisplay}
+                                                  </span>
+                                                </div>
+                                              ) : (
+                                                <div className="mt-3 flex flex-wrap items-center gap-3">
                                             <div className="flex flex-wrap items-center gap-2">
                                               <span className="text-xs font-medium text-gray-700 dark:text-gray-300">+</span>
                                               <button
@@ -3346,7 +3551,7 @@ export function SessionModal({
                                                 className="flex h-10 w-10 items-center justify-center rounded-full border border-emerald-700 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-200"
                                                 onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -1, configuredTarget)}
                                               >
-                                                −
+                                                -
                                               </button>
                                               <button
                                                 type="button"
@@ -3363,11 +3568,11 @@ export function SessionModal({
                                                 className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
                                                 onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -5, configuredTarget)}
                                               >
-                                                −5
+                                                -5
                                               </button>
                                             </div>
                                             <div className="flex flex-wrap items-center gap-2">
-                                              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">−</span>
+                                              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">-</span>
                                               <button
                                                 type="button"
                                                 aria-label={`Increase incorrect or no-response trials for target ${targetIndex + 1}`}
@@ -3386,7 +3591,7 @@ export function SessionModal({
                                                 className="flex h-10 w-10 items-center justify-center rounded-full border border-rose-700 text-rose-700 hover:bg-rose-50 dark:border-rose-400 dark:text-rose-200"
                                                 onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -1, configuredTarget)}
                                               >
-                                                −
+                                                -
                                               </button>
                                               <button
                                                 type="button"
@@ -3403,10 +3608,13 @@ export function SessionModal({
                                                 className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
                                                 onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -5, configuredTarget)}
                                               >
-                                                −5
+                                                -5
                                               </button>
                                             </div>
                                           </div>
+                                              )}
+                                            </>
+                                          )}
                                           <input
                                             type="number"
                                             className="sr-only"

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1940,6 +1940,451 @@ describe('SessionModal', () => {
     expect(submitted.session_note_goal_measurements?.['goal-1']?.data.incorrect_trials).toBeNull();
   }, 15000);
 
+  it('submits configured duration target values as raw trial values with units', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const targetId = '88888888-8888-4888-8888-888888888881';
+    const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals.map((goal) =>
+          goal.id === 'goal-1' ? { ...goal, measurement_type: 'duration' } : goal,
+        ));
+      }
+      if (table === 'authorizations') {
+        return buildChain([
+          {
+            id: 'auth-1',
+            authorization_number: 'AUTH-001',
+            services: [{ service_code: '97153' }],
+          },
+        ]);
+      }
+      if (table === 'goal_targets') {
+        return buildChain([
+          {
+            id: targetId,
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            goal_id: 'goal-1',
+            name: 'Match peer greeting in 4/5 trials',
+            measurement_type: 'duration',
+            graph_config: {},
+            status: 'active',
+            sort_order: 0,
+            created_by: null,
+            updated_by: null,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        ]);
+      }
+      if (table === 'trial_events') {
+        return buildChain([]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        existingSessions={[]}
+        session={{
+          id: 'session-duration-trials',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
+    fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
+      target: { value: 'Duration observed' },
+    });
+    fireEvent.change(screen.getByLabelText(/Duration value for target 1 \(minutes\)/i), {
+      target: { value: '12.5' },
+    });
+    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 1/i), {
+      target: { value: 'Timer started after verbal prompt' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /Add duration trial for target 1/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Save skills/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        session_note_trial_events: [
+          expect.objectContaining({
+            target_id: targetId,
+            trial_number: 1,
+            value: 12.5,
+          }),
+        ],
+      }));
+    });
+    const submitted = onSubmit.mock.calls[0]?.[0] as {
+      session_note_goal_measurements?: Record<string, SessionGoalMeasurementEntry>;
+    };
+    expect(submitted.session_note_goal_measurements?.['goal-1']?.data.measurement_type).toBe('duration');
+    expect(submitted.session_note_goal_measurements?.['goal-1']?.data.target_trials).toBeNull();
+    expect(submitted.session_note_goal_measurements?.['goal-1']?.data.trial_prompt_note)
+      .toBe('Timer started after verbal prompt');
+  }, 15000);
+
+  it('warns before closing when a numeric raw-trial value is typed but not added', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const targetId = '88888888-8888-4888-8888-888888888883';
+    const targetName = 'Match peer greeting in 4/5 trials';
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'linked-note-duration-draft',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: ['Default Goal'],
+      goal_ids: ['goal-1'],
+      goal_measurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'duration',
+            metric_label: 'Duration',
+            metric_unit: 'minutes',
+            targets: [targetName],
+            target: targetName,
+            target_trials: [{
+              target: targetName,
+              metric_value: null,
+              incorrect_trials: null,
+              opportunities: null,
+              trial_prompt_note: null,
+            }],
+          },
+        },
+      },
+      goal_notes: { 'goal-1': '' },
+      session_id: 'session-duration-draft',
+      narrative: '',
+      is_locked: false,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: null,
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T09:00:00.000Z',
+    });
+    const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals.map((goal) =>
+          goal.id === 'goal-1' ? { ...goal, measurement_type: 'duration' } : goal,
+        ));
+      }
+      if (table === 'authorizations') {
+        return buildChain([{ id: 'auth-1', authorization_number: 'AUTH-001', services: [{ service_code: '97153' }] }]);
+      }
+      if (table === 'goal_targets') {
+        return buildChain([
+          {
+            id: targetId,
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            goal_id: 'goal-1',
+            name: targetName,
+            measurement_type: 'duration',
+            graph_config: {},
+            status: 'active',
+            sort_order: 0,
+            created_by: null,
+            updated_by: null,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        ]);
+      }
+      if (table === 'trial_events') {
+        return buildChain([]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        existingSessions={[]}
+        session={{
+          id: 'session-duration-draft',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />,
+    );
+
+    fireEvent.change(await screen.findByLabelText(/Duration value for target 1 \(minutes\)/i), {
+      target: { value: '12.5' },
+    });
+    expect(screen.getByTestId('session-modal-save-state')).toHaveTextContent('Unsaved changes.');
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await userEvent.click(screen.getByRole('button', { name: /^Cancel$/i }));
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  }, 15000);
+
+  it('does not record blank numeric raw trials but accepts explicit zero values', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const targetId = '88888888-8888-4888-8888-888888888884';
+    const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals.map((goal) =>
+          goal.id === 'goal-1' ? { ...goal, measurement_type: 'duration' } : goal,
+        ));
+      }
+      if (table === 'authorizations') {
+        return buildChain([{ id: 'auth-1', authorization_number: 'AUTH-001', services: [{ service_code: '97153' }] }]);
+      }
+      if (table === 'goal_targets') {
+        return buildChain([
+          {
+            id: targetId,
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            goal_id: 'goal-1',
+            name: 'Match peer greeting in 4/5 trials',
+            measurement_type: 'duration',
+            graph_config: {},
+            status: 'active',
+            sort_order: 0,
+            created_by: null,
+            updated_by: null,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        ]);
+      }
+      if (table === 'trial_events') {
+        return buildChain([]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        existingSessions={[]}
+        session={{
+          id: 'session-duration-blank-trial',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Add duration trial for target 1/i }));
+    expect(screen.getByText('0 trials · total 0')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Duration value for target 1 \(minutes\)/i), {
+      target: { value: '0' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /Add duration trial for target 1/i }));
+    expect(screen.getByText('1 trials · total 0')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  }, 15000);
+
+  it('submits task-analysis responses as raw trial events', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const targetId = '88888888-8888-4888-8888-888888888882';
+    const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals.map((goal) =>
+          goal.id === 'goal-1' ? { ...goal, measurement_type: 'taskAnalysis' } : goal,
+        ));
+      }
+      if (table === 'authorizations') {
+        return buildChain([
+          {
+            id: 'auth-1',
+            authorization_number: 'AUTH-001',
+            services: [{ service_code: '97153' }],
+          },
+        ]);
+      }
+      if (table === 'goal_targets') {
+        return buildChain([
+          {
+            id: targetId,
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            goal_id: 'goal-1',
+            name: 'Match peer greeting in 4/5 trials',
+            measurement_type: 'taskAnalysis',
+            graph_config: {},
+            status: 'active',
+            sort_order: 0,
+            created_by: null,
+            updated_by: null,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        ]);
+      }
+      if (table === 'trial_events') {
+        return buildChain([]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        existingSessions={[]}
+        session={{
+          id: 'session-task-analysis-trials',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
+    fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
+      target: { value: 'Task analysis observed' },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /Record independent response for target 1/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Record prompted response for target 1/i }));
+    expect(screen.getByText('+2 · −0')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /Save skills/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        session_note_trial_events: [
+          expect.objectContaining({
+            target_id: targetId,
+            trial_number: 1,
+            response: 'independent',
+          }),
+          expect.objectContaining({
+            target_id: targetId,
+            trial_number: 2,
+            response: 'prompted',
+          }),
+        ],
+      }));
+    });
+    const submitted = onSubmit.mock.calls[0]?.[0] as {
+      session_note_goal_measurements?: Record<string, SessionGoalMeasurementEntry>;
+    };
+    expect(submitted.session_note_goal_measurements?.['goal-1']?.data.measurement_type).toBe('taskAnalysis');
+  }, 15000);
+
   it('keeps aggregate counts nulled when reopening a raw-trial-backed target without new trial clicks', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const targetId = '88888888-8888-4888-8888-888888888889';

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -323,6 +323,214 @@ describe("sessionNotesUpsertHandler", () => {
     expect(trialEventsPostCount).toBe(1);
   });
 
+  it("persists numeric raw trial values for duration targets before saving the session note", async () => {
+    const fetchJsonMock = vi.mocked(fetchJson);
+    let trialEventsPostCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        return { ok: true, status: 201, data: [{ id: "note-with-duration-event" }] };
+      }
+      if (requestUrl.includes("/rest/v1/goal_targets?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: targetId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            goal_id: basePayload.goalIds[0],
+            measurement_type: "duration",
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/sessions?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.sessionId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            therapist_id: basePayload.therapistId,
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "GET") {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "POST") {
+        trialEventsPostCount += 1;
+        const parsedBody = JSON.parse(String(init.body)) as Array<Record<string, unknown>>;
+        expect(parsedBody).toEqual([
+          expect.objectContaining({
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            session_id: basePayload.sessionId,
+            target_id: targetId,
+            goal_id: basePayload.goalIds[0],
+            therapist_id: basePayload.therapistId,
+            trial_number: 1,
+            response: null,
+            value: 12.5,
+            created_by: "actor-1",
+          }),
+        ]);
+        return { ok: true, status: 201, data: [] };
+      }
+      if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes("id=eq.note-with-duration-event")) {
+        return { ok: true, status: 200, data: [buildSessionNoteRow("note-with-duration-event")] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          trialEvents: [{
+            target_id: targetId,
+            trial_number: 1,
+            value: 12.5,
+            metadata: { source: "schedule_capture" },
+          }],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(trialEventsPostCount).toBe(1);
+  });
+
+  it("persists task-analysis raw trial responses before saving the session note", async () => {
+    const fetchJsonMock = vi.mocked(fetchJson);
+    let trialEventsPostCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        return { ok: true, status: 201, data: [{ id: "note-with-task-analysis-events" }] };
+      }
+      if (requestUrl.includes("/rest/v1/goal_targets?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: targetId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            goal_id: basePayload.goalIds[0],
+            measurement_type: "taskAnalysis",
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/sessions?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.sessionId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            therapist_id: basePayload.therapistId,
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "GET") {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.includes("/rest/v1/trial_events") && init?.method === "POST") {
+        trialEventsPostCount += 1;
+        const parsedBody = JSON.parse(String(init.body)) as Array<Record<string, unknown>>;
+        expect(parsedBody).toEqual([
+          expect.objectContaining({
+            target_id: targetId,
+            goal_id: basePayload.goalIds[0],
+            trial_number: 1,
+            response: "independent",
+            value: null,
+            created_by: "actor-1",
+          }),
+          expect.objectContaining({
+            target_id: targetId,
+            goal_id: basePayload.goalIds[0],
+            trial_number: 2,
+            response: "prompted",
+            value: null,
+          }),
+        ]);
+        return { ok: true, status: 201, data: [] };
+      }
+      if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes("id=eq.note-with-task-analysis-events")) {
+        return { ok: true, status: 200, data: [buildSessionNoteRow("note-with-task-analysis-events")] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          trialEvents: [
+            {
+              target_id: targetId,
+              trial_number: 1,
+              response: "independent",
+              metadata: { source: "schedule_capture" },
+            },
+            {
+              target_id: targetId,
+              trial_number: 2,
+              response: "prompted",
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(trialEventsPostCount).toBe(1);
+  });
+
   it("rejects raw trial events outside the saved goal scope", async () => {
     const fetchJsonMock = vi.mocked(fetchJson);
     let noteWriteCount = 0;

--- a/src/server/__tests__/trialEventsHandler.test.ts
+++ b/src/server/__tests__/trialEventsHandler.test.ts
@@ -287,66 +287,75 @@ describe("trialEventsHandler", () => {
     expect(fetchJson).not.toHaveBeenCalled();
   });
 
-  it("rejects value-based measurements without a numeric value", async () => {
-    mockTargetAndSessionLookups("frequency");
+  it.each(["frequency", "rate", "duration", "timeSample", "latency", "IRT"])(
+    "rejects %s measurements without a numeric value",
+    async (measurementType) => {
+      mockTargetAndSessionLookups(measurementType);
 
-    const response = await trialEventsHandler(
-      new Request("http://localhost/api/trial-events", {
-        method: "POST",
-        body: JSON.stringify({
-          session_id: SESSION_ID,
-          target_id: TARGET_ID,
-          trial_number: 1,
+      const response = await trialEventsHandler(
+        new Request("http://localhost/api/trial-events", {
+          method: "POST",
+          body: JSON.stringify({
+            session_id: SESSION_ID,
+            target_id: TARGET_ID,
+            trial_number: 1,
+          }),
         }),
-      }),
-    );
+      );
 
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({ error: "value is required for this target measurement type" });
-    expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "value is required for this target measurement type" });
+      expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
+    },
+  );
 
-  it("rejects standardized responses for value-based measurements", async () => {
-    mockTargetAndSessionLookups("frequency");
+  it.each(["frequency", "rate", "duration", "timeSample", "latency", "IRT"])(
+    "rejects standardized responses for %s measurements",
+    async (measurementType) => {
+      mockTargetAndSessionLookups(measurementType);
 
-    const response = await trialEventsHandler(
-      new Request("http://localhost/api/trial-events", {
-        method: "POST",
-        body: JSON.stringify({
-          session_id: SESSION_ID,
-          target_id: TARGET_ID,
-          trial_number: 1,
-          response: "correct",
-          value: 1,
+      const response = await trialEventsHandler(
+        new Request("http://localhost/api/trial-events", {
+          method: "POST",
+          body: JSON.stringify({
+            session_id: SESSION_ID,
+            target_id: TARGET_ID,
+            trial_number: 1,
+            response: "correct",
+            value: 1,
+          }),
         }),
-      }),
-    );
+      );
 
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({ error: "response is not allowed for this target measurement type" });
-    expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "response is not allowed for this target measurement type" });
+      expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
+    },
+  );
 
-  it("rejects numeric values for response-based measurements", async () => {
-    mockTargetAndSessionLookups("correctIncorrect");
+  it.each(["correctIncorrect", "taskAnalysis"])(
+    "rejects numeric values for %s response-based measurements",
+    async (measurementType) => {
+      mockTargetAndSessionLookups(measurementType);
 
-    const response = await trialEventsHandler(
-      new Request("http://localhost/api/trial-events", {
-        method: "POST",
-        body: JSON.stringify({
-          session_id: SESSION_ID,
-          target_id: TARGET_ID,
-          trial_number: 1,
-          response: "correct",
-          value: 1,
+      const response = await trialEventsHandler(
+        new Request("http://localhost/api/trial-events", {
+          method: "POST",
+          body: JSON.stringify({
+            session_id: SESSION_ID,
+            target_id: TARGET_ID,
+            trial_number: 1,
+            response: "correct",
+            value: 1,
+          }),
         }),
-      }),
-    );
+      );
 
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({ error: "value is not allowed for this target measurement type" });
-    expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "value is not allowed for this target measurement type" });
+      expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
+    },
+  );
 
   it("returns 502 when trial-event capture access cannot be validated", async () => {
     mockTargetAndSessionLookups();
@@ -418,6 +427,38 @@ describe("trialEventsHandler", () => {
       expect.objectContaining({
         method: "POST",
         body: expect.stringContaining("\"value\":3"),
+      }),
+    );
+  });
+
+  it("inserts a duration trial event with a zero value when capture and lock checks allow it", async () => {
+    mockTargetAndSessionLookups("duration");
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(sessionHasLockedNote).mockResolvedValue({ locked: false, upstreamError: false });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      data: [{ id: "event-1", target_id: TARGET_ID, value: 0, response: null }],
+    });
+
+    const response = await trialEventsHandler(
+      new Request("http://localhost/api/trial-events", {
+        method: "POST",
+        body: JSON.stringify({
+          session_id: SESSION_ID,
+          target_id: TARGET_ID,
+          trial_number: 1,
+          value: 0,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(fetchJson).toHaveBeenCalledWith(
+      "https://example.supabase.co/rest/v1/trial_events",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("\"value\":0"),
       }),
     );
   });


### PR DESCRIPTION
## Summary
- add per-measurement session data capture controls for configured goal targets, including response buttons for correct/incorrect/task analysis and numeric trial entry for frequency, rate, duration, time sample, latency, and IRT
- persist configured target captures as raw `trial_events` while preserving target prompt notes and existing BT data-collection-only restrictions
- expand UI and server tests for raw trial payloads, session-note upsert persistence, measurement validation, task-analysis responses, and zero-value numeric events

## Route / Risk
- Linear: WIN-200
- classification: high-risk human-reviewed
- lane: critical
- protected surface: session capture persistence and `src/server/**` test coverage for tenant-scoped write behavior
- non-goals: no schema changes, no session metadata write expansion, no BT permission widening

## Supabase proof
- Hosted project `wnnjeqheqxxyrgsjmygy` confirms `goal_targets.measurement_type` allows `correctIncorrect`, `frequency`, `rate`, `duration`, `timeSample`, `taskAnalysis`, `latency`, and `IRT`.
- Hosted project `wnnjeqheqxxyrgsjmygy` confirms `trial_events.response` allows `correct`, `incorrect`, `noResponse`, `independent`, `prompted`, and `notObserved`, with non-negative numeric `value` support.

## Verification
- PASS `npx vitest run src/components/__tests__/SessionModal.test.tsx src/server/__tests__/sessionNotesUpsertHandler.test.ts src/server/__tests__/trialEventsHandler.test.ts` (115 tests)
- PASS `npm run typecheck`
- PASS `npm run lint`
- PASS `npm run ci:check-focused` (local DB-URL-only checks skipped: missing `SUPABASE_DB_URL` / `DATABASE_URL`; branch protection skipped outside CI)
- PASS `npm run validate:tenant`
- PASS `npm run test:ci` (354 files, 2280 tests)
- PASS `npm run build`
- PASS `npm run test:routes:tier0` (212 Cypress tests)
- PASS `npm run verify:local`
- BLOCKED `npm run ci:playwright`: preflight passed for `https://app.allincompassing.ai`, then `playwright:auth` failed because hosted credentials for `superadmin@test.com` were rejected as invalid email/password. Screenshot: `artifacts/latest/playwright-auth-smoke-failure-1783380720709.png`.

## Review notes
- Tester sidecar mapped the required coverage and recommended raw-trial, upsert, validation, and dirty-state tests.
- Reviewer sidecar found no blocking issues after fixes for prompt-note preservation and numeric draft dirty-state protection.
- Human review required before merge because this is critical-lane session data persistence work.
