### PR TITLE
ci: trigger Supabase validation for RLS helper changes

### DIFF
--- a/.github/workflows/supabase-validate.yml
+++ b/.github/workflows/supabase-validate.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/supabase-validate.yml'
       - 'supabase/migrations/**'
       - 'tests/integration/_helpers/liveRlsHarness.ts'
       - 'tests/integration/live-rls-fixture-schema.contract.test.ts'

--- a/.github/workflows/supabase-validate.yml
+++ b/.github/workflows/supabase-validate.yml
@@ -15,6 +15,8 @@ on:
       - 'supabase/migrations/**'
       - 'tests/integration/_helpers/liveRlsHarness.ts'
       - 'tests/integration/live-rls-fixture-schema.contract.test.ts'
+      - 'tests/integration/liveRlsHarness.unit.test.ts'
+      - 'src/tests/security/ciRlsFixtureMetadata.ts'
       - 'src/tests/security/rls.spec.ts'
 
 jobs:

--- a/docs/DATABASE_PIPELINE.md
+++ b/docs/DATABASE_PIPELINE.md
@@ -22,7 +22,8 @@ The repository does not create per-PR Supabase branches automatically. Branch cr
 1. Pull request touches `supabase/migrations/**`.
    - `supabase-validate.yml` runs `lint-migrations`.
    - The lint step runs `supabase db lint --project-ref "$SUPABASE_PROJECT_REF"` when a project ref is configured.
-2. Push to `main` touches `supabase/migrations/**`.
+2. Push to `main` touches `supabase/migrations/**`, the Supabase Validate workflow,
+   or the hosted RLS fixture helpers/tests.
    - `supabase-validate.yml` runs `test-main`.
    - `test-main` runs `npm test -- --run --reporter=verbose` with `RUN_DB_IT=1`.
    - `supabase-validate.yml` also runs `runtime-migration-parity` to verify newly added migration versions from the merge range exist in the runtime DB's `supabase_migrations.schema_migrations`.
@@ -49,7 +50,13 @@ The repository does not create per-PR Supabase branches automatically. Branch cr
 
 - Triggered by:
   - pull requests that touch `supabase/migrations/**` or `.github/workflows/supabase-validate.yml`
-  - pushes to `main` that touch `supabase/migrations/**`
+  - pushes to `main` that touch `supabase/migrations/**`,
+    `.github/workflows/supabase-validate.yml`,
+    `tests/integration/_helpers/liveRlsHarness.ts`,
+    `tests/integration/liveRlsHarness.unit.test.ts`,
+    `tests/integration/live-rls-fixture-schema.contract.test.ts`,
+    `src/tests/security/ciRlsFixtureMetadata.ts`, or
+    `src/tests/security/rls.spec.ts`
 - Jobs:
   - `lint-migrations` (PR only): checks migrations with Supabase CLI.
   - `test-main` (push only): runs unit/integration suites with hosted Supabase env vars and `RUN_DB_IT=1`.

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -34,10 +34,19 @@ describe("live RLS fixture schema contract", () => {
 
     expect(workflow).toContain("permissions:\n  contents: read");
     expect(pushSection).toContain(
+      "      - '.github/workflows/supabase-validate.yml'",
+    );
+    expect(pushSection).toContain(
       "      - 'tests/integration/_helpers/liveRlsHarness.ts'",
     );
     expect(pushSection).toContain(
       "      - 'tests/integration/live-rls-fixture-schema.contract.test.ts'",
+    );
+    expect(pushSection).toContain(
+      "      - 'tests/integration/liveRlsHarness.unit.test.ts'",
+    );
+    expect(pushSection).toContain(
+      "      - 'src/tests/security/ciRlsFixtureMetadata.ts'",
     );
     expect(pushSection).toContain("      - 'src/tests/security/rls.spec.ts'");
     expect(pushSection).toContain("      - main");


### PR DESCRIPTION
## Summary
- trigger the main Supabase Validate workflow when the shared hosted RLS metadata helper changes
- include its focused regression test in the push path filter

## Why
PR #788 fixed hosted RLS fixture expiry, but the workflow did not list `src/tests/security/ciRlsFixtureMetadata.ts` in `push.paths`, so no trusted Supabase Validate run was created after the fix merged.

## Verification
- `npm run ci:check-focused` passed
- `git diff --check` passed
- trigger scope is limited to the existing Supabase Validate workflow

WIN-217 follow-up.