### PR TITLE
WIN-217 Wait for BCBA schedule readiness

### DIFF
--- a/scripts/lib/playwright-smoke.ts
+++ b/scripts/lib/playwright-smoke.ts
@@ -192,11 +192,12 @@ export const assertRouteAccessible = async (
 
     if (!pathname.includes("/login") && !pathname.includes("/unauthorized") && onExpectedRoute) {
       if (readySelector) {
-        const ready = await page.locator(readySelector).first().isVisible().catch(() => false);
-        if (!ready && attempt < maxAttempts) {
-          await page.waitForTimeout(1000);
-          continue;
-        }
+        const ready = await page
+          .locator(readySelector)
+          .first()
+          .waitFor({ state: "visible", timeout: timeoutMs })
+          .then(() => true)
+          .catch(() => false);
         if (!ready) {
           throw new Error(
             `Route ${routePath} loaded but readiness selector was not visible: ${readySelector}`,

--- a/tests/scripts/playwright-smoke-route-access.test.ts
+++ b/tests/scripts/playwright-smoke-route-access.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Page } from "playwright";
+
+import { assertRouteAccessible } from "../../scripts/lib/playwright-smoke";
+
+describe("assertRouteAccessible readiness", () => {
+  const buildPage = (waitFor: ReturnType<typeof vi.fn>): Page => ({
+    goto: vi.fn().mockResolvedValue(undefined),
+    waitForLoadState: vi.fn().mockResolvedValue(undefined),
+    url: vi.fn().mockReturnValue("https://app.example.com/schedule"),
+    locator: vi.fn().mockReturnValue({
+      first: vi.fn().mockReturnValue({ waitFor }),
+    }),
+  } as unknown as Page);
+
+  it("waits for a delayed route readiness selector using the configured timeout", async () => {
+    const waitFor = vi.fn().mockResolvedValue(undefined);
+    const page = buildPage(waitFor);
+
+    await assertRouteAccessible(page, "https://app.example.com", "/schedule", {
+      readySelector: 'button[aria-label="Day view"]',
+      timeoutMs: 30_000,
+    });
+
+    expect(waitFor).toHaveBeenCalledWith({ state: "visible", timeout: 30_000 });
+  });
+
+  it("fails closed when the readiness selector stays absent", async () => {
+    const page = buildPage(vi.fn().mockRejectedValue(new Error("timeout")));
+
+    await expect(assertRouteAccessible(page, "https://app.example.com", "/schedule", {
+      readySelector: 'button[aria-label="Day view"]',
+      timeoutMs: 100,
+    })).rejects.toThrow('readiness selector was not visible: button[aria-label="Day view"]');
+  });
+});


### PR DESCRIPTION
## Summary
- honor assertRouteAccessible's existing bounded readiness timeout
- wait for delayed schedule hydration instead of sampling visibility immediately
- retain fail-closed behavior when the selector remains absent
- add focused success and timeout coverage

## Root cause evidence
The exact synthetic BCBA passed the same Day view selector multiple times earlier in the failed main job and completed the note roundtrip. The later dedicated run failed after about five seconds because timeoutMs was declared but unused.

## Verification
- focused readiness tests: 2 passed
- typecheck: passed
- lint: passed
- E2E reliability policy: passed
- policy checks: passed
- build: passed
- Schedule orchestration tests: 18 passed
- ProgramsGoalsTab isolated rerun: passed
- full test:ci: blocked by one unrelated ProgramsGoalsTab timing failure that passed in isolation
- hosted BCBA proof: required after human-reviewed merge