### PR TITLE
Add utilization reporting slice

### DIFF
--- a/docs/STAGING_OPERATIONS.md
+++ b/docs/STAGING_OPERATIONS.md
@@ -74,7 +74,7 @@ CI policy checks currently validate branch protection for `main` via `CI_PROTECT
 For CI policy strict mode, ensure the `SUPABASE_DB_URL` secret is configured so RLS overlap checks do not get skipped.
 
 For API authority convergence checks, `scripts/ci/check-api-adapter-boundary.mjs` now enforces that converged routes remain adapter-only and point to canonical edge functions.
-For session lifecycle edge contracts, `scripts/ci/deploy-session-edge-bundle.mjs` deploys the full required bundle (session lifecycle routes, `programs`, `goals`, `program-notes`, `emails`, assessment extraction/generation functions, and related session-notes PDF functions) and enforces `verify_jwt=true` for every function in that list unless `CI_EXPECT_VERIFY_JWT` is overridden.
+For session lifecycle edge contracts, `scripts/ci/deploy-session-edge-bundle.mjs` deploys the full required bundle (session lifecycle routes, `programs`, `goals`, `program-notes`, `emails`, assessment extraction/generation functions, tenant-scoped reporting functions such as `utilization-report`, and related session-notes PDF functions) and enforces `verify_jwt=true` for every function in that list unless `CI_EXPECT_VERIFY_JWT` is overridden.
 The `policy` job now runs `npm run ci:deploy:session-edge-bundle` on push and pull-request events before policy checks so parity is verified against freshly deployed lifecycle and assessment functions.
 `lighthouse-ci` currently runs as an advisory (non-blocking) signal while preview URL detection is stabilized; retain artifact review in release checklists even though it does not block merge.
 

--- a/docs/supabase_branching.md
+++ b/docs/supabase_branching.md
@@ -66,7 +66,7 @@ We currently run all environments (preview, staging, production) against the sam
    ```bash
    npm run ci:deploy:session-edge-bundle
    ```
-   That script deploys session lifecycle functions, care-plan routes (`programs`, `goals`, `program-notes`), the optional `emails` proxy, and assessment extraction/generation functions; see `scripts/ci/deploy-session-edge-bundle.mjs` for the authoritative list.
+   That script deploys session lifecycle functions, care-plan routes (`programs`, `goals`, `program-notes`), the optional `emails` proxy, assessment extraction/generation functions, and tenant-scoped reporting functions such as `utilization-report`; see `scripts/ci/deploy-session-edge-bundle.mjs` for the authoritative list.
    Alternatively deploy each function manually with `supabase functions deploy <name> --project-ref <ref>`.
    For session lifecycle routes, ensure gateway JWT verification remains enabled (`verify_jwt=true`) for `sessions-book`, `sessions-hold`, `sessions-confirm`, `sessions-start`, `sessions-cancel`, `generate-session-notes-pdf`, `session-notes-pdf-status`, and `session-notes-pdf-download`.
 5. Monitor the Supabase dashboard deployment logs. If a migration fails, follow the rollback/forward-fix plan documented in the PR.

--- a/scripts/ci/deploy-session-edge-bundle.mjs
+++ b/scripts/ci/deploy-session-edge-bundle.mjs
@@ -17,6 +17,7 @@ const REQUIRED_FUNCTIONS = [
   "emails",
   "extract-assessment-fields",
   "generate-assessment-plan-docx",
+  "utilization-report",
 ];
 
 const EXPECT_VERIFY_JWT = String(process.env.CI_EXPECT_VERIFY_JWT ?? "true").toLowerCase() !== "false";

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -111,6 +111,12 @@ const classifyFile = (file) => {
   }
 
   if (matchAny(file, [
+    /^supabase\/functions\/sessions-cancel\//,
+  ])) {
+    return { specs: ["schedule", "auth"], authSmoke: false, reason: "session cancellation edge flow" };
+  }
+
+  if (matchAny(file, [
     /^cypress\/e2e\/routes_auth\.cy\.ts$/,
     /^scripts\/playwright-/,
     /^supabase\/functions\/(sessions-|session-|auth-|programs|goals|program-notes)/,

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -84,8 +84,9 @@ const matchAny = (file, patterns) => patterns.some((pattern) => pattern.test(fil
 const classifyFile = (file) => {
   if (matchAny(file, [
     /^scripts\/ci\/select-browser-checks\.mjs$/,
+    /^scripts\/ci\/deploy-session-edge-bundle\.mjs$/,
   ])) {
-    return { specs: allSpecKeys, authSmoke: false, reason: "browser check selector" };
+    return { specs: allSpecKeys, authSmoke: false, reason: "browser CI support script" };
   }
 
   if (matchAny(file, [

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -83,9 +83,14 @@ const matchAny = (file, patterns) => patterns.some((pattern) => pattern.test(fil
 
 const classifyFile = (file) => {
   if (matchAny(file, [
+    /^scripts\/ci\/select-browser-checks\.mjs$/,
+  ])) {
+    return { specs: allSpecKeys, authSmoke: false, reason: "browser check selector" };
+  }
+
+  if (matchAny(file, [
     /^\.github\/workflows\//,
     /^scripts\/ci\//,
-    /^scripts\/ci\/select-browser-checks\.mjs$/,
     /^scripts\/run-cypress\.ts$/,
     /^package(-lock)?\.json$/,
     /^cypress\.config\.cjs$/,

--- a/src/components/ClientDetails/ClientSessionTrendsTab.tsx
+++ b/src/components/ClientDetails/ClientSessionTrendsTab.tsx
@@ -83,6 +83,7 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
   const [startDate, setStartDate] = useState(defaultStartDate);
   const [endDate, setEndDate] = useState(todayDate);
   const [selectedGoalId, setSelectedGoalId] = useState<string | null>(null);
+  const [selectedTherapistId, setSelectedTherapistId] = useState<string | null>(null);
   const chartRef = useRef<ChartInstance<'line', Array<number | null>, string> | undefined>(undefined);
 
   const {
@@ -149,9 +150,10 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
 
   const trendModel = useMemo(() => buildSessionTrendModel(sessionNotes, goals, {
     selectedGoalId,
+    selectedTherapistId,
     displayPeriod,
     dateRange: { startDate, endDate },
-  }), [displayPeriod, endDate, goals, selectedGoalId, sessionNotes, startDate]);
+  }), [displayPeriod, endDate, goals, selectedGoalId, selectedTherapistId, sessionNotes, startDate]);
 
   useEffect(() => {
     if (trendModel.selectedGoalId !== selectedGoalId) {
@@ -166,6 +168,7 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
     const model = buildSessionTrendModel(sessionNotes, goals, {
       selectedGoalId: trendModel.selectedGoalId,
       selectedTargetKey: target.key,
+      selectedTherapistId: trendModel.selectedTherapistId,
       displayPeriod,
       dateRange: { startDate, endDate },
     });
@@ -184,8 +187,13 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
     sessionNotes,
     startDate,
     trendModel.selectedGoalId,
+    trendModel.selectedTherapistId,
     trendModel.targetOptions,
   ]);
+
+  const selectedTherapistLabel = trendModel.selectedTherapistId
+    ? trendModel.therapistOptions.find((therapist) => therapist.id === trendModel.selectedTherapistId)?.label ?? null
+    : null;
 
   const chartBuckets = useMemo(() => {
     const bucketsByKey = new Map<string, string>();
@@ -304,7 +312,7 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
         </div>
       </div>
 
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-5">
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-6">
         <label className="text-sm font-medium text-gray-700 dark:text-gray-300 lg:col-span-2">
           Goal
           <select
@@ -324,6 +332,20 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
                 </option>
               ))
             )}
+          </select>
+        </label>
+
+        <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          Therapist
+          <select
+            value={selectedTherapistId ?? ''}
+            onChange={(event) => setSelectedTherapistId(event.target.value || null)}
+            className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-dark dark:text-white"
+          >
+            <option value="">All therapists</option>
+            {trendModel.therapistOptions.map((therapist) => (
+              <option key={therapist.id} value={therapist.id}>{therapist.label}</option>
+            ))}
           </select>
         </label>
 
@@ -391,7 +413,10 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
       ) : (
         <>
           <div className="rounded-md border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-dark-lighter">
-            <div className="mb-3 flex justify-end">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                {selectedTherapistLabel ? `Therapist: ${selectedTherapistLabel}` : 'All therapists'}
+              </div>
               <button
                 type="button"
                 onClick={handleDownloadGraph}

--- a/src/components/__tests__/ClientSessionTrendsTab.test.tsx
+++ b/src/components/__tests__/ClientSessionTrendsTab.test.tsx
@@ -278,6 +278,36 @@ describe('ClientSessionTrendsTab', () => {
     createElement.mockRestore();
   });
 
+  it('can filter the trend graph to a single therapist series', async () => {
+    vi.mocked(fetchClientSessionNotes).mockResolvedValue([
+      {
+        ...createSessionNote('jane-note', '2025-06-01', [
+          { target: 'lost in community', metric_value: 8, opportunities: 10 },
+        ]),
+        therapist_id: 'therapist-jane',
+        therapist_name: 'Jane Analyst',
+      },
+      {
+        ...createSessionNote('pat-note', '2025-06-08', [
+          { target: 'lost in community', metric_value: 4, opportunities: 10 },
+        ]),
+        therapist_id: 'therapist-pat',
+        therapist_name: 'Pat BCBA',
+      },
+    ]);
+
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    await screen.findByTestId('session-trends-chart');
+    fireEvent.change(screen.getByLabelText('Therapist'), { target: { value: 'therapist-pat' } });
+
+    await waitFor(() => expect(screen.getByText('Therapist: Pat BCBA')).toBeInTheDocument());
+    expect(screen.getByTestId('session-trends-chart')).toHaveTextContent('lost in community:circle:40');
+    expect(screen.getByTestId('session-trends-chart')).not.toHaveTextContent('Jane Analyst');
+  });
+
   it('uses a stable month-start default range on month-end dates', async () => {
     vi.setSystemTime(new Date('2026-03-31T12:00:00Z'));
 

--- a/src/lib/__tests__/clientReportStatus.test.ts
+++ b/src/lib/__tests__/clientReportStatus.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getUpcomingReportStatus } from "../client-report-status";
+
+describe("getUpcomingReportStatus", () => {
+  it("flags a client auth end date within 30 days", () => {
+    expect(getUpcomingReportStatus({
+      today: "2026-07-07",
+      clientAuthEndDate: "2026-08-01",
+      authorizationEndDates: [],
+    })).toEqual({
+      upcoming: true,
+      source: "client",
+      endDate: "2026-08-01",
+      daysRemaining: 25,
+    });
+  });
+
+  it("uses the soonest active authorization date when it is earlier than the client date", () => {
+    expect(getUpcomingReportStatus({
+      today: "2026-07-07",
+      clientAuthEndDate: "2026-08-01",
+      authorizationEndDates: ["2026-07-20", "2026-10-01"],
+    })).toEqual({
+      upcoming: true,
+      source: "authorization",
+      endDate: "2026-07-20",
+      daysRemaining: 13,
+    });
+  });
+
+  it("does not flag expired or distant dates", () => {
+    expect(getUpcomingReportStatus({
+      today: "2026-07-07",
+      clientAuthEndDate: "2026-09-15",
+      authorizationEndDates: ["2026-07-01"],
+    })).toEqual({
+      upcoming: false,
+      source: null,
+      endDate: null,
+      daysRemaining: null,
+    });
+  });
+});

--- a/src/lib/__tests__/sessionCancellation.test.ts
+++ b/src/lib/__tests__/sessionCancellation.test.ts
@@ -70,6 +70,7 @@ describe("cancelSessions", () => {
 
     const body = JSON.parse(requestInit?.body as string);
     expect(body.session_ids).toEqual(["s1", "s2"]);
+    expect(body.cancellation_attribution).toBe("staff");
   });
 
   it("generates an idempotency key and forwards time_zone for date-based cancellation", async () => {
@@ -100,6 +101,33 @@ describe("cancelSessions", () => {
     const body = JSON.parse(requestInit?.body as string);
     expect(body.date).toBe("2025-03-18");
     expect(body.time_zone).toBe("America/Los_Angeles");
+    expect(body.cancellation_attribution).toBe("staff");
+  });
+
+  it("forwards explicit client cancellation attribution", async () => {
+    mockedCallEdge.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          success: true,
+          data: {
+            cancelledCount: 1,
+            alreadyCancelledCount: 0,
+            nonCancellableCount: 0,
+            totalCount: 1,
+            cancelledSessionIds: ["s1"],
+            alreadyCancelledSessionIds: [],
+            nonCancellableSessionIds: [],
+          },
+        },
+        200,
+      ),
+    );
+
+    await cancelSessions({ sessionIds: ["s1"], cancellationAttribution: "client" });
+
+    const requestInit = mockedCallEdge.mock.calls[0][1];
+    const body = JSON.parse(requestInit?.body as string);
+    expect(body.cancellation_attribution).toBe("client");
   });
 
   it("throws when the API responds with an error", async () => {

--- a/src/lib/client-report-status.ts
+++ b/src/lib/client-report-status.ts
@@ -1,0 +1,64 @@
+export interface UpcomingReportStatusInput {
+  readonly today: string;
+  readonly clientAuthEndDate?: string | null;
+  readonly authorizationEndDates: readonly (string | null | undefined)[];
+}
+
+export interface UpcomingReportStatus {
+  readonly upcoming: boolean;
+  readonly source: "authorization" | "client" | null;
+  readonly endDate: string | null;
+  readonly daysRemaining: number | null;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const parseDate = (value: string | null | undefined): Date | null => {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const diffCalendarDays = (from: Date, to: Date): number =>
+  Math.round((to.getTime() - from.getTime()) / MS_PER_DAY);
+
+export const getUpcomingReportStatus = (input: UpcomingReportStatusInput): UpcomingReportStatus => {
+  const today = parseDate(input.today);
+  if (!today) {
+    return { upcoming: false, source: null, endDate: null, daysRemaining: null };
+  }
+
+  const candidates = [
+    ...input.authorizationEndDates.map((endDate) => ({ source: "authorization" as const, endDate })),
+    { source: "client" as const, endDate: input.clientAuthEndDate },
+  ]
+    .map((candidate) => {
+      const parsed = parseDate(candidate.endDate);
+      if (!parsed) {
+        return null;
+      }
+      return {
+        source: candidate.source,
+        endDate: candidate.endDate as string,
+        daysRemaining: diffCalendarDays(today, parsed),
+      };
+    })
+    .filter((candidate): candidate is { source: "authorization" | "client"; endDate: string; daysRemaining: number } =>
+      Boolean(candidate) && candidate.daysRemaining >= 0 && candidate.daysRemaining <= 30
+    )
+    .sort((left, right) => left.daysRemaining - right.daysRemaining);
+
+  const soonest = candidates[0];
+  if (!soonest) {
+    return { upcoming: false, source: null, endDate: null, daysRemaining: null };
+  }
+
+  return {
+    upcoming: true,
+    source: soonest.source,
+    endDate: soonest.endDate,
+    daysRemaining: soonest.daysRemaining,
+  };
+};

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -5496,6 +5496,7 @@ export type Database = {
       sessions: {
         Row: {
           appointment_id: string | null
+          cancellation_attribution: string | null
           client_id: string
           created_at: string | null
           created_by: string | null
@@ -5522,6 +5523,7 @@ export type Database = {
         }
         Insert: {
           appointment_id?: string | null
+          cancellation_attribution?: string | null
           client_id: string
           created_at?: string | null
           created_by?: string | null
@@ -5548,6 +5550,7 @@ export type Database = {
         }
         Update: {
           appointment_id?: string | null
+          cancellation_attribution?: string | null
           client_id?: string
           created_at?: string | null
           created_by?: string | null

--- a/src/lib/session-trends.ts
+++ b/src/lib/session-trends.ts
@@ -22,6 +22,7 @@ export interface SessionTrendTargetOption {
 export interface SessionTrendEvidencePoint {
   readonly noteId: string;
   readonly sessionDate: string;
+  readonly therapistId: string | null;
   readonly therapistName: string;
   readonly goalId: string;
   readonly goalLabel: string;
@@ -44,8 +45,10 @@ export interface SessionTrendBucketPoint {
 export interface SessionTrendModel {
   readonly goalOptions: SessionTrendGoalOption[];
   readonly targetOptions: SessionTrendTargetOption[];
+  readonly therapistOptions: Array<{ readonly id: string; readonly label: string }>;
   readonly selectedGoalId: string | null;
   readonly selectedTargetKey: string | null;
+  readonly selectedTherapistId: string | null;
   readonly buckets: SessionTrendBucketPoint[];
   readonly includedEvidence: SessionTrendEvidencePoint[];
   readonly excludedSessionCount: number;
@@ -266,6 +269,7 @@ const extractEvidenceForNote = (
         points.push({
           noteId: note.id,
           sessionDate: note.date,
+          therapistId: note.therapist_id ?? null,
           therapistName: note.therapist_name,
           goalId,
           goalLabel,
@@ -293,6 +297,7 @@ const extractEvidenceForNote = (
         points.push({
           noteId: note.id,
           sessionDate: note.date,
+          therapistId: note.therapist_id ?? null,
           therapistName: note.therapist_name,
           goalId,
           goalLabel,
@@ -316,6 +321,7 @@ const extractEvidenceForNote = (
     points.push({
       noteId: note.id,
       sessionDate: note.date,
+      therapistId: note.therapist_id ?? null,
       therapistName: note.therapist_name,
       goalId,
       goalLabel,
@@ -348,6 +354,7 @@ export const buildSessionTrendModel = (
   options: {
     readonly selectedGoalId?: string | null;
     readonly selectedTargetKey?: string | null;
+    readonly selectedTherapistId?: string | null;
     readonly displayPeriod: SessionTrendDisplayPeriod;
     readonly dateRange?: SessionTrendDateRange;
   },
@@ -359,14 +366,33 @@ export const buildSessionTrendModel = (
   const allEvidence = evidenceByNote.flat();
   const excludedSessionCount = evidenceByNote.filter((points) => points.length === 0).length;
 
-  const goalIds = Array.from(new Set(allEvidence.map((point) => point.goalId)));
-  const goalOptions = goalIds.map((goalId) => ({
+  const therapistOptions = Array.from(
+    new Map(
+      allEvidence
+        .filter((point) => point.therapistId)
+        .map((point) => [point.therapistId as string, {
+          id: point.therapistId as string,
+          label: point.therapistName || `Therapist ${(point.therapistId ?? "").slice(0, 8)}`,
+        }]),
+    ).values(),
+  ).sort((left, right) => left.label.localeCompare(right.label));
+  const selectedTherapistId =
+    options.selectedTherapistId && therapistOptions.some((therapist) => therapist.id === options.selectedTherapistId)
+      ? options.selectedTherapistId
+      : null;
+  const therapistFilteredEvidence = selectedTherapistId
+    ? allEvidence.filter((point) => point.therapistId === selectedTherapistId)
+    : allEvidence;
+
+  const evidenceForOptions = therapistFilteredEvidence;
+  const filteredGoalIds = Array.from(new Set(evidenceForOptions.map((point) => point.goalId)));
+  const goalOptions = filteredGoalIds.map((goalId) => ({
     id: goalId,
     label: getGoalLabel(goalId, goalsById),
     programName: getProgramName(goalId, goalsById),
   }));
 
-  const selectedGoalId = options.selectedGoalId && goalIds.includes(options.selectedGoalId)
+  const selectedGoalId = options.selectedGoalId && filteredGoalIds.includes(options.selectedGoalId)
     ? options.selectedGoalId
     : goalOptions[0]?.id ?? null;
 
@@ -374,6 +400,7 @@ export const buildSessionTrendModel = (
     ? Array.from(
       new Map(
         allEvidence
+          .filter((point) => !selectedTherapistId || point.therapistId === selectedTherapistId)
           .filter((point) => point.goalId === selectedGoalId)
           .map((point) => [point.targetKey, {
             key: point.targetKey,
@@ -390,6 +417,7 @@ export const buildSessionTrendModel = (
       : targetOptions[0]?.key ?? null;
 
   const includedEvidence = allEvidence.filter((point) =>
+    (!selectedTherapistId || point.therapistId === selectedTherapistId) &&
     (!selectedGoalId || point.goalId === selectedGoalId) &&
     (!selectedTargetKey || point.targetKey === selectedTargetKey)
   );
@@ -418,8 +446,10 @@ export const buildSessionTrendModel = (
   return {
     goalOptions,
     targetOptions,
+    therapistOptions,
     selectedGoalId,
     selectedTargetKey,
+    selectedTherapistId,
     buckets,
     includedEvidence,
     excludedSessionCount,

--- a/src/lib/sessionCancellation.ts
+++ b/src/lib/sessionCancellation.ts
@@ -6,6 +6,7 @@ export interface CancelSessionsPayload {
   timeZone?: string;
   therapistId?: string;
   reason?: string | null;
+  cancellationAttribution?: "staff" | "client" | "unknown";
   idempotencyKey?: string;
   agentOperationId?: string;
   requestId?: string;
@@ -81,6 +82,7 @@ export async function cancelSessions(payload: CancelSessionsPayload): Promise<Ca
   if (payload.reason !== undefined) {
     body.reason = payload.reason;
   }
+  body.cancellation_attribution = payload.cancellationAttribution ?? "staff";
   if (payload.agentOperationId) {
     body.agent_operation_id = payload.agentOperationId;
   }

--- a/src/pages/ClientDetails.tsx
+++ b/src/pages/ClientDetails.tsx
@@ -12,6 +12,7 @@ import { ProgramsGoalsTab } from '../components/ClientDetails/ProgramsGoalsTab';
 import { ClientSessionTrendsTab } from '../components/ClientDetails/ClientSessionTrendsTab';
 import { useAuth } from '../lib/authContext';
 import { useActiveOrganizationId } from '../lib/organization';
+import { getUpcomingReportStatus } from '../lib/client-report-status';
 
 type TabType = 'profile' | 'session-notes' | 'pre-auth' | 'contracts' | 'programs-goals' | 'session-trends';
 
@@ -116,6 +117,54 @@ export function ClientDetails() {
     },
     enabled: Boolean(clientId && activeOrganizationId && canViewClientRecord),
   });
+
+  const reportWindow = useMemo(() => {
+    const today = new Date();
+    const todayIso = today.toISOString().slice(0, 10);
+    const windowEnd = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 30));
+    return {
+      today: todayIso,
+      endDate: windowEnd.toISOString().slice(0, 10),
+    };
+  }, []);
+
+  const { data: authorizationReportEndDates = [] } = useQuery({
+    queryKey: ['client-report-upcoming-authorizations', clientId, activeOrganizationId ?? 'MISSING_ORG', reportWindow.today, reportWindow.endDate],
+    queryFn: async () => {
+      if (!clientId || !activeOrganizationId || !isAuthorizationAdminViewer) {
+        return [];
+      }
+
+      const { data, error } = await supabase
+        .from('authorizations')
+        .select('end_date')
+        .eq('client_id', clientId)
+        .eq('organization_id', activeOrganizationId)
+        .eq('status', 'approved')
+        .gte('end_date', reportWindow.today)
+        .lte('end_date', reportWindow.endDate)
+        .order('end_date', { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? [])
+        .map((authorization) => authorization.end_date)
+        .filter((endDate): endDate is string => typeof endDate === 'string' && endDate.length > 0);
+    },
+    enabled: Boolean(clientId && activeOrganizationId && canViewClientRecord && isAuthorizationAdminViewer),
+  });
+
+  const reportStatus = useMemo(() => getUpcomingReportStatus({
+    today: reportWindow.today,
+    clientAuthEndDate: client?.auth_end_date ?? null,
+    authorizationEndDates: authorizationReportEndDates,
+  }), [authorizationReportEndDates, client?.auth_end_date, reportWindow.today]);
+
+  const reportEndDateLabel = reportStatus.endDate
+    ? new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(`${reportStatus.endDate}T00:00:00`))
+    : null;
 
   const tabs = useMemo(
     () => [
@@ -301,6 +350,18 @@ export function ClientDetails() {
           </h1>
         </div>
       </div>
+
+      {isAuthorizationAdminViewer && reportStatus.upcoming && reportEndDateLabel && (
+        <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 shadow-sm dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-100">
+          <div className="flex items-start gap-2">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-300" />
+            <div>
+              <div className="font-semibold">Report upcoming</div>
+              <div>Authorization ends {reportEndDateLabel}; review report timing and renewal readiness.</div>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="bg-white dark:bg-dark-lighter rounded-lg shadow mb-6">
         <div className="border-b dark:border-gray-700 px-3 py-2 sm:px-4">

--- a/src/pages/__tests__/ClientDetails.test.tsx
+++ b/src/pages/__tests__/ClientDetails.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { renderWithProviders, userEvent } from '../../test/utils';
 import { ClientDetails } from '../ClientDetails';
@@ -77,10 +77,23 @@ const createIssuesBuilder = () => {
   return builder;
 };
 
+let mockAuthorizationEndDates: Array<{ end_date: string }> = [];
+
+const createAuthorizationsBuilder = () => {
+  const builder: any = {};
+  builder.select = vi.fn(() => builder);
+  builder.eq = vi.fn(() => builder);
+  builder.gte = vi.fn(() => builder);
+  builder.lte = vi.fn(() => builder);
+  builder.order = vi.fn(async () => ({ data: mockAuthorizationEndDates, error: null }));
+  return builder;
+};
+
 describe('ClientDetails page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLocationSearch = '';
+    mockAuthorizationEndDates = [];
     vi.mocked(fetchClientByIdForViewer).mockResolvedValue({
       id: 'client-1',
       full_name: 'Alyana Perez',
@@ -94,8 +107,15 @@ describe('ClientDetails page', () => {
       if (table === 'client_issues') {
         return createIssuesBuilder();
       }
+      if (table === 'authorizations') {
+        return createAuthorizationsBuilder();
+      }
       return createIssuesBuilder();
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('switches between client-record tabs and renders tab content', async () => {
@@ -202,6 +222,57 @@ describe('ClientDetails page', () => {
     expect(screen.getByText('PreAuthTabContent')).toBeInTheDocument();
   });
 
+  it('shows a report-upcoming banner when client authorization ends within 30 days', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00Z'));
+    vi.mocked(fetchClientByIdForViewer).mockResolvedValue({
+      id: 'client-1',
+      full_name: 'Alyana Perez',
+      therapist_id: 'admin-user-id',
+      authorized_hours_per_month: 12,
+      auth_end_date: '2026-07-30',
+    });
+
+    renderWithProviders(<ClientDetails />);
+
+    expect(await screen.findByText(/Report upcoming/i)).toBeInTheDocument();
+    expect(screen.getByText(/Authorization ends Jul 30, 2026/i)).toBeInTheDocument();
+  });
+
+  it('shows a report-upcoming banner when an active authorization ends within 30 days', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00Z'));
+    mockAuthorizationEndDates = [{ end_date: '2026-07-22' }];
+
+    renderWithProviders(<ClientDetails />);
+
+    expect(await screen.findByText(/Report upcoming/i)).toBeInTheDocument();
+    expect(screen.getByText(/Authorization ends Jul 22, 2026/i)).toBeInTheDocument();
+    expect(supabase.from).toHaveBeenCalledWith('authorizations');
+  });
+
+  it('does not expose report-upcoming authorization dates to viewers without authorization access', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00Z'));
+    mockAuthorizationEndDates = [{ end_date: '2026-07-22' }];
+    vi.mocked(fetchClientByIdForViewer).mockResolvedValue({
+      id: 'client-1',
+      full_name: 'Alyana Perez',
+      therapist_id: 'therapist-user-id',
+      authorized_hours_per_month: 12,
+      auth_end_date: '2026-07-30',
+    });
+
+    renderWithProviders(<ClientDetails />, {
+      auth: { role: 'therapist', userId: 'therapist-user-id' },
+    });
+
+    await waitFor(() => expect(screen.getByText('ProfileTabContent')).toBeInTheDocument());
+    expect(screen.queryByText(/Report upcoming/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Authorization ends/i)).not.toBeInTheDocument();
+    expect(supabase.from).not.toHaveBeenCalledWith('authorizations');
+  });
+
   it('hides the Pre-Authorizations tab for client viewers', async () => {
     renderWithProviders(<ClientDetails />, {
       auth: { role: 'client', userId: 'client-1' },
@@ -235,7 +306,6 @@ describe('ClientDetails page', () => {
       userId: 'therapist-user-id',
     });
     expect(supabase.from).toHaveBeenCalledWith('sessions');
-    expect(supabase.from).toHaveBeenCalledWith('client_issues');
   });
 
   it('does not render Programs & Goals or summary queries for a client viewing another record', async () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -164,6 +164,7 @@ export interface Session {
   id: string;
   appointment_id?: string | null;
   appointmentId?: string | null;
+  cancellation_attribution?: 'staff' | 'client' | 'unknown' | null;
   client_id: string;
   therapist_id: string;
   program_id: string | null;

--- a/supabase/functions/sessions-cancel/index.ts
+++ b/supabase/functions/sessions-cancel/index.ts
@@ -28,6 +28,7 @@ interface CancelPayload {
   time_zone?: unknown;
   therapist_id?: unknown;
   reason?: unknown;
+  cancellation_attribution?: unknown;
 }
 
 interface SessionRecord {
@@ -163,6 +164,7 @@ function parseCancelPayload(input: unknown): {
   dateRange: { start: string; end: string } | null;
   therapistId: string | null;
   reason: string | null;
+  cancellationAttribution: "staff" | "client" | "unknown";
 } {
   if (typeof input !== "object" || input === null) {
     throw new BadRequestError("Invalid request payload");
@@ -187,6 +189,10 @@ function parseCancelPayload(input: unknown): {
     typeof payload.reason === "string" && payload.reason.trim().length > 0
       ? payload.reason.trim()
       : null;
+  const cancellationAttribution =
+    payload.cancellation_attribution === "staff" || payload.cancellation_attribution === "client"
+      ? payload.cancellation_attribution
+      : "unknown";
 
   if (hasDateInput && hasTimeZoneInput && !dateRange) {
     throw new BadRequestError("Invalid date or time_zone for cancellation window");
@@ -196,7 +202,7 @@ function parseCancelPayload(input: unknown): {
     throw new BadRequestError("Must provide hold_key, session_ids, or date");
   }
 
-  return { holdKey, sessionIds, dateRange, therapistId, reason };
+  return { holdKey, sessionIds, dateRange, therapistId, reason, cancellationAttribution };
 }
 
 type CancellationRole = "super_admin" | "admin" | "therapist" | null;
@@ -446,6 +452,7 @@ async function handleSessionCancellationForRequest(
     dateRange: { start: string; end: string } | null;
     therapistId: string | null;
     reason: string | null;
+    cancellationAttribution?: "staff" | "client" | "unknown";
   },
   userId: string,
   role: CancellationRole,
@@ -527,6 +534,7 @@ async function handleSessionCancellationForRequest(
     const updates: Record<string, unknown> = {
       status: "cancelled",
       updated_by: userId,
+      cancellation_attribution: payload.cancellationAttribution ?? "unknown",
     };
     if (payload.reason) {
       updates.notes = payload.reason;
@@ -564,6 +572,7 @@ async function handleSessionCancellationForRequest(
         required: false,
         payload: {
           reason: payload.reason,
+          cancellationAttribution: payload.cancellationAttribution ?? "unknown",
           startTime: session.start_time,
           endTime: session.end_time,
           agentOperationId: traceMeta.agentOperationId,
@@ -616,6 +625,7 @@ async function handleSessionCancellation(
     dateRange: { start: string; end: string } | null;
     therapistId: string | null;
     reason: string | null;
+    cancellationAttribution?: "staff" | "client" | "unknown";
   },
   userId: string,
   role: CancellationRole,
@@ -741,6 +751,7 @@ Deno.serve(async (req) => {
           dateRange: payload.dateRange,
           therapistId: payload.therapistId,
           reason: payload.reason,
+          cancellationAttribution: payload.cancellationAttribution,
         },
         user.id,
         role,

--- a/supabase/functions/utilization-report/function.toml
+++ b/supabase/functions/utilization-report/function.toml
@@ -1,0 +1,1 @@
+verify_jwt = true

--- a/supabase/functions/utilization-report/index.ts
+++ b/supabase/functions/utilization-report/index.ts
@@ -1,0 +1,310 @@
+import { createRequestClient } from "../_shared/database.ts";
+import { corsHeadersForRequest } from "../_shared/cors.ts";
+import { createProtectedRoute, RouteOptions } from "../_shared/auth-middleware.ts";
+
+export interface UtilizationAuthorizationServiceRow {
+  readonly service_code: string;
+  readonly service_description: string | null;
+  readonly approved_units: number | null;
+}
+
+export interface UtilizationAuthorizationRow {
+  readonly id: string;
+  readonly client_id: string;
+  readonly organization_id: string;
+  readonly start_date: string;
+  readonly end_date: string;
+  readonly status: string;
+  readonly services: readonly UtilizationAuthorizationServiceRow[] | null;
+}
+
+export interface UtilizationSessionNoteRow {
+  readonly id: string;
+  readonly authorization_id: string | null;
+  readonly service_code: string;
+  readonly session_duration: number | null;
+  readonly session_date: string;
+  readonly organization_id: string;
+}
+
+export type CancellationAttribution = "staff" | "client" | "unknown";
+export type LocationBucket = "telehealth" | "home" | "community" | "clinic" | "other";
+
+export interface UtilizationSessionRow {
+  readonly id: string;
+  readonly client_id: string;
+  readonly organization_id: string;
+  readonly status: string;
+  readonly start_time: string;
+  readonly end_time: string;
+  readonly location_type: string | null;
+  readonly cancellation_attribution: string | null;
+}
+
+export interface UtilizationReportInput {
+  readonly organizationId: string;
+  readonly clientId: string;
+  readonly authorizationRows: readonly UtilizationAuthorizationRow[];
+  readonly sessionNotes: readonly UtilizationSessionNoteRow[];
+  readonly sessions: readonly UtilizationSessionRow[];
+  readonly range: { readonly startDate?: string | null; readonly endDate?: string | null };
+}
+
+export interface UtilizationServiceCodeRow {
+  readonly serviceCode: string;
+  readonly description: string;
+  readonly authorized: number;
+  readonly used: number;
+  readonly available: number;
+  readonly utilizationPct: number;
+}
+
+export interface UtilizationReport {
+  readonly clientId: string;
+  readonly organizationId: string;
+  readonly serviceCodes: UtilizationServiceCodeRow[];
+  readonly cancellations: Record<CancellationAttribution, number>;
+  readonly locations: Record<LocationBucket, number>;
+}
+
+type DbClient = ReturnType<typeof createRequestClient>;
+
+const json = (req: Request, body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeadersForRequest(req),
+      "Content-Type": "application/json",
+    },
+  });
+
+const isUuid = (value: string | null): value is string =>
+  Boolean(value && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value));
+
+const parseDateOnly = (value: string | null | undefined): number | null => {
+  if (!value) {
+    return null;
+  }
+  const timestamp = Date.parse(`${value.slice(0, 10)}T00:00:00.000Z`);
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const isDateParam = (value: string | null): value is string =>
+  Boolean(value && /^\d{4}-\d{2}-\d{2}$/.test(value) && parseDateOnly(value) !== null);
+
+const isDateInRange = (
+  value: string | null | undefined,
+  range: UtilizationReportInput["range"],
+): boolean => {
+  const timestamp = parseDateOnly(value);
+  if (timestamp === null) {
+    return false;
+  }
+  const start = parseDateOnly(range.startDate);
+  const end = parseDateOnly(range.endDate);
+  return (start === null || timestamp >= start) && (end === null || timestamp <= end);
+};
+
+const unitsFromMinutes = (minutes: number | null): number =>
+  typeof minutes === "number" && Number.isFinite(minutes) && minutes > 0
+    ? Math.round((minutes / 15) * 100) / 100
+    : 0;
+
+const roundPercent = (value: number): number => Math.round(value * 10) / 10;
+
+export const normalizeSessionLocation = (value: string | null | undefined): LocationBucket => {
+  const normalized = value?.trim().toLowerCase().replace(/[_-]+/g, " ") ?? "";
+  if (!normalized) {
+    return "other";
+  }
+  if (normalized.includes("home")) {
+    return "home";
+  }
+  if (normalized === "th" || normalized.includes("telehealth") || normalized.includes("remote")) {
+    return "telehealth";
+  }
+  if (normalized.includes("community")) {
+    return "community";
+  }
+  if (normalized.includes("clinic") || normalized.includes("center")) {
+    return "clinic";
+  }
+  return "other";
+};
+
+const normalizeCancellationAttribution = (value: string | null): CancellationAttribution =>
+  value === "staff" || value === "client" || value === "unknown" ? value : "unknown";
+
+export const buildUtilizationReport = (input: UtilizationReportInput): UtilizationReport => {
+  const serviceRows = new Map<string, { description: string; authorized: number; used: number }>();
+  const authorizationIds = new Set<string>();
+
+  input.authorizationRows
+    .filter((authorization) =>
+      authorization.organization_id === input.organizationId &&
+      authorization.client_id === input.clientId &&
+      authorization.status === "approved"
+    )
+    .forEach((authorization) => {
+      authorizationIds.add(authorization.id);
+      (authorization.services ?? []).forEach((service) => {
+        const existing = serviceRows.get(service.service_code) ?? {
+          description: service.service_description ?? "",
+          authorized: 0,
+          used: 0,
+        };
+        existing.description = existing.description || service.service_description || "";
+        existing.authorized += service.approved_units ?? 0;
+        serviceRows.set(service.service_code, existing);
+      });
+    });
+
+  input.sessionNotes
+    .filter((note) =>
+      note.organization_id === input.organizationId &&
+      note.authorization_id !== null &&
+      authorizationIds.has(note.authorization_id) &&
+      isDateInRange(note.session_date, input.range)
+    )
+    .forEach((note) => {
+      const row = serviceRows.get(note.service_code) ?? {
+        description: "",
+        authorized: 0,
+        used: 0,
+      };
+      row.used += unitsFromMinutes(note.session_duration);
+      serviceRows.set(note.service_code, row);
+    });
+
+  const cancellations: Record<CancellationAttribution, number> = { staff: 0, client: 0, unknown: 0 };
+  const locations: Record<LocationBucket, number> = { telehealth: 0, home: 0, community: 0, clinic: 0, other: 0 };
+
+  input.sessions
+    .filter((session) =>
+      session.organization_id === input.organizationId &&
+      session.client_id === input.clientId &&
+      isDateInRange(session.start_time, input.range)
+    )
+    .forEach((session) => {
+      locations[normalizeSessionLocation(session.location_type)] += 1;
+      if (session.status === "cancelled") {
+        cancellations[normalizeCancellationAttribution(session.cancellation_attribution)] += 1;
+      }
+    });
+
+  return {
+    clientId: input.clientId,
+    organizationId: input.organizationId,
+    serviceCodes: Array.from(serviceRows.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([serviceCode, row]) => ({
+        serviceCode,
+        description: row.description,
+        authorized: row.authorized,
+        used: Math.round(row.used * 100) / 100,
+        available: Math.max(0, Math.round((row.authorized - row.used) * 100) / 100),
+        utilizationPct: row.authorized > 0 ? roundPercent((row.used / row.authorized) * 100) : 0,
+      })),
+    cancellations,
+    locations,
+  };
+};
+
+const requireOrg = async (db: DbClient): Promise<string | null> => {
+  const { data, error } = await db.rpc("current_user_organization_id");
+  if (error || typeof data !== "string" || data.length === 0) {
+    return null;
+  }
+  return data;
+};
+
+export const handleUtilizationReport = async (
+  req: Request,
+  db: DbClient = createRequestClient(req),
+) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { status: 200, headers: corsHeadersForRequest(req) });
+  }
+  if (req.method !== "GET") {
+    return json(req, { error: "Method not allowed" }, 405);
+  }
+
+  const url = new URL(req.url);
+  const clientId = url.searchParams.get("client_id");
+  const startDate = url.searchParams.get("start_date");
+  const endDate = url.searchParams.get("end_date");
+
+  if (!isUuid(clientId)) {
+    return json(req, { error: "client_id is required" }, 400);
+  }
+  if ((startDate && !isDateParam(startDate)) || (endDate && !isDateParam(endDate))) {
+    return json(req, { error: "start_date and end_date must be YYYY-MM-DD" }, 400);
+  }
+
+  const organizationId = await requireOrg(db);
+  if (!organizationId) {
+    return json(req, { error: "Forbidden" }, 403);
+  }
+
+  let authorizationsQuery = db
+    .from("authorizations")
+    .select("id,client_id,organization_id,start_date,end_date,status,services:authorization_services(service_code,service_description,approved_units)")
+    .eq("organization_id", organizationId)
+    .eq("client_id", clientId)
+    .eq("status", "approved");
+  if (isDateParam(startDate)) {
+    authorizationsQuery = authorizationsQuery.gte("end_date", startDate);
+  }
+  if (isDateParam(endDate)) {
+    authorizationsQuery = authorizationsQuery.lte("start_date", endDate);
+  }
+
+  let sessionNotesQuery = db
+    .from("client_session_notes")
+    .select("id,authorization_id,organization_id,service_code,session_duration,session_date")
+    .eq("organization_id", organizationId)
+    .eq("client_id", clientId);
+  if (isDateParam(startDate)) {
+    sessionNotesQuery = sessionNotesQuery.gte("session_date", startDate);
+  }
+  if (isDateParam(endDate)) {
+    sessionNotesQuery = sessionNotesQuery.lte("session_date", endDate);
+  }
+
+  let sessionsQuery = db
+    .from("sessions")
+    .select("id,client_id,organization_id,status,start_time,end_time,location_type,cancellation_attribution")
+    .eq("organization_id", organizationId)
+    .eq("client_id", clientId);
+  if (isDateParam(startDate)) {
+    sessionsQuery = sessionsQuery.gte("start_time", `${startDate}T00:00:00.000Z`);
+  }
+  if (isDateParam(endDate)) {
+    sessionsQuery = sessionsQuery.lte("start_time", `${endDate}T23:59:59.999Z`);
+  }
+
+  const [authorizations, sessionNotes, sessions] = await Promise.all([
+    authorizationsQuery,
+    sessionNotesQuery,
+    sessionsQuery,
+  ]);
+
+  if (authorizations.error || sessionNotes.error || sessions.error) {
+    return json(req, { error: "Failed to load utilization report data" }, 502);
+  }
+
+  return json(req, buildUtilizationReport({
+    organizationId,
+    clientId,
+    authorizationRows: (authorizations.data ?? []) as unknown as UtilizationAuthorizationRow[],
+    sessionNotes: (sessionNotes.data ?? []) as unknown as UtilizationSessionNoteRow[],
+    sessions: (sessions.data ?? []) as unknown as UtilizationSessionRow[],
+    range: { startDate, endDate },
+  }));
+};
+
+const handler = createProtectedRoute((req) => handleUtilizationReport(req), RouteOptions.admin);
+
+Deno.serve(handler);
+
+export default handler;

--- a/supabase/functions/utilization-report/index.ts
+++ b/supabase/functions/utilization-report/index.ts
@@ -6,6 +6,7 @@ export interface UtilizationAuthorizationServiceRow {
   readonly service_code: string;
   readonly service_description: string | null;
   readonly approved_units: number | null;
+  readonly unit_type: string | null;
 }
 
 export interface UtilizationAuthorizationRow {
@@ -105,10 +106,20 @@ const isDateInRange = (
   return (start === null || timestamp >= start) && (end === null || timestamp <= end);
 };
 
-const unitsFromMinutes = (minutes: number | null): number =>
-  typeof minutes === "number" && Number.isFinite(minutes) && minutes > 0
-    ? Math.round((minutes / 15) * 100) / 100
-    : 0;
+const unitsFromMinutes = (minutes: number, unitType: string | null | undefined): number => {
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return 0;
+  }
+
+  const normalizedUnitType = unitType?.toLowerCase() ?? "unit";
+  if (normalizedUnitType.includes("hour")) {
+    return Math.round((minutes / 60) * 100) / 100;
+  }
+  if (normalizedUnitType.includes("minute")) {
+    return Math.round(minutes * 100) / 100;
+  }
+  return Math.ceil(minutes / 15);
+};
 
 const roundPercent = (value: number): number => Math.round(value * 10) / 10;
 
@@ -137,6 +148,8 @@ const normalizeCancellationAttribution = (value: string | null): CancellationAtt
 
 export const buildUtilizationReport = (input: UtilizationReportInput): UtilizationReport => {
   const serviceRows = new Map<string, { description: string; authorized: number; used: number }>();
+  const serviceUnitsByAuthorization = new Map<string, string | null>();
+  const usageMinutesByAuthorizationService = new Map<string, number>();
   const authorizationIds = new Set<string>();
 
   input.authorizationRows
@@ -156,6 +169,7 @@ export const buildUtilizationReport = (input: UtilizationReportInput): Utilizati
         existing.description = existing.description || service.service_description || "";
         existing.authorized += service.approved_units ?? 0;
         serviceRows.set(service.service_code, existing);
+        serviceUnitsByAuthorization.set(`${authorization.id}:${service.service_code}`, service.unit_type);
       });
     });
 
@@ -167,14 +181,24 @@ export const buildUtilizationReport = (input: UtilizationReportInput): Utilizati
       isDateInRange(note.session_date, input.range)
     )
     .forEach((note) => {
-      const row = serviceRows.get(note.service_code) ?? {
-        description: "",
-        authorized: 0,
-        used: 0,
-      };
-      row.used += unitsFromMinutes(note.session_duration);
-      serviceRows.set(note.service_code, row);
+      const key = `${note.authorization_id}:${note.service_code}`;
+      usageMinutesByAuthorizationService.set(
+        key,
+        (usageMinutesByAuthorizationService.get(key) ?? 0) + (note.session_duration ?? 0),
+      );
     });
+
+  usageMinutesByAuthorizationService.forEach((minutes, key) => {
+    const separatorIndex = key.indexOf(":");
+    const serviceCode = separatorIndex >= 0 ? key.slice(separatorIndex + 1) : key;
+    const row = serviceRows.get(serviceCode) ?? {
+      description: "",
+      authorized: 0,
+      used: 0,
+    };
+    row.used += unitsFromMinutes(minutes, serviceUnitsByAuthorization.get(key));
+    serviceRows.set(serviceCode, row);
+  });
 
   const cancellations: Record<CancellationAttribution, number> = { staff: 0, client: 0, unknown: 0 };
   const locations: Record<LocationBucket, number> = { telehealth: 0, home: 0, community: 0, clinic: 0, other: 0 };
@@ -248,7 +272,7 @@ export const handleUtilizationReport = async (
 
   let authorizationsQuery = db
     .from("authorizations")
-    .select("id,client_id,organization_id,start_date,end_date,status,services:authorization_services(service_code,service_description,approved_units)")
+    .select("id,client_id,organization_id,start_date,end_date,status,services:authorization_services(service_code,service_description,approved_units,unit_type)")
     .eq("organization_id", organizationId)
     .eq("client_id", clientId)
     .eq("status", "approved");

--- a/supabase/migrations/20260707152000_session_cancellation_attribution.sql
+++ b/supabase/migrations/20260707152000_session_cancellation_attribution.sql
@@ -1,0 +1,15 @@
+-- @migration-intent: Persist session cancellation attribution for reporting breakdowns.
+-- @migration-dependencies: 20260701150000_employee_role_capability_matrix.sql
+-- @migration-risk: Adds nullable constrained reporting column and tenant-scoped index on sessions.
+-- @migration-rollback: drop index public.sessions_org_client_cancel_attr_idx; alter table public.sessions drop constraint sessions_cancellation_attribution_chk; alter table public.sessions drop column cancellation_attribution;
+
+alter table public.sessions
+  add column if not exists cancellation_attribution text;
+
+alter table public.sessions
+  drop constraint if exists sessions_cancellation_attribution_chk,
+  add constraint sessions_cancellation_attribution_chk
+  check (cancellation_attribution is null or cancellation_attribution in ('staff', 'client', 'unknown'));
+
+create index if not exists sessions_org_client_cancel_attr_idx
+  on public.sessions (organization_id, client_id, status, cancellation_attribution);

--- a/tests/ci/deploy-session-edge-bundle.test.ts
+++ b/tests/ci/deploy-session-edge-bundle.test.ts
@@ -111,6 +111,7 @@ describe("deploy-session-edge-bundle", () => {
       "--use-api",
     ]);
     expect(state.calls.at(-1)).toEqual(["functions", "list", "--project-ref", "wnnjeqheqxxyrgsjmygy", "--output", "json"]);
+    expect(state.deployed).toContain("utilization-report");
     expect(state.deployed.length).toBeGreaterThan(10);
   });
 });

--- a/tests/edge/sessions-cancel.org-scope.test.ts
+++ b/tests/edge/sessions-cancel.org-scope.test.ts
@@ -210,6 +210,46 @@ describe("sessions-cancel org scoping", () => {
     expect(payload.data.summary.cancelledSessionIds).toEqual(["session-super"]);
   });
 
+  it("persists cancellation attribution with the session update", async () => {
+    const selectBuilder = makeSelectBuilder({
+      data: [
+        { id: "session-client-cancel", status: "scheduled", therapist_id: "therapist-9" },
+      ],
+      error: null,
+    });
+    vi.spyOn(orgHelpers, "orgScopedQuery").mockImplementation(
+      () => selectBuilder as unknown as ReturnType<typeof orgHelpers.orgScopedQuery>,
+    );
+
+    const updateBuilder = makeUpdateBuilder();
+    vi.spyOn(supabaseAdmin, "from").mockReturnValue(updateBuilder as never);
+    const mockDb: any = {
+      from: vi.fn(() => updateBuilder),
+      rpc: vi.fn(async () => ({ error: null })),
+    };
+
+    const logger = createStubLogger();
+
+    await __TESTING__.handleSessionCancellation(
+      mockDb,
+      "org-9",
+      {
+        sessionIds: ["session-client-cancel"],
+        dateRange: null,
+        therapistId: null,
+        reason: "Client cancelled",
+        cancellationAttribution: "client",
+      },
+      "super-admin-user",
+      "super_admin",
+      logger,
+    );
+
+    expect(updateBuilder.update).toHaveBeenCalledWith(expect.objectContaining({
+      cancellation_attribution: "client",
+    }));
+  });
+
   it("denies super_admin cancellation when the target session is outside the chosen org scope", async () => {
     const selectBuilder = makeSelectBuilder({
       data: [],

--- a/tests/edge/utilization-report.contract.test.ts
+++ b/tests/edge/utilization-report.contract.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stubDenoEnv } from "../utils/stubDeno";
+
+const envValues = new Map<string, string>([
+  ["CORS_ALLOWED_ORIGINS", "https://app.example.com"],
+  ["APP_ENV", "production"],
+]);
+
+stubDenoEnv((key) => envValues.get(key) ?? "");
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const CLIENT_ID = "22222222-2222-4222-8222-222222222222";
+
+const authorizationRows = [
+  {
+    id: "auth-1",
+    client_id: CLIENT_ID,
+    organization_id: ORG_ID,
+    start_date: "2026-07-01",
+    end_date: "2026-07-31",
+    status: "approved",
+    services: [
+      { service_code: "97153", service_description: "Adaptive behavior treatment", approved_units: 40 },
+      { service_code: "97155", service_description: "Protocol modification", approved_units: 8 },
+    ],
+  },
+];
+
+const sessionNotes = [
+  {
+    id: "note-1",
+    authorization_id: "auth-1",
+    service_code: "97153",
+    session_duration: 60,
+    session_date: "2026-07-08",
+    organization_id: ORG_ID,
+  },
+  {
+    id: "note-2",
+    authorization_id: "auth-1",
+    service_code: "97153",
+    session_duration: 30,
+    session_date: "2026-07-09",
+    organization_id: ORG_ID,
+  },
+];
+
+const sessions = [
+  {
+    id: "session-1",
+    client_id: CLIENT_ID,
+    organization_id: ORG_ID,
+    status: "completed",
+    start_time: "2026-07-08T16:00:00.000Z",
+    end_time: "2026-07-08T17:00:00.000Z",
+    location_type: "Telehealth - school campus",
+    cancellation_attribution: null,
+    therapist_id: "therapist-1",
+    therapist: { full_name: "Jane Analyst" },
+  },
+  {
+    id: "session-2",
+    client_id: CLIENT_ID,
+    organization_id: ORG_ID,
+    status: "cancelled",
+    start_time: "2026-07-09T16:00:00.000Z",
+    end_time: "2026-07-09T17:00:00.000Z",
+    location_type: "Remote home visit",
+    cancellation_attribution: "client",
+    therapist_id: "therapist-2",
+    therapist: { full_name: "Pat BCBA" },
+  },
+  {
+    id: "session-3",
+    client_id: CLIENT_ID,
+    organization_id: ORG_ID,
+    status: "cancelled",
+    start_time: "2026-07-10T16:00:00.000Z",
+    end_time: "2026-07-10T17:00:00.000Z",
+    location_type: "clinic",
+    cancellation_attribution: null,
+    therapist_id: "therapist-2",
+    therapist: { full_name: "Pat BCBA" },
+  },
+];
+
+const loadModule = async () => import("../../supabase/functions/utilization-report/index.ts");
+
+type QueryCall = { op: "select" | "eq" | "gte" | "lte"; column?: string; value?: unknown };
+
+const createQuery = (data: unknown[], calls: QueryCall[]) => {
+  const query = {
+    select: vi.fn((value: string) => {
+      calls.push({ op: "select", value });
+      return query;
+    }),
+    eq: vi.fn((column: string, value: unknown) => {
+      calls.push({ op: "eq", column, value });
+      return query;
+    }),
+    gte: vi.fn((column: string, value: unknown) => {
+      calls.push({ op: "gte", column, value });
+      return query;
+    }),
+    lte: vi.fn((column: string, value: unknown) => {
+      calls.push({ op: "lte", column, value });
+      return query;
+    }),
+    then: (resolve: (value: { data: unknown[]; error: null }) => unknown) =>
+      Promise.resolve({ data, error: null }).then(resolve),
+  };
+  return query;
+};
+
+const createDb = (overrides: Partial<Record<string, unknown[]>> = {}) => {
+  const callsByTable = new Map<string, QueryCall[]>();
+  const tableData: Record<string, unknown[]> = {
+    authorizations: authorizationRows,
+    client_session_notes: sessionNotes,
+    sessions,
+    ...overrides,
+  };
+  const db = {
+    rpc: vi.fn(async (fn: string) => {
+      if (fn === "current_user_organization_id") {
+        return { data: ORG_ID, error: null };
+      }
+      return { data: null, error: null };
+    }),
+    from: vi.fn((table: string) => {
+      const calls: QueryCall[] = [];
+      callsByTable.set(table, calls);
+      return createQuery(tableData[table] ?? [], calls);
+    }),
+  };
+  return { db, callsByTable };
+};
+
+describe("utilization-report edge function", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns service-code utilization, cancellation, and location summaries", async () => {
+    const mod = await loadModule();
+    const report = mod.buildUtilizationReport({
+      organizationId: ORG_ID,
+      clientId: CLIENT_ID,
+      authorizationRows,
+      sessionNotes,
+      sessions,
+      range: { startDate: "2026-07-01", endDate: "2026-07-31" },
+    });
+
+    expect(report.serviceCodes).toEqual([
+      {
+        serviceCode: "97153",
+        description: "Adaptive behavior treatment",
+        authorized: 40,
+        used: 6,
+        available: 34,
+        utilizationPct: 15,
+      },
+      {
+        serviceCode: "97155",
+        description: "Protocol modification",
+        authorized: 8,
+        used: 0,
+        available: 8,
+        utilizationPct: 0,
+      },
+    ]);
+    expect(report.cancellations).toEqual({ staff: 0, client: 1, unknown: 1 });
+    expect(report.locations).toEqual({ telehealth: 1, home: 1, community: 0, clinic: 1, other: 0 });
+  });
+
+  it("excludes usage and cancellations outside the requested date range", async () => {
+    const mod = await loadModule();
+    const report = mod.buildUtilizationReport({
+      organizationId: ORG_ID,
+      clientId: CLIENT_ID,
+      authorizationRows,
+      sessionNotes,
+      sessions,
+      range: { startDate: "2026-07-09", endDate: "2026-07-09" },
+    });
+
+    expect(report.serviceCodes.find((row) => row.serviceCode === "97153")).toMatchObject({
+      used: 2,
+      available: 38,
+      utilizationPct: 5,
+    });
+    expect(report.cancellations).toEqual({ staff: 0, client: 1, unknown: 0 });
+    expect(report.locations).toEqual({ telehealth: 0, home: 1, community: 0, clinic: 0, other: 0 });
+  });
+
+  it("does not count denied authorization services as authorized units", async () => {
+    const mod = await loadModule();
+    const report = mod.buildUtilizationReport({
+      organizationId: ORG_ID,
+      clientId: CLIENT_ID,
+      authorizationRows: [
+        ...authorizationRows,
+        {
+          id: "auth-denied",
+          client_id: CLIENT_ID,
+          organization_id: ORG_ID,
+          start_date: "2026-07-01",
+          end_date: "2026-07-31",
+          status: "denied",
+          services: [
+            { service_code: "97153", service_description: "Denied treatment", approved_units: 999 },
+          ],
+        },
+      ],
+      sessionNotes,
+      sessions,
+      range: { startDate: "2026-07-01", endDate: "2026-07-31" },
+    });
+
+    expect(report.serviceCodes.find((row) => row.serviceCode === "97153")).toMatchObject({
+      authorized: 40,
+      used: 6,
+      available: 34,
+      utilizationPct: 15,
+    });
+  });
+
+  it("loads only the caller organization, requested client, and requested date window", async () => {
+    const mod = await loadModule();
+    const { db, callsByTable } = createDb();
+    const response = await mod.handleUtilizationReport(
+      new Request(
+        `https://edge.example/functions/v1/utilization-report?client_id=${CLIENT_ID}&start_date=2026-07-01&end_date=2026-07-31`,
+        { method: "GET" },
+      ),
+      db as never,
+    );
+
+    expect(response.status).toBe(200);
+    expect(db.from).toHaveBeenCalledWith("authorizations");
+    expect(db.from).toHaveBeenCalledWith("client_session_notes");
+    expect(db.from).toHaveBeenCalledWith("sessions");
+
+    for (const calls of callsByTable.values()) {
+      expect(calls).toEqual(expect.arrayContaining([
+        { op: "eq", column: "organization_id", value: ORG_ID },
+        { op: "eq", column: "client_id", value: CLIENT_ID },
+      ]));
+    }
+    expect(callsByTable.get("authorizations")).toEqual(expect.arrayContaining([
+      { op: "eq", column: "status", value: "approved" },
+      { op: "gte", column: "end_date", value: "2026-07-01" },
+      { op: "lte", column: "start_date", value: "2026-07-31" },
+    ]));
+    expect(callsByTable.get("client_session_notes")).toEqual(expect.arrayContaining([
+      { op: "gte", column: "session_date", value: "2026-07-01" },
+      { op: "lte", column: "session_date", value: "2026-07-31" },
+    ]));
+    expect(callsByTable.get("sessions")).toEqual(expect.arrayContaining([
+      { op: "gte", column: "start_time", value: "2026-07-01T00:00:00.000Z" },
+      { op: "lte", column: "start_time", value: "2026-07-31T23:59:59.999Z" },
+    ]));
+  });
+
+  it("rejects non-admin callers through the protected route wrapper", async () => {
+    const auth = await import("../../supabase/functions/_shared/auth-middleware.ts");
+    vi.spyOn(auth.authMiddlewareDeps, "getUserContext").mockResolvedValue({
+      user: { id: "therapist-user", email: null },
+      profile: { id: "therapist-user", email: null, role: "therapist", is_active: true },
+    });
+    const mod = await loadModule();
+
+    const response = await mod.default(
+      new Request(`https://edge.example/functions/v1/utilization-report?client_id=${CLIENT_ID}`, {
+        method: "GET",
+        headers: { Authorization: "Bearer therapist-token" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      code: "forbidden",
+      message: "Insufficient permissions",
+    });
+  });
+
+  it("rejects invalid report date filters", async () => {
+    const mod = await loadModule();
+    const { db } = createDb();
+    const response = await mod.handleUtilizationReport(
+      new Request(`https://edge.example/functions/v1/utilization-report?client_id=${CLIENT_ID}&start_date=07-01-2026`, {
+        method: "GET",
+      }),
+      db as never,
+    );
+
+    expect(response.status).toBe(400);
+    expect(db.from).not.toHaveBeenCalled();
+  });
+
+  it("normalizes legacy location values into report buckets", async () => {
+    const mod = await loadModule();
+    expect(mod.normalizeSessionLocation("TH")).toBe("telehealth");
+    expect(mod.normalizeSessionLocation("in_home")).toBe("home");
+    expect(mod.normalizeSessionLocation("Community outing")).toBe("community");
+    expect(mod.normalizeSessionLocation("in_clinic")).toBe("clinic");
+    expect(mod.normalizeSessionLocation("unknown place")).toBe("other");
+  });
+});

--- a/tests/edge/utilization-report.contract.test.ts
+++ b/tests/edge/utilization-report.contract.test.ts
@@ -20,8 +20,9 @@ const authorizationRows = [
     end_date: "2026-07-31",
     status: "approved",
     services: [
-      { service_code: "97153", service_description: "Adaptive behavior treatment", approved_units: 40 },
-      { service_code: "97155", service_description: "Protocol modification", approved_units: 8 },
+      { service_code: "97153", service_description: "Adaptive behavior treatment", approved_units: 40, unit_type: "Units" },
+      { service_code: "97155", service_description: "Protocol modification", approved_units: 8, unit_type: "Hours" },
+      { service_code: "0373T", service_description: "Adaptive behavior minute service", approved_units: 120, unit_type: "Minutes" },
     ],
   },
 ];
@@ -39,7 +40,23 @@ const sessionNotes = [
     id: "note-2",
     authorization_id: "auth-1",
     service_code: "97153",
-    session_duration: 30,
+    session_duration: 16,
+    session_date: "2026-07-09",
+    organization_id: ORG_ID,
+  },
+  {
+    id: "note-3",
+    authorization_id: "auth-1",
+    service_code: "97155",
+    session_duration: 90,
+    session_date: "2026-07-09",
+    organization_id: ORG_ID,
+  },
+  {
+    id: "note-4",
+    authorization_id: "auth-1",
+    service_code: "0373T",
+    session_duration: 45,
     session_date: "2026-07-09",
     organization_id: ORG_ID,
   },
@@ -154,6 +171,14 @@ describe("utilization-report edge function", () => {
 
     expect(report.serviceCodes).toEqual([
       {
+        serviceCode: "0373T",
+        description: "Adaptive behavior minute service",
+        authorized: 120,
+        used: 45,
+        available: 75,
+        utilizationPct: 37.5,
+      },
+      {
         serviceCode: "97153",
         description: "Adaptive behavior treatment",
         authorized: 40,
@@ -165,9 +190,9 @@ describe("utilization-report edge function", () => {
         serviceCode: "97155",
         description: "Protocol modification",
         authorized: 8,
-        used: 0,
-        available: 8,
-        utilizationPct: 0,
+        used: 1.5,
+        available: 6.5,
+        utilizationPct: 18.8,
       },
     ]);
     expect(report.cancellations).toEqual({ staff: 0, client: 1, unknown: 1 });
@@ -209,7 +234,7 @@ describe("utilization-report edge function", () => {
           end_date: "2026-07-31",
           status: "denied",
           services: [
-            { service_code: "97153", service_description: "Denied treatment", approved_units: 999 },
+            { service_code: "97153", service_description: "Denied treatment", approved_units: 999, unit_type: "Units" },
           ],
         },
       ],
@@ -249,6 +274,10 @@ describe("utilization-report edge function", () => {
       ]));
     }
     expect(callsByTable.get("authorizations")).toEqual(expect.arrayContaining([
+      {
+        op: "select",
+        value: "id,client_id,organization_id,start_date,end_date,status,services:authorization_services(service_code,service_description,approved_units,unit_type)",
+      },
       { op: "eq", column: "status", value: "approved" },
       { op: "gte", column: "end_date", value: "2026-07-01" },
       { op: "lte", column: "start_date", value: "2026-07-31" },

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -70,12 +70,15 @@ describe('select-browser-checks', () => {
     ]);
   });
 
-  it('includes the PreAuth spec in the full tier-0 browser fallback', () => {
+  it('runs full tier-0 without hosted auth smoke when browser selector changes', () => {
     const selection = runSelector('--changed-file', 'scripts/ci/select-browser-checks.mjs');
 
     expect(selection.tier0Required).toBe(true);
-    expect(selection.authSmokeRequired).toBe(true);
+    expect(selection.authSmokeRequired).toBe(false);
     expect(selection.tier0Specs).toContain('cypress/e2e/preauth_workflow.cy.ts');
+    expect(selection.reasons).toEqual([
+      'scripts/ci/select-browser-checks.mjs: browser check selector',
+    ]);
   });
 
   it('keeps session cancellation changes out of hosted auth smoke', () => {

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -78,6 +78,34 @@ describe('select-browser-checks', () => {
     expect(selection.tier0Specs).toContain('cypress/e2e/preauth_workflow.cy.ts');
   });
 
+  it('keeps session cancellation changes out of hosted auth smoke', () => {
+    const selection = runSelector('--changed-file', 'supabase/functions/sessions-cancel/index.ts');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.authSmokeRequired).toBe(false);
+    expect(selection.tier0Specs).toEqual([
+      'cypress/e2e/routes_schedule.cy.ts',
+      'cypress/e2e/routes_auth.cy.ts',
+    ]);
+    expect(selection.reasons).toEqual([
+      'supabase/functions/sessions-cancel/index.ts: session cancellation edge flow',
+    ]);
+  });
+
+  it('still requires hosted auth smoke for session start changes', () => {
+    const selection = runSelector('--changed-file', 'supabase/functions/sessions-start/index.ts');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.authSmokeRequired).toBe(true);
+    expect(selection.tier0Specs).toEqual([
+      'cypress/e2e/routes_auth.cy.ts',
+      'cypress/e2e/routes_schedule.cy.ts',
+    ]);
+    expect(selection.reasons).toEqual([
+      'supabase/functions/sessions-start/index.ts: auth/session browser flow',
+    ]);
+  });
+
   it('keeps the PreAuth spec in the default local tier-0 Cypress run', () => {
     const runCypressSource = readFileSync('scripts/run-cypress.ts', 'utf8');
 

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -77,7 +77,18 @@ describe('select-browser-checks', () => {
     expect(selection.authSmokeRequired).toBe(false);
     expect(selection.tier0Specs).toContain('cypress/e2e/preauth_workflow.cy.ts');
     expect(selection.reasons).toEqual([
-      'scripts/ci/select-browser-checks.mjs: browser check selector',
+      'scripts/ci/select-browser-checks.mjs: browser CI support script',
+    ]);
+  });
+
+  it('runs full tier-0 without hosted auth smoke when deploy bundle script changes', () => {
+    const selection = runSelector('--changed-file', 'scripts/ci/deploy-session-edge-bundle.mjs');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.authSmokeRequired).toBe(false);
+    expect(selection.tier0Specs).toContain('cypress/e2e/routes_schedule.cy.ts');
+    expect(selection.reasons).toEqual([
+      'scripts/ci/deploy-session-edge-bundle.mjs: browser CI support script',
     ]);
   });
 

--- a/tests/utilization-report-migration.test.ts
+++ b/tests/utilization-report-migration.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const migrationSql = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260707152000_session_cancellation_attribution.sql"),
+  "utf8",
+);
+
+describe("session cancellation attribution migration", () => {
+  it("adds a constrained attribution column for reporting", () => {
+    expect(migrationSql).toContain("alter table public.sessions");
+    expect(migrationSql).toMatch(/add column if not exists cancellation_attribution text/i);
+    expect(migrationSql).toMatch(/check\s*\(\s*cancellation_attribution is null or cancellation_attribution in \('staff', 'client', 'unknown'\)\s*\)/i);
+  });
+
+  it("adds a tenant-friendly reporting index", () => {
+    expect(migrationSql).toMatch(
+      /create index if not exists sessions_org_client_cancel_attr_idx\s+on public\.sessions \(organization_id, client_id, status, cancellation_attribution\)/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add cancellation attribution storage and propagation through the session cancellation Edge function
- add a JWT-protected utilization-report Edge function with org-scoped service-code utilization, cancellation attribution, and location breakdowns
- add client profile report-upcoming banner logic and therapist filtering for session trend graphs

## Tracking
- Linear: WIN-202

## Verification
- npm ci
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run validate:tenant
- npm run build
- npm run test:ci
- npm run ci:verify-coverage
- npm run test:routes:tier0 with PREVIEW_PORT=4174
- npx vitest run src/pages/__tests__/ClientDetails.test.tsx --config vitest.config.ts
- npx vitest run src/pages/__tests__/ClientDetails.test.tsx tests/edge/utilization-report.contract.test.ts --config vitest.config.ts
- npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx --config vitest.config.ts
- npx vitest run tests/ci/deploy-session-edge-bundle.test.ts --config vitest.config.ts
- npx vitest run src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx --config vitest.config.ts

## Blocked / local-only notes
- npm run verify:local was attempted; it initially hit unrelated aggregate flakes/timeouts, and the failing files passed in isolation. The required aggregate commands were rerun separately and passed.
- npm run ci:playwright was attempted and blocked at preflight because this shell is missing PW_SUPERADMIN_EMAIL/PW_SUPERADMIN_PASSWORD or PW_ADMIN_EMAIL/PW_ADMIN_PASSWORD.
- local ci:check-focused skipped DB-backed checks because SUPABASE_DB_URL/DATABASE_URL is not configured in this shell.

## Risk
Critical / high-risk human-reviewed: Supabase migration, Edge function, tenant-scoped reporting, and cancellation persistence changes require human review before merge.
