### PR TITLE
WIN-205 Add goal-targets edge parity guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
           CI_SUPABASE_AUTH_PARITY_REQUIRED: "true"
           CI_EDGE_ROUTE_PARITY_REQUIRED: "true"
-          SUPABASE_FUNCTION_PARITY_SCOPE: "sessions-book,sessions-hold,sessions-confirm,sessions-start,sessions-cancel,generate-session-notes-pdf,session-notes-pdf-status,session-notes-pdf-download,programs,goals,program-notes"
+          SUPABASE_FUNCTION_PARITY_SCOPE: "sessions-book,sessions-hold,sessions-confirm,sessions-start,sessions-cancel,generate-session-notes-pdf,session-notes-pdf-status,session-notes-pdf-download,programs,goals,goal-targets,program-notes"
           CI_RLS_OVERLAP_REQUIRED: ${{ secrets.SUPABASE_DB_URL != '' && 'true' || 'false' }}
           CI_REQUIRED_CHECKS: "ci-gate"
           API_AUTHORITY_MODE: "edge"

--- a/docs/STAGING_OPERATIONS.md
+++ b/docs/STAGING_OPERATIONS.md
@@ -74,7 +74,7 @@ CI policy checks currently validate branch protection for `main` via `CI_PROTECT
 For CI policy strict mode, ensure the `SUPABASE_DB_URL` secret is configured so RLS overlap checks do not get skipped.
 
 For API authority convergence checks, `scripts/ci/check-api-adapter-boundary.mjs` now enforces that converged routes remain adapter-only and point to canonical edge functions.
-For session lifecycle edge contracts, `scripts/ci/deploy-session-edge-bundle.mjs` deploys the full required bundle (session lifecycle routes, `programs`, `goals`, `program-notes`, `emails`, assessment extraction/generation functions, tenant-scoped reporting functions such as `utilization-report`, and related session-notes PDF functions) and enforces `verify_jwt=true` for every function in that list unless `CI_EXPECT_VERIFY_JWT` is overridden.
+For session lifecycle edge contracts, `scripts/ci/deploy-session-edge-bundle.mjs` deploys the full required bundle (session lifecycle routes, `programs`, `goals`, `goal-targets`, `program-notes`, `emails`, assessment extraction/generation functions, tenant-scoped reporting functions such as `utilization-report`, and related session-notes PDF functions) and enforces `verify_jwt=true` for every function in that list unless `CI_EXPECT_VERIFY_JWT` is overridden.
 The `policy` job now runs `npm run ci:deploy:session-edge-bundle` on push and pull-request events before policy checks so parity is verified against freshly deployed lifecycle and assessment functions.
 `lighthouse-ci` currently runs as an advisory (non-blocking) signal while preview URL detection is stabilized; retain artifact review in release checklists even though it does not block merge.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -212,7 +212,12 @@ Supabase auth parity guard details:
   - `generate-session-notes-pdf`
   - `session-notes-pdf-status`
   - `session-notes-pdf-download`
-- Use `SUPABASE_FUNCTION_PARITY_SCOPE` to pin this focused lifecycle scope in local/CI reruns.
+- Programs/Goals direct-edge scope also includes:
+  - `programs`
+  - `goals`
+  - `goal-targets`
+  - `program-notes`
+- Use `SUPABASE_FUNCTION_PARITY_SCOPE` to pin this focused lifecycle or Programs/Goals scope in local/CI reruns.
 - Fails in CI on mismatch so auth posture drift cannot pass silently.
 
 ## Cypress typing policy

--- a/docs/api/ENDPOINT_OWNERSHIP_MATRIX.md
+++ b/docs/api/ENDPOINT_OWNERSHIP_MATRIX.md
@@ -26,5 +26,5 @@ Notes:
 - `status`, `owner`, and `exception expiry` must stay in sync with:
   - `docs/api/endpoint-convergence-status.json`
   - `docs/api/runtime-exceptions.json`
-- CI enforces direct edge parity for session lifecycle routes (`sessions-hold`, `sessions-confirm`, `sessions-start`, `sessions-cancel`) and session-notes PDF async routes (`generate-session-notes-pdf`, `session-notes-pdf-status`, `session-notes-pdf-download`) so shim-only availability is not sufficient for release.
+- CI enforces direct edge parity for session lifecycle routes (`sessions-hold`, `sessions-confirm`, `sessions-start`, `sessions-cancel`), session-notes PDF async routes (`generate-session-notes-pdf`, `session-notes-pdf-status`, `session-notes-pdf-download`), and Programs/Goals direct-edge routes (`programs`, `goals`, `goal-targets`, `program-notes`) so shim-only availability is not sufficient for release.
 - Remediation details, migration IDs, and rollback/forward-fix instructions are tracked in `docs/SESSION_LIFECYCLE_REMEDIATION_RUNBOOK.md`.

--- a/docs/supabase_branching.md
+++ b/docs/supabase_branching.md
@@ -66,7 +66,7 @@ We currently run all environments (preview, staging, production) against the sam
    ```bash
    npm run ci:deploy:session-edge-bundle
    ```
-   That script deploys session lifecycle functions, care-plan routes (`programs`, `goals`, `program-notes`), the optional `emails` proxy, assessment extraction/generation functions, and tenant-scoped reporting functions such as `utilization-report`; see `scripts/ci/deploy-session-edge-bundle.mjs` for the authoritative list.
+   That script deploys session lifecycle functions, care-plan routes (`programs`, `goals`, `goal-targets`, `program-notes`), the optional `emails` proxy, assessment extraction/generation functions, and tenant-scoped reporting functions such as `utilization-report`; see `scripts/ci/deploy-session-edge-bundle.mjs` for the authoritative list.
    Alternatively deploy each function manually with `supabase functions deploy <name> --project-ref <ref>`.
    For session lifecycle routes, ensure gateway JWT verification remains enabled (`verify_jwt=true`) for `sessions-book`, `sessions-hold`, `sessions-confirm`, `sessions-start`, `sessions-cancel`, `generate-session-notes-pdf`, `session-notes-pdf-status`, and `session-notes-pdf-download`.
 5. Monitor the Supabase dashboard deployment logs. If a migration fails, follow the rollback/forward-fix plan documented in the PR.

--- a/scripts/ci/check-api-contract-smoke.mjs
+++ b/scripts/ci/check-api-contract-smoke.mjs
@@ -11,6 +11,10 @@ const REQUIRED_EDGE_FUNCTIONS = [
   "generate-session-notes-pdf",
   "session-notes-pdf-status",
   "session-notes-pdf-download",
+  "programs",
+  "goals",
+  "goal-targets",
+  "program-notes",
 ];
 
 const CRITICAL_ENDPOINTS = [

--- a/scripts/ci/deploy-session-edge-bundle.mjs
+++ b/scripts/ci/deploy-session-edge-bundle.mjs
@@ -13,6 +13,7 @@ const REQUIRED_FUNCTIONS = [
   "session-notes-pdf-download",
   "programs",
   "goals",
+  "goal-targets",
   "program-notes",
   "emails",
   "extract-assessment-fields",

--- a/scripts/playwright-schedule-blocked-close.ts
+++ b/scripts/playwright-schedule-blocked-close.ts
@@ -444,17 +444,11 @@ async function run(): Promise<void> {
       }));
 
     await withStepTimeout("open-edit-modal", async () => {
-      const openedFromRenderedCard = await openRenderedSessionCard(activePage, booked.sessionId);
-      if (openedFromRenderedCard) {
-        await activePage
-          .locator('[role="dialog"][data-session-status="in_progress"]')
-          .waitFor({ state: "visible", timeout: 90_000 });
-        return;
-      }
-
       let lastUrl = activePage.url();
       let lastBodyText = "";
 
+      // Prefer URL-driven modal state on deploy previews. Netlify's preview drawer
+      // can overlay the schedule grid and swallow rendered-card clicks.
       for (let attempt = 1; attempt <= 3; attempt += 1) {
         const expiresAt = Date.now() + 30 * 60 * 1000;
         const editUrl = `${base}/schedule?scheduleModal=edit&scheduleSessionId=${encodeURIComponent(
@@ -479,6 +473,14 @@ async function run(): Promise<void> {
           continue;
         }
 
+        await activePage
+          .locator('[role="dialog"][data-session-status="in_progress"]')
+          .waitFor({ state: "visible", timeout: 90_000 });
+        return;
+      }
+
+      const openedFromRenderedCard = await openRenderedSessionCard(activePage, booked.sessionId);
+      if (openedFromRenderedCard) {
         await activePage
           .locator('[role="dialog"][data-session-status="in_progress"]')
           .waitFor({ state: "visible", timeout: 90_000 });


### PR DESCRIPTION
## Summary
- add `goal-targets` to the hosted Edge Function deployment parity guard
- include `goal-targets` in the CI Supabase auth parity scope
- update parity/deploy docs so Programs/Goals direct Edge routes are listed together

Linear: WIN-205

## Verification
- `node scripts/ci/check-api-contract-smoke.mjs`
- `npm run ci:check-focused`
- `npm run verify:local`
- Supabase MCP `_list_edge_functions` confirmed `goal-targets` is ACTIVE with `verify_jwt=true` on project `wnnjeqheqxxyrgsjmygy`

## Risk
- Critical protected-path change: touches `.github/workflows/**` and `scripts/ci/**`.
- GitHub CI should prove the secret-backed Supabase parity path with repository secrets.