### PR TITLE
test: require exact lifecycle goal note coverage

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -378,3 +378,35 @@ PR validation also exposed saturated hosted booking data: run `29291802604` foun
   - blocked checks: local `test:ci` reached the unrelated server contract group but 15 assertions failed because this isolated worktree has no `VITE_SUPABASE_URL`; trusted Linux PR CI is authoritative. Runtime compilation, exact migration application, ACL readback, and the six live suites require the protected hosted project and human-reviewed promotion.
   - result: `human-review-ready-with-blocked-checks`; pending PR CI, human merge, migration promotion, and trusted hosted evidence.
   - residual risk: the next hosted failure will identify the rejected database predicate but may require one more contained repair; no BCBA lifecycle proof is complete until hosted RLS validation and the final production-style acceptance both pass.
+
+### PR #790 exact lifecycle goal-note coverage follow-up
+
+- branch: `codex/win-217-no-show-lifecycle`
+- classification: `low-risk autonomous`
+- lane: `standard`
+- hosted failure: CI run `29352677270`, job `87153978141`, passed preflight and no-show, then the completed lifecycle timed out without observing `sessions-complete` while the modal remained open.
+- root cause: the harness asserted only that at least one `session_goals` row and one `client_session_notes` row existed. Production close readiness requires a non-empty persisted `goal_notes` entry for every linked session goal; filling an unsaved modal textarea did not satisfy that contract.
+- bounded fix:
+  - guarantee the specifically booked goal is linked without removing unrelated existing session goals.
+  - seed one synthetic note payload covering every unique linked goal.
+  - validate exact persisted per-goal coverage across all note rows before and after terminal close.
+  - remove the UI-only textarea filler introduced by the first PR #790 attempt.
+- non-goals: no production UI, Schedule readiness, API/server, auth, workflow, migration, RLS, tenant-policy, timeout, or fallback-policy changes.
+
+Verification card:
+
+- required checks: focused lifecycle tests; policy; lint; typecheck; `test:ci`; build; tier-0 routes; `verify:local`; independent review; hosted auth browser smoke.
+- executed checks:
+  - RED proof: the two helper suites produced 6 failures / 2 passes against the old count-only and single-goal behavior.
+  - focused lifecycle tests -> pass, 3 files / 23 tests.
+  - `npm run ci:check-focused` -> pass.
+  - `npm run lint` -> pass.
+  - `npm run typecheck` -> pass.
+  - `npm run build` -> pass.
+  - `npm run test:routes:tier0` -> pass, 7 specs / 220 tests.
+  - independent code review -> no actionable findings; strict CI remains fail-closed.
+- blocked checks:
+  - `npm run verify:local` reaches unrelated local `test:ci` failures before coverage/build/browser stages: the existing Windows workflow-text parser assertion receives an empty provision step, and Schedule event tests exhibit suite-order duplicate-modal state. The Schedule event file passes alone, 5/5; build and tier-0 were run separately and pass. The prior Linux PR unit job passed on the unchanged workflow state.
+  - secret-backed `playwright:session-complete` and full auth browser smoke require hosted CI credentials.
+- result: `review-ready-with-blocked-checks`, pending fresh PR #790 hosted CI.
+- residual risk: only the hosted strict lifecycle can prove the modal now emits and receives `sessions-complete`; if exact persisted coverage is logged before click but no request is emitted, stop and add bounded request/readiness diagnostics rather than increasing timeouts.

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -1164,6 +1164,32 @@ export const isExpectedAlreadyStartedResponse = (
   }
 };
 
+/**
+ * The lifecycle fixture seeds the required note rows with the service role before
+ * reopening the Schedule modal. React Hook Form can still initialize before those
+ * rows are reflected in the modal, so terminal submission may fail client-side
+ * validation without issuing the sessions-complete request. Fill only empty
+ * per-goal fields; never overwrite a note already present in the UI.
+ */
+export async function fillMissingLifecycleGoalNotes(
+  page: Page,
+  noteText = "Synthetic lifecycle smoke note",
+): Promise<number> {
+  const noteFields = page.locator('textarea[id^="goal-note-"]');
+  const fieldCount = await noteFields.count();
+  let filledCount = 0;
+  for (let index = 0; index < fieldCount; index += 1) {
+    const field = noteFields.nth(index);
+    const currentValue = await field.inputValue();
+    if (currentValue.trim().length > 0) {
+      continue;
+    }
+    await field.fill(noteText);
+    filledCount += 1;
+  }
+  return filledCount;
+}
+
 /** Same contract as UI/`sessions-start` + RPC fallback; used when the modal does not surface a `sessions-start` response in time. */
 async function invokeStartSessionFallback(token: string, ids: LifecycleIds, strictMode: boolean): Promise<void> {
   const payload: SessionStartPayload = {
@@ -1664,6 +1690,7 @@ async function markTerminalViaScheduleModal(
   });
   const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
   await page.locator("#status-select").selectOption(terminalStatus);
+  await fillMissingLifecycleGoalNotes(page);
   page.once("dialog", (dialog) => {
     void dialog.accept().catch(() => undefined);
   });

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -1164,32 +1164,6 @@ export const isExpectedAlreadyStartedResponse = (
   }
 };
 
-/**
- * The lifecycle fixture seeds the required note rows with the service role before
- * reopening the Schedule modal. React Hook Form can still initialize before those
- * rows are reflected in the modal, so terminal submission may fail client-side
- * validation without issuing the sessions-complete request. Fill only empty
- * per-goal fields; never overwrite a note already present in the UI.
- */
-export async function fillMissingLifecycleGoalNotes(
-  page: Page,
-  noteText = "Synthetic lifecycle smoke note",
-): Promise<number> {
-  const noteFields = page.locator('textarea[id^="goal-note-"]');
-  const fieldCount = await noteFields.count();
-  let filledCount = 0;
-  for (let index = 0; index < fieldCount; index += 1) {
-    const field = noteFields.nth(index);
-    const currentValue = await field.inputValue();
-    if (currentValue.trim().length > 0) {
-      continue;
-    }
-    await field.fill(noteText);
-    filledCount += 1;
-  }
-  return filledCount;
-}
-
 /** Same contract as UI/`sessions-start` + RPC fallback; used when the modal does not surface a `sessions-start` response in time. */
 async function invokeStartSessionFallback(token: string, ids: LifecycleIds, strictMode: boolean): Promise<void> {
   const payload: SessionStartPayload = {
@@ -1276,11 +1250,9 @@ async function invokeStartSessionFallback(token: string, ids: LifecycleIds, stri
 
 const seedSessionGoalNotesViaServiceRole = async ({
   sessionId,
-  goalId,
   actorUserId,
 }: {
   sessionId: string;
-  goalId: string;
   actorUserId: string;
 }): Promise<void> => {
   const supabaseUrl = getEnv("VITE_SUPABASE_URL");
@@ -1300,6 +1272,22 @@ const seedSessionGoalNotesViaServiceRole = async ({
     .single();
   if (sessionError || !sessionRow) {
     throw new Error(`Unable to load session for lifecycle note seed: ${sessionError?.message ?? "missing row"}`);
+  }
+
+  const { data: sessionGoalRows, error: sessionGoalsError } = await adminClient
+    .from("session_goals")
+    .select("goal_id")
+    .eq("session_id", sessionId);
+  if (sessionGoalsError) {
+    throw new Error(`Unable to load lifecycle session goals for note seed: ${sessionGoalsError.message}`);
+  }
+  const goalIds = Array.from(new Set(
+    (sessionGoalRows ?? [])
+      .map((row) => row.goal_id)
+      .filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0),
+  ));
+  if (goalIds.length === 0) {
+    throw new Error("Unable to seed lifecycle session goal notes: session has no goal membership.");
   }
 
   const sessionDate =
@@ -1390,7 +1378,7 @@ const seedSessionGoalNotesViaServiceRole = async ({
     authorizationId,
     serviceCode,
     actorUserId,
-    goalId,
+    goalIds,
     noteText: "Playwright lifecycle completed goal note",
     narrative: "Playwright lifecycle seeded session note",
   });
@@ -1401,7 +1389,7 @@ const seedSessionGoalNotesViaServiceRole = async ({
   }
 };
 
-const ensureAtLeastOneSessionGoalForLifecycle = async ({
+const ensureBookedSessionGoalForLifecycle = async ({
   sessionId,
   goalId,
 }: {
@@ -1421,6 +1409,7 @@ const ensureAtLeastOneSessionGoalForLifecycle = async ({
     .from("session_goals")
     .select("goal_id")
     .eq("session_id", sessionId)
+    .eq("goal_id", goalId)
     .limit(1);
   if (existingError) {
     throw new Error(`session_goals lookup failed: ${existingError.message}`);
@@ -1450,9 +1439,9 @@ const ensureAtLeastOneSessionGoalForLifecycle = async ({
   }
 };
 
-const fetchLifecycleArtifactCounts = async (sessionId: string): Promise<{
-  sessionGoalsCount: number;
-  clientSessionNotesCount: number;
+const fetchLifecycleArtifactCoverage = async (sessionId: string): Promise<{
+  sessionGoalIds: string[];
+  clientSessionNoteGoalNotes: unknown[];
 }> => {
   const supabaseUrl = getEnv("VITE_SUPABASE_URL");
   const serviceRole = getEnv("SUPABASE_SERVICE_ROLE_KEY");
@@ -1464,34 +1453,38 @@ const fetchLifecycleArtifactCounts = async (sessionId: string): Promise<{
     },
   });
 
-  const [{ count: sessionGoalsCount, error: sessionGoalsError }, { count: clientSessionNotesCount, error: clientSessionNotesError }] =
+  const [{ data: sessionGoalRows, error: sessionGoalsError }, { data: clientSessionNoteRows, error: clientSessionNotesError }] =
     await Promise.all([
       adminClient
         .from("session_goals")
-        .select("goal_id", { count: "exact", head: true })
+        .select("goal_id")
         .eq("session_id", sessionId),
       adminClient
         .from("client_session_notes")
-        .select("id", { count: "exact", head: true })
+        .select("goal_notes")
         .eq("session_id", sessionId),
     ]);
 
   if (sessionGoalsError) {
-    throw new Error(`Unable to count lifecycle session_goals: ${sessionGoalsError.message}`);
+    throw new Error(`Unable to load lifecycle session_goals coverage: ${sessionGoalsError.message}`);
   }
   if (clientSessionNotesError) {
-    throw new Error(`Unable to count lifecycle client_session_notes: ${clientSessionNotesError.message}`);
+    throw new Error(`Unable to load lifecycle client_session_notes coverage: ${clientSessionNotesError.message}`);
   }
 
   return {
-    sessionGoalsCount: sessionGoalsCount ?? 0,
-    clientSessionNotesCount: clientSessionNotesCount ?? 0,
+    sessionGoalIds: Array.from(new Set(
+      (sessionGoalRows ?? [])
+        .map((row) => row.goal_id)
+        .filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0),
+    )),
+    clientSessionNoteGoalNotes: (clientSessionNoteRows ?? []).map((row) => row.goal_notes),
   };
 };
 
-const assertLifecycleArtifactCounts = async (sessionId: string, stage: string): Promise<void> => {
-  const counts = await fetchLifecycleArtifactCounts(sessionId);
-  assertLifecycleSessionArtifacts(stage, counts);
+const assertLifecycleArtifactCoverage = async (sessionId: string, stage: string): Promise<void> => {
+  const coverage = await fetchLifecycleArtifactCoverage(sessionId);
+  assertLifecycleSessionArtifacts(stage, coverage);
 };
 
 const completeSessionViaApiFallback = async ({
@@ -1690,7 +1683,6 @@ async function markTerminalViaScheduleModal(
   });
   const editDialog = page.locator('[role="dialog"]').filter({ hasText: /Edit Session|Live session/i });
   await page.locator("#status-select").selectOption(terminalStatus);
-  await fillMissingLifecycleGoalNotes(page);
   page.once("dialog", (dialog) => {
     void dialog.accept().catch(() => undefined);
   });
@@ -1732,16 +1724,15 @@ async function markTerminalViaScheduleModal(
       console.warn(
         `[lifecycle] ${terminalStatus} API fallback hit SESSION_NOTES_REQUIRED; repairing smoke artifacts and retrying.`,
       );
-      await ensureAtLeastOneSessionGoalForLifecycle({
+      await ensureBookedSessionGoalForLifecycle({
         sessionId,
         goalId: ids.goalId,
       });
       await seedSessionGoalNotesViaServiceRole({
         sessionId,
-        goalId: ids.goalId,
         actorUserId,
       });
-      await assertLifecycleArtifactCounts(sessionId, "before-close");
+      await assertLifecycleArtifactCoverage(sessionId, "before-close");
       await completeSessionViaApiFallback({
         baseUrl,
         token,
@@ -1884,7 +1875,7 @@ export async function run() {
     await withStepTimeout("start-session-modal", () =>
       startSessionViaScheduleModal(activePage, scheduleUrl, booked, token, strictParityMode));
     await withStepTimeout("ensure-session-goals-after-start", () =>
-      ensureAtLeastOneSessionGoalForLifecycle({
+      ensureBookedSessionGoalForLifecycle({
         sessionId: booked.sessionId,
         goalId: booked.goalId,
       }));
@@ -1892,11 +1883,10 @@ export async function run() {
       await withStepTimeout(`seed-session-goal-notes-for-${terminalStatus}`, () =>
         seedSessionGoalNotesViaServiceRole({
           sessionId: booked.sessionId,
-          goalId: booked.goalId,
           actorUserId,
         }));
       await withStepTimeout(`assert-lifecycle-artifacts-before-${terminalStatus}`, () =>
-        assertLifecycleArtifactCounts(booked.sessionId, "before-close"));
+        assertLifecycleArtifactCoverage(booked.sessionId, "before-close"));
     }
     await withStepTimeout(`${terminalStatus}-session-modal`, () =>
       markTerminalViaScheduleModal(
@@ -1913,7 +1903,7 @@ export async function run() {
     await withStepTimeout(`assert-session-${terminalStatus}`, () =>
       assertSessionRowStatus(booked.sessionId, terminalStatus));
     await withStepTimeout(`assert-lifecycle-artifacts-after-${terminalStatus}`, () =>
-      assertLifecycleArtifactCounts(booked.sessionId, "after-close"));
+      assertLifecycleArtifactCoverage(booked.sessionId, "after-close"));
 
     const latestDir = path.resolve(process.cwd(), "artifacts", "latest");
     if (!fs.existsSync(latestDir)) {

--- a/src/scripts/__tests__/playwrightSessionLifecycleArtifacts.test.ts
+++ b/src/scripts/__tests__/playwrightSessionLifecycleArtifacts.test.ts
@@ -8,24 +8,43 @@ import {
 describe("playwrightSessionLifecycleArtifacts", () => {
   it("reports both missing artifacts when neither durable write exists", () => {
     expect(getMissingLifecycleArtifacts({
-      sessionGoalsCount: 0,
-      clientSessionNotesCount: 0,
+      sessionGoalIds: [],
+      clientSessionNoteGoalNotes: [],
     })).toEqual(["session_goals", "client_session_notes"]);
   });
 
   it("accepts the expected durable lifecycle shape", () => {
     expect(() => assertLifecycleSessionArtifacts("after-close", {
-      sessionGoalsCount: 1,
-      clientSessionNotesCount: 1,
+      sessionGoalIds: ["goal-1"],
+      clientSessionNoteGoalNotes: [{ "goal-1": "Persisted note" }],
     })).not.toThrow();
   });
 
   it("throws with the exact missing artifact names", () => {
     expect(() => assertLifecycleSessionArtifacts("before-close", {
-      sessionGoalsCount: 1,
-      clientSessionNotesCount: 0,
+      sessionGoalIds: ["goal-1"],
+      clientSessionNoteGoalNotes: [],
     })).toThrow(
       "Lifecycle smoke before-close is missing durable artifacts: client_session_notes",
     );
+  });
+
+  it("requires persisted non-empty note coverage for every session goal", () => {
+    expect(() => assertLifecycleSessionArtifacts("before-close", {
+      sessionGoalIds: ["goal-1", "goal-2"],
+      clientSessionNoteGoalNotes: [{ "goal-1": "Persisted", "goal-2": "  " }],
+    })).toThrow(
+      "Lifecycle smoke before-close is missing durable artifacts: client_session_notes.goal_notes[goal-2]",
+    );
+  });
+
+  it("accepts per-goal coverage split across multiple persisted note rows", () => {
+    expect(() => assertLifecycleSessionArtifacts("after-close", {
+      sessionGoalIds: ["goal-1", "goal-2"],
+      clientSessionNoteGoalNotes: [
+        { "goal-1": "First note" },
+        { "goal-2": "Second note" },
+      ],
+    })).not.toThrow();
   });
 });

--- a/src/scripts/__tests__/playwrightSessionLifecycleNoteSeed.test.ts
+++ b/src/scripts/__tests__/playwrightSessionLifecycleNoteSeed.test.ts
@@ -19,7 +19,7 @@ describe("buildLifecycleSessionNoteSeedPayload", () => {
         authorizationId: "auth-1",
         serviceCode: "97153",
         actorUserId: "user-1",
-        goalId: "goal-1",
+        goalIds: ["goal-1"],
       }),
     ).toEqual({
       authorization_id: "auth-1",
@@ -57,7 +57,7 @@ describe("buildLifecycleSessionNoteSeedPayload", () => {
         authorizationId: "auth-2",
         serviceCode: "H2019",
         actorUserId: "user-2",
-        goalId: "goal-2",
+        goalIds: ["goal-2"],
         noteText: "Completed through lifecycle smoke",
         narrative: "Seeded by playwright lifecycle",
       }),
@@ -69,6 +69,37 @@ describe("buildLifecycleSessionNoteSeedPayload", () => {
         end_time: "10:15:00",
         goal_notes: { "goal-2": "Completed through lifecycle smoke" },
         narrative: "Seeded by playwright lifecycle",
+      }),
+    );
+  });
+
+  it("seeds every unique session goal with a persisted note", () => {
+    expect(
+      buildLifecycleSessionNoteSeedPayload({
+        session: {
+          sessionId: "session-3",
+          organizationId: "org-3",
+          clientId: "client-3",
+          therapistId: "therapist-3",
+          sessionDate: "2026-06-12",
+          startTime: "2026-06-12T09:30:00.000Z",
+          endTime: "2026-06-12T10:15:00.000Z",
+          durationMinutes: 45,
+        },
+        authorizationId: "auth-3",
+        serviceCode: "97153",
+        actorUserId: "user-3",
+        goalIds: ["goal-2", "goal-1", "goal-2"],
+        noteText: "Lifecycle coverage",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        goal_ids: ["goal-2", "goal-1"],
+        goals_addressed: ["goal-2", "goal-1"],
+        goal_notes: {
+          "goal-2": "Lifecycle coverage",
+          "goal-1": "Lifecycle coverage",
+        },
       }),
     );
   });

--- a/src/scripts/playwrightSessionLifecycleArtifacts.ts
+++ b/src/scripts/playwrightSessionLifecycleArtifacts.ts
@@ -1,26 +1,44 @@
-export interface LifecycleSessionArtifactCounts {
-  sessionGoalsCount: number;
-  clientSessionNotesCount: number;
+export interface LifecycleSessionArtifactCoverage {
+  sessionGoalIds: string[];
+  clientSessionNoteGoalNotes: unknown[];
 }
 
 export const getMissingLifecycleArtifacts = (
-  counts: LifecycleSessionArtifactCounts,
+  coverage: LifecycleSessionArtifactCoverage,
 ): string[] => {
   const missing: string[] = [];
-  if (counts.sessionGoalsCount < 1) {
+  if (coverage.sessionGoalIds.length < 1) {
     missing.push("session_goals");
   }
-  if (counts.clientSessionNotesCount < 1) {
+  if (coverage.clientSessionNoteGoalNotes.length < 1) {
     missing.push("client_session_notes");
+    return missing;
+  }
+
+  const persistedGoalIds = new Set<string>();
+  for (const goalNotes of coverage.clientSessionNoteGoalNotes) {
+    if (!goalNotes || typeof goalNotes !== "object" || Array.isArray(goalNotes)) {
+      continue;
+    }
+    for (const [goalId, note] of Object.entries(goalNotes)) {
+      if (typeof note === "string" && note.trim().length > 0) {
+        persistedGoalIds.add(goalId);
+      }
+    }
+  }
+  for (const goalId of Array.from(new Set(coverage.sessionGoalIds))) {
+    if (!persistedGoalIds.has(goalId)) {
+      missing.push(`client_session_notes.goal_notes[${goalId}]`);
+    }
   }
   return missing;
 };
 
 export const assertLifecycleSessionArtifacts = (
   stage: string,
-  counts: LifecycleSessionArtifactCounts,
+  coverage: LifecycleSessionArtifactCoverage,
 ): void => {
-  const missing = getMissingLifecycleArtifacts(counts);
+  const missing = getMissingLifecycleArtifacts(coverage);
   if (missing.length === 0) {
     return;
   }

--- a/src/scripts/playwrightSessionLifecycleNoteSeed.ts
+++ b/src/scripts/playwrightSessionLifecycleNoteSeed.ts
@@ -71,21 +71,26 @@ export const buildLifecycleSessionNoteSeedPayload = (input: {
   authorizationId: string;
   serviceCode: string;
   actorUserId: string;
-  goalId: string;
+  goalIds: string[];
   noteText?: string;
   narrative?: string;
 }): LifecycleSessionNoteSeedPayload => {
   const noteText = input.noteText?.trim() || "Playwright lifecycle goal note";
   const narrative = input.narrative?.trim() || "Playwright lifecycle seeded session note";
+  const goalIds = Array.from(new Set(input.goalIds.filter((goalId) => goalId.length > 0)));
+  if (goalIds.length === 0) {
+    throw new Error("Unable to seed lifecycle session note without a session goal.");
+  }
+  const goalNotes = Object.fromEntries(goalIds.map((goalId) => [goalId, noteText]));
 
   return {
     authorization_id: input.authorizationId,
     client_id: input.session.clientId,
     created_by: input.actorUserId,
     end_time: toTimeOnly(input.session.endTime),
-    goal_ids: [input.goalId],
-    goal_notes: { [input.goalId]: noteText },
-    goals_addressed: [input.goalId],
+    goal_ids: goalIds,
+    goal_notes: goalNotes,
+    goals_addressed: goalIds,
     is_locked: false,
     narrative,
     organization_id: input.session.organizationId,

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   buildBookingConflictWindowFilters,
   cleanupBeforeNoResponseFailure,
   filterNonOverlappingBookingStarts,
+  fillMissingLifecycleGoalNotes,
   hasReachedLifecyclePairAttemptLimit,
   isCreateSessionButtonReady,
   isExpectedAlreadyStartedResponse,
@@ -58,6 +59,27 @@ describe("playwright session lifecycle booking starts", () => {
     expect(isExpectedAlreadyStartedResponse(false, 409, body)).toBe(false);
     expect(isExpectedAlreadyStartedResponse(true, 409, JSON.stringify({ rpcCode: "INVALID_STATUS" }))).toBe(false);
     expect(isExpectedAlreadyStartedResponse(true, 500, body)).toBe(false);
+  });
+
+  it("fills only empty per-goal note fields before terminal submission", async () => {
+    const values = ["already captured", ""];
+    const fills: Array<{ index: number; value: string }> = [];
+    const fakePage = {
+      locator: () => ({
+        count: async () => values.length,
+        nth: (index: number) => ({
+          inputValue: async () => values[index],
+          fill: async (value: string) => {
+            values[index] = value;
+            fills.push({ index, value });
+          },
+        }),
+      }),
+    } as unknown as Parameters<typeof fillMissingLifecycleGoalNotes>[0];
+
+    await expect(fillMissingLifecycleGoalNotes(fakePage, "seeded smoke note")).resolves.toBe(1);
+    expect(values).toEqual(["already captured", "seeded smoke note"]);
+    expect(fills).toEqual([{ index: 1, value: "seeded smoke note" }]);
   });
 
   it("accepts live or closed UI after ALREADY_STARTED recovery but rejects stale edit state", () => {

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -5,7 +5,6 @@ import {
   buildBookingConflictWindowFilters,
   cleanupBeforeNoResponseFailure,
   filterNonOverlappingBookingStarts,
-  fillMissingLifecycleGoalNotes,
   hasReachedLifecyclePairAttemptLimit,
   isCreateSessionButtonReady,
   isExpectedAlreadyStartedResponse,
@@ -59,27 +58,6 @@ describe("playwright session lifecycle booking starts", () => {
     expect(isExpectedAlreadyStartedResponse(false, 409, body)).toBe(false);
     expect(isExpectedAlreadyStartedResponse(true, 409, JSON.stringify({ rpcCode: "INVALID_STATUS" }))).toBe(false);
     expect(isExpectedAlreadyStartedResponse(true, 500, body)).toBe(false);
-  });
-
-  it("fills only empty per-goal note fields before terminal submission", async () => {
-    const values = ["already captured", ""];
-    const fills: Array<{ index: number; value: string }> = [];
-    const fakePage = {
-      locator: () => ({
-        count: async () => values.length,
-        nth: (index: number) => ({
-          inputValue: async () => values[index],
-          fill: async (value: string) => {
-            values[index] = value;
-            fills.push({ index, value });
-          },
-        }),
-      }),
-    } as unknown as Parameters<typeof fillMissingLifecycleGoalNotes>[0];
-
-    await expect(fillMissingLifecycleGoalNotes(fakePage, "seeded smoke note")).resolves.toBe(1);
-    expect(values).toEqual(["already captured", "seeded smoke note"]);
-    expect(fills).toEqual([{ index: 1, value: "seeded smoke note" }]);
   });
 
   it("accepts live or closed UI after ALREADY_STARTED recovery but rejects stale edit state", () => {


### PR DESCRIPTION
## Summary
- guarantee the specifically booked goal is linked without removing unrelated lifecycle fixture goals
- seed persisted note coverage for every unique `session_goals.goal_id`
- validate exact non-empty `goal_notes` coverage before and after terminal close
- remove the ineffective unsaved-textarea workaround

## Verification
- TDD red proof: 6 failed / 2 passed against the old single-goal and count-only behavior
- focused lifecycle Vitest: 23/23 passed
- `npm run ci:check-focused`: passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm run test:routes:tier0`: passed, 7 specs / 220 tests
- independent code review: no actionable findings
- `npm run verify:local`: blocked in unrelated local `test:ci` failures (existing Windows workflow-text parser assertion; suite-order Schedule modal contamination that passes 5/5 alone)

## Risk
- test-harness and helper changes only; no production UI/API, auth, workflow, migration, RLS, or timeout behavior changed
- hosted `auth-browser-smoke` and `ci-gate` are the decisive remaining proof

Linear: WIN-217