### PR TITLE
WIN-217 Bootstrap hosted BCBA acceptance

### DIFF
--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -86,7 +86,7 @@ const classifyFile = (file) => {
     /^scripts\/ci\/select-browser-checks\.mjs$/,
     /^scripts\/ci\/deploy-session-edge-bundle\.mjs$/,
   ])) {
-    return { specs: allSpecKeys, authSmoke: false, reason: "browser CI support script" };
+    return { specs: allSpecKeys, authSmoke: true, reason: "browser CI support script" };
   }
 
   if (matchAny(file, [

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -82,11 +82,12 @@ const changedFilesForRange = ({ base, head }) => {
 const matchAny = (file, patterns) => patterns.some((pattern) => pattern.test(file));
 
 const classifyFile = (file) => {
-  if (matchAny(file, [
-    /^scripts\/ci\/select-browser-checks\.mjs$/,
-    /^scripts\/ci\/deploy-session-edge-bundle\.mjs$/,
-  ])) {
+  if (/^scripts\/ci\/select-browser-checks\.mjs$/.test(file)) {
     return { specs: allSpecKeys, authSmoke: true, reason: "browser CI support script" };
+  }
+
+  if (/^scripts\/ci\/deploy-session-edge-bundle\.mjs$/.test(file)) {
+    return { specs: allSpecKeys, authSmoke: false, reason: "browser CI support script" };
   }
 
   if (matchAny(file, [

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -70,11 +70,11 @@ describe('select-browser-checks', () => {
     ]);
   });
 
-  it('runs full tier-0 without hosted auth smoke when browser selector changes', () => {
+  it('runs full tier-0 and hosted auth smoke when browser selector changes', () => {
     const selection = runSelector('--changed-file', 'scripts/ci/select-browser-checks.mjs');
 
     expect(selection.tier0Required).toBe(true);
-    expect(selection.authSmokeRequired).toBe(false);
+    expect(selection.authSmokeRequired).toBe(true);
     expect(selection.tier0Specs).toContain('cypress/e2e/preauth_workflow.cy.ts');
     expect(selection.reasons).toEqual([
       'scripts/ci/select-browser-checks.mjs: browser CI support script',


### PR DESCRIPTION
## Summary
- make changes to the browser-scope classifier itself require hosted auth smoke
- preserve the existing deploy-session-edge-bundle scope without credential-backed smoke
- ensure the next main push cannot false-green skip BCBA acceptance

## Evidence
PR #765 merged successfully, but its main run skipped the BCBA actor, acceptance, and cleanup because the classifier's higher-priority self-classification returned authSmoke=false.

## Verification
- selector tests: 10 passed
- selector self-change: authSmokeRequired=true
- deploy bundle change: authSmokeRequired=false
- policy checks: passed
- lint/typecheck: passed on initial revision
- reviewer feedback addressed by splitting the two CI support paths

## Risk
Critical CI policy change. No production access or credential changes. Human review and post-merge main proof required.