### PR TITLE
WIN-207 Add staff invite acceptance onboarding

### DIFF
--- a/scripts/route-audit.ts
+++ b/scripts/route-audit.ts
@@ -95,6 +95,7 @@ export const ROUTES: readonly RouteDefinition[] = [
   { path: '/login', component: 'Login', roles: ['public'], permissions: [] },
   { path: '/signup', component: 'Signup', roles: ['public'], permissions: [] },
   { path: '/auth/recovery', component: 'PasswordRecovery', roles: ['public'], permissions: [] },
+  { path: '/accept-invite', component: 'AcceptInvite', roles: ['public'], permissions: [] },
   { path: '/unauthorized', component: 'Unauthorized', roles: ['public'], permissions: [] },
 
   // Protected routes

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,9 @@ const Signup = React.lazy(() => import('./pages/Signup').then(module => ({ defau
 const PasswordRecovery = React.lazy(() =>
   import('./pages/PasswordRecovery').then(module => ({ default: module.PasswordRecovery })),
 );
+const AcceptInvite = React.lazy(() =>
+  import('./pages/AcceptInvite').then(module => ({ default: module.AcceptInvite })),
+);
 const Layout = React.lazy(() => import('./components/Layout').then(module => ({ default: module.Layout })));
 const Dashboard = React.lazy(() => import('./pages/Dashboard').then(module => ({ default: module.Dashboard })));
 const Schedule = React.lazy(() => import('./pages/Schedule').then(module => ({ default: module.Schedule })));
@@ -163,6 +166,7 @@ function App() {
                   <Route path="/login" element={<Login />} />
                   <Route path="/signup" element={<Signup />} />
                   <Route path="/auth/recovery" element={<PasswordRecovery />} />
+                  <Route path="/accept-invite" element={<AcceptInvite />} />
                   <Route path="/unauthorized" element={<Unauthorized />} />
 
                   {/* Protected Routes */}

--- a/src/components/settings/AdminSettings.tsx
+++ b/src/components/settings/AdminSettings.tsx
@@ -52,11 +52,8 @@ interface EmployeeUser {
 
 interface AdminFormData {
   email: string;
-  password: string;
-  first_name: string;
-  last_name: string;
-  title: string;
   organization_id: string | null;
+  role: AppRole;
   reason: string;
 }
 
@@ -101,11 +98,8 @@ export function AdminSettings() {
   const [selectedAdmin, setSelectedAdmin] = useState<AdminUser | null>(null);
   const [formData, setFormData] = useState<AdminFormData>({
     email: '',
-    password: '',
-    first_name: '',
-    last_name: '',
-    title: '',
     organization_id: null,
+    role: 'bt',
     reason: '',
   });
   const [newPassword, setNewPassword] = useState('');
@@ -131,6 +125,10 @@ export function AdminSettings() {
   }, [user]);
 
   const canOpenAddAdminModal = isSuperAdmin || Boolean(organizationId);
+  const inviteRoleOptions = useMemo(
+    () => EMPLOYEE_ROLE_OPTIONS.filter((role) => isSuperAdmin || (role !== 'bcba' && role !== 'super_admin')),
+    [isSuperAdmin],
+  );
 
   const activeOrganizationId = useMemo(() => {
     if (!isSuperAdmin) {
@@ -463,8 +461,8 @@ export function AdminSettings() {
         : organizationId ?? data.organization_id ?? activeOrganizationId;
 
       if (!targetOrganizationId) {
-        const error = new Error('Organization context is required to create an admin user.');
-        logger.error('Missing organization during admin creation', {
+        const error = new Error('Organization context is required to invite staff.');
+        logger.error('Missing organization during staff invite', {
           error,
           context: { component: 'AdminSettings', operation: 'createAdminMutation' },
           metadata: { hasOrganizationId: false, isSuperAdmin },
@@ -476,15 +474,12 @@ export function AdminSettings() {
         const trimmedReason = data.reason.trim();
         const payload = {
           email: data.email,
-          password: data.password,
-          first_name: data.first_name,
-          last_name: data.last_name,
-          title: data.title,
-          organization_id: targetOrganizationId,
+          organizationId: targetOrganizationId,
+          role: data.role,
           reason: trimmedReason,
         };
 
-        const { error: functionError } = await supabase.functions.invoke('admin-create-user', {
+        const { error: functionError } = await supabase.functions.invoke('admin-invite', {
           body: payload,
         });
 
@@ -492,12 +487,12 @@ export function AdminSettings() {
           throw functionError;
         }
       } catch (error) {
-        logger.error('Admin creation mutation failed', {
+        logger.error('Staff invite mutation failed', {
           error,
           context: { component: 'AdminSettings', operation: 'createAdminMutation' },
           metadata: {
             hasEmail: Boolean(data.email),
-            hasProfileDetails: Boolean(data.first_name || data.last_name || data.title),
+            role: data.role,
             hasOrganizationId: Boolean(targetOrganizationId),
             isSuperAdmin,
           },
@@ -511,7 +506,7 @@ export function AdminSettings() {
       });
       setIsModalOpen(false);
       resetForm();
-      showSuccess('Admin user created successfully');
+      showSuccess('Staff invite sent successfully');
     },
     onError: (error) => {
       showError(error);
@@ -738,11 +733,8 @@ export function AdminSettings() {
   const resetForm = () => {
     setFormData({
       email: '',
-      password: '',
-      first_name: '',
-      last_name: '',
-      title: '',
       organization_id: activeOrganizationId ?? null,
+      role: 'bt',
       reason: '',
     });
   };
@@ -905,11 +897,11 @@ export function AdminSettings() {
         <button
           onClick={() => setIsModalOpen(true)}
           disabled={!canOpenAddAdminModal}
-          title={!canOpenAddAdminModal ? 'Create an organization before adding admins.' : undefined}
+          title={!canOpenAddAdminModal ? 'Create an organization before inviting staff.' : undefined}
           className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-blue-400 disabled:hover:bg-blue-400"
         >
           <Plus className="w-4 h-4 mr-2 inline-block" />
-          Add Admin
+          Invite Staff
         </button>
       </div>
 
@@ -1364,7 +1356,7 @@ export function AdminSettings() {
         )}
       </div>
 
-      {/* Create Admin Modal */}
+      {/* Staff Invite Modal */}
       <Modal
         isOpen={isModalOpen}
         onClose={closeCreateAdminModal}
@@ -1373,7 +1365,7 @@ export function AdminSettings() {
         panelClassName="bg-white dark:bg-dark-lighter rounded-lg shadow-xl w-full max-w-md p-6"
       >
         <h2 id="add-admin-modal-title" className="text-xl font-semibold text-gray-900 dark:text-white mb-6">
-          Add New Admin
+          Invite Staff
         </h2>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -1394,63 +1386,23 @@ export function AdminSettings() {
               </div>
 
               <div>
-                <label htmlFor="add-admin-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Password*
+                <label htmlFor="add-admin-role" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Role*
                 </label>
-                <input
-                  type="password"
-                  name="password"
+                <select
+                  id="add-admin-role"
+                  name="role"
                   required
-                  minLength={8}
-                  value={formData.password}
+                  value={formData.role}
                   onChange={handleInputChange}
-                  id="add-admin-password"
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
-                />
-              </div>
-
-              <div>
-                <label htmlFor="add-admin-first-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  First Name*
-                </label>
-                <input
-                  type="text"
-                  name="first_name"
-                  required
-                  value={formData.first_name}
-                  onChange={handleInputChange}
-                  id="add-admin-first-name"
-                  className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
-                />
-              </div>
-
-              <div>
-                <label htmlFor="add-admin-last-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Last Name*
-                </label>
-                <input
-                  type="text"
-                  name="last_name"
-                  required
-                  value={formData.last_name}
-                  onChange={handleInputChange}
-                  id="add-admin-last-name"
-                  className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
-                />
-              </div>
-
-              <div>
-                <label htmlFor="add-admin-title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Title
-                </label>
-                <input
-                  type="text"
-                  name="title"
-                  value={formData.title}
-                  onChange={handleInputChange}
-                  id="add-admin-title"
-                  className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
-                />
+                >
+                  {inviteRoleOptions.map((role) => (
+                    <option key={role} value={role}>
+                      {ROLE_LABELS[role]}
+                    </option>
+                  ))}
+                </select>
               </div>
 
               <div>
@@ -1476,7 +1428,7 @@ export function AdminSettings() {
                     </select>
                     {!formData.organization_id && (
                       <p className="mt-1 text-xs text-red-600 dark:text-red-400">
-                        Choose an organization before inviting a new admin.
+                        Choose an organization before inviting staff.
                       </p>
                     )}
                   </>
@@ -1492,7 +1444,7 @@ export function AdminSettings() {
                     />
                     {!formData.organization_id && (
                       <p className="mt-1 text-xs text-red-600 dark:text-red-400">
-                        Organization context is required before creating additional admins.
+                        Organization context is required before inviting staff.
                       </p>
                     )}
                   </>
@@ -1501,7 +1453,7 @@ export function AdminSettings() {
 
               <div>
                 <label htmlFor="add-admin-reason" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Reason for admin access*
+                  Reason for staff access*
                 </label>
                 <textarea
                   id="add-admin-reason"
@@ -1511,7 +1463,7 @@ export function AdminSettings() {
                   rows={3}
                   value={formData.reason}
                   onChange={handleInputChange}
-                  placeholder="Explain why this user requires administrative privileges"
+                  placeholder="Explain why this user requires staff access"
                   className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
                 />
                 <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
@@ -1532,7 +1484,7 @@ export function AdminSettings() {
                   disabled={!formData.organization_id}
                   className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  Add Admin
+                  Send Invite
                 </button>
               </div>
             </form>

--- a/src/components/settings/__tests__/AdminSettings.cta.test.tsx
+++ b/src/components/settings/__tests__/AdminSettings.cta.test.tsx
@@ -32,7 +32,7 @@ describe('AdminSettings CTA', () => {
       </QueryClientProvider>
     );
     expect(screen.getByText(/Create organization/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Add Admin' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Invite Staff' })).toBeDisabled();
   });
 });
 

--- a/src/components/settings/__tests__/AdminSettings.test.tsx
+++ b/src/components/settings/__tests__/AdminSettings.test.tsx
@@ -195,7 +195,7 @@ describe('AdminSettings logging', () => {
     });
   });
 
-  it('adds organization metadata when creating an admin user', async () => {
+  it('adds organization metadata when inviting staff', async () => {
     const invokeSpy = vi
       .spyOn(supabase.functions, 'invoke')
       .mockResolvedValue({ data: null, error: null });
@@ -221,19 +221,17 @@ describe('AdminSettings logging', () => {
     try {
       renderWithProviders(<AdminSettings />);
 
-      await userEvent.click(await screen.findByText('Add Admin'));
+      await userEvent.click(await screen.findByText('Invite Staff'));
 
-      const modal = await screen.findByRole('dialog', { name: 'Add New Admin' });
+      const modal = await screen.findByRole('dialog', { name: 'Invite Staff' });
       await userEvent.type(within(modal).getByLabelText('Email*'), 'new.admin@example.com');
-      await userEvent.type(within(modal).getByLabelText('Password*'), 'StrongPass123!');
-      await userEvent.type(within(modal).getByLabelText('First Name*'), 'New');
-      await userEvent.type(within(modal).getByLabelText('Last Name*'), 'Admin');
+      await userEvent.selectOptions(within(modal).getByLabelText('Role*'), 'bt');
       await userEvent.type(
-        within(modal).getByLabelText('Reason for admin access*'),
+        within(modal).getByLabelText('Reason for staff access*'),
         'Granting admin for coverage.'
       );
 
-      const submitButton = within(modal).getByRole('button', { name: 'Add Admin' });
+      const submitButton = within(modal).getByRole('button', { name: 'Send Invite' });
       await waitFor(() => {
         expect(submitButton).toBeEnabled();
       });
@@ -241,11 +239,12 @@ describe('AdminSettings logging', () => {
 
       await waitFor(() => {
         expect(invokeSpy).toHaveBeenCalledWith(
-          'admin-create-user',
+          'admin-invite',
           expect.objectContaining({
             body: expect.objectContaining({
               email: 'new.admin@example.com',
-              organization_id: '11111111-1111-1111-1111-111111111111',
+              organizationId: '11111111-1111-1111-1111-111111111111',
+              role: 'bt',
               reason: 'Granting admin for coverage.',
             }),
           })
@@ -256,7 +255,7 @@ describe('AdminSettings logging', () => {
     }
   }, 20000);
 
-  it('requires a justification before assigning a new admin user', async () => {
+  it('requires a justification before inviting staff', async () => {
     const invokeSpy = vi
       .spyOn(supabase.functions, 'invoke')
       .mockResolvedValue({ data: null, error: null });
@@ -279,16 +278,13 @@ describe('AdminSettings logging', () => {
     try {
       renderWithProviders(<AdminSettings />);
 
-      await userEvent.click(await screen.findByText('Add Admin'));
+      await userEvent.click(await screen.findByText('Invite Staff'));
 
-      const modal = await screen.findByRole('dialog', { name: 'Add New Admin' });
+      const modal = await screen.findByRole('dialog', { name: 'Invite Staff' });
       await userEvent.type(within(modal).getByLabelText('Email*'), 'space.admin@example.com');
-      await userEvent.type(within(modal).getByLabelText('Password*'), 'StrongPass123!');
-      await userEvent.type(within(modal).getByLabelText('First Name*'), 'Space');
-      await userEvent.type(within(modal).getByLabelText('Last Name*'), 'Admin');
-      await userEvent.type(within(modal).getByLabelText('Reason for admin access*'), '          ');
+      await userEvent.type(within(modal).getByLabelText('Reason for staff access*'), '          ');
 
-      const submitButton = within(modal).getByRole('button', { name: 'Add Admin' });
+      const submitButton = within(modal).getByRole('button', { name: 'Send Invite' });
       await userEvent.click(submitButton);
 
       await waitFor(() => {
@@ -928,34 +924,33 @@ describe('AdminSettings super admin access', () => {
     expect(fromSpy).not.toHaveBeenCalledWith('therapists');
   });
 
-  it('creates an admin in the selected organization', async () => {
+  it('invites staff in the selected organization', async () => {
     renderWithProviders(<AdminSettings />);
 
-    await userEvent.click(await screen.findByRole('button', { name: 'Add Admin' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Invite Staff' }));
 
-    const modal = await screen.findByRole('dialog', { name: 'Add New Admin' });
+    const modal = await screen.findByRole('dialog', { name: 'Invite Staff' });
     await userEvent.type(within(modal).getByLabelText('Email*'), 'super.created@example.com');
-    await userEvent.type(within(modal).getByLabelText('Password*'), 'StrongPass123!');
-    await userEvent.type(within(modal).getByLabelText('First Name*'), 'Super');
-    await userEvent.type(within(modal).getByLabelText('Last Name*'), 'Created');
+    await userEvent.selectOptions(within(modal).getByLabelText('Role*'), 'bcba');
     await userEvent.selectOptions(within(modal).getByLabelText('Organization'), 'org-2');
-    await userEvent.type(within(modal).getByLabelText('Reason for admin access*'), 'Coverage for the Sunrise Therapy workspace.');
+    await userEvent.type(within(modal).getByLabelText('Reason for staff access*'), 'Coverage for the Sunrise Therapy workspace.');
 
-    await userEvent.click(within(modal).getByRole('button', { name: 'Add Admin' }));
+    await userEvent.click(within(modal).getByRole('button', { name: 'Send Invite' }));
 
     await waitFor(() => {
       expect(invokeSpy).toHaveBeenCalledWith(
-        'admin-create-user',
+        'admin-invite',
         expect.objectContaining({
           body: expect.objectContaining({
             email: 'super.created@example.com',
-            organization_id: 'org-2',
+            organizationId: 'org-2',
+            role: 'bcba',
             reason: 'Coverage for the Sunrise Therapy workspace.',
           }),
         }),
       );
     });
-    expect(showSuccess).toHaveBeenCalledWith('Admin user created successfully');
+    expect(showSuccess).toHaveBeenCalledWith('Staff invite sent successfully');
   }, 20_000);
 
   it('resets an admin password through the canonical RPC without falling back when available', async () => {
@@ -1056,13 +1051,13 @@ describe('AdminSettings accessibility', () => {
     fromSpy = null;
   });
 
-  it('traps focus within the add admin modal', async () => {
+  it('traps focus within the staff invite modal', async () => {
     renderWithProviders(<AdminSettings />);
 
-    const openModalButton = await screen.findByRole('button', { name: 'Add Admin' });
+    const openModalButton = await screen.findByRole('button', { name: 'Invite Staff' });
     await userEvent.click(openModalButton);
 
-    const modal = await screen.findByRole('dialog', { name: 'Add New Admin' });
+    const modal = await screen.findByRole('dialog', { name: 'Invite Staff' });
     const emailInput = within(modal).getByLabelText('Email*');
 
     await waitFor(() => {
@@ -1071,7 +1066,7 @@ describe('AdminSettings accessibility', () => {
 
     await userEvent.tab({ shift: true });
 
-    const submitButton = within(modal).getByRole('button', { name: 'Add Admin' });
+    const submitButton = within(modal).getByRole('button', { name: 'Send Invite' });
     expect(submitButton).toHaveFocus();
 
     await userEvent.tab();
@@ -1081,18 +1076,18 @@ describe('AdminSettings accessibility', () => {
   it('closes the modal with Escape and restores trigger focus', async () => {
     renderWithProviders(<AdminSettings />);
 
-    const openModalButton = await screen.findByRole('button', { name: 'Add Admin' });
+    const openModalButton = await screen.findByRole('button', { name: 'Invite Staff' });
     openModalButton.focus();
 
     await userEvent.click(openModalButton);
 
-    const modal = await screen.findByRole('dialog', { name: 'Add New Admin' });
+    const modal = await screen.findByRole('dialog', { name: 'Invite Staff' });
     expect(modal).toHaveAttribute('aria-modal', 'true');
 
     await userEvent.keyboard('{Escape}');
 
     await waitFor(() => {
-      expect(screen.queryByRole('dialog', { name: 'Add New Admin' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog', { name: 'Invite Staff' })).not.toBeInTheDocument();
     });
 
     expect(openModalButton).toHaveFocus();

--- a/src/pages/AcceptInvite.tsx
+++ b/src/pages/AcceptInvite.tsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { CheckCircle2, KeyRound, Mail } from 'lucide-react';
+import { callEdge, supabase } from '../lib/supabase';
+import { showError, showSuccess } from '../lib/toast';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+const getErrorMessage = async (response: Response) => {
+  const payload = await response.json().catch(() => null) as { error?: unknown } | null;
+  if (typeof payload?.error === 'string') {
+    if (payload.error === 'invite_expired') return 'This invite has expired. Ask an administrator to send a new invite.';
+    if (payload.error === 'invite_not_found') return 'This invite link is invalid or has already been used.';
+    if (payload.error === 'account_creation_failed') return 'This account could not be created. It may already exist.';
+    return payload.error.replace(/_/g, ' ');
+  }
+  return `Invite acceptance failed (${response.status}).`;
+};
+
+export function AcceptInvite() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const initialToken = useMemo(() => searchParams.get('token')?.trim() ?? '', [searchParams]);
+  const [token] = useState(initialToken);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [acceptedEmail, setAcceptedEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!initialToken || typeof window === 'undefined') {
+      return;
+    }
+
+    window.history.replaceState(window.history.state, '', window.location.pathname);
+  }, [initialToken]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!token) {
+      showError(new Error('Invite token is missing.'));
+      return;
+    }
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      showError(new Error('Password must be at least 8 characters.'));
+      return;
+    }
+    if (password !== confirmPassword) {
+      showError(new Error('Passwords do not match.'));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const response = await callEdge('accept-staff-invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          token,
+          password,
+          first_name: firstName,
+          last_name: lastName,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(await getErrorMessage(response));
+      }
+
+      const payload = await response.json().catch(() => null) as { email?: unknown } | null;
+      const email = typeof payload?.email === 'string' ? payload.email : null;
+      setAcceptedEmail(email);
+      await supabase.auth.signOut();
+      showSuccess('Invite accepted. Sign in with your new password.');
+    } catch (error) {
+      showError(error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (acceptedEmail) {
+    return (
+      <main className="min-h-dvh bg-gray-50 dark:bg-dark flex items-center justify-center px-4 py-10">
+        <section className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-dark-lighter">
+          <CheckCircle2 className="mb-4 h-10 w-10 text-emerald-600" />
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Invite accepted</h1>
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+            {acceptedEmail} can now sign in with the password you just created.
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate('/login', { replace: true })}
+            className="mt-6 w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Go to login
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-dvh bg-gray-50 dark:bg-dark flex items-center justify-center px-4 py-10">
+      <section className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-dark-lighter">
+        <div className="mb-6 flex items-center gap-3">
+          <div className="rounded-full bg-blue-100 p-2 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+            <Mail className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Accept Staff Invite</h1>
+            <p className="text-sm text-gray-600 dark:text-gray-300">Create your password to finish staff onboarding.</p>
+          </div>
+        </div>
+
+        {!token && (
+          <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
+            Invite token is missing.
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label htmlFor="accept-first-name" className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                First name
+              </label>
+              <input
+                id="accept-first-name"
+                value={firstName}
+                onChange={(event) => setFirstName(event.target.value)}
+                className="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+              />
+            </div>
+            <div>
+              <label htmlFor="accept-last-name" className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Last name
+              </label>
+              <input
+                id="accept-last-name"
+                value={lastName}
+                onChange={(event) => setLastName(event.target.value)}
+                className="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="accept-password" className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Password*
+            </label>
+            <input
+              id="accept-password"
+              type="password"
+              required
+              minLength={MIN_PASSWORD_LENGTH}
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="accept-confirm-password" className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Confirm password*
+            </label>
+            <input
+              id="accept-confirm-password"
+              type="password"
+              required
+              minLength={MIN_PASSWORD_LENGTH}
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={!token || isSubmitting}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            <KeyRound className="h-4 w-4" />
+            {isSubmitting ? 'Accepting invite...' : 'Accept invite'}
+          </button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/__tests__/AcceptInvite.test.tsx
+++ b/src/pages/__tests__/AcceptInvite.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderWithProviders, screen, waitFor, userEvent } from '../../test/utils';
+import { AcceptInvite } from '../AcceptInvite';
+import { callEdge, supabase } from '../../lib/supabase';
+import { showError, showSuccess } from '../../lib/toast';
+
+const navigateMock = vi.fn();
+let search = '?token=0123456789abcdef0123456789abcdef';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useSearchParams: () => [new URLSearchParams(search)],
+  };
+});
+
+vi.mock('../../lib/supabase', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/supabase')>('../../lib/supabase');
+  return {
+    ...actual,
+    callEdge: vi.fn(),
+    supabase: {
+      ...actual.supabase,
+      auth: {
+        ...actual.supabase.auth,
+        signOut: vi.fn(async () => ({ error: null })),
+      },
+    },
+  };
+});
+
+vi.mock('../../lib/toast', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/toast')>('../../lib/toast');
+  return {
+    ...actual,
+    showError: vi.fn(),
+    showSuccess: vi.fn(),
+  };
+});
+
+describe('AcceptInvite', () => {
+  beforeEach(() => {
+    search = '?token=0123456789abcdef0123456789abcdef';
+    window.history.pushState({}, '', `/accept-invite${search}`);
+    vi.mocked(callEdge).mockReset();
+    vi.mocked(supabase.auth.signOut).mockClear();
+    vi.mocked(showError).mockClear();
+    vi.mocked(showSuccess).mockClear();
+    navigateMock.mockReset();
+  });
+
+  it('blocks submission when passwords do not match', async () => {
+    renderWithProviders(<AcceptInvite />, { auth: false });
+
+    await userEvent.type(screen.getByLabelText('Password*'), 'StrongPass123!');
+    await userEvent.type(screen.getByLabelText('Confirm password*'), 'Different123!');
+    await userEvent.click(screen.getByRole('button', { name: /accept invite/i }));
+
+    expect(callEdge).not.toHaveBeenCalled();
+    expect(showError).toHaveBeenCalledWith(expect.objectContaining({ message: 'Passwords do not match.' }));
+  });
+
+  it('accepts the invite, signs out any stale session, and shows login handoff', async () => {
+    vi.mocked(callEdge).mockResolvedValue(
+      new Response(JSON.stringify({ email: 'bt.staff@example.com', role: 'bt' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderWithProviders(<AcceptInvite />, { auth: false });
+
+    await waitFor(() => {
+      expect(window.location.search).toBe('');
+    });
+
+    await userEvent.type(screen.getByLabelText('First name'), 'Bea');
+    await userEvent.type(screen.getByLabelText('Last name'), 'Therapist');
+    await userEvent.type(screen.getByLabelText('Password*'), 'StrongPass123!');
+    await userEvent.type(screen.getByLabelText('Confirm password*'), 'StrongPass123!');
+    await userEvent.click(screen.getByRole('button', { name: /accept invite/i }));
+
+    await waitFor(() => {
+      expect(callEdge).toHaveBeenCalledWith(
+        'accept-staff-invite',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            token: '0123456789abcdef0123456789abcdef',
+            password: 'StrongPass123!',
+            first_name: 'Bea',
+            last_name: 'Therapist',
+          }),
+        }),
+      );
+    });
+    expect(supabase.auth.signOut).toHaveBeenCalledTimes(1);
+    expect(showSuccess).toHaveBeenCalledWith('Invite accepted. Sign in with your new password.');
+    expect(await screen.findByText('Invite accepted')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Go to login' }));
+    expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true });
+  });
+
+  it('disables acceptance when the token is missing', async () => {
+    search = '';
+    window.history.pushState({}, '', '/accept-invite');
+
+    renderWithProviders(<AcceptInvite />, { auth: false });
+
+    expect(screen.getByText('Invite token is missing.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /accept invite/i })).toBeDisabled();
+  });
+});

--- a/src/pages/__tests__/AppNavigation.test.tsx
+++ b/src/pages/__tests__/AppNavigation.test.tsx
@@ -83,6 +83,10 @@ vi.mock('../../pages/PasswordRecovery', () => ({
   PasswordRecovery: () => <div>PasswordRecoveryPage</div>,
 }));
 
+vi.mock('../../pages/AcceptInvite', () => ({
+  AcceptInvite: () => <div>AcceptInvitePage</div>,
+}));
+
 vi.mock('../../pages/ClientOnboardingPage', () => ({
   ClientOnboardingPage: () => <div>ClientOnboardingPage</div>,
 }));
@@ -278,6 +282,16 @@ describe('App navigation landing', () => {
     expect(await screen.findByText('PasswordRecoveryPage')).toBeInTheDocument();
     expect(screen.queryByTestId('layout')).not.toBeInTheDocument();
     expect(window.location.pathname).toBe('/auth/recovery');
+  });
+
+  it('renders staff invite acceptance as a public route outside the protected layout', async () => {
+    authRole = 'client';
+    window.history.pushState({}, '', '/accept-invite?token=secret-token');
+    renderApp();
+
+    expect(await screen.findByText('AcceptInvitePage')).toBeInTheDocument();
+    expect(screen.queryByTestId('layout')).not.toBeInTheDocument();
+    expect(window.location.pathname).toBe('/accept-invite');
   });
 
   it('allows admins and super admins to open settings tabs', async () => {

--- a/src/tests/security/edgeFunctionConfig.test.ts
+++ b/src/tests/security/edgeFunctionConfig.test.ts
@@ -10,6 +10,7 @@ describe('edge function config', () => {
       // Public pre-auth endpoints
       'auth-login',
       'auth-signup',
+      'accept-staff-invite',
       // Token-based automation endpoints (no JWT required)
       'admin-actions-retention',
     ]);

--- a/supabase/functions/accept-staff-invite/function.toml
+++ b/supabase/functions/accept-staff-invite/function.toml
@@ -1,0 +1,1 @@
+verify_jwt = false

--- a/supabase/functions/accept-staff-invite/index.ts
+++ b/supabase/functions/accept-staff-invite/index.ts
@@ -1,0 +1,220 @@
+import { z } from "zod";
+import {
+  corsHeadersForRequest,
+  createPublicRoute,
+} from "../_shared/auth-middleware.ts";
+import { supabaseAdmin } from "../_shared/database.ts";
+
+const ACCEPT_INVITE_PATH = "/accept-staff-invite";
+const MIN_PASSWORD_LENGTH = 8;
+
+const StaffRoleSchema = z.enum(["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"]);
+
+const AcceptInviteRequestSchema = z.object({
+  token: z.string().trim().min(16),
+  password: z.string().min(MIN_PASSWORD_LENGTH),
+  first_name: z.string().trim().max(100).optional(),
+  last_name: z.string().trim().max(100).optional(),
+});
+
+type StaffRole = z.infer<typeof StaffRoleSchema>;
+
+type InviteTokenRecord = {
+  id: string;
+  email: string;
+  organization_id: string;
+  token_hash: string;
+  expires_at: string;
+  created_by: string;
+  role: string;
+};
+
+const jsonResponse = (req: Request, status: number, body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeadersForRequest(req), "Content-Type": "application/json" },
+  });
+
+const toHex = (bytes: ArrayBuffer) =>
+  Array.from(new Uint8Array(bytes))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+
+const hashToken = async (token: string) => {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+  return toHex(digest);
+};
+
+const normalizeOptionalName = (value: string | undefined) => {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const deleteInviteToken = async (tokenHash: string) => {
+  const { error } = await supabaseAdmin
+    .from("admin_invite_tokens")
+    .delete()
+    .eq("token_hash", tokenHash);
+
+  if (error) {
+    console.warn("Failed to delete staff invite token", { code: "staff_invite_delete_failed" });
+  }
+};
+
+const createUserRole = async (userId: string, role: StaffRole, grantedBy: string) => {
+  const { data: roleRow, error: roleError } = await supabaseAdmin
+    .from("roles")
+    .select("id,name")
+    .eq("name", role)
+    .single();
+
+  if (roleError || !roleRow?.id) {
+    return { error: "role_not_configured" };
+  }
+
+  const { error: userRoleError } = await supabaseAdmin
+    .from("user_roles")
+    .upsert(
+      {
+        user_id: userId,
+        role_id: roleRow.id,
+        granted_by: grantedBy,
+        granted_at: new Date().toISOString(),
+        is_active: true,
+      },
+      { onConflict: "user_id,role_id" },
+    );
+
+  if (userRoleError) {
+    return { error: "role_assignment_failed" };
+  }
+
+  return { error: null };
+};
+
+async function handleAcceptStaffInvite(req: Request) {
+  if (req.method !== "POST") {
+    return jsonResponse(req, 405, { error: "method_not_allowed" });
+  }
+
+  const parsed = AcceptInviteRequestSchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return jsonResponse(req, 400, {
+      error: "invalid_payload",
+      details: parsed.error.flatten(),
+    });
+  }
+
+  const tokenHash = await hashToken(parsed.data.token);
+  const { data: invite, error: inviteError } = await supabaseAdmin
+    .from("admin_invite_tokens")
+    .select("id,email,organization_id,token_hash,expires_at,created_by,role")
+    .eq("token_hash", tokenHash)
+    .single();
+
+  if (inviteError || !invite) {
+    return jsonResponse(req, 404, { error: "invite_not_found" });
+  }
+
+  const inviteRecord = invite as InviteTokenRecord;
+  if (new Date(inviteRecord.expires_at).getTime() <= Date.now()) {
+    await deleteInviteToken(tokenHash);
+    return jsonResponse(req, 410, { error: "invite_expired" });
+  }
+
+  const roleResult = StaffRoleSchema.safeParse(inviteRecord.role);
+  if (!roleResult.success) {
+    return jsonResponse(req, 409, { error: "invite_role_not_supported" });
+  }
+
+  const firstName = normalizeOptionalName(parsed.data.first_name);
+  const lastName = normalizeOptionalName(parsed.data.last_name);
+  const fullName = [firstName, lastName].filter(Boolean).join(" ") || null;
+
+  const { data: createdUserResult, error: createUserError } = await supabaseAdmin.auth.admin.createUser({
+    email: inviteRecord.email,
+    password: parsed.data.password,
+    email_confirm: true,
+    user_metadata: {
+      first_name: firstName,
+      last_name: lastName,
+      organization_id: inviteRecord.organization_id,
+      organizationId: inviteRecord.organization_id,
+      role: roleResult.data,
+      invited_by: inviteRecord.created_by,
+      accepted_invite_id: inviteRecord.id,
+    },
+  });
+
+  const userId = createdUserResult?.user?.id;
+  if (createUserError || !userId) {
+    return jsonResponse(req, 409, { error: "account_creation_failed" });
+  }
+
+  const cleanupCreatedUser = async () => {
+    const { error } = await supabaseAdmin.auth.admin.deleteUser(userId);
+    if (error) {
+      console.warn("Failed to clean up partially accepted staff invite user", {
+        code: "staff_invite_cleanup_failed",
+      });
+    }
+  };
+
+  const roleAssignment = await createUserRole(userId, roleResult.data, inviteRecord.created_by);
+  if (roleAssignment.error) {
+    await cleanupCreatedUser();
+    return jsonResponse(req, 500, { error: roleAssignment.error });
+  }
+
+  const { error: profileError } = await supabaseAdmin
+    .from("profiles")
+    .upsert(
+      {
+        id: userId,
+        email: inviteRecord.email,
+        first_name: firstName,
+        last_name: lastName,
+        full_name: fullName,
+        organization_id: inviteRecord.organization_id,
+        role: roleResult.data,
+        is_active: true,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "id" },
+    );
+
+  if (profileError) {
+    await cleanupCreatedUser();
+    return jsonResponse(req, 500, { error: "profile_sync_failed" });
+  }
+
+  const { error: actionError } = await supabaseAdmin.from("admin_actions").insert({
+    admin_user_id: inviteRecord.created_by,
+    target_user_id: userId,
+    organization_id: inviteRecord.organization_id,
+    action_type: "staff_invite_accepted",
+    action_details: {
+      invite_id: inviteRecord.id,
+      email: inviteRecord.email,
+      role: roleResult.data,
+      path: ACCEPT_INVITE_PATH,
+    },
+  });
+
+  if (actionError) {
+    console.warn("Failed to log staff invite acceptance", { code: "staff_invite_accept_log_failed" });
+  }
+
+  await deleteInviteToken(tokenHash);
+
+  return jsonResponse(req, 200, {
+    email: inviteRecord.email,
+    role: roleResult.data,
+  });
+}
+
+export const handler = createPublicRoute(async (req) => handleAcceptStaffInvite(req));
+
+Deno.serve(handler);
+
+export default handler;

--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -6,7 +6,7 @@ import {
   RouteOptions,
   type UserContext,
 } from "../_shared/auth-middleware.ts";
-import { createRequestClient } from "../_shared/database.ts";
+import { createRequestClient, supabaseAdmin } from "../_shared/database.ts";
 import { assertAdminOrSuperAdmin } from "../_shared/auth.ts";
 
 const DEFAULT_EXPIRATION_HOURS = 72;
@@ -14,7 +14,6 @@ const MIN_EXPIRATION_HOURS = 1;
 const MAX_EXPIRATION_HOURS = 24 * 7;
 const ADMIN_INVITE_PATH = "/admin/invite";
 const INVITE_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
-const MAX_INVITES_PER_ADMIN_PER_WINDOW = 10;
 
 const InviteRequestSchema = z.object({
   email: z.string().email(),
@@ -25,7 +24,7 @@ const InviteRequestSchema = z.object({
     .min(MIN_EXPIRATION_HOURS)
     .max(MAX_EXPIRATION_HOURS)
     .optional(),
-  role: z.enum(["admin", "super_admin"]).optional(),
+  role: z.enum(["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"]).optional(),
 });
 
 type InviteRequest = z.infer<typeof InviteRequestSchema>;
@@ -162,7 +161,7 @@ async function handleInvite(req: Request, userContext: UserContext) {
     }
 
     const desiredRole = payload.role ?? "admin";
-    if (desiredRole === "super_admin" && userContext.profile.role !== "super_admin") {
+    if ((desiredRole === "super_admin" || desiredRole === "bcba") && userContext.profile.role !== "super_admin") {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
       return jsonResponse(403, { error: "insufficient_role_for_target" });
     }
@@ -173,7 +172,7 @@ async function handleInvite(req: Request, userContext: UserContext) {
     const rawToken = crypto.randomUUID().replace(/-/g, "");
     const tokenHash = await hashToken(rawToken);
 
-    const insertedInvite = (await adminClient.rpc("create_admin_invite_token_rate_limited", {
+    const insertedInvite = (await supabaseAdmin.rpc("create_admin_invite_token_rate_limited", {
       p_email: normalizedEmail,
       p_token_hash: tokenHash,
       p_organization_id: targetOrganizationId,

--- a/supabase/migrations/20260709011818_service_role_admin_invite_token_rpc.sql
+++ b/supabase/migrations/20260709011818_service_role_admin_invite_token_rpc.sql
@@ -1,0 +1,116 @@
+-- @migration-intent: Keep admin/staff invite token issuance atomic while aligning the RPC with service-role-only grants.
+-- @migration-dependencies: 20260628171537_restrict_service_only_security_definer_rpc_grants.sql
+-- @migration-rollback: Restore 20260530140500_atomic_admin_invite_rate_limit.sql and review RPC grants/callers.
+
+begin;
+
+create or replace function public.create_admin_invite_token_rate_limited(
+  p_email text,
+  p_token_hash text,
+  p_organization_id uuid,
+  p_expires_at timestamptz,
+  p_created_by uuid,
+  p_role public.role_type
+)
+returns table(id uuid, expires_at timestamptz, status text)
+language plpgsql
+security definer
+set search_path = public, app, auth
+as $$
+declare
+  v_normalized_email text;
+  v_now timestamptz := timezone('utc', now());
+  v_window_start timestamptz := v_now - interval '1 hour';
+  v_invite_limit integer := 10;
+  v_existing_id uuid;
+  v_existing_expires_at timestamptz;
+  v_recent_invite_count integer;
+  v_inserted public.admin_invite_tokens%rowtype;
+begin
+  -- This function is service-role-only after the June 2026 grant hardening. Caller authorization,
+  -- tenant scope, and elevated-role checks happen in the admin-invite Edge function before this RPC.
+  v_normalized_email := lower(trim(coalesce(p_email, '')));
+  if v_normalized_email = '' then
+    raise exception using errcode = '22023', message = 'Invite email is required';
+  end if;
+
+  if p_created_by is null then
+    raise exception using errcode = '22023', message = 'Inviter user ID is required';
+  end if;
+
+  if p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Organization ID is required';
+  end if;
+
+  if p_token_hash is null or length(trim(p_token_hash)) = 0 then
+    raise exception using errcode = '22023', message = 'Token hash is required';
+  end if;
+
+  if p_expires_at is null or p_expires_at <= v_now then
+    raise exception using errcode = '22023', message = 'Invite expiration must be in the future';
+  end if;
+
+  if p_role is null then
+    raise exception using errcode = '22023', message = 'Invite role is required';
+  end if;
+
+  -- Serialize the full check/prune/count/insert sequence per inviter so bursts cannot share a stale count.
+  perform pg_advisory_xact_lock(hashtextextended('admin-invite:' || p_created_by::text, 0));
+
+  select t.id, t.expires_at
+  into v_existing_id, v_existing_expires_at
+  from public.admin_invite_tokens t
+  where t.email = v_normalized_email
+    and t.organization_id = p_organization_id
+    and t.expires_at > v_now
+  order by t.created_at desc
+  limit 1;
+
+  if v_existing_id is not null then
+    return query select v_existing_id, v_existing_expires_at, 'active_invite_exists'::text;
+    return;
+  end if;
+
+  delete from public.admin_invite_tokens t
+  where t.email = v_normalized_email
+    and t.organization_id = p_organization_id
+    and t.expires_at <= v_now;
+
+  select count(*)::integer
+  into v_recent_invite_count
+  from public.admin_invite_tokens t
+  where t.created_by = p_created_by
+    and t.created_at >= v_window_start;
+
+  if coalesce(v_recent_invite_count, 0) >= v_invite_limit then
+    return query select null::uuid, null::timestamptz, 'rate_limited'::text;
+    return;
+  end if;
+
+  insert into public.admin_invite_tokens (
+    email,
+    token_hash,
+    organization_id,
+    expires_at,
+    created_by,
+    role
+  )
+  values (
+    v_normalized_email,
+    p_token_hash,
+    p_organization_id,
+    p_expires_at,
+    p_created_by,
+    p_role
+  )
+  returning *
+  into v_inserted;
+
+  return query select v_inserted.id, v_inserted.expires_at, 'created'::text;
+end;
+$$;
+
+revoke all on function public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type) from public, anon, authenticated;
+grant execute on function public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type) to service_role;
+
+commit;

--- a/tests/admins/accept_invite_flow.spec.ts
+++ b/tests/admins/accept_invite_flow.spec.ts
@@ -1,0 +1,454 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { stubDenoEnv } from '../utils/stubDeno';
+
+type StoredInviteToken = {
+  id: string;
+  email: string;
+  organization_id: string;
+  token_hash: string;
+  expires_at: string;
+  created_by: string;
+  created_at: string;
+  role: string;
+};
+
+const envValues = new Map<string, string>([
+  ['SUPABASE_URL', 'http://localhost'],
+  ['SUPABASE_SERVICE_ROLE_KEY', 'service-role'],
+]);
+
+stubDenoEnv((key) => envValues.get(key) ?? '');
+
+const inviteTokens: StoredInviteToken[] = [];
+const roleRows = [
+  { id: 'role-bt', name: 'bt' },
+  { id: 'role-admin', name: 'admin' },
+];
+const createdUsers: Array<Record<string, unknown>> = [];
+const upsertedUserRoles: Array<Record<string, unknown>> = [];
+const upsertedProfiles: Array<Record<string, unknown>> = [];
+const adminActionRows: Array<Record<string, unknown>> = [];
+const deletedInviteTokenHashes: string[] = [];
+const deletedAuthUserIds: string[] = [];
+let failCreateUser = false;
+let failUserRoleUpsert = false;
+let failProfileUpsert = false;
+
+const toHex = (bytes: ArrayBuffer) =>
+  Array.from(new Uint8Array(bytes))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+
+const hashToken = async (token: string) => {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token));
+  return toHex(digest);
+};
+
+const makeSingleQuery = (table: string, filters: Record<string, unknown>) => ({
+  single: vi.fn(async () => {
+    if (table === 'admin_invite_tokens') {
+      const match = inviteTokens.find((token) => token.token_hash === filters.token_hash) ?? null;
+      return match ? { data: match, error: null } : { data: null, error: { code: 'PGRST116', message: 'No rows' } };
+    }
+
+    if (table === 'roles') {
+      const match = roleRows.find((role) => role.name === filters.name) ?? null;
+      return match ? { data: match, error: null } : { data: null, error: { code: 'PGRST116', message: 'No rows' } };
+    }
+
+    throw new Error(`Unexpected single query for ${table}`);
+  }),
+});
+
+const makeTableClient = (table: string) => ({
+  select: vi.fn(function select(_columns?: string) {
+    return this;
+  }),
+  eq: vi.fn(function eq(column: string, value: unknown) {
+    return makeSingleQuery(table, { [column]: value });
+  }),
+  upsert: vi.fn(async (payload: Record<string, unknown>) => {
+    if (table === 'user_roles') {
+      if (failUserRoleUpsert) {
+        return { error: { message: 'user role upsert failed' } };
+      }
+      upsertedUserRoles.push(payload);
+      return { error: null };
+    }
+
+    if (table === 'profiles') {
+      if (failProfileUpsert) {
+        return { error: { message: 'profile upsert failed' } };
+      }
+      upsertedProfiles.push(payload);
+      return { error: null };
+    }
+
+    throw new Error(`Unexpected upsert for ${table}`);
+  }),
+  insert: vi.fn(async (payload: Record<string, unknown>) => {
+    if (table === 'admin_actions') {
+      adminActionRows.push(payload);
+      return { error: null };
+    }
+
+    throw new Error(`Unexpected insert for ${table}`);
+  }),
+  delete: vi.fn(function deleteRow() {
+    return {
+      eq: vi.fn(async (column: string, value: unknown) => {
+        if (table !== 'admin_invite_tokens' || column !== 'token_hash') {
+          throw new Error(`Unexpected delete for ${table}.${column}`);
+        }
+
+        deletedInviteTokenHashes.push(String(value));
+        const index = inviteTokens.findIndex((token) => token.token_hash === value);
+        if (index >= 0) {
+          inviteTokens.splice(index, 1);
+        }
+        return { error: null };
+      }),
+    };
+  }),
+});
+
+const supabaseAdmin = {
+  auth: {
+    admin: {
+      createUser: vi.fn(async (payload: Record<string, unknown>) => {
+        if (failCreateUser) {
+          return {
+            data: { user: null },
+            error: { message: 'create user failed' },
+          };
+        }
+        createdUsers.push(payload);
+        return {
+          data: { user: { id: 'new-user-1', email: payload.email } },
+          error: null,
+        };
+      }),
+      deleteUser: vi.fn(async (userId: string) => {
+        deletedAuthUserIds.push(userId);
+        return { error: null };
+      }),
+    },
+  },
+  from: vi.fn((table: string) => makeTableClient(table)),
+};
+
+vi.mock('../../supabase/functions/_shared/database.ts', () => ({
+  supabaseAdmin,
+}));
+
+vi.mock('../../supabase/functions/_shared/auth-middleware.ts', () => ({
+  corsHeadersForRequest: (req: Request) => ({
+    'Access-Control-Allow-Origin': req.headers.get('origin') ?? 'https://app.allincompassing.ai',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-Client-Info, apikey',
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
+  }),
+  createPublicRoute: (handler: (req: Request, context: null) => Promise<Response>) => {
+    return (req: Request) => {
+      if (req.method === 'OPTIONS') {
+        const origin = req.headers.get('origin') ?? 'https://app.allincompassing.ai';
+        return new Response('ok', {
+          headers: {
+            'Access-Control-Allow-Origin': origin,
+            'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+            'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-Client-Info, apikey',
+            'Access-Control-Max-Age': '86400',
+            Vary: 'Origin',
+          },
+        });
+      }
+      return handler(req, null);
+    };
+  },
+}));
+
+describe('accept staff invite edge function', () => {
+  const rawToken = '0123456789abcdef0123456789abcdef';
+
+  const loadHandler = async () => {
+    const module = await import('../../supabase/functions/accept-staff-invite/index.ts');
+    return module.handler as (req: Request) => Promise<Response>;
+  };
+
+  beforeEach(async () => {
+    vi.resetModules();
+    inviteTokens.splice(0, inviteTokens.length);
+    createdUsers.splice(0, createdUsers.length);
+    upsertedUserRoles.splice(0, upsertedUserRoles.length);
+    upsertedProfiles.splice(0, upsertedProfiles.length);
+    adminActionRows.splice(0, adminActionRows.length);
+    deletedInviteTokenHashes.splice(0, deletedInviteTokenHashes.length);
+    deletedAuthUserIds.splice(0, deletedAuthUserIds.length);
+    supabaseAdmin.auth.admin.createUser.mockClear();
+    supabaseAdmin.auth.admin.deleteUser.mockClear();
+    supabaseAdmin.from.mockClear();
+    failCreateUser = false;
+    failUserRoleUpsert = false;
+    failProfileUpsert = false;
+  });
+
+  it('creates the invited BT account, assigns role, updates profile, logs acceptance, and consumes the token', async () => {
+    const tokenHash = await hashToken(rawToken);
+    inviteTokens.push({
+      id: 'invite-1',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      token_hash: tokenHash,
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      created_by: 'admin-1',
+      created_at: new Date().toISOString(),
+      role: 'bt',
+    });
+
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          token: rawToken,
+          password: 'StrongPass123!',
+          first_name: 'Bea',
+          last_name: 'Therapist',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      email: 'bt.staff@example.com',
+      role: 'bt',
+    });
+
+    expect(createdUsers).toHaveLength(1);
+    expect(createdUsers[0]).toMatchObject({
+      email: 'bt.staff@example.com',
+      password: 'StrongPass123!',
+      email_confirm: true,
+      user_metadata: expect.objectContaining({
+        first_name: 'Bea',
+        last_name: 'Therapist',
+        organization_id: 'org-123',
+        role: 'bt',
+      }),
+    });
+
+    expect(upsertedUserRoles).toEqual([
+      expect.objectContaining({
+        user_id: 'new-user-1',
+        role_id: 'role-bt',
+        granted_by: 'admin-1',
+        is_active: true,
+      }),
+    ]);
+    expect(upsertedProfiles).toEqual([
+      expect.objectContaining({
+        id: 'new-user-1',
+        email: 'bt.staff@example.com',
+        first_name: 'Bea',
+        last_name: 'Therapist',
+        organization_id: 'org-123',
+        role: 'bt',
+        is_active: true,
+      }),
+    ]);
+    expect(adminActionRows).toEqual([
+      expect.objectContaining({
+        admin_user_id: 'admin-1',
+        target_user_id: 'new-user-1',
+        organization_id: 'org-123',
+        action_type: 'staff_invite_accepted',
+        action_details: expect.objectContaining({
+          invite_id: 'invite-1',
+          email: 'bt.staff@example.com',
+          role: 'bt',
+        }),
+      }),
+    ]);
+    expect(deletedInviteTokenHashes).toEqual([tokenHash]);
+    expect(inviteTokens).toHaveLength(0);
+  }, 20_000);
+
+  it('rejects replay after a successful invite acceptance', async () => {
+    const tokenHash = await hashToken(rawToken);
+    inviteTokens.push({
+      id: 'invite-1',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      token_hash: tokenHash,
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      created_by: 'admin-1',
+      created_at: new Date().toISOString(),
+      role: 'bt',
+    });
+
+    const handler = await loadHandler();
+    const requestBody = {
+      token: rawToken,
+      password: 'StrongPass123!',
+      first_name: 'Bea',
+      last_name: 'Therapist',
+    };
+
+    const firstResponse = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      }),
+    );
+    expect(firstResponse.status).toBe(200);
+
+    const replayResponse = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      }),
+    );
+
+    expect(replayResponse.status).toBe(404);
+    await expect(replayResponse.json()).resolves.toMatchObject({ error: 'invite_not_found' });
+    expect(createdUsers).toHaveLength(1);
+    expect(deletedInviteTokenHashes).toEqual([tokenHash]);
+  }, 20_000);
+
+  it('does not consume the token when account creation fails', async () => {
+    failCreateUser = true;
+    const tokenHash = await hashToken(rawToken);
+    inviteTokens.push({
+      id: 'invite-create-fails',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      token_hash: tokenHash,
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      created_by: 'admin-1',
+      created_at: new Date().toISOString(),
+      role: 'bt',
+    });
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: 'account_creation_failed' });
+    expect(deletedInviteTokenHashes).toHaveLength(0);
+    expect(inviteTokens).toHaveLength(1);
+  }, 20_000);
+
+  it('deletes the partially created auth user when role assignment fails', async () => {
+    failUserRoleUpsert = true;
+    const tokenHash = await hashToken(rawToken);
+    inviteTokens.push({
+      id: 'invite-role-fails',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      token_hash: tokenHash,
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      created_by: 'admin-1',
+      created_at: new Date().toISOString(),
+      role: 'bt',
+    });
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ error: 'role_assignment_failed' });
+    expect(deletedAuthUserIds).toEqual(['new-user-1']);
+    expect(deletedInviteTokenHashes).toHaveLength(0);
+  }, 20_000);
+
+  it('deletes the partially created auth user when profile sync fails', async () => {
+    failProfileUpsert = true;
+    const tokenHash = await hashToken(rawToken);
+    inviteTokens.push({
+      id: 'invite-profile-fails',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      token_hash: tokenHash,
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      created_by: 'admin-1',
+      created_at: new Date().toISOString(),
+      role: 'bt',
+    });
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ error: 'profile_sync_failed' });
+    expect(deletedAuthUserIds).toEqual(['new-user-1']);
+    expect(deletedInviteTokenHashes).toHaveLength(0);
+  }, 20_000);
+
+  it('returns request-scoped CORS headers for preflight requests', async () => {
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'OPTIONS',
+        headers: { origin: 'https://preview.allincompassing.ai' },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://preview.allincompassing.ai');
+    expect(response.headers.get('Vary')).toBe('Origin');
+    expect(createdUsers).toHaveLength(0);
+  }, 20_000);
+
+  it('rejects missing or expired invite tokens without creating a user', async () => {
+    const tokenHash = await hashToken(rawToken);
+    inviteTokens.push({
+      id: 'invite-expired',
+      email: 'expired@example.com',
+      organization_id: 'org-123',
+      token_hash: tokenHash,
+      expires_at: new Date(Date.now() - 60 * 1000).toISOString(),
+      created_by: 'admin-1',
+      created_at: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+      role: 'bt',
+    });
+
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(410);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invite_expired' });
+    expect(createdUsers).toHaveLength(0);
+    expect(deletedInviteTokenHashes).toEqual([tokenHash]);
+  }, 20_000);
+});

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { stubDenoEnv } from '../utils/stubDeno';
 
-type TestRole = 'client' | 'therapist' | 'admin' | 'super_admin';
+type TestRole = 'client' | 'bt' | 'therapist' | 'admin' | 'super_admin';
 
 type TestUser = {
   id: string;
@@ -66,64 +66,6 @@ const createMockClient = () => ({
       error: null,
     })),
   },
-  rpc: vi.fn(async (functionName: string, params: Record<string, unknown>) => {
-    if (functionName !== 'create_admin_invite_token_rate_limited') {
-      throw new Error(`Unexpected RPC ${functionName}`);
-    }
-
-    const email = String(params.p_email);
-    const organizationId = String(params.p_organization_id);
-    const createdBy = String(params.p_created_by);
-    const now = Date.now();
-    const activeToken = inviteTokens
-      .filter(token => token.email === email && token.organization_id === organizationId)
-      .sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
-
-    if (activeToken && new Date(activeToken.expires_at).getTime() > now) {
-      return {
-        data: [{ id: activeToken.id, expires_at: activeToken.expires_at, status: 'active_invite_exists' }],
-        error: null,
-      };
-    }
-
-    for (let index = inviteTokens.length - 1; index >= 0; index -= 1) {
-      const token = inviteTokens[index];
-      if (
-        token.email === email
-        && token.organization_id === organizationId
-        && new Date(token.expires_at).getTime() <= now
-      ) {
-        inviteTokens.splice(index, 1);
-      }
-    }
-
-    const windowStart = new Date(Date.now() - 60 * 60 * 1000).toISOString();
-    const limit = 10;
-    const recentInviteCount = inviteTokens.filter(token =>
-      token.created_by === createdBy && token.created_at >= windowStart,
-    ).length;
-
-    if (recentInviteCount >= limit) {
-      return { data: [{ id: null, expires_at: null, status: 'rate_limited' }], error: null };
-    }
-
-    const stored: StoredInviteToken = {
-      id: crypto.randomUUID(),
-      email,
-      organization_id: organizationId,
-      token_hash: String(params.p_token_hash),
-      expires_at: String(params.p_expires_at),
-      created_by: createdBy,
-      created_at: new Date().toISOString(),
-      role: String(params.p_role ?? 'admin'),
-    };
-    inviteTokens.push(stored);
-
-    return {
-      data: [{ id: stored.id, expires_at: stored.expires_at, status: 'created' }],
-      error: null,
-    };
-  }),
   from: (table: string) => {
     if (table === 'admin_actions') {
       return {
@@ -135,6 +77,68 @@ const createMockClient = () => ({
     }
     throw new Error(`Unexpected table ${table}`);
   },
+});
+
+const createAdminRpc = vi.fn(async (functionName: string, params: Record<string, unknown>) => {
+  if (functionName !== 'create_admin_invite_token_rate_limited') {
+    throw new Error(`Unexpected service RPC ${functionName}`);
+  }
+
+  const email = String(params.p_email);
+  const organizationId = String(params.p_organization_id);
+  const createdBy = String(params.p_created_by);
+  const now = Date.now();
+  const activeToken = inviteTokens
+    .filter(token =>
+      token.email === email
+      && token.organization_id === organizationId
+      && new Date(token.expires_at).getTime() > now
+    )
+    .sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
+
+  if (activeToken) {
+    return {
+      data: [{ id: activeToken.id, expires_at: activeToken.expires_at, status: 'active_invite_exists' }],
+      error: null,
+    };
+  }
+
+  for (let index = inviteTokens.length - 1; index >= 0; index -= 1) {
+    const token = inviteTokens[index];
+    if (
+      token.email === email
+      && token.organization_id === organizationId
+      && new Date(token.expires_at).getTime() <= now
+    ) {
+      inviteTokens.splice(index, 1);
+    }
+  }
+
+  const windowStart = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const recentInviteCount = inviteTokens.filter(token =>
+    token.created_by === createdBy && token.created_at >= windowStart,
+  ).length;
+
+  if (recentInviteCount >= 10) {
+    return { data: [{ id: null, expires_at: null, status: 'rate_limited' }], error: null };
+  }
+
+  const stored: StoredInviteToken = {
+    id: crypto.randomUUID(),
+    email,
+    organization_id: organizationId,
+    token_hash: String(params.p_token_hash),
+    expires_at: String(params.p_expires_at),
+    created_by: createdBy,
+    created_at: new Date().toISOString(),
+    role: String(params.p_role ?? 'admin'),
+  };
+  inviteTokens.push(stored);
+
+  return {
+    data: [{ id: stored.id, expires_at: stored.expires_at, status: 'created' }],
+    error: null,
+  };
 });
 
 createRequestClient.mockImplementation(() => createMockClient());
@@ -150,6 +154,9 @@ vi.mock('../../supabase/functions/_shared/auth-middleware.ts', () => ({
 
 vi.mock('../../supabase/functions/_shared/database.ts', () => ({
   createRequestClient,
+  supabaseAdmin: {
+    rpc: createAdminRpc,
+  },
 }));
 
 vi.mock('../../supabase/functions/_shared/auth.ts', () => ({
@@ -180,6 +187,7 @@ describe('admin invite edge function', () => {
     logApiAccess.mockClear();
     assertAdminOrSuperAdmin.mockClear();
     createRequestClient.mockClear();
+    createAdminRpc.mockClear();
   });
 
   it('creates a scoped invite token, sends email, and logs the admin action', async () => {
@@ -346,5 +354,63 @@ describe('admin invite edge function', () => {
     expect(inviteTokens).toHaveLength(0);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(adminActionRows).toHaveLength(0);
+  }, 20_000);
+
+  it('prevents standard admins from inviting BCBA staff', async () => {
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'bcba@example.com', role: 'bcba' }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: 'insufficient_role_for_target' });
+    expect(inviteTokens).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adminActionRows).toHaveLength(0);
+  }, 20_000);
+
+  it('allows standard admins to invite BT staff in their organization', async () => {
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'bt.staff@example.com', role: 'bt' }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      inviteId: expect.any(String),
+      expiresAt: expect.any(String),
+    });
+
+    expect(inviteTokens).toHaveLength(1);
+    expect(inviteTokens[0]).toMatchObject({
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      role: 'bt',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, requestInit] = fetchMock.mock.calls[0];
+    const emailPayload = JSON.parse(requestInit?.body as string);
+    expect(emailPayload.variables).toMatchObject({
+      role: 'bt',
+      organization_id: 'org-123',
+    });
+
+    expect(adminActionRows).toHaveLength(1);
+    expect(adminActionRows[0]?.action_details).toMatchObject({
+      email: 'bt.staff@example.com',
+      role: 'bt',
+      email_delivery_status: 'sent',
+    });
   }, 20_000);
 });

--- a/tests/admins/invite_rate_limit_service_role_migration.spec.ts
+++ b/tests/admins/invite_rate_limit_service_role_migration.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const migrationSql = readFileSync(
+  join(process.cwd(), 'supabase/migrations/20260709011818_service_role_admin_invite_token_rpc.sql'),
+  'utf-8',
+).replace(/\r\n/g, '\n');
+
+const functionSql = migrationSql.match(
+  /create or replace function public\.create_admin_invite_token_rate_limited[\s\S]+?\n\$\$;/i,
+)?.[0] ?? '';
+
+describe('service-role admin invite token RPC migration', () => {
+  it('keeps duplicate-active, prune, count, and insert inside the advisory lock RPC', () => {
+    expect(functionSql, 'create_admin_invite_token_rate_limited function should exist').toBeTruthy();
+
+    const lockIndex = functionSql.indexOf('pg_advisory_xact_lock');
+    const activeInviteIndex = functionSql.indexOf('active_invite_exists');
+    const pruneIndex = functionSql.indexOf('delete from public.admin_invite_tokens');
+    const countIndex = functionSql.indexOf('select count(*)::integer');
+    const insertIndex = functionSql.indexOf('insert into public.admin_invite_tokens');
+
+    expect(lockIndex).toBeGreaterThanOrEqual(0);
+    expect(activeInviteIndex).toBeGreaterThan(lockIndex);
+    expect(pruneIndex).toBeGreaterThan(activeInviteIndex);
+    expect(countIndex).toBeGreaterThan(pruneIndex);
+    expect(insertIndex).toBeGreaterThan(countIndex);
+    expect(functionSql).toMatch(/v_invite_limit integer := 10/i);
+    expect(functionSql).toMatch(/created_at >= v_window_start/i);
+    expect(functionSql).toMatch(/rate_limited/i);
+  });
+
+  it('aligns execution grants to the hardened service-role-only boundary', () => {
+    expect(migrationSql).toMatch(/revoke all on function public\.create_admin_invite_token_rate_limited[\s\S]+from public, anon, authenticated;/i);
+    expect(migrationSql).toMatch(/grant execute on function public\.create_admin_invite_token_rate_limited[\s\S]+to service_role;/i);
+    expect(functionSql).not.toMatch(/auth\.uid\(\)/i);
+    expect(functionSql).toMatch(/service-role-only/i);
+  });
+});

--- a/tests/edge/route-audit-policy.test.ts
+++ b/tests/edge/route-audit-policy.test.ts
@@ -33,6 +33,7 @@ const parseAppRouteRoles = (source: string): Map<string, string[]> => {
   routeMap.set('/login', ['public']);
   routeMap.set('/signup', ['public']);
   routeMap.set('/auth/recovery', ['public']);
+  routeMap.set('/accept-invite', ['public']);
   routeMap.set('/unauthorized', ['public']);
   routeMap.set('/', normalizeRoles(['client', 'bt', 'therapist', 'midtier', 'admin_schedule', 'admin', 'bcba', 'super_admin']));
 


### PR DESCRIPTION
## Summary
- Generalize Admin Settings from password-based admin creation to staff invite onboarding.
- Add public `/accept-invite` UI where invited staff set their own password and profile name.
- Add `accept-staff-invite` Edge Function with token validation, auth-user creation, `user_roles`/`profiles` sync, replay handling, expiry handling, and rollback on partial failures.
- Preserve atomic invite token issuance through a service-role-only `create_admin_invite_token_rate_limited` RPC migration.

## Linear
- WIN-207: https://linear.app/winningedgeai/issue/WIN-207/add-staff-invite-acceptance-onboarding

## Route / Risk
- classification: high-risk human-reviewed
- lane: critical
- protected paths: `supabase/functions/**`, `supabase/migrations/**`, `src/App.tsx`, public auth route policy surfaces
- human review required before merge

## Verification Card
Required checks for this critical auth/Supabase slice:
- `npm run lint` - passed
- `npm run typecheck` - passed
- `npm run ci:check-focused` - passed; DB-backed grant/drift checks skipped locally because `SUPABASE_DB_URL` is not configured
- `npm run validate:tenant` - passed
- `npm run build` - passed
- targeted invite/accept tests - passed: `tests/admins/invite_flow.spec.ts`, `tests/admins/accept_invite_flow.spec.ts`, migration contract tests, AcceptInvite/AppNavigation/AdminSettings/policy tests
- `npm run ci:verify-coverage` - passed, line coverage 92.07% >= 86%
- `npm run test:routes:tier0` - passed, 220/220 Cypress route tests
- `npm run ci:playwright` - blocked locally by missing `PW_SUPERADMIN_EMAIL` + `PW_SUPERADMIN_PASSWORD` or `PW_ADMIN_EMAIL` + `PW_ADMIN_PASSWORD`
- `npm run test:ci` - not clean locally; two runs failed in unrelated schedule/programs-goals tests, and each failing file passed when rerun in isolation. Treating as nondeterministic full-suite risk, not a passed gate.

## Reviewer Notes
- Supabase reviewer re-reviewed the final service-role RPC change and reported no remaining Supabase/auth blockers.
- `reports/test-reliability-latest.json` has local line-ending churn only and is intentionally not included in this PR.

## Residual Risk
- Draft until full `test:ci` is clean in CI or a separate flake triage confirms/addresses the unrelated full-suite nondeterminism.
- Hosted Supabase DB grant/drift checks still require configured DB credentials in CI or a protected environment.