### PR TITLE
WIN-217: classify BCBA Schedule data failure path

### DIFF
--- a/scripts/lib/playwright-schedule-session-modal.ts
+++ b/scripts/lib/playwright-schedule-session-modal.ts
@@ -43,7 +43,15 @@ export type ScheduleReadinessFailureState =
   | "unauthorized_redirect"
   | "auth_profile_loading"
   | "missing_organization"
-  | "schedule_data_error"
+  | `schedule_data_error:${"sessions" | "dropdown" | "unknown"}:${
+      | "insufficient_privilege"
+      | "undefined_function"
+      | "undefined_table"
+      | "undefined_column"
+      | "schema_cache"
+      | "jwt"
+      | "raised_exception"
+      | "unknown"}`
   | "schedule_still_loading"
   | "application_error_boundary"
   | "schedule_not_ready";
@@ -58,7 +66,18 @@ export const classifyScheduleReadinessFailure = async (
     return "auth_profile_loading";
   }
   if ((await page.locator('[data-testid="schedule-missing-org"]').count()) > 0) return "missing_organization";
-  if ((await page.locator('[data-testid="schedule-data-load-error"]').count()) > 0) return "schedule_data_error";
+  const scheduleDataError = page.locator('[data-testid="schedule-data-load-error"]');
+  if ((await scheduleDataError.count()) > 0) {
+    const rawPath = await scheduleDataError.getAttribute("data-schedule-error-path");
+    const path = rawPath === "sessions" || rawPath === "dropdown" ? rawPath : "unknown";
+    const rawCategory = await scheduleDataError.getAttribute("data-schedule-error-category");
+    const allowedCategories = new Set([
+      "insufficient_privilege", "undefined_function", "undefined_table", "undefined_column",
+      "schema_cache", "jwt", "raised_exception", "unknown",
+    ]);
+    const category = rawCategory && allowedCategories.has(rawCategory) ? rawCategory : "unknown";
+    return `schedule_data_error:${path}:${category}` as ScheduleReadinessFailureState;
+  }
   if ((await page.locator('[data-testid="schedule-loading"]').count()) > 0) return "schedule_still_loading";
   if ((await page.getByRole("heading", { name: "Something went wrong", exact: true }).count()) > 0) {
     return "application_error_boundary";

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -73,6 +73,30 @@ import {
 } from "../features/scheduling/domain/sessionScope";
 import { filterSessionsBySelectedScope } from "../features/scheduling/domain/sessionFilters";
 import { shouldClearMissingSelection } from "../features/scheduling/domain/selectionGuard";
+
+type ScheduleDataErrorCategory =
+  | "insufficient_privilege"
+  | "undefined_function"
+  | "undefined_table"
+  | "undefined_column"
+  | "schema_cache"
+  | "jwt"
+  | "raised_exception"
+  | "unknown";
+
+const classifyScheduleDataErrorCode = (error: unknown): ScheduleDataErrorCategory => {
+  const code = typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code ?? "")
+    : "";
+  if (code === "42501") return "insufficient_privilege";
+  if (code === "42883") return "undefined_function";
+  if (code === "42P01") return "undefined_table";
+  if (code === "42703") return "undefined_column";
+  if (code === "PGRST202") return "schema_cache";
+  if (code === "PGRST301" || code === "PGRST302") return "jwt";
+  if (code === "P0001") return "raised_exception";
+  return "unknown";
+};
 import { buildScheduleModalOpenResetPlan } from "../features/scheduling/domain/modalOpenResetPlan";
 import { applyScheduleModalOpenPlan } from "../features/scheduling/domain/modalOpenPlanApply";
 import { applyScheduleResetBranch } from "../features/scheduling/domain/scheduleResetBranch";
@@ -713,6 +737,10 @@ export const Schedule = React.memo(() => {
   const dropdownPathFailed =
     !!activeOrganizationId && isDropdownError && directoryLoadRequiresDropdown;
   const scheduleDataLoadFailed = sessionsPathFailed || dropdownPathFailed;
+  const scheduleDataErrorPath = sessionsPathFailed ? "sessions" : dropdownPathFailed ? "dropdown" : "unknown";
+  const scheduleDataErrorCategory = classifyScheduleDataErrorCode(
+    sessionsPathFailed ? sessionsQueryError : dropdownPathFailed ? dropdownQueryError : null,
+  );
 
   const scheduleDataLoadErrorMessage = useMemo(() => {
     if (sessionsPathFailed && sessionsQueryError) {
@@ -2073,6 +2101,8 @@ export const Schedule = React.memo(() => {
         <div
           className="h-full flex items-center justify-center px-4"
           data-testid="schedule-data-load-error"
+          data-schedule-error-path={scheduleDataErrorPath}
+          data-schedule-error-category={scheduleDataErrorCategory}
           role="alert"
           aria-labelledby="schedule-data-load-error-title"
           aria-describedby="schedule-data-load-error-description"

--- a/src/pages/__tests__/Schedule.dataLoadUx.test.tsx
+++ b/src/pages/__tests__/Schedule.dataLoadUx.test.tsx
@@ -147,6 +147,8 @@ describe("Schedule data-load UX", () => {
 
     const banner = await screen.findByTestId("schedule-data-load-error");
     expect(banner).toBeInTheDocument();
+    expect(banner).toHaveAttribute("data-schedule-error-path", "sessions");
+    expect(banner).toHaveAttribute("data-schedule-error-category", "unknown");
     expect(screen.getByRole("alert")).toBeInTheDocument();
     expect(screen.getByText(/Couldn't load schedule/i)).toBeInTheDocument();
     expect(screen.getByText(/get_sessions_optimized failed/i)).toBeInTheDocument();
@@ -181,7 +183,9 @@ describe("Schedule data-load UX", () => {
 
     renderWithProviders(<Schedule />);
 
-    expect(await screen.findByTestId("schedule-data-load-error")).toBeInTheDocument();
+    const banner = await screen.findByTestId("schedule-data-load-error");
+    expect(banner).toHaveAttribute("data-schedule-error-path", "dropdown");
+    expect(banner).toHaveAttribute("data-schedule-error-category", "unknown");
     expect(screen.getByText(/get_dropdown_data failed/i)).toBeInTheDocument();
   });
 

--- a/tests/scripts/playwright-schedule-session-modal.test.ts
+++ b/tests/scripts/playwright-schedule-session-modal.test.ts
@@ -275,16 +275,39 @@ describe("classifyScheduleReadinessFailure", () => {
     url: vi.fn().mockReturnValue(url),
     locator: vi.fn((selector: string) => ({
       count: vi.fn().mockResolvedValue(selector === presentSelector ? 1 : 0),
+      getAttribute: vi.fn().mockResolvedValue(null),
     })),
     getByRole: vi.fn(() => ({
       count: vi.fn().mockResolvedValue(errorBoundary ? 1 : 0),
     })),
   } as unknown as Page);
 
+  it("reports the controlled Schedule data path and allowlisted error category", async () => {
+    const errorBanner = {
+      count: vi.fn().mockResolvedValue(1),
+      getAttribute: vi.fn(async (name: string) => ({
+        "data-schedule-error-path": "sessions",
+        "data-schedule-error-category": "insufficient_privilege",
+      })[name] ?? null),
+    };
+    const empty = {
+      count: vi.fn().mockResolvedValue(0),
+      getAttribute: vi.fn().mockResolvedValue(null),
+    };
+    const page = {
+      url: vi.fn().mockReturnValue("https://app.example.com/schedule"),
+      locator: vi.fn((selector: string) => selector === '[data-testid="schedule-data-load-error"]' ? errorBanner : empty),
+      getByRole: vi.fn(() => empty),
+    } as unknown as Page;
+
+    await expect(classifyScheduleReadinessFailure(page))
+      .resolves.toBe("schedule_data_error:sessions:insufficient_privilege");
+  });
+
   it.each([
     ["auth_profile_loading", '[role="status"][aria-label="Checking role access..."]'],
     ["missing_organization", '[data-testid="schedule-missing-org"]'],
-    ["schedule_data_error", '[data-testid="schedule-data-load-error"]'],
+    ["schedule_data_error:unknown:unknown", '[data-testid="schedule-data-load-error"]'],
     ["schedule_still_loading", '[data-testid="schedule-loading"]'],
   ] as const)("returns the controlled %s state", async (expected, selector) => {
     await expect(classifyScheduleReadinessFailure(


### PR DESCRIPTION
## Summary
- distinguish fallback sessions failures from dropdown failures on the existing Schedule error surface
- map only allowlisted SQLSTATE/PostgREST codes to coarse diagnostic categories
- emit the controlled path/category through the hosted BCBA Playwright classifier without logging messages, payloads, credentials, or PHI

## Verification
- focused Vitest: 26 passed
- typecheck: passed
- lint: passed
- policy checks: passed
- build: passed
- tier-0 routes: 220 passed
- Schedule.event focused rerun: 5 passed
- full test:ci: blocked by repeatable pre-existing Schedule.event query ambiguity in full-suite mode; the same file passes 5/5 alone and the changed focused suites pass

## Risk
Critical-lane diagnostic slice for hosted auth/session acceptance. No auth, RPC, RLS, migration, workflow, provisioning, or data-fetch behavior changes. Human review required before merge.

Linear: WIN-217