### PR TITLE
WIN-217 Require BCBA smoke for shared Playwright helper changes

### DIFF
--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -125,6 +125,7 @@ const classifyFile = (file) => {
   if (matchAny(file, [
     /^cypress\/e2e\/routes_auth\.cy\.ts$/,
     /^scripts\/playwright-/,
+    /^scripts\/lib\/playwright-smoke\.ts$/,
     /^supabase\/functions\/(sessions-|session-|auth-|programs|goals|program-notes)/,
   ])) {
     return { specs: ["auth", "schedule"], authSmoke: true, reason: "auth/session browser flow" };

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -120,6 +120,20 @@ describe('select-browser-checks', () => {
     ]);
   });
 
+  it('requires hosted auth smoke when the shared Playwright route helper changes', () => {
+    const selection = runSelector('--changed-file', 'scripts/lib/playwright-smoke.ts');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.authSmokeRequired).toBe(true);
+    expect(selection.tier0Specs).toEqual([
+      'cypress/e2e/routes_auth.cy.ts',
+      'cypress/e2e/routes_schedule.cy.ts',
+    ]);
+    expect(selection.reasons).toEqual([
+      'scripts/lib/playwright-smoke.ts: auth/session browser flow',
+    ]);
+  });
+
   it('keeps the PreAuth spec in the default local tier-0 Cypress run', () => {
     const runCypressSource = readFileSync('scripts/run-cypress.ts', 'utf8');
 


### PR DESCRIPTION
## Summary
- classify shared Playwright route helper changes as hosted auth/session browser changes
- ensure future main pushes execute the synthetic BCBA acceptance instead of false-green skipping it
- add focused classifier coverage

## Evidence
Post-merge CI for PR #764 was green but skipped both BCBA session acceptance and synthetic actor cleanup because scripts/lib/playwright-smoke.ts was not matched by select-browser-checks.mjs.

## Verification
- classifier tests: 10 passed
- direct classifier output: authSmokeRequired=true for scripts/lib/playwright-smoke.ts
- policy checks: passed
- lint: passed
- typecheck: passed

## Risk
Critical CI policy change. It only expands verification coverage; it does not change production access or credentials. Human review and a post-merge main run are required.