### PR TITLE
Harden admin-users RPC exposure

### DIFF
--- a/docs/ai/admin-users-rpc-exposure-hardening-2026-07-09.md
+++ b/docs/ai/admin-users-rpc-exposure-hardening-2026-07-09.md
@@ -1,0 +1,99 @@
+# Admin Users RPC Exposure Hardening
+
+- issue: WIN-212
+- classification: high-risk human-reviewed
+- lane: critical
+- live project: wnnjeqheqxxyrgsjmygy
+- scope: Repair live-proven `public.get_admin_users` RPC exposure drift, restore the documented service-role metadata wrapper for `public.manage_admin_users`, and normalize `public.admin_users` view grants.
+- non-goals: Do not change `get_admin_users_paged`, the two-argument browser `manage_admin_users` RPC, admin role semantics, RLS policies, UI components, or auth/session code.
+
+## Live Evidence Before Repair
+
+- `public.get_admin_users()` existed as `SECURITY DEFINER`, `search_path=public, auth`, `authenticated_execute=true`, and returned all admin/super-admin rows without caller authorization or organization checks.
+- `public.get_admin_users(p_org_id uuid)` existed as `SECURITY DEFINER`, `authenticated_execute=true`, and delegated to `public.get_admin_users()` without using `p_org_id`.
+- `public.get_admin_users_paged(organization_id uuid, p_limit integer, p_offset integer)` already performed authentication and organization checks and was left unchanged.
+- `public.manage_admin_users(operation text, target_user_id text)` remained the intended authenticated browser RPC with internal checks.
+- `public.manage_admin_users(operation text, target_user_id text, caller_organization_id uuid)` remained limited to `service_role` and `app_admin_executor`.
+- The `public.manage_admin_users(operation text, target_user_id text, metadata jsonb)` compatibility wrapper expected by `src/server/rpc/admin.ts` was absent.
+- `public.admin_users` had `security_barrier=true` and `security_invoker=true`, but live ACLs included DML-style privileges for `authenticated` and `service_role`; intended local hardening grants were read-only.
+
+## Intended Boundary
+
+- `get_admin_users(organization_id uuid default null)` returns `SETOF public.admin_users`.
+- Service-role callers may list all admin users or filter by organization.
+- The service-role branch intentionally reads `auth.users` + `user_roles` + `roles` directly because the `admin_users` view is filtered by `auth.uid()`.
+- Super admins may list all admin users or filter by organization.
+- Regular active admins may list only their own organization and receive `42501` on cross-organization requests.
+- `anon` has no execute/select access.
+- `admin_users` grants are read-only for `authenticated`, `service_role`, and `app_admin_executor`.
+- `manage_admin_users(text,text,jsonb)` exists only for service-role server callers and delegates to the current two-argument implementation.
+
+## Required Verification
+
+- Live post-apply SQL over `pg_proc`, `pg_class`, `aclexplode`, `has_function_privilege`, `pg_get_functiondef`, and `to_regprocedure`.
+- `npx vitest run tests/admins/admin_users_rpc_exposure.spec.ts tests/admins/manage_admin_users_advisor_surface.spec.ts`
+- `npm run ci:check-focused`
+- `npm run test:ci`
+- `npm run validate:tenant`
+- `npm run build`
+- `npm run verify:local` when local prerequisites allow it.
+
+## Verification Card
+
+- Classification: high-risk human-reviewed
+- Lane: critical
+- Change type: database/RLS/migrations/tenant isolation; server/RPC contract typing; docs/handoff
+- Required checks:
+  - `npx vitest run tests/admins/admin_users_rpc_exposure.spec.ts tests/admins/manage_admin_users_advisor_surface.spec.ts tests/admins/cross_org_denied.spec.ts src/server/rpc/__tests__/admin.test.ts`
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run ci:verify-coverage`
+  - `npm run test:routes:tier0`
+  - `npm run verify:local`
+  - Hosted post-apply SQL over `pg_proc`, `pg_class`, `aclexplode`, `has_function_privilege`, `pg_get_functiondef`, and `to_regprocedure`
+- Executed checks:
+  - `npm ci`: pass; installed isolated worktree dependencies. Existing audit output reported 24 vulnerabilities and a Node engine warning for `eslint-visitor-keys@5.0.1` on Node v20.17.0.
+  - `npx vitest run tests/admins/admin_users_rpc_exposure.spec.ts tests/admins/manage_admin_users_advisor_surface.spec.ts`: pass; 2 files, 12 tests.
+  - `npx vitest run tests/admins/admin_users_rpc_exposure.spec.ts tests/admins/manage_admin_users_advisor_surface.spec.ts tests/admins/cross_org_denied.spec.ts src/server/rpc/__tests__/admin.test.ts`: pass; 4 files, 21 tests.
+  - `npm run ci:check-focused`: pass; DB-backed checks skipped because `SUPABASE_DB_URL`/`DATABASE_URL` were not configured.
+  - `npm run validate:tenant`: pass.
+  - `npm run typecheck`: pass.
+  - `npm run build`: pass.
+  - `npm run lint`: pass.
+  - `npm run test:ci` without synthetic Supabase env: fail; 12 tests failed because `VITE_SUPABASE_URL` was missing from the isolated worktree environment.
+  - `npm run test:ci` with synthetic non-secret Supabase env values: pass; 367 files passed, 2377 tests passed, 1 skipped.
+  - `npm run verify:local` with synthetic non-secret Supabase env values: fail; policy, lint, typecheck, and most of `test:ci` ran, then one unrelated test timed out: `tests/ci/deploy-session-edge-bundle.test.ts`.
+  - `npx vitest run tests/ci/deploy-session-edge-bundle.test.ts`: pass on immediate rerun; 1 file, 1 test.
+  - `npm run ci:verify-coverage`: pass; line coverage 92.07% against required 86.00%.
+  - `npm run test:routes:tier0`: pass; 7 Cypress specs, 220 tests.
+  - Post-rebase `npx vitest run tests/admins/admin_users_rpc_exposure.spec.ts tests/admins/manage_admin_users_advisor_surface.spec.ts tests/admins/cross_org_denied.spec.ts src/server/rpc/__tests__/admin.test.ts`: pass; 4 files, 21 tests.
+- Blocked checks:
+  - Hosted post-apply SQL verification is blocked until human-reviewed migration apply. Pre-apply hosted evidence was collected through Supabase MCP and showed the drift this migration repairs.
+  - `npm run verify:local` did not complete as a single green aggregate because `tests/ci/deploy-session-edge-bundle.test.ts` timed out once during the aggregate run; the exact test passed on immediate targeted rerun, and the aggregate components that did not run after the timeout were executed separately and passed.
+- Result: pass-with-blocked-checks
+- Residual risk: The migration touches privileged RPC and grant behavior and still requires human Supabase/security review plus hosted post-apply read-back before production closure.
+
+## PR Hygiene Verdict
+
+- pr-ready: yes, for human review; not autonomous merge-ready
+- lane: critical
+- branch-ready: yes; dedicated `codex/admin-users-rpc-hardening` worktree branch rebased onto `origin/main`
+- linear-ready: yes; `WIN-212`
+- single-purpose: yes
+- unrelated changes: none after removing generated `reports/test-reliability-latest.json`
+- generated artifact drift: none; `src/lib/generated/database.types.ts` is aligned with the repaired `get_admin_users(organization_id uuid default null)` return shape
+- protected-path drift: expected and contained to `supabase/migrations/**` plus supporting test/type/doc files
+- change summary: present
+- verification summary: present
+- pr handoff: ready
+- reviewer: completed; final reviewer found no SQL correctness blocker and requested the verification/pr-hygiene artifacts now recorded here
+- required follow-up: human review, PR checks, and hosted post-apply SQL read-back
+- handoff summary: Repairs live admin-users RPC exposure by replacing unscoped JSON `get_admin_users` overloads with an org-checked `SETOF admin_users` RPC, preserving service-role server listing through direct base-table reads, restoring the service-role-only `manage_admin_users(text,text,jsonb)` compatibility wrapper, and normalizing `admin_users` grants to read-only intended roles.
+
+## Residual Risk
+
+This migration changes privileged Supabase RPC and grant behavior. Human Supabase/security review is required before merge and hosted apply.

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -6604,9 +6604,17 @@ export type Database = {
         }
         Returns: Json
       }
-      get_admin_users:
-        | { Args: never; Returns: Json }
-        | { Args: { p_org_id: string }; Returns: Json }
+      get_admin_users: {
+        Args: { organization_id?: string }
+        Returns: {
+          created_at: string | null
+          email: string | null
+          id: string | null
+          raw_user_meta_data: Json | null
+          user_id: string | null
+          user_role_id: string | null
+        }[]
+      }
       get_admin_users_paged: {
         Args: { organization_id?: string; p_limit?: number; p_offset?: number }
         Returns: {

--- a/supabase/migrations/20260709172500_harden_admin_users_rpc_exposure.sql
+++ b/supabase/migrations/20260709172500_harden_admin_users_rpc_exposure.sql
@@ -1,0 +1,198 @@
+/*
+  @migration-intent: Repair admin-users RPC exposure drift by replacing unscoped get_admin_users overloads, restoring the service-role metadata wrapper, and tightening admin_users view grants.
+  @migration-dependencies: 20251223190000_view_security_and_indexes.sql,20260202124000_forward_fix_admin_users_paged_super_admin_return.sql,20260628221116_repair_manage_admin_users_advisor_surface.sql
+  @migration-rollback: Restore the previous get_admin_users() and get_admin_users(uuid) JSON functions only if a legacy caller is deliberately reintroduced. To reopen admin_users view DML grants, grant the specific privilege back to the specific role; do not restore broad ALL grants.
+*/
+
+begin;
+
+set search_path = public, auth;
+
+-- Remove the legacy JSON-returning overloads. The no-argument overload exposed
+-- every admin/super-admin row to any authenticated caller, and the uuid overload
+-- ignored its organization argument by delegating to the no-argument function.
+drop function if exists public.get_admin_users();
+drop function if exists public.get_admin_users(uuid);
+
+create or replace function public.get_admin_users(
+  organization_id uuid default null
+)
+returns setof public.admin_users
+language plpgsql
+security definer
+stable
+set search_path = public, auth
+as $$
+declare
+  current_user_id uuid := auth.uid();
+  request_role text := current_setting('request.jwt.claim.role', true);
+  is_service_role boolean := request_role = 'service_role';
+  caller_org_id uuid;
+  resolved_org uuid := organization_id;
+  caller_is_super_admin boolean := false;
+  caller_is_admin boolean;
+begin
+  if is_service_role then
+    if resolved_org is null then
+      return query
+      select
+        u.id,
+        ur.id,
+        u.id,
+        u.email::text,
+        u.raw_user_meta_data,
+        u.created_at
+      from auth.users u
+      join public.user_roles ur on ur.user_id = u.id
+      join public.roles r on r.id = ur.role_id
+      where r.name = 'admin'
+      order by u.created_at desc;
+    else
+      return query
+      select
+        u.id,
+        ur.id,
+        u.id,
+        u.email::text,
+        u.raw_user_meta_data,
+        u.created_at
+      from auth.users u
+      join public.user_roles ur on ur.user_id = u.id
+      join public.roles r on r.id = ur.role_id
+      where r.name = 'admin'
+        and public.get_organization_id_from_metadata(u.raw_user_meta_data) = resolved_org
+      order by u.created_at desc;
+    end if;
+
+    return;
+  end if;
+
+  if current_user_id is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  caller_is_super_admin :=
+    coalesce(public.current_user_is_super_admin(), false)
+    or coalesce(app.user_has_role('super_admin'), false);
+
+  select exists (
+    select 1
+    from public.user_roles ur
+    join public.roles r on r.id = ur.role_id
+    where ur.user_id = current_user_id
+      and r.name = 'admin'
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+  ) into caller_is_admin;
+
+  if not caller_is_super_admin and not caller_is_admin then
+    raise exception using errcode = '42501', message = 'Only administrators or super admins can view admin users';
+  end if;
+
+  if caller_is_super_admin then
+    if resolved_org is null then
+      return query
+      select
+        u.id,
+        ur.id,
+        u.id,
+        u.email::text,
+        u.raw_user_meta_data,
+        u.created_at
+      from auth.users u
+      join public.user_roles ur on ur.user_id = u.id
+      join public.roles r on r.id = ur.role_id
+      where r.name = 'admin'
+      order by u.created_at desc;
+    else
+      return query
+      select
+        u.id,
+        ur.id,
+        u.id,
+        u.email::text,
+        u.raw_user_meta_data,
+        u.created_at
+      from auth.users u
+      join public.user_roles ur on ur.user_id = u.id
+      join public.roles r on r.id = ur.role_id
+      where r.name = 'admin'
+        and public.get_organization_id_from_metadata(u.raw_user_meta_data) = resolved_org
+      order by u.created_at desc;
+    end if;
+
+    return;
+  end if;
+
+  select public.get_organization_id_from_metadata(u.raw_user_meta_data)
+  into caller_org_id
+  from auth.users u
+  where u.id = current_user_id;
+
+  if caller_org_id is null then
+    raise exception using errcode = '42501', message = 'Caller is not associated with an organization';
+  end if;
+
+  if resolved_org is null then
+    resolved_org := caller_org_id;
+  elsif resolved_org <> caller_org_id then
+    raise exception using errcode = '42501', message = 'Caller organization mismatch';
+  end if;
+
+  return query
+  select
+    u.id,
+    ur.id,
+    u.id,
+    u.email::text,
+    u.raw_user_meta_data,
+    u.created_at
+  from auth.users u
+  join public.user_roles ur on ur.user_id = u.id
+  join public.roles r on r.id = ur.role_id
+  where r.name = 'admin'
+    and public.get_organization_id_from_metadata(u.raw_user_meta_data) = resolved_org
+  order by u.created_at desc;
+end;
+$$;
+
+revoke execute on function public.get_admin_users(uuid) from public;
+revoke execute on function public.get_admin_users(uuid) from anon;
+grant execute on function public.get_admin_users(uuid) to authenticated;
+grant execute on function public.get_admin_users(uuid) to service_role;
+
+-- Keep the documented server-side removeAdminUser signature available only to
+-- service-role callers. Browser callers continue to use manage_admin_users(text,text).
+create or replace function public.manage_admin_users(
+  operation text,
+  target_user_id text,
+  metadata jsonb
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+begin
+  perform public.manage_admin_users(operation, target_user_id);
+end;
+$$;
+
+revoke execute on function public.manage_admin_users(text, text, jsonb) from public;
+revoke execute on function public.manage_admin_users(text, text, jsonb) from anon;
+revoke execute on function public.manage_admin_users(text, text, jsonb) from authenticated;
+grant execute on function public.manage_admin_users(text, text, jsonb) to service_role;
+
+-- Re-assert the intended view boundary. Historical drift left DML-style grants
+-- on an otherwise read-only admin listing view.
+alter view public.admin_users set (security_barrier = true, security_invoker = true);
+revoke all privileges on public.admin_users from public;
+revoke all privileges on public.admin_users from anon;
+revoke all privileges on public.admin_users from authenticated;
+revoke all privileges on public.admin_users from service_role;
+revoke all privileges on public.admin_users from app_admin_executor;
+grant select on public.admin_users to authenticated;
+grant select on public.admin_users to service_role;
+grant select on public.admin_users to app_admin_executor;
+
+commit;

--- a/tests/admins/admin_users_rpc_exposure.spec.ts
+++ b/tests/admins/admin_users_rpc_exposure.spec.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const migrationSql = () =>
+  readFileSync(
+    join(process.cwd(), 'supabase/migrations/20260709172500_harden_admin_users_rpc_exposure.sql'),
+    'utf-8',
+  );
+
+describe('admin users RPC exposure hardening migration', () => {
+  it('removes the legacy unscoped get_admin_users overloads before recreating the scoped RPC', () => {
+    const sql = migrationSql();
+
+    expect(sql).toMatch(/drop function if exists public\.get_admin_users\(\)/i);
+    expect(sql).toMatch(/drop function if exists public\.get_admin_users\(uuid\)/i);
+    expect(sql).toMatch(/create or replace function public\.get_admin_users\(\s*organization_id uuid default null/i);
+    expect(sql).toMatch(/returns setof public\.admin_users/i);
+    expect(sql).not.toMatch(/return public\.get_admin_users\(\)/i);
+  });
+
+  it('requires an authenticated admin or super admin for non-service-role callers', () => {
+    const sql = migrationSql();
+
+    expect(sql).toMatch(/current_user_id uuid := auth\.uid\(\)/i);
+    expect(sql).toMatch(/current_setting\('request\.jwt\.claim\.role', true\)/i);
+    expect(sql).toMatch(/is_service_role boolean := request_role = 'service_role'/i);
+    expect(sql).toMatch(/caller_is_super_admin :=[\s\S]*coalesce\(public\.current_user_is_super_admin\(\), false\)[\s\S]*or coalesce\(app\.user_has_role\('super_admin'\), false\)/i);
+    expect(sql).toMatch(/r\.name = 'admin'[\s\S]*coalesce\(ur\.is_active, true\) = true[\s\S]*ur\.expires_at is null or ur\.expires_at > now\(\)/i);
+    expect(sql).toMatch(/Only administrators or super admins can view admin users/i);
+  });
+
+  it('preserves organization scoping for regular admin callers', () => {
+    const sql = migrationSql();
+
+    expect(sql).toMatch(/select public\.get_organization_id_from_metadata\(u\.raw_user_meta_data\)[\s\S]*into caller_org_id/i);
+    expect(sql).toMatch(/resolved_org <> caller_org_id[\s\S]*Caller organization mismatch/i);
+    expect(sql).toMatch(/where r\.name = 'admin'[\s\S]*public\.get_organization_id_from_metadata\(u\.raw_user_meta_data\) = resolved_org/i);
+  });
+
+  it('uses explicit base-table queries so service-role callers do not depend on auth.uid-filtered view rows', () => {
+    const sql = migrationSql();
+    const serviceRoleBlock = sql.match(/if is_service_role then[\s\S]*?\n  end if;/i)?.[0] ?? '';
+
+    expect(serviceRoleBlock).toMatch(/from auth\.users u[\s\S]*join public\.user_roles ur on ur\.user_id = u\.id[\s\S]*join public\.roles r on r\.id = ur\.role_id/i);
+    expect(serviceRoleBlock).not.toMatch(/from public\.admin_users/i);
+  });
+
+  it('restores only service-role execute on the metadata compatibility wrapper', () => {
+    const sql = migrationSql();
+
+    expect(sql).toMatch(/create or replace function public\.manage_admin_users\(\s*operation text,\s*target_user_id text,\s*metadata jsonb/i);
+    expect(sql).toMatch(/perform public\.manage_admin_users\(operation,\s*target_user_id\)/i);
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text,\s*text,\s*jsonb\) from public/i);
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text,\s*text,\s*jsonb\) from anon/i);
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text,\s*text,\s*jsonb\) from authenticated/i);
+    expect(sql).toMatch(/grant execute on function public\.manage_admin_users\(text,\s*text,\s*jsonb\) to service_role/i);
+  });
+
+  it('normalizes the admin_users view to read-only grants for intended roles', () => {
+    const sql = migrationSql();
+
+    expect(sql).toMatch(/alter view public\.admin_users set \(security_barrier = true, security_invoker = true\)/i);
+    expect(sql).toMatch(/revoke all privileges on public\.admin_users from public/i);
+    expect(sql).toMatch(/revoke all privileges on public\.admin_users from anon/i);
+    expect(sql).toMatch(/revoke all privileges on public\.admin_users from authenticated/i);
+    expect(sql).toMatch(/revoke all privileges on public\.admin_users from service_role/i);
+    expect(sql).toMatch(/grant select on public\.admin_users to authenticated/i);
+    expect(sql).toMatch(/grant select on public\.admin_users to service_role/i);
+    expect(sql).toMatch(/grant select on public\.admin_users to app_admin_executor/i);
+    expect(sql).not.toMatch(/grant (insert|update|delete|all privileges) on public\.admin_users to authenticated/i);
+  });
+});


### PR DESCRIPTION
- Linear: WIN-212

## Summary
- replace unscoped JSON `get_admin_users` overloads with an org-checked `SETOF admin_users` RPC
- preserve service-role server listing through direct base-table reads and restore the service-role-only `manage_admin_users(text,text,jsonb)` wrapper
- normalize `admin_users` view grants to read-only intended roles and update generated types/tests/handoff evidence

## Live Evidence Before Patch
- hosted `public.get_admin_users()` was `SECURITY DEFINER`, executable by `authenticated`, and returned all admin/super_admin rows without caller/org checks
- hosted `public.get_admin_users(uuid)` delegated to the unscoped no-arg function
- hosted `public.admin_users` had DML-style ACLs for `authenticated`/`service_role`
- hosted `public.manage_admin_users(text,text,jsonb)` was absent while `src/server/rpc/admin.ts` still sends `metadata`

## Verification
- `npm ci` (isolated worktree; existing npm audit and Node engine warnings only)
- `npm run ci:check-focused` (pass; DB-backed checks skipped without `SUPABASE_DB_URL`/`DATABASE_URL`)
- `npm run lint` (pass)
- `npm run typecheck` (pass)
- `npm run validate:tenant` (pass)
- `npm run build` (pass)
- `npx vitest run tests/admins/admin_users_rpc_exposure.spec.ts tests/admins/manage_admin_users_advisor_surface.spec.ts tests/admins/cross_org_denied.spec.ts src/server/rpc/__tests__/admin.test.ts` (pass; 4 files / 21 tests, rerun after rebase)
- `npm run test:ci` with synthetic non-secret Supabase env values (pass; 367 files / 2377 tests, 1 skipped)
- `npm run ci:verify-coverage` (pass; 92.07% line coverage)
- `npm run test:routes:tier0` (pass; 7 specs / 220 tests)

## Known Verification Notes
- `npm run test:ci` without synthetic Supabase env failed only because `VITE_SUPABASE_URL` was missing in this isolated worktree.
- `npm run verify:local` with synthetic Supabase env reached policy/lint/typecheck/test:ci, then timed out once in unrelated `tests/ci/deploy-session-edge-bundle.test.ts`; the exact test passed on immediate targeted rerun, and the remaining aggregate components were run separately and passed.
- Hosted post-apply SQL read-back is still required after human-reviewed migration apply.

## Risk
Critical protected-path change: Supabase RPC/grant exposure and admin tenant boundaries. Human Supabase/security review required before merge/apply.
