### PR TITLE
Validate session note trial opportunity bounds

### DIFF
--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -205,6 +205,119 @@ describe("sessionNotesUpsertHandler", () => {
     expect(payload.goal_notes).toEqual({ "44444444-4444-4444-8444-444444444444": "covered" });
   });
 
+  it("rejects goal measurements when correct trials exceed opportunities", async () => {
+    const fetchJsonMock = vi.mocked(fetchJson);
+    let noteWriteCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        noteWriteCount += 1;
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          goalMeasurements: {
+            [basePayload.goalIds[0]]: {
+              data: {
+                metric_value: 8,
+                opportunities: 7,
+                target: "Playwright smoke target",
+              },
+            },
+          },
+        }),
+      }),
+    );
+    const payload = await response.json() as { code?: string; error?: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.code).toBe("validation_error");
+    expect(payload.error).toBe("Correct trials cannot exceed opportunities.");
+    expect(noteWriteCount).toBe(0);
+  });
+
+  it("rejects target-trial measurements when correct trials exceed opportunities", async () => {
+    const fetchJsonMock = vi.mocked(fetchJson);
+    let noteWriteCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        noteWriteCount += 1;
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          goalMeasurements: {
+            [basePayload.goalIds[0]]: {
+              data: {
+                targets: ["Playwright smoke target"],
+                target_trials: [{
+                  target: "Playwright smoke target",
+                  metric_value: 8,
+                  opportunities: 7,
+                }],
+              },
+            },
+          },
+        }),
+      }),
+    );
+    const payload = await response.json() as { code?: string; error?: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.code).toBe("validation_error");
+    expect(payload.error).toBe("Correct trials cannot exceed opportunities.");
+    expect(noteWriteCount).toBe(0);
+  });
+
   it("persists explicit raw trial events before saving the session note", async () => {
     const fetchJsonMock = vi.mocked(fetchJson);
     let trialEventsPostCount = 0;

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionGoalMeasurementEntry } from "../../types";
 import { sessionNotesUpsertHandler } from "../api/session-notes-upsert";
 
 vi.mock("../api/shared", async () => {
@@ -316,6 +317,97 @@ describe("sessionNotesUpsertHandler", () => {
     expect(payload.code).toBe("validation_error");
     expect(payload.error).toBe("Correct trials cannot exceed opportunities.");
     expect(noteWriteCount).toBe(0);
+  });
+
+  it("allows percent and duration measurements when metric values exceed opportunities", async () => {
+    const fetchJsonMock = vi.mocked(fetchJson);
+    const durationGoalId = "66666666-6666-4666-8666-666666666666";
+    let noteWriteCount = 0;
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl.endsWith("/rest/v1/client_session_notes") && init?.method === "POST") {
+        noteWriteCount += 1;
+        const parsedBody = JSON.parse(String(init.body)) as {
+          goal_measurements?: Record<string, SessionGoalMeasurementEntry>;
+        };
+        expect(parsedBody.goal_measurements?.[basePayload.goalIds[0]]?.data).toEqual(
+          expect.objectContaining({
+            measurement_type: "percent accuracy",
+            metric_label: "Percent",
+            metric_unit: "%",
+            metric_value: 80,
+            opportunities: 10,
+          }),
+        );
+        expect(parsedBody.goal_measurements?.[durationGoalId]?.data).toEqual(
+          expect.objectContaining({
+            measurement_type: "duration",
+            metric_label: "Duration",
+            metric_unit: "minutes",
+            metric_value: 60,
+            opportunities: 1,
+          }),
+        );
+        return { ok: true, status: 201, data: [{ id: "note-percent-duration" }] };
+      }
+      if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes("id=eq.note-percent-duration")) {
+        return { ok: true, status: 200, data: [buildSessionNoteRow("note-percent-duration")] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({
+          ...basePayload,
+          goalIds: [basePayload.goalIds[0], durationGoalId],
+          goalsAddressed: ["Percent goal", "Duration goal"],
+          goalMeasurements: {
+            [basePayload.goalIds[0]]: {
+              data: {
+                measurement_type: "percent accuracy",
+                metric_label: "Percent",
+                metric_unit: "%",
+                metric_value: 80,
+                opportunities: 10,
+              },
+            },
+            [durationGoalId]: {
+              data: {
+                measurement_type: "duration",
+                metric_label: "Duration",
+                metric_unit: "minutes",
+                metric_value: 60,
+                opportunities: 1,
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(noteWriteCount).toBe(1);
   });
 
   it("persists explicit raw trial events before saving the session note", async () => {

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -248,6 +248,38 @@ const normalizeGoalMeasurements = (
   return entries.length > 0 ? Object.fromEntries(entries) : null;
 };
 
+const hasSuccessesBeyondOpportunities = (
+  metricValue: number | null | undefined,
+  opportunities: number | null | undefined,
+): boolean =>
+  typeof metricValue === "number" &&
+  Number.isFinite(metricValue) &&
+  typeof opportunities === "number" &&
+  Number.isFinite(opportunities) &&
+  metricValue > opportunities;
+
+const validateGoalMeasurementOpportunityBounds = (
+  measurements: Record<string, SessionGoalMeasurementEntry> | null,
+): string | null => {
+  if (!measurements) {
+    return null;
+  }
+
+  for (const entry of Object.values(measurements)) {
+    if (hasSuccessesBeyondOpportunities(entry.data.metric_value, entry.data.opportunities)) {
+      return "Correct trials cannot exceed opportunities.";
+    }
+
+    for (const trial of entry.data.target_trials ?? []) {
+      if (hasSuccessesBeyondOpportunities(trial.metric_value, trial.opportunities)) {
+        return "Correct trials cannot exceed opportunities.";
+      }
+    }
+  }
+
+  return null;
+};
+
 /**
  * Keeps `goal_ids` and `goals_addressed` aligned with trimmed `goal_notes` / normalized `goal_measurements`
  * (same merge semantics as SessionModal / AddSessionNoteModal): any goal key present only in maps is
@@ -967,6 +999,10 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
 
   const normalizedGoalNotes = trimGoalNotes(goalNotesForNormalize);
   const normalizedGoalMeasurements = normalizeGoalMeasurements(goalMeasurementsForNormalize ?? null);
+  const measurementBoundsError = validateGoalMeasurementOpportunityBounds(normalizedGoalMeasurements);
+  if (measurementBoundsError) {
+    return errorResponse(request, "validation_error", measurementBoundsError);
+  }
 
   const alignedGoals = alignSessionNoteGoalPayload({
     goalIds: payload.goalIds,

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -258,6 +258,44 @@ const hasSuccessesBeyondOpportunities = (
   Number.isFinite(opportunities) &&
   metricValue > opportunities;
 
+const normalizeMeasurementMetadata = (value: string | null | undefined): string =>
+  value?.trim().toLowerCase() ?? "";
+
+const isCountTrialMeasurement = (entry: SessionGoalMeasurementEntry): boolean => {
+  const metadata = [
+    normalizeMeasurementMetadata(entry.data.measurement_type),
+    normalizeMeasurementMetadata(entry.data.metric_label),
+    normalizeMeasurementMetadata(entry.data.metric_unit),
+  ].filter((value) => value.length > 0);
+
+  if (
+    metadata.some((value) =>
+      value.includes("percent") ||
+      value.includes("%") ||
+      value.includes("accuracy") ||
+      value.includes("fidelity") ||
+      value.includes("duration") ||
+      value.includes("minute") ||
+      value.includes("time") ||
+      value.includes("rate") ||
+      value.includes("per hour")
+    )
+  ) {
+    return false;
+  }
+
+  return metadata.some((value) =>
+    value.includes("count") ||
+    value.includes("correct") ||
+    value.includes("incorrect") ||
+    value.includes("trial") ||
+    value.includes("response") ||
+    value.includes("task analysis") ||
+    value.includes("taskanalysis") ||
+    value.includes("occurrence")
+  );
+};
+
 const validateGoalMeasurementOpportunityBounds = (
   measurements: Record<string, SessionGoalMeasurementEntry> | null,
 ): string | null => {
@@ -266,6 +304,10 @@ const validateGoalMeasurementOpportunityBounds = (
   }
 
   for (const entry of Object.values(measurements)) {
+    if (!isCountTrialMeasurement(entry)) {
+      continue;
+    }
+
     if (hasSuccessesBeyondOpportunities(entry.data.metric_value, entry.data.opportunities)) {
       return "Correct trials cannot exceed opportunities.";
     }


### PR DESCRIPTION
## Summary
- Add server-side validation in `sessionNotesUpsertHandler` so normalized goal measurement successes cannot exceed opportunities.
- Validate both top-level measurement fields and normalized `target_trials` before session-note persistence.
- Add server-boundary regressions that assert invalid `8/7`-style payloads return `validation_error` and do not POST to `client_session_notes`.

## Route task
- classification: high-risk human-reviewed
- lane: critical
- triggering paths: `src/server/api/session-notes-upsert.ts`, `src/server/__tests__/sessionNotesUpsertHandler.test.ts`
- Linear: WIN-183

## Verification
- PASS: `npm ci`
- PASS: `npx vitest run --config vitest.config.ts src/server/__tests__/sessionNotesUpsertHandler.test.ts --reporter=verbose` (28 passed)
- PASS: `npm run ci:check-focused` (via `verify:local`; DB/CI-only checks skipped as documented by script)
- PASS: `npm run lint` (via `verify:local`)
- PASS: `npm run typecheck` (via `verify:local`)
- PASS: `npm run test:ci` with synthetic non-secret Supabase env placeholders (retry passed: 366 files passed, 1 skipped; 2375 tests passed, 1 skipped)
- PASS: `npm run ci:verify-coverage`
- PASS: `npm run build`
- BLOCKED: `npm run test:routes:tier0` could not complete locally because the Cypress preview runner repeatedly left/reacquired port `127.0.0.1:4173` and then exited nonzero without actionable logs.
- BLOCKED: `npm run ci:playwright` not run; `npm run ci:playwright:env-readiness` failed due missing browser target and hosted test personas.

## Risk
Critical path because this changes the app-side server/API save boundary. The change is fail-closed and rejects only finite numeric `metric_value > opportunities`; it does not clamp or mutate clinical data.