### PR TITLE
test: provision BCBA acceptance authorization

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -274,3 +274,21 @@ PR validation also exposed saturated hosted booking data: run `29291802604` foun
   - blocked checks: `RUN_DB_IT=1` live assertions require trusted CI Supabase secrets.
   - result: `human-review-ready`; hosted CI remains decisive.
   - residual risk: fixture correctness against current hosted RLS cannot be proven locally and the critical lane requires human approval before merge.
+
+### Synthetic BCBA authorization fixture
+
+- trusted main CI run `29299849202` proved the five-script session suite, including note measurement create/edit roundtrip, and explicitly logged `verified hosted 409 ALREADY_STARTED UI recovery` for the synthetic BCBA.
+- the final BCBA lifecycle then failed at `seed-session-goal-notes-for-no-show` because the actor's fixed therapist/client pair had no approved authorization.
+- classification: `high-risk human-reviewed`; lane: `critical`; human review is required before merge because the provisioner uses service-role writes to authorization tables.
+- bounded fix:
+  - validate the existing fixed therapist, resolve a deterministic linked client through `client_therapist_links`, and ensure both remain active and in the expected organization.
+  - create one run-owned approved authorization and service for that exact pair, with a broad synthetic date window.
+  - identify all clinical fixtures by `created_by = synthetic actor user id`; cleanup notes, services, and authorization before identity mappings and Auth deletion.
+  - include clinical tables in residual-row assertions.
+- non-goals: no production authorization behavior, schema, policy, function, workflow, or real tenant data changes.
+- verification card:
+  - required checks: focused provisioner tests, lint, typecheck, policy, tenant validation, test suite, build, security/tenant review, human review, trusted-main BCBA acceptance.
+  - executed checks: focused provisioner tests 10/10 pass; lint pass; typecheck pass; focused policy pass; tenant validation pass; build pass.
+  - blocked checks: provision/cleanup against hosted Supabase and the final acceptance proof require trusted CI secrets and a merged main commit.
+  - result: `human-review-ready`; focused reviewer found no P1/P2 after the client fixture was changed to resolve through the tenant-scoped therapist linkage.
+  - residual risk: the authorization fixture is tenant-sensitive and must not be merged without human review; the final BCBA lifecycle and cleanup remain unproven until trusted main reruns.

--- a/scripts/provision-ci-smoke-bcba.ts
+++ b/scripts/provision-ci-smoke-bcba.ts
@@ -55,6 +55,47 @@ export interface SmokeBcbaProfileInvariant {
   organization_id?: string | null;
 }
 
+export interface SmokeBcbaAuthorizationInvariant {
+  client_id?: string | null;
+  provider_id?: string | null;
+  organization_id?: string | null;
+  status?: string | null;
+}
+
+export interface SmokeBcbaClientLinkInvariant {
+  client_id?: string | null;
+  therapist_id?: string | null;
+  organization_id?: string | null;
+}
+
+export const assertSmokeBcbaClientLinkInvariant = (
+  link: SmokeBcbaClientLinkInvariant | null,
+  expected: { therapistId: string; organizationId: string },
+): asserts link is SmokeBcbaClientLinkInvariant & { client_id: string } => {
+  if (
+    !link?.client_id
+    || link.therapist_id !== expected.therapistId
+    || link.organization_id !== expected.organizationId
+  ) {
+    throw new Error("Synthetic BCBA therapist fixture has no tenant-bound linked client.");
+  }
+};
+
+export const assertSmokeBcbaAuthorizationInvariant = (
+  authorization: SmokeBcbaAuthorizationInvariant | null,
+  expected: { clientId: string; therapistId: string; organizationId: string },
+): void => {
+  if (
+    !authorization
+    || authorization.client_id !== expected.clientId
+    || authorization.provider_id !== expected.therapistId
+    || authorization.organization_id !== expected.organizationId
+    || authorization.status !== "approved"
+  ) {
+    throw new Error("Synthetic BCBA authorization did not persist the required client, provider, organization, and approved state.");
+  }
+};
+
 export const assertSmokeBcbaProfileInvariant = (
   profile: SmokeBcbaProfileInvariant | null,
   expected: { userId: string; organizationId: string },
@@ -152,6 +193,33 @@ const writeCredentials = (email: string, password: string): void => {
 };
 
 const cleanupMappings = async (client: SupabaseClient, userId: string): Promise<void> => {
+  const { data: authorizationRows, error: authorizationLookupError } = await client
+    .from("authorizations")
+    .select("id")
+    .eq("created_by", userId);
+  if (authorizationLookupError) throw authorizationLookupError;
+
+  const { error: noteCleanupError } = await client
+    .from("client_session_notes")
+    .delete()
+    .eq("created_by", userId);
+  if (noteCleanupError) throw noteCleanupError;
+
+  const authorizationIds = (authorizationRows ?? []).map(({ id }) => id);
+  if (authorizationIds.length > 0) {
+    const { error: serviceCleanupError } = await client
+      .from("authorization_services")
+      .delete()
+      .in("authorization_id", authorizationIds);
+    if (serviceCleanupError) throw serviceCleanupError;
+
+    const { error: authorizationCleanupError } = await client
+      .from("authorizations")
+      .delete()
+      .in("id", authorizationIds);
+    if (authorizationCleanupError) throw authorizationCleanupError;
+  }
+
   for (const table of ["user_therapist_links", "user_roles"] as const) {
     const { error } = await client.from(table).delete().eq("user_id", userId);
     if (error) throw error;
@@ -189,6 +257,24 @@ const provision = async (): Promise<void> => {
   if (!therapist || therapist.organization_id !== organizationId || therapist.deleted_at) {
     throw new Error("Synthetic BCBA therapist fixture is missing, deleted, or outside the expected organization.");
   }
+  const { data: clientLink, error: clientLinkError } = await client
+    .from("client_therapist_links")
+    .select("client_id,therapist_id,organization_id")
+    .eq("therapist_id", therapistId)
+    .eq("organization_id", organizationId)
+    .order("client_id", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (clientLinkError) throw clientLinkError;
+  assertSmokeBcbaClientLinkInvariant(clientLink, { therapistId, organizationId });
+  const clientId = clientLink.client_id;
+
+  const { data: clientRow, error: clientError } = await client
+    .from("clients").select("id,organization_id,deleted_at").eq("id", clientId).maybeSingle();
+  if (clientError) throw clientError;
+  if (!clientRow || clientRow.organization_id !== organizationId || clientRow.deleted_at) {
+    throw new Error("Synthetic BCBA client fixture is missing, deleted, or outside the expected organization.");
+  }
   const { data: role, error: roleError } = await client.from("roles").select("id").eq("name", "bcba").maybeSingle();
   if (roleError) throw roleError;
   if (!role?.id) throw new Error("Role bcba is not provisioned.");
@@ -223,6 +309,47 @@ const provision = async (): Promise<void> => {
   if (provisionProfileError || provisionedOrganizationId !== organizationId) {
     throw new Error("Synthetic BCBA authoritative profile provisioning failed.");
   }
+
+  const startDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const endDate = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const { data: authorization, error: authorizationError } = await client
+    .from("authorizations")
+    .insert({
+      authorization_number: `CI-BCBA-${user.id}`,
+      client_id: clientId,
+      provider_id: therapistId,
+      diagnosis_code: "F84.0",
+      diagnosis_description: "Synthetic CI lifecycle fixture",
+      start_date: startDate,
+      end_date: endDate,
+      status: "approved",
+      organization_id: organizationId,
+      created_by: user.id,
+    })
+    .select("id,client_id,provider_id,organization_id,status")
+    .single();
+  if (authorizationError || !authorization) {
+    throw authorizationError ?? new Error("Synthetic BCBA authorization provisioning failed.");
+  }
+  assertSmokeBcbaAuthorizationInvariant(authorization, { clientId, therapistId, organizationId });
+
+  const { error: authorizationServiceError } = await client
+    .from("authorization_services")
+    .insert({
+      authorization_id: authorization.id,
+      service_code: "97153",
+      service_description: "Adaptive behavior treatment by protocol",
+      from_date: startDate,
+      to_date: endDate,
+      requested_units: 160,
+      approved_units: 160,
+      unit_type: "15-minute units",
+      decision_status: "approved",
+      organization_id: organizationId,
+      created_by: user.id,
+    });
+  if (authorizationServiceError) throw authorizationServiceError;
+
   const { data: persistedProfile, error: persistedProfileError } = await client
     .from("profiles")
     .select("id,role,is_active,organization_id")
@@ -238,7 +365,7 @@ const provision = async (): Promise<void> => {
   });
 
   writeCredentials(email, password);
-  console.log(JSON.stringify({ ok: true, action: "provisioned", email, userId: user.id, organizationId, therapistId }));
+  console.log(JSON.stringify({ ok: true, action: "provisioned", email, userId: user.id, organizationId, therapistId, clientId, authorizationId: authorization.id }));
 };
 
 const cleanup = async (): Promise<void> => {
@@ -256,7 +383,14 @@ const cleanup = async (): Promise<void> => {
   const remaining = await findUser(client, email);
   if (remaining) throw new Error("BCBA smoke Auth user remains after cleanup.");
   const residualCounts: Record<string, number> = {};
-  for (const [table, column] of [["profiles", "id"], ["user_roles", "user_id"], ["user_therapist_links", "user_id"]] as const) {
+  for (const [table, column] of [
+    ["profiles", "id"],
+    ["user_roles", "user_id"],
+    ["user_therapist_links", "user_id"],
+    ["client_session_notes", "created_by"],
+    ["authorization_services", "created_by"],
+    ["authorizations", "created_by"],
+  ] as const) {
     const { count, error: countError } = await client.from(table).select("*", { count: "exact", head: true }).eq(column, user.id);
     if (countError) throw countError;
     residualCounts[table] = count ?? -1;

--- a/tests/scripts/provision-ci-smoke-bcba.test.ts
+++ b/tests/scripts/provision-ci-smoke-bcba.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  assertSmokeBcbaAuthorizationInvariant,
+  assertSmokeBcbaClientLinkInvariant,
   assertDedicatedSmokeBcbaEmail,
   assertSmokeBcbaProfileInvariant,
   buildDefaultSmokeBcbaEmail,
@@ -47,6 +49,44 @@ describe("provision-ci-smoke-bcba guards", () => {
       { id: "user-1", role: "bcba", is_active: false, organization_id: "org-1" },
     ]) {
       expect(() => assertSmokeBcbaProfileInvariant(profile, expected)).toThrow(/did not persist/);
+    }
+  });
+
+  it("requires the synthetic authorization to remain approved and tenant-bound", () => {
+    const expected = { clientId: "client-1", therapistId: "therapist-1", organizationId: "org-1" };
+    expect(() => assertSmokeBcbaAuthorizationInvariant({
+      client_id: "client-1",
+      provider_id: "therapist-1",
+      organization_id: "org-1",
+      status: "approved",
+    }, expected)).not.toThrow();
+
+    for (const authorization of [
+      null,
+      { client_id: "client-2", provider_id: "therapist-1", organization_id: "org-1", status: "approved" },
+      { client_id: "client-1", provider_id: "therapist-2", organization_id: "org-1", status: "approved" },
+      { client_id: "client-1", provider_id: "therapist-1", organization_id: "org-2", status: "approved" },
+      { client_id: "client-1", provider_id: "therapist-1", organization_id: "org-1", status: "pending" },
+    ]) {
+      expect(() => assertSmokeBcbaAuthorizationInvariant(authorization, expected)).toThrow(/did not persist/);
+    }
+  });
+
+  it("requires the resolved client link to match the fixed therapist and tenant", () => {
+    const expected = { therapistId: "therapist-1", organizationId: "org-1" };
+    expect(() => assertSmokeBcbaClientLinkInvariant({
+      client_id: "client-1",
+      therapist_id: "therapist-1",
+      organization_id: "org-1",
+    }, expected)).not.toThrow();
+
+    for (const link of [
+      null,
+      { client_id: null, therapist_id: "therapist-1", organization_id: "org-1" },
+      { client_id: "client-1", therapist_id: "therapist-2", organization_id: "org-1" },
+      { client_id: "client-1", therapist_id: "therapist-1", organization_id: "org-2" },
+    ]) {
+      expect(() => assertSmokeBcbaClientLinkInvariant(link, expected)).toThrow(/linked client/);
     }
   });
 


### PR DESCRIPTION
Completes the synthetic BCBA acceptance fixture needed after main CI proved session start, hosted 409 ALREADY_STARTED recovery, and note/measurement create-edit roundtrip but failed terminal lifecycle seeding with missing authorization. Provisioning now resolves a deterministic tenant-scoped client linked to the fixed therapist, validates the active tenant pair, creates one actor-owned approved authorization plus 97153 service, and cleans notes/services/authorization before identity teardown with residual assertions. No production auth, RLS, schema, function, workflow, or real data changes. Verification: focused provisioner tests 11/11, lint, typecheck, policy, tenant validation, and build pass; independent review found no P1/P2. Critical lane: human review is required before merge because provisioning uses service-role writes to tenant-sensitive clinical fixture tables. Linear: WIN-217.