### PR TITLE
WIN-217: restore bounded route readiness retries

### DIFF
--- a/scripts/lib/playwright-schedule-session-modal.ts
+++ b/scripts/lib/playwright-schedule-session-modal.ts
@@ -1,0 +1,190 @@
+import type { Page } from "playwright";
+
+export interface ScheduleSessionModalTarget {
+  sessionId: string;
+  therapistId: string;
+  clientId: string;
+  startIso?: string;
+}
+
+export const SCHEDULE_SESSION_SEARCH_PERIODS = 12;
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const validateTarget = (scheduleUrl: string, target: ScheduleSessionModalTarget): void => {
+  for (const [label, value] of [
+    ["sessionId", target.sessionId],
+    ["therapistId", target.therapistId],
+    ["clientId", target.clientId],
+  ] as const) {
+    if (!UUID_PATTERN.test(value)) {
+      throw new Error(`Invalid ${label} for Schedule session lookup.`);
+    }
+  }
+  if (target.startIso && !Number.isFinite(Date.parse(target.startIso))) {
+    throw new Error("Invalid startIso for Schedule session lookup.");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(scheduleUrl);
+  } catch {
+    throw new Error("Invalid Schedule URL for session lookup.");
+  }
+  const localhost = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  const validProtocol = url.protocol === "https:" || (localhost && url.protocol === "http:");
+  if (url.pathname !== "/schedule" || url.username || url.password || url.hash || !validProtocol) {
+    throw new Error("Invalid Schedule URL for session lookup.");
+  }
+};
+
+const describeScheduleFailureState = async (page: Page): Promise<string> => {
+  const pathname = new URL(page.url()).pathname.toLowerCase();
+  if (pathname.includes("/login")) return "login_redirect";
+  if (pathname.includes("/unauthorized")) return "unauthorized_redirect";
+  if ((await page.locator('[data-testid="schedule-missing-org"]').count()) > 0) return "missing_organization";
+  if ((await page.locator('[data-testid="schedule-data-load-error"]').count()) > 0) return "schedule_data_error";
+  if ((await page.locator('[data-testid="schedule-loading"]').count()) > 0) return "schedule_still_loading";
+  return "schedule_not_ready";
+};
+
+const openScheduleFiltersIfCollapsed = async (page: Page): Promise<void> => {
+  await page.locator("#client-filter").first().waitFor({ state: "attached", timeout: 12_000 });
+  const filterDetails = page.locator("details").filter({ has: page.locator("#client-filter") }).first();
+  if ((await filterDetails.count()) === 0) {
+    return;
+  }
+
+  const isOpen = await filterDetails.evaluate((node) => (node instanceof HTMLDetailsElement ? node.open : true));
+  if (!isOpen) {
+    await filterDetails.locator(":scope > summary").click();
+  }
+  await page.locator("select#client-filter").waitFor({ state: "visible", timeout: 10_000 });
+};
+
+const selectExactScheduleFilter = async (
+  page: Page,
+  selector: "#therapist-filter" | "#client-filter",
+  value: string,
+  options: { allowMissingControl?: boolean } = {},
+): Promise<boolean> => {
+  const filter = page.locator(`select${selector}`).first();
+  const attached = await filter
+    .waitFor({ state: "attached", timeout: 12_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!attached) {
+    const lockedControl = page.locator(`div${selector}`).first();
+    const locked = options.allowMissingControl && (await lockedControl.count()) > 0;
+    if (locked) return false;
+    throw new Error(`Required Schedule filter control is missing: ${selector}`);
+  }
+
+  for (let optionAttempt = 0; optionAttempt < 48; optionAttempt += 1) {
+    const values = await filter.evaluate((select) =>
+      Array.from((select as HTMLSelectElement).options).map((option) => option.value),
+    );
+    if (values.includes(value)) {
+      await filter.selectOption(value);
+      if ((await filter.inputValue()) !== value) {
+        throw new Error(`Schedule filter did not retain the requested value: ${selector}`);
+      }
+      return true;
+    }
+    await page.waitForTimeout(250);
+  }
+
+  throw new Error(`Booked session identity is not available in Schedule filter: ${selector}`);
+};
+
+const normalizeWeekView = async (page: Page): Promise<void> => {
+  const weekButton = page.locator('button[aria-label="Week view"]').first();
+  const ready = await weekButton
+    .waitFor({ state: "visible", timeout: 30_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!ready) {
+    throw new Error(`Schedule did not reach calendar readiness: ${await describeScheduleFailureState(page)}`);
+  }
+  if ((await weekButton.getAttribute("aria-pressed")) !== "true") {
+    await weekButton.click();
+    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
+    for (let readinessAttempt = 0; readinessAttempt < 40; readinessAttempt += 1) {
+      if ((await weekButton.getAttribute("aria-pressed")) === "true") return;
+      await page.waitForTimeout(250);
+    }
+    throw new Error("Schedule did not reach calendar readiness: week_view_not_selected");
+  }
+};
+
+export const openScheduleSessionModalFromCalendar = async (
+  page: Page,
+  scheduleUrl: string,
+  target: ScheduleSessionModalTarget,
+  options: { allowLockedTherapist?: boolean } = {},
+): Promise<void> => {
+  validateTarget(scheduleUrl, target);
+  await page.goto(`${scheduleUrl}?_${Date.now()}`, {
+    waitUntil: "networkidle",
+    timeout: 60_000,
+  });
+
+  await normalizeWeekView(page);
+  await openScheduleFiltersIfCollapsed(page);
+  const selectedTherapist = await selectExactScheduleFilter(page, "#therapist-filter", target.therapistId, {
+    allowMissingControl: options.allowLockedTherapist === true,
+  });
+  const selectedClient = await selectExactScheduleFilter(page, "#client-filter", target.clientId);
+  if (selectedTherapist || selectedClient) {
+    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
+    // Schedule applies exact-pair filters after a 300 ms debounce.
+    await page.waitForTimeout(750);
+  }
+
+  let visitedPeriods = 0;
+  let lastInteractionError = "session_card_not_rendered";
+  for (let periodAttempt = 0; periodAttempt < SCHEDULE_SESSION_SEARCH_PERIODS; periodAttempt += 1) {
+    visitedPeriods = periodAttempt + 1;
+    const sessionCard = page.locator(`[data-session-id="${target.sessionId}"]`).first();
+    const visible = await sessionCard
+      .waitFor({ state: "visible", timeout: periodAttempt === 0 ? 12_000 : 5_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (visible) {
+      for (let clickAttempt = 0; clickAttempt < 3; clickAttempt += 1) {
+        try {
+          await sessionCard.scrollIntoViewIfNeeded();
+          await sessionCard.click();
+          const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i }).first();
+          await dialog.waitFor({ state: "visible", timeout: 12_000 });
+          return;
+        } catch (error) {
+          void error;
+          lastInteractionError = "card_click_or_dialog_not_visible";
+          await page.waitForTimeout(500 + clickAttempt * 250);
+        }
+      }
+      break;
+    }
+
+    if (periodAttempt === SCHEDULE_SESSION_SEARCH_PERIODS - 1) {
+      break;
+    }
+
+    const nextPeriodButton = page.getByRole("button", { name: /next period/i }).first();
+    if ((await nextPeriodButton.count()) === 0) {
+      lastInteractionError = "next_period_control_missing";
+      break;
+    }
+    await nextPeriodButton.click();
+    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
+    await page.waitForTimeout(500 + periodAttempt * 250);
+  }
+
+  throw new Error(
+    `Session modal did not open from the scoped Schedule after ${visitedPeriods} period(s). ` +
+      `sessionId=${target.sessionId} sessionStartIso=${target.startIso ?? "unknown"} ` +
+      `lastInteractionError=${lastInteractionError.slice(0, 300)}`,
+  );
+};

--- a/scripts/lib/playwright-smoke.ts
+++ b/scripts/lib/playwright-smoke.ts
@@ -199,6 +199,9 @@ export const assertRouteAccessible = async (
           .then(() => true)
           .catch(() => false);
         if (!ready) {
+          if (attempt < maxAttempts) {
+            continue;
+          }
           throw new Error(
             `Route ${routePath} loaded but readiness selector was not visible: ${readySelector}`,
           );

--- a/scripts/playwright-schedule-blocked-close.ts
+++ b/scripts/playwright-schedule-blocked-close.ts
@@ -23,6 +23,7 @@ import {
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
 import { assertNonAiSessionsEnvContract } from "./lib/playwright-nonai-sessions-contract";
+import { openScheduleSessionModalFromCalendar } from "./lib/playwright-schedule-session-modal";
 import {
   bookSession,
   cancelSession,
@@ -240,38 +241,6 @@ async function getSessionOrganizationId(sessionId: string): Promise<string> {
   return data.organization_id;
 }
 
-async function openRenderedSessionCard(page: Page, sessionId: string): Promise<boolean> {
-  const card = page.locator(`[data-session-id="${sessionId}"]`).first();
-  const openCard = async (): Promise<boolean> => {
-    const visible = await card.isVisible().catch(() => false);
-    if (!visible) {
-      return false;
-    }
-    await card.click();
-    const dialog = page.getByRole("dialog", { name: /edit session|live session/i });
-    return dialog.waitFor({ state: "visible", timeout: 30_000 })
-      .then(() => true)
-      .catch(() => false);
-  };
-
-  await page.getByRole("button", { name: /Week view/i }).click().catch(() => undefined);
-  await page.waitForLoadState("networkidle").catch(() => undefined);
-  if (await openCard()) {
-    return true;
-  }
-
-  for (let step = 0; step < 8; step += 1) {
-    await page.getByRole("button", { name: /Next period/i }).click();
-    await page.waitForLoadState("networkidle").catch(() => undefined);
-    await page.waitForTimeout(500);
-    if (await openCard()) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 async function run(): Promise<void> {
   loadPlaywrightEnv();
   const base = getEnv("PW_BASE_URL", "https://app.allincompassing.ai");
@@ -444,52 +413,20 @@ async function run(): Promise<void> {
       }));
 
     await withStepTimeout("open-edit-modal", async () => {
-      let lastUrl = activePage.url();
-      let lastBodyText = "";
-
-      // Prefer URL-driven modal state on deploy previews. Netlify's preview drawer
-      // can overlay the schedule grid and swallow rendered-card clicks.
-      for (let attempt = 1; attempt <= 3; attempt += 1) {
-        const expiresAt = Date.now() + 30 * 60 * 1000;
-        const editUrl = `${base}/schedule?scheduleModal=edit&scheduleSessionId=${encodeURIComponent(
-          booked.sessionId,
-        )}&scheduleExp=${expiresAt}`;
-
-        await activePage.goto(editUrl, { waitUntil: "domcontentloaded", timeout: 90_000 });
-        await activePage.waitForLoadState("networkidle").catch(() => undefined);
-
-        const dialog = activePage.getByRole("dialog", { name: /edit session|live session/i });
-        const dialogVisible = await dialog.waitFor({ state: "visible", timeout: 30_000 })
-          .then(() => true)
-          .catch(() => false);
-        lastUrl = activePage.url();
-        lastBodyText = await activePage.evaluate(() => document.body.innerText.slice(0, 1000)).catch(() => "");
-
-        if (!dialogVisible) {
-          console.warn(
-            `[blocked-close] edit modal did not open on attempt ${attempt}; url=${lastUrl}`,
-          );
-          await activePage.waitForTimeout(1000);
-          continue;
-        }
-
+      try {
+        await openScheduleSessionModalFromCalendar(activePage, `${base}/schedule`, booked, {
+          allowLockedTherapist: !isTruthy(process.env.PW_ASSERT_ALREADY_STARTED_UI),
+        });
         await activePage
           .locator('[role="dialog"][data-session-status="in_progress"]')
           .waitFor({ state: "visible", timeout: 90_000 });
         return;
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : "unknown scoped Schedule opener failure";
+        throw new Error(
+          `Edit modal did not open for browser-visible in-progress session ${booked.sessionId}: ${detail}`,
+        );
       }
-
-      const openedFromRenderedCard = await openRenderedSessionCard(activePage, booked.sessionId);
-      if (openedFromRenderedCard) {
-        await activePage
-          .locator('[role="dialog"][data-session-status="in_progress"]')
-          .waitFor({ state: "visible", timeout: 90_000 });
-        return;
-      }
-
-      throw new Error(
-        `Edit modal did not open for browser-visible in-progress session ${booked.sessionId}; url=${lastUrl}; body=${JSON.stringify(lastBodyText)}`,
-      );
     });
 
     await withStepTimeout("assert-api-session-in-progress", async () => {

--- a/scripts/playwright-session-capture-adhoc-upsert.ts
+++ b/scripts/playwright-session-capture-adhoc-upsert.ts
@@ -17,6 +17,7 @@ import {
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
 import { assertNonAiSessionsEnvContract } from "./lib/playwright-nonai-sessions-contract";
+import { openScheduleSessionModalFromCalendar } from "./lib/playwright-schedule-session-modal";
 import {
   bookSession,
   cancelSession,
@@ -57,60 +58,6 @@ const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): P
   } finally {
     clearTimeout(timeoutHandle);
   }
-};
-
-const openEditSessionModalFromCalendar = async (
-  page: Page,
-  scheduleUrl: string,
-  sessionId: string,
-  sessionStartIso?: string,
-): Promise<void> => {
-  await page.goto(`${scheduleUrl}?_${Date.now()}`, {
-    waitUntil: "networkidle",
-    timeout: 60000,
-  });
-
-  let visitedPeriods = 0;
-  for (let periodAttempt = 0; periodAttempt < 8; periodAttempt += 1) {
-    visitedPeriods = periodAttempt + 1;
-    let sessionCardVisible = false;
-
-    for (let samePeriodAttempt = 0; samePeriodAttempt < 3; samePeriodAttempt += 1) {
-      const sessionCard = page.locator(`[data-session-id="${sessionId}"]`).first();
-      sessionCardVisible = await sessionCard
-        .waitFor({ state: "visible", timeout: samePeriodAttempt === 0 ? 12_000 : 4_000 })
-        .then(() => true)
-        .catch(() => false);
-      if (!sessionCardVisible) {
-        break;
-      }
-
-      try {
-        await sessionCard.scrollIntoViewIfNeeded();
-        await sessionCard.click();
-        const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
-        await dialog.waitFor({ state: "visible", timeout: 12_000 });
-        return;
-      } catch {
-        await page.waitForTimeout(500 + samePeriodAttempt * 250);
-      }
-    }
-
-    if (sessionCardVisible) {
-      continue;
-    }
-
-    const nextPeriodButton = page.getByRole("button", { name: /next period/i }).first();
-    if ((await nextPeriodButton.count()) === 0) {
-      break;
-    }
-    await nextPeriodButton.click();
-    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
-    await page.waitForTimeout(500 + periodAttempt * 250);
-  }
-  throw new Error(
-    `Session modal (Edit Session / Live session) did not open from the rendered schedule card after ${visitedPeriods} schedule period(s). sessionStartIso=${sessionStartIso ?? "unknown"}`,
-  );
 };
 
 const selectFirstOptionIfEmpty = async (
@@ -291,7 +238,9 @@ async function run(): Promise<void> {
       activePage.on("requestfailed", requestFailedListener);
       activePage.on("console", consoleListener);
       try {
-        await openEditSessionModalFromCalendar(activePage, scheduleUrl, booked.sessionId, booked.startIso);
+        await openScheduleSessionModalFromCalendar(activePage, scheduleUrl, booked, {
+          allowLockedTherapist: !isTruthy(process.env.PW_ASSERT_ALREADY_STARTED_UI),
+        });
         const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
         const capture = editDialog.getByTestId("session-modal-capture-section");
         await capture.waitFor({ state: "visible", timeout: 30_000 });

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -18,6 +18,7 @@ import {
 import {
   assertNonAiSessionsEnvContract,
 } from "./lib/playwright-nonai-sessions-contract";
+import { openScheduleSessionModalFromCalendar } from "./lib/playwright-schedule-session-modal";
 
 /** Canonical /schedule + SessionModal regression: book → Start Session → terminal close (no-show/completed). */
 
@@ -717,83 +718,6 @@ export const buildBookingCandidateStarts = (
   }
 
   return candidates;
-};
-
-const selectScheduleFilterOptionIfPresent = async (
-  page: Page,
-  selector: string,
-  value: string,
-): Promise<boolean> => {
-  const filter = page.locator(`select${selector}`).first();
-  const exists = await filter
-    .waitFor({ state: "attached", timeout: 12_000 })
-    .then(() => true)
-    .catch(() => false);
-  if (!exists) {
-    return false;
-  }
-
-  const deadline = Date.now() + 12_000;
-  while (Date.now() < deadline) {
-    const values = await filter.evaluate((select) =>
-      Array.from((select as HTMLSelectElement).options).map((option) => option.value),
-    );
-    if (values.includes(value)) {
-      await filter.selectOption(value);
-      return true;
-    }
-    await page.waitForTimeout(250);
-  }
-
-  return false;
-};
-
-const openEditSessionModalFromCalendar = async (
-  page: Page,
-  scheduleUrl: string,
-  ids: LifecycleIds,
-): Promise<void> => {
-  await page.goto(`${scheduleUrl}?_${Date.now()}`, {
-    waitUntil: "networkidle",
-    timeout: 60000,
-  });
-
-  const selectedTherapist = await selectScheduleFilterOptionIfPresent(page, "#therapist-filter", ids.therapistId);
-  const selectedClient = await selectScheduleFilterOptionIfPresent(page, "#client-filter", ids.clientId);
-  if (selectedTherapist || selectedClient) {
-    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
-    await page.waitForTimeout(500);
-  }
-
-  let visitedPeriods = 0;
-  for (let periodAttempt = 0; periodAttempt < 8; periodAttempt += 1) {
-    visitedPeriods = periodAttempt + 1;
-    const sessionCard = page.locator(`[data-session-id="${ids.sessionId}"]`).first();
-    const visible = await sessionCard
-      .waitFor({ state: "visible", timeout: periodAttempt === 0 ? 12_000 : 5_000 })
-      .then(() => true)
-      .catch(() => false);
-
-    if (visible) {
-      await sessionCard.scrollIntoViewIfNeeded();
-      await sessionCard.click();
-      const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
-      await dialog.waitFor({ state: "visible", timeout: 12_000 });
-      return;
-    }
-
-    const nextPeriodButton = page.getByRole("button", { name: /next period/i }).first();
-    if ((await nextPeriodButton.count()) === 0) {
-      break;
-    }
-    await nextPeriodButton.click();
-    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
-    await page.waitForTimeout(500 + periodAttempt * 250);
-  }
-
-  throw new Error(
-    `Session modal (Edit Session / Live session) did not open from the rendered schedule card after ${visitedPeriods} schedule period(s). sessionStartIso=${ids.startIso}`,
-  );
 };
 
 async function openSessionModal(page: Page) {
@@ -1642,7 +1566,9 @@ async function startSessionViaScheduleModal(
   token: string,
   strictMode: boolean,
 ): Promise<void> {
-  await openEditSessionModalFromCalendar(page, scheduleUrl, ids);
+  await openScheduleSessionModalFromCalendar(page, scheduleUrl, ids, {
+    allowLockedTherapist: !isTruthy(process.env.PW_ASSERT_ALREADY_STARTED_UI),
+  });
   const startButton = page.getByRole("button", { name: /^Start Session$/i });
   await startButton.waitFor({ state: "visible", timeout: 20_000 });
   await expectStartButtonEnabled(page, startButton);
@@ -1707,7 +1633,9 @@ async function markTerminalViaScheduleModal(
   actorUserId: string,
   strictMode: boolean,
 ): Promise<void> {
-  await openEditSessionModalFromCalendar(page, scheduleUrl, ids);
+  await openScheduleSessionModalFromCalendar(page, scheduleUrl, ids, {
+    allowLockedTherapist: !isTruthy(process.env.PW_ASSERT_ALREADY_STARTED_UI),
+  });
   const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
   await page.locator("#status-select").selectOption(terminalStatus);
   page.once("dialog", (dialog) => {

--- a/scripts/playwright-session-note-measurement-roundtrip.ts
+++ b/scripts/playwright-session-note-measurement-roundtrip.ts
@@ -19,6 +19,7 @@ import {
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
 import { assertNonAiSessionsEnvContract } from "./lib/playwright-nonai-sessions-contract";
+import { openScheduleSessionModalFromCalendar } from "./lib/playwright-schedule-session-modal";
 import {
   bookSession,
   cancelSession,
@@ -185,117 +186,6 @@ const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): P
   } finally {
     clearTimeout(timeoutHandle);
   }
-};
-
-const openScheduleFiltersIfCollapsed = async (page: Page): Promise<void> => {
-  const filterDetails = page.locator("details").filter({ has: page.locator("#client-filter") }).first();
-  const exists = await filterDetails
-    .waitFor({ state: "attached", timeout: 2_000 })
-    .then(() => true)
-    .catch(() => false);
-  if (!exists) {
-    return;
-  }
-
-  const isOpen = await filterDetails.evaluate((node) => (node instanceof HTMLDetailsElement ? node.open : true));
-  if (!isOpen) {
-    await filterDetails.locator(":scope > summary").click();
-  }
-  await page.locator("select#client-filter").waitFor({ state: "visible", timeout: 5_000 });
-};
-
-const selectScheduleFilterOptionIfPresent = async (
-  page: Page,
-  selector: string,
-  value: string,
-): Promise<boolean> => {
-  const filter = page.locator(`select${selector}`).first();
-  const exists = await filter
-    .waitFor({ state: "attached", timeout: 5_000 })
-    .then(() => true)
-    .catch(() => false);
-  if (!exists) {
-    return false;
-  }
-
-  const deadline = Date.now() + 12_000;
-  while (Date.now() < deadline) {
-    const values = await filter.evaluate((select) =>
-      Array.from((select as HTMLSelectElement).options).map((option) => option.value),
-    );
-    if (values.includes(value)) {
-      await filter.selectOption(value);
-      return true;
-    }
-    await page.waitForTimeout(250);
-  }
-
-  return false;
-};
-
-const openEditSessionModalFromCalendar = async (
-  page: Page,
-  scheduleUrl: string,
-  sessionId: string,
-  therapistId: string,
-  clientId: string,
-  sessionStartIso?: string,
-): Promise<void> => {
-  await page.goto(`${scheduleUrl}?_${Date.now()}`, {
-    waitUntil: "networkidle",
-    timeout: 60000,
-  });
-
-  await openScheduleFiltersIfCollapsed(page);
-  const selectedTherapist = await selectScheduleFilterOptionIfPresent(page, "#therapist-filter", therapistId);
-  const selectedClient = await selectScheduleFilterOptionIfPresent(page, "#client-filter", clientId);
-  if (selectedTherapist || selectedClient) {
-    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
-    // Schedule applies filters after a 300 ms debounce; allow that refresh to render before card lookup.
-    await page.waitForTimeout(750);
-  }
-
-  let visitedPeriods = 0;
-  for (let periodAttempt = 0; periodAttempt < 8; periodAttempt += 1) {
-    visitedPeriods = periodAttempt + 1;
-    let sessionCardVisible = false;
-
-    for (let samePeriodAttempt = 0; samePeriodAttempt < 3; samePeriodAttempt += 1) {
-      const sessionCard = page.locator(`[data-session-id="${sessionId}"]`).first();
-      sessionCardVisible = await sessionCard
-        .waitFor({ state: "visible", timeout: samePeriodAttempt === 0 ? 12_000 : 4_000 })
-        .then(() => true)
-        .catch(() => false);
-      if (!sessionCardVisible) {
-        break;
-      }
-
-      try {
-        await sessionCard.scrollIntoViewIfNeeded();
-        await sessionCard.click();
-        const dialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
-        await dialog.waitFor({ state: "visible", timeout: 12_000 });
-        return;
-      } catch {
-        await page.waitForTimeout(500 + samePeriodAttempt * 250);
-      }
-    }
-
-    if (sessionCardVisible) {
-      continue;
-    }
-
-    const nextPeriodButton = page.getByRole("button", { name: /next period/i }).first();
-    if ((await nextPeriodButton.count()) === 0) {
-      break;
-    }
-    await nextPeriodButton.click();
-    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
-    await page.waitForTimeout(500 + periodAttempt * 250);
-  }
-  throw new Error(
-    `Session modal (Edit Session / Live session) did not open from the rendered schedule card after ${visitedPeriods} schedule period(s). sessionStartIso=${sessionStartIso ?? "unknown"}`,
-  );
 };
 
 const ensureGoalCaptureFieldsVisible = async (dialog: ReturnType<Page["locator"]>, goalId: string): Promise<void> => {
@@ -760,14 +650,9 @@ async function run(): Promise<void> {
     });
 
     await withStepTimeout("open-session-modal-clinical", async () => {
-      await openEditSessionModalFromCalendar(
-        activePage,
-        scheduleUrl,
-        booked.sessionId,
-        booked.therapistId,
-        booked.clientId,
-        booked.startIso,
-      );
+      await openScheduleSessionModalFromCalendar(activePage, scheduleUrl, booked, {
+        allowLockedTherapist: !isTruthy(process.env.PW_ASSERT_ALREADY_STARTED_UI),
+      });
       const editDialog = activePage.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
       await selectFirstOptionIfEmpty(
         editDialog.first().locator('#session-note-auth-select, select[name="session_note_authorization_id"]'),

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -202,28 +202,65 @@ describe("check-e2e-reliability-gates", () => {
   test("session note measurement filters the crowded schedule to its booked actor and client", () => {
     const scriptPath = path.join(repoRoot, "scripts", "playwright-session-note-measurement-roundtrip.ts");
     const content = readFileSync(scriptPath, "utf8");
-
-    expect(content).toContain("page.locator(`select${selector}`).first()");
-    expect(content).toContain('selectScheduleFilterOptionIfPresent(page, "#therapist-filter", therapistId)');
-    expect(content).toContain('selectScheduleFilterOptionIfPresent(page, "#client-filter", clientId)');
-    expect(content).toMatch(
-      /await\s+openEditSessionModalFromCalendar\([\s\S]*?booked\.sessionId,[\s\S]*?booked\.therapistId,[\s\S]*?booked\.clientId,[\s\S]*?booked\.startIso/,
+    const helper = readFileSync(
+      path.join(repoRoot, "scripts", "lib", "playwright-schedule-session-modal.ts"),
+      "utf8",
     );
-    expect(content.indexOf('selectScheduleFilterOptionIfPresent(page, "#client-filter", clientId)')).toBeLessThan(
-      content.indexOf('page.locator(`[data-session-id="${sessionId}"]`)'),
+
+    expect(helper).toContain("page.locator(`select${selector}`).first()");
+    expect(helper).toContain('selectExactScheduleFilter(page, "#therapist-filter", target.therapistId');
+    expect(helper).toContain('selectExactScheduleFilter(page, "#client-filter", target.clientId)');
+    expect(content).toContain("openScheduleSessionModalFromCalendar(activePage, scheduleUrl, booked,");
+    expect(helper.indexOf('selectExactScheduleFilter(page, "#client-filter", target.clientId)')).toBeLessThan(
+      helper.indexOf('page.locator(`[data-session-id="${target.sessionId}"]`)'),
     );
   });
 
   test("session note measurement opens collapsed schedule filters before selecting options", () => {
     const scriptPath = path.join(repoRoot, "scripts", "playwright-session-note-measurement-roundtrip.ts");
     const content = readFileSync(scriptPath, "utf8");
-
-    expect(content).toContain('filter({ has: page.locator("#client-filter") })');
-    expect(content).toContain('locator(":scope > summary")');
-    expect(content).toContain('await openScheduleFiltersIfCollapsed(page)');
-    expect(content.indexOf("await openScheduleFiltersIfCollapsed(page)")).toBeLessThan(
-      content.indexOf('selectScheduleFilterOptionIfPresent(page, "#therapist-filter", therapistId)'),
+    const helper = readFileSync(
+      path.join(repoRoot, "scripts", "lib", "playwright-schedule-session-modal.ts"),
+      "utf8",
     );
+
+    expect(helper).toContain('filter({ has: page.locator("#client-filter") })');
+    expect(helper).toContain('locator(":scope > summary")');
+    expect(helper).toContain('await openScheduleFiltersIfCollapsed(page)');
+    expect(helper.indexOf("await openScheduleFiltersIfCollapsed(page)")).toBeLessThan(
+      helper.indexOf('selectExactScheduleFilter(page, "#therapist-filter", target.therapistId'),
+    );
+    expect(content).toContain("openScheduleSessionModalFromCalendar(activePage, scheduleUrl, booked,");
+  });
+
+  test("all rendered Schedule session flows use the shared scoped modal opener", () => {
+    const helperPath = path.join(repoRoot, "scripts", "lib", "playwright-schedule-session-modal.ts");
+    const helper = readFileSync(helperPath, "utf8");
+
+    expect(helper).toContain('select#client-filter');
+    expect(helper).toContain('selectExactScheduleFilter(page, "#therapist-filter", target.therapistId');
+    expect(helper).toContain('button[aria-label="Week view"]');
+    expect(helper).toContain('filter({ has: page.locator("#client-filter") })');
+    expect(helper.indexOf('select#client-filter')).toBeLessThan(
+      helper.indexOf('page.locator(`[data-session-id="${target.sessionId}"]`)'),
+    );
+
+    for (const scriptName of [
+      "playwright-session-lifecycle.ts",
+      "playwright-session-note-measurement-roundtrip.ts",
+      "playwright-session-capture-adhoc-upsert.ts",
+      "playwright-schedule-blocked-close.ts",
+    ]) {
+      const content = readFileSync(path.join(repoRoot, "scripts", scriptName), "utf8");
+      expect(content).toContain('from "./lib/playwright-schedule-session-modal"');
+      expect(content).toContain("openScheduleSessionModalFromCalendar(");
+      expect(content).toContain("allowLockedTherapist: !isTruthy(process.env.PW_ASSERT_ALREADY_STARTED_UI)");
+      expect(content).not.toContain("const openEditSessionModalFromCalendar = async");
+    }
+
+    const blockedClose = readFileSync(path.join(repoRoot, "scripts", "playwright-schedule-blocked-close.ts"), "utf8");
+    expect(blockedClose).not.toContain("scheduleModal=edit");
+    expect(blockedClose).toContain('openScheduleSessionModalFromCalendar(activePage, `${base}/schedule`, booked,');
   });
 
   test("accepts ci:playwright runner invocation semantics", () => {

--- a/tests/scripts/playwright-schedule-session-modal.test.ts
+++ b/tests/scripts/playwright-schedule-session-modal.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Page } from "playwright";
+
+import {
+  openScheduleSessionModalFromCalendar,
+  SCHEDULE_SESSION_SEARCH_PERIODS,
+} from "../../scripts/lib/playwright-schedule-session-modal";
+import {
+  BOOKING_ATTEMPTS_PER_TARGET_PAIR,
+  buildInProgressSessionBookingBaseStart,
+  buildVisibleScheduleBookingAttemptStart,
+} from "../../scripts/lib/playwright-inprogress-session-setup";
+
+describe("openScheduleSessionModalFromCalendar", () => {
+  const target = {
+    sessionId: "30d14e05-c3c9-4f5c-8b7c-8fb6fd07897f",
+    therapistId: "ffe316bc-2c6d-4421-9509-3dbf930d565d",
+    clientId: "23d0285a-2841-47ce-a7cc-99aa5b43dac9",
+    startIso: "2026-08-13T16:00:00.000Z",
+  };
+
+  it("rejects invalid session identity before navigating", async () => {
+    const goto = vi.fn();
+    const page = { goto } as unknown as Page;
+
+    await expect(openScheduleSessionModalFromCalendar(page, "https://app.example.com/schedule", {
+      sessionId: 'not-a-session-id"]',
+      therapistId: "not-a-therapist-id",
+      clientId: "not-a-client-id",
+      startIso: "not-a-date",
+    })).rejects.toThrow(/invalid sessionId/i);
+
+    expect(goto).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-http localhost Schedule URLs before navigating", async () => {
+    const goto = vi.fn();
+    const page = { goto } as unknown as Page;
+
+    await expect(openScheduleSessionModalFromCalendar(page, "ftp://localhost/schedule", target))
+      .rejects.toThrow(/invalid Schedule URL/i);
+    expect(goto).not.toHaveBeenCalled();
+  });
+
+  it("keeps a bounded search horizon that covers the maximum fixture range", () => {
+    const now = new Date("2026-07-12T12:00:00.000Z");
+    const latestStarts = Array.from({ length: 21 }, (_, seed) => {
+      const base = buildInProgressSessionBookingBaseStart(now, seed, "UTC");
+      return buildVisibleScheduleBookingAttemptStart(base, BOOKING_ATTEMPTS_PER_TARGET_PAIR - 1, "UTC");
+    });
+    const maxOffsetDays = Math.ceil(Math.max(...latestStarts.map((start) => start.getTime() - now.getTime())) / 86_400_000);
+
+    expect(maxOffsetDays).toBeLessThanOrEqual((SCHEDULE_SESSION_SEARCH_PERIODS - 1) * 7);
+    expect(SCHEDULE_SESSION_SEARCH_PERIODS).toBe(12);
+  });
+
+  it("normalizes Week view, opens collapsed filters, scopes the client, and traverses before clicking", async () => {
+    const events: string[] = [];
+    let cardWaits = 0;
+    const first = <T extends object>(value: T) => Object.assign(value, { first: () => value });
+    const week = first({
+      waitFor: vi.fn().mockResolvedValue(undefined),
+      getAttribute: vi.fn().mockResolvedValueOnce("false").mockResolvedValue("true"),
+      click: vi.fn(async () => { events.push("week-click"); }),
+    });
+    const clientAttachment = first({ waitFor: vi.fn().mockResolvedValue(undefined) });
+    const details = first({
+      count: vi.fn().mockResolvedValue(1),
+      evaluate: vi.fn().mockResolvedValue(false),
+      locator: vi.fn(() => ({ click: vi.fn(async () => { events.push("summary-click"); }) })),
+    });
+    const lockedTherapist = first({ count: vi.fn().mockResolvedValue(1) });
+    const therapistSelect = first({ waitFor: vi.fn().mockRejectedValue(new Error("absent")) });
+    const clientSelect = first({
+      waitFor: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn((callback: (select: { options: Array<{ value: string }> }) => string[]) =>
+        callback({ options: [{ value: target.clientId }] })),
+      selectOption: vi.fn(async () => { events.push("client-select"); }),
+      inputValue: vi.fn().mockResolvedValue(target.clientId),
+    });
+    const card = first({
+      waitFor: vi.fn(async () => {
+        cardWaits += 1;
+        if (cardWaits === 1) throw new Error("not in this week");
+      }),
+      scrollIntoViewIfNeeded: vi.fn().mockResolvedValue(undefined),
+      click: vi.fn(async () => { events.push("card-click"); }),
+    });
+    const dialog = first({ waitFor: vi.fn().mockResolvedValue(undefined) });
+    const next = first({
+      count: vi.fn().mockResolvedValue(1),
+      click: vi.fn(async () => { events.push("next-click"); }),
+    });
+    const locator = vi.fn((selector: string) => {
+      if (selector === 'button[aria-label="Week view"]') return week;
+      if (selector === "#client-filter") return clientAttachment;
+      if (selector === "details") return { filter: () => details };
+      if (selector === "select#therapist-filter") return therapistSelect;
+      if (selector === "div#therapist-filter") return lockedTherapist;
+      if (selector === "select#client-filter") return clientSelect;
+      if (selector.startsWith("[data-session-id=")) return card;
+      if (selector === '[role="dialog"]') return { filter: () => dialog };
+      throw new Error(`Unexpected locator: ${selector}`);
+    });
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      locator,
+      getByRole: vi.fn(() => next),
+      waitForLoadState: vi.fn().mockResolvedValue(undefined),
+      waitForTimeout: vi.fn().mockResolvedValue(undefined),
+      url: vi.fn().mockReturnValue("https://app.example.com/schedule"),
+    } as unknown as Page;
+
+    await openScheduleSessionModalFromCalendar(page, "https://app.example.com/schedule", target, {
+      allowLockedTherapist: true,
+    });
+
+    expect(events).toEqual(["week-click", "summary-click", "client-select", "next-click", "card-click"]);
+    expect(card.waitFor).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails after the bounded period budget with controlled diagnostics", async () => {
+    const first = <T extends object>(value: T) => Object.assign(value, { first: () => value });
+    const select = (value: string) => first({
+      waitFor: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn((callback: (node: { options: Array<{ value: string }> }) => string[]) =>
+        callback({ options: [{ value }] })),
+      selectOption: vi.fn().mockResolvedValue(undefined),
+      inputValue: vi.fn().mockResolvedValue(value),
+    });
+    const card = first({ waitFor: vi.fn().mockRejectedValue(new Error("absent")) });
+    const next = first({ count: vi.fn().mockResolvedValue(1), click: vi.fn().mockResolvedValue(undefined) });
+    const locator = vi.fn((selector: string) => {
+      if (selector === 'button[aria-label="Week view"]') return first({
+        waitFor: vi.fn().mockResolvedValue(undefined),
+        getAttribute: vi.fn().mockResolvedValue("true"),
+      });
+      if (selector === "#client-filter") return first({ waitFor: vi.fn().mockResolvedValue(undefined) });
+      if (selector === "details") return { filter: () => first({ count: vi.fn().mockResolvedValue(0) }) };
+      if (selector === "select#therapist-filter") return select(target.therapistId);
+      if (selector === "select#client-filter") return select(target.clientId);
+      if (selector.startsWith("[data-session-id=")) return card;
+      throw new Error(`Unexpected locator: ${selector}`);
+    });
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      locator,
+      getByRole: vi.fn(() => next),
+      waitForLoadState: vi.fn().mockResolvedValue(undefined),
+      waitForTimeout: vi.fn().mockResolvedValue(undefined),
+      url: vi.fn().mockReturnValue("https://app.example.com/schedule"),
+    } as unknown as Page;
+
+    const failure = openScheduleSessionModalFromCalendar(
+      page,
+      "https://app.example.com/schedule",
+      target,
+    );
+    await expect(failure).rejects.toThrow(/session_card_not_rendered/);
+    await expect(failure).rejects.toThrow(new RegExp(target.sessionId));
+    await expect(failure).rejects.toThrow(/2026-08-13T16:00:00.000Z/);
+    await expect(failure).rejects.toThrow(/after 12 period\(s\)/);
+
+    expect(card.waitFor).toHaveBeenCalledTimes(SCHEDULE_SESSION_SEARCH_PERIODS);
+    expect(next.click).toHaveBeenCalledTimes(SCHEDULE_SESSION_SEARCH_PERIODS - 1);
+  });
+
+  it("retries a visible card in the same period when the dialog is delayed", async () => {
+    const first = <T extends object>(value: T) => Object.assign(value, { first: () => value });
+    const select = (value: string) => first({
+      waitFor: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn((callback: (node: { options: Array<{ value: string }> }) => string[]) =>
+        callback({ options: [{ value }] })),
+      selectOption: vi.fn().mockResolvedValue(undefined),
+      inputValue: vi.fn().mockResolvedValue(value),
+    });
+    const card = first({
+      waitFor: vi.fn().mockResolvedValue(undefined),
+      scrollIntoViewIfNeeded: vi.fn().mockResolvedValue(undefined),
+      click: vi.fn().mockResolvedValue(undefined),
+    });
+    const dialog = first({
+      waitFor: vi.fn().mockRejectedValueOnce(new Error("raw delayed dialog")).mockResolvedValue(undefined),
+    });
+    const next = first({ count: vi.fn().mockResolvedValue(1), click: vi.fn().mockResolvedValue(undefined) });
+    const locator = vi.fn((selector: string) => {
+      if (selector === 'button[aria-label="Week view"]') return first({
+        waitFor: vi.fn().mockResolvedValue(undefined),
+        getAttribute: vi.fn().mockResolvedValue("true"),
+      });
+      if (selector === "#client-filter") return first({ waitFor: vi.fn().mockResolvedValue(undefined) });
+      if (selector === "details") return { filter: () => first({ count: vi.fn().mockResolvedValue(0) }) };
+      if (selector === "select#therapist-filter") return select(target.therapistId);
+      if (selector === "select#client-filter") return select(target.clientId);
+      if (selector.startsWith("[data-session-id=")) return card;
+      if (selector === '[role="dialog"]') return { filter: () => dialog };
+      throw new Error(`Unexpected locator: ${selector}`);
+    });
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined), locator,
+      getByRole: vi.fn(() => next),
+      waitForLoadState: vi.fn().mockResolvedValue(undefined),
+      waitForTimeout: vi.fn().mockResolvedValue(undefined),
+      url: vi.fn().mockReturnValue("https://app.example.com/schedule"),
+    } as unknown as Page;
+
+    await openScheduleSessionModalFromCalendar(page, "https://app.example.com/schedule", target);
+
+    expect(card.click).toHaveBeenCalledTimes(2);
+    expect(next.click).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the exact therapist option is unavailable", async () => {
+    const first = <T extends object>(value: T) => Object.assign(value, { first: () => value });
+    const therapist = first({
+      waitFor: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockReturnValue([]),
+    });
+    const locator = vi.fn((selector: string) => {
+      if (selector === 'button[aria-label="Week view"]') return first({
+        waitFor: vi.fn().mockResolvedValue(undefined),
+        getAttribute: vi.fn().mockResolvedValue("true"),
+      });
+      if (selector === "#client-filter") return first({ waitFor: vi.fn().mockResolvedValue(undefined) });
+      if (selector === "details") return { filter: () => first({ count: vi.fn().mockResolvedValue(0) }) };
+      if (selector === "select#therapist-filter") return therapist;
+      throw new Error(`Unexpected locator: ${selector}`);
+    });
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined), locator,
+      waitForTimeout: vi.fn().mockResolvedValue(undefined),
+      url: vi.fn().mockReturnValue("https://app.example.com/schedule"),
+    } as unknown as Page;
+
+    await expect(openScheduleSessionModalFromCalendar(page, "https://app.example.com/schedule", target))
+      .rejects.toThrow(/identity is not available.*therapist-filter/i);
+  });
+
+  it("classifies a login redirect when Schedule never becomes ready", async () => {
+    const week = { first: () => week, waitFor: vi.fn().mockRejectedValue(new Error("raw timeout")) };
+    const empty = { count: vi.fn().mockResolvedValue(0) };
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      locator: vi.fn((selector: string) => selector === 'button[aria-label="Week view"]' ? week : empty),
+      url: vi.fn().mockReturnValue("https://app.example.com/login"),
+    } as unknown as Page;
+
+    await expect(openScheduleSessionModalFromCalendar(page, "https://app.example.com/schedule", target))
+      .rejects.toThrow("Schedule did not reach calendar readiness: login_redirect");
+  });
+
+  it("fails with a controlled error when Week view does not become selected", async () => {
+    const week = {
+      first: () => week,
+      waitFor: vi.fn().mockResolvedValue(undefined),
+      getAttribute: vi.fn().mockResolvedValue("false"),
+      click: vi.fn().mockResolvedValue(undefined),
+    };
+    const page = {
+      goto: vi.fn().mockResolvedValue(undefined),
+      locator: vi.fn(() => week),
+      waitForLoadState: vi.fn().mockResolvedValue(undefined),
+      waitForTimeout: vi.fn().mockResolvedValue(undefined),
+      url: vi.fn().mockReturnValue("https://app.example.com/schedule"),
+    } as unknown as Page;
+
+    await expect(openScheduleSessionModalFromCalendar(page, "https://app.example.com/schedule", target))
+      .rejects.toThrow("week_view_not_selected");
+  });
+});

--- a/tests/scripts/playwright-smoke-route-access.test.ts
+++ b/tests/scripts/playwright-smoke-route-access.test.ts
@@ -25,12 +25,32 @@ describe("assertRouteAccessible readiness", () => {
     expect(waitFor).toHaveBeenCalledWith({ state: "visible", timeout: 30_000 });
   });
 
+  it("retries the expected route when readiness appears after the first bounded wait", async () => {
+    const waitFor = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce(undefined);
+    const page = buildPage(waitFor);
+
+    await assertRouteAccessible(page, "https://app.example.com", "/schedule", {
+      readySelector: 'button[aria-label="Day view"]',
+      timeoutMs: 100,
+    });
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(waitFor).toHaveBeenCalledTimes(2);
+  });
+
   it("fails closed when the readiness selector stays absent", async () => {
-    const page = buildPage(vi.fn().mockRejectedValue(new Error("timeout")));
+    const waitFor = vi.fn().mockRejectedValue(new Error("timeout"));
+    const page = buildPage(waitFor);
 
     await expect(assertRouteAccessible(page, "https://app.example.com", "/schedule", {
       readySelector: 'button[aria-label="Day view"]',
       timeoutMs: 100,
     })).rejects.toThrow('readiness selector was not visible: button[aria-label="Day view"]');
+
+    expect(page.goto).toHaveBeenCalledTimes(3);
+    expect(waitFor).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Summary
- restore the intended three-attempt retry when an authenticated expected route has not rendered its readiness selector yet
- keep the existing Day-view positive marker and final fail-closed error unchanged
- add behavioral regression coverage for delayed readiness and persistent absence

## Root cause
PR #764 added a real bounded selector wait but accidentally removed the existing continue for expected-route readiness misses. Run 29192139050 therefore rejected the correctly provisioned/logged-in BCBA after exactly one 15-second wait even though maxAttempts remained three.

## Verification
- targeted route readiness tests: 3 passed (red before fix)
- npm run lint
- npm run typecheck
- npm run ci:check-focused
- npm run test:ci: 2633 passed, 3 environment-dependent skips
- npm run test:routes:tier0: 220 passed
- npm run build

## Risk
Critical-lane auth/session harness helper change. No route roles, RoleGuard, auth fallback, production Schedule behavior, RLS, provisioning, API, database, or workflow changes. Persistent readiness absence still fails after three bounded attempts. Hosted auth-browser-smoke remains decisive.

Linear: WIN-217