### PR TITLE
WIN-217 Preserve BCBA Schedule hydration during readiness

### DIFF
--- a/scripts/lib/playwright-smoke.ts
+++ b/scripts/lib/playwright-smoke.ts
@@ -182,9 +182,9 @@ export const assertRouteAccessible = async (
   const timeoutMs = options?.timeoutMs ?? 15000;
   const maxAttempts = 3;
   let lastPath = "";
+  await page.goto(`${baseUrl}${routePath}`, { waitUntil: "domcontentloaded", timeout: 60000 });
+  await page.waitForLoadState("networkidle").catch(() => undefined);
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    await page.goto(`${baseUrl}${routePath}`, { waitUntil: "domcontentloaded", timeout: 60000 });
-    await page.waitForLoadState("networkidle").catch(() => undefined);
     const pathname = new URL(page.url()).pathname.toLowerCase();
     lastPath = pathname;
 
@@ -213,6 +213,8 @@ export const assertRouteAccessible = async (
     // Give auth/profile hydration a bounded chance before hard-failing.
     if (attempt < maxAttempts && pathname.includes("/unauthorized")) {
       await page.waitForTimeout(1500);
+      await page.goto(`${baseUrl}${routePath}`, { waitUntil: "domcontentloaded", timeout: 60000 });
+      await page.waitForLoadState("networkidle").catch(() => undefined);
       continue;
     }
     break;

--- a/tests/scripts/playwright-smoke-route-access.test.ts
+++ b/tests/scripts/playwright-smoke-route-access.test.ts
@@ -25,7 +25,7 @@ describe("assertRouteAccessible readiness", () => {
     expect(waitFor).toHaveBeenCalledWith({ state: "visible", timeout: 30_000 });
   });
 
-  it("retries the expected route when readiness appears after the first bounded wait", async () => {
+  it("retries readiness on the same document when it appears after the first bounded wait", async () => {
     const waitFor = vi
       .fn()
       .mockRejectedValueOnce(new Error("timeout"))
@@ -37,7 +37,7 @@ describe("assertRouteAccessible readiness", () => {
       timeoutMs: 100,
     });
 
-    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(page.goto).toHaveBeenCalledTimes(1);
     expect(waitFor).toHaveBeenCalledTimes(2);
   });
 
@@ -50,7 +50,56 @@ describe("assertRouteAccessible readiness", () => {
       timeoutMs: 100,
     })).rejects.toThrow('readiness selector was not visible: button[aria-label="Day view"]');
 
-    expect(page.goto).toHaveBeenCalledTimes(3);
+    expect(page.goto).toHaveBeenCalledTimes(1);
     expect(waitFor).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries navigation after unauthorized hydration and then checks readiness", async () => {
+    const waitFor = vi.fn().mockResolvedValue(undefined);
+    const page = buildPage(waitFor);
+    vi.mocked(page.url)
+      .mockReturnValueOnce("https://app.example.com/unauthorized")
+      .mockReturnValueOnce("https://app.example.com/schedule");
+    page.waitForTimeout = vi.fn().mockResolvedValue(undefined);
+
+    await assertRouteAccessible(page, "https://app.example.com", "/schedule", {
+      readySelector: 'button[aria-label="Day view"]',
+      timeoutMs: 100,
+    });
+
+    expect(page.goto).toHaveBeenCalledTimes(2);
+    expect(page.waitForTimeout).toHaveBeenCalledWith(1500);
+    expect(waitFor).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds persistent unauthorized retries and fails closed", async () => {
+    const waitFor = vi.fn();
+    const page = buildPage(waitFor);
+    vi.mocked(page.url).mockReturnValue("https://app.example.com/unauthorized");
+    page.waitForTimeout = vi.fn().mockResolvedValue(undefined);
+
+    await expect(assertRouteAccessible(page, "https://app.example.com", "/schedule", {
+      readySelector: 'button[aria-label="Day view"]',
+      timeoutMs: 100,
+    })).rejects.toThrow("Authenticated user cannot access required route /schedule");
+
+    expect(page.goto).toHaveBeenCalledTimes(3);
+    expect(page.waitForTimeout).toHaveBeenCalledTimes(2);
+    expect(waitFor).not.toHaveBeenCalled();
+  });
+
+  it("fails a login redirect immediately without retrying navigation", async () => {
+    const waitFor = vi.fn();
+    const page = buildPage(waitFor);
+    vi.mocked(page.url).mockReturnValue("https://app.example.com/login");
+    page.waitForTimeout = vi.fn().mockResolvedValue(undefined);
+
+    await expect(assertRouteAccessible(page, "https://app.example.com", "/schedule", {
+      readySelector: 'button[aria-label="Day view"]',
+    })).rejects.toThrow("Authenticated user cannot access required route /schedule");
+
+    expect(page.goto).toHaveBeenCalledTimes(1);
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+    expect(waitFor).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- keep bounded Schedule readiness retries on the same document instead of restarting hydration with each reload
- retain bounded reload recovery for explicit /unauthorized redirects
- add regression coverage for delayed readiness, persistent absence, unauthorized recovery, persistent unauthorized, and login fail-closed behavior

## Production evidence
Main CI run 29197343487 failed twice at the dedicated synthetic-BCBA route check after three 15-second readiness attempts. Each attempt reloaded /schedule, resetting the slower BCBA-scoped hydration. Ordinary session lifecycle, blocked-close, and measurement flows passed before the dedicated BCBA step.

## Verification
- focused route/helper suites: 23 passed
- route readiness suite: 6 passed
- typecheck
- lint
- ci:check-focused
- build
- test:ci: 2646 passed, 3 skipped
- test:routes:tier0: 220 passed
- independent correctness and test reviews approved

## Risk
Critical auth/session CI helper path. No production application, RLS, migration, runtime config, or workflow permission changes. Human review required before merge.