### PR TITLE
Add inline session trial bounds validation

### DIFF
--- a/reports/test-reliability-latest.json
+++ b/reports/test-reliability-latest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-04T00:28:57.993Z",
+  "generatedAt": "2026-07-09T22:54:51.921Z",
   "slo": {
     "suitePassRatePctTarget": 99.5,
     "rollingWindowDays": 14

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -207,8 +207,12 @@ const getCorrectTrialsOpportunityError = (
 
 const getGoalMeasurementOpportunityError = (
   measurements: Record<string, SessionGoalMeasurementEntry>,
+  measurementGoalIds?: ReadonlySet<string>,
 ): string | null => {
-  for (const entry of Object.values(measurements)) {
+  for (const [goalId, entry] of Object.entries(measurements)) {
+    if (measurementGoalIds && !measurementGoalIds.has(goalId)) {
+      continue;
+    }
     const shouldValidate = isCountTrialMeasurementMetadata(
       entry.data.measurement_type,
       entry.data.metric_label,
@@ -1384,7 +1388,11 @@ export function SessionModal({
           })
           .filter((entry): entry is [string, SessionGoalMeasurementEntry] => Boolean(entry)),
       );
-      const measurementBoundsError = getGoalMeasurementOpportunityError(normalizedGoalMeasurementMap);
+      const measurementBoundsGoalIds = isPartialCaptureSave ? new Set(mergeGoalIds) : undefined;
+      const measurementBoundsError = getGoalMeasurementOpportunityError(
+        normalizedGoalMeasurementMap,
+        measurementBoundsGoalIds,
+      );
       if (measurementBoundsError) {
         showError(measurementBoundsError);
         return;
@@ -3286,16 +3294,29 @@ export function SessionModal({
                           const rawTargetTrialRows = Array.isArray(watchedTargetTrials)
                             ? watchedTargetTrials
                             : filteredMeasurementEntry?.data.target_trials ?? [];
+                          const getTargetTrialNullableValue = (
+                            targetIndex: number,
+                            field: 'metric_value' | 'incorrect_trials' | 'opportunities',
+                          ): number | null => {
+                            const trialRow = rawTargetTrialRows[targetIndex];
+                            if (!trialRow || typeof trialRow !== 'object') {
+                              return null;
+                            }
+                            const raw = (trialRow as Record<string, unknown>)[field];
+                            if (typeof raw === 'number' && Number.isFinite(raw)) {
+                              return raw;
+                            }
+                            if (typeof raw === 'string' && raw.trim().length > 0) {
+                              const parsed = Number(raw);
+                              return Number.isFinite(parsed) ? parsed : null;
+                            }
+                            return null;
+                          };
                           const getTargetTrialValue = (
                             targetIndex: number,
                             field: 'metric_value' | 'incorrect_trials' | 'opportunities',
                           ) => {
-                            const trialRow = rawTargetTrialRows[targetIndex];
-                            if (!trialRow || typeof trialRow !== 'object') {
-                              return 0;
-                            }
-                            const raw = (trialRow as Record<string, unknown>)[field];
-                            return typeof raw === 'number' && Number.isFinite(raw) ? raw : Number(raw) || 0;
+                            return getTargetTrialNullableValue(targetIndex, field) ?? 0;
                           };
                           const getTargetTrialNote = (targetIndex: number) => {
                             const trialRow = rawTargetTrialRows[targetIndex];
@@ -3547,7 +3568,7 @@ export function SessionModal({
                                           ? 0
                                           : getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'incorrect_trials', 'pending'))
                                       : targetIncorrectDisplay;
-                                    const targetOpportunitiesDisplay = getTargetTrialValue(sourceIndex, 'opportunities');
+                                    const targetOpportunitiesDisplay = getTargetTrialNullableValue(sourceIndex, 'opportunities');
                                     const targetTrialBoundsError = getCorrectTrialsOpportunityError(
                                       targetCorrectDisplay,
                                       targetOpportunitiesDisplay,
@@ -3564,7 +3585,7 @@ export function SessionModal({
                                       targetValue.trim().length > 0 ||
                                       targetCorrectDisplay > 0 ||
                                       targetIncorrectDisplay > 0 ||
-                                      targetOpportunitiesDisplay > 0 ||
+                                      (targetOpportunitiesDisplay ?? 0) > 0 ||
                                       getTargetTrialNote(sourceIndex).trim().length > 0;
                                     const indexedTargetRegistration = register(indexedTargetFieldKey, {
                                       onChange: (event) => {
@@ -3802,7 +3823,7 @@ export function SessionModal({
                                           <input
                                             type="hidden"
                                             {...register(targetTrialOpportunitiesFieldKey, { setValueAs: toFormNumber })}
-                                            defaultValue={targetOpportunitiesDisplay || ''}
+                                            defaultValue={targetOpportunitiesDisplay ?? ''}
                                           />
                                           {targetTrialBoundsError ? (
                                             <p className="mt-2 rounded-md border border-rose-200 bg-rose-50 px-2 py-1 text-xs font-medium text-rose-700 dark:border-rose-900/60 dark:bg-rose-950/30 dark:text-rose-200">

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -144,6 +144,100 @@ const hasNestedDirtyEntries = (value: unknown): boolean => {
   return Object.values(value as Record<string, unknown>).some((entry) => hasNestedDirtyEntries(entry));
 };
 
+const normalizeMeasurementMetadata = (value: string | null | undefined): string =>
+  value?.trim().toLowerCase() ?? '';
+
+const isCountTrialMeasurementMetadata = (
+  measurementType: string | null | undefined,
+  metricLabel: string | null | undefined,
+  metricUnit: string | null | undefined,
+): boolean => {
+  const metadata = [
+    normalizeMeasurementMetadata(measurementType),
+    normalizeMeasurementMetadata(metricLabel),
+    normalizeMeasurementMetadata(metricUnit),
+  ].filter((value) => value.length > 0);
+
+  if (
+    metadata.some((value) =>
+      value.includes('percent') ||
+      value.includes('%') ||
+      value.includes('accuracy') ||
+      value.includes('fidelity') ||
+      value.includes('duration') ||
+      value.includes('minute') ||
+      value.includes('time') ||
+      value.includes('rate') ||
+      value.includes('per hour')
+    )
+  ) {
+    return false;
+  }
+
+  return metadata.some((value) =>
+    value.includes('count') ||
+    value.includes('correct') ||
+    value.includes('incorrect') ||
+    value.includes('trial') ||
+    value.includes('response') ||
+    value.includes('task analysis') ||
+    value.includes('taskanalysis') ||
+    value.includes('occurrence')
+  );
+};
+
+const hasSuccessesBeyondOpportunities = (
+  metricValue: number | null | undefined,
+  opportunities: number | null | undefined,
+): boolean =>
+  typeof metricValue === 'number' &&
+  Number.isFinite(metricValue) &&
+  typeof opportunities === 'number' &&
+  Number.isFinite(opportunities) &&
+  metricValue > opportunities;
+
+const getCorrectTrialsOpportunityError = (
+  metricValue: number | null | undefined,
+  opportunities: number | null | undefined,
+  shouldValidate: boolean,
+): string | null =>
+  shouldValidate && hasSuccessesBeyondOpportunities(metricValue, opportunities)
+    ? 'Correct trials cannot exceed opportunities.'
+    : null;
+
+const getGoalMeasurementOpportunityError = (
+  measurements: Record<string, SessionGoalMeasurementEntry>,
+): string | null => {
+  for (const entry of Object.values(measurements)) {
+    const shouldValidate = isCountTrialMeasurementMetadata(
+      entry.data.measurement_type,
+      entry.data.metric_label,
+      entry.data.metric_unit,
+    );
+    const entryError = getCorrectTrialsOpportunityError(
+      entry.data.metric_value,
+      entry.data.opportunities,
+      shouldValidate,
+    );
+    if (entryError) {
+      return entryError;
+    }
+
+    for (const trial of entry.data.target_trials ?? []) {
+      const trialError = getCorrectTrialsOpportunityError(
+        trial.metric_value,
+        trial.opportunities,
+        shouldValidate,
+      );
+      if (trialError) {
+        return trialError;
+      }
+    }
+  }
+
+  return null;
+};
+
 const trimString = (value: unknown): string | null => {
   if (typeof value !== 'string') {
     return null;
@@ -1290,6 +1384,11 @@ export function SessionModal({
           })
           .filter((entry): entry is [string, SessionGoalMeasurementEntry] => Boolean(entry)),
       );
+      const measurementBoundsError = getGoalMeasurementOpportunityError(normalizedGoalMeasurementMap);
+      if (measurementBoundsError) {
+        showError(measurementBoundsError);
+        return;
+      }
       const firstDefaultServiceCode = firstServiceCodeOnAuthorization(primaryBillingAuthorization);
       const resolvedAuthorizationId =
         working.session_note_authorization_id?.trim() ||
@@ -3448,13 +3547,24 @@ export function SessionModal({
                                           ? 0
                                           : getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'incorrect_trials', 'pending'))
                                       : targetIncorrectDisplay;
+                                    const targetOpportunitiesDisplay = getTargetTrialValue(sourceIndex, 'opportunities');
+                                    const targetTrialBoundsError = getCorrectTrialsOpportunityError(
+                                      targetCorrectDisplay,
+                                      targetOpportunitiesDisplay,
+                                      !valueCaptureMeta &&
+                                        isCountTrialMeasurementMetadata(
+                                          configuredTarget?.measurement_type ?? selectedGoal?.measurement_type,
+                                          existingMeasurementEntry?.data.metric_label ?? measurementFieldMeta.primaryLabel,
+                                          existingMeasurementEntry?.data.metric_unit ?? measurementFieldMeta.primaryUnit,
+                                        ),
+                                    );
                                     const shouldRenderTargetTrialFields =
                                       isAdhocTarget ||
                                       planGoalHasNoConfiguredTarget ||
                                       targetValue.trim().length > 0 ||
                                       targetCorrectDisplay > 0 ||
                                       targetIncorrectDisplay > 0 ||
-                                      getTargetTrialValue(sourceIndex, 'opportunities') > 0 ||
+                                      targetOpportunitiesDisplay > 0 ||
                                       getTargetTrialNote(sourceIndex).trim().length > 0;
                                     const indexedTargetRegistration = register(indexedTargetFieldKey, {
                                       onChange: (event) => {
@@ -3692,8 +3802,13 @@ export function SessionModal({
                                           <input
                                             type="hidden"
                                             {...register(targetTrialOpportunitiesFieldKey, { setValueAs: toFormNumber })}
-                                            defaultValue={getTargetTrialValue(sourceIndex, 'opportunities') || ''}
+                                            defaultValue={targetOpportunitiesDisplay || ''}
                                           />
+                                          {targetTrialBoundsError ? (
+                                            <p className="mt-2 rounded-md border border-rose-200 bg-rose-50 px-2 py-1 text-xs font-medium text-rose-700 dark:border-rose-900/60 dark:bg-rose-950/30 dark:text-rose-200">
+                                              {targetTrialBoundsError}
+                                            </p>
+                                          ) : null}
                                           <label
                                             htmlFor={`trial-prompt-note-${selectedGoalId}-${targetIndex}`}
                                             className="mt-3 block text-xs font-medium text-gray-600 dark:text-gray-300"

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -3520,6 +3520,126 @@ describe('SessionModal', () => {
     });
   }, 10000);
 
+  it('shows inline trial bounds validation and blocks save progress when correct trials exceed opportunities', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const planTarget = 'Match peer greeting in 4/5 trials';
+    const linkedSessionNote = {
+      id: 'linked-note-over-bounds-target',
+      authorization_id: 'auth-1',
+      service_code: '97153',
+      narrative: '',
+      goal_notes: {
+        'goal-1': 'Observed target trials',
+      },
+      goal_measurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_label: 'Count',
+            metric_unit: 'responses',
+            targets: [planTarget],
+            target: planTarget,
+            metric_value: 8,
+            incorrect_trials: 0,
+            opportunities: 7,
+            target_trials: [
+              {
+                target: planTarget,
+                metric_value: 8,
+                incorrect_trials: 0,
+                opportunities: 7,
+              },
+            ],
+          },
+        },
+      },
+      goal_ids: ['goal-1'],
+      goals_addressed: ['Default Goal'],
+    };
+
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'linked-note-over-bounds-target',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: linkedSessionNote.goals_addressed,
+      goal_ids: linkedSessionNote.goal_ids,
+      goal_measurements: linkedSessionNote.goal_measurements as Record<string, unknown>,
+      goal_notes: linkedSessionNote.goal_notes,
+      session_id: 'session-linked-over-bounds-target',
+      narrative: linkedSessionNote.narrative,
+      is_locked: false,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: null,
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T09:00:00.000Z',
+    });
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      const buildChain = (rows: unknown[]) => {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: rows, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      };
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals);
+      }
+      if (table === 'authorizations') {
+        return buildChain([{ id: 'auth-1', authorization_number: 'AUTH-001', services: [{ service_code: '97153' }] }]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-linked-over-bounds-target',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Observed target trials')).toBeInTheDocument();
+    });
+
+    expect(await screen.findByText('Correct trials cannot exceed opportunities.')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  }, 10000);
+
   it('preserves linked note measurements for drifted saved goals when saving', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const linkedSessionNote = {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -2960,6 +2960,7 @@ describe('SessionModal', () => {
     fireEvent.change(target2PromptFields[target2PromptFields.length - 1], {
       target: { value: 'Prompt note B' },
     });
+    expect(screen.queryByText('Correct trials cannot exceed opportunities.')).not.toBeInTheDocument();
 
     const removeTargetButtons = screen.getAllByRole('button', { name: /Remove target 1/i });
     await userEvent.click(removeTargetButtons[removeTargetButtons.length - 1]);
@@ -3638,6 +3639,127 @@ describe('SessionModal', () => {
     await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
 
     expect(onSubmit).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('does not block Save skills for an out-of-scope behavior row with trial bounds errors', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const behaviorGoalId = 'adhoc-bx-550e8400-e29b-41d4-a716-446655440000';
+    const linkedSessionNote = {
+      id: 'linked-note-partial-save-bounds',
+      authorization_id: 'auth-1',
+      service_code: '97153',
+      narrative: '',
+      goal_notes: {
+        'goal-1': 'Skill target remains in progress',
+        [behaviorGoalId]: 'Behavior target stays on the BX tab',
+      },
+      goal_measurements: {
+        [behaviorGoalId]: {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_label: 'Count',
+            metric_unit: 'responses',
+            targets: ['Behavior target'],
+            target: 'Behavior target',
+            metric_value: 8,
+            incorrect_trials: 0,
+            opportunities: 7,
+            target_trials: [
+              {
+                target: 'Behavior target',
+                metric_value: 8,
+                incorrect_trials: 0,
+                opportunities: 7,
+              },
+            ],
+          },
+        },
+      },
+      goal_ids: ['goal-1', behaviorGoalId],
+      goals_addressed: ['Default Goal', 'Behavior target'],
+    };
+
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'linked-note-partial-save-bounds',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: linkedSessionNote.goals_addressed,
+      goal_ids: linkedSessionNote.goal_ids,
+      goal_measurements: linkedSessionNote.goal_measurements as Record<string, unknown>,
+      goal_notes: linkedSessionNote.goal_notes,
+      session_id: 'session-linked-partial-save-bounds',
+      narrative: linkedSessionNote.narrative,
+      is_locked: false,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: null,
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T09:00:00.000Z',
+    });
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      const buildChain = (rows: unknown[]) => {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: rows, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      };
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals);
+      }
+      if (table === 'authorizations') {
+        return buildChain([{ id: 'auth-1', authorization_number: 'AUTH-001', services: [{ service_code: '97153' }] }]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-linked-partial-save-bounds',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Skill target remains in progress')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Save skills/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
   }, 10000);
 
   it('preserves linked note measurements for drifted saved goals when saving', async () => {


### PR DESCRIPTION
## Summary
- Adds client-side trial/opportunity validation to session capture so count/trial measurements show an inline error when correct trials exceed opportunities.
- Gates the UI validation by measurement metadata so percent, duration, rate, and other non-count measurements are not rejected.
- Adds a SessionModal regression covering inline error display and Save progress blocking for over-bounds target trials.

## Verification
- `npm run ci:check-focused` PASS
- `npm run lint` PASS
- `npm run typecheck` PASS
- `npx vitest run --config vitest.config.ts src/components/__tests__/SessionModal.test.tsx --reporter=verbose` PASS, 65/65
- `npm run test:ci` PASS, 368 files / 2387 tests, 1 skipped because `WIN211_POSTGRES_URL` is not configured
- `npm run ci:verify-coverage` PASS
- `npm run build` PASS
- `npm run test:routes:tier0` PASS, 220/220

## Notes
- Follow-up from WIN-183 after PR #753 was merged.
- This PR is intentionally UI-only; the previous server-side save-path validation landed via #753.