### PR TITLE
WIN-217: open collapsed filters in session proof

### DIFF
--- a/scripts/playwright-session-note-measurement-roundtrip.ts
+++ b/scripts/playwright-session-note-measurement-roundtrip.ts
@@ -187,6 +187,23 @@ const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): P
   }
 };
 
+const openScheduleFiltersIfCollapsed = async (page: Page): Promise<void> => {
+  const filterDetails = page.locator("details").filter({ has: page.locator("#client-filter") }).first();
+  const exists = await filterDetails
+    .waitFor({ state: "attached", timeout: 2_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!exists) {
+    return;
+  }
+
+  const isOpen = await filterDetails.evaluate((node) => (node instanceof HTMLDetailsElement ? node.open : true));
+  if (!isOpen) {
+    await filterDetails.locator(":scope > summary").click();
+  }
+  await page.locator("select#client-filter").waitFor({ state: "visible", timeout: 5_000 });
+};
+
 const selectScheduleFilterOptionIfPresent = async (
   page: Page,
   selector: string,
@@ -229,6 +246,7 @@ const openEditSessionModalFromCalendar = async (
     timeout: 60000,
   });
 
+  await openScheduleFiltersIfCollapsed(page);
   const selectedTherapist = await selectScheduleFilterOptionIfPresent(page, "#therapist-filter", therapistId);
   const selectedClient = await selectScheduleFilterOptionIfPresent(page, "#client-filter", clientId);
   if (selectedTherapist || selectedClient) {

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -214,6 +214,18 @@ describe("check-e2e-reliability-gates", () => {
     );
   });
 
+  test("session note measurement opens collapsed schedule filters before selecting options", () => {
+    const scriptPath = path.join(repoRoot, "scripts", "playwright-session-note-measurement-roundtrip.ts");
+    const content = readFileSync(scriptPath, "utf8");
+
+    expect(content).toContain('filter({ has: page.locator("#client-filter") })');
+    expect(content).toContain('locator(":scope > summary")');
+    expect(content).toContain('await openScheduleFiltersIfCollapsed(page)');
+    expect(content.indexOf("await openScheduleFiltersIfCollapsed(page)")).toBeLessThan(
+      content.indexOf('selectScheduleFilterOptionIfPresent(page, "#therapist-filter", therapistId)'),
+    );
+  });
+
   test("accepts ci:playwright runner invocation semantics", () => {
     const fixtureRoot = createFixture(`tsx scripts/playwright-ci-runner.ts ${runnerChildren.join(" ")}`);
 


### PR DESCRIPTION
## Summary
- address the unresolved Codex P2 from merged PR #767
- open only the Schedule details containing the client filter when it is collapsed
- preserve desktop no-op, already-open, and therapist-locked behavior
- add a reliability contract proving disclosure expansion precedes filter selection

## Verification
- focused reliability test: 10 passed
- npm run lint
- npm run typecheck
- npm run ci:check-focused
- npm run test:ci
- npm run test:routes:tier0: 220 passed
- npm run build

## Risk
Critical-lane auth/session proof harness follow-up. No production UI, auth, API, database, or workflow files changed. Hosted auth-browser-smoke remains decisive.

Linear: WIN-217