### PR TITLE
WIN-208 Prevent stranded staff invites on email failure

### DIFF
--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -25,6 +25,7 @@ const InviteRequestSchema = z.object({
     .max(MAX_EXPIRATION_HOURS)
     .optional(),
   role: z.enum(["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"]).optional(),
+  reason: z.string().trim().min(10).max(1000).optional(),
 });
 
 type InviteRequest = z.infer<typeof InviteRequestSchema>;
@@ -77,6 +78,20 @@ const ensureEmailServiceConfig = () => {
 const buildInviteUrl = (baseUrl: string, token: string) => {
   const trimmed = baseUrl.replace(/\/$/, "");
   return `${trimmed}/accept-invite?token=${token}`;
+};
+
+const rollbackInviteToken = async (inviteId: string, organizationId: string) => {
+  const { error } = await supabaseAdmin
+    .from("admin_invite_tokens")
+    .delete()
+    .eq("id", inviteId)
+    .eq("organization_id", organizationId);
+
+  if (error) {
+    console.error("Failed to roll back invite token after email failure", { code: "invite_token_rollback_failed" });
+  }
+
+  return { error };
 };
 
 async function sendInviteEmail(
@@ -166,6 +181,19 @@ async function handleInvite(req: Request, userContext: UserContext) {
       return jsonResponse(403, { error: "insufficient_role_for_target" });
     }
 
+    const { emailServiceUrl, portalBaseUrl } = ensureEmailServiceConfig();
+    if (!emailServiceUrl) {
+      console.error("ADMIN_INVITE_EMAIL_URL is not configured", { code: 'invite_email_url_missing' });
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
+      return jsonResponse(500, { error: "email_service_unconfigured" });
+    }
+
+    if (!portalBaseUrl) {
+      console.error("ADMIN_PORTAL_URL is not configured", { code: 'portal_url_missing' });
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
+      return jsonResponse(500, { error: "portal_url_unconfigured" });
+    }
+
     const now = new Date();
     const expiresInHours = payload.expiresInHours ?? DEFAULT_EXPIRATION_HOURS;
     const expiresAt = new Date(now.getTime() + expiresInHours * 60 * 60 * 1000);
@@ -211,19 +239,6 @@ async function handleInvite(req: Request, userContext: UserContext) {
       return jsonResponse(500, { error: "invite_creation_failed" });
     }
 
-    const { emailServiceUrl, portalBaseUrl } = ensureEmailServiceConfig();
-    if (!emailServiceUrl) {
-      console.error("ADMIN_INVITE_EMAIL_URL is not configured", { code: 'invite_email_url_missing' });
-      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-      return jsonResponse(500, { error: "email_service_unconfigured" });
-    }
-
-    if (!portalBaseUrl) {
-      console.error("ADMIN_PORTAL_URL is not configured", { code: 'portal_url_missing' });
-      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-      return jsonResponse(500, { error: "portal_url_unconfigured" });
-    }
-
     const inviteUrl = buildInviteUrl(portalBaseUrl, rawToken);
 
     const emailResult = await sendInviteEmail(emailServiceUrl, {
@@ -245,6 +260,7 @@ async function handleInvite(req: Request, userContext: UserContext) {
         invite_id: inviteResult.id,
         role: desiredRole,
         email_delivery_status: emailResult.status,
+        ...(payload.reason ? { reason: payload.reason } : {}),
         ...(emailResult.error ? { email_error: emailResult.error } : {}),
       },
     });
@@ -254,6 +270,11 @@ async function handleInvite(req: Request, userContext: UserContext) {
     }
 
     if (emailResult.status === "failed") {
+      const rollbackResult = await rollbackInviteToken(inviteResult.id, targetOrganizationId);
+      if (rollbackResult.error) {
+        logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
+        return jsonResponse(500, { error: "invite_rollback_failed" });
+      }
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 502);
       return jsonResponse(502, { error: "email_delivery_failed" });
     }

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -58,6 +58,42 @@ let currentUserMetadata: Record<string, unknown> = { organization_id: 'org-123' 
 
 const inviteTokens: StoredInviteToken[] = [];
 const adminActionRows: Array<Record<string, unknown>> = [];
+let rollbackDeleteError: { message: string } | null = null;
+
+const fromTable = (table: string) => {
+  if (table === 'admin_actions') {
+    return {
+      insert: vi.fn(async (payload: Record<string, unknown>) => {
+        adminActionRows.push(payload);
+        return { error: null };
+      }),
+    };
+  }
+  if (table === 'admin_invite_tokens') {
+    return {
+      delete: vi.fn(() => {
+        const filters: Record<string, unknown> = {};
+        const builder = {
+          eq: vi.fn((column: string, value: unknown) => {
+            filters[column] = value;
+            if (filters.id && filters.organization_id && !rollbackDeleteError) {
+              const index = inviteTokens.findIndex(token =>
+                token.id === filters.id && token.organization_id === filters.organization_id,
+              );
+              if (index >= 0) {
+                inviteTokens.splice(index, 1);
+              }
+            }
+            return builder;
+          }),
+          then: (resolve: (value: { error: { message: string } | null }) => void) => resolve({ error: rollbackDeleteError }),
+        };
+        return builder;
+      }),
+    };
+  }
+  throw new Error(`Unexpected table ${table}`);
+};
 
 const createMockClient = () => ({
   auth: {
@@ -66,17 +102,7 @@ const createMockClient = () => ({
       error: null,
     })),
   },
-  from: (table: string) => {
-    if (table === 'admin_actions') {
-      return {
-        insert: vi.fn(async (payload: Record<string, unknown>) => {
-          adminActionRows.push(payload);
-          return { error: null };
-        }),
-      };
-    }
-    throw new Error(`Unexpected table ${table}`);
-  },
+  from: fromTable,
 });
 
 const createAdminRpc = vi.fn(async (functionName: string, params: Record<string, unknown>) => {
@@ -156,6 +182,7 @@ vi.mock('../../supabase/functions/_shared/database.ts', () => ({
   createRequestClient,
   supabaseAdmin: {
     rpc: createAdminRpc,
+    from: fromTable,
   },
 }));
 
@@ -175,6 +202,7 @@ describe('admin invite edge function', () => {
     vi.resetModules();
     inviteTokens.splice(0, inviteTokens.length);
     adminActionRows.splice(0, adminActionRows.length);
+    rollbackDeleteError = null;
     currentUserContext = {
       user: { id: 'admin-1', email: 'admin@example.com' },
       profile: { id: 'profile-1', email: 'admin@example.com', role: 'admin', is_active: true },
@@ -197,7 +225,7 @@ describe('admin invite edge function', () => {
       new Request('https://edge.example.com/admin/invite', {
         method: 'POST',
         headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
-        body: JSON.stringify({ email: 'NewAdmin@example.com' }),
+        body: JSON.stringify({ email: 'NewAdmin@example.com', reason: 'Coverage for staff onboarding.' }),
       }),
     );
 
@@ -228,9 +256,102 @@ describe('admin invite edge function', () => {
     expect(adminActionRows[0]?.action_details).toMatchObject({
       email: 'newadmin@example.com',
       email_delivery_status: 'sent',
+      reason: 'Coverage for staff onboarding.',
     });
 
     expect(assertAdminOrSuperAdmin).toHaveBeenCalledTimes(1);
+  }, 20_000);
+
+  it('does not persist an invite token when the email service URL is missing', async () => {
+    envValues.set('ADMIN_INVITE_EMAIL_URL', '');
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'missing-mailer@example.com', reason: 'Coverage for missing mailer.' }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ error: 'email_service_unconfigured' });
+    expect(createAdminRpc).not.toHaveBeenCalled();
+    expect(inviteTokens).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adminActionRows).toHaveLength(0);
+  }, 20_000);
+
+  it('does not persist an invite token when the portal URL is missing', async () => {
+    envValues.set('ADMIN_PORTAL_URL', '');
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'missing-portal@example.com', reason: 'Coverage for missing portal.' }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ error: 'portal_url_unconfigured' });
+    expect(createAdminRpc).not.toHaveBeenCalled();
+    expect(inviteTokens).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adminActionRows).toHaveLength(0);
+  }, 20_000);
+
+  it('deletes the invite token when email delivery fails', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'mailer-failure@example.com', reason: 'Coverage for mailer failure.' }),
+      }),
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({ error: 'email_delivery_failed' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(inviteTokens).toHaveLength(0);
+    expect(adminActionRows).toHaveLength(1);
+    expect(adminActionRows[0]?.action_details).toMatchObject({
+      email: 'mailer-failure@example.com',
+      email_delivery_status: 'failed',
+      email_error: 'Email service responded with status 503',
+      reason: 'Coverage for mailer failure.',
+    });
+  }, 20_000);
+
+  it('surfaces rollback failure when email delivery fails and token cleanup cannot complete', async () => {
+    rollbackDeleteError = { message: 'delete denied' };
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'rollback-failure@example.com', reason: 'Coverage for rollback failure.' }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invite_rollback_failed' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(inviteTokens).toHaveLength(1);
+    expect(inviteTokens[0]?.email).toBe('rollback-failure@example.com');
+    expect(adminActionRows).toHaveLength(1);
+    expect(adminActionRows[0]?.action_details).toMatchObject({
+      email: 'rollback-failure@example.com',
+      email_delivery_status: 'failed',
+      email_error: 'Email service responded with status 503',
+      reason: 'Coverage for rollback failure.',
+    });
   }, 20_000);
 
   it('replaces an expired invite token with a new one', async () => {


### PR DESCRIPTION
## Summary
- validate invite mailer/portal config before creating an invite token
- roll back the active invite token when invite email delivery fails, and surface `invite_rollback_failed` if cleanup itself fails
- accept `reason` in `admin-invite` and persist it in `admin_actions.action_details`

## Route / Risk
- Linear: WIN-208
- classification: high-risk human-reviewed
- lane: critical
- protected path: `supabase/functions/admin-invite/index.ts`
- tenant boundary: invite token rollback remains scoped by both `id` and `organization_id`; no migration, RLS, grant, or RPC exposure changes

## Verification
- `npm test -- tests/admins/invite_flow.spec.ts --runInBand` passed (11 tests)
- `npm test -- tests/admins/invite_flow.spec.ts tests/admins/accept_invite_flow.spec.ts src/components/settings/__tests__/AdminSettings.test.tsx --runInBand` passed (37 tests)
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run ci:check-focused` passed; local skips: branch protection outside CI, DB grant check missing `SUPABASE_DB_URL`, auth parity disabled locally
- `npm run validate:tenant` passed
- `npm run build` passed
- `npm run test:ci` passed with synthetic local Supabase env (363 files / 2360 tests)
- `npm run ci:verify-coverage` passed (line coverage 92.07% >= 86%)
- `npm run test:routes:tier0` passed (220 Cypress route tests)
- `npm run ci:playwright` blocked locally at preflight: missing `PW_SUPERADMIN_EMAIL` + `PW_SUPERADMIN_PASSWORD` or `PW_ADMIN_EMAIL` + `PW_ADMIN_PASSWORD`

## Review
- Supabase reviewer re-review found no blockers after rollback-failure patch.