### PR TITLE
test: repair hosted RLS fixture lifecycle

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -187,3 +187,36 @@
 - security boundary: fixture changes do not broaden `pull_request.paths`; service-role tests remain unavailable to PR-head code and execute only after a trusted main merge.
 - contract proof: the fixture contract normalizes platform line endings, requires the three exact main-push paths, confirms they are absent from the PR filter, and preserves the push-only database job condition.
 - merge proof requirement: the merge of PR #777 must start `Supabase Validate`; `Run application tests` must execute all six formerly failing suites with no `23502`, no `email_exists`, and no skipped live RLS suite.
+
+#### Second hosted fixture drift repair
+
+- merged PR #777 triggered Supabase Validate run `29280537187`; the trusted `Run application tests` job executed and failed six suites after the first fixture defects were cleared.
+- remaining failure scope:
+  - five shared-harness suites referenced synthetic organization UUIDs before inserting matching `organizations` rows, producing `23503 session_holds_organization_id_fkey`.
+  - `src/tests/security/rls.spec.ts` called the retired two-argument `assign_therapist_role` shape; hosted PostgREST exposes `assign_therapist_role(p_therapist_id)`.
+- classification: `low-risk autonomous`; lane: `standard`.
+- bounded fix:
+  - create UUID-scoped organization rows before dependent live RLS fixtures and delete them last.
+  - use the current unary therapist-role RPC argument in both security fixtures.
+  - make shared-harness setup failure-safe with tracked auth users, reverse-dependency cleanup, surfaced cleanup errors, and UUID auth emails.
+  - move security-suite session-hold cleanup ahead of parent tenant fixture deletion.
+- non-goals: no migration, production schema, RLS, grant, application auth, runtime, or workflow changes.
+- focused proof:
+  - red contract: 2 new organization/cleanup assertions failed before implementation.
+  - fixture schema contract -> pass, 1 file / 9 tests.
+  - `npm run typecheck` -> pass.
+  - `npm run ci:check-focused` -> pass.
+  - `npm run lint` -> pass.
+  - `npm run validate:tenant` -> pass.
+  - `npm run build` -> pass.
+  - `npm run test:ci` -> the fixture contract and 384 files passed; the aggregate failed only the pre-existing Windows CRLF-sensitive workflow-text assertion in `check-e2e-reliability-gates.test.ts` (2685 tests passed, 1 failed, 3 skipped). The same merged-main unit-test job passes on Linux.
+- hosted proof requirement: after merge, Supabase Validate must execute all six affected suites with no `23503`, no `PGRST202`, and no skipped live RLS suite.
+
+Verification card:
+
+- lane: `standard`
+- required checks: focused fixture contract, policy, lint, typecheck, tenant safety, build, full unit suite, reviewer
+- executed checks: focused contract 9/9, policy pass, lint pass, typecheck pass, tenant safety pass, build pass, reviewer no P1/P2
+- blocked checks: hosted database suites require trusted main credentials; local full suite has one unrelated Windows CRLF-sensitive workflow-text failure while merged-main Linux unit tests pass
+- result: `review-ready`, pending PR CI and trusted post-merge Supabase Validate
+- residual risk: hosted schema behavior is not proven until the trusted main run executes all six affected suites without skips

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -115,6 +115,8 @@ let orgAContext: TenantContext | null = null;
 let orgBContext: TenantContext | null = null;
 let adminContext: AdminContext | null = null;
 let otherAdminContext: AdminContext | null = null;
+let orgAId = '';
+let orgBId = '';
 
 const createdLocationIds: string[] = [];
 const createdServiceLineIds: string[] = [];
@@ -150,6 +152,7 @@ const createdAuthorizationServiceIds: string[] = [];
 const createdClientSessionNoteIds: string[] = [];
 const createdClientNoteIds: string[] = [];
 const createdExtraTherapistIds: string[] = [];
+const createdFixtureAuthUserIds: string[] = [];
 
 let sessionCptEntryIdsByOrg: OrgRecordIds | null = null;
 let sessionCptModifierIdsByOrg: OrgRecordIds | null = null;
@@ -189,6 +192,7 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
   }
 
   const userId = createdUser.user.id;
+  createdFixtureAuthUserIds.push(userId);
   const therapistId = userId;
 
   const { error: therapistInsertError } = await serviceClient.from('therapists').insert({
@@ -207,8 +211,7 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
   }
 
   const assignRoleResult = await serviceClient.rpc('assign_therapist_role', {
-    user_email: email,
-    therapist_id: therapistId,
+    p_therapist_id: therapistId,
   });
 
   if (assignRoleResult.error) {
@@ -232,6 +235,7 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
   }
 
   const clientUserId = createdClientUser.user.id;
+  createdFixtureAuthUserIds.push(clientUserId);
 
   await serviceClient.from('profiles').update({ role: 'client' }).eq('id', clientUserId);
 
@@ -300,6 +304,7 @@ const createAdminFixture = async (organizationId: string): Promise<AdminContext>
   }
 
   const userId = createdUser.user.id;
+  createdFixtureAuthUserIds.push(userId);
 
   const assignResult = await serviceClient.rpc('assign_admin_role', {
     user_email: email,
@@ -1000,8 +1005,27 @@ beforeAll(async () => {
   }
 
   runTests = true;
-  const orgAId = randomUUID();
-  const orgBId = randomUUID();
+  orgAId = randomUUID();
+  orgBId = randomUUID();
+  const organizationInsert = await serviceClient
+    .from('organizations')
+    .insert([
+      {
+        id: orgAId,
+        name: 'Security RLS Organization A',
+        slug: `security-rls-org-a-${orgAId}`,
+      },
+      {
+        id: orgBId,
+        name: 'Security RLS Organization B',
+        slug: `security-rls-org-b-${orgBId}`,
+      },
+    ]);
+
+  if (organizationInsert.error) {
+    throw organizationInsert.error;
+  }
+
   orgAContext = await createTenantFixture('orga', orgAId);
   orgBContext = await createTenantFixture('orgb', orgBId);
   adminContext = await createAdminFixture(orgAId);
@@ -1505,6 +1529,10 @@ afterAll(async () => {
     }
   }
 
+  if (createdSessionHoldIds.length > 0) {
+    await serviceClient.from('session_holds').delete().in('id', createdSessionHoldIds);
+  }
+
   const contexts = [orgAContext, orgBContext].filter(Boolean) as TenantContext[];
   for (const context of contexts) {
     const userSessionId = userSessionIdsByUser.get(context.userId);
@@ -1531,10 +1559,6 @@ afterAll(async () => {
 
   if (createdTherapistCertificationIds.length > 0) {
     await serviceClient.from('therapist_certifications').delete().in('id', createdTherapistCertificationIds);
-  }
-
-  if (createdSessionHoldIds.length > 0) {
-    await serviceClient.from('session_holds').delete().in('id', createdSessionHoldIds);
   }
 
   if (createdClientGuardianIds.length > 0) {
@@ -1638,6 +1662,13 @@ afterAll(async () => {
       .eq('id', companySettingsId);
   }
 
+  if (orgAId && orgBId) {
+    await serviceClient
+      .from('admin_actions')
+      .delete()
+      .in('organization_id', [orgAId, orgBId]);
+  }
+
   if (adminContext) {
     await serviceClient.auth.admin.deleteUser(adminContext.userId);
   }
@@ -1648,6 +1679,14 @@ afterAll(async () => {
 
   if (createdAdminActionIds.length > 0) {
     await serviceClient.from('admin_actions').delete().in('id', createdAdminActionIds);
+  }
+
+  for (const userId of createdFixtureAuthUserIds) {
+    await serviceClient.auth.admin.deleteUser(userId);
+  }
+
+  if (orgAId && orgBId) {
+    await serviceClient.from('organizations').delete().in('id', [orgAId, orgBId]);
   }
 });
 
@@ -2007,8 +2046,7 @@ describe('row level security for multi-tenant tables', () => {
     }
 
     const assignRoleResult = await serviceClient.rpc('assign_therapist_role', {
-      user_email: otherTherapistEmail,
-      therapist_id: otherTherapistId,
+      p_therapist_id: otherTherapistId,
     });
 
     if (assignRoleResult.error) {

--- a/tests/integration/_helpers/liveRlsHarness.ts
+++ b/tests/integration/_helpers/liveRlsHarness.ts
@@ -89,7 +89,7 @@ const createAuthFixture = async (
     label: string;
   },
 ): Promise<AdminAuthFixture> => {
-  const email = `${options.label}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}@example.com`;
+  const email = `${options.label}.${randomUUID()}@example.com`;
   const password = `P@ssw0rd-${Math.random().toString(36).slice(2, 10)}`;
   const userMetadata: Record<string, string> = {};
   if (options.organizationId) {
@@ -112,23 +112,34 @@ const createAuthFixture = async (
 
   const userId = createdUser.user.id;
 
-  if (options.role === "admin") {
-    if (!options.organizationId) {
-      throw new Error("Admin fixtures require an organization id");
+  try {
+    if (options.role === "admin") {
+      if (!options.organizationId) {
+        throw new Error("Admin fixtures require an organization id");
+      }
+      const assignResult = await serviceClient.rpc("assign_admin_role", {
+        user_email: email,
+        organization_id: options.organizationId,
+        reason: "integration-test bootstrap",
+      });
+      if (assignResult.error) {
+        throw assignResult.error;
+      }
+    } else if (options.role === "therapist") {
+      await assignNamedRole(serviceClient, userId, "therapist");
     }
-    const assignResult = await serviceClient.rpc("assign_admin_role", {
-      user_email: email,
-      organization_id: options.organizationId,
-      reason: "integration-test bootstrap",
-    });
-    if (assignResult.error) {
-      throw assignResult.error;
-    }
-  } else if (options.role === "therapist") {
-    await assignNamedRole(serviceClient, userId, "therapist");
-  }
 
-  return { userId, email, password, organizationId: options.organizationId };
+    return { userId, email, password, organizationId: options.organizationId };
+  } catch (fixtureError) {
+    const deleteResult = await serviceClient.auth.admin.deleteUser(userId);
+    if (deleteResult.error) {
+      throw new AggregateError(
+        [fixtureError, deleteResult.error],
+        `Failed to create and roll back auth fixture ${options.label}`,
+      );
+    }
+    throw fixtureError;
+  }
 };
 
 const seedOrgData = async (
@@ -293,25 +304,132 @@ export async function setupLiveRlsHarness(): Promise<LiveRlsHarness> {
 
   const orgAId = randomUUID();
   const orgBId = randomUUID();
-  const orgAAdmin = await createAuthFixture(serviceClient, { organizationId: orgAId, role: "admin", label: "admin.org-a" });
-  const orgBAdmin = await createAuthFixture(serviceClient, { organizationId: orgBId, role: "admin", label: "admin.org-b" });
-  const orgATherapist = await createAuthFixture(serviceClient, {
-    organizationId: orgAId,
-    role: "therapist",
-    label: "therapist.org-a",
-  });
-  const orgBTherapist = await createAuthFixture(serviceClient, {
-    organizationId: orgBId,
-    role: "therapist",
-    label: "therapist.org-b",
-  });
-  const outsider = await createAuthFixture(serviceClient, {
-    organizationId: null,
-    role: "none",
-    label: "outsider",
-  });
-  const orgA = await seedOrgData(serviceClient, orgAId, "org-a", orgATherapist.userId);
-  const orgB = await seedOrgData(serviceClient, orgBId, "org-b", orgBTherapist.userId);
+  const authUserIds: string[] = [];
+
+  const cleanupCreatedResources = async (): Promise<void> => {
+    const cleanupErrors: Error[] = [];
+    const recordCleanup = async (
+      label: string,
+      action: () => Promise<{ error: { message: string } | null }>,
+    ): Promise<void> => {
+      try {
+        const result = await action();
+        if (result.error) {
+          cleanupErrors.push(new Error(`${label}: ${result.error.message}`));
+        }
+      } catch (error) {
+        cleanupErrors.push(
+          error instanceof Error ? new Error(`${label}: ${error.message}`) : new Error(`${label}: ${String(error)}`),
+        );
+      }
+    };
+
+    const organizationIds = [orgAId, orgBId];
+    await recordCleanup("session holds", () =>
+      serviceClient.from("session_holds").delete().in("organization_id", organizationIds),
+    );
+    await recordCleanup("billing records", () =>
+      serviceClient.from("billing_records").delete().in("organization_id", organizationIds),
+    );
+    await recordCleanup("sessions", () =>
+      serviceClient.from("sessions").delete().in("organization_id", organizationIds),
+    );
+    await recordCleanup("clients", () =>
+      serviceClient.from("clients").delete().in("organization_id", organizationIds),
+    );
+    await recordCleanup("therapists", () =>
+      serviceClient.from("therapists").delete().in("organization_id", organizationIds),
+    );
+    await recordCleanup("admin actions", () =>
+      serviceClient.from("admin_actions").delete().in("organization_id", organizationIds),
+    );
+    if (authUserIds.length > 0) {
+      await recordCleanup("user roles", () =>
+        serviceClient.from("user_roles").delete().in("user_id", authUserIds),
+      );
+    }
+    for (const userId of [...authUserIds].reverse()) {
+      await recordCleanup(`auth user ${userId}`, () => serviceClient.auth.admin.deleteUser(userId));
+    }
+    await recordCleanup("organizations", () =>
+      serviceClient.from("organizations").delete().in("id", [orgAId, orgBId]),
+    );
+
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, "Failed to clean up live RLS fixture resources");
+    }
+  };
+
+  let resources:
+    | {
+        orgAAdmin: AdminAuthFixture;
+        orgBAdmin: AdminAuthFixture;
+        orgATherapist: AdminAuthFixture;
+        orgBTherapist: AdminAuthFixture;
+        outsider: AdminAuthFixture;
+        orgA: OrgDataFixture;
+        orgB: OrgDataFixture;
+      }
+    | undefined;
+
+  try {
+    const organizationInsert = await serviceClient.from("organizations").insert([
+      {
+        id: orgAId,
+        name: "Live RLS Organization A",
+        slug: `live-rls-org-a-${orgAId}`,
+      },
+      {
+        id: orgBId,
+        name: "Live RLS Organization B",
+        slug: `live-rls-org-b-${orgBId}`,
+      },
+    ]);
+    if (organizationInsert.error) {
+      throw organizationInsert.error;
+    }
+
+    const createTrackedAuthFixture = async (
+      options: Parameters<typeof createAuthFixture>[1],
+    ): Promise<AdminAuthFixture> => {
+      const fixture = await createAuthFixture(serviceClient, options);
+      authUserIds.push(fixture.userId);
+      return fixture;
+    };
+
+    const orgAAdmin = await createTrackedAuthFixture({ organizationId: orgAId, role: "admin", label: "admin.org-a" });
+    const orgBAdmin = await createTrackedAuthFixture({ organizationId: orgBId, role: "admin", label: "admin.org-b" });
+    const orgATherapist = await createTrackedAuthFixture({
+      organizationId: orgAId,
+      role: "therapist",
+      label: "therapist.org-a",
+    });
+    const orgBTherapist = await createTrackedAuthFixture({
+      organizationId: orgBId,
+      role: "therapist",
+      label: "therapist.org-b",
+    });
+    const outsider = await createTrackedAuthFixture({
+      organizationId: null,
+      role: "none",
+      label: "outsider",
+    });
+    const orgA = await seedOrgData(serviceClient, orgAId, "org-a", orgATherapist.userId);
+    const orgB = await seedOrgData(serviceClient, orgBId, "org-b", orgBTherapist.userId);
+    resources = { orgAAdmin, orgBAdmin, orgATherapist, orgBTherapist, outsider, orgA, orgB };
+  } catch (setupError) {
+    try {
+      await cleanupCreatedResources();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [setupError, cleanupError],
+        "Failed to set up and roll back live RLS fixture resources",
+      );
+    }
+    throw setupError;
+  }
+
+  const { orgAAdmin, orgBAdmin, orgATherapist, orgBTherapist, outsider, orgA, orgB } = resources;
 
   const signInAdmin = async (admin: AdminAuthFixture): Promise<TypedClient> => {
     const client = createUserClient(supabaseUrl, supabaseAnonKey);
@@ -325,18 +443,7 @@ export async function setupLiveRlsHarness(): Promise<LiveRlsHarness> {
     return client;
   };
 
-  const cleanup = async (): Promise<void> => {
-    await serviceClient.from("session_holds").delete().in("id", [orgA.sessionHoldId, orgB.sessionHoldId]);
-    await serviceClient.from("billing_records").delete().in("id", [orgA.billingRecordId, orgB.billingRecordId]);
-    await serviceClient.from("sessions").delete().in("id", [orgA.sessionId, orgB.sessionId]);
-    await serviceClient.from("clients").delete().in("id", [orgA.clientId, orgB.clientId]);
-    await serviceClient.from("therapists").delete().in("id", [orgA.therapistId, orgB.therapistId]);
-    await serviceClient.auth.admin.deleteUser(orgAAdmin.userId);
-    await serviceClient.auth.admin.deleteUser(orgBAdmin.userId);
-    await serviceClient.auth.admin.deleteUser(orgATherapist.userId);
-    await serviceClient.auth.admin.deleteUser(orgBTherapist.userId);
-    await serviceClient.auth.admin.deleteUser(outsider.userId);
-  };
+  const cleanup = cleanupCreatedResources;
 
   return {
     enabled: true,

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -13,6 +13,14 @@ const therapistInsertBodies = (source: string) =>
     (match) => match[1],
   );
 
+const assignTherapistRoleBodies = (source: string) =>
+  Array.from(
+    source.matchAll(
+      /\.rpc\(["']assign_therapist_role["'],\s*\{([\s\S]*?)\n\s*\}\)/g,
+    ),
+    (match) => match[1],
+  );
+
 describe("live RLS fixture schema contract", () => {
   it("runs hosted database validation when live RLS fixtures merge to main", () => {
     const workflow = readRepoFile(".github/workflows/supabase-validate.yml");
@@ -56,6 +64,45 @@ describe("live RLS fixture schema contract", () => {
     expect(source).toContain("${clientId}@example.com");
   });
 
+  it("creates and removes organization rows around shared live RLS data", () => {
+    const source = readRepoFile("tests/integration/_helpers/liveRlsHarness.ts");
+    const organizationInsert = source.indexOf('.from("organizations").insert(');
+    const firstAuthFixture = source.indexOf(
+      "const orgAAdmin = await createTrackedAuthFixture",
+    );
+
+    expect(organizationInsert).toBeGreaterThan(-1);
+    expect(organizationInsert).toBeLessThan(firstAuthFixture);
+    expect(source).toContain(
+      '.from("organizations").delete().in("id", [orgAId, orgBId])',
+    );
+    expect(source).toContain("await cleanupCreatedResources();");
+    expect(source).toContain("throw new AggregateError(cleanupErrors");
+    expect(source).toContain(
+      '.from("admin_actions").delete().in("organization_id", organizationIds)',
+    );
+  });
+
+  it("creates and removes organization rows around the security RLS fixtures", () => {
+    const source = readRepoFile("src/tests/security/rls.spec.ts");
+    const organizationInsert = source.indexOf(".from('organizations')\n    .insert([");
+    const firstTenantFixture = source.indexOf(
+      "orgAContext = await createTenantFixture('orga', orgAId)",
+    );
+
+    expect(organizationInsert).toBeGreaterThan(-1);
+    expect(organizationInsert).toBeLessThan(firstTenantFixture);
+    expect(source).toContain("slug: `security-rls-org-a-${orgAId}`");
+    expect(source).toContain("slug: `security-rls-org-b-${orgBId}`");
+    expect(source).toContain(
+      ".from('organizations').delete().in('id', [orgAId, orgBId])",
+    );
+    expect(source).toMatch(
+      /\.from\('admin_actions'\)\s*\.delete\(\)\s*\.in\('organization_id', \[orgAId, orgBId\]\)/,
+    );
+    expect(source.match(/createdFixtureAuthUserIds\.push\(/g)).toHaveLength(3);
+  });
+
   it("seeds required therapist names in every security RLS fixture", () => {
     const source = readRepoFile("src/tests/security/rls.spec.ts");
     const inserts = therapistInsertBodies(source);
@@ -95,5 +142,17 @@ describe("live RLS fixture schema contract", () => {
     expect(adminSetup).toMatch(
       /const email = `admin\.\$\{randomUUID\(\)\}@example\.com`/,
     );
+  });
+
+  it("calls the current one-argument therapist role RPC in security fixtures", () => {
+    const source = readRepoFile("src/tests/security/rls.spec.ts");
+    const calls = assignTherapistRoleBodies(source);
+
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call).toContain("p_therapist_id:");
+      expect(call).not.toContain("user_email:");
+      expect(call).not.toMatch(/(^|\n)\s*therapist_id:/);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- seed UUID-scoped organizations before hosted RLS fixtures reference them
- update security fixtures to the hosted unary assign_therapist_role RPC contract
- make synthetic teardown failure-safe and remove sessions, audit rows, auth users, and organizations in dependency order
- track the repair and trusted post-merge proof requirement under WIN-217

## Verification
- focused fixture contract: 9/9 pass
- npm run ci:check-focused: pass
- npm run lint: pass
- npm run typecheck: pass
- npm run validate:tenant: pass
- npm run build: pass
- npm run test:ci: 384 files / 2685 tests pass; aggregate has the existing Windows-only CRLF workflow-text assertion failure (merged-main Linux unit-tests pass)
- reviewer: no remaining P1/P2

## Hosted acceptance
After merge, Supabase Validate must execute all six affected live suites without 23503, PGRST202, or skips.

Linear: WIN-217