### PR TITLE
Fix Session Trends over-range chart scale

### DIFF
--- a/src/components/ClientDetails/ClientSessionTrendsTab.tsx
+++ b/src/components/ClientDetails/ClientSessionTrendsTab.tsx
@@ -10,7 +10,7 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { BarChart3, Download, Inbox, Loader2 } from 'lucide-react';
+import { AlertTriangle, BarChart3, Download, Inbox, Loader2 } from 'lucide-react';
 import type { Chart as ChartInstance, ChartData, ChartOptions, PointStyle } from 'chart.js';
 import type { Goal } from '../../types';
 import { fetchClientSessionNotes } from '../../lib/session-notes';
@@ -50,6 +50,8 @@ const todayDate = (): string => toLocalDateInputValue(new Date());
 
 const formatPercent = (value: number): string =>
   Number.isInteger(value) ? `${value}%` : `${value.toFixed(1)}%`;
+
+const roundUpToNextTen = (value: number): number => Math.ceil(value / 10) * 10;
 
 const targetSeriesColors = [
   '#2563eb',
@@ -210,6 +212,17 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
 
   const chartEvidence = useMemo(() => targetSeries.flatMap((series) => series.evidence), [targetSeries]);
 
+  const maxChartValue = useMemo(() => {
+    const values = targetSeries.flatMap((series) => series.buckets.map((bucket) => bucket.median));
+    return values.length > 0 ? Math.max(...values) : 100;
+  }, [targetSeries]);
+
+  const chartYMax = Math.max(100, roundUpToNextTen(maxChartValue));
+  const overRangeBucketCount = targetSeries.reduce(
+    (count, series) => count + series.buckets.filter((bucket) => bucket.median > 100).length,
+    0,
+  );
+
   const chartData = useMemo<ChartData<'line', Array<number | null>, string>>(() => ({
     labels: chartBuckets.map((bucket) => bucket.label),
     datasets: targetSeries.map((series) => {
@@ -264,7 +277,7 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
     scales: {
       y: {
         min: 0,
-        max: 100,
+        max: chartYMax,
         title: {
           display: true,
           text: 'Median % of opportunities',
@@ -280,7 +293,7 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
         },
       },
     },
-  }), [chartBuckets, displayPeriod, targetSeries]);
+  }), [chartBuckets, chartYMax, displayPeriod, targetSeries]);
 
   const recentEvidence = chartEvidence
     .slice()
@@ -426,6 +439,14 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
                 Download graph
               </button>
             </div>
+            {overRangeBucketCount > 0 && (
+              <div className="mb-3 flex items-start rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-100">
+                <AlertTriangle className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0" />
+                <span>
+                  {overRangeBucketCount} plotted value{overRangeBucketCount === 1 ? ' exceeds' : 's exceed'} 100% because recorded successes are greater than opportunities.
+                </span>
+              </div>
+            )}
             <div className="h-80">
               <Line ref={chartRef} options={chartOptions} data={chartData} />
             </div>

--- a/src/components/__tests__/ClientSessionTrendsTab.test.tsx
+++ b/src/components/__tests__/ClientSessionTrendsTab.test.tsx
@@ -7,7 +7,13 @@ import { fetchClientSessionNotes } from '../../lib/session-notes';
 import { supabase } from '../../lib/supabase';
 
 vi.mock('react-chartjs-2', () => ({
-  Line: React.forwardRef(({ data }: { data: { labels: string[]; datasets: Array<{ label: string; data: number[]; pointStyle?: string; borderColor?: string }> } }, ref) => {
+  Line: React.forwardRef(({
+    data,
+    options,
+  }: {
+    data: { labels: string[]; datasets: Array<{ label: string; data: Array<number | null>; pointStyle?: string; borderColor?: string }> };
+    options?: { scales?: { y?: { max?: number } } };
+  }, ref) => {
     if (ref && typeof ref !== 'function') {
       ref.current = {
         toBase64Image: vi.fn(() => 'data:image/png;base64,chart-image'),
@@ -16,7 +22,7 @@ vi.mock('react-chartjs-2', () => ({
 
     return (
       <div data-testid="session-trends-chart">
-        {data.labels.join(',')}:{data.datasets.map((dataset) => `${dataset.label}:${dataset.pointStyle}:${dataset.data.join('|')}:${dataset.borderColor}`).join(';')}
+        {data.labels.join(',')}:{data.datasets.map((dataset) => `${dataset.label}:${dataset.pointStyle}:${dataset.data.join('|')}:${dataset.borderColor}`).join(';')}:yMax={options?.scales?.y?.max ?? 'unset'}
       </div>
     );
   }),
@@ -193,6 +199,48 @@ describe('ClientSessionTrendsTab', () => {
 
     expect(chart).toHaveTextContent('lost in community:circle:90');
     expect(chart).toHaveTextContent('cross street safely:rectRot:45');
+    expect(chart).toHaveTextContent('yMax=100');
+  });
+
+  it('expands the chart scale and flags evidence above 100 percent', async () => {
+    vi.mocked(fetchClientSessionNotes).mockResolvedValue([
+      createSessionNote('over-range-note', '2025-06-15', [
+        { target: 'complete opportunities independently', metric_value: 8, opportunities: 7 },
+      ]),
+    ]);
+
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    const chart = await screen.findByTestId('session-trends-chart');
+
+    expect(chart).toHaveTextContent('complete opportunities independently:circle:114.3');
+    expect(chart).toHaveTextContent('yMax=120');
+    expect(screen.getByText('1 plotted value exceeds 100% because recorded successes are greater than opportunities.')).toBeInTheDocument();
+    expect(screen.getByText('114.3% (8/7)')).toBeInTheDocument();
+  });
+
+  it('keeps the scale and warning aligned with aggregated plotted medians', async () => {
+    vi.mocked(fetchClientSessionNotes).mockResolvedValue([
+      createSessionNote('over-range-note', '2025-06-15', [
+        { target: 'complete opportunities independently', metric_value: 8, opportunities: 7 },
+      ]),
+      createSessionNote('lower-companion-note', '2025-06-22', [
+        { target: 'complete opportunities independently', metric_value: 8, opportunities: 10 },
+      ]),
+    ]);
+
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    const chart = await screen.findByTestId('session-trends-chart');
+
+    expect(chart).toHaveTextContent('complete opportunities independently:circle:97.1');
+    expect(chart).toHaveTextContent('yMax=100');
+    expect(screen.queryByText(/plotted value.*100%/i)).not.toBeInTheDocument();
+    expect(screen.getByText('114.3% (8/7)')).toBeInTheDocument();
   });
 
   it('keeps target point symbols distinct beyond six target series', async () => {


### PR DESCRIPTION
## Summary
- Let Session Trends chart y-axis expand above 100 when plotted bucket medians exceed 100%.
- Add a local warning only when a plotted median exceeds 100%, keeping warning and chart scale aligned.
- Add regression coverage for normal data, the 8/7 over-range case, and a raw over-range evidence row whose monthly median remains <=100.

## Route
- Linear: WIN-183
- classification: low-risk autonomous
- lane: standard
- triggering paths: src/components/ClientDetails/ClientSessionTrendsTab.tsx, src/components/__tests__/ClientSessionTrendsTab.test.tsx
- protected-path drift: none

## Verification
- npm test -- src/components/__tests__/ClientSessionTrendsTab.test.tsx -> pass (10 tests)
- npm run verify:local -> pass
- commit hook npm run ci:check-focused -> pass

## Review
- specification-engineer: scoped as standard UI-only slice
- test-engineer: confirmed focused component test plus verify:local baseline
- code-review-engineer: first review requested warning/chart grain alignment; fixed
- code-review-engineer: second review reported no findings

## Residual Risk
- This is display-only. Existing persisted successes > opportunities are still possible and should be handled in a separate server/data-validation slice if desired.