### PR TITLE
Extend goal target graph editing

### DIFF
--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -511,6 +511,18 @@ const buildGoalTargetGraphConfig = (measurementType: TargetMeasurementType): Rec
   aggregation: measurementType === "frequency" ? "sum" : "session_summary",
 });
 
+const normalizeGoalTargetGraphConfig = (
+  measurementType: TargetMeasurementType,
+  graphConfig: Record<string, unknown> | undefined,
+): Record<string, unknown> => ({
+  ...buildGoalTargetGraphConfig(measurementType),
+  ...(graphConfig ?? {}),
+});
+
+const GRAPH_CHART_TYPES = ["line", "bar"] as const;
+const GRAPH_SOURCES = ["trial_events", "session_notes"] as const;
+const GRAPH_AGGREGATIONS = ["session_summary", "sum", "average", "count"] as const;
+
 const upsertById = <T extends { id: string }>(current: T[] | undefined, nextItem: T): T[] => {
   const existingItems = Array.isArray(current) ? current : [];
   const existingIndex = existingItems.findIndex((item) => item.id === nextItem.id);
@@ -781,23 +793,55 @@ function GoalTargetCard({
       name: string;
       measurement_type: TargetMeasurementType;
       status: GoalTarget["status"];
+      graph_config?: Record<string, unknown>;
     }) => void;
   } | null;
   updatingTargetId: string | null;
 }) {
   const [isEditing, setIsEditing] = useState(false);
+  const normalizedGraphConfig = normalizeGoalTargetGraphConfig(target.measurement_type, target.graph_config);
   const [editName, setEditName] = useState(target.name);
   const [editMeasurementType, setEditMeasurementType] = useState<TargetMeasurementType>(target.measurement_type);
   const [editStatus, setEditStatus] = useState<GoalTarget["status"]>(target.status);
+  const [editGraphChart, setEditGraphChart] = useState(String(normalizedGraphConfig.defaultChart));
+  const [editGraphSource, setEditGraphSource] = useState(String(normalizedGraphConfig.source));
+  const [editGraphAggregation, setEditGraphAggregation] = useState(String(normalizedGraphConfig.aggregation));
   const editNameValue = editName.trim();
+  const editedGraphConfig = {
+    defaultChart: editGraphChart,
+    source: editGraphSource,
+    aggregation: editGraphAggregation,
+  };
+  const graphConfigChanged =
+    editedGraphConfig.defaultChart !== String(normalizedGraphConfig.defaultChart) ||
+    editedGraphConfig.source !== String(normalizedGraphConfig.source) ||
+    editedGraphConfig.aggregation !== String(normalizedGraphConfig.aggregation);
   const isSaving = updatingTargetId === target.id && updateGoalTarget?.isLoading === true;
 
   useEffect(() => {
     if (isEditing) return;
+    const nextGraphConfig = normalizeGoalTargetGraphConfig(target.measurement_type, target.graph_config);
     setEditName(target.name);
     setEditMeasurementType(target.measurement_type);
     setEditStatus(target.status);
-  }, [isEditing, target.measurement_type, target.name, target.status]);
+    setEditGraphChart(String(nextGraphConfig.defaultChart));
+    setEditGraphSource(String(nextGraphConfig.source));
+    setEditGraphAggregation(String(nextGraphConfig.aggregation));
+  }, [isEditing, target.graph_config, target.measurement_type, target.name, target.status]);
+
+  const resetEditor = () => {
+    const nextGraphConfig = normalizeGoalTargetGraphConfig(target.measurement_type, target.graph_config);
+    setEditName(target.name);
+    setEditMeasurementType(target.measurement_type);
+    setEditStatus(target.status);
+    setEditGraphChart(String(nextGraphConfig.defaultChart));
+    setEditGraphSource(String(nextGraphConfig.source));
+    setEditGraphAggregation(String(nextGraphConfig.aggregation));
+  };
+  const handleMeasurementTypeChange = (measurementType: TargetMeasurementType) => {
+    setEditMeasurementType(measurementType);
+    setEditGraphAggregation(String(buildGoalTargetGraphConfig(measurementType).aggregation));
+  };
 
   return (
     <div className="rounded-md border border-slate-200 bg-white px-3 py-3 text-xs dark:border-slate-700 dark:bg-dark">
@@ -814,9 +858,7 @@ function GoalTargetCard({
               title={isEditing ? "Cancel target edit" : "Edit target"}
               onClick={() => {
                 if (isEditing) {
-                  setEditName(target.name);
-                  setEditMeasurementType(target.measurement_type);
-                  setEditStatus(target.status);
+                  resetEditor();
                   setIsEditing(false);
                   return;
                 }
@@ -848,7 +890,7 @@ function GoalTargetCard({
               <select
                 aria-label={`Measurement type for ${target.name}`}
                 value={editMeasurementType}
-                onChange={(event) => setEditMeasurementType(event.target.value as TargetMeasurementType)}
+                onChange={(event) => handleMeasurementTypeChange(event.target.value as TargetMeasurementType)}
                 className="mt-1 w-full rounded-md border-slate-300 bg-white text-sm shadow-sm dark:border-slate-600 dark:bg-dark"
               >
                 {TARGET_MEASUREMENT_TYPES.map((measurementType) => (
@@ -873,13 +915,58 @@ function GoalTargetCard({
               </select>
             </label>
           </div>
+          <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <label className="block text-xs font-medium text-slate-700 dark:text-slate-200">
+              Chart
+              <select
+                aria-label={`Graph chart for ${target.name}`}
+                value={editGraphChart}
+                onChange={(event) => setEditGraphChart(event.target.value)}
+                className="mt-1 w-full rounded-md border-slate-300 bg-white text-sm shadow-sm dark:border-slate-600 dark:bg-dark"
+              >
+                {GRAPH_CHART_TYPES.map((chartType) => (
+                  <option key={chartType} value={chartType}>
+                    {chartType}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-xs font-medium text-slate-700 dark:text-slate-200">
+              Source
+              <select
+                aria-label={`Graph source for ${target.name}`}
+                value={editGraphSource}
+                onChange={(event) => setEditGraphSource(event.target.value)}
+                className="mt-1 w-full rounded-md border-slate-300 bg-white text-sm shadow-sm dark:border-slate-600 dark:bg-dark"
+              >
+                {GRAPH_SOURCES.map((source) => (
+                  <option key={source} value={source}>
+                    {source}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-xs font-medium text-slate-700 dark:text-slate-200">
+              Aggregation
+              <select
+                aria-label={`Graph aggregation for ${target.name}`}
+                value={editGraphAggregation}
+                onChange={(event) => setEditGraphAggregation(event.target.value)}
+                className="mt-1 w-full rounded-md border-slate-300 bg-white text-sm shadow-sm dark:border-slate-600 dark:bg-dark"
+              >
+                {GRAPH_AGGREGATIONS.map((aggregation) => (
+                  <option key={aggregation} value={aggregation}>
+                    {aggregation}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
           <div className="mt-3 flex flex-wrap justify-end gap-2">
             <button
               type="button"
               onClick={() => {
-                setEditName(target.name);
-                setEditMeasurementType(target.measurement_type);
-                setEditStatus(target.status);
+                resetEditor();
                 setIsEditing(false);
               }}
               disabled={isSaving}
@@ -896,6 +983,7 @@ function GoalTargetCard({
                   name: editNameValue,
                   measurement_type: editMeasurementType,
                   status: editStatus,
+                  ...(graphConfigChanged ? { graph_config: editedGraphConfig } : {}),
                 });
                 setIsEditing(false);
               }}
@@ -914,6 +1002,7 @@ function GoalTargetCard({
         <span>
           Graph: {String(target.graph_config?.defaultChart ?? "line")} from{" "}
           {String(target.graph_config?.source ?? "trial_events")}
+          {target.graph_config?.aggregation ? ` (${String(target.graph_config.aggregation)})` : ""}
         </span>
       </div>
       {goalTargetsLoading ? (
@@ -955,6 +1044,7 @@ function GoalCard({
       name: string;
       measurement_type: TargetMeasurementType;
       status: GoalTarget["status"];
+      graph_config?: Record<string, unknown>;
     }) => void;
   } | null;
   updatingTargetId: string | null;
@@ -2215,11 +2305,13 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
       name,
       measurement_type,
       status,
+      graph_config,
     }: {
       target: GoalTarget;
       name: string;
       measurement_type: TargetMeasurementType;
       status: GoalTarget["status"];
+      graph_config?: Record<string, unknown>;
     }) => {
       const response = await callEdgeFunctionHttp(`${GOAL_TARGETS_EDGE_PATH}?target_id=${encodeURIComponent(target.id)}`, {
         method: "PATCH",
@@ -2227,6 +2319,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
           name,
           measurement_type,
           status,
+          ...(graph_config ? { graph_config } : {}),
         }),
       });
       if (!response.ok) {

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -816,6 +816,13 @@ function GoalTargetCard({
     editedGraphConfig.defaultChart !== String(normalizedGraphConfig.defaultChart) ||
     editedGraphConfig.source !== String(normalizedGraphConfig.source) ||
     editedGraphConfig.aggregation !== String(normalizedGraphConfig.aggregation);
+  const graphConfigIncomplete =
+    !target.graph_config ||
+    target.graph_config.defaultChart === undefined ||
+    target.graph_config.source === undefined ||
+    target.graph_config.aggregation === undefined;
+  const measurementTypeChanged = editMeasurementType !== target.measurement_type;
+  const shouldPersistGraphConfig = graphConfigChanged || graphConfigIncomplete || measurementTypeChanged;
   const isSaving = updatingTargetId === target.id && updateGoalTarget?.isLoading === true;
 
   useEffect(() => {
@@ -983,7 +990,7 @@ function GoalTargetCard({
                   name: editNameValue,
                   measurement_type: editMeasurementType,
                   status: editStatus,
-                  ...(graphConfigChanged ? { graph_config: editedGraphConfig } : {}),
+                  ...(shouldPersistGraphConfig ? { graph_config: editedGraphConfig } : {}),
                 });
                 setIsEditing(false);
               }}

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1563,6 +1563,127 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
   });
 
+  it("persists normalized graph config when a legacy target is edited without graph field changes", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "program-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              name: "Communication Program",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goals?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "goal-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              program_id: "program-1",
+              title: "Increase functional communication",
+              description: "Client uses functional communication.",
+              original_text: "Original clinical wording",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goal-targets?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "target-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              goal_id: "goal-1",
+              name: "Mands for help",
+              measurement_type: "correctIncorrect",
+              graph_config: { defaultChart: "bar", source: "trial_events" },
+              status: "active",
+              sort_order: 0,
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "PATCH" && path === "/api/goal-targets?target_id=target-1") {
+        const body = JSON.parse(String(init?.body));
+        return new Response(
+          JSON.stringify({
+            id: "target-1",
+            organization_id: ORG_ID,
+            client_id: "client-1",
+            goal_id: "goal-1",
+            name: "Mands for help independently",
+            measurement_type: "correctIncorrect",
+            graph_config: body.graph_config,
+            status: "active",
+            sort_order: 0,
+            created_at: "2026-02-11T00:00:00.000Z",
+            updated_at: "2026-02-12T00:00:00.000Z",
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/trial-events?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "midtier",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findByText("Mands for help")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Edit target Mands for help" }));
+    fireEvent.change(screen.getByLabelText("Target name for Mands for help"), {
+      target: { value: "Mands for help independently" },
+    });
+    await user.click(screen.getByRole("button", { name: "Save target Mands for help" }));
+
+    await waitFor(() => {
+      expect(callEdgeFunctionHttp).toHaveBeenCalledWith(
+        "goal-targets?target_id=target-1",
+        expect.objectContaining({ method: "PATCH" }),
+      );
+    });
+    const updateCall = vi
+      .mocked(callEdgeFunctionHttp)
+      .mock.calls.find(([path, init]) => path === "goal-targets?target_id=target-1" && init?.method === "PATCH");
+    const body = JSON.parse(String(updateCall?.[1]?.body)) as {
+      graph_config?: Record<string, unknown>;
+    };
+    expect(body.graph_config).toEqual({
+      defaultChart: "bar",
+      source: "trial_events",
+      aggregation: "session_summary",
+    });
+  });
+
   it("does not expose existing target editing to view-only therapist roles", async () => {
     vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
       const method = (init?.method ?? "GET").toUpperCase();

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1245,10 +1245,12 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
         return new Response(JSON.stringify([targetRecord]), { status: 200 });
       }
       if (method === "PATCH" && path === "/api/goal-targets?target_id=target-1") {
+        const body = JSON.parse(String(init?.body));
         targetRecord = {
           ...targetRecord,
           name: "Mands for help independently",
           measurement_type: "correctIncorrect",
+          graph_config: body.graph_config,
           status: "mastered",
           updated_at: "2026-02-12T00:00:00.000Z",
         };
@@ -1309,11 +1311,256 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     };
     expect(body.measurement_type).toBe("correctIncorrect");
     expect(body.status).toBe("mastered");
-    expect(body.graph_config).toBeUndefined();
+    expect(body.graph_config).toEqual({
+      defaultChart: "bar",
+      source: "trial_events",
+      aggregation: "session_summary",
+    });
     expect(showSuccess).toHaveBeenCalledWith("Target updated");
     expect(await screen.findByText("Mands for help independently")).toBeInTheDocument();
     expect(screen.getByText("Measurement: Correct / incorrect")).toBeInTheDocument();
     expect(screen.getByText(/Graph: bar from/i)).toBeInTheDocument();
+  });
+
+  it("lets a midtier edit an existing goal target graph configuration", async () => {
+    let targetRecord = {
+      id: "target-1",
+      organization_id: ORG_ID,
+      client_id: "client-1",
+      goal_id: "goal-1",
+      name: "Mands for help",
+      measurement_type: "frequency",
+      graph_config: { defaultChart: "bar", source: "trial_events", aggregation: "sum" },
+      status: "active",
+      sort_order: 0,
+      created_at: "2026-02-11T00:00:00.000Z",
+      updated_at: "2026-02-11T00:00:00.000Z",
+    };
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "program-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              name: "Communication Program",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goals?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "goal-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              program_id: "program-1",
+              title: "Increase functional communication",
+              description: "Client uses functional communication.",
+              original_text: "Original clinical wording",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goal-targets?")) {
+        return new Response(JSON.stringify([targetRecord]), { status: 200 });
+      }
+      if (method === "PATCH" && path === "/api/goal-targets?target_id=target-1") {
+        targetRecord = {
+          ...targetRecord,
+          graph_config: { defaultChart: "line", source: "session_notes", aggregation: "session_summary" },
+          updated_at: "2026-02-12T00:00:00.000Z",
+        };
+        return new Response(JSON.stringify(targetRecord), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/trial-events?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "midtier",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findByText("Mands for help")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Edit target Mands for help" }));
+
+    fireEvent.change(screen.getByLabelText("Graph chart for Mands for help"), {
+      target: { value: "line" },
+    });
+    fireEvent.change(screen.getByLabelText("Graph source for Mands for help"), {
+      target: { value: "session_notes" },
+    });
+    fireEvent.change(screen.getByLabelText("Graph aggregation for Mands for help"), {
+      target: { value: "session_summary" },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save target Mands for help" }));
+
+    await waitFor(() => {
+      expect(callEdgeFunctionHttp).toHaveBeenCalledWith(
+        "goal-targets?target_id=target-1",
+        expect.objectContaining({
+          method: "PATCH",
+        }),
+      );
+    });
+    const updateCall = vi
+      .mocked(callEdgeFunctionHttp)
+      .mock.calls.find(([path, init]) => path === "goal-targets?target_id=target-1" && init?.method === "PATCH");
+    const body = JSON.parse(String(updateCall?.[1]?.body)) as {
+      graph_config?: Record<string, unknown>;
+    };
+    expect(body.graph_config).toEqual({
+      defaultChart: "line",
+      source: "session_notes",
+      aggregation: "session_summary",
+    });
+    expect(showSuccess).toHaveBeenCalledWith("Target updated");
+    expect(await screen.findByText(/Graph: line from session_notes/i)).toBeInTheDocument();
+  });
+
+  it("keeps frequency target graph aggregation aligned with creation defaults when stored config is incomplete", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && path.startsWith("/api/programs?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "program-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              name: "Communication Program",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goals?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "goal-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              program_id: "program-1",
+              title: "Increase functional communication",
+              description: "Client uses functional communication.",
+              original_text: "Original clinical wording",
+              status: "active",
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/goal-targets?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "target-1",
+              organization_id: ORG_ID,
+              client_id: "client-1",
+              goal_id: "goal-1",
+              name: "Mands for help",
+              measurement_type: "frequency",
+              graph_config: { defaultChart: "bar", source: "trial_events" },
+              status: "active",
+              sort_order: 0,
+              created_at: "2026-02-11T00:00:00.000Z",
+              updated_at: "2026-02-11T00:00:00.000Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (method === "PATCH" && path === "/api/goal-targets?target_id=target-1") {
+        const body = JSON.parse(String(init?.body));
+        return new Response(
+          JSON.stringify({
+            id: "target-1",
+            organization_id: ORG_ID,
+            client_id: "client-1",
+            goal_id: "goal-1",
+            name: "Mands for help",
+            measurement_type: "frequency",
+            graph_config: body.graph_config,
+            status: "active",
+            sort_order: 0,
+            created_at: "2026-02-11T00:00:00.000Z",
+            updated_at: "2026-02-12T00:00:00.000Z",
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "GET" && path.startsWith("/api/trial-events?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+        return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "midtier",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findByText("Mands for help")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Edit target Mands for help" }));
+    fireEvent.change(screen.getByLabelText("Graph chart for Mands for help"), {
+      target: { value: "line" },
+    });
+    await user.click(screen.getByRole("button", { name: "Save target Mands for help" }));
+
+    await waitFor(() => {
+      expect(callEdgeFunctionHttp).toHaveBeenCalledWith(
+        "goal-targets?target_id=target-1",
+        expect.objectContaining({ method: "PATCH" }),
+      );
+    });
+    const updateCall = vi
+      .mocked(callEdgeFunctionHttp)
+      .mock.calls.find(([path, init]) => path === "goal-targets?target_id=target-1" && init?.method === "PATCH");
+    const body = JSON.parse(String(updateCall?.[1]?.body)) as {
+      graph_config?: Record<string, unknown>;
+    };
+    expect(body.graph_config).toEqual({
+      defaultChart: "line",
+      source: "trial_events",
+      aggregation: "sum",
+    });
   });
 
   it("does not expose existing target editing to view-only therapist roles", async () => {


### PR DESCRIPTION
## Summary
- Extends goal target editing with graph config controls for chart type, source, and aggregation.
- Keeps measurement type and graph aggregation aligned by re-normalizing aggregation defaults when the target measurement type changes.
- Adds regression coverage for direct graph config edits, legacy/incomplete graph configs, and the frequency-to-correct/incorrect measurement drift path.

## Verification
- TDD red: `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx -t "lets a midtier edit an existing goal target graph configuration" --reporter=verbose` failed before graph controls existed.
- TDD red: `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx -t "keeps frequency target graph aggregation aligned" --reporter=verbose` failed before frequency default normalization.
- TDD red: `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx -t "lets a midtier edit an existing goal target through the goal-targets PATCH route" --reporter=verbose` failed before measurement-type changes emitted normalized `graph_config`.
- `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx -t "target" --reporter=verbose` (pass after final rebase: 8 passed, 59 skipped)
- `npx vitest run src/components/__tests__/ProgramsGoalsTab.test.tsx --reporter=verbose` (pass: 67 passed)
- `npm run ci:check-focused` (pass; DB/CI-only checks skipped locally as expected without `SUPABASE_DB_URL`/CI parity flags)
- `npm run lint` (pass)
- `npm run typecheck` (pass)
- `npm run test:ci` (pass: 366 files passed, 1 skipped; 2375 tests passed, 1 skipped)
- `npm run ci:verify-coverage` (pass: line coverage 92.07% >= 86%)
- `npm run build` (pass)
- `npm run test:routes:tier0` (pass: 7 specs, 220 tests)

## Notes
- No backend, auth policy, Supabase, migration, or CI files changed.
- Target criteria editing remains out of scope because target criteria is goal-level data in the current schema/API, not a target-level field.