### PR TITLE
WIN-197: restore super_admin precedence over bcba

### DIFF
--- a/supabase/functions/_shared/auth-middleware.ts
+++ b/supabase/functions/_shared/auth-middleware.ts
@@ -591,7 +591,7 @@ export const requireTherapist = (allowedRoles: Role[] = ['therapist']) =>
 export const requireAdmin = (allowedRoles: Role[] = ['admin', 'bcba', 'super_admin']) =>
   ({ allowedRoles });
 
-export const requireSuperAdmin = (allowedRoles: Role[] = ['bcba', 'super_admin']) =>
+export const requireSuperAdmin = (allowedRoles: Role[] = ['super_admin']) =>
   ({ allowedRoles });
 
 /**
@@ -605,7 +605,7 @@ export const RouteOptions = {
   staffAdmin: { requireAuth: true, allowedRoles: ['admin_schedule', 'admin', 'bcba', 'super_admin'] as Role[] },
   admin: { requireAuth: true, allowedRoles: ['admin', 'bcba', 'super_admin'] as Role[] },
   programsGoals: { requireAuth: true, allowedRoles: ['bt', 'therapist', 'midtier', 'admin', 'bcba', 'super_admin'] as Role[] },
-  superAdmin: { requireAuth: true, allowedRoles: ['bcba', 'super_admin'] as Role[] },
+  superAdmin: { requireAuth: true, allowedRoles: ['super_admin'] as Role[] },
 };
 
 export const __TESTING__ = {

--- a/supabase/migrations/20260707121500_super_admin_bcba_role_precedence.sql
+++ b/supabase/migrations/20260707121500_super_admin_bcba_role_precedence.sql
@@ -1,0 +1,128 @@
+-- @migration-intent: Break the BCBA/super-admin precedence tie so global super_admin consistently outranks BCBA in profile sync and employee listings.
+-- @migration-dependencies: 20260706023600_bcba_exact_capability_matrix.sql,20260702222500_restrict_employee_users_paged_execute_grants.sql
+-- @migration-rollback: Re-apply 20260701150000_employee_role_capability_matrix.sql and 20260702120000_super_admin_employee_role_listing.sql if BCBA must regain parity with super_admin.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_user_role_from_junction(p_user_id uuid)
+RETURNS public.role_type
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  user_role text;
+BEGIN
+  SELECT r.name INTO user_role
+  FROM public.user_roles ur
+  JOIN public.roles r ON ur.role_id = r.id
+  WHERE ur.user_id = p_user_id
+    AND COALESCE(ur.is_active, true) = true
+    AND (ur.expires_at IS NULL OR ur.expires_at > now())
+  ORDER BY
+    CASE r.name
+      WHEN 'super_admin' THEN 8
+      WHEN 'bcba' THEN 7
+      WHEN 'admin' THEN 6
+      WHEN 'admin_schedule' THEN 5
+      WHEN 'midtier' THEN 4
+      WHEN 'therapist' THEN 3
+      WHEN 'bt' THEN 2
+      WHEN 'client' THEN 1
+      ELSE 0
+    END DESC
+  LIMIT 1;
+
+  RETURN COALESCE(user_role::public.role_type, 'client'::public.role_type);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_employee_users_paged(
+  p_organization_id uuid DEFAULT NULL,
+  p_limit integer DEFAULT 100,
+  p_offset integer DEFAULT 0
+)
+RETURNS TABLE (
+  id uuid,
+  email text,
+  first_name text,
+  last_name text,
+  full_name text,
+  title text,
+  role public.role_type,
+  is_active boolean,
+  organization_id uuid,
+  created_at timestamptz,
+  last_login_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+STABLE
+SET search_path = public, app, pg_temp
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  is_super_admin boolean := public.current_user_is_super_admin();
+  limit_value integer := GREATEST(p_limit, 1);
+  offset_value integer := GREATEST(p_offset, 0);
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '28000', MESSAGE = 'Authentication required';
+  END IF;
+
+  IF NOT is_super_admin THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Only super administrators can view employee users';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.email,
+    p.first_name,
+    p.last_name,
+    p.full_name,
+    p.title,
+    effective_role.role,
+    p.is_active,
+    p.organization_id,
+    p.created_at,
+    p.last_login_at
+  FROM public.profiles p
+  JOIN LATERAL (
+    SELECT r.name::public.role_type AS role
+    FROM public.user_roles ur
+    JOIN public.roles r ON r.id = ur.role_id
+    WHERE ur.user_id = p.id
+      AND COALESCE(ur.is_active, true) = true
+      AND (ur.expires_at IS NULL OR ur.expires_at > now())
+      AND r.name IN ('bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin')
+    ORDER BY
+      CASE r.name
+        WHEN 'super_admin' THEN 8
+        WHEN 'bcba' THEN 7
+        WHEN 'admin' THEN 6
+        WHEN 'admin_schedule' THEN 5
+        WHEN 'midtier' THEN 4
+        WHEN 'therapist' THEN 3
+        WHEN 'bt' THEN 2
+        ELSE 0
+      END DESC
+    LIMIT 1
+  ) effective_role ON true
+  WHERE effective_role.role <> 'client'::public.role_type
+    AND (p_organization_id IS NULL OR p.organization_id = p_organization_id)
+  ORDER BY
+    p.last_name ASC NULLS LAST,
+    p.first_name ASC NULLS LAST,
+    p.email ASC
+  LIMIT limit_value
+  OFFSET offset_value;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_user_role_from_junction(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_employee_users_paged(uuid, integer, integer) TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/tests/edge/auth-middleware.role-resolution.test.ts
+++ b/tests/edge/auth-middleware.role-resolution.test.ts
@@ -14,6 +14,24 @@ describe('auth middleware org-scoped admin role resolution', () => {
     vi.resetModules();
   });
 
+  it('keeps super-admin-only route options restricted to super_admin', async () => {
+    const module = await import('../../supabase/functions/_shared/auth-middleware.ts');
+
+    expect(module.RouteOptions.superAdmin.allowedRoles).toEqual(['super_admin']);
+    expect(module.requireSuperAdmin().allowedRoles).toEqual(['super_admin']);
+  });
+
+  it('prefers super_admin over bcba when both active canonical grants are present', async () => {
+    const module = await import('../../supabase/functions/_shared/auth-middleware.ts');
+
+    expect(
+      module.__TESTING__.resolveRoleFromRoleRows([
+        { is_active: true, roles: { name: 'bcba' } },
+        { is_active: true, roles: { name: 'super_admin' } },
+      ]),
+    ).toBe('super_admin');
+  });
+
   it('does not elevate org-scoped alias rows when organization context is missing', async () => {
     const module = await import('../../supabase/functions/_shared/auth-middleware.ts');
 

--- a/tests/employee-role-capability-matrix-migration.test.ts
+++ b/tests/employee-role-capability-matrix-migration.test.ts
@@ -33,6 +33,12 @@ const BCBA_EXACT_CAPABILITY_MIGRATION_PATH = path.join(
   'migrations',
   '20260706023600_bcba_exact_capability_matrix.sql',
 );
+const SUPER_ADMIN_PRECEDENCE_MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260707121500_super_admin_bcba_role_precedence.sql',
+);
 const SMOKE_SQL_PATH = path.join(process.cwd(), 'tests', 'sql', 'employee_role_capability_smoke.sql');
 
 const sql = readFileSync(MIGRATION_PATH, 'utf8');
@@ -40,6 +46,7 @@ const exposeProgramGoalRpcSql = readFileSync(EXPOSE_PROGRAM_GOAL_RPC_MIGRATION_P
 const employeeRoleListingSql = readFileSync(EMPLOYEE_ROLE_LISTING_MIGRATION_PATH, 'utf8');
 const employeeRoleListingGrantsSql = readFileSync(EMPLOYEE_ROLE_LISTING_GRANTS_MIGRATION_PATH, 'utf8');
 const bcbaExactCapabilitySql = readFileSync(BCBA_EXACT_CAPABILITY_MIGRATION_PATH, 'utf8');
+const superAdminPrecedenceSql = readFileSync(SUPER_ADMIN_PRECEDENCE_MIGRATION_PATH, 'utf8');
 const smokeSql = readFileSync(SMOKE_SQL_PATH, 'utf8');
 
 const extractFunctionFrom = (sourceSql: string, name: string): string => {
@@ -52,6 +59,8 @@ const extractFunctionFrom = (sourceSql: string, name: string): string => {
 
 const extractFunction = (name: string): string => extractFunctionFrom(sql, name);
 const extractBcbaExactFunction = (name: string): string => extractFunctionFrom(bcbaExactCapabilitySql, name);
+const extractSuperAdminPrecedenceFunction = (name: string): string =>
+  extractFunctionFrom(superAdminPrecedenceSql, name);
 
 describe('employee role capability matrix migration', () => {
   it('keeps bt and midtier out of broad therapist/org_member helper aliases', () => {
@@ -185,6 +194,16 @@ describe('employee role capability matrix migration', () => {
     expect(employeeRoleListingSql).toContain('(ur.expires_at IS NULL OR ur.expires_at > now())');
     expect(employeeRoleListingSql).toContain('effective_role.role');
     expect(employeeRoleListingSql).not.toContain('WHERE p.role <>');
+  });
+
+  it('adds a follow-up migration that makes super_admin outrank bcba in junction and listing helpers', () => {
+    const junctionRoleFunction = extractSuperAdminPrecedenceFunction('public.get_user_role_from_junction');
+    const employeeListingFunction = extractSuperAdminPrecedenceFunction('public.get_employee_users_paged');
+
+    expect(junctionRoleFunction).toContain("WHEN 'super_admin' THEN 8");
+    expect(junctionRoleFunction).toContain("WHEN 'bcba' THEN 7");
+    expect(employeeListingFunction).toContain("WHEN 'super_admin' THEN 8");
+    expect(employeeListingFunction).toContain("WHEN 'bcba' THEN 7");
   });
 
   it('restricts employee listing RPC execution to authenticated callers', () => {


### PR DESCRIPTION
## Summary
- restrict edge `superAdmin` route options to `super_admin` so BCBA no longer qualifies for super-admin-only functions
- add a follow-up migration that breaks the SQL precedence tie so `public.get_user_role_from_junction` and `public.get_employee_users_paged` prefer `super_admin` over `bcba`
- lock the behavior with focused middleware and migration regression tests

## Verification
- `npx vitest run tests/edge/auth-middleware.role-resolution.test.ts`
- `npx vitest run tests/employee-role-capability-matrix-migration.test.ts`
- `npm run verify:local`
- `npm run validate:tenant`
- `npm run ci:playwright` *(fails in hosted auth smoke: `superadmin@test.com` login returns `Invalid email or password` before the rest of the suite runs)*

## Risk
- Protected-path change limited to shared edge super-admin gating plus the two SQL precedence helpers; downstream SQL helpers from `20260706023600_bcba_exact_capability_matrix.sql` remain unchanged.
