### PR TITLE
WIN-217: stabilize measurement session calendar lookup

### DIFF
--- a/scripts/playwright-session-note-measurement-roundtrip.ts
+++ b/scripts/playwright-session-note-measurement-roundtrip.ts
@@ -187,16 +187,55 @@ const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): P
   }
 };
 
+const selectScheduleFilterOptionIfPresent = async (
+  page: Page,
+  selector: string,
+  value: string,
+): Promise<boolean> => {
+  const filter = page.locator(`select${selector}`).first();
+  const exists = await filter
+    .waitFor({ state: "attached", timeout: 5_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!exists) {
+    return false;
+  }
+
+  const deadline = Date.now() + 12_000;
+  while (Date.now() < deadline) {
+    const values = await filter.evaluate((select) =>
+      Array.from((select as HTMLSelectElement).options).map((option) => option.value),
+    );
+    if (values.includes(value)) {
+      await filter.selectOption(value);
+      return true;
+    }
+    await page.waitForTimeout(250);
+  }
+
+  return false;
+};
+
 const openEditSessionModalFromCalendar = async (
   page: Page,
   scheduleUrl: string,
   sessionId: string,
+  therapistId: string,
+  clientId: string,
   sessionStartIso?: string,
 ): Promise<void> => {
   await page.goto(`${scheduleUrl}?_${Date.now()}`, {
     waitUntil: "networkidle",
     timeout: 60000,
   });
+
+  const selectedTherapist = await selectScheduleFilterOptionIfPresent(page, "#therapist-filter", therapistId);
+  const selectedClient = await selectScheduleFilterOptionIfPresent(page, "#client-filter", clientId);
+  if (selectedTherapist || selectedClient) {
+    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
+    // Schedule applies filters after a 300 ms debounce; allow that refresh to render before card lookup.
+    await page.waitForTimeout(750);
+  }
 
   let visitedPeriods = 0;
   for (let periodAttempt = 0; periodAttempt < 8; periodAttempt += 1) {
@@ -703,7 +742,14 @@ async function run(): Promise<void> {
     });
 
     await withStepTimeout("open-session-modal-clinical", async () => {
-      await openEditSessionModalFromCalendar(activePage, scheduleUrl, booked.sessionId, booked.startIso);
+      await openEditSessionModalFromCalendar(
+        activePage,
+        scheduleUrl,
+        booked.sessionId,
+        booked.therapistId,
+        booked.clientId,
+        booked.startIso,
+      );
       const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
       await selectFirstOptionIfEmpty(
         editDialog.first().locator('#session-note-auth-select, select[name="session_note_authorization_id"]'),

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -199,6 +199,21 @@ describe("check-e2e-reliability-gates", () => {
     expect(resolveOpportunityCountForMetric(8, Number.NaN)).toBe(8);
   });
 
+  test("session note measurement filters the crowded schedule to its booked actor and client", () => {
+    const scriptPath = path.join(repoRoot, "scripts", "playwright-session-note-measurement-roundtrip.ts");
+    const content = readFileSync(scriptPath, "utf8");
+
+    expect(content).toContain("page.locator(`select${selector}`).first()");
+    expect(content).toContain('selectScheduleFilterOptionIfPresent(page, "#therapist-filter", therapistId)');
+    expect(content).toContain('selectScheduleFilterOptionIfPresent(page, "#client-filter", clientId)');
+    expect(content).toMatch(
+      /await\s+openEditSessionModalFromCalendar\([\s\S]*?booked\.sessionId,[\s\S]*?booked\.therapistId,[\s\S]*?booked\.clientId,[\s\S]*?booked\.startIso/,
+    );
+    expect(content.indexOf('selectScheduleFilterOptionIfPresent(page, "#client-filter", clientId)')).toBeLessThan(
+      content.indexOf('page.locator(`[data-session-id="${sessionId}"]`)'),
+    );
+  });
+
   test("accepts ci:playwright runner invocation semantics", () => {
     const fixtureRoot = createFixture(`tsx scripts/playwright-ci-runner.ts ${runnerChildren.join(" ")}`);
 


### PR DESCRIPTION
## Summary
- filter the hosted measurement roundtrip schedule to the exact booked therapist and client before locating its session card
- preserve locked-therapist behavior by targeting select controls only
- wait through the schedule filter debounce before card lookup
- add a reliability contract covering the filtered invocation order

## Root cause
Run 29179821153 successfully started the session, then timed out reopening it from an unfiltered schedule showing 353 therapists and 401 clients. The dedicated BCBA acceptance step was skipped after that earlier child failed.

## Verification
- npm test -- --run tests/ci/check-e2e-reliability-gates.test.ts (9 passed)
- npm run lint
- npm run typecheck
- npm run ci:check-focused
- npm run test:ci (380 files passed, 2631 tests passed; 1 file/3 tests skipped for absent WIN211_POSTGRES_URL)
- npm run test:routes:tier0 (220 passed)
- npm run build

## Risk
Critical-lane CI/auth-session proof harness change; production application, auth, API, database, and workflow files are unchanged. Hosted auth-browser-smoke remains the decisive post-merge proof.

Linear: WIN-217