### PR TITLE
Hide schedule goal capture for admin scheduling roles

### DIFF
--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -266,6 +266,7 @@ interface SessionModalProps {
   onRetryAction?: (() => void) | undefined;
   onSessionStarted?: () => void | Promise<void>;
   dataCollectionOnly?: boolean;
+  hideGoalCaptureFields?: boolean;
 }
 
 export function SessionModal({
@@ -287,6 +288,7 @@ export function SessionModal({
   onRetryAction,
   onSessionStarted,
   dataCollectionOnly = false,
+  hideGoalCaptureFields = false,
 }: SessionModalProps) {
   const [isPlanSummaryExpanded, setIsPlanSummaryExpanded] = useState(false);
   const [selectedProgramIds, setSelectedProgramIds] = useState<string[]>(() =>
@@ -314,6 +316,7 @@ export function SessionModal({
   const conflictHeadingId = 'session-modal-conflicts-heading';
   const queryClient = useQueryClient();
   const isDataCollectionOnly = Boolean(dataCollectionOnly && session?.id);
+  const shouldHideGoalCaptureFields = hideGoalCaptureFields;
 
   const resolvedTimeZone = useMemo(() => resolveSchedulingTimeZone(timeZone), [timeZone]);
 
@@ -1578,13 +1581,17 @@ export function SessionModal({
   }, [session, isInProgressSession]);
   const modalSubtitle = useMemo(() => {
     if (!session) {
-      return 'Choose therapist, client, time, and plan details before creating this appointment.';
+      return shouldHideGoalCaptureFields
+        ? 'Choose therapist, client, and time before creating this appointment.'
+        : 'Choose therapist, client, time, and plan details before creating this appointment.';
     }
     if (isInProgressSession) {
-      return 'Log trials and per-goal notes, then save to sync. Use Close session when the visit ends.';
+      return shouldHideGoalCaptureFields
+        ? 'Review scheduling details and save updates while the visit is active.'
+        : 'Log trials and per-goal notes, then save to sync. Use Close session when the visit ends.';
     }
     return 'Review core details first, then add notes before saving.';
-  }, [session, isInProgressSession]);
+  }, [session, isInProgressSession, shouldHideGoalCaptureFields]);
   const sessionNoteGoalIds = useMemo(
     () => mergeUniqueGoalIds(
       Array.isArray(goalIds) ? goalIds : [],
@@ -2305,7 +2312,9 @@ export function SessionModal({
                 <p className="mt-1">
                   {isDataCollectionOnly
                     ? 'Session details are read-only. Save progress to sync data collection.'
-                    : 'You can adjust program and goals while active; save to keep the plan in sync with the schedule.'}
+                    : shouldHideGoalCaptureFields
+                      ? 'Session details stay focused on scheduling fields while active.'
+                      : 'You can adjust program and goals while active; save to keep the plan in sync with the schedule.'}
                 </p>
               </div>
             )}
@@ -2333,7 +2342,9 @@ export function SessionModal({
                 <div>
                   <h3 className="text-sm font-semibold text-gray-900 dark:text-white">People &amp; Plan</h3>
                   <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    Pick the therapist, client, and care-plan details for this session.
+                    {shouldHideGoalCaptureFields
+                      ? 'Pick the therapist and client for this session.'
+                      : 'Pick the therapist, client, and care-plan details for this session.'}
                   </p>
                 </div>
                 <button
@@ -2356,10 +2367,12 @@ export function SessionModal({
                     <p className="font-semibold text-gray-900 dark:text-white">Client</p>
                     <p className="mt-1 truncate">{selectedClient?.full_name ?? 'Not selected'}</p>
                   </div>
-                  <div className="min-w-0">
-                    <p className="font-semibold text-gray-900 dark:text-white">Primary goal</p>
-                    <p className="mt-1 truncate">{selectedPrimaryGoal?.title ?? 'Not selected'}</p>
-                  </div>
+                  {!shouldHideGoalCaptureFields ? (
+                    <div className="min-w-0">
+                      <p className="font-semibold text-gray-900 dark:text-white">Primary goal</p>
+                      <p className="mt-1 truncate">{selectedPrimaryGoal?.title ?? 'Not selected'}</p>
+                    </div>
+                  ) : null}
                 </div>
               )}
 
@@ -2415,7 +2428,7 @@ export function SessionModal({
               </div>
             </div>
 
-            {selectedPrimaryGoal && (
+            {!shouldHideGoalCaptureFields && selectedPrimaryGoal && (
               <>
                 <details className="rounded-lg border border-blue-200 bg-blue-50 text-xs text-blue-800 dark:border-blue-900/40 dark:bg-blue-900/20 dark:text-blue-100 sm:hidden">
                   <summary className="cursor-pointer list-none px-3 py-2.5 [&::-webkit-details-marker]:hidden">
@@ -2498,7 +2511,7 @@ export function SessionModal({
               </div>
             )}
 
-            {(programs.length === 0 || activePrograms.length === 0 || availableProgramGroups.length === 0) && (
+            {!shouldHideGoalCaptureFields && (programs.length === 0 || activePrograms.length === 0 || availableProgramGroups.length === 0) && (
               <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 sm:p-4">
                 {programs.length === 0 || activePrograms.length === 0
                   ? 'No active programs found for this client. Create or activate a program before starting a session.'
@@ -2506,6 +2519,8 @@ export function SessionModal({
               </div>
             )}
 
+            {!shouldHideGoalCaptureFields ? (
+              <>
             <div className="space-y-2 sm:space-y-0">
               <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 sm:sr-only">
                 Program &amp; goals
@@ -2812,6 +2827,13 @@ export function SessionModal({
                 Select one or more programs above to load goals instantly on mobile and desktop.
               </div>
             )}
+              </>
+            ) : (
+              <>
+                <input type="hidden" {...register('program_id')} />
+                <input type="hidden" {...register('goal_id')} />
+              </>
+            )}
             </section>
 
             <section className="space-y-4 rounded-xl border border-gray-200 p-4 dark:border-gray-700">
@@ -2937,7 +2959,7 @@ export function SessionModal({
             </div>
             </section>
 
-            {session?.id && (
+            {session?.id && !shouldHideGoalCaptureFields && (
               <section
                 ref={sessionCaptureSectionRef}
                 className="rounded-xl border border-indigo-200 bg-indigo-50/70 p-4 space-y-4 dark:border-indigo-900/40 dark:bg-indigo-900/10"

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -716,6 +716,9 @@ export function SessionModal({
     if (!sessionDetails) {
       return;
     }
+    if (shouldHideGoalCaptureFields && clientId !== session?.client_id) {
+      return;
+    }
     if (sessionDetails.program_id) {
       setValue('program_id', sessionDetails.program_id);
       setSelectedProgramIds((current) =>
@@ -727,7 +730,7 @@ export function SessionModal({
     if (sessionDetails.goal_id) {
       setValue('goal_id', sessionDetails.goal_id);
     }
-  }, [sessionDetails, setValue]);
+  }, [clientId, session?.client_id, sessionDetails, setValue, shouldHideGoalCaptureFields]);
 
   useEffect(() => {
     if (!session?.id) {
@@ -752,6 +755,9 @@ export function SessionModal({
   }, [getValues, session?.goal_id, session?.id, sessionDetails?.goal_id, sessionGoalRows, setValue]);
 
   useEffect(() => {
+    if (shouldHideGoalCaptureFields) {
+      return;
+    }
     if (!isProgramsFetched) {
       return;
     }
@@ -806,9 +812,12 @@ export function SessionModal({
       }
       return nextProgram?.id ? [nextProgram.id] : [];
     });
-  }, [isProgramsFetched, programs, programId, goalId, goalIds, session?.id, setValue]);
+  }, [goalId, goalIds, isProgramsFetched, programId, programs, session?.id, setValue, shouldHideGoalCaptureFields]);
 
   useEffect(() => {
+    if (shouldHideGoalCaptureFields) {
+      return;
+    }
     if (!isGoalsFetched) {
       return;
     }
@@ -852,9 +861,13 @@ export function SessionModal({
     selectedProgramIds,
     session?.id,
     setValue,
+    shouldHideGoalCaptureFields,
   ]);
 
   useEffect(() => {
+    if (shouldHideGoalCaptureFields) {
+      return;
+    }
     if (!goalId) {
       return;
     }
@@ -871,9 +884,12 @@ export function SessionModal({
         setValue('program_id', primaryGoalProgramId);
       }
     }
-  }, [goalId, goalIds, goalsById, programId, setValue]);
+  }, [goalId, goalIds, goalsById, programId, setValue, shouldHideGoalCaptureFields]);
 
   useEffect(() => {
+    if (shouldHideGoalCaptureFields) {
+      return;
+    }
     const programsFromGoals = mergeUniqueGoalIds(Array.isArray(goalIds) ? goalIds : [], goalId ? [goalId] : [])
       .map((selectedGoalId) => goalsById.get(selectedGoalId)?.program_id)
       .filter((id): id is string => Boolean(id));
@@ -889,7 +905,7 @@ export function SessionModal({
         ? current
         : next;
     });
-  }, [goalId, goalIds, setValue]);
+  }, [goalId, goalIds, goalsById, programId, shouldHideGoalCaptureFields]);
 
   const updateProgramSelection = useCallback(
     (nextProgramIds: string[]) => {
@@ -1363,6 +1379,25 @@ export function SessionModal({
             notes: session.notes ?? '',
           }
         : {};
+      const schedulerOnlyClinicalFields: Partial<Session> = shouldHideGoalCaptureFields
+        ? session
+          ? working.client_id === session.client_id
+            ? {
+                program_id: session.program_id ?? '',
+                goal_id: session.goal_id ?? '',
+                goal_ids: session.goal_ids ?? [],
+              }
+            : {
+                program_id: '',
+                goal_id: '',
+                goal_ids: [],
+              }
+          : {
+              program_id: '',
+              goal_id: '',
+              goal_ids: [],
+            }
+        : {};
       const transformed: SessionModalSubmitData = {
         ...working,
         ...(session?.id ? { id: session.id } : {}),
@@ -1386,6 +1421,7 @@ export function SessionModal({
         // If a timezone prop is provided, normalize to UTC for consumers expecting Z times
         start_time: timeZone ? toUtcSessionIsoString(working.start_time, resolvedTimeZone) : working.start_time,
         end_time: timeZone ? toUtcSessionIsoString(working.end_time, resolvedTimeZone) : working.end_time,
+        ...schedulerOnlyClinicalFields,
         ...lockedSessionFields,
       };
       await onSubmit(transformed);

--- a/src/components/__tests__/SchedulingIntegration.test.tsx
+++ b/src/components/__tests__/SchedulingIntegration.test.tsx
@@ -189,7 +189,9 @@ describe('Scheduling Integration - End-to-End Flow', () => {
     );
 
     // Render the Schedule page
-    renderWithProviders(<Schedule />);
+    renderWithProviders(<Schedule />, {
+      auth: { role: 'bcba', organizationId: 'org-a' },
+    });
 
     // Wait for filters to be ready
     await screen.findByRole('combobox', { name: /therapist/i });

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1743,6 +1743,58 @@ describe('SessionModal', () => {
     });
   });
 
+  it('keeps scheduler-only client reassignment from silently repopulating clinical plan fields', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        hideGoalCaptureFields
+        clients={[
+          ...mockClients,
+          {
+            ...mockClients[0],
+            id: 'test-client-2',
+            full_name: 'Test Client 2',
+            email: 'client2@example.com',
+          },
+        ]}
+        session={{
+          id: 'session-admin-client-reassign',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          goal_ids: ['goal-1'],
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'scheduled',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-2');
+    const updateButton = screen.getByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(updateButton).not.toBeDisabled());
+    await userEvent.click(updateButton);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'session-admin-client-reassign',
+        client_id: 'test-client-2',
+        program_id: '',
+        goal_id: '',
+        goal_ids: [],
+      }));
+    });
+  });
+
   it('submits normalized per-target trials with session capture', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const buildChain = (rows: unknown[]) => {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1695,6 +1695,54 @@ describe('SessionModal', () => {
     expect(screen.getByRole('tab', { name: /^BX$/i })).toBeInTheDocument();
   });
 
+  it('hides goal planning and session capture fields when schedule goal capture is suppressed', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        hideGoalCaptureFields
+        session={{
+          id: 'session-admin-schedule-edit',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'scheduled',
+          notes: 'Schedule only note',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    expect(screen.getByText('Edit Session')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /Program/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /Primary Goal/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Programs in this session/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Goals in this session/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('session-modal-capture-section')).not.toBeInTheDocument();
+
+    const updateButton = screen.getByRole('button', { name: /Update Session/i });
+    await waitFor(() => expect(updateButton).not.toBeDisabled());
+    await userEvent.click(updateButton);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'session-admin-schedule-edit',
+        program_id: 'program-1',
+        goal_id: 'goal-1',
+        therapist_id: 'test-therapist-1',
+        client_id: 'test-client-1',
+      }));
+    });
+  });
+
   it('submits normalized per-target trials with session capture', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const buildChain = (rows: unknown[]) => {

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1878,6 +1878,7 @@ export const Schedule = React.memo(() => {
         existingSessions={displayData.sessions}
         timeZone={userTimeZone}
         dataCollectionOnly={effectiveRole === "bt" && Boolean(selectedSession?.id)}
+        hideGoalCaptureFields={effectiveRole === "admin" || effectiveRole === "admin_schedule"}
         defaultTherapistId={selectedTherapist}
         defaultClientId={selectedClient}
         retryHint={retryHint}

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -104,6 +104,7 @@ vi.mock("../../components/SessionModal", () => ({
     session,
     retryHint,
     dataCollectionOnly,
+    hideGoalCaptureFields,
   }: {
     isOpen: boolean;
     onClose: () => void;
@@ -111,12 +112,14 @@ vi.mock("../../components/SessionModal", () => ({
     session?: { id: string };
     retryHint?: string | null;
     dataCollectionOnly?: boolean;
+    hideGoalCaptureFields?: boolean;
   }) =>
     isOpen ? (
       <div data-testid="session-modal">
         <div data-testid="modal-mode">{session ? "edit" : "create"}</div>
         <div data-testid="retry-hint">{retryHint ?? ""}</div>
         <div data-testid="data-collection-only">{dataCollectionOnly ? "true" : "false"}</div>
+        <div data-testid="hide-goal-capture-fields">{hideGoalCaptureFields ? "true" : "false"}</div>
         <button
           aria-label="submit-create"
           onClick={() => {
@@ -579,6 +582,23 @@ describe("Schedule orchestration integration hardening", () => {
     );
     expect(showSuccessMock).toHaveBeenCalledWith("Session data collection saved");
     expect(showErrorMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["admin", "admin", "true"],
+    ["admin schedule", "admin_schedule", "true"],
+    ["bcba", "bcba", "false"],
+  ] as const)("wires goal-capture visibility for %s schedule sessions", async (_label, role, expectedHidden) => {
+    renderWithProviders(<Schedule />, {
+      auth: { role, organizationId: "org-1" },
+    });
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+
+    fireEvent.click(screen.getAllByLabelText("Add session")[0]);
+    await screen.findByTestId("session-modal");
+
+    expect(screen.getByTestId("hide-goal-capture-fields")).toHaveTextContent(expectedHidden);
   });
 
   it("manual live capture persistence can resolve the edit session from submitted id", async () => {


### PR DESCRIPTION
## Summary
- hide goal and session-capture UI in the Schedule -> SessionModal path for `admin` and `admin_schedule`
- keep BT schedule data-collection behavior intact and leave BCBA role behavior unchanged
- add focused tests for both modal suppression and Schedule role-to-prop wiring

## Verification
- Passed: `npx vitest run src/components/__tests__/SessionModal.test.tsx`
- Passed: `npx vitest run src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
- Passed: `npm run typecheck`
- Passed: `npm run lint`
- Passed: `npm run ci:check-focused`
- Passed: `npm run build`
- Failed: `npm run test:routes:tier0` (`Cypress` exited with `EPIPE: broken pipe`)
- Timed out / not clean: `npm run verify:local` (timed out around 123s and surfaced unrelated `AIDocumentationService` network failures with `fetch failed` / `ECONNREFUSED`)

## Notes
- No Linear issue linked for this slice.
- Left unrelated untracked `codex_alignment*` artifacts out of the commit.
