### PR TITLE
WIN-206 Add all-user account password settings

### DIFF
--- a/cypress/support/routeScenarios.ts
+++ b/cypress/support/routeScenarios.ts
@@ -53,6 +53,7 @@ export const routeGroups = {
     },
     { path: "/clients", roles: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
     { path: "/clients/client-1", roles: ["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
+    { path: "/account", roles: ["client", "bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
     { path: "/documentation", roles: ["client", "bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
     { path: "/authorizations", roles: ["midtier", "admin_schedule", "admin", "bcba", "super_admin"] },
     { path: "/family", roles: [] },

--- a/scripts/route-audit.ts
+++ b/scripts/route-audit.ts
@@ -117,6 +117,7 @@ export const ROUTES: readonly RouteDefinition[] = [
   },
   { path: '/therapists/new', component: 'TherapistOnboarding', roles: ['admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
   { path: '/documentation', component: 'Documentation', roles: ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
+  { path: '/account', component: 'Account', roles: ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
   { path: '/fill-docs', component: 'FillDocs', roles: ['bt', 'therapist', 'midtier', 'admin', 'bcba', 'super_admin'], permissions: [] },
   { path: '/authorizations', component: 'Authorizations', roles: ['midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },
   { path: '/messages', component: 'MessagesInbox', roles: ['bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'], permissions: [] },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ const Documentation = React.lazy(() =>
 const FillDocs = React.lazy(() => import('./pages/FillDocs').then(module => ({ default: module.FillDocs })));
 const Billing = React.lazy(() => import('./pages/Billing').then(module => ({ default: module.Billing })));
 const Settings = React.lazy(() => import('./pages/Settings').then(module => ({ default: module.Settings })));
+const Account = React.lazy(() => import('./pages/Account').then(module => ({ default: module.Account })));
 const SuperAdminFeatureFlags = React.lazy(() =>
   import('./pages/SuperAdminFeatureFlags').then(module => ({ default: module.SuperAdminFeatureFlags })),
 );
@@ -226,6 +227,9 @@ function App() {
 
                     {/* Documentation - accessible to all authenticated users */}
                     <Route path="documentation" element={<Documentation />} />
+
+                    {/* Account - accessible to all authenticated users */}
+                    <Route path="account" element={<Account />} />
 
                     {/* Fill Docs - accessible to therapists and above */}
                     <Route

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -195,6 +195,13 @@ export function Sidebar() {
       roles: ['admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
+    {
+      icon: User,
+      label: 'My Account',
+      path: '/account',
+      roles: ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'] as AppRole[],
+      requiresGuardian: false,
+    },
   ];
 
   // Mobile menu button

--- a/src/components/settings/UserSettings.tsx
+++ b/src/components/settings/UserSettings.tsx
@@ -35,6 +35,24 @@ export function UserSettings() {
 
   const handleUpdateProfile = async (data: UserSettingsForm) => {
     try {
+      const isPasswordChangeRequested = isChangingPassword && data.current_password && data.new_password;
+      const currentEmail = user?.email?.trim() || data.email.trim();
+
+      if (isPasswordChangeRequested) {
+        if (!currentEmail) {
+          throw new Error('Unable to verify your current password. Please sign out and sign in again.');
+        }
+
+        const { data: verificationData, error: verificationError } = await supabase.auth.signInWithPassword({
+          email: currentEmail,
+          password: data.current_password,
+        });
+
+        if (verificationError || (user?.id && verificationData.user?.id !== user.id)) {
+          throw new Error('Current password is incorrect.');
+        }
+      }
+
       const updates = {
         email: data.email,
         data: {
@@ -49,7 +67,7 @@ export function UserSettings() {
       if (updateError) throw updateError;
 
       // Handle password change if requested
-      if (isChangingPassword && data.current_password && data.new_password) {
+      if (isPasswordChangeRequested) {
         const { error: passwordError } = await supabase.auth.updateUser({
           password: data.new_password,
         });

--- a/src/components/settings/__tests__/UserSettings.test.tsx
+++ b/src/components/settings/__tests__/UserSettings.test.tsx
@@ -1,0 +1,95 @@
+import type React from 'react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { renderWithProviders, screen, userEvent, waitFor } from '../../../test/utils';
+import { UserSettings } from '../UserSettings';
+
+const mocks = vi.hoisted(() => ({
+  signInWithPassword: vi.fn(),
+  updateUser: vi.fn(),
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+}));
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signInWithPassword: mocks.signInWithPassword,
+      updateUser: mocks.updateUser,
+    },
+  },
+}));
+
+vi.mock('../../../lib/toast', () => ({
+  showSuccess: mocks.showSuccess,
+  showError: mocks.showError,
+}));
+
+vi.mock('../../../lib/authContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'bt-user-id',
+      email: 'bt@example.com',
+      user_metadata: {},
+    },
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('UserSettings password changes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.signInWithPassword.mockResolvedValue({ data: { user: { id: 'bt-user-id' } }, error: null });
+    mocks.updateUser.mockResolvedValue({ data: { user: { id: 'bt-user-id' } }, error: null });
+  });
+
+  it('verifies the current password before changing to a new password', async () => {
+    renderWithProviders(<UserSettings />, {
+      auth: { role: 'bt', userId: 'bt-user-id', email: 'bt@example.com' },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /change password/i }));
+    await userEvent.type(screen.getByLabelText(/^Current Password$/i), 'OldPass123!');
+    await userEvent.type(screen.getByLabelText(/^New Password$/i), 'NewPass123!');
+    await userEvent.type(screen.getByLabelText(/^Confirm New Password$/i), 'NewPass123!');
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mocks.signInWithPassword).toHaveBeenCalledWith({
+        email: 'bt@example.com',
+        password: 'OldPass123!',
+      });
+    });
+    expect(mocks.updateUser).toHaveBeenCalledWith({
+      email: 'bt@example.com',
+      data: {
+        first_name: '',
+        last_name: '',
+        title: '',
+      },
+    });
+    expect(mocks.updateUser).toHaveBeenCalledWith({ password: 'NewPass123!' });
+    expect(mocks.showSuccess).toHaveBeenCalledWith('Profile updated successfully');
+  });
+
+  it('does not update the password when current password verification fails', async () => {
+    mocks.signInWithPassword.mockResolvedValue({
+      data: { user: null },
+      error: new Error('Invalid login credentials'),
+    });
+
+    renderWithProviders(<UserSettings />, {
+      auth: { role: 'bt', userId: 'bt-user-id', email: 'bt@example.com' },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /change password/i }));
+    await userEvent.type(screen.getByLabelText(/^Current Password$/i), 'WrongPass123!');
+    await userEvent.type(screen.getByLabelText(/^New Password$/i), 'NewPass123!');
+    await userEvent.type(screen.getByLabelText(/^Confirm New Password$/i), 'NewPass123!');
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mocks.showError).toHaveBeenCalled();
+    });
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,0 +1,13 @@
+import { UserSettings } from '../components/settings/UserSettings';
+
+export function Account() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My Account</h1>
+      </div>
+
+      <UserSettings />
+    </div>
+  );
+}

--- a/src/pages/__tests__/AppNavigation.test.tsx
+++ b/src/pages/__tests__/AppNavigation.test.tsx
@@ -99,6 +99,10 @@ vi.mock('../../pages/Settings', () => ({
   Settings: () => <div>SettingsPage</div>,
 }));
 
+vi.mock('../../pages/Account', () => ({
+  Account: () => <div>AccountPage</div>,
+}));
+
 vi.mock('../../pages/SuperAdminFeatureFlags', () => ({
   SuperAdminFeatureFlags: () => <div>SuperAdminFeatureFlagsPage</div>,
 }));
@@ -298,6 +302,19 @@ describe('App navigation landing', () => {
       await waitFor(() => {
         expect(window.location.pathname).toBe('/unauthorized');
       });
+
+      view.unmount();
+    }
+  });
+
+  it('allows every authenticated role to open personal account settings', async () => {
+    for (const role of ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'] as const) {
+      authRole = role;
+      window.history.pushState({}, '', '/account');
+      const view = renderApp();
+
+      expect(await screen.findByText('AccountPage')).toBeInTheDocument();
+      expect(window.location.pathname).toBe('/account');
 
       view.unmount();
     }

--- a/src/server/routes/__tests__/guards.test.ts
+++ b/src/server/routes/__tests__/guards.test.ts
@@ -18,6 +18,7 @@ const expectedPaths = [
   '/therapists/:therapistId',
   '/therapists/new',
   '/documentation',
+  '/account',
   '/fill-docs',
   '/authorizations',
   '/messages',

--- a/src/server/routes/guards.ts
+++ b/src/server/routes/guards.ts
@@ -81,6 +81,12 @@ const guardDefinitions: readonly GuardWithMatcher[] = [
     supabasePolicies: ['public.profiles: role_scoped_select'],
   }),
   createGuard({
+    path: '/account',
+    allowedRoles: ['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin'],
+    requiredPermissions: [],
+    supabasePolicies: ['public.profiles: role_scoped_update'],
+  }),
+  createGuard({
     path: '/fill-docs',
     allowedRoles: ['bt', 'therapist', 'midtier', 'admin', 'bcba', 'super_admin'],
     requiredPermissions: [],


### PR DESCRIPTION
## Summary
- Add `/account` as a personal account route available to every authenticated role, including `bt` and legacy `therapist`.
- Add `My Account` navigation while keeping organization `/settings` limited to admin, BCBA, and super admin roles.
- Require Supabase Auth current-password verification before applying a user password change.
- Update route audit, guard matrix, Cypress route scenarios, and unit tests for the new account route and password verification behavior.

## Verification Card
- Classification: high-risk human-reviewed
- Lane: critical
- Change type: UI/page, auth/routing, server route guard metadata
- Required checks: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, `npm run test:routes:tier0`, `npm run ci:playwright`, `npm run validate:tenant`, `npm run verify:local`
- Executed checks:
  - `npm ci`: passed
  - focused Vitest route/password/guard/audit checks: passed
  - `npm run ci:check-focused`: passed
  - `npm run lint`: passed
  - `npm run typecheck`: passed
  - `npm run build`: passed
  - `npm run test:routes:tier0`: passed, 220/220 Cypress route tests
  - `npm run test:ci` with synthetic local Supabase URL/key: passed, 360 files and 2341 tests
  - `npm run validate:tenant`: passed
  - `npm run verify:local` with synthetic local Supabase URL/key: passed
- Blocked checks:
  - `npm run ci:playwright`: blocked locally at `playwright:preflight` because smoke credentials are not configured (`PW_SUPERADMIN_EMAIL`/`PW_SUPERADMIN_PASSWORD` or admin equivalents)
- Result: pass-with-blocked-checks
- Residual risk: human review required before merge due protected auth/routing and `src/server/**` guard metadata; final Playwright auth/session coverage should run in an environment with smoke credentials.

## Linear
- WIN-206