### PR TITLE
WIN-217 Carry BCBA booking authority through edge

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -103,10 +103,22 @@
   - `npm run validate:tenant` -> pass
   - `npm run test:routes:tier0` -> first run had one unrelated client-root redirect timing failure; bounded rerun passed, 7 specs / 220 tests
   - `npm run build` -> pass
-  - `npm run test:ci` -> changed booking tests pass; aggregate local run reached 381 passed files / 2667 passed tests and failed only the existing Windows CRLF-sensitive workflow-text assertion in `check-e2e-reliability-gates.test.ts`
+  - `npm run test:ci` -> changed booking and edge authorization tests pass; latest aggregate local run reached 382 passed files / 2671 passed tests and failed only the existing Windows CRLF-sensitive workflow-text assertion in `check-e2e-reliability-gates.test.ts`
 - blocked checks:
   - `npm run verify:local` -> not repeated because its `test:ci` stage deterministically reaches the unrelated Windows-only CRLF assertion above
   - credential-backed Playwright proof -> required on the hosted main workflow after human review and merge
 - reviewer: security/code review completed with no blocking authorization findings
 - result: `pass-with-blocked-checks`
 - residual risk: the booking path performs one additional fail-closed exact-role RPC when BCBA authority may be needed; final production proof remains pending until the PR is reviewed, merged, deployed, and the dedicated BCBA lifecycle and measurement checks pass with zero-residue cleanup
+
+### PR #774 review follow-up
+
+- P1 downstream edge authorization: `sessions-hold` and `sessions-confirm` both use the shared target-therapist authorization helper, which still omitted exact `bcba`; the helper now includes persisted BCBA without changing the target therapist or organization scope.
+- P2 therapist self-booking availability: exact BCBA authority is now queried in the Node booking boundary only when base roles do not authorize the caller or a therapist is booking another therapist row. Therapist self-booking no longer depends on the BCBA RPC.
+- cancellation non-goal: `sessions-cancel` also imports the shared helper, but its earlier explicit cancellation-role gate still excludes BCBA-only callers, so cancellation authority is unchanged.
+- red proof:
+  - exact BCBA returned 403 from the shared edge authorization helper
+  - therapist self-booking returned 502 when the unnecessary BCBA RPC returned 503
+- focused green proof:
+  - Node booking, role payload, edge authorization, and hold/confirm shared-helper contract tests -> pass, 5 files / 49 tests
+- deployment requirement: the shared edge bundle deploys only on a push to `main`; PR checks cannot serve as final production evidence. After human merge, require `deploy-session-edge`, dedicated BCBA lifecycle, measurement roundtrip, and zero-residue cleanup to pass on the main workflow.

--- a/src/server/__tests__/bookHandler.test.ts
+++ b/src/server/__tests__/bookHandler.test.ts
@@ -135,6 +135,47 @@ const validPayload = {
   timeZone: "UTC",
 };
 
+const createSuccessfulBookResult = ({
+  sessionId,
+  createdBy,
+}: {
+  sessionId: string;
+  createdBy: string;
+}) => ({
+  session: {
+    id: sessionId,
+    client_id: "client-1",
+    therapist_id: "therapist-1",
+    program_id: "program-1",
+    goal_id: "goal-1",
+    start_time: "2025-01-01T10:00:00Z",
+    end_time: "2025-01-01T11:00:00Z",
+    status: "scheduled",
+    notes: "",
+    created_at: "2025-01-01T09:00:00Z",
+    created_by: createdBy,
+    updated_at: "2025-01-01T09:00:00Z",
+    updated_by: createdBy,
+    duration_minutes: 60,
+  },
+  sessions: [],
+  hold: {
+    holdKey: `hold-${sessionId}`,
+    holdId: `hold-${sessionId}`,
+    startTime: "2025-01-01T10:00:00Z",
+    endTime: "2025-01-01T11:00:00Z",
+    expiresAt: "2025-01-01T10:05:00Z",
+    holds: [],
+  },
+  cpt: {
+    code: "97153",
+    description: "Adaptive behavior treatment by protocol",
+    modifiers: [],
+    source: "fallback",
+    durationMinutes: 60,
+  },
+});
+
 const TEST_SUPABASE_URL = "https://testing.supabase.co";
 const TEST_SUPABASE_ANON_KEY = "testing-anon-key";
 const TEST_SUPABASE_EDGE_URL = "https://testing.supabase.co/functions/v1/";
@@ -485,45 +526,41 @@ describe("bookHandler", () => {
       }),
       http.get(`${TEST_SUPABASE_URL}/auth/v1/user`, () => HttpResponse.json({ id: "bcba-user" })),
     );
-    bookSessionMock.mockResolvedValueOnce({
-      session: {
-        id: "session-bcba",
-        client_id: "client-1",
-        therapist_id: "therapist-1",
-        program_id: "program-1",
-        goal_id: "goal-1",
-        start_time: "2025-01-01T10:00:00Z",
-        end_time: "2025-01-01T11:00:00Z",
-        status: "scheduled",
-        notes: "",
-        created_at: "2025-01-01T09:00:00Z",
-        created_by: "bcba-user",
-        updated_at: "2025-01-01T09:00:00Z",
-        updated_by: "bcba-user",
-        duration_minutes: 60,
-      },
-      sessions: [],
-      hold: {
-        holdKey: "hold-bcba",
-        holdId: "hold-bcba",
-        startTime: "2025-01-01T10:00:00Z",
-        endTime: "2025-01-01T11:00:00Z",
-        expiresAt: "2025-01-01T10:05:00Z",
-        holds: [],
-      },
-      cpt: {
-        code: "97153",
-        description: "Adaptive behavior treatment by protocol",
-        modifiers: [],
-        source: "fallback",
-        durationMinutes: 60,
-      },
-    });
+    bookSessionMock.mockResolvedValueOnce(createSuccessfulBookResult({
+      sessionId: "session-bcba",
+      createdBy: "bcba-user",
+    }));
 
     const bookHandler = await importBookHandler();
     const response = await bookHandler(createRequest(validPayload));
 
     expect(response.status).toBe(200);
+    expect(bookSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not depend on BCBA authority when a therapist books their own row", async () => {
+    let bcbaRoleChecks = 0;
+    server.use(
+      http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/user_has_role_for_org`, async ({ request }) => {
+        const body = await request.json() as { role_name?: string };
+        if (body.role_name === "bcba") {
+          bcbaRoleChecks += 1;
+          return new HttpResponse(null, { status: 503 });
+        }
+        return HttpResponse.json(body.role_name === "therapist");
+      }),
+      http.get(`${TEST_SUPABASE_URL}/auth/v1/user`, () => HttpResponse.json({ id: "therapist-1" })),
+    );
+    bookSessionMock.mockResolvedValueOnce(createSuccessfulBookResult({
+      sessionId: "session-therapist-self",
+      createdBy: "therapist-1",
+    }));
+
+    const bookHandler = await importBookHandler();
+    const response = await bookHandler(createRequest(validPayload));
+
+    expect(response.status).toBe(200);
+    expect(bcbaRoleChecks).toBe(0);
     expect(bookSessionMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
+++ b/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
@@ -16,6 +16,7 @@ import {
   currentUserCanManageLockedTrialEvent,
   currentUserCanManageProgramsGoals,
   currentUserCanTakeClientData,
+  currentUserIsBcbaForOrg,
   getSupabaseConfig,
   resolveOrgAndRoleWithStatus,
   resolveSchedulingOrgAndRoleWithStatus,
@@ -100,6 +101,24 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
     expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/rest/v1/rpc/current_user_can_manage_programs_goals");
     const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
     expect(JSON.parse(String(init.body))).toEqual({ target_organization_id: "org-1" });
+  });
+
+  it("checks exact persisted BCBA authority within the requested organization", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(currentUserIsBcbaForOrg(accessToken, "org-1")).resolves.toEqual({
+      allowed: true,
+      upstreamError: false,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/rest/v1/rpc/user_has_role_for_org");
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({
+      role_name: "bcba",
+      target_organization_id: "org-1",
+    });
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${accessToken}`);
   });
 
   it("checks trial-event capture and lock helpers through exposed public RPC wrappers", async () => {
@@ -266,35 +285,6 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
     });
   });
 
-  it("checks exact persisted BCBA authority for scheduling within the resolved organization", async () => {
-    fetchSpy
-      .mockResolvedValueOnce(jsonResponse(false))
-      .mockResolvedValueOnce(jsonResponse("org-1"))
-      .mockResolvedValueOnce(jsonResponse(false))
-      .mockResolvedValueOnce(jsonResponse(false))
-      .mockResolvedValueOnce(jsonResponse(false))
-      .mockResolvedValueOnce(jsonResponse(false))
-      .mockResolvedValueOnce(jsonResponse(true));
-
-    await expect(resolveSchedulingOrgAndRoleWithStatus(accessToken, "therapist-1")).resolves.toEqual({
-      organizationId: "org-1",
-      isTherapist: false,
-      isAdmin: false,
-      isOrgMember: false,
-      isBcba: true,
-      isSuperAdmin: false,
-      upstreamError: false,
-      resolvedViaServiceRole: false,
-    });
-    expect(fetchSpy).toHaveBeenCalledTimes(7);
-    const bcbaInit = fetchSpy.mock.calls[6]?.[1] as RequestInit;
-    expect(JSON.parse(String(bcbaInit.body))).toEqual({
-      role_name: "bcba",
-      target_organization_id: "org-1",
-    });
-    expect((bcbaInit.headers as Record<string, string>).Authorization).toBe(`Bearer ${accessToken}`);
-  });
-
   it("derives scheduling org context from the target therapist for super-admins without direct org context", async () => {
     fetchSpy
       .mockResolvedValueOnce(jsonResponse(true))
@@ -306,7 +296,6 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       isTherapist: false,
       isAdmin: false,
       isOrgMember: false,
-      isBcba: false,
       isSuperAdmin: true,
       upstreamError: false,
       resolvedViaServiceRole: false,
@@ -330,7 +319,6 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       isTherapist: false,
       isAdmin: false,
       isOrgMember: false,
-      isBcba: false,
       isSuperAdmin: true,
       upstreamError: false,
       resolvedViaServiceRole: true,
@@ -352,7 +340,6 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       isTherapist: false,
       isAdmin: false,
       isOrgMember: false,
-      isBcba: false,
       isSuperAdmin: true,
       upstreamError: false,
       resolvedViaServiceRole: true,
@@ -370,7 +357,6 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       isTherapist: false,
       isAdmin: false,
       isOrgMember: false,
-      isBcba: false,
       isSuperAdmin: true,
       upstreamError: false,
       resolvedViaServiceRole: false,

--- a/src/server/api/book.ts
+++ b/src/server/api/book.ts
@@ -3,6 +3,7 @@ import { bookSession, deriveBookSessionOccurrences } from "../bookSession";
 import {
   consumeRateLimit,
   corsHeadersForRequest,
+  currentUserIsBcbaForOrg,
   errorResponse,
   fetchAuthenticatedUserIdWithStatus,
   fetchJson,
@@ -97,7 +98,6 @@ async function assertBookRequestScope(
     isTherapist,
     isAdmin,
     isOrgMember,
-    isBcba,
     isSuperAdmin,
     upstreamError: roleUpstreamError,
     resolvedViaServiceRole,
@@ -123,7 +123,7 @@ async function assertBookRequestScope(
   const canUseServiceRoleScopeFallback = isSuperAdmin && serviceRoleHeaders !== null;
   const usingServiceRoleScope = resolvedViaServiceRole;
 
-  if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember && !isBcba)) {
+  if (!organizationId) {
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 
@@ -132,6 +132,24 @@ async function assertBookRequestScope(
     return errorResponse(request, "upstream_error", "Unable to validate authenticated user", { status: 502 });
   }
   if (!currentUserId) {
+    return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
+  }
+
+  let isBcba = false;
+  const requiresBcbaAuthority =
+    !isAdmin &&
+    !isSuperAdmin &&
+    ((!isTherapist && !isOrgMember) ||
+      (isTherapist && body.session.therapist_id !== currentUserId));
+  if (requiresBcbaAuthority) {
+    const bcbaAuthority = await currentUserIsBcbaForOrg(accessToken, organizationId);
+    if (bcbaAuthority.upstreamError) {
+      return errorResponse(request, "upstream_error", "Unable to validate BCBA booking access", { status: 502 });
+    }
+    isBcba = bcbaAuthority.allowed;
+  }
+
+  if (!isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember && !isBcba) {
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 

--- a/src/server/api/shared.ts
+++ b/src/server/api/shared.ts
@@ -263,6 +263,27 @@ export async function currentUserCanManageProgramsGoals(
   return { allowed: result.data === true, upstreamError: false };
 }
 
+export async function currentUserIsBcbaForOrg(
+  accessToken: string,
+  organizationId: string,
+): Promise<{ allowed: boolean; upstreamError: boolean }> {
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const result = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/user_has_role_for_org`, {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      apikey: anonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ role_name: "bcba", target_organization_id: organizationId }),
+  });
+
+  return {
+    allowed: result.ok && result.data === true,
+    upstreamError: !result.ok && (result.status >= 500 || result.status === 0),
+  };
+}
+
 export async function currentUserCanDeleteGoalTargets(
   accessToken: string,
   organizationId: string,
@@ -484,43 +505,11 @@ type OrgRoleResolution = Awaited<ReturnType<typeof resolveOrgAndRoleWithStatus>>
 export async function resolveSchedulingOrgAndRoleWithStatus(
   accessToken: string,
   therapistId: string,
-): Promise<OrgRoleResolution & { isBcba: boolean; resolvedViaServiceRole: boolean }> {
+): Promise<OrgRoleResolution & { resolvedViaServiceRole: boolean }> {
   const roleResolution = await resolveOrgAndRoleWithStatus(accessToken);
-  if (roleResolution.upstreamError) {
+  if (roleResolution.upstreamError || roleResolution.organizationId) {
     return {
       ...roleResolution,
-      isBcba: false,
-      resolvedViaServiceRole: false,
-    };
-  }
-
-  if (roleResolution.organizationId) {
-    const alreadyAuthorizedWithoutBcba =
-      roleResolution.isAdmin ||
-      roleResolution.isSuperAdmin ||
-      (roleResolution.isOrgMember && !roleResolution.isTherapist);
-    if (alreadyAuthorizedWithoutBcba) {
-      return {
-        ...roleResolution,
-        isBcba: false,
-        resolvedViaServiceRole: false,
-      };
-    }
-
-    const { supabaseUrl, anonKey } = getSupabaseConfig();
-    const bcbaResult = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/user_has_role_for_org`, {
-      method: "POST",
-      headers: {
-        ...JSON_HEADERS,
-        apikey: anonKey,
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify({ role_name: "bcba", target_organization_id: roleResolution.organizationId }),
-    });
-    return {
-      ...roleResolution,
-      isBcba: bcbaResult.ok && bcbaResult.data === true,
-      upstreamError: !bcbaResult.ok && (bcbaResult.status >= 500 || bcbaResult.status === 0),
       resolvedViaServiceRole: false,
     };
   }
@@ -528,7 +517,6 @@ export async function resolveSchedulingOrgAndRoleWithStatus(
   if (!roleResolution.isSuperAdmin) {
     return {
       ...roleResolution,
-      isBcba: false,
       resolvedViaServiceRole: false,
     };
   }
@@ -537,7 +525,6 @@ export async function resolveSchedulingOrgAndRoleWithStatus(
   if (trimmedTherapistId.length === 0) {
     return {
       ...roleResolution,
-      isBcba: false,
       resolvedViaServiceRole: false,
     };
   }
@@ -567,7 +554,6 @@ export async function resolveSchedulingOrgAndRoleWithStatus(
     return {
       ...roleResolution,
       organizationId: userScopedTherapistRow.organization_id,
-      isBcba: false,
       resolvedViaServiceRole: false,
     };
   }
@@ -576,7 +562,6 @@ export async function resolveSchedulingOrgAndRoleWithStatus(
   if (!serviceRoleKey) {
     return {
       ...roleResolution,
-      isBcba: false,
       upstreamError:
         roleResolution.upstreamError || (!userScopedTherapistResult.ok && userScopedTherapistResult.status >= 500),
       resolvedViaServiceRole: false,
@@ -605,7 +590,6 @@ export async function resolveSchedulingOrgAndRoleWithStatus(
   return {
     ...roleResolution,
     organizationId: resolvedOrganizationId,
-    isBcba: false,
     upstreamError:
       roleResolution.upstreamError ||
       (resolvedOrganizationId === null &&

--- a/supabase/functions/_shared/authorization.ts
+++ b/supabase/functions/_shared/authorization.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from "npm:@supabase/supabase-js@2.50.0";
 
-type RoleName = "therapist" | "admin" | "super_admin";
+type RoleName = "therapist" | "admin" | "super_admin" | "bcba";
 
 interface AuthorizationFailure {
   status: number;
@@ -23,7 +23,7 @@ export async function evaluateTherapistAuthorization(
   client: SupabaseClient,
   therapistId: string,
 ): Promise<TherapistAuthorizationResult> {
-  const roles: RoleName[] = ["therapist", "admin", "super_admin"];
+  const roles: RoleName[] = ["therapist", "admin", "super_admin", "bcba"];
 
   for (const role of roles) {
     const { data, error } = await client.rpc("user_has_role_for_org", {

--- a/tests/edge/scheduling-authorization.bcba.test.ts
+++ b/tests/edge/scheduling-authorization.bcba.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { evaluateTherapistAuthorization } from "../../supabase/functions/_shared/authorization";
+
+describe("scheduling edge therapist authorization", () => {
+  it("allows an exact BCBA role to authorize a target therapist", async () => {
+    const rpc = vi.fn(async (_name: string, args: { role_name?: string }) => ({
+      data: args.role_name === "bcba",
+      error: null,
+    }));
+
+    const result = await evaluateTherapistAuthorization(
+      { rpc } as never,
+      "therapist-row-1",
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(rpc.mock.calls.map(([, args]) => args)).toEqual([
+      { role_name: "therapist", target_therapist_id: "therapist-row-1" },
+      { role_name: "admin", target_therapist_id: "therapist-row-1" },
+      { role_name: "super_admin", target_therapist_id: "therapist-row-1" },
+      { role_name: "bcba", target_therapist_id: "therapist-row-1" },
+    ]);
+  });
+
+  it("denies callers when no target-scoped scheduling role matches", async () => {
+    const rpc = vi.fn(async () => ({ data: false, error: null }));
+
+    const result = await evaluateTherapistAuthorization(
+      { rpc } as never,
+      "therapist-row-1",
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      failure: {
+        status: 403,
+        body: { success: false, error: "Forbidden" },
+      },
+    });
+  });
+
+  it("fails closed when exact BCBA role validation errors", async () => {
+    const rpc = vi.fn(async (_name: string, args: { role_name?: string }) =>
+      args.role_name === "bcba"
+        ? { data: null, error: { message: "role lookup unavailable" } }
+        : { data: false, error: null });
+
+    const result = await evaluateTherapistAuthorization(
+      { rpc } as never,
+      "therapist-row-1",
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      failure: {
+        status: 500,
+        body: { success: false, error: "Role validation failed" },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- carry exact persisted `bcba` booking authority through the shared edge authorization used by `sessions-hold` and `sessions-confirm`
- move the Node BCBA role lookup to the point where booking actually needs it
- keep ordinary therapist self-booking independent from BCBA RPC availability

## Review findings addressed
- P1 from PR #774: downstream hold/confirm authorization omitted exact BCBA and would still return 403
- P2 from PR #774: self-booking therapists could receive 502 when an unnecessary BCBA role lookup degraded

## Security boundary
- exact persisted role only; no metadata/profile fallback
- target therapist / organization scoping remains unchanged
- super-admin-only service-role fallback remains unchanged
- `sessions-cancel` authority is unchanged because its earlier explicit role gate still excludes BCBA-only callers
- no migrations, RLS, grants, secrets, or workflow changes

## Verification
- red proof: edge BCBA returned 403; therapist self-booking returned 502 on BCBA RPC 503
- focused post-rebase: 5 files / 49 tests passed
- policy, lint, typecheck, tenant safety, build passed
- tier-0 routes: 7 specs / 220 tests passed
- full local CI: 382 passed files / 2671 passed tests; sole failure is existing Windows CRLF-sensitive workflow-text assertion. Hosted Linux CI is authoritative.

## Deployment proof required
This changes `supabase/functions/_shared/authorization.ts`. Final proof requires human merge, main-only `deploy-session-edge`, dedicated BCBA lifecycle + measurement roundtrip, and zero-residue cleanup.

Tracking: WIN-217
Follow-up to #774.