### PR TITLE
WIN-215 Enforce goal target lifecycle authorization

### DIFF
--- a/cypress/e2e/goal_target_lifecycle.cy.ts
+++ b/cypress/e2e/goal_target_lifecycle.cy.ts
@@ -1,0 +1,291 @@
+/// <reference types="cypress" />
+
+type TestRole = "midtier" | "bcba";
+type DeleteMode = "success" | "conflict";
+
+const jsonHeaders = { "content-type": "application/json" };
+const organizationId = "00000000-0000-0000-0000-000000000001";
+const nowIso = "2026-07-10T00:00:00.000Z";
+
+const syntheticClient = {
+  id: "client-1",
+  organization_id: organizationId,
+  full_name: "Synthetic Lifecycle Client",
+  email: "synthetic-client@example.test",
+  date_of_birth: "2018-01-01",
+  insurance_info: {},
+  service_preference: [],
+  one_to_one_units: 0,
+  supervision_units: 0,
+  parent_consult_units: 0,
+  assessment_units: 0,
+  auth_units: 0,
+  availability_hours: {},
+  created_at: nowIso,
+};
+
+const syntheticProgram = {
+  id: "program-1",
+  organization_id: organizationId,
+  client_id: syntheticClient.id,
+  name: "Synthetic Communication Program",
+  description: "Synthetic browser-only program",
+  status: "active",
+  created_at: nowIso,
+  updated_at: nowIso,
+};
+
+const syntheticGoal = {
+  id: "goal-1",
+  organization_id: organizationId,
+  client_id: syntheticClient.id,
+  program_id: syntheticProgram.id,
+  domain_id: null,
+  title: "Synthetic Functional Communication Goal",
+  description: "Synthetic browser-only goal",
+  original_text: "Synthetic source wording",
+  measurement_type: "frequency",
+  status: "active",
+  source: "manual",
+  created_at: nowIso,
+  updated_at: nowIso,
+};
+
+const buildTargets = () => [
+  {
+    id: "target-active",
+    organization_id: organizationId,
+    client_id: syntheticClient.id,
+    goal_id: syntheticGoal.id,
+    name: "Synthetic Active Target",
+    measurement_type: "frequency",
+    graph_config: { defaultChart: "bar", source: "trial_events", aggregation: "sum" },
+    status: "active",
+    sort_order: 0,
+    created_at: nowIso,
+    updated_at: nowIso,
+  },
+  {
+    id: "target-archived",
+    organization_id: organizationId,
+    client_id: syntheticClient.id,
+    goal_id: syntheticGoal.id,
+    name: "Synthetic Archived Target",
+    measurement_type: "frequency",
+    graph_config: { defaultChart: "bar", source: "trial_events", aggregation: "sum" },
+    status: "archived",
+    sort_order: 1,
+    created_at: nowIso,
+    updated_at: nowIso,
+  },
+];
+
+const seedAuth = (role: TestRole): void => {
+  cy.visit("/clients/client-1?tab=programs-goals", {
+    onBeforeLoad(win) {
+      win.localStorage.setItem("auth-storage", JSON.stringify({
+        user: {
+          id: `stub-${role}`,
+          email: `${role}@example.test`,
+          role,
+          full_name: `${role} synthetic tester`,
+        },
+        role,
+        accessToken: `stub-access-token-${role}`,
+        refreshToken: `stub-refresh-token-${role}`,
+        expiresAt: Date.now() + 3_600_000,
+        profile: {
+          id: `stub-${role}`,
+          email: `${role}@example.test`,
+          role,
+          organization_id: organizationId,
+          is_active: true,
+          created_at: nowIso,
+          updated_at: nowIso,
+        },
+      }));
+    },
+  });
+  cy.wait("@runtimeConfig");
+};
+
+const installLifecycleStubs = (deleteMode: DeleteMode = "success"): void => {
+  let targets = buildTargets();
+
+  cy.intercept("**/(rest|auth|storage)/v1/**", (req) => {
+    throw new Error(`Unstubbed Supabase request in goal-target lifecycle spec: ${req.method} ${req.url}`);
+  });
+  cy.intercept("**/functions/v1/**", (req) => {
+    throw new Error(`Unstubbed Edge request in goal-target lifecycle spec: ${req.method} ${req.url}`);
+  });
+
+  cy.intercept("GET", "**/auth/v1/user", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: { user: null },
+  });
+  cy.intercept("GET", "**/rest/v1/profiles**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  });
+  cy.intercept("GET", "**/rest/v1/user_roles**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  });
+  cy.intercept("GET", "**/rest/v1/user_therapist_links**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [{ therapist_id: "synthetic-staff-1" }],
+  });
+  cy.intercept("GET", "**/rest/v1/client_therapist_links**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [{ client_id: syntheticClient.id, therapist_id: "synthetic-staff-1" }],
+  });
+  cy.intercept("GET", "**/rest/v1/clients**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: syntheticClient,
+  }).as("clientDetail");
+  cy.intercept("GET", "**/rest/v1/sessions**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  });
+  cy.intercept("GET", "**/rest/v1/client_issues**", {
+    statusCode: 200,
+    headers: { ...jsonHeaders, "content-range": "0-0/0" },
+    body: [],
+  });
+  cy.intercept("HEAD", "**/rest/v1/client_issues**", {
+    statusCode: 200,
+    headers: { "content-range": "0-0/0" },
+  });
+  cy.intercept("GET", "**/rest/v1/authorizations**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  });
+  cy.intercept("GET", "**/rest/v1/goal_domains**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  });
+
+  cy.intercept("GET", "**/functions/v1/programs**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [syntheticProgram],
+  }).as("programs");
+  cy.intercept("GET", "**/functions/v1/goals**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [syntheticGoal],
+  }).as("goals");
+  cy.intercept("GET", "**/functions/v1/goal-targets**", (req) => {
+    req.reply({ statusCode: 200, headers: jsonHeaders, body: targets });
+  }).as("goalTargets");
+  cy.intercept("PATCH", "**/functions/v1/goal-targets**", (req) => {
+    const targetId = new URL(req.url).searchParams.get("target_id");
+    const requestedStatus = req.body?.status as "active" | "archived";
+    const existing = targets.find((target) => target.id === targetId);
+    if (!existing) {
+      req.reply({ statusCode: 404, headers: jsonHeaders, body: { error: "Goal target not found" } });
+      return;
+    }
+    targets = targets.map((target) => target.id === targetId ? { ...target, status: requestedStatus } : target);
+    req.reply({ statusCode: 200, headers: jsonHeaders, body: { ...existing, status: requestedStatus } });
+  }).as("patchGoalTarget");
+  cy.intercept("DELETE", "**/functions/v1/goal-targets**", (req) => {
+    const targetId = new URL(req.url).searchParams.get("target_id");
+    if (deleteMode === "conflict") {
+      req.reply({
+        statusCode: 409,
+        headers: jsonHeaders,
+        body: { error: "Goal target has trial history and cannot be deleted" },
+      });
+      return;
+    }
+    targets = targets.filter((target) => target.id !== targetId);
+    req.reply({ statusCode: 200, headers: jsonHeaders, body: { id: targetId } });
+  }).as("deleteGoalTarget");
+  cy.intercept("GET", "**/functions/v1/trial-events**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  });
+  cy.intercept("GET", "**/functions/v1/program-notes**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  });
+  cy.intercept("GET", "**/api/assessment-documents**", {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: [],
+  });
+};
+
+describe("goal target lifecycle", () => {
+  it("allows midtier Archive and Restore actions but never exposes Delete", () => {
+    installLifecycleStubs();
+    seedAuth("midtier");
+
+    cy.get('[aria-label="Archive target Synthetic Active Target"]').should("be.visible");
+    cy.get('[aria-label^="Delete target"]').should("not.exist");
+    cy.get('[aria-label="Archive target Synthetic Active Target"]').click();
+    cy.wait("@patchGoalTarget").its("request.body").should("deep.equal", { status: "archived" });
+    cy.contains("Synthetic Active Target").should("not.exist");
+
+    cy.contains("button", "Show archived targets").click();
+    cy.contains("Synthetic Active Target").should("be.visible");
+    cy.get('[aria-label="Restore target Synthetic Archived Target"]').should("be.visible");
+    cy.get('[aria-label^="Delete target"]').should("not.exist");
+
+    cy.get('[aria-label="Restore target Synthetic Archived Target"]').click();
+    cy.wait("@patchGoalTarget").its("request.body").should("deep.equal", { status: "active" });
+    cy.get('[aria-label^="Delete target"]').should("not.exist");
+  });
+
+  it("limits BCBA Delete to archived targets, honors cancellation, and removes on success", () => {
+    installLifecycleStubs();
+    seedAuth("bcba");
+    let shouldConfirmDelete = false;
+
+    cy.get('[aria-label="Delete target Synthetic Active Target"]').should("not.exist");
+    cy.contains("button", "Show archived targets").click();
+    cy.get('[aria-label="Delete target Synthetic Archived Target"]').should("be.visible");
+
+    cy.window().then((win) => {
+      cy.stub(win, "confirm").callsFake(() => shouldConfirmDelete);
+    });
+    cy.get('[aria-label="Delete target Synthetic Archived Target"]').click();
+    cy.get("@deleteGoalTarget.all").should("have.length", 0);
+    cy.contains("Synthetic Archived Target").should("be.visible");
+
+    cy.then(() => {
+      shouldConfirmDelete = true;
+    });
+    cy.get('[aria-label="Delete target Synthetic Archived Target"]').click();
+    cy.wait("@deleteGoalTarget").its("response.statusCode").should("eq", 200);
+    cy.contains("Synthetic Archived Target").should("not.exist");
+  });
+
+  it("retains the archived target and Delete action after a 409 conflict", () => {
+    installLifecycleStubs("conflict");
+    seedAuth("bcba");
+
+    cy.contains("button", "Show archived targets").click();
+    cy.window().then((win) => {
+      cy.stub(win, "confirm").returns(true);
+    });
+    cy.get('[aria-label="Delete target Synthetic Archived Target"]').click();
+    cy.wait("@deleteGoalTarget").its("response.statusCode").should("eq", 409);
+
+    cy.contains("Goal target has trial history and cannot be deleted").should("be.visible");
+    cy.contains("Synthetic Archived Target").should("be.visible");
+    cy.get('[aria-label="Delete target Synthetic Archived Target"]').should("be.visible");
+  });
+});

--- a/docs/superpowers/plans/2026-07-10-goal-target-lifecycle-authz.md
+++ b/docs/superpowers/plans/2026-07-10-goal-target-lifecycle-authz.md
@@ -86,3 +86,15 @@
 - [ ] Compare hosted migration/function state, apply only the new migration, deploy `goal-targets`, and verify the live function version and catalog grants.
 - [ ] Use synthetic same-org role fixtures or safe transactional SQL to prove BCBA success, midtier denial, cross-org denial, and referenced-target preservation without exposing production data.
 - [ ] Run `pr-hygiene`, commit, push, open a PR linked to `WIN-215`, update Linear to In Review, and report live checks/blockers.
+
+## Execution Handoff
+
+- Status: implementation and hosted enforcement complete; PR preparation in progress.
+- Lane: `critical` (auth, RLS/grants, tenant-sensitive migration, server and Edge boundaries).
+- Delivered scope: exact BCBA/super-admin delete capability; midtier archive/restore without delete; archived/unused/same-org RLS deletion; non-cascading trial-history preservation; server/Edge/UI parity.
+- Focused verification: 7 files / 119 tests passed; dedicated Cypress lifecycle spec 3/3 passed.
+- Full local verification: `npm run verify:local` passed, including policy checks, lint, typecheck, test/coverage, build, and 220/220 tier-0 route tests. `npm run validate:tenant` also passed.
+- Hosted proof: both migrations applied; `goal-targets` Edge v3 active with JWT verification; authenticated synthetic midtier archive/restore succeeded and delete returned zero rows; BCBA deleted only archived unused data; active/history/cross-org checks denied; trial history remained; synthetic cleanup counts were zero.
+- Advisor follow-through: the exposed public capability wrapper was changed to `SECURITY INVOKER`; the follow-up security advisor returned no goal-target lifecycle findings.
+- Blocked check: `npm run ci:playwright` preflight passed, then hosted auth rejected the configured super-admin credential as invalid before product smoke execution.
+- Stop condition: no further lifecycle or permission expansion without fresh routing.

--- a/docs/superpowers/plans/2026-07-10-goal-target-lifecycle-authz.md
+++ b/docs/superpowers/plans/2026-07-10-goal-target-lifecycle-authz.md
@@ -1,0 +1,88 @@
+# Goal Target Lifecycle Authorization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove that midtier users can archive/restore goal targets but cannot hard-delete, while BCBA users can hard-delete only archived, unused, same-organization targets.
+
+**Architecture:** A dedicated exact-role capability plus a strict RLS DELETE policy own the destructive authorization invariant, while the non-cascading foreign key remains the final history guard. Edge and server adapters preflight for clear errors and delete through request-scoped credentials, while the React UI presents explicit lifecycle actions and role-gates Delete.
+
+**Tech Stack:** React, TypeScript, Vitest, Supabase Edge Functions, PostgreSQL/RLS, React Query.
+
+## Global Constraints
+
+- Cross-organization mutation must remain impossible.
+- Trial history must never cascade-delete or be rewritten.
+- Hard-delete requires exact BCBA authority or the existing super-admin override, archived status, and zero referencing trial events.
+- Midtier may archive/restore but never hard-delete.
+- Authenticated DELETE is usable only through the strict same-org BCBA/super-admin RLS policy.
+- Edge and server fallback handlers must remain behaviorally equivalent.
+- Use red-green-refactor; no production code before a covering failing test.
+
+---
+
+### Task 1: Database lifecycle contract
+
+**Files:**
+- Create: `supabase/migrations/20260710153231_goal_target_lifecycle_authz.sql`
+- Create: `tests/goal-target-lifecycle-authz-migration.test.ts`
+
+**Interfaces:**
+- Produces: `app.current_user_can_delete_goal_targets(target_organization_id uuid) returns boolean` and restricted public wrapper.
+- Produces: `goal_targets_bcba_delete_archived_unused` authenticated DELETE RLS policy.
+
+- [ ] Write migration contract tests for restricted EXECUTE grants, caller/org/role checks, authenticated DELETE grant, same-org exact-role archived/unused RLS policy, and the unchanged non-cascading history constraint.
+- [ ] Run `npm test -- --run tests/goal-target-lifecycle-authz-migration.test.ts` and confirm RED because the generated migration/capability/policy do not exist.
+- [ ] Confirm `supabase migration new goal_target_lifecycle_authz` generated `20260710153231_goal_target_lifecycle_authz.sql` and keep all schema work in that file.
+- [ ] Implement the minimal exact-role capability, restricted public wrapper, authenticated DELETE grant, strict DELETE policy, and PostgREST schema reload without changing the non-cascading foreign key.
+- [ ] Re-run the targeted migration tests and confirm GREEN.
+
+### Task 2: Edge and server DELETE parity
+
+**Files:**
+- Modify: `supabase/functions/goal-targets/index.ts`
+- Modify: `src/server/api/goal-targets.ts`
+- Modify: `src/server/__tests__/goalTargetsHandler.test.ts`
+- Modify: `tests/goal-targets-trial-events-edge-access.test.ts`
+
+**Interfaces:**
+- Consumes: `current_user_can_delete_goal_targets`, target preflight reads, RLS-protected DELETE, and FK error code `23503`.
+- Produces: DELETE `?target_id=<uuid>` with 200/400/403/404/409/502 behavior.
+
+- [ ] Add failing server and Edge contract tests for invalid UUID, denied role, missing/out-of-scope target, non-archived target, target with history, RPC failure, and successful deletion.
+- [ ] Run the focused handler/Edge tests and confirm RED because DELETE returns 405.
+- [ ] Implement DELETE in both adapters using only request-scoped credentials, capability/status preflight, and the RLS-protected table delete; map FK/history failures to 409.
+- [ ] Re-run the focused tests and confirm GREEN.
+
+### Task 3: Role capability and explicit lifecycle UI
+
+**Files:**
+- Modify: `src/lib/roles.ts`
+- Modify: `src/lib/__tests__/roles.test.ts`
+- Modify: `src/components/ClientDetails/ProgramsGoalsTab.tsx`
+- Modify: `src/components/__tests__/ProgramsGoalsTab.test.tsx`
+
+**Interfaces:**
+- Produces: `deleteGoalTargets` capability for BCBA/super-admin.
+- Produces: explicit Archive, Restore, and Delete target actions with an archived section.
+
+- [ ] Add failing role tests for BCBA/super-admin delete capability and midtier denial.
+- [ ] Add failing UI tests for midtier archive/restore without Delete, BCBA archived-target Delete with confirmation, delete cancellation/error/success, active default list, and archived section toggle.
+- [ ] Run the focused role/UI tests and confirm RED.
+- [ ] Implement the capability, lifecycle mutations, filtering, archived section, confirmation, cache updates, and failure-safe loading state.
+- [ ] Re-run the focused tests and confirm GREEN.
+
+### Task 4: Protected-path verification and hosted proof
+
+**Files:**
+- Modify only generated database types if the RPC is represented there by the repository's established generation workflow.
+- Update: this plan/checklist and Linear issue `WIN-215` with executed evidence.
+
+**Interfaces:**
+- Consumes: Tasks 1-3 complete behavior.
+- Produces: verification card, reviewer verdicts, hosted migration/function proof, and PR-ready branch.
+
+- [ ] Run focused tests, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run validate:tenant`, `npm run test:routes:tier0`, `npm run build`, `npm run ci:playwright`, and `npm run verify:local`; record blocked checks separately.
+- [ ] Complete code-review, test, security, and Supabase specialist review; resolve all critical/important findings and re-run covering tests.
+- [ ] Compare hosted migration/function state, apply only the new migration, deploy `goal-targets`, and verify the live function version and catalog grants.
+- [ ] Use synthetic same-org role fixtures or safe transactional SQL to prove BCBA success, midtier denial, cross-org denial, and referenced-target preservation without exposing production data.
+- [ ] Run `pr-hygiene`, commit, push, open a PR linked to `WIN-215`, update Linear to In Review, and report live checks/blockers.

--- a/docs/superpowers/specs/2026-07-10-goal-target-lifecycle-authz-design.md
+++ b/docs/superpowers/specs/2026-07-10-goal-target-lifecycle-authz-design.md
@@ -1,0 +1,43 @@
+# Goal Target Lifecycle Authorization Design
+
+## Objective
+
+Implement a tenant-safe target lifecycle in which a midtier can archive or restore a goal target, while only a BCBA (and the existing super-admin override) can hard-delete an eligible target.
+
+## Authorization contract
+
+- All reads and mutations remain scoped to the caller's active organization.
+- `manageProgramsGoals` continues to govern ordinary target creation and editing.
+- A new `deleteGoalTargets` frontend capability is granted only to `bcba` and `super_admin`; it controls presentation only and is never the security boundary.
+- Database deletion authority is checked from active `user_roles` through a dedicated exact-role capability and a strict RLS DELETE policy. Midtier, therapist, admin, BT, client, and unauthenticated callers cannot hard-delete.
+- Midtier remains able to archive and restore through the existing authenticated PATCH boundary. “Archive only” refers to destructive lifecycle actions; this slice does not remove the established non-destructive target-edit permissions from midtier.
+
+## Data integrity contract
+
+- Hard deletion is allowed only when the target is already `archived` and no `trial_events` row references it.
+- A referenced target returns `TARGET_HAS_TRIAL_HISTORY`; the HTTP adapters map this to `409 Conflict` and instruct the caller to keep it archived.
+- A non-archived target returns `TARGET_NOT_ARCHIVED` and maps to `409 Conflict`.
+- Trial events are never deleted or cascaded by this feature.
+- Missing and out-of-scope targets return a non-disclosing `TARGET_NOT_FOUND` response.
+
+## Architecture
+
+The database owns the destructive invariant through `app.current_user_can_delete_goal_targets(uuid)`, a restricted public capability wrapper, and `goal_targets_bcba_delete_archived_unused`, an authenticated DELETE RLS policy. The policy requires the caller's active organization, exact BCBA or super-admin authority, archived status, and no visible trial history. Authenticated DELETE is granted only alongside this RLS policy; the non-cascading foreign key remains the authoritative concurrency and history guard.
+
+Both the Supabase Edge Function and the server fallback add DELETE support using the request-scoped client. They preflight the delete capability and target status for clear responses, then issue the RLS-protected DELETE. They share an HTTP response contract: 400 invalid identifier, 403 unauthorized, 404 missing/out-of-scope, 409 not archived or referenced, 502 capability validation failure, and 200 with the deleted target identifier on success.
+
+The Programs/Goals UI replaces status-dropdown-only lifecycle management with explicit Archive, Restore, and Delete actions. Active targets render by default; archived targets render in an expandable archived section. Delete is shown only when `deleteGoalTargets` is present and the target is archived. Confirmation names the target and explains irreversibility. Failed mutations retain visible state and display the server error.
+
+## Verification
+
+- Migration contract tests prove restricted capability EXECUTE grants, caller/org/exact-role checks, the DELETE grant plus strict RLS policy, archived/history guards, and the unchanged non-cascading foreign key.
+- Handler tests prove Edge/server parity for BCBA success and all error mappings.
+- Role/UI tests prove midtier archive/restore without Delete, BCBA Delete visibility, confirmation behavior, and archived filtering.
+- Tenant validation and hosted smoke prove cross-organization deletion is impossible and trial history is preserved.
+
+## Non-goals
+
+- Cascading or rewriting trial history.
+- Removing existing non-destructive midtier target-edit permissions.
+- Deleting goals or programs.
+- Broad role-system refactoring.

--- a/docs/superpowers/specs/2026-07-10-goal-target-lifecycle-authz-design.md
+++ b/docs/superpowers/specs/2026-07-10-goal-target-lifecycle-authz-design.md
@@ -15,10 +15,10 @@ Implement a tenant-safe target lifecycle in which a midtier can archive or resto
 ## Data integrity contract
 
 - Hard deletion is allowed only when the target is already `archived` and no `trial_events` row references it.
-- A referenced target returns `TARGET_HAS_TRIAL_HISTORY`; the HTTP adapters map this to `409 Conflict` and instruct the caller to keep it archived.
-- A non-archived target returns `TARGET_NOT_ARCHIVED` and maps to `409 Conflict`.
+- A referenced target maps to `409 Conflict`: a PostgreSQL foreign-key conflict returns `Goal target has trial history and cannot be deleted`; a strict-RLS zero-row delete after archived preflight returns `Goal target has trial history or is no longer eligible for deletion`.
+- A non-archived target returns `409 Conflict` with `Only archived goal targets can be deleted`.
 - Trial events are never deleted or cascaded by this feature.
-- Missing and out-of-scope targets return a non-disclosing `TARGET_NOT_FOUND` response.
+- Missing and out-of-scope targets return a non-disclosing `404 Goal target not found` response.
 
 ## Architecture
 

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -775,16 +775,32 @@ function GoalFieldList({
 }
 
 function GoalTargetCard({
+  canDelete,
   clientId,
+  deleteGoalTarget,
+  deletingTargetId,
   goalTargetsLoading,
+  lifecycleTargetId,
   organizationId,
+  setGoalTargetArchiveState,
   target,
   updateGoalTarget,
   updatingTargetId,
 }: {
+  canDelete: boolean;
   clientId: string;
+  deleteGoalTarget: {
+    isLoading: boolean;
+    mutate: (target: GoalTarget) => void;
+  };
+  deletingTargetId: string | null;
   goalTargetsLoading: boolean;
+  lifecycleTargetId: string | null;
   organizationId: string | null;
+  setGoalTargetArchiveState: {
+    isLoading: boolean;
+    mutate: (input: { target: GoalTarget; status: "active" | "archived" }) => void;
+  } | null;
   target: GoalTarget;
   updateGoalTarget: {
     isLoading: boolean;
@@ -824,6 +840,9 @@ function GoalTargetCard({
   const measurementTypeChanged = editMeasurementType !== target.measurement_type;
   const shouldPersistGraphConfig = graphConfigChanged || graphConfigIncomplete || measurementTypeChanged;
   const isSaving = updatingTargetId === target.id && updateGoalTarget?.isLoading === true;
+  const isLifecyclePending = lifecycleTargetId === target.id && setGoalTargetArchiveState?.isLoading === true;
+  const isDeleting = deletingTargetId === target.id && deleteGoalTarget.isLoading;
+  const lifecycleActionsBusy = lifecycleTargetId !== null || deletingTargetId !== null;
 
   useEffect(() => {
     if (isEditing) return;
@@ -858,7 +877,7 @@ function GoalTargetCard({
           <span className="rounded-full bg-slate-100 px-2 py-0.5 uppercase text-slate-500 dark:bg-slate-800 dark:text-slate-300">
             {target.status}
           </span>
-          {updateGoalTarget && (
+          {updateGoalTarget && target.status !== "archived" && (
             <button
               type="button"
               aria-label={isEditing ? `Cancel editing target ${target.name}` : `Edit target ${target.name}`}
@@ -875,6 +894,36 @@ function GoalTargetCard({
               className="rounded-md border border-slate-200 p-1.5 text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 disabled:opacity-50"
             >
               {isEditing ? <X className="h-3.5 w-3.5" aria-hidden="true" /> : <Pencil className="h-3.5 w-3.5" aria-hidden="true" />}
+            </button>
+          )}
+          {setGoalTargetArchiveState && (
+            <button
+              type="button"
+              aria-label={`${target.status === "archived" ? "Restore" : "Archive"} target ${target.name}`}
+              onClick={() => setGoalTargetArchiveState.mutate({
+                target,
+                status: target.status === "archived" ? "active" : "archived",
+              })}
+              disabled={lifecycleActionsBusy}
+              className="rounded-md border border-slate-200 px-2 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 disabled:opacity-50"
+            >
+              {isLifecyclePending ? "Saving..." : target.status === "archived" ? "Restore" : "Archive"}
+            </button>
+          )}
+          {canDelete && target.status === "archived" && (
+            <button
+              type="button"
+              aria-label={`Delete target ${target.name}`}
+              onClick={() => {
+                const confirmed = typeof window === "undefined" || window.confirm(
+                  `Delete target "${target.name}"? This action is irreversible.`,
+                );
+                if (confirmed) deleteGoalTarget.mutate(target);
+              }}
+              disabled={lifecycleActionsBusy}
+              className="rounded-md border border-rose-200 px-2 py-1.5 text-xs font-medium text-rose-700 hover:bg-rose-50 dark:border-rose-800 dark:text-rose-300 dark:hover:bg-rose-900/30 disabled:opacity-50"
+            >
+              {isDeleting ? "Deleting..." : "Delete"}
             </button>
           )}
         </div>
@@ -1024,12 +1073,17 @@ function GoalTargetCard({
 function GoalCard({
   archivingGoalId,
   archiveGoal,
+  canDeleteGoalTargets,
   clientId,
+  deleteGoalTarget,
+  deletingTargetId,
   domainsById,
   goal,
   goalTargetsForGoal,
   goalTargetsLoading,
+  lifecycleTargetId,
   organizationId,
+  setGoalTargetArchiveState,
   updateGoalTarget,
   updatingTargetId,
 }: {
@@ -1038,12 +1092,23 @@ function GoalCard({
     isLoading: boolean;
     mutate: (goal: Goal) => void;
   };
+  canDeleteGoalTargets: boolean;
   clientId: string;
+  deleteGoalTarget: {
+    isLoading: boolean;
+    mutate: (target: GoalTarget) => void;
+  };
+  deletingTargetId: string | null;
   domainsById: Record<string, GoalDomain>;
   goal: Goal;
   goalTargetsForGoal: GoalTarget[];
   goalTargetsLoading: boolean;
+  lifecycleTargetId: string | null;
   organizationId: string | null;
+  setGoalTargetArchiveState: {
+    isLoading: boolean;
+    mutate: (input: { target: GoalTarget; status: "active" | "archived" }) => void;
+  } | null;
   updateGoalTarget: {
     isLoading: boolean;
     mutate: (input: {
@@ -1056,6 +1121,26 @@ function GoalCard({
   } | null;
   updatingTargetId: string | null;
 }) {
+  const [showArchivedTargets, setShowArchivedTargets] = useState(false);
+  const activeTargets = goalTargetsForGoal.filter((target) => target.status !== "archived");
+  const archivedTargets = goalTargetsForGoal.filter((target) => target.status === "archived");
+  const renderTargetCard = (target: GoalTarget) => (
+    <GoalTargetCard
+      key={target.id}
+      canDelete={canDeleteGoalTargets}
+      clientId={clientId}
+      deleteGoalTarget={deleteGoalTarget}
+      deletingTargetId={deletingTargetId}
+      goalTargetsLoading={goalTargetsLoading}
+      lifecycleTargetId={lifecycleTargetId}
+      organizationId={organizationId}
+      setGoalTargetArchiveState={setGoalTargetArchiveState}
+      target={target}
+      updateGoalTarget={updateGoalTarget}
+      updatingTargetId={updatingTargetId}
+    />
+  );
+
   return (
     <div className="rounded-md border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-dark-lighter/30">
       <div className="flex items-start justify-between gap-2">
@@ -1107,17 +1192,26 @@ function GoalCard({
           <p className="text-xs text-slate-500">No target-level measurement definitions yet.</p>
         ) : (
           <div className="space-y-3">
-            {goalTargetsForGoal.map((target) => (
-              <GoalTargetCard
-                key={target.id}
-                clientId={clientId}
-                goalTargetsLoading={goalTargetsLoading}
-                organizationId={organizationId}
-                target={target}
-                updateGoalTarget={updateGoalTarget}
-                updatingTargetId={updatingTargetId}
-              />
-            ))}
+            {activeTargets.length === 0 && !showArchivedTargets && (
+              <p className="text-xs text-slate-500">No active targets.</p>
+            )}
+            {activeTargets.map(renderTargetCard)}
+            {archivedTargets.length > 0 && (
+              <button
+                type="button"
+                aria-expanded={showArchivedTargets}
+                onClick={() => setShowArchivedTargets((current) => !current)}
+                className="rounded-md border border-slate-200 px-2 py-1.5 text-xs font-medium text-slate-600 hover:bg-white dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+              >
+                {showArchivedTargets ? "Hide archived targets" : `Show archived targets (${archivedTargets.length})`}
+              </button>
+            )}
+            {showArchivedTargets && archivedTargets.length > 0 && (
+              <section aria-label="Archived targets" className="space-y-3 border-t border-slate-200 pt-3 dark:border-slate-700">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Archived targets</p>
+                {archivedTargets.map(renderTargetCard)}
+              </section>
+            )}
           </div>
         )}
       </div>
@@ -1130,6 +1224,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const organizationId = useActiveOrganizationId();
   const { hasCapability, session } = useAuth();
   const canManageProgramsGoals = hasCapability("manageProgramsGoals");
+  const canDeleteGoalTargets = hasCapability("deleteGoalTargets");
   const publishSectionRef = useRef<HTMLDivElement | null>(null);
   const assessmentDocumentsQueryKey = ["assessment-documents", client.id, organizationId ?? "MISSING_ORG"] as const;
   const clientProgramsQueryKey = buildClientProgramsQueryKey(client.id, organizationId);
@@ -1199,6 +1294,8 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
   const [archivingProgramId, setArchivingProgramId] = useState<string | null>(null);
   const [archivingGoalId, setArchivingGoalId] = useState<string | null>(null);
   const [updatingTargetId, setUpdatingTargetId] = useState<string | null>(null);
+  const [lifecycleTargetId, setLifecycleTargetId] = useState<string | null>(null);
+  const [deletingTargetId, setDeletingTargetId] = useState<string | null>(null);
   const [isUploadProcessing, setIsUploadProcessing] = useState(false);
   const [assessmentDocumentsNeedsRetry, setAssessmentDocumentsNeedsRetry] = useState(false);
 
@@ -2347,6 +2444,67 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
     onError: showError,
     onSettled: () => {
       setUpdatingTargetId(null);
+    },
+  });
+
+  const setGoalTargetArchiveState = useMutation({
+    mutationFn: async ({
+      target,
+      status,
+    }: {
+      target: GoalTarget;
+      status: "active" | "archived";
+    }) => {
+      const response = await callEdgeFunctionHttp(
+        `${GOAL_TARGETS_EDGE_PATH}?target_id=${encodeURIComponent(target.id)}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ status }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(await parseApiErrorMessage(response, `Failed to ${status === "archived" ? "archive" : "restore"} target.`));
+      }
+      return parseJson<GoalTarget>(response);
+    },
+    onMutate: ({ target }) => {
+      setLifecycleTargetId(target.id);
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData<GoalTarget[]>(goalTargetsQueryKey, (current) =>
+        mapById(current, updated.id, (currentTarget) => ({ ...currentTarget, ...updated })),
+      );
+      showSuccess(updated.status === "archived" ? "Target archived" : "Target restored");
+    },
+    onError: showError,
+    onSettled: () => {
+      setLifecycleTargetId(null);
+    },
+  });
+
+  const deleteGoalTarget = useMutation({
+    mutationFn: async (target: GoalTarget) => {
+      const response = await callEdgeFunctionHttp(
+        `${GOAL_TARGETS_EDGE_PATH}?target_id=${encodeURIComponent(target.id)}`,
+        { method: "DELETE" },
+      );
+      if (!response.ok) {
+        throw new Error(await parseApiErrorMessage(response, "Failed to delete target."));
+      }
+      return target;
+    },
+    onMutate: (target) => {
+      setDeletingTargetId(target.id);
+    },
+    onSuccess: (deleted) => {
+      queryClient.setQueryData<GoalTarget[]>(goalTargetsQueryKey, (current) =>
+        (current ?? []).filter((target) => target.id !== deleted.id),
+      );
+      showSuccess(`Target "${deleted.name}" deleted`);
+    },
+    onError: showError,
+    onSettled: () => {
+      setDeletingTargetId(null);
     },
   });
 
@@ -3517,12 +3675,17 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                                 key={goal.id}
                                 archiveGoal={archiveGoal}
                                 archivingGoalId={archivingGoalId}
+                                canDeleteGoalTargets={canDeleteGoalTargets}
                                 clientId={client.id}
+                                deleteGoalTarget={deleteGoalTarget}
+                                deletingTargetId={deletingTargetId}
                                 domainsById={goalDomainsById}
                                 goal={goal}
                                 goalTargetsForGoal={targetsByGoalId[goal.id] ?? []}
                                 goalTargetsLoading={goalTargetsLoading}
+                                lifecycleTargetId={lifecycleTargetId}
                                 organizationId={organizationId}
+                                setGoalTargetArchiveState={canManageProgramsGoals ? setGoalTargetArchiveState : null}
                                 updateGoalTarget={canManageProgramsGoals ? updateGoalTarget : null}
                                 updatingTargetId={updatingTargetId}
                               />

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -70,6 +70,99 @@ const buildClient = (overrides: Partial<ProgramsGoalsTabClient> = {}): ProgramsG
   ...overrides,
 });
 
+type LifecycleTarget = {
+  id: string;
+  organization_id: string;
+  client_id: string;
+  goal_id: string;
+  name: string;
+  measurement_type: "frequency";
+  graph_config: { defaultChart: "bar"; source: "trial_events" };
+  status: "active" | "archived";
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+};
+
+const buildLifecycleTarget = (
+  id: string,
+  name: string,
+  status: LifecycleTarget["status"],
+): LifecycleTarget => ({
+  id,
+  organization_id: ORG_ID,
+  client_id: "client-1",
+  goal_id: "goal-1",
+  name,
+  measurement_type: "frequency",
+  graph_config: { defaultChart: "bar", source: "trial_events" },
+  status,
+  sort_order: 0,
+  created_at: "2026-02-11T00:00:00.000Z",
+  updated_at: "2026-02-11T00:00:00.000Z",
+});
+
+const mockGoalTargetLifecycleApi = (
+  initialTargets: LifecycleTarget[],
+  deleteResponse: Response = new Response(JSON.stringify({ deleted_target_id: "target-archived" }), { status: 200 }),
+) => {
+  let targets = initialTargets;
+  vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (method === "GET" && path.startsWith("/api/programs?")) {
+      return new Response(JSON.stringify([{
+        id: "program-1",
+        organization_id: ORG_ID,
+        client_id: "client-1",
+        name: "Communication Program",
+        status: "active",
+        created_at: "2026-02-11T00:00:00.000Z",
+        updated_at: "2026-02-11T00:00:00.000Z",
+      }]), { status: 200 });
+    }
+    if (method === "GET" && path.startsWith("/api/goals?")) {
+      return new Response(JSON.stringify([{
+        id: "goal-1",
+        organization_id: ORG_ID,
+        client_id: "client-1",
+        program_id: "program-1",
+        title: "Increase functional communication",
+        description: "Client uses functional communication.",
+        original_text: "Original clinical wording",
+        status: "active",
+        created_at: "2026-02-11T00:00:00.000Z",
+        updated_at: "2026-02-11T00:00:00.000Z",
+      }]), { status: 200 });
+    }
+    if (method === "GET" && path.startsWith("/api/goal-targets?")) {
+      return new Response(JSON.stringify(targets), { status: 200 });
+    }
+    if (method === "PATCH" && path.startsWith("/api/goal-targets?target_id=")) {
+      const targetId = new URL(path, "http://localhost").searchParams.get("target_id");
+      const body = JSON.parse(String(init?.body)) as { status: LifecycleTarget["status"] };
+      const updated = targets.find((target) => target.id === targetId);
+      if (!updated) return new Response(JSON.stringify({ error: "Not found" }), { status: 404 });
+      targets = targets.map((target) => target.id === targetId ? { ...target, status: body.status } : target);
+      return new Response(JSON.stringify({ ...updated, status: body.status }), { status: 200 });
+    }
+    if (method === "DELETE" && path.startsWith("/api/goal-targets?target_id=")) {
+      if (deleteResponse.ok) {
+        const targetId = new URL(path, "http://localhost").searchParams.get("target_id");
+        targets = targets.filter((target) => target.id !== targetId);
+      }
+      return deleteResponse.clone();
+    }
+    if (method === "GET" && path.startsWith("/api/trial-events?")) return new Response(JSON.stringify([]), { status: 200 });
+    if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+    if (method === "GET" && path.startsWith("/api/assessment-documents?")) return new Response(JSON.stringify([]), { status: 200 });
+    if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify([]), { status: 200 });
+    if (method === "GET" && path.startsWith("/api/assessment-drafts?")) {
+      return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+    }
+    return new Response(JSON.stringify({ error: "Not handled in lifecycle test" }), { status: 500 });
+  });
+};
+
 const buildAcceptedDraftGoals = () => [
   ...Array.from({ length: 20 }, (_, index) => ({
     id: `child-${index + 1}`,
@@ -1320,6 +1413,183 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(await screen.findByText("Mands for help independently")).toBeInTheDocument();
     expect(screen.getByText("Measurement: Correct / incorrect")).toBeInTheDocument();
     expect(screen.getByText(/Graph: bar from/i)).toBeInTheDocument();
+  });
+
+  it("gives midtier explicit Archive and Restore actions without exposing Delete", async () => {
+    mockGoalTargetLifecycleApi([
+      buildLifecycleTarget("target-active", "Mands for help", "active"),
+      buildLifecycleTarget("target-archived", "Archived imitation", "archived"),
+    ]);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "midtier",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findByText("Mands for help")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Delete target/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Archive target Mands for help" }));
+    await waitFor(() => {
+      expect(callEdgeFunctionHttp).toHaveBeenCalledWith(
+        "goal-targets?target_id=target-active",
+        expect.objectContaining({ method: "PATCH", body: JSON.stringify({ status: "archived" }) }),
+      );
+    });
+    expect(showSuccess).toHaveBeenCalledWith("Target archived");
+    expect(screen.queryByText("Mands for help")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Show archived targets/i }));
+    expect(await screen.findByText("Archived imitation")).toBeInTheDocument();
+    expect(screen.getByText("Mands for help")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Restore target Archived imitation" }));
+    await waitFor(() => {
+      expect(callEdgeFunctionHttp).toHaveBeenCalledWith(
+        "goal-targets?target_id=target-archived",
+        expect.objectContaining({ method: "PATCH", body: JSON.stringify({ status: "active" }) }),
+      );
+    });
+    expect(showSuccess).toHaveBeenCalledWith("Target restored");
+    expect(screen.getByText("Archived imitation")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Delete target/i })).not.toBeInTheDocument();
+  });
+
+  it("cancels BCBA target deletion without issuing a request", async () => {
+    mockGoalTargetLifecycleApi([
+      buildLifecycleTarget("target-archived", "Archived imitation", "archived"),
+    ]);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: { role: "bcba", organizationId: ORG_ID, accessToken: "test-access-token" },
+    });
+
+    await user.click(await screen.findByRole("button", { name: /Show archived targets/i }));
+    await user.click(screen.getByRole("button", { name: "Delete target Archived imitation" }));
+
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringMatching(/Archived imitation.*irreversible/i));
+    expect(
+      vi.mocked(callEdgeFunctionHttp).mock.calls.some(([, init]) => init?.method === "DELETE"),
+    ).toBe(false);
+    expect(screen.getByText("Archived imitation")).toBeInTheDocument();
+  });
+
+  it("shows BCBA Delete only for archived targets and requires irreversible confirmation", async () => {
+    mockGoalTargetLifecycleApi([
+      buildLifecycleTarget("target-active", "Mands for help", "active"),
+      buildLifecycleTarget("target-archived", "Archived imitation", "archived"),
+    ]);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "bcba",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    expect(await screen.findByText("Mands for help")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete target Mands for help" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Show archived targets/i }));
+
+    await user.click(screen.getByRole("button", { name: "Delete target Archived imitation" }));
+
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringMatching(/Archived imitation.*irreversible/i));
+    await waitFor(() => {
+      expect(callEdgeFunctionHttp).toHaveBeenCalledWith(
+        "goal-targets?target_id=target-archived",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+    await waitFor(() => expect(screen.queryByText("Archived imitation")).not.toBeInTheDocument());
+    expect(showSuccess).toHaveBeenCalledWith('Target "Archived imitation" deleted');
+  });
+
+  it("retains an archived target when BCBA deletion fails", async () => {
+    mockGoalTargetLifecycleApi(
+      [buildLifecycleTarget("target-archived", "Archived imitation", "archived")],
+      new Response(JSON.stringify({ error: "Goal target has trial history and cannot be deleted" }), { status: 409 }),
+    );
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: {
+        role: "bcba",
+        organizationId: ORG_ID,
+        accessToken: "test-access-token",
+      },
+    });
+
+    await user.click(await screen.findByRole("button", { name: /Show archived targets/i }));
+    expect(await screen.findByText("Archived imitation")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Delete target Archived imitation" }));
+
+    await waitFor(() => {
+      expect(vi.mocked(showError).mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({ message: "Goal target has trial history and cannot be deleted" }),
+      );
+    });
+    expect(screen.getByText("Archived imitation")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete target Archived imitation" })).toBeEnabled();
+  });
+
+  it("disables every target lifecycle action while an archive request is pending", async () => {
+    mockGoalTargetLifecycleApi([
+      buildLifecycleTarget("target-active", "Mands for help", "active"),
+      buildLifecycleTarget("target-archived", "Archived imitation", "archived"),
+    ]);
+    const baseApi = vi.mocked(callApi).getMockImplementation();
+    vi.mocked(callApi).mockImplementation((path: string, init?: RequestInit) => {
+      if (init?.method === "PATCH" && path === "/api/goal-targets?target_id=target-active") {
+        return new Promise<Response>(() => {});
+      }
+      return baseApi!(path, init);
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: { role: "bcba", organizationId: ORG_ID, accessToken: "test-access-token" },
+    });
+
+    await user.click(await screen.findByRole("button", { name: /Show archived targets/i }));
+    await user.click(screen.getByRole("button", { name: "Archive target Mands for help" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Archive target Mands for help" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Restore target Archived imitation" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Delete target Archived imitation" })).toBeDisabled();
+    });
+  });
+
+  it("disables every target lifecycle action while a delete request is pending", async () => {
+    mockGoalTargetLifecycleApi([
+      buildLifecycleTarget("target-active", "Mands for help", "active"),
+      buildLifecycleTarget("target-archived", "Archived imitation", "archived"),
+    ]);
+    const baseApi = vi.mocked(callApi).getMockImplementation();
+    vi.mocked(callApi).mockImplementation((path: string, init?: RequestInit) => {
+      if (init?.method === "DELETE" && path === "/api/goal-targets?target_id=target-archived") {
+        return new Promise<Response>(() => {});
+      }
+      return baseApi!(path, init);
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: { role: "bcba", organizationId: ORG_ID, accessToken: "test-access-token" },
+    });
+
+    await user.click(await screen.findByRole("button", { name: /Show archived targets/i }));
+    await user.click(screen.getByRole("button", { name: "Delete target Archived imitation" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Archive target Mands for help" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Restore target Archived imitation" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Delete target Archived imitation" })).toBeDisabled();
+    });
   });
 
   it("lets a midtier edit an existing goal target graph configuration", async () => {

--- a/src/lib/__tests__/roles.test.ts
+++ b/src/lib/__tests__/roles.test.ts
@@ -18,6 +18,15 @@ describe('role capability matrix', () => {
     expect(roleHasCapability('bcba', 'viewSettings')).toBe(true);
   });
 
+  it('reserves hard-delete of goal targets for BCBA and super-admin', () => {
+    expect(rolesForCapability('deleteGoalTargets')).toEqual(['bcba', 'super_admin']);
+    expect(roleHasCapability('bcba', 'deleteGoalTargets')).toBe(true);
+    expect(roleHasCapability('super_admin', 'deleteGoalTargets')).toBe(true);
+    expect(roleHasCapability('midtier', 'deleteGoalTargets')).toBe(false);
+    expect(roleHasCapability('admin', 'deleteGoalTargets')).toBe(false);
+    expect(roleHasCapability('therapist', 'deleteGoalTargets')).toBe(false);
+  });
+
   it('keeps admin_schedule and BT scoped to their exact capabilities', () => {
     expect(roleHasCapability('admin_schedule', 'manageClients')).toBe(true);
     expect(roleHasCapability('admin_schedule', 'manageProgramsGoals')).toBe(false);

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -12,6 +12,7 @@ export type AppCapability =
   | 'accessSuperAdminTools'
   | 'assignClientsToStaff'
   | 'dataTaking'
+  | 'deleteGoalTargets'
   | 'lockSessionNotes'
   | 'manageAuthorizations'
   | 'manageClients'
@@ -70,6 +71,7 @@ const allCapabilities: readonly AppCapability[] = [
   'accessSuperAdminTools',
   'assignClientsToStaff',
   'dataTaking',
+  'deleteGoalTargets',
   'lockSessionNotes',
   'manageAuthorizations',
   'manageClients',
@@ -169,6 +171,7 @@ export const ROLE_CAPABILITIES: Record<AppRole, readonly AppCapability[]> = {
   bcba: [
     'assignClientsToStaff',
     'dataTaking',
+    'deleteGoalTargets',
     'lockSessionNotes',
     'manageAuthorizations',
     'manageClients',

--- a/src/server/__tests__/goalTargetsHandler.test.ts
+++ b/src/server/__tests__/goalTargetsHandler.test.ts
@@ -5,6 +5,7 @@ vi.mock("../api/shared", async () => {
   const actual = await vi.importActual<typeof import("../api/shared")>("../api/shared");
   return {
     ...actual,
+    currentUserCanDeleteGoalTargets: vi.fn(),
     currentUserCanManageProgramsGoals: vi.fn(),
     fetchJson: vi.fn(),
     getAccessToken: vi.fn(),
@@ -15,6 +16,7 @@ vi.mock("../api/shared", async () => {
 });
 
 import {
+  currentUserCanDeleteGoalTargets,
   currentUserCanManageProgramsGoals,
   fetchJson,
   getAccessToken,
@@ -26,6 +28,7 @@ import {
 const ACCESS_TOKEN = "token-123";
 const ORG_ID = "11111111-1111-4111-8111-111111111111";
 const GOAL_ID = "22222222-2222-4222-8222-222222222222";
+const TARGET_ID = "33333333-3333-4333-8333-333333333333";
 
 describe("goalTargetsHandler", () => {
   beforeEach(() => {
@@ -101,5 +104,220 @@ describe("goalTargetsHandler", () => {
       expect.stringContaining("/rest/v1/goal_targets?select=*&organization_id=eq."),
       expect.objectContaining({ method: "GET" }),
     );
+  });
+
+  it("returns 400 when DELETE target_id is missing", async () => {
+    const response = await goalTargetsHandler(
+      new Request("http://localhost/api/goal-targets", { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "target_id is required" });
+    expect(currentUserCanDeleteGoalTargets).not.toHaveBeenCalled();
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when DELETE target_id is not a UUID", async () => {
+    const response = await goalTargetsHandler(
+      new Request("http://localhost/api/goal-targets?target_id=not-a-uuid", { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "target_id must be a valid UUID" });
+    expect(currentUserCanDeleteGoalTargets).not.toHaveBeenCalled();
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("denies DELETE when the exact goal-target delete capability rejects the caller", async () => {
+    vi.mocked(currentUserCanDeleteGoalTargets).mockResolvedValue({ allowed: false, upstreamError: false });
+
+    const response = await goalTargetsHandler(
+      new Request(`http://localhost/api/goal-targets?target_id=${TARGET_ID}`, { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+    expect(currentUserCanDeleteGoalTargets).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID);
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when the exact goal-target delete capability cannot be validated", async () => {
+    vi.mocked(currentUserCanDeleteGoalTargets).mockResolvedValue({ allowed: false, upstreamError: true });
+
+    const response = await goalTargetsHandler(
+      new Request(`http://localhost/api/goal-targets?target_id=${TARGET_ID}`, { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "Unable to validate goal-target delete access" });
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("deletes an archived unused target through request-scoped RLS credentials", async () => {
+    vi.mocked(currentUserCanDeleteGoalTargets).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: TARGET_ID, status: "archived" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: TARGET_ID }],
+      });
+
+    const response = await goalTargetsHandler(
+      new Request(`http://localhost/api/goal-targets?target_id=${TARGET_ID}`, { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: TARGET_ID });
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining(
+        `/rest/v1/goal_targets?select=id,status&id=eq.${TARGET_ID}&organization_id=eq.${ORG_ID}&limit=1`,
+      ),
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: `Bearer ${ACCESS_TOKEN}` }),
+      }),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining(`/rest/v1/goal_targets?id=eq.${TARGET_ID}&organization_id=eq.${ORG_ID}`),
+      expect.objectContaining({
+        method: "DELETE",
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${ACCESS_TOKEN}`,
+          Prefer: "return=representation",
+        }),
+      }),
+    );
+  });
+
+  it("returns actionable 409 when the database preserves a target with trial history", async () => {
+    vi.mocked(currentUserCanDeleteGoalTargets).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: TARGET_ID, status: "archived" }],
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        data: {
+          code: "23503",
+          message: "update or delete on table goal_targets violates foreign key constraint",
+        },
+      });
+
+    const response = await goalTargetsHandler(
+      new Request(`http://localhost/api/goal-targets?target_id=${TARGET_ID}`, { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: "Goal target has trial history and cannot be deleted",
+    });
+    expect(fetchJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 409 without deleting when the target is not archived", async () => {
+    vi.mocked(currentUserCanDeleteGoalTargets).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [{ id: TARGET_ID, status: "active" }],
+    });
+
+    const response = await goalTargetsHandler(
+      new Request(`http://localhost/api/goal-targets?target_id=${TARGET_ID}`, { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: "Only archived goal targets can be deleted" });
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("returns 409 when RLS preserves an archived target with an empty delete representation", async () => {
+    vi.mocked(currentUserCanDeleteGoalTargets).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: TARGET_ID, status: "archived" }],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] });
+
+    const response = await goalTargetsHandler(
+      new Request(`http://localhost/api/goal-targets?target_id=${TARGET_ID}`, { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: "Goal target has trial history or is no longer eligible for deletion",
+    });
+  });
+
+  it("returns 404 without DELETE when the target is missing or outside the active organization", async () => {
+    vi.mocked(currentUserCanDeleteGoalTargets).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson).mockResolvedValueOnce({ ok: true, status: 200, data: [] });
+
+    const response = await goalTargetsHandler(
+      new Request(`http://localhost/api/goal-targets?target_id=${TARGET_ID}`, { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Goal target not found" });
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("returns 502 when the same-organization target preflight fails", async () => {
+    vi.mocked(currentUserCanDeleteGoalTargets).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      data: { message: "upstream unavailable" },
+    });
+
+    const response = await goalTargetsHandler(
+      new Request(`http://localhost/api/goal-targets?target_id=${TARGET_ID}`, { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "Failed to load goal target" });
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 502 when an eligible target DELETE fails for a non-history infrastructure error", async () => {
+    vi.mocked(currentUserCanDeleteGoalTargets).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: TARGET_ID, status: "archived" }],
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        data: { code: "08006", message: "connection failure" },
+      });
+
+    const response = await goalTargetsHandler(
+      new Request(`http://localhost/api/goal-targets?target_id=${TARGET_ID}`, { method: "DELETE" }),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "Failed to delete goal target" });
   });
 });

--- a/src/server/__tests__/sharedGoalTargetCapability.test.ts
+++ b/src/server/__tests__/sharedGoalTargetCapability.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../env", () => ({
+  getOptionalServerEnv: (key: string) => {
+    if (key === "SUPABASE_URL") return "https://example.supabase.co/";
+    if (key === "SUPABASE_ANON_KEY") return "anon-key";
+    return undefined;
+  },
+  getRequiredServerEnv: vi.fn(),
+}));
+
+import { currentUserCanDeleteGoalTargets } from "../api/shared";
+
+describe("currentUserCanDeleteGoalTargets", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls the restricted RPC with bearer credentials and organization scope", async () => {
+    fetchMock.mockResolvedValue(new Response("true", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    await expect(currentUserCanDeleteGoalTargets("access-token", "org-1")).resolves.toEqual({
+      allowed: true,
+      upstreamError: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.supabase.co/rest/v1/rpc/current_user_can_delete_goal_targets",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          apikey: "anon-key",
+          Authorization: "Bearer access-token",
+        },
+        body: JSON.stringify({ target_organization_id: "org-1" }),
+      },
+    );
+  });
+});

--- a/src/server/api/goal-targets.ts
+++ b/src/server/api/goal-targets.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   CORS_HEADERS,
+  currentUserCanDeleteGoalTargets,
   currentUserCanManageProgramsGoals,
   fetchJson,
   getAccessToken,
@@ -116,6 +117,65 @@ export async function goalTargetsHandler(request: Request): Promise<Response> {
       return json({ error: "Failed to load goal targets" }, result.status || 500);
     }
     return json(result.data ?? []);
+  }
+
+  if (request.method === "DELETE") {
+    const url = new URL(request.url);
+    const targetId = url.searchParams.get("target_id");
+    if (!targetId) {
+      return json({ error: "target_id is required" }, 400);
+    }
+    if (!isUuid(targetId)) {
+      return json({ error: "target_id must be a valid UUID" }, 400);
+    }
+
+    const canDelete = await currentUserCanDeleteGoalTargets(accessToken, organizationId);
+    if (canDelete.upstreamError) {
+      return json({ error: "Unable to validate goal-target delete access" }, 502);
+    }
+    if (!canDelete.allowed) {
+      return json({ error: "Forbidden" }, 403);
+    }
+
+    const encodedTargetId = encodeURIComponent(targetId);
+    const encodedOrganizationId = encodeURIComponent(organizationId);
+    const targetResult = await fetchJson<Array<{ id: string; status: string }>>(
+      `${supabaseUrl}/rest/v1/goal_targets?select=id,status&id=eq.${encodedTargetId}&organization_id=eq.${encodedOrganizationId}&limit=1`,
+      { method: "GET", headers },
+    );
+    if (!targetResult.ok) {
+      return json({ error: "Failed to load goal target" }, 502);
+    }
+    const target = Array.isArray(targetResult.data) ? targetResult.data[0] : null;
+    if (!target) {
+      return json({ error: "Goal target not found" }, 404);
+    }
+    if (target.status !== "archived") {
+      return json({ error: "Only archived goal targets can be deleted" }, 409);
+    }
+
+    const deleteResult = await fetchJson<Array<{ id: string }>>(
+      `${supabaseUrl}/rest/v1/goal_targets?id=eq.${encodedTargetId}&organization_id=eq.${encodedOrganizationId}`,
+      {
+        method: "DELETE",
+        headers: { ...headers, Prefer: "return=representation" },
+      },
+    );
+    if (!deleteResult.ok) {
+      const errorCode =
+        deleteResult.data && !Array.isArray(deleteResult.data) && typeof deleteResult.data === "object"
+          ? (deleteResult.data as { code?: unknown }).code
+          : null;
+      if (errorCode === "23503") {
+        return json({ error: "Goal target has trial history and cannot be deleted" }, 409);
+      }
+      return json({ error: "Failed to delete goal target" }, 502);
+    }
+    const deleted = Array.isArray(deleteResult.data) ? deleteResult.data[0] : null;
+    if (!deleted) {
+      return json({ error: "Goal target has trial history or is no longer eligible for deletion" }, 409);
+    }
+    return json(deleted);
   }
 
   if (request.method === "POST") {

--- a/src/server/api/shared.ts
+++ b/src/server/api/shared.ts
@@ -263,6 +263,27 @@ export async function currentUserCanManageProgramsGoals(
   return { allowed: result.data === true, upstreamError: false };
 }
 
+export async function currentUserCanDeleteGoalTargets(
+  accessToken: string,
+  organizationId: string,
+): Promise<{ allowed: boolean; upstreamError: boolean }> {
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const result = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/current_user_can_delete_goal_targets`, {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      apikey: anonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ target_organization_id: organizationId }),
+  });
+
+  if (!result.ok) {
+    return { allowed: false, upstreamError: true };
+  }
+  return { allowed: result.data === true, upstreamError: false };
+}
+
 export async function currentUserCanTakeClientData(
   accessToken: string,
   organizationId: string,

--- a/supabase/functions/goal-targets/index.ts
+++ b/supabase/functions/goal-targets/index.ts
@@ -65,6 +65,20 @@ const currentUserCanManageProgramsGoals = async (
   return { allowed: data === true, upstreamError: false };
 };
 
+const currentUserCanDeleteGoalTargets = async (
+  db: ReturnType<typeof createRequestClient>,
+  orgId: string,
+): Promise<CapabilityResult> => {
+  const { data, error } = await db.rpc("current_user_can_delete_goal_targets", {
+    target_organization_id: orgId,
+  });
+  if (error) {
+    console.error("current_user_can_delete_goal_targets rpc error", error);
+    return { allowed: false, upstreamError: true };
+  }
+  return { allowed: data === true, upstreamError: false };
+};
+
 const loadGoalScope = async (
   db: ReturnType<typeof createRequestClient>,
   orgId: string,
@@ -114,6 +128,46 @@ export const handleGoalTargets = async (req: Request) => {
     const { data, error } = await query;
     if (error) return json(req, { error: "Failed to load goal targets" }, 500);
     return json(req, data ?? []);
+  }
+
+  if (req.method === "DELETE") {
+    const url = new URL(req.url);
+    const targetId = url.searchParams.get("target_id");
+    if (!targetId) return json(req, { error: "target_id is required" }, 400);
+    if (!isUuid(targetId)) return json(req, { error: "target_id must be a valid UUID" }, 400);
+
+    const canDelete = await currentUserCanDeleteGoalTargets(db, orgId);
+    if (canDelete.upstreamError) return json(req, { error: "Unable to validate goal-target delete access" }, 502);
+    if (!canDelete.allowed) return json(req, { error: "Forbidden" }, 403);
+
+    const { data: targets, error: targetError } = await db
+      .from("goal_targets")
+      .select("id,status")
+      .eq("organization_id", orgId)
+      .eq("id", targetId)
+      .limit(1);
+    if (targetError) return json(req, { error: "Failed to load goal target" }, 502);
+    const target = targets?.[0] as { id: string; status: string } | undefined;
+    if (!target) return json(req, { error: "Goal target not found" }, 404);
+    if (target.status !== "archived") {
+      return json(req, { error: "Only archived goal targets can be deleted" }, 409);
+    }
+
+    const { data, error } = await db
+      .from("goal_targets")
+      .delete()
+      .eq("organization_id", orgId)
+      .eq("id", targetId)
+      .select("id")
+      .limit(1);
+    if (error && error.code === "23503") {
+      return json(req, { error: "Goal target has trial history and cannot be deleted" }, 409);
+    }
+    if (error) return json(req, { error: "Failed to delete goal target" }, 502);
+    if (!data || data.length === 0) {
+      return json(req, { error: "Goal target has trial history or is no longer eligible for deletion" }, 409);
+    }
+    return json(req, data[0]);
   }
 
   const allowed = await currentUserCanManageProgramsGoals(db, orgId);

--- a/supabase/migrations/20260710153231_goal_target_lifecycle_authz.sql
+++ b/supabase/migrations/20260710153231_goal_target_lifecycle_authz.sql
@@ -1,0 +1,57 @@
+-- @migration-intent: Add exact BCBA goal-target deletion authority while preserving organization scope and trial history.
+-- @migration-dependencies: 20260706023600_bcba_exact_capability_matrix.sql,20260703173000_goal_targets_trial_events.sql,20260707121500_super_admin_bcba_role_precedence.sql
+-- @migration-rollback: Drop the goal-target delete policy and delete capability wrappers, then revoke DELETE on public.goal_targets from authenticated.
+
+begin;
+
+create or replace function app.current_user_can_delete_goal_targets(target_organization_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select app.current_user_has_exact_role_for_org(
+    target_organization_id,
+    array['bcba']::text[]
+  );
+$$;
+
+revoke execute on function app.current_user_can_delete_goal_targets(uuid) from public, anon;
+grant execute on function app.current_user_can_delete_goal_targets(uuid) to authenticated, service_role;
+
+create or replace function public.current_user_can_delete_goal_targets(target_organization_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select app.current_user_can_delete_goal_targets(target_organization_id);
+$$;
+
+revoke execute on function public.current_user_can_delete_goal_targets(uuid) from public, anon;
+grant execute on function public.current_user_can_delete_goal_targets(uuid) to authenticated, service_role;
+
+revoke delete on table public.goal_targets from anon;
+grant delete on table public.goal_targets to authenticated;
+
+drop policy if exists goal_targets_bcba_delete_archived_unused on public.goal_targets;
+create policy goal_targets_bcba_delete_archived_unused
+  on public.goal_targets
+  for delete
+  to authenticated
+  using (
+    organization_id = app.current_user_organization_id()
+    and app.current_user_can_delete_goal_targets(organization_id)
+    and status = 'archived'
+    and not exists (
+      select 1
+      from public.trial_events
+      where trial_events.target_id = goal_targets.id
+    )
+  );
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260710161038_goal_target_delete_capability_invoker.sql
+++ b/supabase/migrations/20260710161038_goal_target_delete_capability_invoker.sql
@@ -1,0 +1,11 @@
+-- @migration-intent: Keep the public goal-target delete capability wrapper invoker-scoped so the exposed RPC does not elevate authenticated callers.
+-- @migration-dependencies: 20260710153231_goal_target_lifecycle_authz.sql
+-- @migration-rollback: Restore SECURITY DEFINER only if the public wrapper must elevate callers; the app helper remains the narrowly scoped authority boundary.
+
+begin;
+
+alter function public.current_user_can_delete_goal_targets(uuid) security invoker;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/edge/goal-targets.parity.contract.test.ts
+++ b/tests/edge/goal-targets.parity.contract.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stubDenoEnv } from "../utils/stubDeno";
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const TARGET_ID = "33333333-3333-4333-8333-333333333333";
+
+stubDenoEnv((key) => {
+  if (key === "CORS_ALLOWED_ORIGINS") return "https://app.example.com";
+  if (key === "APP_ENV") return "production";
+  return "";
+});
+
+const createRequestClientMock = vi.fn();
+
+async function loadGoalTargetsModule() {
+  vi.doMock("../../supabase/functions/_shared/database.ts", () => ({
+    createRequestClient: createRequestClientMock,
+  }));
+  return import("../../supabase/functions/goal-targets/index.ts");
+}
+
+const buildDb = ({
+  deleteCapabilityData = true,
+  deleteCapabilityError = null,
+  preflightData = [{ id: TARGET_ID, status: "archived" }],
+  preflightError = null,
+  deleteData = [{ id: TARGET_ID }],
+  deleteError = null,
+}: {
+  deleteCapabilityData?: boolean;
+  deleteCapabilityError?: { message: string } | null;
+  preflightData?: Array<{ id: string; status: string }>;
+  preflightError?: { code?: string; message: string } | null;
+  deleteData?: Array<{ id: string }>;
+  deleteError?: { code?: string; message: string } | null;
+} = {}) => {
+  const deleteMock = vi.fn(() => ({
+    eq: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          limit: vi.fn(async () => ({ data: deleteData, error: deleteError })),
+        })),
+      })),
+    })),
+  }));
+  const db = {
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: { id: "bcba-1" } }, error: null })),
+    },
+    rpc: vi.fn(async (name: string) => {
+      if (name === "current_user_organization_id") return { data: ORG_ID, error: null };
+      if (name === "current_user_can_delete_goal_targets") {
+        return { data: deleteCapabilityData, error: deleteCapabilityError };
+      }
+      throw new Error(`Unexpected RPC: ${name}`);
+    }),
+    from: vi.fn((table: string) => {
+      if (table !== "goal_targets") throw new Error(`Unexpected table: ${table}`);
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              limit: vi.fn(async () => ({ data: preflightData, error: preflightError })),
+            })),
+          })),
+        })),
+        delete: deleteMock,
+      };
+    }),
+  };
+  return { db, deleteMock };
+};
+
+const deleteRequest = () => new Request(
+  `https://edge.example.com/functions/v1/goal-targets?target_id=${TARGET_ID}`,
+  { method: "DELETE", headers: { Authorization: "Bearer token" } },
+);
+
+describe("goal-targets Edge/server DELETE parity", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    createRequestClientMock.mockReset();
+  });
+
+  it("returns 400 for missing target_id", async () => {
+    const { db, deleteMock } = buildDb();
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(
+      new Request("https://edge.example.com/functions/v1/goal-targets", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "target_id is required" });
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid target_id", async () => {
+    const { db, deleteMock } = buildDb();
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(
+      new Request("https://edge.example.com/functions/v1/goal-targets?target_id=invalid", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "target_id must be a valid UUID" });
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when delete capability denies the caller", async () => {
+    const { db, deleteMock } = buildDb({ deleteCapabilityData: false });
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(deleteRequest());
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(db.from).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when delete capability cannot be validated", async () => {
+    const { db, deleteMock } = buildDb({
+      deleteCapabilityData: false,
+      deleteCapabilityError: { message: "RPC unavailable" },
+    });
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(deleteRequest());
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: "Unable to validate goal-target delete access" });
+    expect(db.from).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 without DELETE for a non-archived target", async () => {
+    const { db, deleteMock } = buildDb({
+      preflightData: [{ id: TARGET_ID, status: "active" }],
+    });
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(deleteRequest());
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Only archived goal targets can be deleted" });
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("maps FK history preservation to actionable 409", async () => {
+    const { db } = buildDb({
+      deleteError: { code: "23503", message: "trial_events_target_id_fkey" },
+    });
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(deleteRequest());
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Goal target has trial history and cannot be deleted",
+    });
+  });
+
+  it("returns the deleted target representation on success", async () => {
+    const { db, deleteMock } = buildDb();
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(deleteRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: TARGET_ID });
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 404 without DELETE for a missing or cross-organization target", async () => {
+    const { db, deleteMock } = buildDb({ preflightData: [] });
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(deleteRequest());
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Goal target not found" });
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when RLS preserves a preflighted archived target", async () => {
+    const { db, deleteMock } = buildDb({ deleteData: [] });
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(deleteRequest());
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Goal target has trial history or is no longer eligible for deletion",
+    });
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 502 for target-preflight infrastructure errors", async () => {
+    const { db, deleteMock } = buildDb({
+      preflightError: { message: "upstream unavailable" },
+    });
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(deleteRequest());
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to load goal target" });
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 for non-history DELETE infrastructure errors", async () => {
+    const { db } = buildDb({
+      deleteError: { code: "08006", message: "connection failure" },
+    });
+    createRequestClientMock.mockReturnValue(db);
+    const module = await loadGoalTargetsModule();
+
+    const response = await module.handleGoalTargets(deleteRequest());
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to delete goal target" });
+  });
+});

--- a/tests/goal-targets-trial-events-edge-access.test.ts
+++ b/tests/goal-targets-trial-events-edge-access.test.ts
@@ -18,6 +18,43 @@ describe("goal target and trial event edge access boundaries", () => {
     expect(goalTargetsSource).toContain("if (allowed.upstreamError) return json(req, { error: \"Unable to validate program-goal access\" }, 502);");
   });
 
+  it("uses the exact goal-target delete capability and preserves its upstream failure distinction", () => {
+    expect(goalTargetsSource).toContain('db.rpc("current_user_can_delete_goal_targets", {');
+    expect(goalTargetsSource).toContain("target_organization_id: orgId");
+    expect(goalTargetsSource).toContain(
+      'if (canDelete.upstreamError) return json(req, { error: "Unable to validate goal-target delete access" }, 502);',
+    );
+    expect(goalTargetsSource).toContain('if (!canDelete.allowed) return json(req, { error: "Forbidden" }, 403);');
+  });
+
+  it("implements DELETE through the request-scoped client and same-organization RLS filters", () => {
+    expect(goalTargetsSource).toContain('if (req.method === "DELETE")');
+    expect(goalTargetsSource).toContain('const db = createRequestClient(req);');
+    expect(goalTargetsSource).not.toContain("supabaseAdmin");
+    expect(goalTargetsSource).toMatch(
+      /from\("goal_targets"\)[\s\S]*\.delete\(\)[\s\S]*\.eq\("organization_id", orgId\)[\s\S]*\.eq\("id", targetId\)/,
+    );
+  });
+
+  it("preflights archived status and maps preserved trial history to actionable conflicts", () => {
+    expect(goalTargetsSource).toContain('select("id,status")');
+    expect(goalTargetsSource).toContain('target.status !== "archived"');
+    expect(goalTargetsSource).toContain('json(req, { error: "Only archived goal targets can be deleted" }, 409)');
+    expect(goalTargetsSource).toContain('error.code === "23503"');
+    expect(goalTargetsSource).toContain(
+      'json(req, { error: "Goal target has trial history and cannot be deleted" }, 409)',
+    );
+    expect(goalTargetsSource).toContain(
+      'json(req, { error: "Goal target has trial history or is no longer eligible for deletion" }, 409)',
+    );
+  });
+
+  it("distinguishes target absence from upstream lifecycle infrastructure failures", () => {
+    expect(goalTargetsSource).toContain('if (!target) return json(req, { error: "Goal target not found" }, 404);');
+    expect(goalTargetsSource).toContain('if (targetError) return json(req, { error: "Failed to load goal target" }, 502);');
+    expect(goalTargetsSource).toContain('if (error) return json(req, { error: "Failed to delete goal target" }, 502);');
+  });
+
   it("does not collapse trial-event data-taking or lock RPC failures into normal denials", () => {
     expect(trialEventsSource).toContain("type CapabilityResult = { allowed: boolean; upstreamError: boolean }");
     expect(trialEventsSource).toContain("type LockStateResult = { locked: boolean; upstreamError: boolean }");

--- a/tests/integration/goal-target-lifecycle-migration.contract.test.ts
+++ b/tests/integration/goal-target-lifecycle-migration.contract.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const lifecycleMigration = readFileSync(
+  path.join(
+    process.cwd(),
+    "supabase",
+    "migrations",
+    "20260710153231_goal_target_lifecycle_authz.sql",
+  ),
+  "utf8",
+);
+
+const goalTargetsMigration = readFileSync(
+  path.join(
+    process.cwd(),
+    "supabase",
+    "migrations",
+    "20260703173000_goal_targets_trial_events.sql",
+  ),
+  "utf8",
+);
+
+const capabilityInvokerMigration = readFileSync(
+  path.join(
+    process.cwd(),
+    "supabase",
+    "migrations",
+    "20260710161038_goal_target_delete_capability_invoker.sql",
+  ),
+  "utf8",
+);
+
+describe("goal target lifecycle authorization migration", () => {
+  it("adds an exact BCBA delete capability and a restricted public wrapper", () => {
+    expect(lifecycleMigration).toContain(
+      "create or replace function app.current_user_can_delete_goal_targets(target_organization_id uuid)",
+    );
+    expect(lifecycleMigration).toMatch(
+      /app\.current_user_can_delete_goal_targets[\s\S]*app\.current_user_has_exact_role_for_org\([\s\S]*target_organization_id[\s\S]*array\['bcba'\]::text\[\][\s\S]*\)/i,
+    );
+    expect(lifecycleMigration).toContain(
+      "create or replace function public.current_user_can_delete_goal_targets(target_organization_id uuid)",
+    );
+    expect(lifecycleMigration).toContain(
+      "select app.current_user_can_delete_goal_targets(target_organization_id);",
+    );
+    expect(lifecycleMigration).toContain(
+      "grant execute on function public.current_user_can_delete_goal_targets(uuid) to authenticated, service_role;",
+    );
+    expect(lifecycleMigration).toContain(
+      "revoke execute on function public.current_user_can_delete_goal_targets(uuid) from public, anon;",
+    );
+  });
+
+  it("keeps the exposed capability wrapper invoker-scoped", () => {
+    expect(capabilityInvokerMigration).toContain(
+      "alter function public.current_user_can_delete_goal_targets(uuid) security invoker;",
+    );
+    expect(capabilityInvokerMigration).not.toMatch(
+      /alter function public\.current_user_can_delete_goal_targets\(uuid\) security definer/i,
+    );
+    expect(capabilityInvokerMigration).toContain("notify pgrst, 'reload schema';");
+  });
+
+  it("grants authenticated DELETE while continuing to deny anonymous callers", () => {
+    expect(lifecycleMigration).toContain(
+      "grant delete on table public.goal_targets to authenticated;",
+    );
+    expect(lifecycleMigration).toContain(
+      "revoke delete on table public.goal_targets from anon;",
+    );
+  });
+
+  it("limits authenticated DELETE to archived unused same-org targets for exact BCBA authority", () => {
+    expect(lifecycleMigration).toContain(
+      "create policy goal_targets_bcba_delete_archived_unused",
+    );
+
+    const deletePolicy = lifecycleMigration.match(
+      /create policy goal_targets_bcba_delete_archived_unused[\s\S]*?;/i,
+    )?.[0];
+
+    expect(deletePolicy).toBeDefined();
+    expect(deletePolicy).toMatch(/on public\.goal_targets[\s\S]*for delete[\s\S]*to authenticated/i);
+    expect(deletePolicy).toContain(
+      "organization_id = app.current_user_organization_id()",
+    );
+    expect(deletePolicy).toContain(
+      "app.current_user_can_delete_goal_targets(organization_id)",
+    );
+    expect(deletePolicy).toMatch(/status\s*=\s*'archived'/i);
+    expect(deletePolicy).toMatch(
+      /not exists\s*\([\s\S]*from public\.trial_events[\s\S]*target_id\s*=\s*goal_targets\.id[\s\S]*\)/i,
+    );
+    expect(deletePolicy).not.toContain("current_user_can_manage_programs_goals");
+  });
+
+  it("does not replace the non-cascading trial-event target foreign key", () => {
+    expect(goalTargetsMigration).toMatch(
+      /add constraint trial_events_target_id_fkey[\s\S]*foreign key \(target_id\) references public\.goal_targets\(id\)/i,
+    );
+    expect(goalTargetsMigration).not.toMatch(
+      /foreign key \(target_id\) references public\.goal_targets\(id\) on delete cascade/i,
+    );
+    expect(lifecycleMigration).not.toContain("drop constraint if exists trial_events_target_id_fkey");
+    expect(lifecycleMigration).not.toMatch(
+      /foreign key \(target_id\) references public\.goal_targets\(id\) on delete cascade/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add exact BCBA/super-admin goal-target delete capability while keeping midtier archive/restore-only
- enforce archived, unused, same-organization deletion in RLS and preserve trial history
- keep server and Edge DELETE behavior aligned and expose explicit Archive, Restore, and Delete UI actions
- link: WIN-215

## Verification

- npm run verify:local
- npm run validate:tenant
- focused Vitest: 7 files, 119 tests passed
- Cypress lifecycle spec: 3 passed
- isolated tier-0 routes: 220 passed
- hosted synthetic RLS matrix: midtier archive/restore allowed and delete denied; BCBA archived-unused delete allowed; active/history/cross-org denied; cleanup zero
- Supabase goal-targets Edge v3 active with verify_jwt=true
- post-hardening Supabase advisor: no goal-target lifecycle security finding

## Blocked check

- npm run ci:playwright preflight passed, then hosted auth rejected the configured superadmin@test.com credential as invalid before product smoke execution.

## Risk

Critical lane: authentication, RLS/grants, tenant-sensitive migrations, server and Edge boundaries. Human review is required before merge.