### PR TITLE
WIN-217 Authorize persisted BCBA session bookings

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -69,3 +69,44 @@
   - `npm run lint` -> pass
   - `npm run typecheck` -> pass
 - Test/code review approved the one-line condition-based wait with no findings.
+
+## Post-merge production booking authorization follow-up
+
+- branch: `codex/win-217-bcba-booking-scope`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- production failure: the dedicated BCBA acceptance actor reached the legacy booking boundary with a persisted `bcba` role, but booking returned 403 because the scheduling resolver recognized only therapist, admin, org-admin, org-member, and super-admin roles.
+- bounded fix:
+  - resolve exact BCBA authority through `user_has_role_for_org` for the already-resolved organization
+  - allow that explicit capability to book an in-organization therapist row without treating BCBA as an admin or therapist globally
+  - preserve super-admin-only service-role fallback and fail closed on BCBA role RPC outages
+- non-goals: no role hierarchy changes, metadata fallback, migration, grant, RLS, workflow, or synthetic-role changes
+
+### Verification card
+
+- required checks:
+  - focused booking and role-resolution contract tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run test:routes:tier0`
+  - `npm run build`
+  - credential-backed hosted BCBA acceptance
+- executed checks:
+  - red proof: focused booking test returned 403 before the production change
+  - focused Vitest regression and contract tests -> pass, 2 files / 43 tests
+  - `npm run ci:check-focused` -> pass
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm run validate:tenant` -> pass
+  - `npm run test:routes:tier0` -> first run had one unrelated client-root redirect timing failure; bounded rerun passed, 7 specs / 220 tests
+  - `npm run build` -> pass
+  - `npm run test:ci` -> changed booking tests pass; aggregate local run reached 381 passed files / 2667 passed tests and failed only the existing Windows CRLF-sensitive workflow-text assertion in `check-e2e-reliability-gates.test.ts`
+- blocked checks:
+  - `npm run verify:local` -> not repeated because its `test:ci` stage deterministically reaches the unrelated Windows-only CRLF assertion above
+  - credential-backed Playwright proof -> required on the hosted main workflow after human review and merge
+- reviewer: security/code review completed with no blocking authorization findings
+- result: `pass-with-blocked-checks`
+- residual risk: the booking path performs one additional fail-closed exact-role RPC when BCBA authority may be needed; final production proof remains pending until the PR is reviewed, merged, deployed, and the dedicated BCBA lifecycle and measurement checks pass with zero-residue cleanup

--- a/src/server/__tests__/bookHandler.test.ts
+++ b/src/server/__tests__/bookHandler.test.ts
@@ -477,6 +477,75 @@ describe("bookHandler", () => {
     expect(bookSessionMock).not.toHaveBeenCalled();
   });
 
+  it("allows persisted BCBA staff to book an in-org therapist row", async () => {
+    server.use(
+      http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/user_has_role_for_org`, async ({ request }) => {
+        const body = await request.json() as { role_name?: string };
+        return HttpResponse.json(body.role_name === "bcba");
+      }),
+      http.get(`${TEST_SUPABASE_URL}/auth/v1/user`, () => HttpResponse.json({ id: "bcba-user" })),
+    );
+    bookSessionMock.mockResolvedValueOnce({
+      session: {
+        id: "session-bcba",
+        client_id: "client-1",
+        therapist_id: "therapist-1",
+        program_id: "program-1",
+        goal_id: "goal-1",
+        start_time: "2025-01-01T10:00:00Z",
+        end_time: "2025-01-01T11:00:00Z",
+        status: "scheduled",
+        notes: "",
+        created_at: "2025-01-01T09:00:00Z",
+        created_by: "bcba-user",
+        updated_at: "2025-01-01T09:00:00Z",
+        updated_by: "bcba-user",
+        duration_minutes: 60,
+      },
+      sessions: [],
+      hold: {
+        holdKey: "hold-bcba",
+        holdId: "hold-bcba",
+        startTime: "2025-01-01T10:00:00Z",
+        endTime: "2025-01-01T11:00:00Z",
+        expiresAt: "2025-01-01T10:05:00Z",
+        holds: [],
+      },
+      cpt: {
+        code: "97153",
+        description: "Adaptive behavior treatment by protocol",
+        modifiers: [],
+        source: "fallback",
+        durationMinutes: 60,
+      },
+    });
+
+    const bookHandler = await importBookHandler();
+    const response = await bookHandler(createRequest(validPayload));
+
+    expect(response.status).toBe(200);
+    expect(bookSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when persisted BCBA booking authority cannot be verified", async () => {
+    server.use(
+      http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/user_has_role_for_org`, async ({ request }) => {
+        const body = await request.json() as { role_name?: string };
+        return body.role_name === "bcba"
+          ? new HttpResponse(null, { status: 503 })
+          : HttpResponse.json(false);
+      }),
+      http.get(`${TEST_SUPABASE_URL}/auth/v1/user`, () => HttpResponse.json({ id: "bcba-user" })),
+    );
+
+    const bookHandler = await importBookHandler();
+    const response = await bookHandler(createRequest(validPayload));
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({ code: "upstream_error" });
+    expect(bookSessionMock).not.toHaveBeenCalled();
+  });
+
   it("returns 502 when org resolution dependency fails", async () => {
     server.use(
       http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/current_user_organization_id`, () =>

--- a/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
+++ b/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
@@ -266,6 +266,35 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
     });
   });
 
+  it("checks exact persisted BCBA authority for scheduling within the resolved organization", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse("org-1"))
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(resolveSchedulingOrgAndRoleWithStatus(accessToken, "therapist-1")).resolves.toEqual({
+      organizationId: "org-1",
+      isTherapist: false,
+      isAdmin: false,
+      isOrgMember: false,
+      isBcba: true,
+      isSuperAdmin: false,
+      upstreamError: false,
+      resolvedViaServiceRole: false,
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(7);
+    const bcbaInit = fetchSpy.mock.calls[6]?.[1] as RequestInit;
+    expect(JSON.parse(String(bcbaInit.body))).toEqual({
+      role_name: "bcba",
+      target_organization_id: "org-1",
+    });
+    expect((bcbaInit.headers as Record<string, string>).Authorization).toBe(`Bearer ${accessToken}`);
+  });
+
   it("derives scheduling org context from the target therapist for super-admins without direct org context", async () => {
     fetchSpy
       .mockResolvedValueOnce(jsonResponse(true))
@@ -277,6 +306,7 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       isTherapist: false,
       isAdmin: false,
       isOrgMember: false,
+      isBcba: false,
       isSuperAdmin: true,
       upstreamError: false,
       resolvedViaServiceRole: false,
@@ -300,6 +330,7 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       isTherapist: false,
       isAdmin: false,
       isOrgMember: false,
+      isBcba: false,
       isSuperAdmin: true,
       upstreamError: false,
       resolvedViaServiceRole: true,
@@ -321,6 +352,7 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       isTherapist: false,
       isAdmin: false,
       isOrgMember: false,
+      isBcba: false,
       isSuperAdmin: true,
       upstreamError: false,
       resolvedViaServiceRole: true,
@@ -338,6 +370,7 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       isTherapist: false,
       isAdmin: false,
       isOrgMember: false,
+      isBcba: false,
       isSuperAdmin: true,
       upstreamError: false,
       resolvedViaServiceRole: false,

--- a/src/server/api/book.ts
+++ b/src/server/api/book.ts
@@ -97,6 +97,7 @@ async function assertBookRequestScope(
     isTherapist,
     isAdmin,
     isOrgMember,
+    isBcba,
     isSuperAdmin,
     upstreamError: roleUpstreamError,
     resolvedViaServiceRole,
@@ -122,7 +123,7 @@ async function assertBookRequestScope(
   const canUseServiceRoleScopeFallback = isSuperAdmin && serviceRoleHeaders !== null;
   const usingServiceRoleScope = resolvedViaServiceRole;
 
-  if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember)) {
+  if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember && !isBcba)) {
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 
@@ -134,7 +135,7 @@ async function assertBookRequestScope(
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 
-  if (isTherapist && !isAdmin && !isSuperAdmin && body.session.therapist_id !== currentUserId) {
+  if (isTherapist && !isAdmin && !isSuperAdmin && !isBcba && body.session.therapist_id !== currentUserId) {
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 

--- a/src/server/api/shared.ts
+++ b/src/server/api/shared.ts
@@ -484,11 +484,43 @@ type OrgRoleResolution = Awaited<ReturnType<typeof resolveOrgAndRoleWithStatus>>
 export async function resolveSchedulingOrgAndRoleWithStatus(
   accessToken: string,
   therapistId: string,
-): Promise<OrgRoleResolution & { resolvedViaServiceRole: boolean }> {
+): Promise<OrgRoleResolution & { isBcba: boolean; resolvedViaServiceRole: boolean }> {
   const roleResolution = await resolveOrgAndRoleWithStatus(accessToken);
-  if (roleResolution.upstreamError || roleResolution.organizationId) {
+  if (roleResolution.upstreamError) {
     return {
       ...roleResolution,
+      isBcba: false,
+      resolvedViaServiceRole: false,
+    };
+  }
+
+  if (roleResolution.organizationId) {
+    const alreadyAuthorizedWithoutBcba =
+      roleResolution.isAdmin ||
+      roleResolution.isSuperAdmin ||
+      (roleResolution.isOrgMember && !roleResolution.isTherapist);
+    if (alreadyAuthorizedWithoutBcba) {
+      return {
+        ...roleResolution,
+        isBcba: false,
+        resolvedViaServiceRole: false,
+      };
+    }
+
+    const { supabaseUrl, anonKey } = getSupabaseConfig();
+    const bcbaResult = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/user_has_role_for_org`, {
+      method: "POST",
+      headers: {
+        ...JSON_HEADERS,
+        apikey: anonKey,
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ role_name: "bcba", target_organization_id: roleResolution.organizationId }),
+    });
+    return {
+      ...roleResolution,
+      isBcba: bcbaResult.ok && bcbaResult.data === true,
+      upstreamError: !bcbaResult.ok && (bcbaResult.status >= 500 || bcbaResult.status === 0),
       resolvedViaServiceRole: false,
     };
   }
@@ -496,6 +528,7 @@ export async function resolveSchedulingOrgAndRoleWithStatus(
   if (!roleResolution.isSuperAdmin) {
     return {
       ...roleResolution,
+      isBcba: false,
       resolvedViaServiceRole: false,
     };
   }
@@ -504,6 +537,7 @@ export async function resolveSchedulingOrgAndRoleWithStatus(
   if (trimmedTherapistId.length === 0) {
     return {
       ...roleResolution,
+      isBcba: false,
       resolvedViaServiceRole: false,
     };
   }
@@ -533,6 +567,7 @@ export async function resolveSchedulingOrgAndRoleWithStatus(
     return {
       ...roleResolution,
       organizationId: userScopedTherapistRow.organization_id,
+      isBcba: false,
       resolvedViaServiceRole: false,
     };
   }
@@ -541,6 +576,7 @@ export async function resolveSchedulingOrgAndRoleWithStatus(
   if (!serviceRoleKey) {
     return {
       ...roleResolution,
+      isBcba: false,
       upstreamError:
         roleResolution.upstreamError || (!userScopedTherapistResult.ok && userScopedTherapistResult.status >= 500),
       resolvedViaServiceRole: false,
@@ -569,6 +605,7 @@ export async function resolveSchedulingOrgAndRoleWithStatus(
   return {
     ...roleResolution,
     organizationId: resolvedOrganizationId,
+    isBcba: false,
     upstreamError:
       roleResolution.upstreamError ||
       (resolvedOrganizationId === null &&


### PR DESCRIPTION
## Summary
- resolve exact persisted `bcba` authority only in the booking-specific scheduling resolver
- allow BCBA staff to book a different in-organization therapist row without mapping BCBA to admin or therapist
- fail closed when the exact role RPC is unavailable and preserve super-admin-only service-role fallback

## Risk
Critical auth/server boundary. The change is organization-scoped, uses persisted `user_roles` authority through `user_has_role_for_org`, and does not alter migrations, grants, RLS, metadata fallback, or shared role hierarchy.

## Verification
- red proof: new BCBA regression returned 403 before the production change
- focused Vitest: 2 files / 43 tests passed
- `npm run ci:check-focused` passed
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run validate:tenant` passed
- `npm run test:routes:tier0` rerun passed 7 specs / 220 tests (initial unrelated redirect timing flake)
- `npm run build` passed
- `npm run test:ci`: changed tests passed; aggregate Windows run had 381 passed files / 2667 passed tests and one pre-existing CRLF-sensitive workflow-text failure. Linux hosted CI is authoritative.

## Tracking
- Linear: WIN-217
- Human review and hosted BCBA acceptance proof remain required.