### PR TITLE
test: stabilize hosted RLS fixtures

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -239,3 +239,20 @@ Verification card:
   - residual risk: the full lifecycle and measurement roundtrip remain unproven until the merged-main hosted job passes both commands and cleanup.
 
 PR validation also exposed saturated hosted booking data: run `29291802604` found eight authorized therapist-client pairs, but the first three had no conflict-free candidate window and the default three-pair bound stopped before the remaining candidates. The harness default now checks all eight already-bounded candidates while preserving the environment override, excluded-pair tracking, and the five-minute booking step timeout. Focused regression: 15/15 pass after a red default-bound assertion.
+
+### Hosted Supabase RLS fixture stabilization
+
+- main Supabase Validate run `29290517486` failed from deterministic test-fixture defects before its later Auth `429` cascade.
+- classification: `low-risk autonomous`; lane: `standard`; production schema, policies, auth code, workflows, and shared Supabase helpers are non-goals.
+- bounded repair in `src/tests/security/rls.spec.ts`:
+  - cache one access token per synthetic actor and create isolated request clients with that actor's bearer token, avoiding repeated password endpoint calls without sharing identities.
+  - replace unsupported post-insert conflict chaining with an error-checked role insert.
+  - send date/time-only values to `ai_session_notes` date/time columns.
+  - seed the retention transcript against its own tracked synthetic session to preserve the one-transcript-per-session constraint.
+- tenant boundary: every actor remains bound to its own JWT and organization; all cross-organization assertions remain unchanged.
+- verification card:
+  - required checks: focused RLS test, lint, typecheck, policy, tenant validation, test suite, build, reviewer, trusted hosted Supabase Validate.
+  - executed checks: focused local static path 121/121 pass; lint pass; typecheck pass; focused policy pass; tenant validation pass; build pass; independent tenant review found no P1/P2; the isolated Schedule close-readiness test passed 4/4 after one full-suite concurrency failure.
+  - blocked checks: the live RLS path and Auth rate-limit proof require trusted hosted Supabase credentials; local `test:ci` retains the pre-existing Windows workflow-text parsing failure in `check-e2e-reliability-gates` (12/13 pass), while Linux CI is authoritative for that contract.
+  - result: `review-ready` after remaining local gates and reviewer; hosted validation remains decisive.
+  - residual risk: unrelated live integration suites in the same failed run may require a subsequent isolated fixture repair after these first causes are removed.

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -153,6 +153,7 @@ const createdClientSessionNoteIds: string[] = [];
 const createdClientNoteIds: string[] = [];
 const createdExtraTherapistIds: string[] = [];
 const createdFixtureAuthUserIds: string[] = [];
+const createdRetentionSessionIds: string[] = [];
 
 let sessionCptEntryIdsByOrg: OrgRecordIds | null = null;
 let sessionCptModifierIdsByOrg: OrgRecordIds | null = null;
@@ -171,6 +172,7 @@ let therapistCertificationIdsByOrg: OrgRecordIds | null = null;
 let clientRoleId: string | null = null;
 
 const userSessionIdsByUser = new Map<string, string>();
+const actorAccessTokensByEmail = new Map<string, string>();
 
 const createTenantFixture = async (label: string, organizationId: string): Promise<TenantContext> => {
   if (!serviceClient) {
@@ -355,20 +357,30 @@ const createTherapistCertificationFixture = async (
 };
 
 const signInWithPassword = async (email: string, password: string): Promise<TypedClient> => {
-  const client = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
+  let accessToken = actorAccessTokensByEmail.get(email);
+  if (!accessToken) {
+    const authClient = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const signInResult = await authClient.auth.signInWithPassword({
+      email,
+      password,
+    });
 
-  const signInResult = await client.auth.signInWithPassword({
-    email,
-    password,
-  });
-
-  if (signInResult.error) {
-    throw signInResult.error;
+    if (signInResult.error) {
+      throw signInResult.error;
+    }
+    accessToken = signInResult.data.session?.access_token;
+    if (!accessToken) {
+      throw new Error(`Supabase sign-in did not return an access token for ${email}`);
+    }
+    actorAccessTokensByEmail.set(email, accessToken);
   }
 
-  return client;
+  return createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
 };
 
 const signInTherapist = async (context: TenantContext): Promise<TypedClient> => {
@@ -610,9 +622,9 @@ const ensureAiSessionNotesSeeded = async (): Promise<void> => {
         session_id: context.sessionId,
         therapist_id: context.therapistId,
         client_id: context.clientId,
-        session_date: start.toISOString(),
-        start_time: start.toISOString(),
-        end_time: end.toISOString(),
+        session_date: start.toISOString().slice(0, 10),
+        start_time: start.toISOString().slice(11, 19),
+        end_time: end.toISOString().slice(11, 19),
         session_duration: 45,
         ai_generated_summary: `Automated summary ${label}`,
         ai_confidence_score: 0.88,
@@ -949,11 +961,13 @@ const createGuardianFixture = async (tenant: TenantContext): Promise<GuardianCon
   await serviceClient.from('profiles').update({ role: 'client' }).eq('id', guardianId);
 
   const resolvedRoleId = await resolveClientRoleId();
-  await serviceClient
+  const roleInsert = await serviceClient
     .from('user_roles')
-    .insert({ user_id: guardianId, role_id: resolvedRoleId })
-    .onConflict('user_id, role_id')
-    .ignore();
+    .insert({ user_id: guardianId, role_id: resolvedRoleId });
+
+  if (roleInsert.error) {
+    throw roleInsert.error;
+  }
 
   const { data: insertedGuardian, error: guardianInsertError } = await serviceClient
     .from('client_guardians')
@@ -1609,6 +1623,10 @@ afterAll(async () => {
 
   if (createdSessionTranscriptIds.length > 0) {
     await serviceClient.from('session_transcripts').delete().in('id', createdSessionTranscriptIds);
+  }
+
+  if (createdRetentionSessionIds.length > 0) {
+    await serviceClient.from('sessions').delete().in('id', createdRetentionSessionIds);
   }
 
   if (createdAiCacheIds.length > 0) {
@@ -3263,8 +3281,25 @@ describe('session transcription consent enforcement', () => {
       return;
     }
 
-    const targetSessionId = orgAContext.sessionId;
+    const targetSessionId = randomUUID();
     const retentionCreatedAt = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const retentionStart = new Date(Date.now() - 4 * 24 * 60 * 60 * 1000);
+    const retentionEnd = new Date(retentionStart.getTime() + 60 * 60 * 1000);
+    const retentionSessionInsert = await serviceClient.from('sessions').insert({
+      id: targetSessionId,
+      client_id: orgAContext.clientId,
+      therapist_id: orgAContext.therapistId,
+      start_time: retentionStart.toISOString(),
+      end_time: retentionEnd.toISOString(),
+      status: 'completed',
+      organization_id: orgAContext.organizationId,
+      has_transcription_consent: true,
+    });
+
+    if (retentionSessionInsert.error) {
+      throw retentionSessionInsert.error;
+    }
+    createdRetentionSessionIds.push(targetSessionId);
 
     const transcriptInsert = await serviceClient
       .from('session_transcripts')


### PR DESCRIPTION
## Summary
- cache one actor-specific JWT per synthetic RLS fixture identity to avoid hosted Auth password rate-limit cascades
- repair guardian role insertion and AI session-note date/time fixture shapes
- preserve the one-transcript-per-session contract with a tracked retention session

## Scope
Test fixtures and WIN-217 handoff only. No production schema, RLS policy, auth code, workflow, or shared Supabase helper changes.

## Verification
- focused RLS static path: 121/121 pass
- lint: pass
- typecheck: pass
- ci:check-focused: pass
- validate:tenant: pass
- build: pass
- independent tenant review: no P1/P2
- test:ci: blocked locally by the pre-existing Windows workflow-text parsing failure; isolated Schedule close-readiness rerun passed 4/4

## Hosted acceptance
Trusted-main Supabase Validate is decisive for the live RLS/Auth path after merge.

Linear: WIN-217