### PR TITLE
test: persist hosted RLS actor markers

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -327,3 +327,20 @@ PR validation also exposed saturated hosted booking data: run `29291802604` foun
   - blocked checks: local Windows full coverage has one unrelated CRLF-sensitive workflow-text assertion in `check-e2e-reliability-gates`; the same contract passes in Linux CI, which is authoritative for PR closure.
   - result: `pass-with-blocked-checks`, pending PR CI.
   - residual risk: trusted-main BCBA acceptance remains blocked until this unit gate fix merges and main reruns; Linux CI must confirm the complete coverage suite.
+
+### Hosted RLS Auth marker hydration follow-up
+
+- trusted main Supabase Validate run `29340501370` passed runtime migration parity but all six live RLS files stopped at the first synthetic actor with `42501 One active synthetic RLS role is required`.
+- a rollback-only production database probe proved the deployed RPC succeeds when the actor has `marker=true`, an unexpired marker timestamp, and exactly one active `admin` role; the probe deliberately raised at completion so all synthetic rows rolled back.
+- classification: `high-risk human-reviewed`; lane: `critical`; the bounded repair remains test-only but mutates hosted Auth app metadata with the service role.
+- bounded fix:
+  - explicitly persist the expiring `ci_rls_fixture` app-metadata marker after each hosted Auth actor is created.
+  - read the actor back through the Admin API and fail before role/profile provisioning unless the marker is present and unexpired.
+  - keep the existing service-only RPC, complete role-cardinality check, tenant derivation, grants, and fail-closed assertions unchanged.
+- non-goals: no migration, RLS policy, function, grant, workflow, production auth behavior, role taxonomy, or real tenant data change.
+- verification card:
+  - required checks: red/green marker helper contract, lint, typecheck, focused RLS paths, policy, tenant validation, build, security/test review, human review, and trusted hosted Supabase Validate.
+  - executed checks: the helper contract failed before implementation and passed 3/3 afterward; seven focused files passed 145/145; lint passed; typecheck passed; policy passed; tenant validation passed; build passed; rollback-only hosted RPC probe passed with `{admin}` and the exact marker preconditions; independent code and security review found no remaining P1/P2.
+  - blocked checks: the six live RLS suites require trusted CI secrets and remain decisive; local Windows full coverage reached 2697 passing tests with two unrelated failures in the CRLF-sensitive workflow parser and the Node Blob test implementation.
+  - result: `human-review-ready`; pending PR checks, human review, and trusted hosted validation.
+  - residual risk: Admin API create behavior is the only prerequisite not directly observable after failed-run cleanup; explicit update plus readback makes that prerequisite deterministic and observable on the next hosted run.

--- a/src/tests/security/ciRlsFixtureMetadata.ts
+++ b/src/tests/security/ciRlsFixtureMetadata.ts
@@ -1,0 +1,35 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type CiRlsAppMetadata = {
+  ci_rls_fixture: true;
+  ci_rls_expires_at: string;
+};
+
+export const buildCiRlsAppMetadata = (): CiRlsAppMetadata => ({
+  ci_rls_fixture: true,
+  ci_rls_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+});
+
+export const persistCiRlsAppMetadata = async (
+  serviceClient: SupabaseClient,
+  userId: string,
+  metadata: CiRlsAppMetadata = buildCiRlsAppMetadata(),
+): Promise<void> => {
+  const updateResult = await serviceClient.auth.admin.updateUserById(userId, {
+    app_metadata: metadata,
+  });
+  if (updateResult.error) {
+    throw updateResult.error;
+  }
+
+  const readResult = await serviceClient.auth.admin.getUserById(userId);
+  if (readResult.error || !readResult.data.user) {
+    throw readResult.error ?? new Error('Synthetic RLS actor metadata readback failed');
+  }
+
+  const persisted = readResult.data.user.app_metadata;
+  const expiresAt = Date.parse(String(persisted.ci_rls_expires_at ?? ''));
+  if (persisted.ci_rls_fixture !== true || !Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+    throw new Error('Synthetic RLS actor metadata was not persisted with an unexpired marker');
+  }
+};

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -4,6 +4,10 @@ import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { computeEnvironmentGuidance, resolveSupabaseTestEnv } from './supabaseEnv';
+import {
+  buildCiRlsAppMetadata,
+  persistCiRlsAppMetadata,
+} from './ciRlsFixtureMetadata';
 import type { Database } from '../../lib/generated/database.types';
 
 type TypedClient = SupabaseClient<Database, 'public', Database['public']>;
@@ -174,15 +178,11 @@ let clientRoleId: string | null = null;
 const userSessionIdsByUser = new Map<string, string>();
 const actorAccessTokensByEmail = new Map<string, string>();
 
-const buildCiRlsAppMetadata = () => ({
-  ci_rls_fixture: true,
-  ci_rls_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-});
-
 const provisionCiRlsProfile = async (userId: string, organizationId: string): Promise<void> => {
   if (!serviceClient) {
     throw new Error('Service client not initialized');
   }
+  await persistCiRlsAppMetadata(serviceClient, userId);
   const result = await (serviceClient as SupabaseClient).rpc('provision_ci_rls_fixture_profile', {
     p_user_id: userId,
     p_organization_id: organizationId,

--- a/tests/integration/_helpers/liveRlsHarness.ts
+++ b/tests/integration/_helpers/liveRlsHarness.ts
@@ -2,6 +2,11 @@ import { randomUUID } from "node:crypto";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "../../../src/lib/generated/database.types";
 import {
+  buildCiRlsAppMetadata,
+  persistCiRlsAppMetadata,
+  type CiRlsAppMetadata,
+} from "../../../src/tests/security/ciRlsFixtureMetadata";
+import {
   computeEnvironmentGuidance,
   resolveSupabaseTestEnv,
 } from "../../../src/tests/security/supabaseEnv";
@@ -17,10 +22,13 @@ type AdminAuthFixture = {
 
 type LiveRlsFixtureRole = "admin" | "therapist" | "none";
 
-export const buildLiveRlsAppMetadata = () => ({
-  ci_rls_fixture: true,
-  ci_rls_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-});
+export const buildLiveRlsAppMetadata = buildCiRlsAppMetadata;
+
+export const persistLiveRlsAppMetadata = (
+  serviceClient: TypedClient,
+  userId: string,
+  metadata: CiRlsAppMetadata,
+) => persistCiRlsAppMetadata(serviceClient, userId, metadata);
 
 type OrgDataFixture = {
   therapistId: string;
@@ -106,12 +114,13 @@ const createAuthFixture = async (
     userMetadata.role = options.role;
   }
 
+  const appMetadata = buildLiveRlsAppMetadata();
   const { data: createdUser, error: createUserError } = await serviceClient.auth.admin.createUser({
     email,
     password,
     email_confirm: true,
     user_metadata: userMetadata,
-    app_metadata: buildLiveRlsAppMetadata(),
+    app_metadata: appMetadata,
   });
 
   if (createUserError || !createdUser?.user) {
@@ -121,6 +130,8 @@ const createAuthFixture = async (
   const userId = createdUser.user.id;
 
   try {
+    await persistLiveRlsAppMetadata(serviceClient, userId, appMetadata);
+
     if (options.role === "admin") {
       if (!options.organizationId) {
         throw new Error("Admin fixtures require an organization id");

--- a/tests/integration/liveRlsHarness.unit.test.ts
+++ b/tests/integration/liveRlsHarness.unit.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { buildLiveRlsAppMetadata } from "./_helpers/liveRlsHarness.ts";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildLiveRlsAppMetadata,
+  persistLiveRlsAppMetadata,
+} from "./_helpers/liveRlsHarness.ts";
 
 describe("live RLS harness actor metadata", () => {
   it("marks the actor as an expiring service-created fixture", () => {
@@ -8,5 +11,42 @@ describe("live RLS harness actor metadata", () => {
     expect(metadata.ci_rls_fixture).toBe(true);
     expect(new Date(metadata.ci_rls_expires_at).getTime()).toBeGreaterThan(before);
     expect(new Date(metadata.ci_rls_expires_at).getTime()).toBeLessThanOrEqual(before + 60 * 60 * 1000 + 1000);
+  });
+
+  it("persists and reads back the expiring marker before provisioning", async () => {
+    const appMetadata = buildLiveRlsAppMetadata();
+    const updateUserById = vi.fn().mockResolvedValue({ data: { user: {} }, error: null });
+    const getUserById = vi.fn().mockResolvedValue({
+      data: { user: { app_metadata: appMetadata } },
+      error: null,
+    });
+
+    await persistLiveRlsAppMetadata(
+      { auth: { admin: { updateUserById, getUserById } } } as never,
+      "00000000-0000-4000-8000-000000000001",
+      appMetadata,
+    );
+
+    expect(updateUserById).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-000000000001",
+      { app_metadata: appMetadata },
+    );
+    expect(getUserById).toHaveBeenCalledWith("00000000-0000-4000-8000-000000000001");
+  });
+
+  it("fails closed when Auth does not return the persisted marker", async () => {
+    const updateUserById = vi.fn().mockResolvedValue({ data: { user: {} }, error: null });
+    const getUserById = vi.fn().mockResolvedValue({
+      data: { user: { app_metadata: {} } },
+      error: null,
+    });
+
+    await expect(
+      persistLiveRlsAppMetadata(
+        { auth: { admin: { updateUserById, getUserById } } } as never,
+        "00000000-0000-4000-8000-000000000001",
+        buildLiveRlsAppMetadata(),
+      ),
+    ).rejects.toThrow("Synthetic RLS actor metadata was not persisted with an unexpired marker");
   });
 });


### PR DESCRIPTION
## Summary

- explicitly persist the expiring synthetic RLS marker through the Auth Admin API
- read the actor back and fail closed unless the marker is present and unexpired
- route every normal security-spec provisioning call through the shared hydration helper
- leave the deployed service-only RPC, role cardinality, tenant derivation, grants, and negative guardrails unchanged

## Route

- issue: WIN-217
- classification: high-risk human-reviewed
- lane: critical
- protected surface: hosted Auth service-role test fixtures
- non-goals: migrations, RLS policies, grants, workflows, production auth behavior, real tenant rows

## Evidence

- trusted main Supabase Validate `29340501370`: all six hosted suites failed at the first actor with `42501`
- rollback-only production SQL probe: RPC succeeded with `marker=true`, unexpired expiry, and `roles={admin}`; deliberate final exception rolled all rows back
- RED: marker persistence contract failed before implementation
- focused: 7 files / 145 tests pass
- lint, typecheck, policy, tenant validation, build pass
- full local coverage: 2697 pass; 2 unrelated Windows/runtime failures (workflow CRLF parser and Node Blob implementation)
- independent code review: no remaining P1/P2
- independent security review: no P1/P2; synthetic UUID-tracked `@example.com` actors only

## Required hosted proof

- trusted Supabase Validate must execute and pass all six live RLS suites without skips
- human review is required before merge because this is critical-lane service-role fixture work
