### PR TITLE
test: provision hosted RLS profiles safely

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -292,3 +292,22 @@ PR validation also exposed saturated hosted booking data: run `29291802604` foun
   - blocked checks: provision/cleanup against hosted Supabase and the final acceptance proof require trusted CI secrets and a merged main commit.
   - result: `human-review-ready`; focused reviewer found no P1/P2 after the client fixture was changed to resolve through the tenant-scoped therapist linkage.
   - residual risk: the authorization fixture is tenant-sensitive and must not be merged without human review; the final BCBA lifecycle and cleanup remain unproven until trusted main reruns.
+
+### Hosted RLS profile-guard provisioning follow-up
+
+- merged PR #781 triggered Supabase Validate run `29333204173`; runtime migration parity passed, but all six live RLS files stopped during setup with `42501 role is immutable for this role`.
+- root cause: service-key PostgREST fixture upserts do not populate the request JWT role setting used by the profile immutability guard, so the explicit profile hydration added in PR #781 is rejected before any tenant assertion runs.
+- classification: `high-risk human-reviewed`; lane: `critical`; the repair adds one service-only security-definer function and updates hosted tenant fixtures.
+- bounded fix:
+  - require a synthetic `@example.com` auth user carrying an unexpired service-authored app-metadata marker.
+  - require exactly one active role across the complete authoritative `user_roles` set and reject unexpected or additional roles, including `super_admin`.
+  - derive the organization from the non-deleted therapist/client record or admin auth metadata and require it to match the requested tenant.
+  - use the existing transaction-local profile-guard bypass only inside the function, revoke execution from public/anon/authenticated, and grant it only to `service_role`.
+  - call the function only after each fixture's authoritative role and tenant record exist; leave the no-organization outsider fail-closed.
+- non-goals: no production RLS-policy relaxation, user-facing auth behavior, workflow change, real user/data mutation, or broader profile-guard bypass.
+- verification card:
+  - required checks: migration contract, focused live-RLS static paths, lint, typecheck, policy, tenant validation, build, security review, test review, human review, and trusted hosted Supabase Validate.
+  - executed checks: red migration contract failed before the migration existed; eight focused files 146/146 passed; lint pass; typecheck pass; policy pass; tenant validation pass; build pass; security review identified and the patch closed an additional-role fail-closed gap; hosted-path tests now cover wrong-tenant, expired-marker, and authenticated-caller rejection.
+  - blocked checks: applying the migration and running `RUN_DB_IT=1` require the trusted main Supabase workflow and secrets; the local full coverage suite timed out after 182 seconds in unrelated AI-documentation network/finalization tests before producing a result.
+  - result: `human-review-ready`; final security/test review found no remaining P1/P2 after the additional-role and cleanup fixes.
+  - residual risk: the service-only RPC and hosted fixture path remain unproven against the deployed schema until a trusted post-merge Supabase Validate run passes all six files.

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -174,6 +174,24 @@ let clientRoleId: string | null = null;
 const userSessionIdsByUser = new Map<string, string>();
 const actorAccessTokensByEmail = new Map<string, string>();
 
+const buildCiRlsAppMetadata = () => ({
+  ci_rls_fixture: true,
+  ci_rls_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+});
+
+const provisionCiRlsProfile = async (userId: string, organizationId: string): Promise<void> => {
+  if (!serviceClient) {
+    throw new Error('Service client not initialized');
+  }
+  const result = await (serviceClient as SupabaseClient).rpc('provision_ci_rls_fixture_profile', {
+    p_user_id: userId,
+    p_organization_id: organizationId,
+  });
+  if (result.error || result.data !== organizationId) {
+    throw result.error ?? new Error('Synthetic RLS profile provisioning returned the wrong organization');
+  }
+};
+
 const createTenantFixture = async (label: string, organizationId: string): Promise<TenantContext> => {
   if (!serviceClient) {
     throw new Error('Service client not initialized');
@@ -187,6 +205,7 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
     password,
     email_confirm: true,
     user_metadata: { organization_id: organizationId },
+    app_metadata: buildCiRlsAppMetadata(),
   });
 
   if (createUserError || !createdUser?.user) {
@@ -220,16 +239,7 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
     throw assignRoleResult.error;
   }
 
-  const therapistProfileResult = await serviceClient.from('profiles').upsert({
-    id: userId,
-    email,
-    role: 'therapist',
-    is_active: true,
-    organization_id: organizationId,
-  }, { onConflict: 'id' });
-  if (therapistProfileResult.error) {
-    throw therapistProfileResult.error;
-  }
+  await provisionCiRlsProfile(userId, organizationId);
 
   const clientEmail = `${label}.client.${randomUUID()}@example.com`;
   const clientPassword = `P@ssw0rd-${Math.random().toString(36).slice(2, 10)}`;
@@ -239,6 +249,7 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
     password: clientPassword,
     email_confirm: true,
     user_metadata: { organization_id: organizationId },
+    app_metadata: buildCiRlsAppMetadata(),
   });
 
   if (clientUserError || !createdClientUser?.user) {
@@ -247,27 +258,6 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
 
   const clientUserId = createdClientUser.user.id;
   createdFixtureAuthUserIds.push(clientUserId);
-
-  const clientProfileResult = await serviceClient.from('profiles').upsert({
-    id: clientUserId,
-    email: clientEmail,
-    role: 'client',
-    is_active: true,
-    organization_id: organizationId,
-  }, { onConflict: 'id' });
-  if (clientProfileResult.error) {
-    throw clientProfileResult.error;
-  }
-
-  const resolvedClientRoleId = await resolveClientRoleId();
-  const clientRoleResult = await serviceClient.from('user_roles').insert({
-    user_id: clientUserId,
-    role_id: resolvedClientRoleId,
-    is_active: true,
-  });
-  if (clientRoleResult.error) {
-    throw clientRoleResult.error;
-  }
 
   const { error: clientInsertError } = await serviceClient.from('clients').insert({
     id: clientUserId,
@@ -280,6 +270,17 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
   if (clientInsertError) {
     throw clientInsertError;
   }
+
+  const resolvedClientRoleId = await resolveClientRoleId();
+  const clientRoleResult = await serviceClient.from('user_roles').insert({
+    user_id: clientUserId,
+    role_id: resolvedClientRoleId,
+    is_active: true,
+  });
+  if (clientRoleResult.error) {
+    throw clientRoleResult.error;
+  }
+  await provisionCiRlsProfile(clientUserId, organizationId);
 
   const sessionId = randomUUID();
   const start = new Date(Date.now() - 60 * 60 * 1000);
@@ -327,6 +328,7 @@ const createAdminFixture = async (organizationId: string): Promise<AdminContext>
     password,
     email_confirm: true,
     user_metadata: { organization_id: organizationId },
+    app_metadata: buildCiRlsAppMetadata(),
   });
 
   if (createUserError || !createdUser?.user) {
@@ -346,16 +348,7 @@ const createAdminFixture = async (organizationId: string): Promise<AdminContext>
     throw assignResult.error;
   }
 
-  const profileResult = await serviceClient.from('profiles').upsert({
-    id: userId,
-    email,
-    role: 'admin',
-    is_active: true,
-    organization_id: organizationId,
-  }, { onConflict: 'id' });
-  if (profileResult.error) {
-    throw profileResult.error;
-  }
+  await provisionCiRlsProfile(userId, organizationId);
 
   return { email, password, userId, organizationId };
 };
@@ -988,6 +981,7 @@ const createGuardianFixture = async (tenant: TenantContext): Promise<GuardianCon
     password,
     email_confirm: true,
     user_metadata: { organization_id: tenant.organizationId },
+    app_metadata: buildCiRlsAppMetadata(),
   });
 
   if (createGuardianError || !createdUser?.user) {
@@ -996,8 +990,6 @@ const createGuardianFixture = async (tenant: TenantContext): Promise<GuardianCon
 
   const guardianId = createdUser.user.id;
   createdGuardianUserIds.push(guardianId);
-
-  await serviceClient.from('profiles').update({ role: 'client' }).eq('id', guardianId);
 
   const resolvedRoleId = await resolveClientRoleId();
   const roleInsert = await serviceClient
@@ -1126,6 +1118,70 @@ beforeAll(async () => {
     companySettingsId = insertResult.data.id;
     originalCompanyName = insertResult.data.company_name;
   }
+});
+
+describe('synthetic RLS profile provisioning guardrails', () => {
+  it('rejects a tenant mismatch for an otherwise valid synthetic therapist', async () => {
+    if (!runTests || !serviceClient || !orgAContext || !orgBContext) {
+      console.log('⏭️  Skipping synthetic profile tenant-mismatch test - setup incomplete.');
+      return;
+    }
+
+    const result = await (serviceClient as SupabaseClient).rpc('provision_ci_rls_fixture_profile', {
+      p_user_id: orgAContext.userId,
+      p_organization_id: orgBContext.organizationId,
+    });
+
+    expect(result.error?.code).toBe('42501');
+  });
+
+  it('rejects an expired synthetic actor marker', async () => {
+    if (!runTests || !serviceClient || !orgAContext) {
+      console.log('⏭️  Skipping expired synthetic profile test - setup incomplete.');
+      return;
+    }
+
+    const expiredMetadata = {
+      ci_rls_fixture: true,
+      ci_rls_expires_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    };
+    const expireResult = await serviceClient.auth.admin.updateUserById(orgAContext.userId, {
+      app_metadata: expiredMetadata,
+    });
+    if (expireResult.error) {
+      throw expireResult.error;
+    }
+
+    const result = await (serviceClient as SupabaseClient).rpc('provision_ci_rls_fixture_profile', {
+      p_user_id: orgAContext.userId,
+      p_organization_id: orgAContext.organizationId,
+    });
+    const restoreResult = await serviceClient.auth.admin.updateUserById(orgAContext.userId, {
+      app_metadata: buildCiRlsAppMetadata(),
+    });
+    if (restoreResult.error) {
+      throw restoreResult.error;
+    }
+    expect(result.error?.code).toBe('42501');
+  });
+
+  it('denies the provisioning RPC to an authenticated therapist', async () => {
+    if (!runTests || !orgAContext) {
+      console.log('⏭️  Skipping synthetic profile grant test - setup incomplete.');
+      return;
+    }
+
+    const therapistClient = await signInTherapist(orgAContext);
+    try {
+      const result = await (therapistClient as SupabaseClient).rpc('provision_ci_rls_fixture_profile', {
+        p_user_id: orgAContext.userId,
+        p_organization_id: orgAContext.organizationId,
+      });
+      expect(result.error).toBeTruthy();
+    } finally {
+      await therapistClient.auth.signOut();
+    }
+  });
 });
 
 describe('admin organization scoping', () => {
@@ -1738,6 +1794,12 @@ afterAll(async () => {
     await serviceClient.from('admin_actions').delete().in('id', createdAdminActionIds);
   }
 
+  if (createdFixtureAuthUserIds.length > 0) {
+    await serviceClient.from('user_roles').delete().in('user_id', createdFixtureAuthUserIds);
+    await serviceClient.from('clients').delete().in('id', createdFixtureAuthUserIds);
+    await serviceClient.from('therapists').delete().in('id', createdFixtureAuthUserIds);
+  }
+
   for (const userId of createdFixtureAuthUserIds) {
     await serviceClient.auth.admin.deleteUser(userId);
   }
@@ -2078,6 +2140,7 @@ describe('row level security for multi-tenant tables', () => {
       password: otherTherapistPassword,
       email_confirm: true,
       user_metadata: { organization_id: orgAContext.organizationId },
+      app_metadata: buildCiRlsAppMetadata(),
     });
 
     if (otherUserError || !otherUser?.user) {
@@ -2110,7 +2173,7 @@ describe('row level security for multi-tenant tables', () => {
       throw assignRoleResult.error;
     }
 
-    await serviceClient.from('profiles').update({ role: 'therapist' }).eq('id', otherTherapistId);
+    await provisionCiRlsProfile(otherTherapistId, orgAContext.organizationId);
 
     const { data: authorizationRow, error: authorizationError } = await serviceClient
       .from('authorizations')

--- a/supabase/migrations/20260714130000_provision_ci_rls_fixture_profile.sql
+++ b/supabase/migrations/20260714130000_provision_ci_rls_fixture_profile.sql
@@ -1,0 +1,94 @@
+-- @migration-intent: Give service-role CI one fail-closed path to align expiring synthetic RLS actors without weakening profile auth-field immutability.
+-- @migration-dependencies: public.profiles,public.user_roles,public.roles,public.therapists,public.clients,20260407105500_enforce_profile_immutability_respect_bypass.sql
+-- @migration-rollback: Drop public.provision_ci_rls_fixture_profile(uuid, uuid).
+
+begin;
+
+create or replace function public.provision_ci_rls_fixture_profile(
+  p_user_id uuid,
+  p_organization_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  resolved_role public.role_type;
+  resolved_organization_id uuid;
+  updated_rows integer;
+begin
+  if p_user_id is null or p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Synthetic RLS user and organization are required';
+  end if;
+
+  select min(r.name)::public.role_type
+  into resolved_role
+  from public.user_roles ur
+  join public.roles r on r.id = ur.role_id
+  join auth.users u
+    on u.id = ur.user_id
+   and lower(u.email) like '%.%@example.com'
+   and u.raw_app_meta_data ->> 'ci_rls_fixture' = 'true'
+   and (u.raw_app_meta_data ->> 'ci_rls_expires_at')::timestamptz > now()
+  where ur.user_id = p_user_id
+    and coalesce(ur.is_active, true) = true
+    and (ur.expires_at is null or ur.expires_at > now())
+  having count(distinct r.name) = 1
+     and bool_and(r.name in ('client', 'therapist', 'admin'));
+
+  if resolved_role is null then
+    raise exception using errcode = '42501', message = 'One active synthetic RLS role is required';
+  end if;
+
+  if resolved_role = 'therapist'::public.role_type then
+    select t.organization_id
+    into resolved_organization_id
+    from public.therapists t
+    where t.id = p_user_id
+      and t.deleted_at is null;
+  elsif resolved_role = 'client'::public.role_type then
+    select c.organization_id
+    into resolved_organization_id
+    from public.clients c
+    where c.id = p_user_id
+      and c.deleted_at is null;
+  elsif resolved_role = 'admin'::public.role_type then
+    select public.get_organization_id_from_metadata(u.raw_user_meta_data)
+    into resolved_organization_id
+    from auth.users u
+    where u.id = p_user_id;
+  end if;
+
+  if resolved_organization_id is null or resolved_organization_id <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Synthetic RLS actor organization mismatch';
+  end if;
+
+  perform set_config('app.bypass_profile_role_guard', 'on', true);
+  update public.profiles
+  set role = resolved_role,
+      organization_id = resolved_organization_id,
+      is_active = true,
+      updated_at = now()
+  where id = p_user_id;
+  get diagnostics updated_rows = row_count;
+  perform set_config('app.bypass_profile_role_guard', 'off', true);
+
+  if updated_rows <> 1 then
+    raise exception using errcode = 'P0002', message = 'Synthetic RLS profile is missing';
+  end if;
+
+  return resolved_organization_id;
+exception
+  when others then
+    perform set_config('app.bypass_profile_role_guard', 'off', true);
+    raise;
+end;
+$$;
+
+revoke execute on function public.provision_ci_rls_fixture_profile(uuid, uuid) from public;
+revoke execute on function public.provision_ci_rls_fixture_profile(uuid, uuid) from anon;
+revoke execute on function public.provision_ci_rls_fixture_profile(uuid, uuid) from authenticated;
+grant execute on function public.provision_ci_rls_fixture_profile(uuid, uuid) to service_role;
+
+commit;

--- a/tests/integration/_helpers/liveRlsHarness.ts
+++ b/tests/integration/_helpers/liveRlsHarness.ts
@@ -17,17 +17,9 @@ type AdminAuthFixture = {
 
 type LiveRlsFixtureRole = "admin" | "therapist" | "none";
 
-export const buildLiveRlsProfileFixture = (fixture: {
-  userId: string;
-  email: string;
-  organizationId: string | null;
-  role: LiveRlsFixtureRole;
-}) => ({
-  id: fixture.userId,
-  email: fixture.email,
-  organization_id: fixture.organizationId,
-  role: fixture.role === "none" ? "client" as const : fixture.role,
-  is_active: true,
+export const buildLiveRlsAppMetadata = () => ({
+  ci_rls_fixture: true,
+  ci_rls_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
 });
 
 type OrgDataFixture = {
@@ -119,6 +111,7 @@ const createAuthFixture = async (
     password,
     email_confirm: true,
     user_metadata: userMetadata,
+    app_metadata: buildLiveRlsAppMetadata(),
   });
 
   if (createUserError || !createdUser?.user) {
@@ -144,16 +137,14 @@ const createAuthFixture = async (
       await assignNamedRole(serviceClient, userId, "therapist");
     }
 
-    const profileResult = await serviceClient
-      .from("profiles")
-      .upsert(buildLiveRlsProfileFixture({
-        userId,
-        email,
-        organizationId: options.organizationId,
-        role: options.role,
-      }), { onConflict: "id" });
-    if (profileResult.error) {
-      throw profileResult.error;
+    if (options.role === "admin") {
+      const profileResult = await (serviceClient as SupabaseClient).rpc(
+        "provision_ci_rls_fixture_profile",
+        { p_user_id: userId, p_organization_id: options.organizationId },
+      );
+      if (profileResult.error || profileResult.data !== options.organizationId) {
+        throw profileResult.error ?? new Error("Synthetic RLS profile provisioning returned the wrong organization");
+      }
     }
 
     return { userId, email, password, organizationId: options.organizationId };
@@ -443,6 +434,18 @@ export async function setupLiveRlsHarness(): Promise<LiveRlsHarness> {
     });
     const orgA = await seedOrgData(serviceClient, orgAId, "org-a", orgATherapist.userId);
     const orgB = await seedOrgData(serviceClient, orgBId, "org-b", orgBTherapist.userId);
+    for (const [actor, organizationId] of [
+      [orgATherapist, orgAId],
+      [orgBTherapist, orgBId],
+    ] as const) {
+      const profileResult = await (serviceClient as SupabaseClient).rpc(
+        "provision_ci_rls_fixture_profile",
+        { p_user_id: actor.userId, p_organization_id: organizationId },
+      );
+      if (profileResult.error || profileResult.data !== organizationId) {
+        throw profileResult.error ?? new Error("Synthetic RLS therapist profile provisioning returned the wrong organization");
+      }
+    }
     resources = { orgAAdmin, orgBAdmin, orgATherapist, orgBTherapist, outsider, orgA, orgB };
   } catch (setupError) {
     try {

--- a/tests/integration/liveRlsHarness.unit.test.ts
+++ b/tests/integration/liveRlsHarness.unit.test.ts
@@ -1,32 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { buildLiveRlsProfileFixture } from "./_helpers/liveRlsHarness.ts";
+import { buildLiveRlsAppMetadata } from "./_helpers/liveRlsHarness.ts";
 
-describe("live RLS harness profile fixtures", () => {
-  it("keeps tenant and role state explicit for privileged actors", () => {
-    expect(buildLiveRlsProfileFixture({
-      userId: "admin-1",
-      email: "admin@example.com",
-      organizationId: "org-1",
-      role: "admin",
-    })).toEqual({
-      id: "admin-1",
-      email: "admin@example.com",
-      organization_id: "org-1",
-      role: "admin",
-      is_active: true,
-    });
-  });
-
-  it("keeps no-org outsiders fail-closed without inventing a privileged role", () => {
-    expect(buildLiveRlsProfileFixture({
-      userId: "outsider-1",
-      email: "outsider@example.com",
-      organizationId: null,
-      role: "none",
-    })).toMatchObject({
-      organization_id: null,
-      role: "client",
-      is_active: true,
-    });
+describe("live RLS harness actor metadata", () => {
+  it("marks the actor as an expiring service-created fixture", () => {
+    const before = Date.now();
+    const metadata = buildLiveRlsAppMetadata();
+    expect(metadata.ci_rls_fixture).toBe(true);
+    expect(new Date(metadata.ci_rls_expires_at).getTime()).toBeGreaterThan(before);
+    expect(new Date(metadata.ci_rls_expires_at).getTime()).toBeLessThanOrEqual(before + 60 * 60 * 1000 + 1000);
   });
 });

--- a/tests/integration/provision-ci-rls-fixture-profile-migration.test.ts
+++ b/tests/integration/provision-ci-rls-fixture-profile-migration.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  resolve("supabase/migrations/20260714130000_provision_ci_rls_fixture_profile.sql"),
+  "utf8",
+);
+
+describe("service-only synthetic RLS fixture profile provisioning", () => {
+  it("requires an expiring service-created actor and one active authoritative role", () => {
+    expect(migration).toMatch(/raw_app_meta_data ->> 'ci_rls_fixture' = 'true'/i);
+    expect(migration).toMatch(/raw_app_meta_data ->> 'ci_rls_expires_at'/i);
+    expect(migration).toMatch(/from public\.user_roles/i);
+    expect(migration).toMatch(/join public\.roles/i);
+    expect(migration).toMatch(/coalesce\(ur\.is_active, true\) = true/i);
+    expect(migration).toMatch(/count\(distinct r\.name\) = 1/i);
+    expect(migration).toMatch(/bool_and\(r\.name in \('client', 'therapist', 'admin'\)\)/i);
+  });
+
+  it("validates tenant ownership from the role-specific authoritative record", () => {
+    expect(migration).toMatch(/from public\.therapists/i);
+    expect(migration).toMatch(/from public\.clients/i);
+    expect(migration).toMatch(/get_organization_id_from_metadata/i);
+    expect(migration).toMatch(/resolved_organization_id <> p_organization_id/i);
+  });
+
+  it("uses the profile guard bypass and remains service-role only", () => {
+    expect(migration).toMatch(/set_config\('app\.bypass_profile_role_guard', 'on', true\)/i);
+    expect(migration).toMatch(/if updated_rows <> 1 then/i);
+    expect(migration).toMatch(/when others then[\s\S]*set_config\('app\.bypass_profile_role_guard', 'off', true\)/i);
+    expect(migration).toMatch(/revoke execute on function public\.provision_ci_rls_fixture_profile\(uuid, uuid\) from public/i);
+    expect(migration).toMatch(/from anon/i);
+    expect(migration).toMatch(/from authenticated/i);
+    expect(migration).toMatch(/grant execute on function public\.provision_ci_rls_fixture_profile\(uuid, uuid\) to service_role/i);
+  });
+});


### PR DESCRIPTION
## Summary
- replace failing direct profile upserts in hosted RLS fixtures with a service-role-only provisioning RPC
- require an unexpired synthetic actor marker, exactly one active authoritative role, and a matching authoritative tenant record
- add hosted rejection coverage for wrong tenant, expired marker, and authenticated callers, plus partial-setup cleanup

## Root cause
Trusted main Supabase Validate run 29333204173 stopped all six live RLS files during setup with 42501 role is immutable for this role. Service-key PostgREST fixture writes did not populate the request JWT role setting used by the profile immutability guard.

## Safety
- critical lane; human review required
- no production RLS policy relaxation or user-facing auth behavior change
- function has an empty search path, transaction-local guard bypass, explicit synthetic email/app-metadata/expiry checks, authoritative role and organization derivation, and service-role-only EXECUTE
- actors with any extra or unexpected active role, including super_admin, fail closed

## Verification
- focused RLS/migration suite: 146/146
- lint: pass
- typecheck: pass
- policy: pass
- tenant validation: pass
- build: pass
- final security/test review: no P1/P2
- local full coverage suite: timed out after 182 seconds in unrelated AI-documentation network/finalization tests
- trusted post-merge Supabase Validate remains decisive for the live database path

Linear: WIN-217