### PR TITLE
WIN-217 Recover BCBA session auth and session start

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -56,3 +56,16 @@
 - unrelated changes: none in this isolated worktree
 - protected-path drift: `src/lib/authContext.tsx` is intentionally protected and remains critical-lane
 - human merge blocker: required review and CI, including credential-backed auth/session smoke
+
+## PR #761 CI follow-up
+
+- After `main` was merged into the PR branch, both the CI `unit-tests` job and the separate `tenant-safety` workflow failed on the same assertion in `AddSessionNoteModal.test.tsx`.
+- Root cause: the BT locking test queried the `Default Goal` checkbox synchronously while the modal's sessions/programs/goals queries were still rendering the `Loading sessions...` state.
+- Fix: await the existing accessible checkbox boundary with `findByRole`, matching the established pattern used by the surrounding asynchronous goal-loading tests.
+- Focused verification: `npm run test -- src/components/__tests__/AddSessionNoteModal.test.tsx --run` -> pass, 21 tests.
+- Full verification after the fix:
+  - `npm run test:ci` with synthetic non-secret Supabase configuration -> pass, 373 files / 2476 tests, 1 integration test skipped for unavailable `WIN211_POSTGRES_URL`
+  - `npm run validate:tenant` -> pass
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+- Test/code review approved the one-line condition-based wait with no findings.

--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -1,0 +1,58 @@
+# WIN-217 BCBA Session Auth Recovery Handoff
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- Linear: `WIN-217`
+- branch: `codex/bcba-session-auth-recovery`
+- files touched:
+  - `src/lib/authContext.tsx`
+  - `src/lib/__tests__/authContext.initializeAuth.test.tsx`
+  - `src/features/scheduling/domain/sessionStart.ts`
+  - `src/features/scheduling/domain/__tests__/sessionStart.test.ts`
+  - planning and handoff documentation for WIN-217
+- required agents: specification-engineer -> software-architect -> implementation-engineer -> code-review-engineer -> test-engineer -> security-engineer
+
+## Change summary
+
+- Supabase profile and role query results now preserve deterministic HTTP 401 status. Confirmed unauthorized auth queries use the existing fail-closed state, storage, sign-out, and query-cache cleanup path.
+- Auth generations prevent delayed bootstrap or refresh responses from clearing or overwriting a newer valid session.
+- Session start treats only HTTP 409 plus `rpcCode: "ALREADY_STARTED"` as idempotent success. `INVALID_STATUS` and all other conflicts remain errors.
+- No role, tenant, RLS, grant, migration, Edge Function, server authority, billing, or runtime-config behavior changed.
+
+## Verification card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- change type: auth/session lifecycle; UI-to-server API integration
+- required checks:
+  - focused Vitest regression tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run test:routes:tier0`
+  - `npm run build`
+  - `npm run ci:playwright`
+  - `npm run verify:local`
+- executed checks:
+  - focused Vitest regression tests -> pass, 2 files / 12 tests
+  - `npm run ci:check-focused` -> pass
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm run test:routes:tier0` -> pass, 7 specs / 220 tests
+  - `npm run build` -> pass
+  - `npm run test:ci` with synthetic non-secret Supabase configuration -> fail outside the changed files: `AddSessionNoteModal.test.tsx` cannot find the `Default Goal` checkbox in `locks BT session metadata and goal structure while leaving data collection editable`; the isolated file reproduces 1 failure / 20 passes
+  - `npm run ci:playwright` -> blocked at preflight because no `PW_SUPERADMIN_*` or `PW_ADMIN_*` credentials are available
+- blocked checks:
+  - `npm run verify:local` -> its `test:ci` stage deterministically reaches the unrelated AddSessionNoteModal failure above; remaining constituent checks were run separately
+  - secret-backed Playwright smoke -> required in CI
+- reviewer: code-review-engineer approved after auth-generation race fix; security-engineer approved with no remaining findings
+- result: `pass-with-blocked-checks`
+- residual risk: hosted confirmation still depends on CI credentials and a fresh BCBA browser session; human review remains mandatory before merge
+
+## PR hygiene inputs
+
+- single purpose: yes
+- unrelated changes: none in this isolated worktree
+- protected-path drift: `src/lib/authContext.tsx` is intentionally protected and remains critical-lane
+- human merge blocker: required review and CI, including credential-backed auth/session smoke

--- a/docs/superpowers/plans/2026-07-10-bcba-session-auth-recovery.md
+++ b/docs/superpowers/plans/2026-07-10-bcba-session-auth-recovery.md
@@ -1,0 +1,64 @@
+# BCBA Session Auth Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover confirmed stale Supabase sessions and make confirmed already-started conflicts idempotent.
+
+**Architecture:** Preserve structured response metadata at the two existing boundaries. Session-start recovery is local to its domain adapter; auth-query recovery is local to `AuthProvider` and reuses fail-closed cleanup.
+
+**Tech Stack:** React, TypeScript, Supabase JS, Vitest.
+
+## Global Constraints
+
+- Linear issue WIN-217 is required.
+- Only `rpcCode: "ALREADY_STARTED"` is idempotent.
+- Only Supabase query `status === 401` initiates stale-session cleanup.
+- No permission, schema, RLS, server, Edge, billing, or runtime-config changes.
+
+---
+
+### Task 1: Session-start idempotency
+
+**Files:**
+- Modify: `src/features/scheduling/domain/sessionStart.ts`
+- Test: `src/features/scheduling/domain/__tests__/sessionStart.test.ts`
+
+**Interfaces:**
+- Consumes: `/api/sessions-start` JSON response containing optional `rpcCode`.
+- Produces: `startSessionFromModal(request): Promise<void>` that resolves for 2xx and confirmed `ALREADY_STARTED` only.
+
+- [ ] Add failing tests for `ALREADY_STARTED` resolution and `INVALID_STATUS` rejection.
+- [ ] Run the focused test and confirm the new test fails for the expected conflict.
+- [ ] Parse the fallback payload before error normalization and return only for status 409 plus `rpcCode === "ALREADY_STARTED"`.
+- [ ] Run the focused test and confirm all cases pass.
+
+### Task 2: Confirmed stale-auth cleanup
+
+**Files:**
+- Modify: `src/lib/authContext.tsx`
+- Test: existing focused `src/lib/__tests__/authContext*.test.tsx` fixture selected after inspection
+
+**Interfaces:**
+- Consumes: Supabase query results with numeric `status`.
+- Produces: auth fetch results that distinguish data, transient failure, and unauthorized failure.
+
+- [ ] Add a failing test showing query status 401 clears user/session/profile/role and signs out.
+- [ ] Add a control proving a 503 profile failure preserves current signed-in behavior.
+- [ ] Run the focused auth test and confirm the 401 case fails before implementation.
+- [ ] Preserve query status and invoke the existing fail-closed cleanup only for confirmed 401.
+- [ ] Run the focused auth test and confirm both cases pass.
+
+### Task 3: Critical-lane closure
+
+**Files:**
+- Create: `docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md`
+
+**Interfaces:**
+- Consumes: route classification, executed commands, reviews, and live PR state.
+- Produces: verification card and PR-ready handoff linked to WIN-217.
+
+- [ ] Run targeted tests.
+- [ ] Run `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run test:routes:tier0`, and `npm run build`.
+- [ ] Run `npm run ci:playwright` and `npm run verify:local` when the required environment is available; otherwise record exact blockers.
+- [ ] Obtain code-review and security-review passes.
+- [ ] Write the verification card, run PR hygiene, commit, push, and open a human-reviewed PR.

--- a/docs/superpowers/specs/2026-07-10-bcba-session-auth-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-10-bcba-session-auth-recovery-design.md
@@ -1,0 +1,31 @@
+# BCBA Session Auth Recovery Design
+
+Issue: WIN-217
+
+## Goal
+
+Restore the BCBA session workflow when a browser holds an invalid Supabase session and make repeated session-start requests safely idempotent.
+
+## Design
+
+Session start remains server-authoritative. The client accepts a conflict as success only when the structured response contains `rpcCode: "ALREADY_STARTED"`; `INVALID_STATUS` and every other non-success response remain visible failures. After the idempotent result, the existing `onSessionStarted` callback refreshes authoritative session data and closes the modal.
+
+Auth bootstrap and auth-state refresh preserve the HTTP status returned by Supabase profile and role queries. A deterministic query status of 401 triggers the existing fail-closed local-state and credential cleanup path. Missing profiles, RLS denials, network failures, and 5xx responses retain current behavior and cannot expand permissions.
+
+## Scope
+
+- `src/features/scheduling/domain/sessionStart.ts`
+- `src/features/scheduling/domain/__tests__/sessionStart.test.ts`
+- `src/lib/authContext.tsx`
+- existing focused auth-context tests
+- this design, implementation plan, and lane handoff
+
+## Non-goals
+
+- No migrations, RLS, grants, role precedence, session-note billing rules, server authority, Edge Functions, runtime configuration, or UI redesign.
+- No status-only or message-only conflict recovery.
+- No global fetch interception.
+
+## Verification
+
+Use test-first coverage for `ALREADY_STARTED`, `INVALID_STATUS`, confirmed query 401, and transient non-401 failures. Then run the critical auth/session verification matrix and require code, security, and human review before merge.

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -423,7 +423,7 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
     expect(screen.getByLabelText(/end time/i)).toBeDisabled();
     expect(screen.getByLabelText(/^therapist$/i)).toBeDisabled();
     expect(screen.getByLabelText(/link to session/i)).toBeDisabled();
-    expect(screen.getByRole('checkbox', { name: /default goal/i })).toBeDisabled();
+    expect(await screen.findByRole('checkbox', { name: /default goal/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /add target/i })).toBeDisabled();
     expect(screen.getByLabelText(/^target$/i)).toBeDisabled();
 

--- a/src/features/scheduling/domain/__tests__/sessionStart.test.ts
+++ b/src/features/scheduling/domain/__tests__/sessionStart.test.ts
@@ -49,5 +49,43 @@ describe("startSessionFromModal", () => {
       }),
     );
   });
+
+  it("treats a confirmed already-started conflict as idempotent success", async () => {
+    callApiMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        code: "conflict",
+        message: "Session already started",
+        rpcCode: "ALREADY_STARTED",
+      }), { status: 409 }),
+    );
+
+    const { startSessionFromModal } = await import("../sessionStart");
+    await expect(startSessionFromModal({
+      sessionId: "11111111-1111-1111-1111-111111111111",
+      programId: "22222222-2222-2222-2222-222222222222",
+      goalId: "33333333-3333-3333-3333-333333333333",
+    })).resolves.toBeUndefined();
+  });
+
+  it("keeps non-idempotent session conflicts visible", async () => {
+    callApiMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        code: "conflict",
+        message: "Only scheduled sessions can be started",
+        rpcCode: "INVALID_STATUS",
+      }), { status: 409 }),
+    );
+
+    const { startSessionFromModal } = await import("../sessionStart");
+    await expect(startSessionFromModal({
+      sessionId: "11111111-1111-1111-1111-111111111111",
+      programId: "22222222-2222-2222-2222-222222222222",
+      goalId: "33333333-3333-3333-3333-333333333333",
+    })).rejects.toMatchObject({
+      message: "Only scheduled sessions can be started",
+      status: 409,
+      code: "conflict",
+    });
+  });
 });
 

--- a/src/features/scheduling/domain/sessionStart.ts
+++ b/src/features/scheduling/domain/sessionStart.ts
@@ -40,6 +40,9 @@ export async function startSessionFromModal(request: StartSessionRequest): Promi
     } catch {
       fallbackPayload = null;
     }
+    if (response.status === 409 && fallbackPayload?.rpcCode === "ALREADY_STARTED") {
+      return;
+    }
     throw toNormalizedApiError(
       fallbackPayload,
       response.status,

--- a/src/lib/__tests__/authContext.initializeAuth.test.tsx
+++ b/src/lib/__tests__/authContext.initializeAuth.test.tsx
@@ -138,6 +138,37 @@ describe('AuthProvider initializeAuth resilience', () => {
     expect(mockSignOut).toHaveBeenCalledTimes(1);
   });
 
+  it('clears an initial session when the profile query confirms unauthorized', async () => {
+    mockGetSession.mockResolvedValueOnce({
+      data: {
+        session: {
+          user: {
+            id: 'user-1',
+            email: 'user@example.com',
+          },
+        },
+      },
+      error: null,
+    });
+    mockProfilesMaybeSingle.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'JWT expired', code: 'PGRST301' },
+      status: 401,
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(mockSignOut).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('user')).toHaveTextContent('none');
+    expect(screen.getByTestId('role')).toHaveTextContent('none');
+    expect(screen.getByTestId('effective-role')).toHaveTextContent('client');
+    expect(mockQueryClientClear).toHaveBeenCalled();
+  });
+
   it('retries initialization after signing out when the first session fetch fails', async () => {
     mockGetSession
       .mockRejectedValueOnce(new Error('network down'))
@@ -223,6 +254,7 @@ describe('AuthProvider initializeAuth resilience', () => {
     mockProfilesMaybeSingle.mockResolvedValueOnce({
       data: null,
       error: { message: 'temporary profile fetch failure' },
+      status: 503,
     });
 
     await authStateChangeListenerRef.current?.('TOKEN_REFRESHED', {
@@ -233,6 +265,74 @@ describe('AuthProvider initializeAuth resilience', () => {
     });
 
     await waitFor(() => expect(screen.getByTestId('role')).toHaveTextContent('admin'));
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('ignores a delayed unauthorized response from an older auth generation', async () => {
+    mockGetSession.mockResolvedValueOnce({
+      data: {
+        session: {
+          user: {
+            id: 'user-1',
+            email: 'one@example.com',
+          },
+        },
+      },
+      error: null,
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('user-1'));
+
+    let resolveOldProfile!: (value: unknown) => void;
+    const oldProfileResult = new Promise((resolve) => {
+      resolveOldProfile = resolve;
+    });
+    mockProfilesMaybeSingle
+      .mockImplementationOnce(() => oldProfileResult)
+      .mockResolvedValueOnce({
+        data: {
+          id: 'user-2',
+          email: 'two@example.com',
+          role: 'bcba',
+          is_active: true,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        error: null,
+        status: 200,
+      });
+
+    authStateChangeListenerRef.current?.('TOKEN_REFRESHED', {
+      user: {
+        id: 'user-1',
+        email: 'one@example.com',
+      },
+    });
+    await waitFor(() => expect(mockProfilesMaybeSingle).toHaveBeenCalledTimes(2));
+
+    authStateChangeListenerRef.current?.('SIGNED_IN', {
+      user: {
+        id: 'user-2',
+        email: 'two@example.com',
+      },
+    });
+    await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('user-2'));
+
+    resolveOldProfile({
+      data: null,
+      error: { message: 'JWT expired', code: 'PGRST301' },
+      status: 401,
+    });
+
+    await waitFor(() => expect(screen.getByTestId('role')).toHaveTextContent('bcba'));
+    expect(screen.getByTestId('user')).toHaveTextContent('user-2');
+    expect(mockSignOut).not.toHaveBeenCalled();
   });
 
   it('ignores token refresh events while sign-out is in progress', async () => {

--- a/src/lib/authContext.tsx
+++ b/src/lib/authContext.tsx
@@ -217,6 +217,13 @@ export const useAuth = () => {
   return context;
 };
 
+class AuthQueryUnauthorizedError extends Error {
+  constructor(readonly source: 'profile' | 'role') {
+    super(`Supabase ${source} query returned 401`);
+    this.name = 'AuthQueryUnauthorizedError';
+  }
+}
+
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<UserProfile | null>(null);
@@ -226,6 +233,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [roleFromAssignments, setRoleFromAssignments] = useState<Role | null>(null);
   const [authFlow, setAuthFlow] = useState<'normal' | 'password_recovery'>('normal');
   const signOutInProgressRef = useRef(false);
+  const authGenerationRef = useRef(0);
 
   const metadataRole = useMemo<Role | null>(() => {
     if (!user) return null;
@@ -321,7 +329,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         .eq('id', userId)
         .maybeSingle();
 
-      const { data, error } = await primaryQuery;
+      const { data, error, status } = await primaryQuery;
+
+      if (status === 401) {
+        throw new AuthQueryUnauthorizedError('profile');
+      }
 
       if (error && isMissingOrganizationIdColumnError(error)) {
         logger.warn('Profiles table is missing organization_id; retrying profile fetch without it', {
@@ -331,11 +343,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           },
         });
 
-        const { data: fallbackData, error: fallbackError } = await supabase
+        const { data: fallbackData, error: fallbackError, status: fallbackStatus } = await supabase
           .from('profiles')
           .select(PROFILE_SELECT_COLUMNS_FALLBACK)
           .eq('id', userId)
           .maybeSingle();
+
+        if (fallbackStatus === 401) {
+          throw new AuthQueryUnauthorizedError('profile');
+        }
 
         if (fallbackError) {
           logger.error('Failed to fetch profile record after fallback select', {
@@ -364,6 +380,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       return data;
     } catch (error) {
+      if (error instanceof AuthQueryUnauthorizedError) {
+        throw error;
+      }
       logger.error('Failed to fetch profile record', {
         error: toError(error, 'Profile fetch failed'),
         metadata: {
@@ -377,10 +396,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const fetchAssignedRole = useCallback(async (userId: string): Promise<Role | null> => {
     try {
-      const { data, error } = await supabase
+      const { data, error, status } = await supabase
         .from('user_roles')
         .select('is_active, expires_at, roles(name)')
         .eq('user_id', userId);
+
+      if (status === 401) {
+        throw new AuthQueryUnauthorizedError('role');
+      }
 
       if (error || !Array.isArray(data)) {
         logger.warn('Unable to resolve role assignments; falling back to profile role', {
@@ -395,6 +418,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       return resolveRoleFromRoleRows(data as RoleRow[]);
     } catch (error) {
+      if (error instanceof AuthQueryUnauthorizedError) {
+        throw error;
+      }
       logger.warn('Role assignment lookup failed unexpectedly; falling back to profile role', {
         error: toError(error, 'Role assignment query failed'),
         metadata: {
@@ -413,15 +439,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     ]) as Promise<T>;
   };
 
-  const forceInactiveAccountSignOut = useCallback(async (userId: string, source: string) => {
-    logger.warn('Inactive account detected during auth runtime; forcing sign-out', {
+  const forceAuthSessionSignOut = useCallback(async (
+    userId: string,
+    source: string,
+    reason: 'inactive-account' | 'unauthorized-query',
+  ) => {
+    logger.warn('Auth session is no longer usable; forcing sign-out', {
       metadata: {
-        scope: 'authContext.inactiveAccount',
+        scope: 'authContext.forceAuthSessionSignOut',
         userId,
         source,
+        reason,
       },
     });
 
+    authGenerationRef.current += 1;
     signOutInProgressRef.current = true;
     setAuthFlow('normal');
     setSession(null);
@@ -437,12 +469,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
       await supabase.auth.signOut();
     } catch (error) {
-      logger.warn('Failed to fully sign out inactive account session', {
-        error: toError(error, 'Inactive account sign-out failed'),
+      logger.warn('Failed to fully clear unusable auth session', {
+        error: toError(error, 'Auth session sign-out failed'),
         metadata: {
-          scope: 'authContext.inactiveAccount',
+          scope: 'authContext.forceAuthSessionSignOut',
           userId,
           source,
+          reason,
         },
       });
     } finally {
@@ -453,6 +486,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   const performInitialization = useCallback(async () => {
+    const initializationGeneration = authGenerationRef.current;
     const {
       data: { session: initialSession },
       error,
@@ -462,14 +496,38 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       throw error;
     }
 
+    if (authGenerationRef.current !== initializationGeneration) {
+      return;
+    }
+
     if (initialSession?.user) {
       setUser(initialSession.user);
       setSession(initialSession);
       setProfileLoading(true);
-      const profileData = await withTimeout(fetchProfile(initialSession.user.id), 'fetchProfile');
-      const assignedRole = await withTimeout(fetchAssignedRole(initialSession.user.id), 'fetchAssignedRole');
+      let profileData: UserProfile | null;
+      let assignedRole: Role | null;
+      try {
+        profileData = await withTimeout(fetchProfile(initialSession.user.id), 'fetchProfile');
+        assignedRole = await withTimeout(fetchAssignedRole(initialSession.user.id), 'fetchAssignedRole');
+      } catch (error) {
+        if (error instanceof AuthQueryUnauthorizedError) {
+          if (authGenerationRef.current !== initializationGeneration) {
+            return;
+          }
+          await forceAuthSessionSignOut(
+            initialSession.user.id,
+            `initializeAuth:${error.source}`,
+            'unauthorized-query',
+          );
+          return;
+        }
+        throw error;
+      }
+      if (authGenerationRef.current !== initializationGeneration) {
+        return;
+      }
       if (profileData && profileData.is_active === false) {
-        await forceInactiveAccountSignOut(initialSession.user.id, 'initializeAuth');
+        await forceAuthSessionSignOut(initialSession.user.id, 'initializeAuth', 'inactive-account');
         return;
       }
       setProfile(profileData);
@@ -493,7 +551,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setProfile(null);
     setRoleFromAssignments(null);
     setProfileLoading(false);
-  }, [fetchAssignedRole, fetchProfile, forceInactiveAccountSignOut]);
+  }, [fetchAssignedRole, fetchProfile, forceAuthSessionSignOut]);
 
   const initializeAuth = useCallback(async () => {
     setLoading(true);
@@ -545,7 +603,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, [performInitialization]);
 
-  const refreshProfileForSession = useCallback(async (nextSession: Session, event: string) => {
+  const refreshProfileForSession = useCallback(async (
+    nextSession: Session,
+    event: string,
+    authGeneration: number,
+  ) => {
+    if (authGenerationRef.current !== authGeneration) {
+      return;
+    }
     setProfileLoading(true);
     logger.debug('Refreshing profile after auth state change', {
       metadata: {
@@ -556,24 +621,48 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       },
     });
 
-    const [profileData, assignedRole] = await Promise.all([
-      withTimeout(
-        fetchProfile(nextSession.user.id),
-        'fetchProfile in onAuthStateChange',
-        10000
-      ).catch((error) => {
-        logger.error('Failed to fetch profile in auth state change', {
-          error: toError(error, 'Profile fetch failed in listener'),
-          metadata: {
-            scope: 'authContext.onAuthStateChange',
-            userId: nextSession.user.id,
-            event,
-          },
-        });
-        return null;
-      }),
-      fetchAssignedRole(nextSession.user.id),
-    ]);
+    let profileData: UserProfile | null;
+    let assignedRole: Role | null;
+    try {
+      [profileData, assignedRole] = await Promise.all([
+        withTimeout(
+          fetchProfile(nextSession.user.id),
+          'fetchProfile in onAuthStateChange',
+          10000
+        ).catch((error) => {
+          if (error instanceof AuthQueryUnauthorizedError) {
+            throw error;
+          }
+          logger.error('Failed to fetch profile in auth state change', {
+            error: toError(error, 'Profile fetch failed in listener'),
+            metadata: {
+              scope: 'authContext.onAuthStateChange',
+              userId: nextSession.user.id,
+              event,
+            },
+          });
+          return null;
+        }),
+        fetchAssignedRole(nextSession.user.id),
+      ]);
+    } catch (error) {
+      if (error instanceof AuthQueryUnauthorizedError) {
+        if (authGenerationRef.current !== authGeneration) {
+          return;
+        }
+        await forceAuthSessionSignOut(
+          nextSession.user.id,
+          `authStateChange:${event}:${error.source}`,
+          'unauthorized-query',
+        );
+        return;
+      }
+      throw error;
+    }
+
+    if (authGenerationRef.current !== authGeneration) {
+      return;
+    }
 
     logger.debug('Completed profile refresh after auth state change', {
       metadata: {
@@ -586,7 +675,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     });
 
     if (profileData && profileData.is_active === false) {
-      await forceInactiveAccountSignOut(nextSession.user.id, `authStateChange:${event}`);
+      await forceAuthSessionSignOut(nextSession.user.id, `authStateChange:${event}`, 'inactive-account');
       return;
     }
 
@@ -605,7 +694,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       return null;
     });
     setProfileLoading(false);
-  }, [fetchAssignedRole, fetchProfile, forceInactiveAccountSignOut]);
+  }, [fetchAssignedRole, fetchProfile, forceAuthSessionSignOut]);
 
   const waitForSignedOutEvent = useCallback((timeoutMs = 5000): Promise<void> => {
     return new Promise((resolve) => {
@@ -645,6 +734,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     // Listen for auth changes
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       try {
+        const authGeneration = authGenerationRef.current + 1;
+        authGenerationRef.current = authGeneration;
         if (signOutInProgressRef.current) {
           if (event === 'SIGNED_OUT' || !session?.user) {
             setAuthFlow('normal');
@@ -668,7 +759,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           // this callback. Schedule profile refresh in a separate task to avoid
           // re-entrancy stalls that can lead to timeout errors during SIGNED_IN.
           window.setTimeout(() => {
-            void refreshProfileForSession(session, event);
+            void refreshProfileForSession(session, event, authGeneration);
           }, 0);
         } else {
           const stubAuthState = readStubAuthState();
@@ -726,7 +817,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         (payload) => {
           const nextProfile = payload.new as UserProfile;
           if (nextProfile.is_active === false) {
-            void forceInactiveAccountSignOut(user.id, 'profilesRealtimeUpdate');
+            void forceAuthSessionSignOut(user.id, 'profilesRealtimeUpdate', 'inactive-account');
             return;
           }
           setProfile(nextProfile);
@@ -737,7 +828,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [user, forceInactiveAccountSignOut]);
+  }, [user, forceAuthSessionSignOut]);
 
   const signIn = async (email: string, password: string) => {
     try {
@@ -814,6 +905,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const signOut = async () => {
     try {
       setLoading(true);
+      authGenerationRef.current += 1;
       signOutInProgressRef.current = true;
 
       // Optimistically clear local auth state so route-level queries disable


### PR DESCRIPTION
## Summary
- clear stale Supabase auth only on deterministic profile/role query 401 responses
- guard auth cleanup and profile commits with session generations so stale responses cannot sign out a newer user
- treat only sessions-start 409 responses with rpcCode ALREADY_STARTED as idempotent success

## Verification
- focused Vitest: 2 files, 12 tests passed
- ci:check-focused, lint, typecheck, build passed
- tier-0 Cypress: 7 specs, 220 tests passed
- code and security re-review approved
- test:ci blocked by an existing AddSessionNoteModal assertion failure reproducible in isolation (Default Goal checkbox absent)
- ci:playwright blocked locally by missing PW_ADMIN/PW_SUPERADMIN credentials; required in CI

## Risk
Critical auth/session boundary change. No role, tenant, RLS, migration, Edge, server authority, billing, or runtime-config changes. Human review required.

Linear: WIN-217