### PR TITLE
test: use wall clock for hosted RLS fixtures

### DIFF
--- a/src/tests/security/ciRlsFixtureMetadata.ts
+++ b/src/tests/security/ciRlsFixtureMetadata.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { vi } from 'vitest';
 
 export type CiRlsAppMetadata = {
   ci_rls_fixture: true;
@@ -7,9 +8,13 @@ export type CiRlsAppMetadata = {
 
 export type CiRlsFixtureRole = 'admin' | 'therapist' | 'client';
 
+const getRlsWallClockNow = (): number => vi.getRealSystemTime();
+
 export const buildCiRlsAppMetadata = (): CiRlsAppMetadata => ({
   ci_rls_fixture: true,
-  ci_rls_expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  // The shared Vitest setup freezes Date for deterministic tests. Hosted
+  // Postgres uses wall-clock time, so fixture expiry must use the real clock.
+  ci_rls_expires_at: new Date(getRlsWallClockNow() + 60 * 60 * 1000).toISOString(),
 });
 
 export const persistCiRlsAppMetadata = async (
@@ -31,7 +36,7 @@ export const persistCiRlsAppMetadata = async (
 
   const persisted = readResult.data.user.app_metadata;
   const expiresAt = Date.parse(String(persisted.ci_rls_expires_at ?? ''));
-  if (persisted.ci_rls_fixture !== true || !Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+  if (persisted.ci_rls_fixture !== true || !Number.isFinite(expiresAt) || expiresAt <= getRlsWallClockNow()) {
     throw new Error('Synthetic RLS actor metadata was not persisted with an unexpired marker');
   }
 };
@@ -52,7 +57,7 @@ export const reconcileCiRlsFixtureRole = async (
     !/^.+\..+@example\.com$/i.test(actor.email ?? '')
     || actor.app_metadata.ci_rls_fixture !== true
     || !Number.isFinite(expiresAt)
-    || expiresAt <= Date.now()
+    || expiresAt <= getRlsWallClockNow()
   ) {
     throw new Error('Synthetic RLS actor is not eligible for role reconciliation');
   }
@@ -96,7 +101,7 @@ export const reconcileCiRlsFixtureRole = async (
     throw activeResult.error;
   }
 
-  const now = Date.now();
+  const now = getRlsWallClockNow();
   const activeRoleIds = (activeResult.data ?? [])
     .filter((row) => !row.expires_at || Date.parse(row.expires_at) > now)
     .map((row) => row.role_id);

--- a/tests/integration/liveRlsHarness.unit.test.ts
+++ b/tests/integration/liveRlsHarness.unit.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("live RLS harness actor metadata", () => {
   it("marks the actor as an expiring service-created fixture", () => {
-    const before = Date.now();
+    const before = vi.getRealSystemTime();
     const metadata = buildLiveRlsAppMetadata();
     expect(metadata.ci_rls_fixture).toBe(true);
     expect(new Date(metadata.ci_rls_expires_at).getTime()).toBeGreaterThan(before);
@@ -47,6 +47,26 @@ describe("live RLS harness actor metadata", () => {
         { auth: { admin: { updateUserById, getUserById } } } as never,
         "00000000-0000-4000-8000-000000000001",
         buildLiveRlsAppMetadata(),
+      ),
+    ).rejects.toThrow("Synthetic RLS actor metadata was not persisted with an unexpired marker");
+  });
+
+  it("rejects a marker expired against the real wall clock", async () => {
+    const expiredMetadata = {
+      ...buildLiveRlsAppMetadata(),
+      ci_rls_expires_at: new Date(vi.getRealSystemTime() - 60_000).toISOString(),
+    };
+    const updateUserById = vi.fn().mockResolvedValue({ data: { user: {} }, error: null });
+    const getUserById = vi.fn().mockResolvedValue({
+      data: { user: { app_metadata: expiredMetadata } },
+      error: null,
+    });
+
+    await expect(
+      persistLiveRlsAppMetadata(
+        { auth: { admin: { updateUserById, getUserById } } } as never,
+        "00000000-0000-4000-8000-000000000001",
+        expiredMetadata,
       ),
     ).rejects.toThrow("Synthetic RLS actor metadata was not persisted with an unexpired marker");
   });
@@ -110,5 +130,28 @@ describe("live RLS harness actor metadata", () => {
       "00000000-0000-4000-8000-000000000001",
     );
     expect(activeStatusEq).toHaveBeenCalledWith("is_active", true);
+  });
+
+  it("rejects a role fixture expired against the real wall clock", async () => {
+    const getUserById = vi.fn().mockResolvedValue({
+      data: {
+        user: {
+          email: "admin.fixture@example.com",
+          app_metadata: {
+            ...buildLiveRlsAppMetadata(),
+            ci_rls_expires_at: new Date(vi.getRealSystemTime() - 60_000).toISOString(),
+          },
+        },
+      },
+      error: null,
+    });
+
+    await expect(
+      reconcileLiveRlsRole(
+        { auth: { admin: { getUserById } }, from: vi.fn() } as never,
+        "00000000-0000-4000-8000-000000000001",
+        "admin",
+      ),
+    ).rejects.toThrow("Synthetic RLS actor is not eligible for role reconciliation");
   });
 });


### PR DESCRIPTION
## Summary
- use Vitest real wall-clock time when generating hosted CI RLS actor expiry markers
- use the same clock for metadata and role readback validation
- add regression tests for markers expired against wall clock but still future relative to the frozen test clock

## Evidence
- `tests/integration/liveRlsHarness.unit.test.ts`: 6/6 passed
- `npm run typecheck`: passed
- `npm run ci:check-focused`: passed
- `git diff --check`: passed

## Hosted failure addressed
Trusted main Supabase Validate run `29348531383` reached the diagnostic RPC and reported `marker=true`, `unexpired=false`, with all six suites failing. The shared Vitest setup freezes `Date` to 2025 while hosted Postgres is in 2026; this patch aligns the fixture metadata and validators with the real wall clock.

WIN-217 follow-up.