### PR TITLE
Add BT profile staff invite action

### DIFF
--- a/src/components/TherapistDetails/ProfileTab.tsx
+++ b/src/components/TherapistDetails/ProfileTab.tsx
@@ -10,9 +10,10 @@ import { useAuth } from '../../lib/authContext';
 import { showSuccess, showError } from '../../lib/toast';
 import { TherapistModal } from '../TherapistModal';
 import type { AvailabilityHours } from '../../types';
+import { StaffInviteModal, type StaffInviteFormData } from '../settings/StaffInviteModal';
 
 interface ProfileTabProps {
-  therapist: { id: string; full_name: string; title?: string; email?: string; phone?: string; specialties?: string[]; street?: string; city?: string; state?: string; zip_code?: string; facility?: string; employee_type?: string; availability_hours?: AvailabilityHours; };
+  therapist: { id: string; organization_id?: string | null; full_name: string; title?: string; email?: string; phone?: string; specialties?: string[]; street?: string; city?: string; state?: string; zip_code?: string; facility?: string; employee_type?: string; availability_hours?: AvailabilityHours; };
 }
 
 interface Note {
@@ -35,14 +36,25 @@ interface Issue {
 }
 
 export function ProfileTab({ therapist }: ProfileTabProps) {
-  const { hasRole, profile, effectiveRole } = useAuth();
+  const { hasRole, profile, user, effectiveRole } = useAuth();
+  const metadata = user?.user_metadata ?? {};
+  const metadataOrganizationId =
+    typeof metadata.organization_id === 'string'
+      ? metadata.organization_id
+      : typeof metadata.organizationId === 'string'
+        ? metadata.organizationId
+        : null;
+  const inviteOrganizationId =
+    therapist.organization_id ?? profile?.organization_id ?? metadataOrganizationId;
+  const canInviteStaff = hasRole('admin');
   const isOwnProfile = Boolean(
     effectiveRole === 'therapist' &&
-      (profile.id === therapist.id ||
-        (profile.email && therapist.email && profile.email.toLowerCase() === therapist.email.toLowerCase())),
+      (profile?.id === therapist.id ||
+        (profile?.email && therapist.email && profile.email.toLowerCase() === therapist.email.toLowerCase())),
   );
   
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
   const [isAddNoteModalOpen, setIsAddNoteModalOpen] = useState(false);
   const [isAddIssueModalOpen, setIsAddIssueModalOpen] = useState(false);
   const [noteContent, setNoteContent] = useState('');
@@ -108,6 +120,42 @@ export function ProfileTab({ therapist }: ProfileTabProps) {
       queryClient.invalidateQueries({ queryKey: ['therapist', therapist.id] });
       setIsEditModalOpen(false);
       showSuccess('Therapist updated successfully');
+    },
+    onError: (error) => {
+      showError(error);
+    },
+  });
+
+  const inviteStaffMutation = useMutation({
+    mutationFn: async (data: StaffInviteFormData) => {
+      if (!data.email.trim()) {
+        throw new Error('Email is required before inviting staff.');
+      }
+
+      if (!data.organization_id) {
+        throw new Error('Organization context is required to invite staff.');
+      }
+
+      const trimmedReason = data.reason.trim();
+      if (trimmedReason.length < 10) {
+        throw new Error('Please provide a reason with at least 10 characters.');
+      }
+
+      const { error } = await supabase.functions.invoke('admin-invite', {
+        body: {
+          email: data.email.trim(),
+          organizationId: data.organization_id,
+          role: 'bt',
+          reason: trimmedReason,
+        },
+      });
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admins'] });
+      setIsInviteModalOpen(false);
+      showSuccess('Staff invite sent successfully');
     },
     onError: (error) => {
       showError(error);
@@ -206,15 +254,26 @@ export function ProfileTab({ therapist }: ProfileTabProps) {
               </p>
             </div>
           </div>
-          {(hasRole('admin') || isOwnProfile) && (
-            <button
-              onClick={() => setIsEditModalOpen(true)}
-              className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 flex items-center"
-            >
-              <Edit2 className="w-4 h-4 mr-1" />
-              Edit
-            </button>
-          )}
+          <div className="flex flex-wrap justify-end gap-2">
+            {canInviteStaff && therapist.email && (
+              <button
+                onClick={() => setIsInviteModalOpen(true)}
+                className="px-3 py-1.5 text-sm font-medium text-blue-700 bg-blue-50 rounded-md shadow-sm hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:bg-blue-900/20 dark:text-blue-200 dark:hover:bg-blue-900/30 flex items-center"
+              >
+                <Mail className="w-4 h-4 mr-1" />
+                Invite to app
+              </button>
+            )}
+            {(hasRole('admin') || isOwnProfile) && (
+              <button
+                onClick={() => setIsEditModalOpen(true)}
+                className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 flex items-center"
+              >
+                <Edit2 className="w-4 h-4 mr-1" />
+                Edit
+              </button>
+            )}
+          </div>
         </div>
         
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
@@ -479,6 +538,23 @@ export function ProfileTab({ therapist }: ProfileTabProps) {
           therapist={therapist}
         />
       )}
+
+      <StaffInviteModal
+        isOpen={isInviteModalOpen}
+        onClose={() => setIsInviteModalOpen(false)}
+        onSubmit={inviteStaffMutation.mutateAsync}
+        initialData={{
+          email: therapist.email ?? '',
+          organization_id: inviteOrganizationId ?? null,
+          role: 'bt',
+          reason: `Invite ${therapist.full_name} to access their BT profile.`,
+        }}
+        roleOptions={['bt']}
+        title="Invite BT to app"
+        submitLabel="Send invite"
+        organizationLabel="Organization"
+        roleLocked
+      />
       
       {/* Add Note Modal */}
       {isAddNoteModalOpen && (

--- a/src/components/__tests__/TherapistProfileInvite.test.tsx
+++ b/src/components/__tests__/TherapistProfileInvite.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderWithProviders, screen, waitFor, userEvent, within } from '../../test/utils';
+import { ProfileTab } from '../TherapistDetails/ProfileTab';
+import { useAuth } from '../../lib/authContext';
+import { supabase } from '../../lib/supabase';
+import { showSuccess } from '../../lib/toast';
+
+vi.mock('../../lib/authContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../lib/toast', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/toast')>('../../lib/toast');
+  return {
+    ...actual,
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+  };
+});
+
+const therapist = {
+  id: 'therapist-1',
+  organization_id: '11111111-1111-1111-1111-111111111111',
+  full_name: 'Taylor BT',
+  title: 'BT',
+  email: 'taylor.bt@example.com',
+  phone: '555-0100',
+};
+
+const mockAuth = (role: 'client' | 'bt' | 'admin' | 'bcba' | 'super_admin' = 'admin') => {
+  vi.mocked(useAuth).mockReturnValue({
+    user: {
+      id: `${role}-user-id`,
+      email: `${role}@example.com`,
+      user_metadata: {
+        organization_id: '11111111-1111-1111-1111-111111111111',
+      },
+    },
+    profile: {
+      id: `${role}-profile-id`,
+      email: `${role}@example.com`,
+      role,
+      organization_id: '11111111-1111-1111-1111-111111111111',
+      is_active: true,
+    },
+    effectiveRole: role,
+    hasRole: vi.fn((requiredRole: string) => {
+      const ranks: Record<string, number> = {
+        client: 1,
+        bt: 2,
+        therapist: 3,
+        midtier: 4,
+        admin_schedule: 5,
+        admin: 6,
+        bcba: 7,
+        super_admin: 8,
+      };
+      return (ranks[role] ?? 0) >= (ranks[requiredRole] ?? 0);
+    }),
+    hasCapability: vi.fn(),
+    hasAnyCapability: vi.fn(),
+    hasAnyRole: vi.fn(),
+    isAdmin: vi.fn(() => role === 'admin' || role === 'bcba' || role === 'super_admin'),
+    isSuperAdmin: vi.fn(() => role === 'super_admin'),
+    loading: false,
+    profileLoading: false,
+    session: null,
+    metadataRole: role,
+    roleMismatch: false,
+    authFlow: 'normal',
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn(),
+    resetPassword: vi.fn(),
+    updateProfile: vi.fn(),
+  } as unknown as ReturnType<typeof useAuth>);
+};
+
+describe('Therapist profile staff invite', () => {
+  let invokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockAuth('admin');
+    invokeSpy = vi.spyOn(supabase.functions, 'invoke').mockResolvedValue({ data: null, error: null });
+    vi.mocked(showSuccess).mockClear();
+  });
+
+  afterEach(() => {
+    invokeSpy.mockRestore();
+    vi.mocked(useAuth).mockReset();
+  });
+
+  it('lets admins invite the BT from their profile with a locked BT role', async () => {
+    renderWithProviders(<ProfileTab therapist={therapist} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /invite to app/i }));
+
+    const modal = screen.getByRole('dialog', { name: /invite bt to app/i });
+    expect(within(modal).getByLabelText('Email*')).toHaveValue('taylor.bt@example.com');
+    expect(within(modal).getByLabelText('Role*')).toHaveValue('bt');
+    expect(within(modal).getByLabelText('Role*')).toBeDisabled();
+    expect(within(modal).getByLabelText('Organization')).toHaveValue('11111111-1111-1111-1111-111111111111');
+
+    await userEvent.clear(within(modal).getByLabelText('Reason for staff access*'));
+    await userEvent.type(within(modal).getByLabelText('Reason for staff access*'), 'Invite Taylor for BT data collection.');
+    await userEvent.click(within(modal).getByRole('button', { name: /send invite/i }));
+
+    await waitFor(() => {
+      expect(invokeSpy).toHaveBeenCalledWith(
+        'admin-invite',
+        expect.objectContaining({
+          body: {
+            email: 'taylor.bt@example.com',
+            organizationId: '11111111-1111-1111-1111-111111111111',
+            role: 'bt',
+            reason: 'Invite Taylor for BT data collection.',
+          },
+        }),
+      );
+    });
+    expect(showSuccess).toHaveBeenCalledWith('Staff invite sent successfully');
+  }, 20000);
+
+  it('does not expose the invite action to BT viewers', () => {
+    mockAuth('bt');
+
+    renderWithProviders(<ProfileTab therapist={therapist} />);
+
+    expect(screen.queryByRole('button', { name: /invite to app/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/settings/AdminSettings.tsx
+++ b/src/components/settings/AdminSettings.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '../../lib/authContext';
 import { Modal } from '../common/Modal';
 import type { PostgrestError } from '@supabase/supabase-js';
 import { ROLE_LABELS, type AppRole } from '../../lib/roles';
+import { StaffInviteModal, type StaffInviteFormData } from './StaffInviteModal';
 
 const ADMIN_USER_FETCH_LIMIT = 200;
 const EMPLOYEE_USER_FETCH_LIMIT = 200;
@@ -50,13 +51,6 @@ interface EmployeeUser {
   last_login_at: string | null;
 }
 
-interface AdminFormData {
-  email: string;
-  organization_id: string | null;
-  role: AppRole;
-  reason: string;
-}
-
 interface GuardianQueueEntry {
   id: string;
   guardian_id: string;
@@ -96,7 +90,7 @@ export function AdminSettings() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
   const [selectedAdmin, setSelectedAdmin] = useState<AdminUser | null>(null);
-  const [formData, setFormData] = useState<AdminFormData>({
+  const [formData, setFormData] = useState<StaffInviteFormData>({
     email: '',
     organization_id: null,
     role: 'bt',
@@ -110,7 +104,6 @@ export function AdminSettings() {
   const [selectedOrganizationId, setSelectedOrganizationId] = useState<string>(ALL_ORGANIZATIONS_VALUE);
   const [selectedTherapistByAdmin, setSelectedTherapistByAdmin] = useState<Record<string, string>>({});
 
-  const addAdminEmailRef = useRef<HTMLInputElement>(null);
   const resetPasswordInputRef = useRef<HTMLInputElement>(null);
 
   const queryClient = useQueryClient();
@@ -455,7 +448,7 @@ export function AdminSettings() {
   }, [adminTherapistLinksError]);
 
   const createAdminMutation = useMutation({
-    mutationFn: async (data: AdminFormData) => {
+    mutationFn: async (data: StaffInviteFormData) => {
       const targetOrganizationId = isSuperAdmin
         ? data.organization_id ?? activeOrganizationId
         : organizationId ?? data.organization_id ?? activeOrganizationId;
@@ -840,16 +833,15 @@ export function AdminSettings() {
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const trimmedReason = formData.reason.trim();
+  const handleSubmit = async (data: StaffInviteFormData) => {
+    const trimmedReason = data.reason.trim();
 
     if (trimmedReason.length < 10) {
       showError(new Error('Please provide a reason with at least 10 characters.'));
       return;
     }
 
-    await createAdminMutation.mutateAsync({ ...formData, reason: trimmedReason });
+    await createAdminMutation.mutateAsync({ ...data, reason: trimmedReason });
   };
 
   const handlePasswordReset = async (e: React.FormEvent) => {
@@ -878,16 +870,6 @@ export function AdminSettings() {
         metadata: { requestId: entry.id, selectedClientCount: selectedClients.length },
       });
     }
-  };
-
-  const handleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
-  ) => {
-    const { name, value } = e.target;
-    setFormData(prev => ({
-      ...prev,
-      [name]: value,
-    }));
   };
 
   return (
@@ -1356,139 +1338,15 @@ export function AdminSettings() {
         )}
       </div>
 
-      {/* Staff Invite Modal */}
-      <Modal
+      <StaffInviteModal
         isOpen={isModalOpen}
         onClose={closeCreateAdminModal}
-        titleId="add-admin-modal-title"
-        initialFocusRef={addAdminEmailRef}
-        panelClassName="bg-white dark:bg-dark-lighter rounded-lg shadow-xl w-full max-w-md p-6"
-      >
-        <h2 id="add-admin-modal-title" className="text-xl font-semibold text-gray-900 dark:text-white mb-6">
-          Invite Staff
-        </h2>
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <label htmlFor="add-admin-email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Email*
-                </label>
-                <input
-                  ref={addAdminEmailRef}
-                  type="email"
-                  name="email"
-                  required
-                  value={formData.email}
-                  onChange={handleInputChange}
-                  id="add-admin-email"
-                  className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
-                />
-              </div>
-
-              <div>
-                <label htmlFor="add-admin-role" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Role*
-                </label>
-                <select
-                  id="add-admin-role"
-                  name="role"
-                  required
-                  value={formData.role}
-                  onChange={handleInputChange}
-                  className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
-                >
-                  {inviteRoleOptions.map((role) => (
-                    <option key={role} value={role}>
-                      {ROLE_LABELS[role]}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label htmlFor="add-admin-organization" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Organization
-                </label>
-                {isSuperAdmin ? (
-                  <>
-                    <select
-                      id="add-admin-organization"
-                      name="organization_id"
-                      value={formData.organization_id ?? ''}
-                      onChange={handleInputChange}
-                      required
-                      className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
-                    >
-                      <option value="">Select organization</option>
-                      {organizationOptions.map((option) => (
-                        <option key={option.id} value={option.id}>
-                          {option.name ?? option.id}
-                        </option>
-                      ))}
-                    </select>
-                    {!formData.organization_id && (
-                      <p className="mt-1 text-xs text-red-600 dark:text-red-400">
-                        Choose an organization before inviting staff.
-                      </p>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    <input
-                      type="text"
-                      name="organization_id"
-                      value={formData.organization_id ?? ''}
-                      readOnly
-                      id="add-admin-organization"
-                      className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
-                    />
-                    {!formData.organization_id && (
-                      <p className="mt-1 text-xs text-red-600 dark:text-red-400">
-                        Organization context is required before inviting staff.
-                      </p>
-                    )}
-                  </>
-                )}
-              </div>
-
-              <div>
-                <label htmlFor="add-admin-reason" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Reason for staff access*
-                </label>
-                <textarea
-                  id="add-admin-reason"
-                  name="reason"
-                  required
-                  minLength={10}
-                  rows={3}
-                  value={formData.reason}
-                  onChange={handleInputChange}
-                  placeholder="Explain why this user requires staff access"
-                  className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
-                />
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  Provide a short justification that will be stored in the audit log.
-                </p>
-              </div>
-
-              <div className="flex justify-end space-x-3 pt-4">
-                <button
-                  type="button"
-                  onClick={closeCreateAdminModal}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark border border-gray-300 dark:border-gray-600 rounded-md shadow-sm hover:bg-gray-50 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={!formData.organization_id}
-                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Send Invite
-                </button>
-              </div>
-            </form>
-      </Modal>
+        onSubmit={handleSubmit}
+        initialData={formData}
+        roleOptions={inviteRoleOptions}
+        organizationOptions={organizationOptions}
+        isSuperAdmin={isSuperAdmin}
+      />
 
       {/* Password Reset Modal */}
       <Modal

--- a/src/components/settings/StaffInviteModal.tsx
+++ b/src/components/settings/StaffInviteModal.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Modal } from '../common/Modal';
+import { ROLE_LABELS, type AppRole } from '../../lib/roles';
+
+export interface StaffInviteFormData {
+  email: string;
+  organization_id: string | null;
+  role: AppRole;
+  reason: string;
+}
+
+interface StaffInviteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: StaffInviteFormData) => Promise<void>;
+  organizationOptions?: Array<{ id: string; name?: string | null }>;
+  isSuperAdmin?: boolean;
+  roleOptions: readonly AppRole[];
+  initialData: StaffInviteFormData;
+  title?: string;
+  submitLabel?: string;
+  organizationLabel?: string;
+  roleLocked?: boolean;
+}
+
+export function StaffInviteModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  organizationOptions = [],
+  isSuperAdmin = false,
+  roleOptions,
+  initialData,
+  title = 'Invite Staff',
+  submitLabel = 'Send Invite',
+  organizationLabel = 'Organization',
+  roleLocked = false,
+}: StaffInviteModalProps) {
+  const emailRef = useRef<HTMLInputElement>(null);
+  const [formData, setFormData] = useState<StaffInviteFormData>(initialData);
+
+  useEffect(() => {
+    if (isOpen) {
+      setFormData(initialData);
+    }
+  }, [initialData, isOpen]);
+
+  const handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = event.target;
+    setFormData((previous) => ({
+      ...previous,
+      [name]: name === 'organization_id' && value.length === 0 ? null : value,
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    await onSubmit({
+      ...formData,
+      email: formData.email.trim(),
+      reason: formData.reason.trim(),
+    });
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      titleId="staff-invite-modal-title"
+      initialFocusRef={emailRef}
+      panelClassName="bg-white dark:bg-dark-lighter rounded-lg shadow-xl w-full max-w-md p-6"
+    >
+      <h2 id="staff-invite-modal-title" className="text-xl font-semibold text-gray-900 dark:text-white mb-6">
+        {title}
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="staff-invite-email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Email*
+          </label>
+          <input
+            ref={emailRef}
+            type="email"
+            name="email"
+            required
+            value={formData.email}
+            onChange={handleInputChange}
+            id="staff-invite-email"
+            className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="staff-invite-role" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Role*
+          </label>
+          <select
+            id="staff-invite-role"
+            name="role"
+            required
+            value={formData.role}
+            onChange={handleInputChange}
+            disabled={roleLocked}
+            className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-100 dark:bg-dark dark:text-gray-200 dark:disabled:bg-gray-800"
+          >
+            {roleOptions.map((role) => (
+              <option key={role} value={role}>
+                {ROLE_LABELS[role]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="staff-invite-organization" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            {organizationLabel}
+          </label>
+          {isSuperAdmin ? (
+            <>
+              <select
+                id="staff-invite-organization"
+                name="organization_id"
+                value={formData.organization_id ?? ''}
+                onChange={handleInputChange}
+                required
+                className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+              >
+                <option value="">Select organization</option>
+                {organizationOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.name ?? option.id}
+                  </option>
+                ))}
+              </select>
+              {!formData.organization_id && (
+                <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                  Choose an organization before inviting staff.
+                </p>
+              )}
+            </>
+          ) : (
+            <>
+              <input
+                type="text"
+                name="organization_id"
+                value={formData.organization_id ?? ''}
+                readOnly
+                id="staff-invite-organization"
+                className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+              />
+              {!formData.organization_id && (
+                <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                  Organization context is required before inviting staff.
+                </p>
+              )}
+            </>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="staff-invite-reason" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Reason for staff access*
+          </label>
+          <textarea
+            id="staff-invite-reason"
+            name="reason"
+            required
+            minLength={10}
+            rows={3}
+            value={formData.reason}
+            onChange={handleInputChange}
+            placeholder="Explain why this user requires staff access"
+            className="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-dark dark:text-gray-200"
+          />
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Provide a short justification that will be stored in the audit log.
+          </p>
+        </div>
+
+        <div className="flex justify-end space-x-3 pt-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark border border-gray-300 dark:border-gray-600 rounded-md shadow-sm hover:bg-gray-50 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!formData.organization_id}
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- add an Invite to app action on BT profile pages for admin-capable users
- reuse the existing admin-invite edge function and staff invite acceptance flow
- extract the existing Admin Settings invite form into a shared StaffInviteModal
- add focused tests for profile invite payload and BT viewer visibility

## Verification
Passed locally:
- npm test -- src/components/__tests__/TherapistProfileInvite.test.tsx --runInBand
- npm test -- src/components/settings/__tests__/AdminSettings.test.tsx --runInBand
- npm run typecheck
- npm run lint
- npm run ci:check-focused
- $env:VITE_SUPABASE_URL='https://test.supabase.co'; $env:VITE_SUPABASE_ANON_KEY='test-anon-key'; npm run test:ci
- npm run ci:verify-coverage
- npm run build

Blocked / not completed:
- npm run test:routes:tier0 failed locally with Cypress/Node EPIPE process failure and left orphaned Cypress processes; no app assertion failure or screenshots were produced.
- npm run ci:playwright was not run locally because the smoke suite depends on configured hosted/test credentials.

## Risk
- UI-only profile entry point and modal extraction.
- No edge function, migration, RLS, auth library, runtime config, or tenant policy changes.
- Profile invite sends the existing admin-invite payload with role locked to bt.