### PR TITLE
Clean stale user therapist links safely

### DIFF
--- a/docs/ai/WIN-211-user-therapist-links-cleanup-handoff.md
+++ b/docs/ai/WIN-211-user-therapist-links-cleanup-handoff.md
@@ -126,7 +126,7 @@ where q.quarantine_batch = '20260709170000_quarantine_stale_user_therapist_links
   - Supabase connector migration apply: passed
   - Supabase connector post-apply aggregate check: passed; 0 stale live links, 1 quarantined row, 0 rerun delete candidates
   - `npx vitest run tests/integration/user-therapist-links-cleanup-migration.contract.test.ts --reporter=verbose`: passed, 1 file / 4 tests
-  - `WIN211_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:<ephemeral-port>/postgres npx vitest run tests/integration/user-therapist-links-cleanup-migration.postgres.test.js --reporter=verbose`: passed against a disposable `postgres:16` Docker container, 1 file / 1 test
+  - `WIN211_POSTGRES_URL=<masked local disposable Postgres URL> npx vitest run tests/integration/user-therapist-links-cleanup-migration.postgres.test.js --reporter=verbose`: passed against a disposable `postgres:16` Docker container, 1 file / 1 test
     - executed the actual migration SQL twice
     - verified stale rows are quarantined then deleted
     - verified restored links already present in the quarantine batch are not deleted when they no longer evaluate stale

--- a/docs/ai/WIN-211-user-therapist-links-cleanup-handoff.md
+++ b/docs/ai/WIN-211-user-therapist-links-cleanup-handoff.md
@@ -1,0 +1,172 @@
+# WIN-211 User Therapist Link Cleanup Handoff
+
+## Scope
+
+- classification: high-risk human-reviewed
+- lane: critical
+- issue: WIN-211
+- branch: codex/cleanup-stale-therapist-links
+- protected surface: `supabase/migrations/**`, tenant-scoped link data, role-scoped session/admin link behavior
+
+## Route Task
+
+- why: the slice changes Supabase data hygiene for `public.user_therapist_links`, a tenant-sensitive table used by session authorization and admin therapist-link RPCs.
+- triggering paths:
+  - `supabase/migrations/20260709170000_quarantine_stale_user_therapist_links.sql`
+  - `tests/integration/user-therapist-links-cleanup-migration.contract.test.ts`
+  - `docs/ai/WIN-211-user-therapist-links-cleanup-handoff.md`
+- required agents:
+  - specification-engineer
+  - software-architect
+  - implementation-engineer
+  - code-review-engineer
+  - test-engineer
+  - security-engineer
+  - supabase-reviewer
+- reviewer required: yes
+- verify-change required: yes
+- linear required: yes
+
+## Tenant Boundary
+
+`public.user_therapist_links` rows must only connect a supported active user role to an active therapist in the same organization. Cross-tenant links, links whose user organization cannot be resolved by `app.resolve_user_organization_id`, links with a missing therapist, links to inactive/deleted therapists, and links whose user has no active supported role are stale.
+
+The cleanup intentionally preserves supported semantics currently present in the codebase:
+
+- provider/session links: `therapist`, `bt`
+- scoped staff read or route fallback paths: `midtier`, `admin_schedule`, `bcba`
+- admin therapist-link RPCs: `admin`, `super_admin`, `org_admin`, `org_super_admin`
+
+## Hosted Pre-Apply Evidence
+
+Supabase project: `wnnjeqheqxxyrgsjmygy`
+
+Aggregate-only evidence from the Supabase connector, with no row identifiers copied into this file:
+
+- total `user_therapist_links`: 4
+- resolver-based total links: 4
+- resolver-based stale link count: 1
+- resolver-based missing user org count: 1
+- resolver-based missing therapist count: 0
+- resolver-based cross-org count: 0
+- resolver-based inactive/deleted therapist count: 0
+- resolver-based no supported active role count: 1
+- resolver-based duplicate pair count: 0
+- proposed quarantine/delete count: 1
+
+## Hosted Apply And Post-Apply Evidence
+
+Applied through the Supabase connector with logical migration name `quarantine_stale_user_therapist_links`.
+
+- hosted migration ledger row: version `20260709161951`, name `quarantine_stale_user_therapist_links`
+- live total links after apply: 3
+- live stale links after apply: 0
+- quarantine batch count: 1
+- quarantined rows absent from live table: 1
+- rerun delete candidates for this batch: 0
+- live duplicate pair count: 0
+- quarantine table grants:
+  - `postgres`: owner privileges
+  - `service_role`: `SELECT`
+- quarantine RLS policies:
+  - `user_therapist_links_quarantine_service_role_select`: `SELECT` to `{service_role}`, `USING (true)`, no `WITH CHECK`
+- quarantine RLS enabled: true
+- quarantine RLS forced: true
+
+The local filename remains `20260709170000_quarantine_stale_user_therapist_links.sql` so it sorts after the merged `20260709162000_*` migration in this repository. The hosted connector assigned its own ledger version during apply. If a later Supabase CLI deploy checks only migration versions and reruns this file, the cleanup DML is idempotent for the current hosted state: there are zero stale live links and zero rerun delete candidates.
+
+## Implementation
+
+Migration `20260709170000_quarantine_stale_user_therapist_links.sql`:
+
+- creates `public.user_therapist_links_quarantine`
+- enables and forces RLS on the quarantine table
+- adds an explicit `service_role` select policy on the quarantine table
+- revokes all access from `public`, `anon`, `authenticated`, and `service_role`
+- grants only `select` to `service_role` for privileged inspection; no post-migration insert/delete grant is left on the quarantine table
+- resolves user-side organization with `app.resolve_user_organization_id`, not `profiles.organization_id` alone
+- inserts matching stale rows into quarantine using a predicate, not hardcoded IDs
+- deletes only rows from the named quarantine batch that still match the computed `is_stale` predicate on rerun
+- leaves admin-users RPC exposure out of scope
+
+`src/lib/generated/database.types.ts` is intentionally unchanged. The new table is a service-role-only forensic table with no app or server typed consumer in this slice; generated type exposure should be added only if a reviewed typed consumer is introduced.
+
+Rollback path requires reviewed service-role restore from `public.user_therapist_links_quarantine` for the named batch. Suggested restore shape:
+
+```sql
+insert into public.user_therapist_links (id, user_id, therapist_id, created_at)
+select q.link_id, q.user_id, q.therapist_id, q.link_created_at
+from public.user_therapist_links_quarantine q
+where q.quarantine_batch = '20260709170000_quarantine_stale_user_therapist_links'
+  and not exists (
+    select 1
+    from public.user_therapist_links utl
+    where utl.id = q.link_id
+  );
+```
+
+## Verification Card
+
+- classification: high-risk human-reviewed
+- lane: critical
+- change type:
+  - database/RLS/migration/tenant isolation
+  - tenant-scoped data cleanup
+- required checks:
+  - `npx vitest run tests/integration/user-therapist-links-cleanup-migration.contract.test.ts --reporter=verbose`
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run verify:local` when locally meaningful
+- executed checks:
+  - Supabase connector pre-apply aggregate check: passed; 1 stale link identified, no row identifiers copied
+  - Supabase connector migration apply: passed
+  - Supabase connector post-apply aggregate check: passed; 0 stale live links, 1 quarantined row, 0 rerun delete candidates
+  - `npx vitest run tests/integration/user-therapist-links-cleanup-migration.contract.test.ts --reporter=verbose`: passed, 1 file / 4 tests
+  - `WIN211_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:<ephemeral-port>/postgres npx vitest run tests/integration/user-therapist-links-cleanup-migration.postgres.test.js --reporter=verbose`: passed against a disposable `postgres:16` Docker container, 1 file / 1 test
+    - executed the actual migration SQL twice
+    - verified stale rows are quarantined then deleted
+    - verified restored links already present in the quarantine batch are not deleted when they no longer evaluate stale
+    - verified newly stale links are quarantined/deleted on a later run
+    - verified forced RLS and service-role-only quarantine grants after migration execution
+  - `npx vitest run tests/integration/user-therapist-links-cleanup-migration.contract.test.ts tests/integration/user-therapist-links-cleanup-migration.postgres.test.js --reporter=verbose`: passed for default local mode, 4 contract tests passed and 1 Postgres-backed test skipped without `WIN211_POSTGRES_URL`
+  - `npm run verify:local`: passed
+    - includes `npm run ci:check-focused`
+    - includes `npm run lint`
+    - includes `npm run typecheck`
+    - includes `npm run test:ci`
+    - includes `npm run ci:verify-coverage`
+    - includes `npm run build`
+    - includes `npm run test:routes:tier0`, 7 Cypress specs / 220 tests passed
+  - `npm run lint`: passed after adding the seeded cleanup rerun test
+  - `npm run typecheck`: passed after adding the seeded cleanup rerun test
+- blocked checks:
+  - `npm run verify:local` skipped branch protection outside CI.
+  - `npm run verify:local` skipped privileged function DB grant check and Supabase preview drift check because `SUPABASE_DB_URL`/`DATABASE_URL` is not configured locally; hosted Supabase connector evidence above covers this slice's applied database state.
+- result:
+  - pass for local verification and hosted post-apply evidence
+- residual risk:
+  - critical-lane human review and live PR checks remain required before merge
+  - hosted `service_role` bypasses RLS, so the quarantine table intentionally keeps only a minimal explicit `SELECT` grant and no authenticated/anon grants
+  - hosted ledger version was assigned by the Supabase connector and differs from the local filename timestamp; the SQL is idempotent if later applied by local version
+
+## PR Hygiene Verdict
+
+- pr-ready: yes, after final diff check and PR creation
+- lane: critical
+- branch-ready: yes
+- linear-ready: yes, WIN-211
+- single-purpose: yes
+- unrelated changes: no; generated test reliability timestamp drift restored
+- generated artifact drift: none required; database types intentionally unchanged because the quarantine table is service-role-only and has no typed app/server consumer
+- protected-path drift: expected `supabase/migrations/**`
+- change summary: present
+- verification summary: present
+- pr handoff: ready after PR URL is created
+- reviewer: approved by final code-review-engineer after the Postgres-backed migration test was added; security-engineer and supabase-reviewer approved current SQL
+- required follow-up:
+  - open PR for human review
+  - keep admin-users RPC exposure audit as a separate slice

--- a/supabase/migrations/20260709170000_quarantine_stale_user_therapist_links.sql
+++ b/supabase/migrations/20260709170000_quarantine_stale_user_therapist_links.sql
@@ -1,0 +1,142 @@
+-- @migration-intent: Quarantine and remove objectively stale user_therapist_links rows without hardcoded production IDs.
+-- @migration-dependencies: public.user_therapist_links, public.therapists, public.user_roles, public.roles, app.resolve_user_organization_id
+-- @migration-rollback: Reinsert rows from public.user_therapist_links_quarantine where quarantine_batch = '20260709170000_quarantine_stale_user_therapist_links' if a reviewed restore is required.
+
+begin;
+
+create table if not exists public.user_therapist_links_quarantine (
+  id uuid primary key default gen_random_uuid(),
+  quarantine_batch text not null,
+  quarantined_at timestamptz not null default now(),
+  link_id uuid not null,
+  user_id uuid not null,
+  therapist_id uuid not null,
+  link_created_at timestamptz not null,
+  reason text not null,
+  user_organization_id uuid,
+  therapist_organization_id uuid,
+  therapist_status text,
+  therapist_deleted_at timestamptz,
+  had_supported_active_role boolean not null,
+  unique (quarantine_batch, link_id)
+);
+
+alter table public.user_therapist_links_quarantine enable row level security;
+alter table public.user_therapist_links_quarantine force row level security;
+
+drop policy if exists user_therapist_links_quarantine_service_role_all
+  on public.user_therapist_links_quarantine;
+drop policy if exists user_therapist_links_quarantine_service_role_select
+  on public.user_therapist_links_quarantine;
+create policy user_therapist_links_quarantine_service_role_select
+  on public.user_therapist_links_quarantine
+  for select
+  to service_role
+  using (true);
+
+revoke all on table public.user_therapist_links_quarantine from public;
+revoke all on table public.user_therapist_links_quarantine from anon;
+revoke all on table public.user_therapist_links_quarantine from authenticated;
+revoke all on table public.user_therapist_links_quarantine from service_role;
+grant select on table public.user_therapist_links_quarantine to service_role;
+
+with stale_links as (
+  select
+    evaluated.*,
+    evaluated.user_organization_id is null
+      or evaluated.therapist_organization_id is null
+      or evaluated.user_organization_id is distinct from evaluated.therapist_organization_id
+      or lower(coalesce(evaluated.therapist_status, 'active')) <> 'active'
+      or evaluated.therapist_deleted_at is not null
+      or not evaluated.had_supported_active_role as is_stale
+  from (
+    select
+      utl.id as link_id,
+      utl.user_id,
+      utl.therapist_id,
+      utl.created_at as link_created_at,
+      app.resolve_user_organization_id(utl.user_id) as user_organization_id,
+      t.organization_id as therapist_organization_id,
+      t.status as therapist_status,
+      t.deleted_at as therapist_deleted_at,
+      exists (
+        select 1
+        from public.user_roles ur
+        join public.roles r on r.id = ur.role_id
+        where ur.user_id = utl.user_id
+          and coalesce(ur.is_active, true) = true
+          and (ur.expires_at is null or ur.expires_at > now())
+          and r.name in (
+            'therapist',
+            'bt',
+            'midtier',
+            'admin_schedule',
+            'admin',
+            'bcba',
+            'super_admin',
+            'org_admin',
+            'org_super_admin'
+          )
+      ) as had_supported_active_role
+    from public.user_therapist_links utl
+    left join public.therapists t on t.id = utl.therapist_id
+  ) evaluated
+), quarantined as (
+  insert into public.user_therapist_links_quarantine (
+    quarantine_batch,
+    link_id,
+    user_id,
+    therapist_id,
+    link_created_at,
+    reason,
+    user_organization_id,
+    therapist_organization_id,
+    therapist_status,
+    therapist_deleted_at,
+    had_supported_active_role
+  )
+  select
+    '20260709170000_quarantine_stale_user_therapist_links',
+    link_id,
+    user_id,
+    therapist_id,
+    link_created_at,
+    concat_ws(
+      ';',
+      case when user_organization_id is null then 'missing_user_organization' end,
+      case when therapist_organization_id is null then 'missing_therapist' end,
+      case
+        when user_organization_id is not null
+          and therapist_organization_id is not null
+          and user_organization_id is distinct from therapist_organization_id
+        then 'organization_mismatch'
+      end,
+      case when lower(coalesce(therapist_status, 'active')) <> 'active' then 'inactive_therapist' end,
+      case when therapist_deleted_at is not null then 'deleted_therapist' end,
+      case when not had_supported_active_role then 'missing_supported_active_role' end
+    ) as reason,
+    user_organization_id,
+    therapist_organization_id,
+    therapist_status,
+    therapist_deleted_at,
+    had_supported_active_role
+  from stale_links
+  where is_stale
+  on conflict (quarantine_batch, link_id) do nothing
+  returning link_id
+), quarantined_links as (
+  select link_id from quarantined
+  union
+  select q.link_id
+  from public.user_therapist_links_quarantine q
+  join stale_links sl on sl.link_id = q.link_id
+  where q.quarantine_batch = '20260709170000_quarantine_stale_user_therapist_links'
+    and sl.is_stale
+)
+delete from public.user_therapist_links utl
+using quarantined_links q
+where utl.id = q.link_id;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/integration/user-therapist-links-cleanup-migration.contract.test.ts
+++ b/tests/integration/user-therapist-links-cleanup-migration.contract.test.ts
@@ -1,0 +1,291 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260709170000_quarantine_stale_user_therapist_links.sql'
+);
+
+const readMigration = () => fs.readFileSync(MIGRATION_PATH, 'utf8').replace(/\r\n/g, '\n');
+
+const QUARANTINE_BATCH = '20260709170000_quarantine_stale_user_therapist_links';
+const SUPPORTED_ROLES = [
+  'therapist',
+  'bt',
+  'midtier',
+  'admin_schedule',
+  'admin',
+  'bcba',
+  'super_admin',
+  'org_admin',
+  'org_super_admin',
+] as const;
+
+type LinkRow = {
+  id: string;
+  userId: string;
+  therapistId: string;
+  createdAt: string;
+};
+
+type TherapistRow = {
+  id: string;
+  organizationId: string | null;
+  status?: string | null;
+  deletedAt?: string | null;
+};
+
+type UserRoleRow = {
+  userId: string;
+  role: string;
+  isActive?: boolean | null;
+  expiresAt?: string | null;
+};
+
+type QuarantineRow = {
+  quarantineBatch: string;
+  linkId: string;
+  reason: string;
+  userOrganizationId: string | null;
+  therapistOrganizationId: string | null;
+  therapistStatus: string | null;
+  therapistDeletedAt: string | null;
+  hadSupportedActiveRole: boolean;
+};
+
+type CleanupState = {
+  links: LinkRow[];
+  therapists: TherapistRow[];
+  userOrganizations: Map<string, string | null>;
+  userRoles: UserRoleRow[];
+  quarantine: QuarantineRow[];
+};
+
+const now = new Date('2026-07-09T00:00:00.000Z');
+
+const hasSupportedActiveRole = (roles: UserRoleRow[], userId: string) =>
+  roles.some((role) => {
+    const expiresAt = role.expiresAt ? new Date(role.expiresAt) : null;
+    return (
+      role.userId === userId &&
+      (role.isActive ?? true) &&
+      (!expiresAt || expiresAt > now) &&
+      SUPPORTED_ROLES.includes(role.role as (typeof SUPPORTED_ROLES)[number])
+    );
+  });
+
+const applyCleanupModel = (state: CleanupState) => {
+  const evaluated = state.links.map((link) => {
+    const therapist = state.therapists.find((candidate) => candidate.id === link.therapistId);
+    const userOrganizationId = state.userOrganizations.get(link.userId) ?? null;
+    const therapistOrganizationId = therapist?.organizationId ?? null;
+    const therapistStatus = therapist?.status ?? null;
+    const therapistDeletedAt = therapist?.deletedAt ?? null;
+    const hadSupportedActiveRole = hasSupportedActiveRole(state.userRoles, link.userId);
+    const isStale =
+      userOrganizationId === null ||
+      therapistOrganizationId === null ||
+      userOrganizationId !== therapistOrganizationId ||
+      (therapistStatus ?? 'active').toLowerCase() !== 'active' ||
+      therapistDeletedAt !== null ||
+      !hadSupportedActiveRole;
+    const reason = [
+      userOrganizationId === null ? 'missing_user_organization' : null,
+      therapistOrganizationId === null ? 'missing_therapist' : null,
+      userOrganizationId !== null && therapistOrganizationId !== null && userOrganizationId !== therapistOrganizationId
+        ? 'organization_mismatch'
+        : null,
+      (therapistStatus ?? 'active').toLowerCase() !== 'active' ? 'inactive_therapist' : null,
+      therapistDeletedAt !== null ? 'deleted_therapist' : null,
+      !hadSupportedActiveRole ? 'missing_supported_active_role' : null,
+    ]
+      .filter(Boolean)
+      .join(';');
+
+    return {
+      link,
+      isStale,
+      reason,
+      userOrganizationId,
+      therapistOrganizationId,
+      therapistStatus,
+      therapistDeletedAt,
+      hadSupportedActiveRole,
+    };
+  });
+
+  const newlyQuarantined = new Set<string>();
+
+  for (const stale of evaluated.filter((candidate) => candidate.isStale)) {
+    const alreadyQuarantined = state.quarantine.some(
+      (row) => row.quarantineBatch === QUARANTINE_BATCH && row.linkId === stale.link.id
+    );
+
+    if (!alreadyQuarantined) {
+      state.quarantine.push({
+        quarantineBatch: QUARANTINE_BATCH,
+        linkId: stale.link.id,
+        reason: stale.reason,
+        userOrganizationId: stale.userOrganizationId,
+        therapistOrganizationId: stale.therapistOrganizationId,
+        therapistStatus: stale.therapistStatus,
+        therapistDeletedAt: stale.therapistDeletedAt,
+        hadSupportedActiveRole: stale.hadSupportedActiveRole,
+      });
+      newlyQuarantined.add(stale.link.id);
+    }
+  }
+
+  const staleByLinkId = new Map(evaluated.map((candidate) => [candidate.link.id, candidate.isStale]));
+  const deleteCandidates = new Set([
+    ...newlyQuarantined,
+    ...state.quarantine
+      .filter((row) => row.quarantineBatch === QUARANTINE_BATCH && staleByLinkId.get(row.linkId) === true)
+      .map((row) => row.linkId),
+  ]);
+
+  state.links = state.links.filter((link) => !deleteCandidates.has(link.id));
+};
+
+describe('stale user therapist link cleanup migration contract', () => {
+  it('quarantines matching links before deleting them from the live table', () => {
+    const sql = readMigration();
+
+    expect(sql).toContain('create table if not exists public.user_therapist_links_quarantine');
+    expect(sql).toContain('with stale_links as (');
+    expect(sql).toContain('or not evaluated.had_supported_active_role as is_stale');
+    expect(sql).toContain('), quarantined as (');
+    expect(sql).toContain('insert into public.user_therapist_links_quarantine');
+    expect(sql).toContain('from stale_links\n  where is_stale');
+    expect(sql).toContain('), quarantined_links as (');
+    expect(sql).toContain("where q.quarantine_batch = '20260709170000_quarantine_stale_user_therapist_links'\n    and sl.is_stale");
+    expect(sql).toContain('delete from public.user_therapist_links utl\nusing quarantined_links q\nwhere utl.id = q.link_id;');
+    expect(sql.indexOf('insert into public.user_therapist_links_quarantine')).toBeLessThan(
+      sql.indexOf('delete from public.user_therapist_links utl')
+    );
+    expect(sql).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  });
+
+  it('uses the supported admin and provider link semantics in the stale predicate', () => {
+    const sql = readMigration();
+
+    expect(sql).toContain('app.resolve_user_organization_id(utl.user_id) as user_organization_id');
+    for (const role of [
+      'therapist',
+      'bt',
+      'midtier',
+      'admin_schedule',
+      'admin',
+      'bcba',
+      'super_admin',
+      'org_admin',
+      'org_super_admin',
+    ]) {
+      expect(sql).toContain(`'${role}'`);
+    }
+    expect(sql).toContain('user_organization_id is null');
+    expect(sql).toContain('therapist_organization_id is null');
+    expect(sql).toContain('user_organization_id is distinct from therapist_organization_id');
+    expect(sql).toContain("lower(coalesce(therapist_status, 'active')) <> 'active'");
+    expect(sql).toContain('therapist_deleted_at is not null');
+    expect(sql).toContain('not had_supported_active_role');
+    expect(sql).toContain('missing_user_organization');
+    expect(sql).toContain('missing_supported_active_role');
+    expect(sql).not.toContain('left join public.profiles');
+  });
+
+  it('keeps quarantine records service-role only', () => {
+    const sql = readMigration();
+
+    expect(sql).toContain('alter table public.user_therapist_links_quarantine enable row level security;');
+    expect(sql).toContain('alter table public.user_therapist_links_quarantine force row level security;');
+    expect(sql).toContain('drop policy if exists user_therapist_links_quarantine_service_role_select');
+    expect(sql).toContain('create policy user_therapist_links_quarantine_service_role_select');
+    expect(sql).toContain('on public.user_therapist_links_quarantine');
+    expect(sql).toContain('for select');
+    expect(sql).toContain('to service_role');
+    expect(sql).toContain('using (true)');
+    expect(sql).toContain('revoke all on table public.user_therapist_links_quarantine from public;');
+    expect(sql).toContain('revoke all on table public.user_therapist_links_quarantine from anon;');
+    expect(sql).toContain('revoke all on table public.user_therapist_links_quarantine from authenticated;');
+    expect(sql).toContain('revoke all on table public.user_therapist_links_quarantine from service_role;');
+    expect(sql).toContain('grant select on table public.user_therapist_links_quarantine to service_role;');
+    expect(sql).not.toContain('grant select, insert');
+    expect(sql).not.toContain('grant select, insert, delete');
+    expect(sql).not.toContain('grant select on table public.user_therapist_links_quarantine to authenticated;');
+    expect(sql).not.toContain('grant select on table public.user_therapist_links_quarantine to anon;');
+  });
+
+  it('keeps cleanup stable across reruns and only deletes links that still evaluate stale', () => {
+    const state: CleanupState = {
+      links: [
+        { id: 'valid-link', userId: 'valid-user', therapistId: 'therapist-a', createdAt: '2026-07-01T00:00:00Z' },
+        { id: 'missing-org-link', userId: 'missing-org-user', therapistId: 'therapist-a', createdAt: '2026-07-01T00:00:00Z' },
+        { id: 'cross-org-link', userId: 'cross-org-user', therapistId: 'therapist-a', createdAt: '2026-07-01T00:00:00Z' },
+        { id: 'inactive-therapist-link', userId: 'valid-user', therapistId: 'therapist-inactive', createdAt: '2026-07-01T00:00:00Z' },
+        { id: 'missing-role-link', userId: 'missing-role-user', therapistId: 'therapist-a', createdAt: '2026-07-01T00:00:00Z' },
+      ],
+      therapists: [
+        { id: 'therapist-a', organizationId: 'org-a', status: 'active', deletedAt: null },
+        { id: 'therapist-inactive', organizationId: 'org-a', status: 'inactive', deletedAt: null },
+      ],
+      userOrganizations: new Map([
+        ['valid-user', 'org-a'],
+        ['missing-org-user', null],
+        ['cross-org-user', 'org-b'],
+        ['missing-role-user', 'org-a'],
+      ]),
+      userRoles: [
+        { userId: 'valid-user', role: 'therapist' },
+        { userId: 'missing-org-user', role: 'bt' },
+        { userId: 'cross-org-user', role: 'admin' },
+        { userId: 'missing-role-user', role: 'client' },
+      ],
+      quarantine: [],
+    };
+
+    applyCleanupModel(state);
+    expect(state.links.map((link) => link.id)).toEqual(['valid-link']);
+    expect(state.quarantine.map((row) => row.linkId).sort()).toEqual([
+      'cross-org-link',
+      'inactive-therapist-link',
+      'missing-org-link',
+      'missing-role-link',
+    ]);
+    expect(state.quarantine.find((row) => row.linkId === 'missing-org-link')?.reason).toBe('missing_user_organization');
+
+    applyCleanupModel(state);
+    expect(state.links.map((link) => link.id)).toEqual(['valid-link']);
+    expect(state.quarantine).toHaveLength(4);
+
+    state.links.push({
+      id: 'missing-org-link',
+      userId: 'missing-org-user',
+      therapistId: 'therapist-a',
+      createdAt: '2026-07-01T00:00:00Z',
+    });
+    state.userOrganizations.set('missing-org-user', 'org-a');
+
+    applyCleanupModel(state);
+    expect(state.links.map((link) => link.id).sort()).toEqual(['missing-org-link', 'valid-link']);
+    expect(state.quarantine).toHaveLength(4);
+
+    state.links.push({
+      id: 'new-stale-link',
+      userId: 'new-stale-user',
+      therapistId: 'therapist-a',
+      createdAt: '2026-07-01T00:00:00Z',
+    });
+    state.userOrganizations.set('new-stale-user', null);
+    state.userRoles.push({ userId: 'new-stale-user', role: 'bt' });
+
+    applyCleanupModel(state);
+    expect(state.links.map((link) => link.id).sort()).toEqual(['missing-org-link', 'valid-link']);
+    expect(state.quarantine.map((row) => row.linkId)).toContain('new-stale-link');
+    expect(state.quarantine).toHaveLength(5);
+  });
+});

--- a/tests/integration/user-therapist-links-cleanup-migration.postgres.test.js
+++ b/tests/integration/user-therapist-links-cleanup-migration.postgres.test.js
@@ -1,0 +1,306 @@
+// @vitest-environment node
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { Client } from 'pg';
+import { selectSuite } from '../utils/testControls.ts';
+
+const POSTGRES_URL = process.env.WIN211_POSTGRES_URL;
+const runIfPostgres = selectSuite({
+  run: Boolean(POSTGRES_URL),
+  reason: 'WIN211_POSTGRES_URL is not configured',
+});
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260709170000_quarantine_stale_user_therapist_links.sql'
+);
+const QUARANTINE_BATCH = '20260709170000_quarantine_stale_user_therapist_links';
+
+const ids = {
+  orgA: '00000000-0000-0000-0000-0000000000a1',
+  orgB: '00000000-0000-0000-0000-0000000000b1',
+  validUser: '00000000-0000-0000-0000-000000000101',
+  missingOrgUser: '00000000-0000-0000-0000-000000000102',
+  crossOrgUser: '00000000-0000-0000-0000-000000000103',
+  missingRoleUser: '00000000-0000-0000-0000-000000000104',
+  newStaleUser: '00000000-0000-0000-0000-000000000105',
+  therapistA: '00000000-0000-0000-0000-000000000201',
+  therapistInactive: '00000000-0000-0000-0000-000000000202',
+  validLink: '00000000-0000-0000-0000-000000000301',
+  missingOrgLink: '00000000-0000-0000-0000-000000000302',
+  crossOrgLink: '00000000-0000-0000-0000-000000000303',
+  inactiveTherapistLink: '00000000-0000-0000-0000-000000000304',
+  missingRoleLink: '00000000-0000-0000-0000-000000000305',
+  newStaleLink: '00000000-0000-0000-0000-000000000306',
+};
+
+const queryArray = async (client, sql, values = []) => {
+  const result = await client.query(sql, values);
+  return result.rows.map((row) => row.value);
+};
+
+const resetHarness = async (client) => {
+  await client.query(`
+    create extension if not exists pgcrypto;
+    do $$
+    begin
+      if not exists (select 1 from pg_roles where rolname = 'anon') then create role anon; end if;
+      if not exists (select 1 from pg_roles where rolname = 'authenticated') then create role authenticated; end if;
+      if not exists (select 1 from pg_roles where rolname = 'service_role') then create role service_role; end if;
+    end $$;
+
+    drop table if exists public.user_therapist_links_quarantine cascade;
+    drop table if exists public.user_therapist_links cascade;
+    drop table if exists public.therapists cascade;
+    drop table if exists public.user_roles cascade;
+    drop table if exists public.roles cascade;
+    drop table if exists public.win211_user_orgs cascade;
+    drop schema if exists app cascade;
+
+    create schema app;
+    create table public.win211_user_orgs (
+      user_id uuid primary key,
+      organization_id uuid
+    );
+    create function app.resolve_user_organization_id(target_user_id uuid)
+    returns uuid
+    language sql
+    stable
+    as $$
+      select organization_id
+      from public.win211_user_orgs
+      where user_id = target_user_id
+    $$;
+
+    create table public.therapists (
+      id uuid primary key,
+      organization_id uuid,
+      status text,
+      deleted_at timestamptz
+    );
+    create table public.roles (
+      id uuid primary key default gen_random_uuid(),
+      name text not null unique
+    );
+    create table public.user_roles (
+      user_id uuid not null,
+      role_id uuid not null references public.roles(id),
+      is_active boolean,
+      expires_at timestamptz
+    );
+    create table public.user_therapist_links (
+      id uuid primary key,
+      user_id uuid not null,
+      therapist_id uuid not null,
+      created_at timestamptz not null default now()
+    );
+  `);
+};
+
+const seedHarness = async (client) => {
+  await client.query(`
+    insert into public.roles (name)
+    values ('therapist'), ('bt'), ('admin'), ('client')
+    on conflict (name) do nothing;
+  `);
+  await client.query(
+    `
+      insert into public.win211_user_orgs (user_id, organization_id)
+      values
+        ($1, $2),
+        ($3, null),
+        ($4, $5),
+        ($6, $2);
+    `,
+    [ids.validUser, ids.orgA, ids.missingOrgUser, ids.crossOrgUser, ids.orgB, ids.missingRoleUser]
+  );
+  await client.query(
+    `
+      insert into public.therapists (id, organization_id, status, deleted_at)
+      values
+        ($1, $2, 'active', null),
+        ($3, $2, 'inactive', null);
+    `,
+    [ids.therapistA, ids.orgA, ids.therapistInactive]
+  );
+  await client.query(
+    `
+      insert into public.user_roles (user_id, role_id, is_active, expires_at)
+      select $1::uuid, id, true, null::timestamptz from public.roles where name = 'therapist'
+      union all select $2::uuid, id, true, null::timestamptz from public.roles where name = 'bt'
+      union all select $3::uuid, id, true, null::timestamptz from public.roles where name = 'admin'
+      union all select $4::uuid, id, true, null::timestamptz from public.roles where name = 'client';
+    `,
+    [ids.validUser, ids.missingOrgUser, ids.crossOrgUser, ids.missingRoleUser]
+  );
+  await client.query(
+    `
+      insert into public.user_therapist_links (id, user_id, therapist_id, created_at)
+      values
+        ($1, $2, $3, '2026-07-01T00:00:00Z'),
+        ($4, $5, $3, '2026-07-01T00:00:00Z'),
+        ($6, $7, $3, '2026-07-01T00:00:00Z'),
+        ($8, $2, $9, '2026-07-01T00:00:00Z'),
+        ($10, $11, $3, '2026-07-01T00:00:00Z');
+    `,
+    [
+      ids.validLink,
+      ids.validUser,
+      ids.therapistA,
+      ids.missingOrgLink,
+      ids.missingOrgUser,
+      ids.crossOrgLink,
+      ids.crossOrgUser,
+      ids.inactiveTherapistLink,
+      ids.therapistInactive,
+      ids.missingRoleLink,
+      ids.missingRoleUser,
+    ]
+  );
+};
+
+runIfPostgres('stale user therapist link cleanup migration postgres execution', () => {
+  let client;
+  const migrationSql = fs.readFileSync(MIGRATION_PATH, 'utf8');
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: POSTGRES_URL });
+    await client.connect();
+    await resetHarness(client);
+    await seedHarness(client);
+  });
+
+  afterAll(async () => {
+    await client?.end();
+  });
+
+  it('executes the real migration twice and only deletes links that still evaluate stale', async () => {
+    await client.query(migrationSql);
+
+    await expect(
+      queryArray(client, 'select id as value from public.user_therapist_links order by id')
+    ).resolves.toEqual([ids.validLink]);
+    await expect(
+      queryArray(client, 'select link_id as value from public.user_therapist_links_quarantine order by link_id')
+    ).resolves.toEqual([
+      ids.missingOrgLink,
+      ids.crossOrgLink,
+      ids.inactiveTherapistLink,
+      ids.missingRoleLink,
+    ]);
+
+    await client.query(migrationSql);
+    await expect(
+      queryArray(client, 'select link_id as value from public.user_therapist_links_quarantine order by link_id')
+    ).resolves.toHaveLength(4);
+
+    await client.query(
+      `
+        insert into public.user_therapist_links (id, user_id, therapist_id, created_at)
+        values ($1, $2, $3, '2026-07-01T00:00:00Z')
+      `,
+      [ids.missingOrgLink, ids.missingOrgUser, ids.therapistA]
+    );
+    await client.query(
+      `
+        update public.win211_user_orgs
+        set organization_id = $1
+        where user_id = $2
+      `,
+      [ids.orgA, ids.missingOrgUser]
+    );
+
+    await client.query(migrationSql);
+    await expect(
+      queryArray(client, 'select id as value from public.user_therapist_links order by id')
+    ).resolves.toEqual([ids.validLink, ids.missingOrgLink]);
+    await expect(
+      queryArray(client, 'select link_id as value from public.user_therapist_links_quarantine order by link_id')
+    ).resolves.toHaveLength(4);
+
+    await client.query('insert into public.win211_user_orgs (user_id, organization_id) values ($1, null)', [
+      ids.newStaleUser,
+    ]);
+    await client.query(
+      `
+        insert into public.user_roles (user_id, role_id, is_active, expires_at)
+        select $1::uuid, id, true, null::timestamptz from public.roles where name = 'bt'
+      `,
+      [ids.newStaleUser]
+    );
+    await client.query(
+      `
+        insert into public.user_therapist_links (id, user_id, therapist_id, created_at)
+        values ($1, $2, $3, '2026-07-01T00:00:00Z')
+      `,
+      [ids.newStaleLink, ids.newStaleUser, ids.therapistA]
+    );
+
+    await client.query(migrationSql);
+    await expect(
+      queryArray(client, 'select id as value from public.user_therapist_links order by id')
+    ).resolves.toEqual([ids.validLink, ids.missingOrgLink]);
+    await expect(
+      queryArray(client, 'select link_id as value from public.user_therapist_links_quarantine order by link_id')
+    ).resolves.toEqual([
+      ids.missingOrgLink,
+      ids.crossOrgLink,
+      ids.inactiveTherapistLink,
+      ids.missingRoleLink,
+      ids.newStaleLink,
+    ]);
+
+    await expect(
+      queryArray(
+        client,
+        `
+          select grantee || ':' || privilege_type as value
+          from information_schema.role_table_grants
+          where table_schema = 'public'
+            and table_name = 'user_therapist_links_quarantine'
+            and grantee in ('anon', 'authenticated', 'service_role')
+          order by value
+        `
+      )
+    ).resolves.toEqual(['service_role:SELECT']);
+    await expect(
+      client.query(
+        `
+          select relrowsecurity, relforcerowsecurity
+          from pg_class c
+          join pg_namespace n on n.oid = c.relnamespace
+          where n.nspname = 'public'
+            and c.relname = 'user_therapist_links_quarantine'
+        `
+      )
+    ).resolves.toMatchObject({ rows: [{ relrowsecurity: true, relforcerowsecurity: true }] });
+    await expect(
+      client.query(
+        `
+          select policyname, cmd, roles, qual, with_check
+          from pg_policies
+          where schemaname = 'public'
+            and tablename = 'user_therapist_links_quarantine'
+        `
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          policyname: 'user_therapist_links_quarantine_service_role_select',
+          cmd: 'SELECT',
+          roles: '{service_role}',
+          qual: 'true',
+          with_check: null,
+        },
+      ],
+    });
+    await expect(
+      client.query(
+        'select count(*)::int as count from public.user_therapist_links_quarantine where quarantine_batch = $1',
+        [QUARANTINE_BATCH]
+      )
+    ).resolves.toMatchObject({ rows: [{ count: 5 }] });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Supabase migration to quarantine and delete objectively stale `public.user_therapist_links` rows without hardcoded production IDs.
- Keeps quarantine records forced-RLS and service-role `SELECT` only.
- Documents hosted pre/post-apply evidence, rollback shape, generated-types exception, and critical-lane handoff in `docs/ai/WIN-211-user-therapist-links-cleanup-handoff.md`.

## Hosted evidence
- Supabase project `wnnjeqheqxxyrgsjmygy` had 1 resolver-based stale link before apply.
- Migration was applied through the Supabase connector under logical name `quarantine_stale_user_therapist_links`.
- Post-apply: 3 live links, 0 stale live links, 1 quarantined row, 0 rerun delete candidates, 0 duplicate link pairs.

## Verification
- `WIN211_POSTGRES_URL=<masked local disposable Postgres URL> npx vitest run tests/integration/user-therapist-links-cleanup-migration.postgres.test.js --reporter=verbose` passed against disposable `postgres:16`.
- `npx vitest run tests/integration/user-therapist-links-cleanup-migration.contract.test.ts tests/integration/user-therapist-links-cleanup-migration.postgres.test.js --reporter=verbose` passed; Postgres test skips by approved helper without `WIN211_POSTGRES_URL`.
- `npm run verify:local` passed.
- Follow-up masking check: `npm run ci:check-focused` passed, and `npm run ci:secrets` no longer reports committed secret risk; local run still reports missing unconfigured environment secrets.

## Review notes
- Critical lane / high-risk human-reviewed because this touches `supabase/migrations/**` and tenant-sensitive link data.
- Human review remains required before merge.

Linear: WIN-211