### PR TITLE
db: expose hosted RLS fixture guard stage

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -361,3 +361,20 @@ PR validation also exposed saturated hosted booking data: run `29291802604` foun
   - blocked checks: trusted live suites require CI secrets and remain decisive.
   - result: `human-review-ready`; pending PR CI, human merge, and trusted hosted validation.
   - residual risk: the previous RPC error combines multiple predicates, so only the trusted run can confirm authoritative role state was the remaining failed precondition.
+
+### Hosted RLS profile-guard predicate diagnostics
+
+- trusted main Supabase Validate run `29345329595` passed 2558 tests after PR #786 reconciled and read back each synthetic actor's exact authoritative role, but the same six hosted suites still failed with the RPC's composite `42501`.
+- live `pg_get_functiondef` inspection confirmed production matches the committed function; Auth audit evidence confirms dotted synthetic emails, and the harness confirms the expected active/non-expiring role singleton before the RPC. The remaining unobserved boundary is the database view of `auth.users.raw_app_meta_data` marker/expiry.
+- classification: `high-risk human-reviewed`; lane: `critical`; the forward migration replaces only the existing service-only function body with staged fail-closed checks.
+- bounded change:
+  - preserve the function signature, `SECURITY DEFINER`, empty search path, service-role-only ACL, existing role allowlist/cardinality, authoritative tenant derivation, profile update, bypass reset, and return semantics.
+  - separate actor existence, dotted email, raw marker, parseable/future expiry, active role cardinality, and allowed-role checks.
+  - return only stage-specific generic `42501` messages plus boolean/count detail; never include actor IDs, emails, metadata, role values, or tenant IDs.
+- non-goals: no policy, RLS, table, role taxonomy, caller grant, workflow, production-user mutation, or acceptance-criteria relaxation; this diagnostic migration does not yet claim to repair the hidden actor-state defect.
+- verification card:
+  - required checks: RED/green migration contract; focused hosted-RLS tests; policy; lint; typecheck; `test:ci`; tenant validation; build; independent code/test/security review; human review; exact migration promotion; live ACL/function-definition verification; trusted Supabase Validate.
+  - executed checks: the generated empty migration failed 4/4 contract tests before implementation and passed 4/4 after; nine focused files passed 159/159; the 14 server contracts affected by the missing local public test configuration pass with explicit synthetic values; policy and migration governance passed; tenant validation passed; lint passed; typecheck passed; build passed; live production definition/ACL inspection confirmed the predecessor function is deployed and service-role-only; final specification, architecture, code, test, and security review found no remaining P1/P2 after the tenant-read and contract-strengthening fixes.
+  - blocked checks: local `test:ci` reached the unrelated server contract group but 15 assertions failed because this isolated worktree has no `VITE_SUPABASE_URL`; trusted Linux PR CI is authoritative. Runtime compilation, exact migration application, ACL readback, and the six live suites require the protected hosted project and human-reviewed promotion.
+  - result: `human-review-ready-with-blocked-checks`; pending PR CI, human merge, migration promotion, and trusted hosted evidence.
+  - residual risk: the next hosted failure will identify the rejected database predicate but may require one more contained repair; no BCBA lifecycle proof is complete until hosted RLS validation and the final production-style acceptance both pass.

--- a/supabase/migrations/20260714153227_decompose_ci_rls_fixture_profile_guard.sql
+++ b/supabase/migrations/20260714153227_decompose_ci_rls_fixture_profile_guard.sql
@@ -1,0 +1,207 @@
+-- @migration-intent: Decompose the service-only synthetic RLS profile guard so trusted CI can identify the rejected prerequisite without exposing actor data.
+-- @migration-dependencies: public.provision_ci_rls_fixture_profile(uuid,uuid),public.profiles,public.user_roles,public.roles,public.therapists,public.clients
+-- @migration-rollback: Reapply the function body from 20260714130000_provision_ci_rls_fixture_profile.sql.
+
+begin;
+
+create or replace function public.provision_ci_rls_fixture_profile(
+  p_user_id uuid,
+  p_organization_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  actor_email text;
+  actor_marker_ok boolean := false;
+  actor_expiry_text text;
+  email_shape_ok boolean := false;
+  actor_unexpired boolean := false;
+  active_role_count integer := 0;
+  distinct_role_count integer := 0;
+  allowed_roles_ok boolean := false;
+  selected_role_name text;
+  resolved_role public.role_type;
+  resolved_organization_id uuid;
+  updated_rows integer;
+begin
+  if p_user_id is null or p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Synthetic RLS user and organization are required';
+  end if;
+
+  select
+    u.email,
+    u.raw_app_meta_data ->> 'ci_rls_fixture' = 'true',
+    u.raw_app_meta_data ->> 'ci_rls_expires_at'
+  into
+    actor_email,
+    actor_marker_ok,
+    actor_expiry_text
+  from auth.users u
+  where u.id = p_user_id;
+
+  if not found then
+    raise exception using
+      errcode = '42501',
+      message = 'Synthetic RLS actor is missing',
+      detail = format(
+        'email_shape=%s marker=%s unexpired=%s active_role_count=%s distinct_role_count=%s allowed_roles=%s',
+        email_shape_ok, actor_marker_ok, actor_unexpired, active_role_count, distinct_role_count, allowed_roles_ok
+      );
+  end if;
+
+  email_shape_ok := coalesce(lower(actor_email) like '%.%@example.com', false);
+  if not email_shape_ok then
+    raise exception using
+      errcode = '42501',
+      message = 'Synthetic RLS actor email is not eligible',
+      detail = format(
+        'email_shape=%s marker=%s unexpired=%s active_role_count=%s distinct_role_count=%s allowed_roles=%s',
+        email_shape_ok, actor_marker_ok, actor_unexpired, active_role_count, distinct_role_count, allowed_roles_ok
+      );
+  end if;
+
+  if not coalesce(actor_marker_ok, false) then
+    raise exception using
+      errcode = '42501',
+      message = 'Synthetic RLS actor marker is required',
+      detail = format(
+        'email_shape=%s marker=%s unexpired=%s active_role_count=%s distinct_role_count=%s allowed_roles=%s',
+        email_shape_ok, actor_marker_ok, actor_unexpired, active_role_count, distinct_role_count, allowed_roles_ok
+      );
+  end if;
+
+  if actor_expiry_text is null then
+    raise exception using
+      errcode = '42501',
+      message = 'Synthetic RLS actor expiry is invalid',
+      detail = format(
+        'email_shape=%s marker=%s unexpired=%s active_role_count=%s distinct_role_count=%s allowed_roles=%s',
+        email_shape_ok, actor_marker_ok, actor_unexpired, active_role_count, distinct_role_count, allowed_roles_ok
+      );
+  end if;
+
+  begin
+    actor_unexpired := actor_expiry_text::timestamptz > now();
+  exception
+    when invalid_datetime_format or datetime_field_overflow then
+      raise exception using
+        errcode = '42501',
+        message = 'Synthetic RLS actor expiry is invalid',
+        detail = format(
+          'email_shape=%s marker=%s unexpired=%s active_role_count=%s distinct_role_count=%s allowed_roles=%s',
+          email_shape_ok, actor_marker_ok, actor_unexpired, active_role_count, distinct_role_count, allowed_roles_ok
+        );
+  end;
+
+  if not actor_unexpired then
+    raise exception using
+      errcode = '42501',
+      message = 'Synthetic RLS actor marker is expired',
+      detail = format(
+        'email_shape=%s marker=%s unexpired=%s active_role_count=%s distinct_role_count=%s allowed_roles=%s',
+        email_shape_ok, actor_marker_ok, actor_unexpired, active_role_count, distinct_role_count, allowed_roles_ok
+      );
+  end if;
+
+  select
+    count(*)::integer,
+    count(distinct r.name)::integer,
+    coalesce(bool_and(r.name in ('client', 'therapist', 'admin')), false),
+    min(r.name)
+  into
+    active_role_count,
+    distinct_role_count,
+    allowed_roles_ok,
+    selected_role_name
+  from public.user_roles ur
+  join public.roles r on r.id = ur.role_id
+  where ur.user_id = p_user_id
+    and coalesce(ur.is_active, true) = true
+    and (ur.expires_at is null or ur.expires_at > now());
+
+  if distinct_role_count = 0 then
+    raise exception using
+      errcode = '42501',
+      message = 'Synthetic RLS actor has no active role',
+      detail = format(
+        'email_shape=%s marker=%s unexpired=%s active_role_count=%s distinct_role_count=%s allowed_roles=%s',
+        email_shape_ok, actor_marker_ok, actor_unexpired, active_role_count, distinct_role_count, allowed_roles_ok
+      );
+  end if;
+
+  if distinct_role_count <> 1 then
+    raise exception using
+      errcode = '42501',
+      message = 'Synthetic RLS actor must have exactly one active role',
+      detail = format(
+        'email_shape=%s marker=%s unexpired=%s active_role_count=%s distinct_role_count=%s allowed_roles=%s',
+        email_shape_ok, actor_marker_ok, actor_unexpired, active_role_count, distinct_role_count, allowed_roles_ok
+      );
+  end if;
+
+  if not allowed_roles_ok then
+    raise exception using
+      errcode = '42501',
+      message = 'Synthetic RLS actor role is not allowed',
+      detail = format(
+        'email_shape=%s marker=%s unexpired=%s active_role_count=%s distinct_role_count=%s allowed_roles=%s',
+        email_shape_ok, actor_marker_ok, actor_unexpired, active_role_count, distinct_role_count, allowed_roles_ok
+      );
+  end if;
+
+  resolved_role := selected_role_name::public.role_type;
+
+  if resolved_role = 'therapist'::public.role_type then
+    select t.organization_id
+    into resolved_organization_id
+    from public.therapists t
+    where t.id = p_user_id
+      and t.deleted_at is null;
+  elsif resolved_role = 'client'::public.role_type then
+    select c.organization_id
+    into resolved_organization_id
+    from public.clients c
+    where c.id = p_user_id
+      and c.deleted_at is null;
+  elsif resolved_role = 'admin'::public.role_type then
+    select public.get_organization_id_from_metadata(u.raw_user_meta_data)
+    into resolved_organization_id
+    from auth.users u
+    where u.id = p_user_id;
+  end if;
+
+  if resolved_organization_id is null or resolved_organization_id <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Synthetic RLS actor organization mismatch';
+  end if;
+
+  perform set_config('app.bypass_profile_role_guard', 'on', true);
+  update public.profiles
+  set role = resolved_role,
+      organization_id = resolved_organization_id,
+      is_active = true,
+      updated_at = now()
+  where id = p_user_id;
+  get diagnostics updated_rows = row_count;
+  perform set_config('app.bypass_profile_role_guard', 'off', true);
+
+  if updated_rows <> 1 then
+    raise exception using errcode = 'P0002', message = 'Synthetic RLS profile is missing';
+  end if;
+
+  return resolved_organization_id;
+exception
+  when others then
+    perform set_config('app.bypass_profile_role_guard', 'off', true);
+    raise;
+end;
+$$;
+
+revoke execute on function public.provision_ci_rls_fixture_profile(uuid, uuid) from public;
+revoke execute on function public.provision_ci_rls_fixture_profile(uuid, uuid) from anon;
+revoke execute on function public.provision_ci_rls_fixture_profile(uuid, uuid) from authenticated;
+grant execute on function public.provision_ci_rls_fixture_profile(uuid, uuid) to service_role;
+
+commit;

--- a/tests/integration/provision-ci-rls-fixture-profile-migration.test.ts
+++ b/tests/integration/provision-ci-rls-fixture-profile-migration.test.ts
@@ -3,19 +3,36 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const migration = readFileSync(
-  resolve("supabase/migrations/20260714130000_provision_ci_rls_fixture_profile.sql"),
+  resolve("supabase/migrations/20260714153227_decompose_ci_rls_fixture_profile_guard.sql"),
   "utf8",
 );
+const executableMigration = migration.replace(/--.*$/gm, "");
 
 describe("service-only synthetic RLS fixture profile provisioning", () => {
   it("requires an expiring service-created actor and one active authoritative role", () => {
-    expect(migration).toMatch(/raw_app_meta_data ->> 'ci_rls_fixture' = 'true'/i);
-    expect(migration).toMatch(/raw_app_meta_data ->> 'ci_rls_expires_at'/i);
-    expect(migration).toMatch(/from public\.user_roles/i);
-    expect(migration).toMatch(/join public\.roles/i);
-    expect(migration).toMatch(/coalesce\(ur\.is_active, true\) = true/i);
-    expect(migration).toMatch(/count\(distinct r\.name\) = 1/i);
-    expect(migration).toMatch(/bool_and\(r\.name in \('client', 'therapist', 'admin'\)\)/i);
+    expect(executableMigration).toMatch(/select\s+u\.email,\s+u\.raw_app_meta_data ->> 'ci_rls_fixture' = 'true',\s+u\.raw_app_meta_data ->> 'ci_rls_expires_at'\s+into\s+actor_email,\s+actor_marker_ok,\s+actor_expiry_text\s+from auth\.users u\s+where u\.id = p_user_id/i);
+    expect(executableMigration).toMatch(/lower\(actor_email\) like '%\.%@example\.com'/i);
+    expect(executableMigration).toMatch(/from public\.user_roles/i);
+    expect(executableMigration).toMatch(/join public\.roles/i);
+    expect(executableMigration).toMatch(/coalesce\(ur\.is_active, true\) = true/i);
+    expect(executableMigration).toMatch(/count\(distinct r\.name\)::integer/i);
+    expect(executableMigration).toMatch(/bool_and\(r\.name in \('client', 'therapist', 'admin'\)\)/i);
+    expect(executableMigration).toMatch(/if not found then\s*raise exception using[\s\S]*?message = 'Synthetic RLS actor is missing'[\s\S]*?end if;/i);
+    expect(executableMigration).toMatch(/email_shape_ok := coalesce\([\s\S]*?;\s*if not email_shape_ok then\s*raise exception using[\s\S]*?message = 'Synthetic RLS actor email is not eligible'[\s\S]*?end if;/i);
+    expect(executableMigration).toMatch(/if not coalesce\(actor_marker_ok, false\) then\s*raise exception using[\s\S]*?message = 'Synthetic RLS actor marker is required'[\s\S]*?end if;/i);
+    expect(executableMigration).toMatch(/if actor_expiry_text is null then\s*raise exception using[\s\S]*?message = 'Synthetic RLS actor expiry is invalid'[\s\S]*?end if;/i);
+    expect(executableMigration).toMatch(/begin\s*actor_unexpired := actor_expiry_text::timestamptz > now\(\);\s*exception\s*when invalid_datetime_format or datetime_field_overflow then\s*raise exception using[\s\S]*?message = 'Synthetic RLS actor expiry is invalid'[\s\S]*?end;/i);
+    expect(executableMigration).toMatch(/if not actor_unexpired then\s*raise exception using[\s\S]*?message = 'Synthetic RLS actor marker is expired'[\s\S]*?end if;/i);
+    expect(executableMigration).toMatch(/if distinct_role_count = 0 then\s*raise exception using[\s\S]*?message = 'Synthetic RLS actor has no active role'[\s\S]*?end if;/i);
+    expect(executableMigration).toMatch(/if distinct_role_count <> 1 then\s*raise exception using[\s\S]*?message = 'Synthetic RLS actor must have exactly one active role'[\s\S]*?end if;/i);
+    expect(executableMigration).toMatch(/if not allowed_roles_ok then\s*raise exception using[\s\S]*?message = 'Synthetic RLS actor role is not allowed'[\s\S]*?end if;/i);
+  });
+
+  it("reports only non-sensitive staged predicate evidence", () => {
+    expect(migration).toMatch(/email_shape=%s marker=%s unexpired=%s active_role_count=%s distinct_role_count=%s allowed_roles=%s/i);
+    expect(migration).not.toMatch(/detail[\s\S]{0,200}p_user_id/i);
+    expect(migration).not.toMatch(/detail[\s\S]{0,200}actor_email/i);
+    expect(migration).not.toMatch(/detail[\s\S]{0,200}raw_app_meta_data/i);
   });
 
   it("validates tenant ownership from the role-specific authoritative record", () => {
@@ -26,12 +43,21 @@ describe("service-only synthetic RLS fixture profile provisioning", () => {
   });
 
   it("uses the profile guard bypass and remains service-role only", () => {
+    expect(migration).toMatch(/security definer/i);
+    expect(migration).toMatch(/set search_path = ''/i);
     expect(migration).toMatch(/set_config\('app\.bypass_profile_role_guard', 'on', true\)/i);
     expect(migration).toMatch(/if updated_rows <> 1 then/i);
     expect(migration).toMatch(/when others then[\s\S]*set_config\('app\.bypass_profile_role_guard', 'off', true\)/i);
-    expect(migration).toMatch(/revoke execute on function public\.provision_ci_rls_fixture_profile\(uuid, uuid\) from public/i);
-    expect(migration).toMatch(/from anon/i);
-    expect(migration).toMatch(/from authenticated/i);
-    expect(migration).toMatch(/grant execute on function public\.provision_ci_rls_fixture_profile\(uuid, uuid\) to service_role/i);
+    expect(executableMigration).toMatch(/revoke execute on function public\.provision_ci_rls_fixture_profile\(uuid, uuid\) from public;/i);
+    expect(executableMigration).toMatch(/revoke execute on function public\.provision_ci_rls_fixture_profile\(uuid, uuid\) from anon;/i);
+    expect(executableMigration).toMatch(/revoke execute on function public\.provision_ci_rls_fixture_profile\(uuid, uuid\) from authenticated;/i);
+    const grantStatements = [
+      ...executableMigration.matchAll(
+        /grant\s+execute\s+on\s+function\s+public\.provision_ci_rls_fixture_profile\(uuid, uuid\)[\s\S]*?;/gi,
+      ),
+    ].map((match) => match[0].replace(/\s+/g, " ").trim().toLowerCase());
+    expect(grantStatements).toEqual([
+      "grant execute on function public.provision_ci_rls_fixture_profile(uuid, uuid) to service_role;",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- replace the existing service-only synthetic profile RPC with equivalent staged fail-closed checks
- expose only generic rejection stages and boolean/count detail so trusted hosted CI can identify the hidden predicate
- preserve the RPC signature, role/tenant acceptance set, profile update, bypass reset, empty search path, and service-role-only ACL

## Routing and scope

- Linear: WIN-217
- classification: high-risk human-reviewed
- lane: critical
- triggering path: `supabase/migrations/**` and a tenant-sensitive `SECURITY DEFINER` RPC
- human review and merge required

Non-goals: no RLS/policy/table/role-taxonomy/workflow changes, no caller grant expansion, no production-user mutation, and no authorization predicate relaxation. This migration is diagnostic and does not yet claim the hosted actor-state defect is repaired.

## Evidence

Trusted main Supabase Validate run `29345329595` passed 2558 tests but the same six hosted suites failed with the predecessor's composite `42501`. Production `pg_get_functiondef` and ACL inspection match the predecessor migration; harness evidence already proves dotted synthetic emails and an exact expected active/non-expiring role singleton. The raw database Auth marker/expiry projection remains the hidden boundary.

## Verification card

- migration contract: RED 4/4 against generated empty migration; GREEN 4/4 after implementation
- focused hosted-RLS paths: 9 files, 159/159 passed
- `npm run ci:check-focused`: passed, including migration governance and privileged-grant static checks
- `npm run validate:tenant`: passed
- `npm run lint -- --quiet`: passed
- `npm run typecheck`: passed
- `npm run build`: passed
- missing-public-config server contracts: 14/14 passed with explicit synthetic public values
- `git diff --check`: passed
- specification, architecture, code, test, and security reviews: no remaining P1/P2

Blocked locally: full `npm run test:ci` reached 15 unrelated server-contract failures because this isolated worktree has no `VITE_SUPABASE_URL`; the affected file passes 14/14 with synthetic public configuration. Trusted Linux PR CI is authoritative. PostgreSQL compilation, exact migration promotion, live ACL/function-definition readback, and hosted RLS execution remain post-review gates.

## Residual risk

The next trusted hosted run will identify the rejected predicate and may require one more contained repair. The BCBA production-style acceptance mission remains incomplete until all six hosted RLS suites and the final BCBA lifecycle proof pass.
