### PR TITLE
test: hydrate hosted RLS actors authoritatively

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -256,3 +256,21 @@ PR validation also exposed saturated hosted booking data: run `29291802604` foun
   - blocked checks: the live RLS path and Auth rate-limit proof require trusted hosted Supabase credentials; local `test:ci` retains the pre-existing Windows workflow-text parsing failure in `check-e2e-reliability-gates` (12/13 pass), while Linux CI is authoritative for that contract.
   - result: `review-ready` after remaining local gates and reviewer; hosted validation remains decisive.
   - residual risk: unrelated live integration suites in the same failed run may require a subsequent isolated fixture repair after these first causes are removed.
+
+### Hosted Supabase Validate fixture hydration
+
+- main run `29303205785` failed 47 live integration assertions across six files while runtime migration parity passed.
+- shared evidence showed newly created actors resolving to default or stale hosted rows (including `test-session-1`), empty tenant reads, and `42501` authorization failures.
+- classification: `high-risk human-reviewed`; lane: `critical`; the change is test-only but uses service-role fixture writes against hosted tenant-sensitive tables.
+- bounded fix:
+  - explicitly upsert active, tenant-bound profiles for synthetic therapist, client, and admin actors and fail on hydration errors.
+  - add the authoritative active `user_roles` mapping for client actors instead of relying on `profiles.role` alone.
+  - preserve a null-organization, unprivileged outsider profile for fail-closed assertions.
+  - compare hosted timestamp values by instant rather than PostgreSQL's equivalent UTC offset formatting.
+- non-goals: no RLS policy, migration, function, workflow, production auth, or tenant behavior changes.
+- verification card:
+  - required checks: focused fixture/RLS tests, lint, typecheck, policy, tenant validation, build, tenant-focused review, human review, trusted hosted Supabase Validate rerun.
+  - executed checks: seven focused files 141/141 pass; lint pass; typecheck pass; focused policy pass; tenant validation pass; build pass; focused reviewer found no P1/P2.
+  - blocked checks: `RUN_DB_IT=1` live assertions require trusted CI Supabase secrets.
+  - result: `human-review-ready`; hosted CI remains decisive.
+  - residual risk: fixture correctness against current hosted RLS cannot be proven locally and the critical lane requires human approval before merge.

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -220,7 +220,16 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
     throw assignRoleResult.error;
   }
 
-  await serviceClient.from('profiles').update({ role: 'therapist' }).eq('id', userId);
+  const therapistProfileResult = await serviceClient.from('profiles').upsert({
+    id: userId,
+    email,
+    role: 'therapist',
+    is_active: true,
+    organization_id: organizationId,
+  }, { onConflict: 'id' });
+  if (therapistProfileResult.error) {
+    throw therapistProfileResult.error;
+  }
 
   const clientEmail = `${label}.client.${randomUUID()}@example.com`;
   const clientPassword = `P@ssw0rd-${Math.random().toString(36).slice(2, 10)}`;
@@ -239,7 +248,26 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
   const clientUserId = createdClientUser.user.id;
   createdFixtureAuthUserIds.push(clientUserId);
 
-  await serviceClient.from('profiles').update({ role: 'client' }).eq('id', clientUserId);
+  const clientProfileResult = await serviceClient.from('profiles').upsert({
+    id: clientUserId,
+    email: clientEmail,
+    role: 'client',
+    is_active: true,
+    organization_id: organizationId,
+  }, { onConflict: 'id' });
+  if (clientProfileResult.error) {
+    throw clientProfileResult.error;
+  }
+
+  const resolvedClientRoleId = await resolveClientRoleId();
+  const clientRoleResult = await serviceClient.from('user_roles').insert({
+    user_id: clientUserId,
+    role_id: resolvedClientRoleId,
+    is_active: true,
+  });
+  if (clientRoleResult.error) {
+    throw clientRoleResult.error;
+  }
 
   const { error: clientInsertError } = await serviceClient.from('clients').insert({
     id: clientUserId,
@@ -316,6 +344,17 @@ const createAdminFixture = async (organizationId: string): Promise<AdminContext>
 
   if (assignResult.error) {
     throw assignResult.error;
+  }
+
+  const profileResult = await serviceClient.from('profiles').upsert({
+    id: userId,
+    email,
+    role: 'admin',
+    is_active: true,
+    organization_id: organizationId,
+  }, { onConflict: 'id' });
+  if (profileResult.error) {
+    throw profileResult.error;
   }
 
   return { email, password, userId, organizationId };
@@ -3020,7 +3059,7 @@ describe('session holds enforce role-scoped access', () => {
         .single();
 
       expect(updateResult.error).toBeNull();
-      expect(updateResult.data?.end_time).toBe(updatedEnd);
+      expect(new Date(updateResult.data?.end_time ?? '').toISOString()).toBe(updatedEnd);
 
       const deleteResult = await supabaseOrgA
         .from('session_holds')

--- a/tests/integration/_helpers/liveRlsHarness.ts
+++ b/tests/integration/_helpers/liveRlsHarness.ts
@@ -15,6 +15,21 @@ type AdminAuthFixture = {
   organizationId: string | null;
 };
 
+type LiveRlsFixtureRole = "admin" | "therapist" | "none";
+
+export const buildLiveRlsProfileFixture = (fixture: {
+  userId: string;
+  email: string;
+  organizationId: string | null;
+  role: LiveRlsFixtureRole;
+}) => ({
+  id: fixture.userId,
+  email: fixture.email,
+  organization_id: fixture.organizationId,
+  role: fixture.role === "none" ? "client" as const : fixture.role,
+  is_active: true,
+});
+
 type OrgDataFixture = {
   therapistId: string;
   clientId: string;
@@ -85,7 +100,7 @@ const createAuthFixture = async (
   serviceClient: TypedClient,
   options: {
     organizationId: string | null;
-    role: "admin" | "therapist" | "none";
+    role: LiveRlsFixtureRole;
     label: string;
   },
 ): Promise<AdminAuthFixture> => {
@@ -127,6 +142,18 @@ const createAuthFixture = async (
       }
     } else if (options.role === "therapist") {
       await assignNamedRole(serviceClient, userId, "therapist");
+    }
+
+    const profileResult = await serviceClient
+      .from("profiles")
+      .upsert(buildLiveRlsProfileFixture({
+        userId,
+        email,
+        organizationId: options.organizationId,
+        role: options.role,
+      }), { onConflict: "id" });
+    if (profileResult.error) {
+      throw profileResult.error;
     }
 
     return { userId, email, password, organizationId: options.organizationId };

--- a/tests/integration/liveRlsHarness.unit.test.ts
+++ b/tests/integration/liveRlsHarness.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildLiveRlsProfileFixture } from "./_helpers/liveRlsHarness.ts";
+
+describe("live RLS harness profile fixtures", () => {
+  it("keeps tenant and role state explicit for privileged actors", () => {
+    expect(buildLiveRlsProfileFixture({
+      userId: "admin-1",
+      email: "admin@example.com",
+      organizationId: "org-1",
+      role: "admin",
+    })).toEqual({
+      id: "admin-1",
+      email: "admin@example.com",
+      organization_id: "org-1",
+      role: "admin",
+      is_active: true,
+    });
+  });
+
+  it("keeps no-org outsiders fail-closed without inventing a privileged role", () => {
+    expect(buildLiveRlsProfileFixture({
+      userId: "outsider-1",
+      email: "outsider@example.com",
+      organizationId: null,
+      role: "none",
+    })).toMatchObject({
+      organization_id: null,
+      role: "client",
+      is_active: true,
+    });
+  });
+});


### PR DESCRIPTION
Fixes the remaining Supabase Validate fixture failures from main run 29303205785. Synthetic therapist, client, and admin actors now fail closed unless profiles are explicitly hydrated with the intended tenant and role; client fixtures also receive an active user_roles mapping. The shared outsider remains organization-less and unprivileged. Timestamp comparison is normalized by instant. No production RLS policy, migration, function, workflow, or auth behavior changes. Verification: focused 141/141, lint, typecheck, policy, tenant validation, and build pass; independent review found no P1/P2. Critical lane: human review is required before merge because these tests perform service-role hosted tenant fixture writes. Linear: WIN-217.