### PR TITLE
WIN-217 Repair live RLS test fixtures

### DIFF
--- a/.github/workflows/supabase-validate.yml
+++ b/.github/workflows/supabase-validate.yml
@@ -1,5 +1,8 @@
 name: Supabase Validate
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
@@ -10,6 +13,9 @@ on:
       - main
     paths:
       - 'supabase/migrations/**'
+      - 'tests/integration/_helpers/liveRlsHarness.ts'
+      - 'tests/integration/live-rls-fixture-schema.contract.test.ts'
+      - 'src/tests/security/rls.spec.ts'
 
 jobs:
   lint-migrations:

--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -169,12 +169,21 @@
 - non-goals: no production schema, migration, RLS, grant, auth, runtime, workflow, or application behavior changes
 - local verification:
   - red proof: the new fixture contract failed 5/5 assertions before the repair
-  - focused fixture contract -> pass, 1 file / 5 tests
+  - focused fixture contract -> pass, 1 file / 6 tests
   - `npm run ci:check-focused` -> pass
   - `npm run lint` -> pass
   - `npm run typecheck` -> pass
   - `npm run validate:tenant` -> pass
   - `npm run build` -> pass
-  - `npm run test:ci` -> fixture contract and 384 files passed; aggregate failed only the existing Windows CRLF-sensitive workflow-text assertion in `check-e2e-reliability-gates.test.ts` (2681 tests passed, 1 failed, 3 skipped)
+  - `npm run test:ci` -> fixture contract and 384 files passed; aggregate failed only the existing Windows CRLF-sensitive workflow-text assertion in `check-e2e-reliability-gates.test.ts` (2682 tests passed, 1 failed, 3 skipped)
 - residual risk: the affected live database suites require hosted credentials, so the repair remains unproven until Supabase Validate reruns successfully on the focused PR.
 - next proof: merge the fixture-only repair after hosted Supabase Validate passes, then require the fresh main workflow to pass the dedicated BCBA lifecycle, measurement roundtrip, and zero-residue cleanup.
+
+#### Hosted validation trigger follow-up
+
+- PR #777 initially could not launch the decisive database job: `Supabase Validate` watched only migration changes, and its credential-backed `test-main` job intentionally runs only on trusted pushes to `main`.
+- reclassification: `high-risk human-reviewed`; lane: `critical` because `.github/workflows/supabase-validate.yml` is protected CI policy.
+- bounded workflow fix: add only the three live-fixture/test files to the existing `push.paths` filter and declare `permissions: contents: read`.
+- security boundary: fixture changes do not broaden `pull_request.paths`; service-role tests remain unavailable to PR-head code and execute only after a trusted main merge.
+- contract proof: the fixture contract normalizes platform line endings, requires the three exact main-push paths, confirms they are absent from the PR filter, and preserves the push-only database job condition.
+- merge proof requirement: the merge of PR #777 must start `Supabase Validate`; `Run application tests` must execute all six formerly failing suites with no `23502`, no `email_exists`, and no skipped live RLS suite.

--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -154,3 +154,27 @@
 - Hosted structural verification confirms both active-status predicates, `SECURITY DEFINER`, and fixed `search_path=public`.
 - Focused migration, runtime-parity, and edge authorization tests pass, 3 files / 17 tests.
 - Remaining proof: fresh PR CI and review, human merge, then the main-run dedicated BCBA lifecycle, measurement roundtrip, and zero-residue cleanup.
+
+### Post-merge Supabase Validate fixture repair
+
+- main run: Supabase Validate `29276383954`, job `86906395257`
+- failure scope: five live RLS suites failed because their shared therapist fixture omitted the schema-required `first_name` and `last_name`; the security RLS suite also reused timestamp-only auth emails while the test environment freezes `Date`, causing `email_exists` on later runs.
+- classification: `low-risk autonomous`
+- lane: `standard`
+- bounded fix:
+  - seed the required therapist name fields in the shared live RLS harness and security RLS fixtures
+  - derive shared harness record emails from fixture UUIDs
+  - use `randomUUID()` for security-suite auth identities so repeated and parallel runs do not collide when time is frozen
+  - add a source contract test covering the required therapist fields and run-unique identity inputs
+- non-goals: no production schema, migration, RLS, grant, auth, runtime, workflow, or application behavior changes
+- local verification:
+  - red proof: the new fixture contract failed 5/5 assertions before the repair
+  - focused fixture contract -> pass, 1 file / 5 tests
+  - `npm run ci:check-focused` -> pass
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm run validate:tenant` -> pass
+  - `npm run build` -> pass
+  - `npm run test:ci` -> fixture contract and 384 files passed; aggregate failed only the existing Windows CRLF-sensitive workflow-text assertion in `check-e2e-reliability-gates.test.ts` (2681 tests passed, 1 failed, 3 skipped)
+- residual risk: the affected live database suites require hosted credentials, so the repair remains unproven until Supabase Validate reruns successfully on the focused PR.
+- next proof: merge the fixture-only repair after hosted Supabase Validate passes, then require the fresh main workflow to pass the dedicated BCBA lifecycle, measurement roundtrip, and zero-residue cleanup.

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -174,7 +174,7 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
     throw new Error('Service client not initialized');
   }
 
-  const email = `${label}.${Date.now()}@example.com`;
+  const email = `${label}.${randomUUID()}@example.com`;
   const password = `P@ssw0rd-${Math.random().toString(36).slice(2, 10)}`;
 
   const { data: createdUser, error: createUserError } = await serviceClient.auth.admin.createUser({
@@ -194,6 +194,8 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
   const { error: therapistInsertError } = await serviceClient.from('therapists').insert({
     id: therapistId,
     email,
+    first_name: label.toUpperCase(),
+    last_name: 'Therapist',
     full_name: `${label.toUpperCase()} Therapist`,
     specialties: ['aba'],
     max_clients: 5,
@@ -215,7 +217,7 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
 
   await serviceClient.from('profiles').update({ role: 'therapist' }).eq('id', userId);
 
-  const clientEmail = `${label}.client.${Date.now()}@example.com`;
+  const clientEmail = `${label}.client.${randomUUID()}@example.com`;
   const clientPassword = `P@ssw0rd-${Math.random().toString(36).slice(2, 10)}`;
 
   const { data: createdClientUser, error: clientUserError } = await serviceClient.auth.admin.createUser({
@@ -283,7 +285,7 @@ const createAdminFixture = async (organizationId: string): Promise<AdminContext>
     throw new Error('Service client not initialized');
   }
 
-  const email = `admin.${Date.now()}@example.com`;
+  const email = `admin.${randomUUID()}@example.com`;
   const password = `P@ssw0rd-${Math.random().toString(36).slice(2, 10)}`;
 
   const { data: createdUser, error: createUserError } = await serviceClient.auth.admin.createUser({
@@ -1973,7 +1975,7 @@ describe('row level security for multi-tenant tables', () => {
       return;
     }
 
-    const otherTherapistEmail = `other.therapist.${Date.now()}@example.com`;
+    const otherTherapistEmail = `other.therapist.${randomUUID()}@example.com`;
     const otherTherapistPassword = `P@ssw0rd-${Math.random().toString(36).slice(2, 10)}`;
     const { data: otherUser, error: otherUserError } = await serviceClient.auth.admin.createUser({
       email: otherTherapistEmail,
@@ -1992,6 +1994,8 @@ describe('row level security for multi-tenant tables', () => {
     const { error: therapistInsertError } = await serviceClient.from('therapists').insert({
       id: otherTherapistId,
       email: otherTherapistEmail,
+      first_name: 'Other',
+      last_name: 'Therapist',
       full_name: `Other Therapist ${randomSuffix()}`,
       specialties: ['aba'],
       max_clients: 5,

--- a/tests/integration/_helpers/liveRlsHarness.ts
+++ b/tests/integration/_helpers/liveRlsHarness.ts
@@ -142,7 +142,9 @@ const seedOrgData = async (
 
   const therapistInsert = await serviceClient.from("therapists").insert({
     id: therapistId,
-    email: `${label}.therapist.${Date.now()}@example.com`,
+    email: `${label}.therapist.${therapistId}@example.com`,
+    first_name: label.toUpperCase(),
+    last_name: "Therapist",
     full_name: `${label.toUpperCase()} Therapist`,
     specialties: ["aba"],
     max_clients: 5,
@@ -155,7 +157,7 @@ const seedOrgData = async (
 
   const clientInsert = await serviceClient.from("clients").insert({
     id: clientId,
-    email: `${label}.client.${Date.now()}@example.com`,
+    email: `${label}.client.${clientId}@example.com`,
     full_name: `${label.toUpperCase()} Client`,
     date_of_birth: "2016-01-01",
     one_to_one_units: 4,

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readRepoFile = (path: string) =>
+  readFileSync(resolve(process.cwd(), path), "utf8");
+
+const therapistInsertBodies = (source: string) =>
+  Array.from(
+    source.matchAll(
+      /\.from\(["']therapists["']\)\.insert\(\{([\s\S]*?)\n\s*\}\);/g,
+    ),
+    (match) => match[1],
+  );
+
+describe("live RLS fixture schema contract", () => {
+  it("seeds required therapist names in the shared live RLS harness", () => {
+    const source = readRepoFile("tests/integration/_helpers/liveRlsHarness.ts");
+    const inserts = therapistInsertBodies(source);
+
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]).toContain("first_name:");
+    expect(inserts[0]).toContain("last_name:");
+    expect(inserts[0]).toContain("${therapistId}@example.com");
+    expect(source).toContain("${clientId}@example.com");
+  });
+
+  it("seeds required therapist names in every security RLS fixture", () => {
+    const source = readRepoFile("src/tests/security/rls.spec.ts");
+    const inserts = therapistInsertBodies(source);
+
+    expect(inserts.length).toBeGreaterThanOrEqual(2);
+    for (const insert of inserts) {
+      expect(insert).toContain("first_name:");
+      expect(insert).toContain("last_name:");
+    }
+  });
+
+  it("uses a run-unique therapist auth email when Date is frozen", () => {
+    const source = readRepoFile("src/tests/security/rls.spec.ts");
+    const fixtureSetup = source.match(
+      /const createTenantFixture[\s\S]*?const password/,
+    )?.[0];
+
+    expect(fixtureSetup).toMatch(
+      /const email = `\$\{label\}\.\$\{randomUUID\(\)\}@example\.com`/,
+    );
+  });
+
+  it("uses a run-unique client auth email when Date is frozen", () => {
+    const source = readRepoFile("src/tests/security/rls.spec.ts");
+
+    expect(source).toContain(
+      "const clientEmail = `${label}.client.${randomUUID()}@example.com`;",
+    );
+  });
+
+  it("uses run-unique admin auth emails when Date is frozen", () => {
+    const source = readRepoFile("src/tests/security/rls.spec.ts");
+
+    const adminSetup = source.match(
+      /const createAdminFixture[\s\S]*?const password/,
+    )?.[0];
+    expect(adminSetup).toMatch(
+      /const email = `admin\.\$\{randomUUID\(\)\}@example\.com`/,
+    );
+  });
+});

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const readRepoFile = (path: string) =>
-  readFileSync(resolve(process.cwd(), path), "utf8");
+  readFileSync(resolve(process.cwd(), path), "utf8").replace(/\r\n/g, "\n");
 
 const therapistInsertBodies = (source: string) =>
   Array.from(
@@ -14,6 +14,37 @@ const therapistInsertBodies = (source: string) =>
   );
 
 describe("live RLS fixture schema contract", () => {
+  it("runs hosted database validation when live RLS fixtures merge to main", () => {
+    const workflow = readRepoFile(".github/workflows/supabase-validate.yml");
+    const pullRequestSection = workflow.match(
+      /  pull_request:\n([\s\S]*?)  push:/,
+    )?.[1];
+    const pushSection = workflow.match(/  push:\n([\s\S]*?)\njobs:/)?.[1];
+    const testMainJob = workflow.match(
+      /  test-main:\n([\s\S]*?)\n  runtime-migration-parity:/,
+    )?.[1];
+
+    expect(workflow).toContain("permissions:\n  contents: read");
+    expect(pushSection).toContain(
+      "      - 'tests/integration/_helpers/liveRlsHarness.ts'",
+    );
+    expect(pushSection).toContain(
+      "      - 'tests/integration/live-rls-fixture-schema.contract.test.ts'",
+    );
+    expect(pushSection).toContain("      - 'src/tests/security/rls.spec.ts'");
+    expect(pushSection).toContain("      - main");
+    expect(pullRequestSection).not.toContain("liveRlsHarness.ts");
+    expect(pullRequestSection).not.toContain(
+      "live-rls-fixture-schema.contract.test.ts",
+    );
+    expect(pullRequestSection).not.toContain("rls.spec.ts");
+    expect(testMainJob).toContain("    if: github.event_name == 'push'");
+    expect(testMainJob).toContain(
+      "SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || secrets.SUPABASE_SECRET_KEY }}",
+    );
+    expect(testMainJob).toContain("RUN_DB_IT: '1'");
+  });
+
   it("seeds required therapist names in the shared live RLS harness", () => {
     const source = readRepoFile("tests/integration/_helpers/liveRlsHarness.ts");
     const inserts = therapistInsertBodies(source);


### PR DESCRIPTION
## Summary
- seed schema-required therapist first and last names in live RLS fixtures
- replace frozen-clock timestamp identities with UUID-backed synthetic identities
- add a fixture source contract that prevents recurrence
- document the main Supabase Validate failure and hosted proof requirement

## Root cause
Main Supabase Validate run 29276383954 failed five shared-harness suites with PostgreSQL 23502 because therapist fixtures omitted required names. The security RLS suite also hit email_exists because global setup freezes Date while fixture emails used Date.now().

## Verification
- focused fixture contract: pass (1 file / 5 tests)
- npm run ci:check-focused: pass
- npm run lint: pass
- npm run typecheck: pass
- npm run validate:tenant: pass
- npm run build: pass
- npm run test:ci: 384 files / 2681 tests passed; one unrelated Windows-only CRLF-sensitive workflow parser assertion failed in check-e2e-reliability-gates.test.ts

## Hosted acceptance
Supabase Validate with RUN_DB_IT=1 is decisive. All six previously affected suites must execute without 23502 or email_exists and must not skip.

Linear: WIN-217