### PR TITLE
test: reconcile hosted RLS actor roles

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -344,3 +344,20 @@ PR validation also exposed saturated hosted booking data: run `29291802604` foun
   - blocked checks: the six live RLS suites require trusted CI secrets and remain decisive; local Windows full coverage reached 2697 passing tests with two unrelated failures in the CRLF-sensitive workflow parser and the Node Blob test implementation.
   - result: `human-review-ready`; pending PR checks, human review, and trusted hosted validation.
   - residual risk: Admin API create behavior is the only prerequisite not directly observable after failed-run cleanup; explicit update plus readback makes that prerequisite deterministic and observable on the next hosted run.
+
+### Hosted RLS authoritative-role reconciliation follow-up
+
+- trusted main Supabase Validate run `29343649846` proved Auth marker update/readback was not sufficient: all six live RLS files still failed the composite role guard after 2557 other tests passed.
+- classification: `high-risk human-reviewed`; lane: `critical`; the change remains test-only but uses service-role writes to authoritative `user_roles` rows for newly created synthetic actors.
+- bounded fix:
+  - require a just-created dotted `@example.com` actor with a true, unexpired Auth app-metadata marker before any role mutation.
+  - deactivate role rows only for that synthetic user ID, upsert the explicitly expected `admin`, `therapist`, or `client` role as active/non-expiring, and read back the complete active set.
+  - fail closed unless the active set is the exact expected singleton before calling the unchanged service-only profile RPC.
+  - route all normal provisioning paths through the shared marker -> role -> RPC preflight; keep wrong-tenant, expired-marker, and authenticated-caller guardrail calls raw.
+- non-goals: no migration, function, RLS policy, grant, workflow, production auth/role behavior, real user mutation, or tenant derivation change.
+- verification card:
+  - required checks: red/green role-reconciliation contract, focused hosted-RLS static paths, lint, typecheck, policy, tenant validation, build, code/security/test review, human review, and trusted hosted Supabase Validate.
+  - executed checks: the role-reconciliation contract failed before implementation and passed 4/4 afterward, including explicit actor scoping on the destructive update and verification read; nine focused hosted-RLS files passed 158/158; lint, typecheck, policy, tenant validation, and build passed; independent code review found one scoping-assertion test gap and the final contract closes it; final security review found no P1/P2.
+  - blocked checks: trusted live suites require CI secrets and remain decisive.
+  - result: `human-review-ready`; pending PR CI, human merge, and trusted hosted validation.
+  - residual risk: the previous RPC error combines multiple predicates, so only the trusted run can confirm authoritative role state was the remaining failed precondition.

--- a/src/tests/security/ciRlsFixtureMetadata.ts
+++ b/src/tests/security/ciRlsFixtureMetadata.ts
@@ -5,6 +5,8 @@ export type CiRlsAppMetadata = {
   ci_rls_expires_at: string;
 };
 
+export type CiRlsFixtureRole = 'admin' | 'therapist' | 'client';
+
 export const buildCiRlsAppMetadata = (): CiRlsAppMetadata => ({
   ci_rls_fixture: true,
   ci_rls_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
@@ -31,5 +33,74 @@ export const persistCiRlsAppMetadata = async (
   const expiresAt = Date.parse(String(persisted.ci_rls_expires_at ?? ''));
   if (persisted.ci_rls_fixture !== true || !Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
     throw new Error('Synthetic RLS actor metadata was not persisted with an unexpired marker');
+  }
+};
+
+export const reconcileCiRlsFixtureRole = async (
+  serviceClient: SupabaseClient,
+  userId: string,
+  expectedRole: CiRlsFixtureRole,
+): Promise<void> => {
+  const actorResult = await serviceClient.auth.admin.getUserById(userId);
+  if (actorResult.error || !actorResult.data.user) {
+    throw actorResult.error ?? new Error('Synthetic RLS actor readback failed before role reconciliation');
+  }
+
+  const actor = actorResult.data.user;
+  const expiresAt = Date.parse(String(actor.app_metadata.ci_rls_expires_at ?? ''));
+  if (
+    !/^.+\..+@example\.com$/i.test(actor.email ?? '')
+    || actor.app_metadata.ci_rls_fixture !== true
+    || !Number.isFinite(expiresAt)
+    || expiresAt <= Date.now()
+  ) {
+    throw new Error('Synthetic RLS actor is not eligible for role reconciliation');
+  }
+
+  const roleLookup = await serviceClient
+    .from('roles')
+    .select('id')
+    .eq('name', expectedRole)
+    .maybeSingle();
+  if (roleLookup.error || !roleLookup.data?.id) {
+    throw roleLookup.error ?? new Error(`Synthetic RLS fixture role ${expectedRole} is missing`);
+  }
+
+  const deactivateResult = await serviceClient
+    .from('user_roles')
+    .update({ is_active: false })
+    .eq('user_id', userId);
+  if (deactivateResult.error) {
+    throw deactivateResult.error;
+  }
+
+  const upsertResult = await serviceClient.from('user_roles').upsert(
+    {
+      user_id: userId,
+      role_id: roleLookup.data.id,
+      is_active: true,
+      expires_at: null,
+    },
+    { onConflict: 'user_id,role_id' },
+  );
+  if (upsertResult.error) {
+    throw upsertResult.error;
+  }
+
+  const activeResult = await serviceClient
+    .from('user_roles')
+    .select('role_id, is_active, expires_at')
+    .eq('user_id', userId)
+    .eq('is_active', true);
+  if (activeResult.error) {
+    throw activeResult.error;
+  }
+
+  const now = Date.now();
+  const activeRoleIds = (activeResult.data ?? [])
+    .filter((row) => !row.expires_at || Date.parse(row.expires_at) > now)
+    .map((row) => row.role_id);
+  if (activeRoleIds.length !== 1 || activeRoleIds[0] !== roleLookup.data.id) {
+    throw new Error(`Synthetic RLS actor role reconciliation failed for ${expectedRole}`);
   }
 };

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -7,6 +7,8 @@ import { computeEnvironmentGuidance, resolveSupabaseTestEnv } from './supabaseEn
 import {
   buildCiRlsAppMetadata,
   persistCiRlsAppMetadata,
+  reconcileCiRlsFixtureRole,
+  type CiRlsFixtureRole,
 } from './ciRlsFixtureMetadata';
 import type { Database } from '../../lib/generated/database.types';
 
@@ -178,11 +180,16 @@ let clientRoleId: string | null = null;
 const userSessionIdsByUser = new Map<string, string>();
 const actorAccessTokensByEmail = new Map<string, string>();
 
-const provisionCiRlsProfile = async (userId: string, organizationId: string): Promise<void> => {
+const provisionCiRlsProfile = async (
+  userId: string,
+  organizationId: string,
+  expectedRole: CiRlsFixtureRole,
+): Promise<void> => {
   if (!serviceClient) {
     throw new Error('Service client not initialized');
   }
   await persistCiRlsAppMetadata(serviceClient, userId);
+  await reconcileCiRlsFixtureRole(serviceClient, userId, expectedRole);
   const result = await (serviceClient as SupabaseClient).rpc('provision_ci_rls_fixture_profile', {
     p_user_id: userId,
     p_organization_id: organizationId,
@@ -239,7 +246,7 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
     throw assignRoleResult.error;
   }
 
-  await provisionCiRlsProfile(userId, organizationId);
+  await provisionCiRlsProfile(userId, organizationId, 'therapist');
 
   const clientEmail = `${label}.client.${randomUUID()}@example.com`;
   const clientPassword = `P@ssw0rd-${Math.random().toString(36).slice(2, 10)}`;
@@ -280,7 +287,7 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
   if (clientRoleResult.error) {
     throw clientRoleResult.error;
   }
-  await provisionCiRlsProfile(clientUserId, organizationId);
+  await provisionCiRlsProfile(clientUserId, organizationId, 'client');
 
   const sessionId = randomUUID();
   const start = new Date(Date.now() - 60 * 60 * 1000);
@@ -348,7 +355,7 @@ const createAdminFixture = async (organizationId: string): Promise<AdminContext>
     throw assignResult.error;
   }
 
-  await provisionCiRlsProfile(userId, organizationId);
+  await provisionCiRlsProfile(userId, organizationId, 'admin');
 
   return { email, password, userId, organizationId };
 };
@@ -2173,7 +2180,7 @@ describe('row level security for multi-tenant tables', () => {
       throw assignRoleResult.error;
     }
 
-    await provisionCiRlsProfile(otherTherapistId, orgAContext.organizationId);
+    await provisionCiRlsProfile(otherTherapistId, orgAContext.organizationId, 'therapist');
 
     const { data: authorizationRow, error: authorizationError } = await serviceClient
       .from('authorizations')

--- a/tests/integration/_helpers/liveRlsHarness.ts
+++ b/tests/integration/_helpers/liveRlsHarness.ts
@@ -4,7 +4,9 @@ import type { Database } from "../../../src/lib/generated/database.types";
 import {
   buildCiRlsAppMetadata,
   persistCiRlsAppMetadata,
+  reconcileCiRlsFixtureRole,
   type CiRlsAppMetadata,
+  type CiRlsFixtureRole,
 } from "../../../src/tests/security/ciRlsFixtureMetadata";
 import {
   computeEnvironmentGuidance,
@@ -29,6 +31,12 @@ export const persistLiveRlsAppMetadata = (
   userId: string,
   metadata: CiRlsAppMetadata,
 ) => persistCiRlsAppMetadata(serviceClient, userId, metadata);
+
+export const reconcileLiveRlsRole = (
+  serviceClient: TypedClient,
+  userId: string,
+  expectedRole: CiRlsFixtureRole,
+) => reconcileCiRlsFixtureRole(serviceClient, userId, expectedRole);
 
 type OrgDataFixture = {
   therapistId: string;
@@ -146,6 +154,10 @@ const createAuthFixture = async (
       }
     } else if (options.role === "therapist") {
       await assignNamedRole(serviceClient, userId, "therapist");
+    }
+
+    if (options.role !== "none") {
+      await reconcileLiveRlsRole(serviceClient, userId, options.role);
     }
 
     if (options.role === "admin") {

--- a/tests/integration/liveRlsHarness.unit.test.ts
+++ b/tests/integration/liveRlsHarness.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildLiveRlsAppMetadata,
   persistLiveRlsAppMetadata,
+  reconcileLiveRlsRole,
 } from "./_helpers/liveRlsHarness.ts";
 
 describe("live RLS harness actor metadata", () => {
@@ -48,5 +49,66 @@ describe("live RLS harness actor metadata", () => {
         buildLiveRlsAppMetadata(),
       ),
     ).rejects.toThrow("Synthetic RLS actor metadata was not persisted with an unexpired marker");
+  });
+
+  it("reconciles the complete active role set to the expected fixture role", async () => {
+    const expectedRoleId = "00000000-0000-4000-8000-000000000010";
+    const maybeSingle = vi.fn().mockResolvedValue({ data: { id: expectedRoleId }, error: null });
+    const roleEq = vi.fn().mockReturnValue({ maybeSingle });
+    const roleSelect = vi.fn().mockReturnValue({ eq: roleEq });
+    const deactivateUserEq = vi.fn().mockResolvedValue({ error: null });
+    const update = vi.fn().mockReturnValue({ eq: deactivateUserEq });
+    const upsert = vi.fn().mockResolvedValue({ error: null });
+    const activeStatusEq = vi.fn().mockResolvedValue({
+      data: [{ role_id: expectedRoleId }],
+      error: null,
+    });
+    const activeUserEq = vi.fn().mockReturnValue({ eq: activeStatusEq });
+    const activeSelect = vi.fn().mockReturnValue({ eq: activeUserEq });
+    const appMetadata = buildLiveRlsAppMetadata();
+    const getUserById = vi.fn().mockResolvedValue({
+      data: {
+        user: {
+          email: "admin.fixture@example.com",
+          app_metadata: appMetadata,
+        },
+      },
+      error: null,
+    });
+    const from = vi.fn((table: string) =>
+      table === "roles"
+        ? { select: roleSelect }
+        : { update, upsert, select: activeSelect },
+    );
+
+    await reconcileLiveRlsRole(
+      { auth: { admin: { getUserById } }, from } as never,
+      "00000000-0000-4000-8000-000000000001",
+      "admin",
+    );
+
+    expect(from).toHaveBeenNthCalledWith(1, "roles");
+    expect(from).toHaveBeenNthCalledWith(2, "user_roles");
+    expect(from).toHaveBeenNthCalledWith(3, "user_roles");
+    expect(from).toHaveBeenNthCalledWith(4, "user_roles");
+    expect(update).toHaveBeenCalledWith({ is_active: false });
+    expect(deactivateUserEq).toHaveBeenCalledWith(
+      "user_id",
+      "00000000-0000-4000-8000-000000000001",
+    );
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        user_id: "00000000-0000-4000-8000-000000000001",
+        role_id: expectedRoleId,
+        is_active: true,
+        expires_at: null,
+      },
+      { onConflict: "user_id,role_id" },
+    );
+    expect(activeUserEq).toHaveBeenCalledWith(
+      "user_id",
+      "00000000-0000-4000-8000-000000000001",
+    );
+    expect(activeStatusEq).toHaveBeenCalledWith("is_active", true);
   });
 });


### PR DESCRIPTION
## Summary

- reconcile each newly created hosted RLS fixture actor to its exact authoritative role before profile provisioning
- fail closed unless the actor is an eligible synthetic user and its complete active role set is the expected singleton
- keep negative RPC guardrails raw and leave production RPC, policies, grants, auth behavior, and workflows unchanged

## Routing and risk

- Linear: WIN-217
- classification: high-risk human-reviewed
- lane: critical
- triggering surface: test-only service-role writes to tenant-sensitive `user_roles`
- human review and merge required

## Scope

- allowed: hosted RLS test helpers, RLS tests, focused helper contract, existing BCBA handoff evidence
- non-goals: migrations, functions, RLS policies, grants, workflows, production auth/role behavior, tenant derivation, or real user/data mutation
- stop condition: any need to alter a production authorization boundary or weaken the service-only profile RPC

## Verification

- red/green role-reconciliation contract: 4/4 passed
- focused hosted-RLS suite: 9 files, 158/158 passed
- `npm run ci:check-focused`: passed
- `npm run validate:tenant`: passed
- `npm run lint -- --quiet`: passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `git diff --check`: passed
- code review: actor-scoping assertion gap identified and closed; no remaining implementation P1/P2
- security review: no P1/P2

## Hosted evidence

Trusted main Supabase Validate run `29343649846` passed 2557 tests before all six live RLS suites failed the composite service-only profile guard with `42501 One active synthetic RLS role is required`. This change makes authoritative fixture role state deterministic and verifies it before invoking the unchanged RPC. Trusted post-merge Supabase Validate remains decisive.
