### PR TITLE
test: await IEHP generation controls

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -311,3 +311,19 @@ PR validation also exposed saturated hosted booking data: run `29291802604` foun
   - blocked checks: applying the migration and running `RUN_DB_IT=1` require the trusted main Supabase workflow and secrets; the local full coverage suite timed out after 182 seconds in unrelated AI-documentation network/finalization tests before producing a result.
   - result: `human-review-ready`; final security/test review found no remaining P1/P2 after the additional-role and cleanup fixes.
   - residual risk: the service-only RPC and hosted fixture path remain unproven against the deployed schema until a trusted post-merge Supabase Validate run passes all six files.
+
+### Trusted-main IEHP generation test synchronization
+
+- trusted main CI run `29339215591` stopped in `unit-tests` before build and the hosted BCBA acceptance job could run.
+- root cause: both IEHP DOCX tests synchronized on the assessment document row, then synchronously queried a button whose label is updated by a later selected-assessment effect. Under full coverage load, the query could race that state update.
+- classification: `low-risk autonomous`; lane: `standard`.
+- bounded fix:
+  - await the existing accessible `Generate completed IEHP DOCX` button in both equivalent tests.
+  - preserve the existing enabled-state wait and all production component behavior.
+- non-goals: no component, route, auth, workflow, database, or runtime behavior changes.
+- verification card:
+  - required checks: focused repeated regressions, full component test file, policy, lint, typecheck, full unit coverage, build, reviewer, PR CI.
+  - executed checks: both focused IEHP tests passed five consecutive runs; full component file passed 98/98; policy, lint, typecheck, and build passed; tier-0 routes passed 220/220; full coverage reached 2691 passing tests with the IEHP tests green; focused reviewer found no P1/P2.
+  - blocked checks: local Windows full coverage has one unrelated CRLF-sensitive workflow-text assertion in `check-e2e-reliability-gates`; the same contract passes in Linux CI, which is authoritative for PR closure.
+  - result: `pass-with-blocked-checks`, pending PR CI.
+  - residual risk: trusted-main BCBA acceptance remains blocked until this unit gate fix merges and main reruns; Linux CI must confirm the complete coverage suite.

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -4282,7 +4282,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
 
     await screen.findByText("iehp-fba.docx");
-    const generateDocxButton = screen.getByRole("button", { name: /Generate completed IEHP DOCX/i });
+    const generateDocxButton = await screen.findByRole("button", { name: /Generate completed IEHP DOCX/i });
     await waitFor(() => {
       expect(generateDocxButton).not.toBeDisabled();
     });
@@ -4359,7 +4359,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
 
     await screen.findByText("iehp-fba.docx");
-    const generateDocxButton = screen.getByRole("button", { name: /Generate completed IEHP DOCX/i });
+    const generateDocxButton = await screen.findByRole("button", { name: /Generate completed IEHP DOCX/i });
     await waitFor(() => {
       expect(generateDocxButton).not.toBeDisabled();
     });


### PR DESCRIPTION
## Summary
- wait for the IEHP generation control after selected-assessment state hydrates
- update both equivalent IEHP DOCX tests
- record trusted-main failure evidence and verification in the BCBA handoff

## Root cause
Trusted-main CI run 29339215591 synchronized on the IEHP document row, then synchronously queried a button whose accessible name is updated by a later effect. Under full coverage load, that query raced the state update and blocked the hosted BCBA acceptance job.

## Verification
- both affected tests: 5 consecutive passes each
- ProgramsGoalsTab test file: 98/98 pass before and after rebase
- policy: pass
- lint: pass
- typecheck: pass
- build: pass
- tier-0 routes: 220/220 pass
- full local coverage: 2691 pass; one unrelated Windows CRLF-sensitive workflow-text assertion blocked (same contract passes on Linux CI)
- focused reviewer: no P1/P2

## Scope
No production component, auth, routing, workflow, database, or runtime behavior changes.

Linear: WIN-217