### PR TITLE
WIN-217 Add hosted BCBA session acceptance proof

### DIFF
--- a/.github/workflows/bcba-smoke-janitor.yml
+++ b/.github/workflows/bcba-smoke-janitor.yml
@@ -1,0 +1,32 @@
+name: BCBA Smoke Actor Janitor
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup-expired-bcba-smoke-actors:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Delete expired dedicated BCBA smoke actors
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npx tsx scripts/provision-ci-smoke-bcba.ts --sweep-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,6 +534,13 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: npx tsx scripts/provision-ci-smoke-admin.ts
 
+      - name: Provision synthetic BCBA smoke actor
+        if: steps.browser_scope.outputs.auth_smoke_required == 'true' && github.event_name != 'pull_request'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npx tsx scripts/provision-ci-smoke-bcba.ts
+
       - name: Install Playwright browser
         if: steps.browser_scope.outputs.auth_smoke_required == 'true'
         run: npx playwright install --with-deps chromium
@@ -631,6 +638,26 @@ jobs:
           export PW_CI_CHILD_TIMEOUT_MS=480000
           echo "Running non-AI session browser smoke suite."
           npm run ci:playwright:session-smoke
+
+      - name: BCBA session acceptance proof
+        if: steps.browser_scope.outputs.auth_smoke_required == 'true' && github.event_name != 'pull_request'
+        env:
+          PW_BASE_URL: ${{ secrets.PW_BASE_URL }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY || secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CI_SESSION_PARITY_REQUIRED: true
+          PW_ASSERT_ALREADY_STARTED_UI: true
+        run: |
+          npm run playwright:session-lifecycle
+          npm run playwright:session-note-measurement-roundtrip
+
+      - name: Cleanup synthetic BCBA smoke actor
+        if: always() && steps.browser_scope.outputs.auth_smoke_required == 'true' && github.event_name != 'pull_request'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npx tsx scripts/provision-ci-smoke-bcba.ts --cleanup
 
       - name: Cleanup auth smoke admin
         if: always() && steps.browser_scope.outputs.auth_smoke_required == 'true'

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -1589,7 +1589,7 @@ const cleanupCreatedProgramGoal = async (ids: Pick<LifecycleIds, "createdProgram
   await archiveLifecycleProgramGoal(adminClient, ids);
 };
 
-async function assertSessionRowStatus(sessionId: string, expected: string): Promise<void> {
+async function readSessionRowStatus(sessionId: string): Promise<string> {
   const supabaseUrl = getEnv("VITE_SUPABASE_URL");
   const serviceRole = getEnv("SUPABASE_SERVICE_ROLE_KEY");
   const adminClient = createClient(supabaseUrl, serviceRole, {
@@ -1603,7 +1603,33 @@ async function assertSessionRowStatus(sessionId: string, expected: string): Prom
   if (error) {
     throw new Error(`sessions status read failed: ${error.message}`);
   }
-  const status = data && typeof data === "object" && "status" in data ? String((data as { status: unknown }).status) : "";
+  return data && typeof data === "object" && "status" in data ? String((data as { status: unknown }).status) : "";
+}
+
+export async function waitForSessionStatus(
+  sessionId: string,
+  expected: string,
+  options: {
+    readStatus?: (sessionId: string) => Promise<string>;
+    intervalMs?: number;
+    timeoutMs?: number;
+  } = {},
+): Promise<void> {
+  const readStatus = options.readStatus ?? readSessionRowStatus;
+  const intervalMs = options.intervalMs ?? 500;
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const deadline = Date.now() + timeoutMs;
+  let status = "";
+  do {
+    status = await readStatus(sessionId);
+    if (status === expected) return;
+    if (intervalMs > 0) await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  } while (Date.now() < deadline);
+  throw new Error(`Expected session status ${expected}, got ${status || "unknown"}`);
+}
+
+async function assertSessionRowStatus(sessionId: string, expected: string): Promise<void> {
+  const status = await readSessionRowStatus(sessionId);
   if (status !== expected) {
     throw new Error(`Expected session status ${expected}, got ${status || "unknown"}`);
   }

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -1224,6 +1224,19 @@ const expectStartButtonEnabled = async (
   throw new Error("Start Session stayed disabled after opening the edit modal (program/goal data may not have loaded).");
 };
 
+export const isExpectedAlreadyStartedResponse = (
+  enabled: boolean,
+  status: number,
+  body: string,
+): boolean => {
+  if (!enabled || status !== 409) return false;
+  try {
+    return (JSON.parse(body) as { rpcCode?: unknown }).rpcCode === "ALREADY_STARTED";
+  } catch {
+    return false;
+  }
+};
+
 /** Same contract as UI/`sessions-start` + RPC fallback; used when the modal does not surface a `sessions-start` response in time. */
 async function invokeStartSessionFallback(token: string, ids: LifecycleIds, strictMode: boolean): Promise<void> {
   const payload: SessionStartPayload = {
@@ -1609,6 +1622,12 @@ async function startSessionViaScheduleModal(
   await expectStartButtonEnabled(page, startButton);
   const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
 
+  const assertAlreadyStartedRecovery = /^(1|true|yes)$/i.test(process.env.PW_ASSERT_ALREADY_STARTED_UI ?? "");
+  if (assertAlreadyStartedRecovery) {
+    await invokeStartSessionFallback(token, ids, strictMode);
+    await waitForSessionStatus(ids.sessionId, "in_progress");
+  }
+
   let uiEmittedStart = false;
   try {
     const [startResponse] = await Promise.all([
@@ -1620,7 +1639,10 @@ async function startSessionViaScheduleModal(
     ]);
     const startBody = await startResponse.text();
     if (!startResponse.ok()) {
-      throw new Error(`sessions-start failed (${startResponse.status()}) from ${startResponse.url()}: ${startBody.slice(0, 800)}`);
+      if (!isExpectedAlreadyStartedResponse(assertAlreadyStartedRecovery, startResponse.status(), startBody)) {
+        throw new Error(`sessions-start failed (${startResponse.status()}) from ${startResponse.url()}: ${startBody.slice(0, 800)}`);
+      }
+      console.log("[lifecycle] verified hosted 409 ALREADY_STARTED UI recovery");
     }
     uiEmittedStart = true;
   } catch (error) {
@@ -1635,7 +1657,15 @@ async function startSessionViaScheduleModal(
   }
 
   if (uiEmittedStart) {
-    await editDialog.waitFor({ state: "hidden", timeout: 90_000 }).catch(() => undefined);
+    if (assertAlreadyStartedRecovery) {
+      await editDialog.waitFor({ state: "hidden", timeout: 90_000 });
+      const failureAlert = page.getByText(/Failed to start session/i).first();
+      if (await failureAlert.isVisible().catch(() => false)) {
+        throw new Error("ALREADY_STARTED recovery left a visible session-start failure alert.");
+      }
+    } else {
+      await editDialog.waitFor({ state: "hidden", timeout: 90_000 }).catch(() => undefined);
+    }
   }
   await page.goto(scheduleUrl, { waitUntil: "networkidle", timeout: 60000 });
 }

--- a/scripts/provision-ci-smoke-bcba.ts
+++ b/scripts/provision-ci-smoke-bcba.ts
@@ -1,0 +1,181 @@
+import { randomBytes } from "node:crypto";
+import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const DEFAULT_ORGANIZATION_ID = "5238e88b-6198-4862-80a2-dbe15bbeabdd";
+const DEFAULT_THERAPIST_ID = "5238e88b-6198-4862-80a2-100000000001";
+
+const getEnv = (name: string, fallback?: string): string => {
+  const value = process.env[name]?.trim() || fallback;
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+};
+
+export const buildDefaultSmokeBcbaEmail = (): string => {
+  const runId = process.env.GITHUB_RUN_ID?.trim() || String(Date.now());
+  const attempt = process.env.GITHUB_RUN_ATTEMPT?.trim() || "1";
+  return `playwright.ci.bcba.${runId}.${attempt}@example.com`.toLowerCase();
+};
+
+export const assertDedicatedSmokeBcbaEmail = (email: string): void => {
+  if (!/^playwright\.ci\.bcba\.[a-z0-9_.-]+@example\.com$/i.test(email)) {
+    throw new Error("Refusing to mutate non-dedicated CI BCBA account email.");
+  }
+};
+
+export const getMissingBcbaProvisionSecrets = (env: NodeJS.ProcessEnv = process.env): string[] =>
+  ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"].filter((name) => !env[name]?.trim());
+
+export const shouldSkipSecretlessPullRequest = (env: NodeJS.ProcessEnv = process.env): boolean =>
+  env.GITHUB_EVENT_NAME === "pull_request" && getMissingBcbaProvisionSecrets(env).length > 0;
+
+const createAdmin = (): SupabaseClient => createClient(
+  getEnv("SUPABASE_URL"),
+  getEnv("SUPABASE_SERVICE_ROLE_KEY"),
+  { auth: { autoRefreshToken: false, persistSession: false } },
+);
+
+const listUsers = async (client: SupabaseClient) => {
+  const users = [];
+  for (let page = 1; page <= 100; page += 1) {
+    const { data, error } = await client.auth.admin.listUsers({ page, perPage: 200 });
+    if (error) throw error;
+    users.push(...data.users);
+    if (data.users.length < 200) return users;
+  }
+  throw new Error("Refusing incomplete Auth user scan after 100 pages.");
+};
+
+const findUser = async (client: SupabaseClient, email: string) =>
+  (await listUsers(client)).find((user) => user.email?.toLowerCase() === email) ?? null;
+
+const writeCredentials = (email: string, password: string): void => {
+  process.stdout.write(`::add-mask::${password}\n`);
+  const githubEnv = process.env.GITHUB_ENV?.trim();
+  if (githubEnv) {
+    appendFileSync(githubEnv, `PW_SCHEDULE_EMAIL=${email}\nPW_SCHEDULE_PASSWORD=${password}\n`);
+  }
+};
+
+const cleanupMappings = async (client: SupabaseClient, userId: string): Promise<void> => {
+  for (const table of ["user_therapist_links", "user_roles"] as const) {
+    const { error } = await client.from(table).delete().eq("user_id", userId);
+    if (error) throw error;
+  }
+  const { error: profileError } = await client.from("profiles").delete().eq("id", userId);
+  if (profileError) throw profileError;
+};
+
+const sweepExpiredActors = async (client: SupabaseClient): Promise<void> => {
+  const now = Date.now();
+  for (const user of await listUsers(client)) {
+    const email = user.email?.toLowerCase() ?? "";
+    if (!/^playwright\.ci\.bcba\.[a-z0-9_.-]+@example\.com$/i.test(email)) continue;
+    const expiresAt = Date.parse(String(user.app_metadata?.smoke_expires_at ?? ""));
+    const createdAt = Date.parse(user.created_at);
+    if ((Number.isFinite(expiresAt) && expiresAt > now) || (!Number.isFinite(expiresAt) && createdAt > now - 6 * 60 * 60 * 1000)) continue;
+    await cleanupMappings(client, user.id);
+    const { error } = await client.auth.admin.deleteUser(user.id);
+    if (error) throw error;
+    console.log(JSON.stringify({ ok: true, action: "swept_expired", email, userId: user.id }));
+  }
+};
+
+const provision = async (): Promise<void> => {
+  const email = (process.env.CI_SMOKE_BCBA_EMAIL?.trim() || buildDefaultSmokeBcbaEmail()).toLowerCase();
+  assertDedicatedSmokeBcbaEmail(email);
+  const organizationId = DEFAULT_ORGANIZATION_ID;
+  const therapistId = DEFAULT_THERAPIST_ID;
+  const client = createAdmin();
+  await sweepExpiredActors(client);
+
+  const { data: therapist, error: therapistError } = await client
+    .from("therapists").select("id,organization_id,deleted_at").eq("id", therapistId).maybeSingle();
+  if (therapistError) throw therapistError;
+  if (!therapist || therapist.organization_id !== organizationId || therapist.deleted_at) {
+    throw new Error("Synthetic BCBA therapist fixture is missing, deleted, or outside the expected organization.");
+  }
+  const { data: role, error: roleError } = await client.from("roles").select("id").eq("name", "bcba").maybeSingle();
+  if (roleError) throw roleError;
+  if (!role?.id) throw new Error("Role bcba is not provisioned.");
+
+  const password = `C1-${randomBytes(18).toString("base64url")}!Aa`;
+  const metadata = { role: "bcba", signup_role: "bcba", organization_id: organizationId, organizationId };
+  const appMetadata = { smoke_actor: "bcba", smoke_expires_at: new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString() };
+  let user = await findUser(client, email);
+  if (user) {
+    const { error } = await client.auth.admin.updateUserById(user.id, { password, email_confirm: true, user_metadata: metadata, app_metadata: appMetadata });
+    if (error) throw error;
+    await cleanupMappings(client, user.id);
+  } else {
+    const { data, error } = await client.auth.admin.createUser({ email, password, email_confirm: true, user_metadata: metadata, app_metadata: appMetadata });
+    if (error) throw error;
+    if (!data.user) throw new Error("Supabase did not return the created BCBA smoke user.");
+    user = data.user;
+  }
+
+  const { error: profileError } = await client.from("profiles").upsert({
+    id: user.id, email, role: "bcba", is_active: true, first_name: "Playwright", last_name: "BCBA",
+    organization_id: organizationId,
+  }, { onConflict: "id" });
+  if (profileError) throw profileError;
+  const { error: roleMapError } = await client.from("user_roles").insert({ user_id: user.id, role_id: role.id, is_active: true });
+  if (roleMapError) throw roleMapError;
+  const { error: linkError } = await client.from("user_therapist_links").insert({ user_id: user.id, therapist_id: therapistId });
+  if (linkError) throw linkError;
+
+  writeCredentials(email, password);
+  console.log(JSON.stringify({ ok: true, action: "provisioned", email, userId: user.id, organizationId, therapistId }));
+};
+
+const cleanup = async (): Promise<void> => {
+  const email = (process.env.CI_SMOKE_BCBA_EMAIL?.trim() || process.env.PW_SCHEDULE_EMAIL?.trim() || buildDefaultSmokeBcbaEmail()).toLowerCase();
+  assertDedicatedSmokeBcbaEmail(email);
+  const client = createAdmin();
+  const user = await findUser(client, email);
+  if (!user) {
+    console.log(JSON.stringify({ ok: true, action: "cleanup_skipped", email, reason: "not_found" }));
+    return;
+  }
+  await cleanupMappings(client, user.id);
+  const { error } = await client.auth.admin.deleteUser(user.id);
+  if (error) throw error;
+  const remaining = await findUser(client, email);
+  if (remaining) throw new Error("BCBA smoke Auth user remains after cleanup.");
+  const residualCounts: Record<string, number> = {};
+  for (const [table, column] of [["profiles", "id"], ["user_roles", "user_id"], ["user_therapist_links", "user_id"]] as const) {
+    const { count, error: countError } = await client.from(table).select("*", { count: "exact", head: true }).eq(column, user.id);
+    if (countError) throw countError;
+    residualCounts[table] = count ?? -1;
+  }
+  if (Object.values(residualCounts).some((count) => count !== 0)) {
+    throw new Error(`BCBA smoke mappings remain after cleanup: ${JSON.stringify(residualCounts)}`);
+  }
+  console.log(JSON.stringify({ ok: true, action: "deleted", email, userId: user.id, residualIdentityRows: residualCounts }));
+};
+
+const sweepOnly = async (): Promise<void> => {
+  const client = createAdmin();
+  await sweepExpiredActors(client);
+  console.log(JSON.stringify({ ok: true, action: "sweep_complete" }));
+};
+
+const main = async (): Promise<void> => {
+  const missing = getMissingBcbaProvisionSecrets();
+  if (missing.length) {
+    if (shouldSkipSecretlessPullRequest()) {
+      console.log(JSON.stringify({ ok: true, action: "skipped", reason: "missing_pull_request_secrets", missing }));
+      return;
+    }
+    throw new Error(`Missing required Supabase admin secrets: ${missing.join(", ")}.`);
+  }
+  if (process.argv.includes("--sweep-only")) {
+    await sweepOnly();
+  } else {
+    await (process.argv.includes("--cleanup") ? cleanup() : provision());
+  }
+};
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href && process.env.VITEST !== "true";
+if (isDirectRun) main().catch((error) => { console.error(JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })); process.exit(1); });

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -7,6 +7,7 @@ import {
   filterNonOverlappingBookingStarts,
   hasReachedLifecyclePairAttemptLimit,
   isCreateSessionButtonReady,
+  isExpectedAlreadyStartedResponse,
   shouldTryNextLifecyclePairAfterAttempts,
 } from "../../scripts/playwright-session-lifecycle";
 
@@ -46,6 +47,14 @@ describe("playwright session lifecycle booking starts", () => {
     expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: null })).toBe(true);
     expect(isCreateSessionButtonReady({ disabled: "", ariaDisabled: null })).toBe(false);
     expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: "true" })).toBe(false);
+  });
+
+  it("accepts only the explicit hosted ALREADY_STARTED recovery contract", () => {
+    const body = JSON.stringify({ rpcCode: "ALREADY_STARTED" });
+    expect(isExpectedAlreadyStartedResponse(true, 409, body)).toBe(true);
+    expect(isExpectedAlreadyStartedResponse(false, 409, body)).toBe(false);
+    expect(isExpectedAlreadyStartedResponse(true, 409, JSON.stringify({ rpcCode: "INVALID_STATUS" }))).toBe(false);
+    expect(isExpectedAlreadyStartedResponse(true, 500, body)).toBe(false);
   });
 
   it("filters booking starts that overlap occupied sessions or holds", () => {

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
   isCreateSessionButtonReady,
   isExpectedAlreadyStartedResponse,
   shouldTryNextLifecyclePairAfterAttempts,
+  waitForSessionStatus,
 } from "../../scripts/playwright-session-lifecycle";
 
 const originalGithubRunId = process.env.GITHUB_RUN_ID;
@@ -55,6 +56,23 @@ describe("playwright session lifecycle booking starts", () => {
     expect(isExpectedAlreadyStartedResponse(false, 409, body)).toBe(false);
     expect(isExpectedAlreadyStartedResponse(true, 409, JSON.stringify({ rpcCode: "INVALID_STATUS" }))).toBe(false);
     expect(isExpectedAlreadyStartedResponse(true, 500, body)).toBe(false);
+  });
+
+  it("waits until the hosted session reaches the expected status", async () => {
+    const statuses = ["scheduled", "scheduled", "in_progress"];
+    await expect(waitForSessionStatus("session-1", "in_progress", {
+      readStatus: async () => statuses.shift() ?? "in_progress",
+      intervalMs: 0,
+      timeoutMs: 100,
+    })).resolves.toBeUndefined();
+  });
+
+  it("fails closed when the hosted session never reaches the expected status", async () => {
+    await expect(waitForSessionStatus("session-1", "in_progress", {
+      readStatus: async () => "scheduled",
+      intervalMs: 0,
+      timeoutMs: 0,
+    })).rejects.toThrow("Expected session status in_progress, got scheduled");
   });
 
   it("filters booking starts that overlap occupied sessions or holds", () => {

--- a/tests/scripts/provision-ci-smoke-bcba.test.ts
+++ b/tests/scripts/provision-ci-smoke-bcba.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertDedicatedSmokeBcbaEmail,
+  buildDefaultSmokeBcbaEmail,
+  getMissingBcbaProvisionSecrets,
+  shouldSkipSecretlessPullRequest,
+} from "../../scripts/provision-ci-smoke-bcba";
+
+describe("provision-ci-smoke-bcba guards", () => {
+  it("only accepts dedicated disposable BCBA emails", () => {
+    expect(() => assertDedicatedSmokeBcbaEmail("playwright.ci.bcba.123.1@example.com")).not.toThrow();
+    expect(() => assertDedicatedSmokeBcbaEmail("bcba@example.com")).toThrow(/Refusing/);
+  });
+
+  it("builds a dedicated email", () => {
+    expect(buildDefaultSmokeBcbaEmail()).toMatch(/^playwright\.ci\.bcba\..+@example\.com$/);
+  });
+
+  it("skips only secretless pull requests", () => {
+    const env = { GITHUB_EVENT_NAME: "pull_request" } as NodeJS.ProcessEnv;
+    expect(getMissingBcbaProvisionSecrets(env)).toEqual(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+    expect(shouldSkipSecretlessPullRequest(env)).toBe(true);
+    expect(shouldSkipSecretlessPullRequest({ ...env, GITHUB_EVENT_NAME: "push" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- provision a short-lived synthetic BCBA Auth actor bound only to the existing smoke tenant and therapist
- exercise the real hosted stale-modal 409 ALREADY_STARTED recovery and require modal closure with no failure alert
- run the existing session-note measurement save/edit/readback flow with BCBA credentials
- verify identity cleanup and add an hourly expired-actor janitor

## Risk
Critical-lane test and CI change. It uses the service role only inside GitHub Actions, hard-locks tenant IDs to synthetic fixtures, skips hosted mutation on pull requests, and requires human review before merge.

## Verification
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run test:ci (379 files passed, 2625 tests passed)
- npm run build
- npm run validate:tenant
- PREVIEW_PORT=4174 npm run test:routes:tier0 (220 passed)
- focused provisioner and lifecycle tests (14 passed)

## Hosted proof
The new BCBA acceptance step requires protected Actions secrets and intentionally runs on a non-PR push after merge. PR CI validates the harness without provisioning an actor.