### PR TITLE
WIN-210 harden Supabase drift repair

### DIFF
--- a/docs/ai/WIN-210-supabase-drift-repair-handoff.md
+++ b/docs/ai/WIN-210-supabase-drift-repair-handoff.md
@@ -1,0 +1,195 @@
+# WIN-210 Supabase Drift Repair Handoff
+
+Date: 2026-07-09
+
+Linear: https://linear.app/winningedgeai/issue/WIN-210/apply-supabase-drift-repair-for-goal-domains-and-session-start-authz
+
+## Scope
+
+Apply and verify the hosted Supabase drift repair for project `wnnjeqheqxxyrgsjmygy`.
+
+Allowed migration payloads:
+
+- `supabase/migrations/20260706143000_goal_domains_and_structured_draft_goals.sql`
+- `supabase/migrations/20260707193703_start_session_employee_role_authz.sql`
+- `supabase/migrations/20260709162000_harden_goal_domain_and_session_link_authz.sql`
+
+Non-goals:
+
+- Do not harden `admin-users` RPC/function in this slice.
+- Do not modify unrelated migrations, app code, CI, secrets, or runtime configuration.
+- Do not read `.env*` files.
+
+## Route
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- triggering paths: `supabase/migrations/**`
+- risk rationale: hosted DDL/RLS/grant/RPC changes affect tenant-scoped goal access and session-start authorization.
+
+## Hosted Pre-Apply Evidence
+
+Supabase connector checks against `wnnjeqheqxxyrgsjmygy` showed:
+
+- `public.goal_domains` was absent.
+- `public.assessment_draft_goals` and `public.goals` existed.
+- `app.current_user_has_exact_role_for_org(uuid, text[])`, `public.user_therapist_links`, `public.record_session_audit(uuid, text, uuid, jsonb)`, and `public.set_updated_at()` existed.
+- `public.start_session_with_goals(uuid, uuid, uuid, uuid[], timestamptz, uuid)` existed but did not contain `app.current_user_has_exact_role_for_org` or `public.user_therapist_links` checks.
+- Hosted migration history contained prerequisite repairs under generated versions:
+  - `20260703200149 goal_targets_trial_events`
+  - `20260706120432 bcba_exact_capability_matrix`
+- Hosted migration history did not contain the target local versions `20260706143000` or `20260707193703`.
+
+## Hosted Apply Result
+
+Applied with the Supabase connector migration tool, using the exact SQL payloads from the two initial local migration files and the follow-up hardening migration added by this branch.
+
+Supabase recorded generated hosted versions:
+
+- `20260709150513 goal_domains_and_structured_draft_goals`
+- `20260709150554 start_session_employee_role_authz`
+- `20260709151806 harden_goal_domain_and_session_link_authz`
+- `20260709153326 harden_goal_domain_service_role_truncate`
+- `20260709153416 harden_user_therapist_links_service_role_truncate`
+- `20260709153903 normalize_goal_domain_and_link_acls`
+
+The final local migration `20260709162000_harden_goal_domain_and_session_link_authz.sql` includes the review corrections from the later hosted corrective entries above. Fresh environments should use the final local SQL; the hosted project reached the same final state through the original hardening apply plus corrective connector migrations.
+
+## Hosted Post-Apply Evidence
+
+Supabase connector metadata checks showed:
+
+- `public.goal_domains` exists.
+- `public.assessment_draft_goals` includes `domain_id`, `clinical_goal_type`, `teaching_strategies`, `operational_definition`, and `baseline`.
+- Expected constraints exist:
+  - `goal_domains_id_organization_id_key`
+  - `goals_domain_id_fkey`
+  - `assessment_draft_goals_domain_id_fkey`
+  - `assessment_draft_goals_clinical_goal_type_chk`
+- RLS is enabled on `public.goal_domains`.
+- Expected goal-domain policies exist:
+  - `goal_domains_service_role_all`
+  - `goal_domains_org_read`
+  - `goal_domains_org_insert`
+  - `goal_domains_org_update`
+- Expected grants are present:
+  - `anon` cannot select `public.goal_domains`.
+  - `authenticated` can select, insert, and update `public.goal_domains`.
+  - `service_role` can delete `public.goal_domains`.
+  - `anon` cannot execute `public.start_session_with_goals(...)`.
+  - `authenticated` and `service_role` can execute `public.start_session_with_goals(...)`.
+- `public.start_session_with_goals(...)` now contains:
+  - `app.current_user_has_exact_role_for_org`
+  - `public.user_therapist_links`
+  - exact start-role array `admin`, `admin_schedule`, `midtier`, `bcba`
+  - therapist/BT role array `therapist`, `bt`
+
+## Security Review Follow-Up
+
+The security review found two live hardening gaps after the initial hosted apply:
+
+- `public.goal_domains` still had authenticated `DELETE` and `TRUNCATE` privileges from pre-existing ACL drift.
+- `public.user_therapist_links` had broad anon/authenticated table privileges while `start_session_with_goals` used it as a linked-user trust table.
+
+The forward-fix migration `20260709162000_harden_goal_domain_and_session_link_authz.sql` addressed those gaps by:
+
+- revoking all `anon` privileges on `goal_domains` and `user_therapist_links`
+- revoking authenticated destructive/write privileges on `user_therapist_links`
+- revoking authenticated `DELETE` and `TRUNCATE` on `goal_domains`
+- preserving authenticated `SELECT` on `user_therapist_links`
+- requiring the linked-user session-start branch to pass active exact `therapist`/`bt` role checks and join the linked therapist row back to the same session organization
+
+Post-hardening Supabase connector checks showed:
+
+- `anon` cannot select `goal_domains` or `user_therapist_links`.
+- `authenticated` can select/insert/update `goal_domains`, but cannot delete or truncate it.
+- `authenticated` can select `user_therapist_links`, but cannot insert, update, delete, or truncate it.
+- `service_role` can delete `goal_domains` and `user_therapist_links`, but cannot truncate either table.
+- `start_session_with_goals` contains the `public.therapists` join, same-org check, active role check, and non-deleted therapist check for linked-user authorization.
+- goal-domain orphan reference counts are `0` for `goals` and `assessment_draft_goals`.
+- duplicate active goal-domain names are `0`.
+
+Residual hosted data hygiene findings:
+
+- `user_therapist_links` still has `1` cross-org or missing-profile link row.
+- `user_therapist_links` still has `1` link row whose user lacks an active `therapist`/`bt` role.
+- Those anomalous links map to `0` scheduled sessions in the hosted check.
+- The hardened RPC no longer authorizes linked starts from link existence alone.
+
+## Verification Plan
+
+Required local checks for this critical database/RLS/RPC slice:
+
+- targeted migration/session tests
+- `npm run ci:check-focused`
+- `npm run test:ci`
+- `npm run validate:tenant`
+- `npm run build`
+- `npm run verify:local` when the local environment can run the route gate
+
+Browser/auth checks are relevant because `start_session_with_goals` affects session lifecycle. Local execution may require seeded browser credentials or protected systems; any unrun browser/auth gate must be called out in the PR and final handoff.
+
+## Verification Card
+
+- lane: `critical`
+- required checks:
+  - `npm run ci:check-focused`
+  - targeted migration/session tests
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright` when hosted browser credentials are available
+- executed checks:
+  - Supabase connector pre-apply drift/dependency checks
+  - Supabase connector migration apply for the three hosted repairs
+  - Supabase connector post-apply ACL, RLS, FK, orphan, duplicate, and function-body checks
+  - `npx vitest run tests/integration/goal-domains-migration.contract.test.ts tests/employee-role-capability-matrix-migration.test.ts src/server/__tests__/sessionsStartHandler.test.ts --reporter=verbose`
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run ci:verify-coverage`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run validate:tenant`
+  - `npm run ci:playwright:env-readiness`
+  - post-review fix: `npx vitest run tests/integration/goal-domains-migration.contract.test.ts tests/employee-role-capability-matrix-migration.test.ts src/server/__tests__/sessionsStartHandler.test.ts --reporter=verbose`
+  - post-review fix: `npm run ci:check-focused`
+  - post-review fix: Supabase connector ACL probe for `goal_domains` and `user_therapist_links`
+- blocked checks:
+  - `npm run ci:playwright` was not run locally because readiness failed with missing browser target, hosted persona credentials, Supabase runtime keys, service-role access, foreign IDs, and assessment-smoke fixture inputs in the process environment.
+- result:
+  - local policy, lint, typecheck, test, coverage, build, route, and tenant gates passed after one full-suite test retry
+  - hosted Supabase object-level repair checks passed
+  - hosted final ACL vector:
+    - `goal_domains`: `authenticated` has `INSERT`, `SELECT`, `UPDATE`; `service_role` has `DELETE`, `INSERT`, `SELECT`, `UPDATE`; no `anon` grants
+    - `user_therapist_links`: `authenticated` has `SELECT`; `service_role` has `DELETE`, `INSERT`, `SELECT`, `UPDATE`; no `anon` grants
+- residual risk:
+  - local browser/auth Playwright smoke remains CI/secret-backed
+  - hosted `user_therapist_links` still has stale data hygiene findings, but the hardened RPC no longer authorizes linked session starts from link existence alone
+
+## Residual Risk
+
+- The hosted migration ledger records Supabase-generated versions rather than the original local migration timestamps. The object-level checks above are the source of truth for applied behavior.
+- The previously identified `admin-users` RPC/function exposure remains out of scope and should be handled as the next protected Supabase hardening slice.
+
+## PR Hygiene Verdict
+
+- pr-ready: yes, with `ci:playwright` explicitly deferred to secret-backed CI because local readiness failed
+- lane: `critical`
+- branch-ready: yes, `codex/apply-supabase-drift-repair`
+- linear-ready: yes, `WIN-210`
+- single-purpose: yes
+- unrelated changes: none
+- generated artifact drift: none
+- protected-path drift: expected, `supabase/migrations/**`
+- change summary: present
+- verification summary: present
+- pr handoff: ready
+- reviewer: completed, request-change findings addressed with ACL normalization
+- required follow-up:
+  - run/confirm `ci:playwright` in CI or an environment with hosted browser credentials
+  - clean stale `user_therapist_links` data rows in a separate protected slice
+  - address the previously identified `admin-users` RPC/function exposure in a separate protected slice
+- handoff summary: WIN-210 reconciles hosted Supabase goal-domain/session-start drift, then hardens trust-table ACLs and linked session-start authorization after reviewer findings. Hosted Supabase object and ACL probes show the expected final state; local policy, targeted tests, full Vitest, coverage, build, route tier-0, and tenant checks passed. Local browser/auth Playwright smoke is blocked by missing hosted credentials in this process environment and should be confirmed in CI.

--- a/supabase/migrations/20260709162000_harden_goal_domain_and_session_link_authz.sql
+++ b/supabase/migrations/20260709162000_harden_goal_domain_and_session_link_authz.sql
@@ -1,0 +1,250 @@
+-- @migration-intent: Revoke excess goal-domain/link-table privileges and require active same-org therapist/BT authority for linked session starts.
+-- @migration-dependencies: 20260706143000_goal_domains_and_structured_draft_goals.sql,20260707193703_start_session_employee_role_authz.sql
+-- @migration-rollback: Re-run 20260707193703_start_session_employee_role_authz.sql and restore prior table grants only if direct authenticated delete/truncate is intentionally needed.
+
+begin;
+
+revoke all on table public.goal_domains from anon;
+revoke all on table public.goal_domains from authenticated;
+grant select, insert, update on table public.goal_domains to authenticated;
+revoke all on table public.goal_domains from service_role;
+grant select, insert, update, delete on table public.goal_domains to service_role;
+
+revoke all on table public.user_therapist_links from anon;
+revoke all on table public.user_therapist_links from authenticated;
+grant select on table public.user_therapist_links to authenticated;
+revoke all on table public.user_therapist_links from service_role;
+grant select, insert, update, delete on table public.user_therapist_links to service_role;
+
+create or replace function public.start_session_with_goals(
+  p_session_id uuid,
+  p_program_id uuid,
+  p_goal_id uuid,
+  p_goal_ids uuid[] default null,
+  p_started_at timestamptz default null,
+  p_actor_id uuid default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_session record;
+  v_started_at timestamptz;
+  v_goal_ids uuid[];
+  v_goal_count integer := 0;
+  v_goal_id uuid;
+  v_goal_match_count integer := 0;
+  v_actor_id uuid;
+  v_is_super_admin boolean := false;
+  v_has_start_authority boolean := false;
+begin
+  if p_session_id is null or p_program_id is null or p_goal_id is null then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'MISSING_FIELDS',
+      'error_message', 'session_id, program_id, and goal_id are required'
+    );
+  end if;
+
+  select
+    s.id,
+    s.organization_id,
+    s.client_id,
+    s.therapist_id,
+    s.status,
+    s.started_at
+  into v_session
+  from public.sessions s
+  where s.id = p_session_id
+  for update;
+
+  if v_session.id is null then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'SESSION_NOT_FOUND',
+      'error_message', 'Session not found'
+    );
+  end if;
+
+  v_actor_id := auth.uid();
+  if v_actor_id is null then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'UNAUTHORIZED',
+      'error_message', 'Authentication required'
+    );
+  end if;
+
+  if p_actor_id is not null and p_actor_id <> v_actor_id then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'FORBIDDEN',
+      'error_message', 'Actor mismatch'
+    );
+  end if;
+
+  select coalesce(public.current_user_is_super_admin(), false)
+    into v_is_super_admin;
+
+  if v_is_super_admin then
+    v_has_start_authority := true;
+  else
+    select coalesce(app.current_user_has_exact_role_for_org(
+      v_session.organization_id,
+      array['admin', 'admin_schedule', 'midtier', 'bcba']::text[]
+    ), false)
+      into v_has_start_authority;
+
+    if not v_has_start_authority then
+      select coalesce(app.current_user_has_exact_role_for_org(
+        v_session.organization_id,
+        array['therapist', 'bt']::text[]
+      ), false)
+      and exists (
+        select 1
+        from public.user_therapist_links utl
+        join public.therapists t on t.id = utl.therapist_id
+        where utl.user_id = v_actor_id
+          and utl.therapist_id = v_session.therapist_id
+          and t.organization_id = v_session.organization_id
+          and t.deleted_at is null
+      )
+      into v_has_start_authority;
+    end if;
+
+    if not v_has_start_authority then
+      select coalesce(app.current_user_has_exact_role_for_org(
+        v_session.organization_id,
+        array['therapist', 'bt']::text[]
+      ), false)
+      and v_session.therapist_id = v_actor_id
+      into v_has_start_authority;
+    end if;
+  end if;
+
+  if not v_has_start_authority then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'FORBIDDEN',
+      'error_message', 'Not authorized to start this session'
+    );
+  end if;
+
+  if v_session.started_at is not null then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'ALREADY_STARTED',
+      'error_message', 'Session already started'
+    );
+  end if;
+
+  if v_session.status <> 'scheduled' then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'INVALID_STATUS',
+      'error_message', 'Only scheduled sessions can be started'
+    );
+  end if;
+
+  v_goal_ids := coalesce(p_goal_ids, array[]::uuid[]);
+  v_goal_ids := array_append(v_goal_ids, p_goal_id);
+  v_goal_ids := array(select distinct x from unnest(v_goal_ids) as x where x is not null);
+
+  select count(*)
+    into v_goal_match_count
+  from public.goals g
+  where g.id = p_goal_id
+    and g.program_id = p_program_id
+    and g.client_id = v_session.client_id
+    and g.organization_id = v_session.organization_id;
+
+  if v_goal_match_count <> 1 then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'GOAL_NOT_FOUND',
+      'error_message', 'Goal not found for this program'
+    );
+  end if;
+
+  if array_length(v_goal_ids, 1) is not null then
+    select count(*)
+      into v_goal_count
+    from public.goals g
+    where g.id = any(v_goal_ids)
+      and g.program_id = p_program_id
+      and g.client_id = v_session.client_id
+      and g.organization_id = v_session.organization_id;
+
+    if v_goal_count <> array_length(v_goal_ids, 1) then
+      return jsonb_build_object(
+        'success', false,
+        'error_code', 'INVALID_GOALS',
+        'error_message', 'One or more goals are invalid for this session'
+      );
+    end if;
+  end if;
+
+  v_started_at := coalesce(p_started_at, now());
+
+  update public.sessions
+  set
+    program_id = p_program_id,
+    goal_id = p_goal_id,
+    started_at = v_started_at,
+    status = 'in_progress'
+  where id = v_session.id;
+
+  if array_length(v_goal_ids, 1) is not null then
+    foreach v_goal_id in array v_goal_ids loop
+      insert into public.session_goals (
+        session_id,
+        goal_id,
+        organization_id,
+        client_id,
+        program_id
+      ) values (
+        v_session.id,
+        v_goal_id,
+        v_session.organization_id,
+        v_session.client_id,
+        p_program_id
+      )
+      on conflict (session_id, goal_id) do update
+      set
+        organization_id = excluded.organization_id,
+        client_id = excluded.client_id,
+        program_id = excluded.program_id;
+    end loop;
+  end if;
+
+  perform public.record_session_audit(
+    v_session.id,
+    'session_started',
+    v_actor_id,
+    jsonb_build_object(
+      'programId', p_program_id,
+      'goalId', p_goal_id,
+      'goalIds', v_goal_ids,
+      'startedAt', v_started_at
+    )
+  );
+
+  return jsonb_build_object(
+    'success', true,
+    'session', jsonb_build_object(
+      'id', v_session.id,
+      'started_at', v_started_at
+    )
+  );
+end;
+$$;
+
+revoke execute on function public.start_session_with_goals(uuid, uuid, uuid, uuid[], timestamptz, uuid) from public;
+revoke execute on function public.start_session_with_goals(uuid, uuid, uuid, uuid[], timestamptz, uuid) from anon;
+grant execute on function public.start_session_with_goals(uuid, uuid, uuid, uuid[], timestamptz, uuid) to authenticated;
+grant execute on function public.start_session_with_goals(uuid, uuid, uuid, uuid[], timestamptz, uuid) to service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/employee-role-capability-matrix-migration.test.ts
+++ b/tests/employee-role-capability-matrix-migration.test.ts
@@ -45,6 +45,12 @@ const START_SESSION_AUTHZ_MIGRATION_PATH = path.join(
   'migrations',
   '20260707193703_start_session_employee_role_authz.sql',
 );
+const START_SESSION_LINK_HARDENING_MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260709162000_harden_goal_domain_and_session_link_authz.sql',
+);
 const SMOKE_SQL_PATH = path.join(process.cwd(), 'tests', 'sql', 'employee_role_capability_smoke.sql');
 
 const sql = readFileSync(MIGRATION_PATH, 'utf8');
@@ -54,6 +60,7 @@ const employeeRoleListingGrantsSql = readFileSync(EMPLOYEE_ROLE_LISTING_GRANTS_M
 const bcbaExactCapabilitySql = readFileSync(BCBA_EXACT_CAPABILITY_MIGRATION_PATH, 'utf8');
 const superAdminPrecedenceSql = readFileSync(SUPER_ADMIN_PRECEDENCE_MIGRATION_PATH, 'utf8');
 const startSessionAuthzSql = readFileSync(START_SESSION_AUTHZ_MIGRATION_PATH, 'utf8');
+const startSessionLinkHardeningSql = readFileSync(START_SESSION_LINK_HARDENING_MIGRATION_PATH, 'utf8');
 const smokeSql = readFileSync(SMOKE_SQL_PATH, 'utf8');
 
 const extractFunctionFrom = (sourceSql: string, name: string): string => {
@@ -69,6 +76,8 @@ const extractBcbaExactFunction = (name: string): string => extractFunctionFrom(b
 const extractSuperAdminPrecedenceFunction = (name: string): string =>
   extractFunctionFrom(superAdminPrecedenceSql, name);
 const extractStartSessionAuthzFunction = (name: string): string => extractFunctionFrom(startSessionAuthzSql, name);
+const extractStartSessionLinkHardeningFunction = (name: string): string =>
+  extractFunctionFrom(startSessionLinkHardeningSql, name);
 
 describe('employee role capability matrix migration', () => {
   it('keeps bt and midtier out of broad therapist/org_member helper aliases', () => {
@@ -249,5 +258,26 @@ describe('employee role capability matrix migration', () => {
       'revoke execute on function public.start_session_with_goals(uuid, uuid, uuid, uuid[], timestamptz, uuid) from anon;',
     );
     expect(startSessionAuthzSql).toContain("notify pgrst, 'reload schema';");
+  });
+
+  it('hardens linked therapist session-start authority with active same-org role checks', () => {
+    const functionSql = extractStartSessionLinkHardeningFunction('public.start_session_with_goals');
+
+    expect(functionSql).toContain("array['therapist', 'bt']::text[]");
+    expect(functionSql).toContain('from public.user_therapist_links utl');
+    expect(functionSql).toContain('join public.therapists t on t.id = utl.therapist_id');
+    expect(functionSql).toContain('and t.organization_id = v_session.organization_id');
+    expect(functionSql).toContain('and t.deleted_at is null');
+    expect(functionSql.indexOf("array['therapist', 'bt']::text[]")).toBeLessThan(
+      functionSql.indexOf('from public.user_therapist_links utl'),
+    );
+    expect(startSessionLinkHardeningSql).toContain('revoke all on table public.user_therapist_links from anon;');
+    expect(startSessionLinkHardeningSql).toContain('revoke all on table public.user_therapist_links from authenticated;');
+    expect(startSessionLinkHardeningSql).toContain('grant select on table public.user_therapist_links to authenticated;');
+    expect(startSessionLinkHardeningSql).toContain('revoke all on table public.user_therapist_links from service_role;');
+    expect(startSessionLinkHardeningSql).toContain('grant select, insert, update, delete on table public.user_therapist_links to service_role;');
+    expect(startSessionLinkHardeningSql).not.toContain(
+      'grant select, insert, update, delete, truncate on table public.user_therapist_links',
+    );
   });
 });

--- a/tests/integration/goal-domains-migration.contract.test.ts
+++ b/tests/integration/goal-domains-migration.contract.test.ts
@@ -9,7 +9,14 @@ describe("goal domains migration contract", () => {
     "migrations",
     "20260706143000_goal_domains_and_structured_draft_goals.sql",
   );
+  const hardeningMigrationPath = join(
+    process.cwd(),
+    "supabase",
+    "migrations",
+    "20260709162000_harden_goal_domain_and_session_link_authz.sql",
+  );
   const sql = readFileSync(migrationPath, "utf8").replace(/\s+/g, " ");
+  const hardeningSql = readFileSync(hardeningMigrationPath, "utf8").replace(/\s+/g, " ");
 
   it("enforces goal domain tenant scope at the database boundary", () => {
     expect(sql).toContain("create temporary table legacy_goal_domain_backfill");
@@ -29,5 +36,14 @@ describe("goal domains migration contract", () => {
     expect(sql).toContain(
       "add constraint assessment_draft_goals_domain_id_fkey foreign key (domain_id, organization_id) references public.goal_domains(id, organization_id)",
     );
+  });
+
+  it("removes authenticated destructive privileges from goal domains", () => {
+    expect(hardeningSql).toContain("revoke all on table public.goal_domains from anon");
+    expect(hardeningSql).toContain("revoke all on table public.goal_domains from authenticated");
+    expect(hardeningSql).toContain("grant select, insert, update on table public.goal_domains to authenticated");
+    expect(hardeningSql).toContain("revoke all on table public.goal_domains from service_role");
+    expect(hardeningSql).toContain("grant select, insert, update, delete on table public.goal_domains to service_role");
+    expect(hardeningSql).not.toContain("grant select, insert, update, delete, truncate on table public.goal_domains");
   });
 });


### PR DESCRIPTION
## Summary
- Apply and document hosted Supabase drift repair for goal domains and `start_session_with_goals` authorization under WIN-210.
- Add a forward-fix migration that normalizes ACLs for `goal_domains` and `user_therapist_links`, and hardens linked session-start authority with same-org therapist plus active exact `therapist`/`bt` role checks.
- Add static migration contract coverage and a critical-lane handoff with hosted Supabase evidence, verification card, and PR hygiene verdict.

## Hosted Supabase evidence
- Project: `wnnjeqheqxxyrgsjmygy`
- Applied via Supabase connector:
  - `20260709150513 goal_domains_and_structured_draft_goals`
  - `20260709150554 start_session_employee_role_authz`
  - `20260709151806 harden_goal_domain_and_session_link_authz`
  - `20260709153326 harden_goal_domain_service_role_truncate`
  - `20260709153416 harden_user_therapist_links_service_role_truncate`
  - `20260709153903 normalize_goal_domain_and_link_acls`
- Final hosted ACL vector:
  - `goal_domains`: `authenticated` = `INSERT`, `SELECT`, `UPDATE`; `service_role` = `DELETE`, `INSERT`, `SELECT`, `UPDATE`; no `anon` grants.
  - `user_therapist_links`: `authenticated` = `SELECT`; `service_role` = `DELETE`, `INSERT`, `SELECT`, `UPDATE`; no `anon` grants.

## Verification
- `npx vitest run tests/integration/goal-domains-migration.contract.test.ts tests/employee-role-capability-matrix-migration.test.ts src/server/__tests__/sessionsStartHandler.test.ts --reporter=verbose`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci` (rerun passed after one non-deterministic full-suite ProgramsGoalsTab failure; isolated file passed)
- `npm run ci:verify-coverage`
- `npm run build`
- `npm run test:routes:tier0`
- `npm run validate:tenant`
- `npm run ci:playwright:env-readiness` failed locally because hosted browser credentials/runtime/service-role inputs are not present in the process environment; `ci:playwright` was not run locally and should run in CI/secret-backed environment.

## Residual risk
- Hosted `user_therapist_links` still contains stale data hygiene anomalies, but the hardened RPC no longer trusts link existence alone.
- Previously identified `admin-users` RPC/function exposure is intentionally out of scope for this slice.

Linear: WIN-210
