### PR TITLE
WIN-217: preserve synthetic BCBA tenant context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,6 +539,7 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY || secrets.SUPABASE_ANON_KEY }}
         run: npx tsx scripts/provision-ci-smoke-bcba.ts
 
       - name: Install Playwright browser

--- a/scripts/provision-ci-smoke-bcba.ts
+++ b/scripts/provision-ci-smoke-bcba.ts
@@ -24,8 +24,14 @@ export const assertDedicatedSmokeBcbaEmail = (email: string): void => {
   }
 };
 
-export const getMissingBcbaProvisionSecrets = (env: NodeJS.ProcessEnv = process.env): string[] =>
-  ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"].filter((name) => !env[name]?.trim());
+export const getMissingBcbaProvisionSecrets = (
+  env: NodeJS.ProcessEnv = process.env,
+  requirePublishableKey = false,
+): string[] => [
+  "SUPABASE_URL",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  ...(requirePublishableKey ? ["SUPABASE_PUBLISHABLE_KEY"] : []),
+].filter((name) => !env[name]?.trim());
 
 export const shouldSkipSecretlessPullRequest = (env: NodeJS.ProcessEnv = process.env): boolean =>
   env.GITHUB_EVENT_NAME === "pull_request" && getMissingBcbaProvisionSecrets(env).length > 0;
@@ -35,6 +41,93 @@ const createAdmin = (): SupabaseClient => createClient(
   getEnv("SUPABASE_SERVICE_ROLE_KEY"),
   { auth: { autoRefreshToken: false, persistSession: false } },
 );
+
+const createAuthenticatedProbeClient = (): SupabaseClient => createClient(
+  getEnv("SUPABASE_URL"),
+  getEnv("SUPABASE_PUBLISHABLE_KEY"),
+  { auth: { autoRefreshToken: false, persistSession: false } },
+);
+
+export interface SmokeBcbaProfileInvariant {
+  id?: string | null;
+  role?: string | null;
+  is_active?: boolean | null;
+  organization_id?: string | null;
+}
+
+export const assertSmokeBcbaProfileInvariant = (
+  profile: SmokeBcbaProfileInvariant | null,
+  expected: { userId: string; organizationId: string },
+): void => {
+  if (
+    !profile
+    || profile.id !== expected.userId
+    || profile.role !== "bcba"
+    || profile.is_active !== true
+    || profile.organization_id !== expected.organizationId
+  ) {
+    throw new Error("Synthetic BCBA profile did not persist the required identity, role, active state, and organization context.");
+  }
+};
+
+export const verifySmokeBcbaAuthenticatedReadiness = async (
+  client: SupabaseClient,
+  credentials: { email: string; password: string; userId: string; organizationId: string },
+): Promise<void> => {
+  const { data: signInData, error: signInError } = await client.auth.signInWithPassword({
+    email: credentials.email,
+    password: credentials.password,
+  });
+  if (signInError) throw new Error("Synthetic BCBA authenticated readiness login failed.");
+
+  let readinessError: unknown = null;
+  try {
+    if (signInData.user?.id !== credentials.userId) {
+      throw new Error("Synthetic BCBA authenticated readiness resolved an unexpected identity.");
+    }
+    const { data: profile, error: profileError } = await client
+      .from("profiles")
+      .select("id,role,is_active,organization_id")
+      .eq("id", credentials.userId)
+      .maybeSingle();
+    if (profileError) {
+      throw new Error("Synthetic BCBA authenticated readiness could not read its profile.");
+    }
+    try {
+      assertSmokeBcbaProfileInvariant(profile, {
+        userId: credentials.userId,
+        organizationId: credentials.organizationId,
+      });
+    } catch {
+      throw new Error("Synthetic BCBA authenticated readiness did not resolve the expected organization.");
+    }
+
+    const now = Date.now();
+    const { error: sessionsError } = await client.rpc("get_sessions_optimized", {
+      p_start_date: new Date(now - 24 * 60 * 60 * 1000).toISOString(),
+      p_end_date: new Date(now + 24 * 60 * 60 * 1000).toISOString(),
+      p_therapist_id: null,
+      p_client_id: null,
+    });
+    if (sessionsError) {
+      throw new Error("Synthetic BCBA authenticated readiness could not load org-scoped sessions.");
+    }
+  } catch (error) {
+    readinessError = error;
+  }
+
+  const { error: signOutError } = await client.auth.signOut();
+  if (readinessError && signOutError) {
+    const message = readinessError instanceof Error
+      ? readinessError.message
+      : "Synthetic BCBA authenticated readiness failed.";
+    throw new Error(`${message} Authenticated readiness logout also failed.`);
+  }
+  if (readinessError) throw readinessError;
+  if (signOutError) {
+    throw new Error("Synthetic BCBA authenticated readiness logout failed.");
+  }
+};
 
 const listUsers = async (client: SupabaseClient) => {
   const users = [];
@@ -125,6 +218,25 @@ const provision = async (): Promise<void> => {
   const { error: linkError } = await client.from("user_therapist_links").insert({ user_id: user.id, therapist_id: therapistId });
   if (linkError) throw linkError;
 
+  const { data: provisionedOrganizationId, error: provisionProfileError } = await client
+    .rpc("provision_ci_smoke_bcba_profile", { p_user_id: user.id });
+  if (provisionProfileError || provisionedOrganizationId !== organizationId) {
+    throw new Error("Synthetic BCBA authoritative profile provisioning failed.");
+  }
+  const { data: persistedProfile, error: persistedProfileError } = await client
+    .from("profiles")
+    .select("id,role,is_active,organization_id")
+    .eq("id", user.id)
+    .maybeSingle();
+  if (persistedProfileError) throw persistedProfileError;
+  assertSmokeBcbaProfileInvariant(persistedProfile, { userId: user.id, organizationId });
+  await verifySmokeBcbaAuthenticatedReadiness(createAuthenticatedProbeClient(), {
+    email,
+    password,
+    userId: user.id,
+    organizationId,
+  });
+
   writeCredentials(email, password);
   console.log(JSON.stringify({ ok: true, action: "provisioned", email, userId: user.id, organizationId, therapistId }));
 };
@@ -162,7 +274,9 @@ const sweepOnly = async (): Promise<void> => {
 };
 
 const main = async (): Promise<void> => {
-  const missing = getMissingBcbaProvisionSecrets();
+  const cleanupRequested = process.argv.includes("--cleanup");
+  const sweepRequested = process.argv.includes("--sweep-only");
+  const missing = getMissingBcbaProvisionSecrets(process.env, !cleanupRequested && !sweepRequested);
   if (missing.length) {
     if (shouldSkipSecretlessPullRequest()) {
       console.log(JSON.stringify({ ok: true, action: "skipped", reason: "missing_pull_request_secrets", missing }));
@@ -170,10 +284,10 @@ const main = async (): Promise<void> => {
     }
     throw new Error(`Missing required Supabase admin secrets: ${missing.join(", ")}.`);
   }
-  if (process.argv.includes("--sweep-only")) {
+  if (sweepRequested) {
     await sweepOnly();
   } else {
-    await (process.argv.includes("--cleanup") ? cleanup() : provision());
+    await (cleanupRequested ? cleanup() : provision());
   }
 };
 

--- a/supabase/migrations/20260713014000_provision_ci_smoke_bcba_profile.sql
+++ b/supabase/migrations/20260713014000_provision_ci_smoke_bcba_profile.sql
@@ -1,0 +1,69 @@
+-- @migration-intent: Give service-role CI provisioning one authoritative, fail-closed path to align a disposable BCBA profile with its active role and therapist organization.
+-- @migration-dependencies: public.profiles,public.user_roles,public.roles,public.user_therapist_links,public.therapists,20260407105500_enforce_profile_immutability_respect_bypass.sql
+-- @migration-rollback: Drop public.provision_ci_smoke_bcba_profile(uuid).
+
+begin;
+
+create or replace function public.provision_ci_smoke_bcba_profile(p_user_id uuid)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  resolved_organization_id uuid;
+  updated_rows integer;
+begin
+  select (array_agg(distinct t.organization_id))[1]
+  into resolved_organization_id
+  from public.user_roles ur
+  join auth.users u
+    on u.id = ur.user_id
+   and lower(u.email) ~ '^playwright\.ci\.bcba\.[a-z0-9_.-]+@example\.com$'
+   and u.raw_app_meta_data ->> 'smoke_actor' = 'bcba'
+   and (u.raw_app_meta_data ->> 'smoke_expires_at')::timestamptz > now()
+  join public.roles r
+    on r.id = ur.role_id
+   and r.name = 'bcba'
+  join public.user_therapist_links utl
+    on utl.user_id = ur.user_id
+  join public.therapists t
+    on t.id = utl.therapist_id
+   and t.deleted_at is null
+  where ur.user_id = p_user_id
+    and coalesce(ur.is_active, true) = true
+    and (ur.expires_at is null or ur.expires_at > now())
+  having count(distinct t.organization_id) = 1;
+
+  if resolved_organization_id is null then
+    raise exception using errcode = '42501', message = 'Authoritative BCBA role and therapist organization are required';
+  end if;
+
+  perform set_config('app.bypass_profile_role_guard', 'on', true);
+  update public.profiles
+  set role = 'bcba'::public.role_type,
+      organization_id = resolved_organization_id,
+      is_active = true,
+      updated_at = now()
+  where id = p_user_id;
+  get diagnostics updated_rows = row_count;
+  perform set_config('app.bypass_profile_role_guard', 'off', true);
+
+  if updated_rows <> 1 then
+    raise exception using errcode = 'P0002', message = 'Synthetic BCBA profile is missing';
+  end if;
+
+  return resolved_organization_id;
+exception
+  when others then
+    perform set_config('app.bypass_profile_role_guard', 'off', true);
+    raise;
+end;
+$$;
+
+revoke execute on function public.provision_ci_smoke_bcba_profile(uuid) from public;
+revoke execute on function public.provision_ci_smoke_bcba_profile(uuid) from anon;
+revoke execute on function public.provision_ci_smoke_bcba_profile(uuid) from authenticated;
+grant execute on function public.provision_ci_smoke_bcba_profile(uuid) to service_role;
+
+commit;

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -277,6 +277,19 @@ describe("check-e2e-reliability-gates", () => {
     expect(lifecycle).not.toContain("document.body.innerText");
   });
 
+  test("synthetic BCBA provisioning keeps authenticated preflight and unconditional cleanup contracts", () => {
+    const workflow = readFileSync(path.join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+    const provisionStep = workflow.match(/- name: Provision synthetic BCBA smoke actor[\s\S]*?run: npx tsx scripts\/provision-ci-smoke-bcba\.ts\n/)?.[0] ?? "";
+    const cleanupStart = workflow.indexOf("- name: Cleanup synthetic BCBA smoke actor");
+    const cleanupEnd = workflow.indexOf("- name: Cleanup auth smoke admin", cleanupStart);
+    const cleanupStep = cleanupStart >= 0 && cleanupEnd > cleanupStart
+      ? workflow.slice(cleanupStart, cleanupEnd)
+      : "";
+
+    expect(provisionStep).toContain("SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY || secrets.SUPABASE_ANON_KEY }}");
+    expect(cleanupStep).toContain("if: always()");
+  });
+
   test("accepts ci:playwright runner invocation semantics", () => {
     const fixtureRoot = createFixture(`tsx scripts/playwright-ci-runner.ts ${runnerChildren.join(" ")}`);
 

--- a/tests/integration/provision-ci-smoke-bcba-profile-migration.test.ts
+++ b/tests/integration/provision-ci-smoke-bcba-profile-migration.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  resolve("supabase/migrations/20260713014000_provision_ci_smoke_bcba_profile.sql"),
+  "utf8",
+);
+
+describe("service-only synthetic BCBA profile provisioning migration", () => {
+  it("derives tenant context from authoritative role and therapist mappings", () => {
+    expect(migration).toMatch(/from public\.user_roles/i);
+    expect(migration).toMatch(/join auth\.users/i);
+    expect(migration).toMatch(/playwright\\\.ci\\\.bcba/i);
+    expect(migration).toMatch(/raw_app_meta_data ->> 'smoke_actor' = 'bcba'/i);
+    expect(migration).toMatch(/raw_app_meta_data ->> 'smoke_expires_at'/i);
+    expect(migration).toMatch(/r\.name = 'bcba'/i);
+    expect(migration).toMatch(/join public\.user_therapist_links/i);
+    expect(migration).toMatch(/join public\.therapists/i);
+    expect(migration).toMatch(/count\(distinct t\.organization_id\) = 1/i);
+    expect(migration).not.toMatch(/raw_user_meta_data|auth\.jwt|user_metadata/i);
+  });
+
+  it("keeps the privileged RPC service-only", () => {
+    expect(migration).toMatch(/revoke execute on function public\.provision_ci_smoke_bcba_profile\(uuid\) from public/i);
+    expect(migration).toMatch(/from anon/i);
+    expect(migration).toMatch(/from authenticated/i);
+    expect(migration).toMatch(/grant execute on function public\.provision_ci_smoke_bcba_profile\(uuid\) to service_role/i);
+  });
+});

--- a/tests/scripts/provision-ci-smoke-bcba.test.ts
+++ b/tests/scripts/provision-ci-smoke-bcba.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   assertDedicatedSmokeBcbaEmail,
+  assertSmokeBcbaProfileInvariant,
   buildDefaultSmokeBcbaEmail,
   getMissingBcbaProvisionSecrets,
   shouldSkipSecretlessPullRequest,
+  verifySmokeBcbaAuthenticatedReadiness,
 } from "../../scripts/provision-ci-smoke-bcba";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 describe("provision-ci-smoke-bcba guards", () => {
   it("only accepts dedicated disposable BCBA emails", () => {
@@ -19,7 +22,150 @@ describe("provision-ci-smoke-bcba guards", () => {
   it("skips only secretless pull requests", () => {
     const env = { GITHUB_EVENT_NAME: "pull_request" } as NodeJS.ProcessEnv;
     expect(getMissingBcbaProvisionSecrets(env)).toEqual(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]);
+    expect(getMissingBcbaProvisionSecrets(env, true)).toEqual([
+      "SUPABASE_URL",
+      "SUPABASE_SERVICE_ROLE_KEY",
+      "SUPABASE_PUBLISHABLE_KEY",
+    ]);
     expect(shouldSkipSecretlessPullRequest(env)).toBe(true);
     expect(shouldSkipSecretlessPullRequest({ ...env, GITHUB_EVENT_NAME: "push" })).toBe(false);
+  });
+
+  it("requires the persisted synthetic profile to retain BCBA tenant context", () => {
+    const expected = { userId: "user-1", organizationId: "org-1" };
+    expect(() => assertSmokeBcbaProfileInvariant({
+      id: "user-1",
+      role: "bcba",
+      is_active: true,
+      organization_id: "org-1",
+    }, expected)).not.toThrow();
+
+    for (const profile of [
+      null,
+      { id: "user-1", role: "client", is_active: true, organization_id: "org-1" },
+      { id: "user-1", role: "bcba", is_active: true, organization_id: null },
+      { id: "user-1", role: "bcba", is_active: false, organization_id: "org-1" },
+    ]) {
+      expect(() => assertSmokeBcbaProfileInvariant(profile, expected)).toThrow(/did not persist/);
+    }
+  });
+
+  it("proves authenticated organization resolution and the bounded sessions RPC", async () => {
+    const signOut = vi.fn().mockResolvedValue({ error: null });
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { id: "user-1", role: "bcba", is_active: true, organization_id: "org-1" },
+      error: null,
+    });
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+    const client = {
+      auth: {
+        signInWithPassword: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } }, error: null }),
+        signOut,
+      },
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({ maybeSingle })),
+        })),
+      })),
+      rpc,
+    } as unknown as SupabaseClient;
+
+    await expect(verifySmokeBcbaAuthenticatedReadiness(client, {
+      email: "playwright.ci.bcba.1.1@example.com",
+      password: "synthetic-password",
+      userId: "user-1",
+      organizationId: "org-1",
+    })).resolves.toBeUndefined();
+    expect(rpc.mock.calls.map(([name]) => name)).toEqual(["get_sessions_optimized"]);
+    const rpcArgs = rpc.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(rpcArgs.p_therapist_id).toBeNull();
+    expect(rpcArgs.p_client_id).toBeNull();
+    expect(Date.parse(String(rpcArgs.p_start_date))).not.toBeNaN();
+    expect(Date.parse(String(rpcArgs.p_end_date))).not.toBeNaN();
+    expect(Date.parse(String(rpcArgs.p_end_date)) - Date.parse(String(rpcArgs.p_start_date)))
+      .toBe(48 * 60 * 60 * 1000);
+    expect(signOut).toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing org", { id: "user-1", role: "bcba", is_active: true, organization_id: null }, null, /expected organization/],
+    ["sessions denied", { id: "user-1", role: "bcba", is_active: true, organization_id: "org-1" }, { code: "42501" }, /org-scoped sessions/],
+  ])("fails closed when authenticated readiness reports %s", async (_label, profile, rpcError, expected) => {
+    const signOut = vi.fn().mockResolvedValue({ error: null });
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: rpcError });
+    const client = {
+      auth: {
+        signInWithPassword: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } }, error: null }),
+        signOut,
+      },
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({ data: profile, error: null }),
+          })),
+        })),
+      })),
+      rpc,
+    } as unknown as SupabaseClient;
+
+    await expect(verifySmokeBcbaAuthenticatedReadiness(client, {
+      email: "playwright.ci.bcba.1.1@example.com",
+      password: "synthetic-password",
+      userId: "user-1",
+      organizationId: "org-1",
+    })).rejects.toThrow(expected);
+    expect(signOut).toHaveBeenCalled();
+    if (_label === "missing org") expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when authenticated readiness cannot sign out", async () => {
+    const client = {
+      auth: {
+        signInWithPassword: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } }, error: null }),
+        signOut: vi.fn().mockResolvedValue({ error: { message: "logout failed" } }),
+      },
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: "user-1", role: "bcba", is_active: true, organization_id: "org-1" },
+              error: null,
+            }),
+          })),
+        })),
+      })),
+      rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
+    } as unknown as SupabaseClient;
+
+    await expect(verifySmokeBcbaAuthenticatedReadiness(client, {
+      email: "playwright.ci.bcba.1.1@example.com",
+      password: "synthetic-password",
+      userId: "user-1",
+      organizationId: "org-1",
+    })).rejects.toThrow(/logout failed/);
+  });
+
+  it("stops before profile or RPC work when authenticated readiness login fails", async () => {
+    const from = vi.fn();
+    const rpc = vi.fn();
+    const signOut = vi.fn();
+    const client = {
+      auth: {
+        signInWithPassword: vi.fn().mockResolvedValue({ data: { user: null }, error: { message: "denied" } }),
+        signOut,
+      },
+      from,
+      rpc,
+    } as unknown as SupabaseClient;
+
+    await expect(verifySmokeBcbaAuthenticatedReadiness(client, {
+      email: "playwright.ci.bcba.1.1@example.com",
+      password: "synthetic-password",
+      userId: "user-1",
+      organizationId: "org-1",
+    })).rejects.toThrow(/login failed/);
+    expect(from).not.toHaveBeenCalled();
+    expect(rpc).not.toHaveBeenCalled();
+    expect(signOut).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add a service-role-only, disposable-actor-scoped RPC that derives BCBA organization context from active role and therapist mappings
- make synthetic provisioning fail fast unless the persisted profile, authenticated self-read, and bounded sessions RPC all prove the expected tenant context
- provide the publishable key only to the authenticated provision preflight and pin unconditional cleanup in CI tests

## Hosted root cause
Main run 29216309217 emitted schedule_data_error:sessions:insufficient_privilege. Hosted pg_proc proved authenticated EXECUTE was present; Postgres logs showed the actual fail-closed error was Organization context is required. The generated actor's profile organization resolved NULL.

## Tenant boundary
No metadata-derived org authorization and no grant/RLS widening. The privileged RPC accepts only an unexpired app_metadata-marked playwright.ci.bcba.* actor with an active BCBA role and therapist links resolving to exactly one organization. PUBLIC, anon, and authenticated execute are revoked.

## Verification
- focused tests: 24 passed
- typecheck: passed
- lint: passed
- policy: passed
- tenant validation: passed
- build: passed
- tier-0 browser: 220 passed
- test:ci attempted but timed out at 5m on pre-existing ai-documentation localhost fetch behavior; CI is authoritative for full suite
- security/code review: approved

## Required post-review sequence
1. Human review
2. Apply migration 20260713014000 to hosted Supabase
3. Merge PR
4. Confirm main synthetic provision preflight, BCBA lifecycle, measurement roundtrip, and zero-residue cleanup

Linear: WIN-217