### PR TITLE
test: accept live modal after session-start recovery

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -220,3 +220,20 @@ Verification card:
 - blocked checks: hosted database suites require trusted main credentials; local full suite has one unrelated Windows CRLF-sensitive workflow-text failure while merged-main Linux unit tests pass
 - result: `review-ready`, pending PR CI and trusted post-merge Supabase Validate
 - residual risk: hosted schema behavior is not proven until the trusted main run executes all six affected suites without skips
+
+### Hosted ALREADY_STARTED modal proof repair
+
+- main CI run `29280537191`, job `86921889442`, passed authentication, booking, session fallback start, hosted status polling, and explicit `409 ALREADY_STARTED` recovery before timing out in the proof harness.
+- root cause: the lifecycle locator matched both `Edit Session` and `Live session`, then waited for that combined locator to become hidden. The successful recovery correctly transitioned the same visible dialog from edit mode to live mode, so the assertion could never finish.
+- classification: `low-risk autonomous`; lane: `standard`.
+- bounded fix:
+  - scope the hidden-state wait to `[data-session-modal-mode="edit"]`.
+  - accept either a visible live modal or a closed modal after recovery.
+  - continue rejecting a stale edit modal or visible session-start failure alert.
+- non-goals: no production modal, route, auth, workflow, database, or runtime behavior changes.
+- verification card:
+  - required checks: focused lifecycle regression, lint, typecheck, reviewer, hosted auth-browser-smoke.
+  - executed checks: red proof 2/2 new assertions failed before implementation; focused regression 15/15 pass; lint pass; typecheck pass.
+  - blocked checks: hosted auth-browser-smoke requires the trusted main workflow and synthetic credentials.
+  - result: `review-ready`, pending PR checks and trusted post-merge acceptance.
+  - residual risk: the full lifecycle and measurement roundtrip remain unproven until the merged-main hosted job passes both commands and cleanup.

--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -237,3 +237,5 @@ Verification card:
   - blocked checks: hosted auth-browser-smoke requires the trusted main workflow and synthetic credentials.
   - result: `review-ready`, pending PR checks and trusted post-merge acceptance.
   - residual risk: the full lifecycle and measurement roundtrip remain unproven until the merged-main hosted job passes both commands and cleanup.
+
+PR validation also exposed saturated hosted booking data: run `29291802604` found eight authorized therapist-client pairs, but the first three had no conflict-free candidate window and the default three-pair bound stopped before the remaining candidates. The harness default now checks all eight already-bounded candidates while preserving the environment override, excluded-pair tracking, and the five-minute booking step timeout. Focused regression: 15/15 pass after a red default-bound assertion.

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -57,7 +57,7 @@ const isTruthy = (value: string | undefined): boolean => /^(1|true|yes)$/i.test(
 const STEP_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_STEP_TIMEOUT_MS ?? "300000");
 const UI_BOOK_RESPONSE_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_UI_BOOK_RESPONSE_TIMEOUT_MS ?? "45000");
 const CLEANUP_BEFORE_FAILURE_TIMEOUT_MS = Number(process.env.PW_LIFECYCLE_CLEANUP_BEFORE_FAILURE_TIMEOUT_MS ?? "5000");
-const MAX_LIFECYCLE_PAIR_ATTEMPTS = Number(process.env.PW_LIFECYCLE_MAX_PAIR_ATTEMPTS ?? "3");
+const MAX_LIFECYCLE_PAIR_ATTEMPTS = Number(process.env.PW_LIFECYCLE_MAX_PAIR_ATTEMPTS ?? "8");
 
 const withStepTimeout = async <T>(label: string, operation: () => Promise<T>): Promise<T> => {
   console.log(`[lifecycle] start ${label}`);

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -1555,6 +1555,22 @@ export async function waitForSessionStatus(
   throw new Error(`Expected session status ${expected}, got ${status || "unknown"}`);
 }
 
+export const SESSION_EDIT_DIALOG_SELECTOR =
+  '[role="dialog"][data-session-modal-mode="edit"]';
+
+export function getAlreadyStartedRecoveryUiError(state: {
+  modalMode: string | null;
+  failureAlertVisible: boolean;
+}): string | null {
+  if (state.modalMode === "edit") {
+    return "ALREADY_STARTED recovery left the edit dialog visible.";
+  }
+  if (state.failureAlertVisible) {
+    return "ALREADY_STARTED recovery left a visible session-start failure alert.";
+  }
+  return null;
+}
+
 async function assertSessionRowStatus(sessionId: string, expected: string): Promise<void> {
   const status = await readSessionRowStatus(sessionId);
   if (status !== expected) {
@@ -1575,7 +1591,7 @@ async function startSessionViaScheduleModal(
   const startButton = page.getByRole("button", { name: /^Start Session$/i });
   await startButton.waitFor({ state: "visible", timeout: 20_000 });
   await expectStartButtonEnabled(page, startButton);
-  const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
+  const editDialog = page.locator(SESSION_EDIT_DIALOG_SELECTOR);
 
   const assertAlreadyStartedRecovery = /^(1|true|yes)$/i.test(process.env.PW_ASSERT_ALREADY_STARTED_UI ?? "");
   if (assertAlreadyStartedRecovery) {
@@ -1615,8 +1631,15 @@ async function startSessionViaScheduleModal(
     if (assertAlreadyStartedRecovery) {
       await editDialog.waitFor({ state: "hidden", timeout: 90_000 });
       const failureAlert = page.getByText(/Failed to start session/i).first();
-      if (await failureAlert.isVisible().catch(() => false)) {
-        throw new Error("ALREADY_STARTED recovery left a visible session-start failure alert.");
+      const visibleSessionDialog = page
+        .locator('[role="dialog"][data-session-modal-mode]:visible')
+        .first();
+      const recoveryError = getAlreadyStartedRecoveryUiError({
+        modalMode: (await visibleSessionDialog.getAttribute("data-session-modal-mode").catch(() => null)),
+        failureAlertVisible: await failureAlert.isVisible().catch(() => false),
+      });
+      if (recoveryError) {
+        throw new Error(recoveryError);
       }
     } else {
       await editDialog.waitFor({ state: "hidden", timeout: 90_000 }).catch(() => undefined);

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -8,6 +8,8 @@ import {
   hasReachedLifecyclePairAttemptLimit,
   isCreateSessionButtonReady,
   isExpectedAlreadyStartedResponse,
+  getAlreadyStartedRecoveryUiError,
+  SESSION_EDIT_DIALOG_SELECTOR,
   shouldTryNextLifecyclePairAfterAttempts,
   waitForSessionStatus,
 } from "../../scripts/playwright-session-lifecycle";
@@ -56,6 +58,27 @@ describe("playwright session lifecycle booking starts", () => {
     expect(isExpectedAlreadyStartedResponse(false, 409, body)).toBe(false);
     expect(isExpectedAlreadyStartedResponse(true, 409, JSON.stringify({ rpcCode: "INVALID_STATUS" }))).toBe(false);
     expect(isExpectedAlreadyStartedResponse(true, 500, body)).toBe(false);
+  });
+
+  it("accepts live or closed UI after ALREADY_STARTED recovery but rejects stale edit state", () => {
+    expect(SESSION_EDIT_DIALOG_SELECTOR).toBe(
+      '[role="dialog"][data-session-modal-mode="edit"]',
+    );
+    expect(
+      getAlreadyStartedRecoveryUiError({ modalMode: "live", failureAlertVisible: false }),
+    ).toBeNull();
+    expect(
+      getAlreadyStartedRecoveryUiError({ modalMode: null, failureAlertVisible: false }),
+    ).toBeNull();
+    expect(
+      getAlreadyStartedRecoveryUiError({ modalMode: "edit", failureAlertVisible: false }),
+    ).toContain("edit dialog");
+  });
+
+  it("rejects a visible session-start failure alert after ALREADY_STARTED recovery", () => {
+    expect(
+      getAlreadyStartedRecoveryUiError({ modalMode: "live", failureAlertVisible: true }),
+    ).toContain("failure alert");
   });
 
   it("waits until the hosted session reaches the expected status", async () => {

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -182,6 +182,8 @@ describe("playwright session lifecycle booking starts", () => {
   });
 
   it("bounds hosted lifecycle target pair attempts", () => {
+    expect(hasReachedLifecyclePairAttemptLimit({ attemptedPairCount: 7 })).toBe(false);
+    expect(hasReachedLifecyclePairAttemptLimit({ attemptedPairCount: 8 })).toBe(true);
     expect(hasReachedLifecyclePairAttemptLimit({ attemptedPairCount: 2, maxPairAttempts: 3 })).toBe(false);
     expect(hasReachedLifecyclePairAttemptLimit({ attemptedPairCount: 3, maxPairAttempts: 3 })).toBe(true);
     expect(hasReachedLifecyclePairAttemptLimit({ attemptedPairCount: 1, maxPairAttempts: 0 })).toBe(true);


### PR DESCRIPTION
## Summary
- scope the post-409 wait to the edit-mode session dialog
- accept the expected edit-to-live transition or modal closure
- retain fail-closed checks for stale edit UI and visible start errors
- document hosted run 29280537191 under WIN-217

## Root cause
The hosted recovery succeeded and the modal transitioned from Edit Session to Live session. The proof harness matched both titles and then waited for the combined locator to become hidden, so success timed out.

## Verification
- red proof: 2 new assertions failed before implementation
- focused lifecycle suite: 15/15 pass
- npm run lint: pass
- npm run typecheck: pass
- npm run ci:check-focused: pass

## Hosted acceptance
After merge, the trusted auth-browser-smoke must pass the explicit 409 recovery, lifecycle terminal flow, measurement roundtrip, and cleanup.

Linear: WIN-217