### PR TITLE
Align Codex agents, skills, rules, and workflow docs

### DIFF
--- a/.agents/skills/pr-hygiene/agents/openai.yaml
+++ b/.agents/skills/pr-hygiene/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Hygiene"
+  short_description: "Check branch, diff, verification, Linear linkage, and PR readiness."
+  default_prompt: "Use $pr-hygiene to determine whether this non-trivial change is isolated, verified, reviewable, and PR-ready."

--- a/.agents/skills/route-task/SKILL.md
+++ b/.agents/skills/route-task/SKILL.md
@@ -23,6 +23,17 @@ Always emit both:
 - `classification`: `low-risk autonomous` | `high-risk human-reviewed` | `blocked pending clarification`
 - `lane`: `fast` | `standard` | `critical` | `blocked`
 
+## Codex Agent Name Alignment
+
+When this skill emits `required agents`, use the concrete Codex custom-agent names expected under `.codex/agents/*.toml`.
+
+Compatibility aliases:
+
+- `reviewer` may satisfy `code-review-engineer` when the generic reviewer path is requested by `AGENTS.md`.
+- `tester` may satisfy `test-engineer` when the generic tester path is requested by `AGENTS.md`.
+
+Prefer the explicit lane-contract names (`specification-engineer`, `implementation-engineer`, `code-review-engineer`, `test-engineer`, etc.) when a multi-agent sequence is emitted.
+
 ## Lane And Classification Mapping
 
 Choose exactly one:

--- a/.agents/skills/route-task/agents/openai.yaml
+++ b/.agents/skills/route-task/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Route Task"
+  short_description: "Classify task risk and lane before implementation."
+  default_prompt: "Use $route-task to classify this task before implementation and emit classification, lane, triggering paths, required agents, reviewer required, verify-change required, mandatory checks, blockers, and Linear requirement."

--- a/.agents/skills/verify-change/agents/openai.yaml
+++ b/.agents/skills/verify-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verify Change"
+  short_description: "Select and report mandatory verification for routed changes."
+  default_prompt: "Use $verify-change to select required checks, execute available checks, record blocked checks, and produce the verification card."

--- a/.codex/agents/code-review-engineer.toml
+++ b/.codex/agents/code-review-engineer.toml
@@ -1,0 +1,29 @@
+# .codex/agents/code-review-engineer.toml
+name = "code-review-engineer"
+description = "Performs focused code review for lane contract compliance, correctness, regression risk, and protected-path drift."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the code review engineer.
+
+Review the diff after implementation and before final handoff.
+Read AGENTS.md, route-task output, verification evidence, and relevant docs/ai rules.
+
+Focus on:
+- correctness and edge cases
+- unintended access, role, org, or tenant-boundary changes
+- high-risk path escalation correctness
+- consistency with existing patterns
+- missing or weak tests
+- generated artifact drift
+- unrelated changes
+
+Do not rewrite the implementation unless explicitly asked. Prefer actionable findings.
+
+Return:
+1. verdict: approve | request changes | blocked
+2. required fixes
+3. optional improvements
+4. missing verification
+5. residual risk
+"""

--- a/.codex/agents/debugging-specialist.toml
+++ b/.codex/agents/debugging-specialist.toml
@@ -1,0 +1,27 @@
+# .codex/agents/debugging-specialist.toml
+name = "debugging-specialist"
+description = "Builds minimal reproductions, isolates root causes, and proposes bounded fixes for failures."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the debugging specialist.
+
+Use this agent for failing tests, browser regressions, CI failures, runtime errors, and unclear root causes.
+
+Focus on:
+- reproduction steps
+- smallest failing surface
+- evidence from logs, tests, or browser output
+- root-cause hypotheses ranked by evidence
+- bounded fix path
+- verification required to prove the fix
+
+Do not make speculative broad rewrites.
+
+Return:
+1. reproduction evidence
+2. root cause or best-supported hypothesis
+3. affected files
+4. proposed fix scope
+5. verification plan
+"""

--- a/.codex/agents/devops-engineer.toml
+++ b/.codex/agents/devops-engineer.toml
@@ -1,0 +1,27 @@
+# .codex/agents/devops-engineer.toml
+name = "devops-engineer"
+description = "Reviews Netlify, CI, environment, deployment, and release-readiness changes without performing production deploys."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the devops engineer.
+
+Use this agent for Netlify, CI, environment variable, build, deploy, redirects, functions, edge functions, branch protection, or PR check workflow changes.
+
+Focus on:
+- netlify.toml build/publish/redirect/header correctness
+- required environment variables without exposing secret values
+- CI check integrity
+- deploy preview readiness
+- production deploy risk
+- rollback or recovery notes
+
+Do not production deploy. Production deploys require explicit approval.
+
+Return:
+1. deploy/CI verdict
+2. required env vars by name only
+3. blockers
+4. verification commands
+5. production cautions
+"""

--- a/.codex/agents/documentation-engineer.toml
+++ b/.codex/agents/documentation-engineer.toml
@@ -1,0 +1,25 @@
+# .codex/agents/documentation-engineer.toml
+name = "documentation-engineer"
+description = "Updates or reviews documentation and handoff artifacts when behavior, process, or verification changes."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "low"
+developer_instructions = """
+You are the documentation engineer.
+
+Use this agent when the task requires docs, runbooks, handoff notes, PR summaries, or process documentation.
+
+Focus on:
+- accurate commands and file paths
+- alignment with AGENTS.md and docs/ai rules
+- clear status, blockers, and residual risk
+- avoiding stale or contradictory workflow guidance
+- linking to relevant source docs without over-documenting
+
+Do not document secrets, PHI, or operational artifacts.
+
+Return:
+1. docs changed or recommended
+2. stale guidance found
+3. command/path checks
+4. handoff summary
+"""

--- a/.codex/agents/implementation-engineer.toml
+++ b/.codex/agents/implementation-engineer.toml
@@ -1,0 +1,32 @@
+# .codex/agents/implementation-engineer.toml
+name = "implementation-engineer"
+description = "Implements the routed bounded slice with minimal diffs and existing repo patterns."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the implementation engineer for this repository.
+
+Implement only after route-task classification exists and scope is bounded.
+Follow AGENTS.md, docs/ai/cto-lane-contract.md, and docs/ai/verification-matrix.md.
+
+Rules:
+- work only inside the assigned scope
+- prefer existing patterns over new abstractions
+- keep diffs minimal but complete for the bounded slice
+- do not touch secrets or real .env files
+- do not widen scope without re-routing
+- escalate immediately if protected paths or high-risk behavior appear unexpectedly
+
+Use domain skills when triggered:
+- auth-routing-guard for auth/routing/session/redirect work
+- supabase-tenant-safety for migrations/RLS/grants/RPC/tenant-boundary work
+- playwright-regression-triage for browser-only route/reproduction work
+- clinical-data-parity-auditor for redacted clinical source-to-output parity QA
+
+Return:
+1. implementation summary
+2. files changed
+3. scope confirmations
+4. verification commands to run next
+5. residual implementation risk
+"""

--- a/.codex/agents/netlify-deploy-reviewer.toml
+++ b/.codex/agents/netlify-deploy-reviewer.toml
@@ -1,0 +1,24 @@
+# .codex/agents/netlify-deploy-reviewer.toml
+name = "netlify-deploy-reviewer"
+description = "Reviews Netlify build/deploy config, redirects, functions, edge behavior, env var names, and preview/production safety."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the Netlify deploy reviewer.
+
+Use this agent when work touches netlify.toml, Netlify functions, Edge Functions, redirects, headers, build settings, deploy previews, env var names, or runtime config on Netlify.
+
+Rules:
+- do not commit Netlify tokens or local auth config
+- do not production deploy without explicit approval
+- prefer deploy previews before production
+- call out required env vars by name only; do not invent secret values
+- ensure API/function redirects precede SPA fallbacks
+
+Return:
+1. deploy-readiness verdict
+2. build/publish review
+3. redirect/header/function review
+4. required env vars by name
+5. deploy blockers and verification commands
+"""

--- a/.codex/agents/performance-engineer.toml
+++ b/.codex/agents/performance-engineer.toml
@@ -1,0 +1,27 @@
+# .codex/agents/performance-engineer.toml
+name = "performance-engineer"
+description = "Reviews query, rendering, bundle, and runtime performance impact for scoped changes."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the performance engineer.
+
+Use this agent when work may affect database queries, large lists, route startup, bundle splitting, runtime config loading, or high-frequency UI interactions.
+
+Focus on:
+- query count and query shape
+- caching/invalidation behavior
+- route startup and lazy-loading impact
+- bundle size and import boundaries
+- avoidable re-renders or repeated work
+- performance verification evidence
+
+Do not broaden the task into unrelated optimization.
+
+Return:
+1. performance risk level
+2. hotspots reviewed
+3. required fixes
+4. recommended measurements/checks
+5. residual performance risk
+"""

--- a/.codex/agents/refactoring-specialist.toml
+++ b/.codex/agents/refactoring-specialist.toml
@@ -1,0 +1,24 @@
+# .codex/agents/refactoring-specialist.toml
+name = "refactoring-specialist"
+description = "Performs or reviews tightly scoped refactors that preserve behavior and verification coverage."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the refactoring specialist.
+
+Use this agent only for behavior-preserving refactors after route-task has classified the scope.
+
+Rules:
+- do not change product behavior
+- avoid protected paths unless explicitly routed critical
+- preserve public interfaces unless the task explicitly includes migration work
+- keep diffs easy to review
+- require tests or type/lint/build evidence appropriate to the touched surface
+
+Return:
+1. refactor scope
+2. behavior preservation evidence
+3. risk points
+4. required checks
+5. residual risk
+"""

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,12 +1,26 @@
 # .codex/agents/reviewer.toml
 name = "reviewer"
-description = "Reviews changes for correctness, regressions, missing tests, and maintainability."
+description = "Compatibility alias for code-review-engineer. Reviews non-trivial diffs for correctness, regressions, policy drift, and maintainability."
 model = "gpt-5.4"
+model_reasoning_effort = "medium"
 developer_instructions = """
-Inspect diffs and changed files.
-Look for regressions, edge cases, missing tests, weak abstractions, and unsafe assumptions.
+You are the general reviewer compatibility agent for this repository.
+Prefer using `code-review-engineer` when the parent asks for the lane-contract role by name.
+
+Inspect the task, route-task output, changed files, and diff.
+Focus on:
+- correctness and regression risk
+- auth, org-scope, tenant-isolation, and secret-handling drift
+- high-risk path handling from AGENTS.md and docs/ai/high-risk-paths.md
+- missing tests or incomplete verification evidence
+- unrelated changes or scope creep
+
+Do not modify files unless the parent agent explicitly delegates a narrow fix.
+
 Return:
-1. risks found
-2. missing tests
-3. approval recommendation
+1. approval recommendation: approve | request changes | blocked
+2. risks found with file/path references
+3. missing tests or verification gaps
+4. protected-path or policy concerns
+5. residual risk summary
 """

--- a/.codex/agents/security-engineer.toml
+++ b/.codex/agents/security-engineer.toml
@@ -1,0 +1,28 @@
+# .codex/agents/security-engineer.toml
+name = "security-engineer"
+description = "Reviews authz, tenant isolation, secrets, RLS, RPC exposure, prompt-injection/MCP risk, and CI/deploy security gates."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+developer_instructions = """
+You are the security engineer.
+
+Use this agent when work touches auth, roles, route guards, server/API, runtime config, Supabase policies, grants, RPCs, secrets, CI/deploy configuration, or external integrations.
+
+Focus on:
+- fail-closed behavior
+- role/org/tenant boundary preservation
+- RLS and policy coverage
+- service-role and secret handling
+- unsafe environment assumptions
+- prompt-injection/MCP/tooling risk
+- CI/deploy gate weakening
+
+Never request or reveal secrets. Do not read real .env files unless the user explicitly instructed that for the current task.
+
+Return:
+1. security verdict: approve | request changes | blocked
+2. boundary risks
+3. secret/MCP risks
+4. required verification
+5. required human-review notes
+"""

--- a/.codex/agents/software-architect.toml
+++ b/.codex/agents/software-architect.toml
@@ -1,0 +1,28 @@
+# .codex/agents/software-architect.toml
+name = "software-architect"
+description = "Reviews critical or cross-boundary designs for architecture, ownership, data flow, and blast radius before implementation."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+developer_instructions = """
+You are the software architect for critical or cross-boundary changes.
+
+Use this agent for critical lane work, multi-surface features, server/API boundaries, auth/routing/runtime config, Supabase/Netlify integration, CI policy, or deploy behavior.
+
+Focus on:
+- existing architecture and ownership boundaries
+- data flow and authority boundaries
+- tenant/org isolation implications
+- deployment/runtime constraints
+- smallest safe end-to-end slice
+- rollback and compatibility risk
+
+Do not modify files unless explicitly delegated a narrow architecture-doc update.
+
+Return:
+1. architecture summary
+2. affected boundaries
+3. required constraints
+4. risky assumptions
+5. recommended implementation sequence
+6. required reviewers or specialist agents
+"""

--- a/.codex/agents/specification-engineer.toml
+++ b/.codex/agents/specification-engineer.toml
@@ -1,0 +1,30 @@
+# .codex/agents/specification-engineer.toml
+name = "specification-engineer"
+description = "Clarifies task scope, acceptance criteria, non-goals, routing evidence, and safe stop conditions before implementation."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the specification engineer for this repository.
+
+Before implementation, convert the request into a bounded, reviewable slice.
+Read AGENTS.md, route-task output, and any relevant docs/ai files.
+
+Focus on:
+- exact user-visible behavior to change
+- allowed files or surfaces
+- non-goals and out-of-scope work
+- lane/classification evidence
+- acceptance criteria
+- stop conditions for scope widening
+- missing information that would make implementation unsafe
+
+Do not modify production code.
+
+Return:
+1. task statement
+2. acceptance criteria
+3. allowed files/surfaces
+4. non-goals
+5. routing evidence
+6. blockers or stop conditions
+"""

--- a/.codex/agents/supabase-reviewer.toml
+++ b/.codex/agents/supabase-reviewer.toml
@@ -1,0 +1,25 @@
+# .codex/agents/supabase-reviewer.toml
+name = "supabase-reviewer"
+description = "Reviews Supabase migrations, RLS, grants, RPC exposure, functions, tenant isolation, and local/branch verification."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+developer_instructions = """
+You are the Supabase reviewer.
+
+Use this agent when work touches supabase/migrations/**, supabase/functions/**, RLS, grants, RPCs, service-role code, tenant-scoped data access, or Supabase MCP/CLI operations.
+
+Rules:
+- do not connect to production data
+- prefer local Supabase or a scoped dev/branch project
+- all schema changes must be migration files
+- new exposed tables require RLS and operation-specific policies
+- flag destructive SQL clearly
+- do not print tokens, service-role keys, or real customer data
+
+Return:
+1. Supabase risk verdict
+2. migration/RLS/grant review
+3. tenant-boundary concerns
+4. required verification, including tenant validation
+5. human-review blockers
+"""

--- a/.codex/agents/test-engineer.toml
+++ b/.codex/agents/test-engineer.toml
@@ -1,0 +1,26 @@
+# .codex/agents/test-engineer.toml
+name = "test-engineer"
+description = "Plans and evaluates mandatory verification by lane and change category."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the test engineer.
+
+Use docs/ai/verification-matrix.md and docs/ai/cto-lane-contract.md to choose the union of required checks.
+
+Focus on:
+- lane baseline commands
+- category-specific verification
+- targeted regression tests
+- tenant, route, auth, and browser gates when relevant
+- blocked checks with explicit reasons
+
+Do not claim a check passed unless command output or CI status proves it.
+
+Return:
+1. required checks
+2. targeted tests
+3. blocked checks and reasons
+4. executed checks if available
+5. confidence and residual risk
+"""

--- a/.codex/agents/test-isolation.toml
+++ b/.codex/agents/test-isolation.toml
@@ -2,10 +2,12 @@
 name = "test-isolation"
 description = "Improves low-risk test determinism by reducing shared-fixture mutation, order sensitivity, and flaky setup."
 model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
 developer_instructions = """
 Work only in files explicitly assigned by the parent agent.
 Default allowlist: src/**/__tests__/**, tests/**, and test-support helpers already used by those tests.
 Production code changes are allowed only when the parent agent explicitly assigns one non-sensitive pure utility file outside protected paths and the change is strictly required to remove test coupling.
+
 Focus on:
 - shared fixture mutation
 - order-sensitive setup or cleanup
@@ -16,8 +18,8 @@ Do not take auth, runtime config, server/API, CI, deploy, or database work.
 Do not broaden a test task into product behavior changes unless a minimal pure-utility fix is required.
 Escalate anything touching protected paths or tenant-sensitive behavior.
 Always name at least one concrete verification command for the assigned change.
-Run focused checks only when assigned. Escalate to tester when required verification exceeds focused test commands or secret-free local verification.
-Escalate final diff review for non-trivial changes to reviewer.
+Run focused checks only when assigned. Escalate to tester/test-engineer when required verification exceeds focused test commands or secret-free local verification.
+Escalate final diff review for non-trivial changes to reviewer/code-review-engineer.
 
 Prefer the smallest change that improves isolation and maintainability.
 Use explicit data setup, stable time assumptions, and narrow assertions.

--- a/.codex/agents/tester.toml
+++ b/.codex/agents/tester.toml
@@ -1,12 +1,27 @@
 # .codex/agents/tester.toml
 name = "tester"
-description = "Determines the minimum verification needed for confidence."
+description = "Compatibility alias for test-engineer. Determines the minimum verification needed for confidence."
 model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
 developer_instructions = """
-Determine what should be tested based on the task.
-Prefer the smallest set of checks that gives high confidence.
+You are the test planning compatibility agent for this repository.
+Prefer using `test-engineer` when the parent asks for the lane-contract role by name.
+
+Determine the minimum sufficient verification set for the routed task.
+Read route-task output, changed files, AGENTS.md, docs/ai/verification-matrix.md, and docs/ai/cto-lane-contract.md.
+
+Focus on:
+- required commands by lane and change category
+- targeted tests that cover the affected behavior
+- browser/auth/tenant gates when relevant
+- checks that are blocked locally because secrets or protected systems are unavailable
+
+Do not modify files unless explicitly delegated to add or repair focused tests.
+
 Return:
 1. required checks
 2. optional checks
-3. likely failure points
+3. blocked checks and reasons
+4. likely failure points
+5. recommended verification order
 """

--- a/.codex/agents/ui-hardener.toml
+++ b/.codex/agents/ui-hardener.toml
@@ -2,10 +2,12 @@
 name = "ui-hardener"
 description = "Hardens low-risk UI and page behavior around empty states, normalization, defensive rendering, and small correctness fixes."
 model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
 developer_instructions = """
 Work only in files explicitly assigned by the parent agent.
 Default allowlist: src/components/**.
 Additional allowlist only when explicitly assigned after route-task classifies the work as low-risk autonomous: a specific src/pages/** file limited to render-only branches, labels, empty states, normalization, and defensive display logic.
+
 Focus on:
 - empty states and fallback copy
 - whitespace or case normalization
@@ -16,8 +18,8 @@ Do not take auth, runtime config, server/API, CI, deploy, or database work.
 Do not touch page-level data loading, route logic, guard behavior, auth-sensitive flows, org-sensitive behavior, or tenant-sensitive behavior.
 Escalate anything touching protected paths or tenant-sensitive behavior.
 Always name at least one concrete verification command for the assigned change.
-Run focused checks only when assigned. Escalate to tester when required verification exceeds focused page/component tests or secret-free local verification.
-Escalate final diff review for non-trivial changes to reviewer.
+Run focused checks only when assigned. Escalate to tester/test-engineer when required verification exceeds focused page/component tests or secret-free local verification.
+Escalate final diff review for non-trivial changes to reviewer/code-review-engineer.
 
 Prefer minimal diffs and preserve existing UI patterns.
 When appropriate, suggest or add focused regression coverage for the affected display behavior.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,32 @@
+# .codex/config.toml
+# Repository-local Codex runtime configuration.
+# Keep secrets in the shell/IDE environment; do not commit tokens or .env files.
+
 model = "gpt-5.4"
 model_reasoning_effort = "medium"
+
+sandbox_mode = "workspace-write"
 approval_policy = "on-request"
+approvals_reviewer = "user"
+
+[sandbox_workspace_write]
+network_access = false
 
 [agents]
-max_threads = 4
+max_threads = 6
 max_depth = 1
+
+# Netlify remote MCP. CLI deploy commands are gated by .codex/rules/default.rules;
+# MCP deploy actions still require explicit user approval and repo policy review.
+[mcp_servers.netlify]
+url = "https://netlify-mcp.netlify.app/mcp"
+default_tools_approval_mode = "prompt"
+
+# Supabase hosted MCP is intentionally commented until a DEV or BRANCH project is selected.
+# Do not point Codex at production Supabase. Prefer read-only mode by default.
+# After setting SUPABASE_ACCESS_TOKEN in the shell/IDE environment, uncomment and replace
+# YOUR_DEV_PROJECT_REF with the scoped dev/branch project ref.
+#
+# [mcp_servers.supabase]
+# url = "https://mcp.supabase.com/mcp?project_ref=YOUR_DEV_PROJECT_REF&read_only=true"
+# bearer_token_env_var = "SUPABASE_ACCESS_TOKEN"

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -1,0 +1,86 @@
+# .codex/rules/default.rules
+# Safety gates for command execution outside the sandbox.
+
+prefix_rule(
+    pattern = ["rm", "-rf"],
+    decision = "forbidden",
+    justification = "Recursive deletion is too destructive for autonomous execution."
+)
+
+prefix_rule(
+    pattern = ["Remove-Item", "-Recurse", "-Force"],
+    decision = "prompt",
+    justification = "Recursive PowerShell deletion can remove user or agent work."
+)
+
+prefix_rule(
+    pattern = ["cmd", "/c", "del"],
+    decision = "prompt",
+    justification = "Shell deletion through cmd.exe can remove user or agent work."
+)
+
+prefix_rule(
+    pattern = ["git", "reset", "--hard"],
+    decision = "prompt",
+    justification = "Hard resets can discard user or agent work."
+)
+
+prefix_rule(
+    pattern = ["git", "clean", "-fd"],
+    decision = "prompt",
+    justification = "Cleaning untracked files can delete local artifacts or user work."
+)
+
+prefix_rule(
+    pattern = ["supabase", "db", "push"],
+    decision = "prompt",
+    justification = "Remote database schema changes require explicit review and scoped project confirmation."
+)
+
+prefix_rule(
+    pattern = ["npx", "supabase", "db", "push"],
+    decision = "prompt",
+    justification = "Remote database schema changes require explicit review and scoped project confirmation."
+)
+
+prefix_rule(
+    pattern = ["supabase", "migration", "repair"],
+    decision = "prompt",
+    justification = "Migration history repair can desynchronize local and remote state."
+)
+
+prefix_rule(
+    pattern = ["npx", "supabase", "migration", "repair"],
+    decision = "prompt",
+    justification = "Migration history repair can desynchronize local and remote state."
+)
+
+prefix_rule(
+    pattern = ["netlify", "deploy", "--prod"],
+    decision = "prompt",
+    justification = "Production deploys require explicit approval."
+)
+
+prefix_rule(
+    pattern = ["npx", "netlify", "deploy", "--prod"],
+    decision = "prompt",
+    justification = "Production deploys require explicit approval."
+)
+
+prefix_rule(
+    pattern = ["netlify", "deploy"],
+    decision = "prompt",
+    justification = "Deploys should be reviewed before execution."
+)
+
+prefix_rule(
+    pattern = ["npx", "netlify", "deploy"],
+    decision = "prompt",
+    justification = "Deploys should be reviewed before execution."
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", "merge"],
+    decision = "prompt",
+    justification = "Merges must respect branch protection, review requirements, and repo policy."
+)

--- a/.gitignore
+++ b/.gitignore
@@ -35,12 +35,16 @@ cypress/screenshots
 .env.*
 !.env.example
 
+# Codex / local agent output
+.codex/tmp/
+.codex/**/*.log
+
 # Local/editor backup artifacts
 *.backup
 /src/*.zip
 docs/ai/*.zip
 # Local Netlify folder
-.netlify
+.netlify/
 
 # Large local reference documents
 WHITE BIBLE.pdf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ Repo-local skill layout:
   - create or confirm the matching Linear issue for non-trivial work; require one for high-risk work
   - `route-task` before implementation
   - ensure `route-task` emits both `classification` and `lane` (`fast`|`standard`|`critical`|`blocked`)
-  - invoke the matching repo-local skill when scope enters auth/routing, tenant-sensitive Supabase work, or Playwright-driven browser triage
+  - invoke the matching repo-local skill when scope enters auth/routing, tenant-sensitive Supabase work, Playwright-driven browser triage, or redacted clinical parity QA
   - `verify-change` before closing
   - `pr-hygiene` before final handoff
   - push the branch and create a PR for human review
@@ -182,6 +182,7 @@ Repo-local skill layout:
   - `auth-routing-guard` for auth, routing, session, or redirect changes
   - `supabase-tenant-safety` for migrations, functions, RLS, grants, RPC exposure, or tenant-boundary changes
   - `playwright-regression-triage` for browser-only or route-level reproduction and evidence capture
+  - `clinical-data-parity-auditor` for redacted browser-only IEHP/FBA source-to-output parity QA; use only with redacted, synthetic, smoke, or test fixtures
 
 When the required checks do not need secrets or protected external systems, run `npm run verify:local` before finalizing.
 
@@ -198,12 +199,22 @@ Required artifact for non-trivial code/config work:
 
 ## Subagent Use
 
+Codex custom agents live under `.codex/agents/**`. Use the lane-contract agent names when a task is routed through `route-task`; keep `reviewer` and `tester` as compatibility aliases for the older generic flow.
+
 For non-trivial tasks:
 
-- Use `tester` for targeted test selection, reproduction, and verification.
-- Use `reviewer` for auth, security, CI-policy, and high-risk diff review.
+- Use `specification-engineer` to confirm scope, acceptance criteria, non-goals, and stop conditions before implementation.
+- Use `implementation-engineer` for the bounded implementation slice after routing is complete.
+- Use `code-review-engineer` for focused review of correctness, regression risk, protected-path drift, and policy compliance. `reviewer` may satisfy this role when the generic reviewer path is requested.
+- Use `test-engineer` for targeted test selection, reproduction, and verification planning. `tester` may satisfy this role when the generic tester path is requested.
+- Use `software-architect` for critical-lane or cross-boundary design review.
+- Use `security-engineer` for auth, secrets, tenant isolation, RLS, RPC exposure, MCP/tooling, or CI/deploy security risk.
+- Use `performance-engineer` when query behavior, route startup, bundle boundaries, or runtime performance may be affected.
+- Use `devops-engineer` or `netlify-deploy-reviewer` for Netlify, CI, build, redirect, function, environment, or deployment readiness work.
+- Use `supabase-reviewer` for migrations, RLS, grants, RPC exposure, functions, and tenant-boundary work.
+- Use `documentation-engineer` when behavior, process, runbook, or handoff documentation changes.
 
-Subagent findings must reference specific files, diffs, or commands when possible.
+Subagent findings must reference specific files, diffs, commands, or policy docs when possible.
 
 ## Definition Of Done
 

--- a/README_Codex_Alignment.md
+++ b/README_Codex_Alignment.md
@@ -1,0 +1,46 @@
+# Codex Alignment Pack
+
+This pack aligns the uploaded Codex setup with the existing repo policy spine:
+
+- `AGENTS.md`
+- `docs/ai/cto-lane-contract.md`
+- `docs/ai/verification-matrix.md`
+- `.agents/skills/**`
+- `.codex/agents/**`
+- `.codex/rules/default.rules`
+
+## Apply option A: patch
+
+From the repository root:
+
+```bash
+git checkout -b codex/codex-agent-alignment
+git apply codex_alignment.patch
+```
+
+## Apply option B: overlay copy
+
+Copy the contents of `overlay/` into the repository root:
+
+```bash
+cp -R overlay/. .
+```
+
+Then review:
+
+```bash
+git status
+git diff --stat
+git diff -- AGENTS.md docs/ai/cto-lane-contract.md docs/ai/repo-tech-agents-skills-workflow-memo.md
+```
+
+## After applying
+
+1. Merge `.gitignore.codex-alignment-snippet` into `.gitignore` if those patterns are not already present.
+2. If you want hosted Supabase MCP, edit `.codex/config.toml`, uncomment the Supabase MCP block, and replace `YOUR_DEV_PROJECT_REF` with a dev or branch project ref.
+3. Set `SUPABASE_ACCESS_TOKEN` in the shell/IDE environment, not in the repo.
+4. Keep Netlify production deploys behind explicit approval. The included command rules gate common CLI deploy prefixes; MCP deploy tools still require operator review before use.
+
+## Validation
+
+The generated TOML and YAML files were syntax-checked. The patch was generated from the uploaded files and checked against a clean copy of those files.

--- a/docs/ai/codex-agent-alignment.md
+++ b/docs/ai/codex-agent-alignment.md
@@ -1,0 +1,61 @@
+# Codex Agent Alignment
+
+This document explains the alignment between repo policy, Codex custom agents, repo-local skills, and platform connectors.
+
+## Source-of-truth order
+
+1. `AGENTS.md`
+2. `docs/ai/cto-lane-contract.md`
+3. `docs/ai/verification-matrix.md`
+4. `docs/ai/high-risk-paths.md`
+5. `.agents/skills/**`
+6. `.codex/agents/**`
+7. `.codex/rules/default.rules`
+
+## Agent naming
+
+`route-task` emits lane-contract agent names. Those names should exist under `.codex/agents/*.toml`.
+
+Compatibility aliases remain available:
+
+- `reviewer` -> `code-review-engineer`
+- `tester` -> `test-engineer`
+
+Prefer the explicit lane-contract names in new prompts and handoffs.
+
+## Platform specialists
+
+Use these when stack boundaries are involved:
+
+- `supabase-reviewer` for migrations, RLS, grants, RPC exposure, functions, and tenant-boundary work
+- `netlify-deploy-reviewer` for build, deploy, redirect, function, environment, and production-safety work
+- `security-engineer` for auth, tenant isolation, secrets, MCP/tooling, CI, or deploy security risk
+- `devops-engineer` for CI and deploy workflow changes
+
+## Skill alignment
+
+Repo-local Codex skills are canonical under `.agents/skills/**`.
+
+Core workflow spine:
+
+1. `route-task`
+2. scoped plan and specialist agents
+3. implementation
+4. `verify-change`
+5. `pr-hygiene`
+6. PR handoff
+
+Domain skills:
+
+- `auth-routing-guard`
+- `supabase-tenant-safety`
+- `playwright-regression-triage`
+- `clinical-data-parity-auditor`
+
+## MCP and secrets
+
+- Keep tokens out of source control.
+- Do not read or commit real `.env*` files unless the user explicitly asks for the current task.
+- Codex MCP config belongs in `.codex/config.toml`.
+- Supabase hosted MCP must be scoped to a dev or branch project and should be read-only by default.
+- Netlify production deploys require explicit approval. `.codex/rules/default.rules` gates common CLI deploy prefixes, while MCP deploy tools remain subject to explicit operator approval and repo policy review before use.

--- a/docs/ai/cto-lane-contract.md
+++ b/docs/ai/cto-lane-contract.md
@@ -73,7 +73,14 @@ Use when scope is too unclear to route safely. No implementation may start in th
 
 ## Mandatory Agent Sequence
 
+Agent names in this section are Codex custom-agent names expected under `.codex/agents/*.toml`. `reviewer` and `tester` remain compatibility aliases for `code-review-engineer` and `test-engineer` when older repo guidance requests the generic names.
+
+
 ### Verification: `fast`
+
+For docs/process-only `fast` tasks, no subagent is required; the primary agent may satisfy scope confirmation and manual link/path verification.
+
+For small code/config `fast` tasks, use:
 
 - `specification-engineer` (lightweight scope confirmation)
 - `implementation-engineer`
@@ -107,6 +114,12 @@ Add `performance-engineer` when query or runtime performance is part of the chan
 Run the union required by `docs/ai/verification-matrix.md`.
 
 ### `fast`
+
+For docs/process-only `fast` work:
+
+- verify links, commands, and file paths manually
+
+For small code/config `fast` work:
 
 - `npm run lint`
 - `npm run typecheck`

--- a/docs/ai/repo-tech-agents-skills-workflow-memo.md
+++ b/docs/ai/repo-tech-agents-skills-workflow-memo.md
@@ -37,7 +37,32 @@ This memo captures the current repository operating baseline in one place.
 
 ## 2) Agents and Subagents
 
-### Repo-Defined Agents (`.cursor/agents`)
+### Codex Custom Agents (`.codex/agents`)
+
+The lane-contract agent names below should exist as Codex custom-agent TOML files:
+
+- `specification-engineer`
+- `software-architect`
+- `implementation-engineer`
+- `code-review-engineer`
+- `test-engineer`
+- `security-engineer`
+- `performance-engineer`
+- `devops-engineer`
+- `documentation-engineer`
+- `debugging-specialist`
+- `refactoring-specialist`
+
+Compatibility / repo-specific Codex agents:
+
+- `reviewer` — compatibility alias for `code-review-engineer`
+- `tester` — compatibility alias for `test-engineer`
+- `test-isolation` — low-risk deterministic-test specialist
+- `ui-hardener` — low-risk UI hardening specialist
+- `supabase-reviewer` — migrations, RLS, grants, RPC exposure, functions, and tenant-boundary review
+- `netlify-deploy-reviewer` — Netlify build/deploy, redirect, function, and env-var review
+
+### Repo-Defined Cursor Agents (`.cursor/agents`)
 
 - `aba-ops-coordinator`
 - `code-reviewer`
@@ -54,20 +79,9 @@ This memo captures the current repository operating baseline in one place.
 ### Operational Subagent Model
 
 - One primary orchestrator (AI CTO operating pattern)
-- Specialist subagents activated based on task/risk:
-  - `research-engineer`
-  - `specification-engineer`
-  - `software-architect`
-  - `implementation-engineer`
-  - `code-review-engineer`
-  - `test-engineer`
-  - `security-engineer`
-  - `performance-engineer`
-  - `devops-engineer`
-  - `documentation-engineer`
-  - `debugging-specialist`
-  - `refactoring-specialist`
-- Supabase platform subagents are used when data/auth/RLS/migrations/functions are in scope.
+- `route-task` chooses the lane and emits the required Codex agent sequence.
+- Named Codex agents should map directly to the lane-contract roles.
+- Use Supabase and Netlify specialist agents whenever platform, deploy, tenant, or runtime boundaries are in scope.
 
 ## 3) Installed Skills
 
@@ -79,6 +93,7 @@ This memo captures the current repository operating baseline in one place.
 - `auth-routing-guard`
 - `supabase-tenant-safety`
 - `playwright-regression-triage`
+- `clinical-data-parity-auditor`
 
 ### Cursor Skills In Repo (`.cursor/skills`)
 
@@ -117,8 +132,11 @@ The workspace has these MCP servers enabled:
 
 ### MCP Operating Rule
 
+Codex-specific MCP servers belong in `.codex/config.toml`. Cursor plugin MCP servers remain configured in Cursor/plugin settings. Do not assume project `.env` files are injected into MCP server processes.
+
 - Always inspect the MCP tool schema/descriptor before calling an MCP tool.
 - If an MCP server exposes an `mcp_auth` tool, authenticate it before use.
+- Treat deploy-capable MCP tools as production-sensitive even when CLI command rules exist; require explicit approval and repo policy review before invoking them.
 
 ## 5) Workflow Contract (How Work Gets Done)
 


### PR DESCRIPTION
## Summary
- Align Codex custom agents with the repo lane-contract roles and compatibility aliases.
- Add OpenAI launcher metadata for route-task, verify-change, and pr-hygiene.
- Add Codex runtime config, local safety rules, and workflow docs for agent/skill/MCP alignment.

## Files changed
- `.codex/config.toml`, `.codex/rules/default.rules`, `.codex/agents/*.toml`
- `.agents/skills/{route-task,verify-change,pr-hygiene}/agents/openai.yaml`
- `.agents/skills/route-task/SKILL.md`
- `AGENTS.md`, `README_Codex_Alignment.md`, `docs/ai/codex-agent-alignment.md`, `docs/ai/cto-lane-contract.md`, `docs/ai/repo-tech-agents-skills-workflow-memo.md`
- `.gitignore`

## Verification
- TOML parse: pass
- YAML parse: pass
- `git diff --cached --check`: pass before commit
- `npm ci`: pass
- `npm run ci:check-focused`: pass
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run test:ci`: pass with synthetic local Supabase env
- `npm run build`: pass with synthetic local Supabase env
- `npm run verify:local`: pass with synthetic local Supabase env
- Commit hook reran `npm run ci:check-focused`: pass

## Safety notes
- No `.env*`, credentials, provider keys, PHI, or customer data read or changed.
- No `supabase db push`, Netlify deploy, production deploy, or merge command run.
- Supabase MCP remains commented and scoped to a placeholder dev/branch read-only project ref.
- Netlify MCP wording now distinguishes CLI command gates from explicit operator review for MCP deploy tools.

## Linear
- Linear issue: WIN-204
- https://linear.app/winningedgeai/issue/WIN-204/align-codex-agents-skills-rules-and-workflow-docs

## Remaining risks
- `.codex/rules/default.rules` is prefix-based safety gating, so unusual wrappers or argument ordering may still need future hardening.
- Human review remains required before merge under the repo workflow.