### PR TITLE
WIN-217 Classify hosted BCBA Schedule readiness

### DIFF
--- a/scripts/lib/playwright-schedule-session-modal.ts
+++ b/scripts/lib/playwright-schedule-session-modal.ts
@@ -38,13 +38,31 @@ const validateTarget = (scheduleUrl: string, target: ScheduleSessionModalTarget)
   }
 };
 
-const describeScheduleFailureState = async (page: Page): Promise<string> => {
+export type ScheduleReadinessFailureState =
+  | "login_redirect"
+  | "unauthorized_redirect"
+  | "auth_profile_loading"
+  | "missing_organization"
+  | "schedule_data_error"
+  | "schedule_still_loading"
+  | "application_error_boundary"
+  | "schedule_not_ready";
+
+export const classifyScheduleReadinessFailure = async (
+  page: Page,
+): Promise<ScheduleReadinessFailureState> => {
   const pathname = new URL(page.url()).pathname.toLowerCase();
   if (pathname.includes("/login")) return "login_redirect";
   if (pathname.includes("/unauthorized")) return "unauthorized_redirect";
+  if ((await page.locator('[role="status"][aria-label="Checking role access..."]').count()) > 0) {
+    return "auth_profile_loading";
+  }
   if ((await page.locator('[data-testid="schedule-missing-org"]').count()) > 0) return "missing_organization";
   if ((await page.locator('[data-testid="schedule-data-load-error"]').count()) > 0) return "schedule_data_error";
   if ((await page.locator('[data-testid="schedule-loading"]').count()) > 0) return "schedule_still_loading";
+  if ((await page.getByRole("heading", { name: "Something went wrong", exact: true }).count()) > 0) {
+    return "application_error_boundary";
+  }
   return "schedule_not_ready";
 };
 
@@ -104,7 +122,7 @@ const normalizeWeekView = async (page: Page): Promise<void> => {
     .then(() => true)
     .catch(() => false);
   if (!ready) {
-    throw new Error(`Schedule did not reach calendar readiness: ${await describeScheduleFailureState(page)}`);
+    throw new Error(`Schedule did not reach calendar readiness: ${await classifyScheduleReadinessFailure(page)}`);
   }
   if ((await weekButton.getAttribute("aria-pressed")) !== "true") {
     await weekButton.click();

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -18,7 +18,10 @@ import {
 import {
   assertNonAiSessionsEnvContract,
 } from "./lib/playwright-nonai-sessions-contract";
-import { openScheduleSessionModalFromCalendar } from "./lib/playwright-schedule-session-modal";
+import {
+  classifyScheduleReadinessFailure,
+  openScheduleSessionModalFromCalendar,
+} from "./lib/playwright-schedule-session-modal";
 
 /** Canonical /schedule + SessionModal regression: book → Start Session → terminal close (no-show/completed). */
 
@@ -1771,6 +1774,11 @@ export async function run() {
         capturedAccessToken = candidateToken;
         break;
       } catch {
+        const scheduleState = await classifyScheduleReadinessFailure(attemptPage)
+          .catch(() => "diagnostic_unavailable" as const);
+        console.error(
+          `[lifecycle] credential candidate rejected candidate=${candidate.label} scheduleState=${scheduleState}`,
+        );
         await attemptContext.close();
       }
     }

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -263,6 +263,20 @@ describe("check-e2e-reliability-gates", () => {
     expect(blockedClose).toContain('openScheduleSessionModalFromCalendar(activePage, `${base}/schedule`, booked,');
   });
 
+  test("session lifecycle records a controlled Schedule state before rejecting credentials", () => {
+    const lifecycle = readFileSync(
+      path.join(repoRoot, "scripts", "playwright-session-lifecycle.ts"),
+      "utf8",
+    );
+
+    expect(lifecycle).toContain("classifyScheduleReadinessFailure(attemptPage)");
+    expect(lifecycle).toContain("scheduleState=${scheduleState}");
+    expect(lifecycle.indexOf("classifyScheduleReadinessFailure(attemptPage)")).toBeLessThan(
+      lifecycle.indexOf("await attemptContext.close()"),
+    );
+    expect(lifecycle).not.toContain("document.body.innerText");
+  });
+
   test("accepts ci:playwright runner invocation semantics", () => {
     const fixtureRoot = createFixture(`tsx scripts/playwright-ci-runner.ts ${runnerChildren.join(" ")}`);
 

--- a/tests/scripts/playwright-schedule-session-modal.test.ts
+++ b/tests/scripts/playwright-schedule-session-modal.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Page } from "playwright";
 
 import {
+  classifyScheduleReadinessFailure,
   openScheduleSessionModalFromCalendar,
   SCHEDULE_SESSION_SEARCH_PERIODS,
 } from "../../scripts/lib/playwright-schedule-session-modal";
@@ -266,5 +267,49 @@ describe("openScheduleSessionModalFromCalendar", () => {
 
     await expect(openScheduleSessionModalFromCalendar(page, "https://app.example.com/schedule", target))
       .rejects.toThrow("week_view_not_selected");
+  });
+});
+
+describe("classifyScheduleReadinessFailure", () => {
+  const buildPage = (url: string, presentSelector?: string, errorBoundary = false): Page => ({
+    url: vi.fn().mockReturnValue(url),
+    locator: vi.fn((selector: string) => ({
+      count: vi.fn().mockResolvedValue(selector === presentSelector ? 1 : 0),
+    })),
+    getByRole: vi.fn(() => ({
+      count: vi.fn().mockResolvedValue(errorBoundary ? 1 : 0),
+    })),
+  } as unknown as Page);
+
+  it.each([
+    ["auth_profile_loading", '[role="status"][aria-label="Checking role access..."]'],
+    ["missing_organization", '[data-testid="schedule-missing-org"]'],
+    ["schedule_data_error", '[data-testid="schedule-data-load-error"]'],
+    ["schedule_still_loading", '[data-testid="schedule-loading"]'],
+  ] as const)("returns the controlled %s state", async (expected, selector) => {
+    await expect(classifyScheduleReadinessFailure(
+      buildPage("https://app.example.com/schedule", selector),
+    )).resolves.toBe(expected);
+  });
+
+  it.each([
+    ["https://app.example.com/login", "login_redirect"],
+    ["https://app.example.com/unauthorized", "unauthorized_redirect"],
+  ] as const)("classifies %s before inspecting rendered Schedule state", async (url, expected) => {
+    const page = buildPage(url, '[data-testid="schedule-loading"]');
+    await expect(classifyScheduleReadinessFailure(page)).resolves.toBe(expected);
+    expect(page.locator).not.toHaveBeenCalled();
+  });
+
+  it("recognizes the public application error boundary without capturing its text", async () => {
+    await expect(classifyScheduleReadinessFailure(
+      buildPage("https://app.example.com/schedule", undefined, true),
+    )).resolves.toBe("application_error_boundary");
+  });
+
+  it("falls back to a controlled state without serializing page content", async () => {
+    await expect(classifyScheduleReadinessFailure(
+      buildPage("https://app.example.com/schedule"),
+    )).resolves.toBe("schedule_not_ready");
   });
 });


### PR DESCRIPTION
## Summary
- classify the exact redacted Schedule state when a credential reaches /schedule without calendar readiness
- emit the controlled state before closing the synthetic actor context
- reuse the same classifier in the scoped Schedule modal helper
- add behavioral and static regression coverage

## Controlled evidence
Possible values are limited to login_redirect, unauthorized_redirect, auth_profile_loading, missing_organization, schedule_data_error, schedule_still_loading, application_error_boundary, schedule_not_ready, or diagnostic_unavailable. No page text, screenshots, response bodies, credentials, tokens, or PHI are captured.

## Verification card
- classification: high-risk human-reviewed
- lane: critical
- change type: auth/session browser diagnostics
- focused: 35 passed
- typecheck: passed
- lint: passed
- ci:check-focused: passed
- build: passed
- test:ci: 2655 passed, 3 skipped
- test:routes:tier0: 220 passed
- ci:playwright: required hosted gate; local secrets unavailable
- security/architecture review: approved
- specification/test review: approved

## Risk
No runtime app, auth policy, role access, tenant boundary, RLS, workflow secret, or readiness behavior changes. Human review remains required before merge.