### PR TITLE
WIN-217: repair BCBA and trusted RLS validation

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -450,6 +450,7 @@ Verification card:
 PR #791 follow-up:
 
 - first PR unit run `29372715973` exposed that CI supplies Supabase secrets even when `RUN_DB_IT` is absent. Routing the RLS suites through Node unconditionally changed the ordinary mocked unit contract and produced 27 failures; this was a test-environment containment defect, not new hosted policy evidence.
-- the RLS files now use Node only when `RUN_DB_IT` is explicitly `1` or `true`; ordinary CI retains jsdom/MSW behavior, while the trusted main-only Supabase workflow already sets `RUN_DB_IT: '1'` and therefore retains real Node Auth/REST/Storage transport.
-- added a static workflow/config contract and reproduced the ordinary CI shape locally with synthetic Supabase environment values: all 124 security RLS tests passed. The four focused helper/contract files pass 38/38; lint and typecheck pass.
+- the first containment correction restored jsdom without `RUN_DB_IT`, but rerun `29373376848` proved ordinary CI still entered the hosted fixture lifecycle because `CI=true` independently enabled the suite; the real secret-backed run again produced 27 mixed live/mock failures.
+- suite execution, Node routing, and MSW passthrough now all require explicit `RUN_DB_IT`. Ordinary CI keeps static contracts but does not create hosted fixtures; the trusted main-only Supabase workflow already sets `RUN_DB_IT: '1'` and therefore retains real Node Auth/REST/Storage transport.
+- the workflow/config contract asserts all three gates share the explicit trust predicate. The four focused helper/contract files pass 38/38; lint, typecheck, and policy pass. Trusted hosted proof remains pending.
 - the PR `auth-browser-smoke` job was green only because change-scope deliberately skipped provisioning and acceptance. It is not counted as BCBA proof; the main push job remains decisive after human merge.

--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -446,3 +446,10 @@ Verification card:
   - trusted Supabase Auth/REST/Storage validation and the production-style BCBA lifecycle require protected CI credentials.
 - result: `human-review-ready-with-blocked-checks`; pending PR CI, human review, merge, trusted Supabase Validate, and main auth browser smoke.
 - residual risk: local tests cannot prove actual hosted Auth/REST/Storage transit or the fixed hosted BCBA fixture; those two trusted post-merge checks remain decisive.
+
+PR #791 follow-up:
+
+- first PR unit run `29372715973` exposed that CI supplies Supabase secrets even when `RUN_DB_IT` is absent. Routing the RLS suites through Node unconditionally changed the ordinary mocked unit contract and produced 27 failures; this was a test-environment containment defect, not new hosted policy evidence.
+- the RLS files now use Node only when `RUN_DB_IT` is explicitly `1` or `true`; ordinary CI retains jsdom/MSW behavior, while the trusted main-only Supabase workflow already sets `RUN_DB_IT: '1'` and therefore retains real Node Auth/REST/Storage transport.
+- added a static workflow/config contract and reproduced the ordinary CI shape locally with synthetic Supabase environment values: all 124 security RLS tests passed. The four focused helper/contract files pass 38/38; lint and typecheck pass.
+- the PR `auth-browser-smoke` job was green only because change-scope deliberately skipped provisioning and acceptance. It is not counted as BCBA proof; the main push job remains decisive after human merge.

--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -410,3 +410,39 @@ Verification card:
   - secret-backed `playwright:session-complete` and full auth browser smoke require hosted CI credentials.
 - result: `review-ready-with-blocked-checks`, pending fresh PR #790 hosted CI.
 - residual risk: only the hosted strict lifecycle can prove the modal now emits and receives `sessions-complete`; if exact persisted coverage is logged before click but no request is emitted, stop and add bounded request/readiness diagnostics rather than increasing timeouts.
+
+### WIN-217 BCBA provisioning and trusted RLS transport repair
+
+- branch: `codex/win-217-bcba-rls-validation-repair`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- root causes:
+  - main CI assumed the fixed BCBA therapist already had a `client_therapist_links` row, while the hosted fixture instead has one client shared by same-tenant sessions and approved authorizations.
+  - the trusted `admin_actions` test omitted the organization required by the deployed tenant-scoped policy.
+  - MSW wildcard handlers intercepted marked live Supabase REST/Auth requests, and jsdom `Blob` uploads stalled all six Storage policy tests.
+- bounded fix:
+  - deterministically resolve exactly one client from the intersection of same-org therapist sessions and approved authorizations, then retain the existing active-client tenant checks.
+  - include and assert `organization_id` in the admin action fixture.
+  - require `RUN_DB_IT`, the configured Supabase host, and an exact internal test marker before MSW passthrough; run live RLS files under Node and upload `Uint8Array` bodies.
+- non-goals: no migration, production policy, grant, workflow, runtime auth, tenant model, timeout, or real customer-data change.
+
+Verification card:
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- change type: CI smoke fixture plus database/RLS/Storage integration-test harness
+- required checks: focused RED/GREEN tests; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run validate:tenant`; `npm run build`; `npm run test:routes:tier0`; independent code, security, and Supabase review; trusted hosted Supabase Validate; main auth browser smoke.
+- executed checks:
+  - RED proof: 2 files / 7 tests failed before implementation for the missing resolver and permissive unmarked bypass.
+  - focused GREEN tests: 3 files / 28 tests passed.
+  - secretless RLS load paths: 124 security tests and 16 integration tests passed.
+  - `npm run ci:check-focused`, `npm run lint -- --quiet`, `npm run typecheck`, `npm run validate:tenant`, and `npm run build` passed.
+  - `npm run test:ci` reached 2710 passing tests; focused reruns reproduce only the two unrelated Windows baseline failures described below.
+  - tier-0 routes reached 212 passes; one spec had two preview-server 404 session-setup failures while the other six specs passed.
+  - independent code, security, and Supabase reviews found no actionable findings.
+- blocked checks:
+  - local Windows `test:ci` remains blocked by the existing CRLF-sensitive workflow-text assertion and jsdom `Blob.text()` mismatch; neither affected file changed.
+  - local tier-0 completion is blocked by transient preview-server 404s during `routes_client.cy.ts` session setup.
+  - trusted Supabase Auth/REST/Storage validation and the production-style BCBA lifecycle require protected CI credentials.
+- result: `human-review-ready-with-blocked-checks`; pending PR CI, human review, merge, trusted Supabase Validate, and main auth browser smoke.
+- residual risk: local tests cannot prove actual hosted Auth/REST/Storage transit or the fixed hosted BCBA fixture; those two trusted post-merge checks remain decisive.

--- a/scripts/provision-ci-smoke-bcba.ts
+++ b/scripts/provision-ci-smoke-bcba.ts
@@ -62,23 +62,49 @@ export interface SmokeBcbaAuthorizationInvariant {
   status?: string | null;
 }
 
-export interface SmokeBcbaClientLinkInvariant {
+export interface SmokeBcbaSessionInvariant {
   client_id?: string | null;
   therapist_id?: string | null;
   organization_id?: string | null;
 }
 
-export const assertSmokeBcbaClientLinkInvariant = (
-  link: SmokeBcbaClientLinkInvariant | null,
+export const resolveSmokeBcbaClientId = (
+  sessions: SmokeBcbaSessionInvariant[],
+  authorizations: SmokeBcbaAuthorizationInvariant[],
   expected: { therapistId: string; organizationId: string },
-): asserts link is SmokeBcbaClientLinkInvariant & { client_id: string } => {
-  if (
-    !link?.client_id
-    || link.therapist_id !== expected.therapistId
-    || link.organization_id !== expected.organizationId
-  ) {
-    throw new Error("Synthetic BCBA therapist fixture has no tenant-bound linked client.");
+): string => {
+  const sessionClientIds = new Set<string>();
+  for (const session of sessions) {
+    if (
+      !session.client_id
+      || session.therapist_id !== expected.therapistId
+      || session.organization_id !== expected.organizationId
+    ) {
+      throw new Error("Synthetic BCBA therapist fixture must resolve exactly one active tenant-bound client through sessions and authorizations.");
+    }
+    sessionClientIds.add(session.client_id);
   }
+
+  const authorizationClientIds = new Set<string>();
+  for (const authorization of authorizations) {
+    if (
+      !authorization.client_id
+      || authorization.provider_id !== expected.therapistId
+      || authorization.organization_id !== expected.organizationId
+      || authorization.status !== "approved"
+    ) {
+      throw new Error("Synthetic BCBA therapist fixture must resolve exactly one active tenant-bound client through sessions and authorizations.");
+    }
+    authorizationClientIds.add(authorization.client_id);
+  }
+
+  const commonClientIds = [...sessionClientIds]
+    .filter((clientId) => authorizationClientIds.has(clientId))
+    .sort();
+  if (commonClientIds.length !== 1) {
+    throw new Error("Synthetic BCBA therapist fixture must resolve exactly one active tenant-bound client through sessions and authorizations.");
+  }
+  return commonClientIds[0];
 };
 
 export const assertSmokeBcbaAuthorizationInvariant = (
@@ -257,17 +283,28 @@ const provision = async (): Promise<void> => {
   if (!therapist || therapist.organization_id !== organizationId || therapist.deleted_at) {
     throw new Error("Synthetic BCBA therapist fixture is missing, deleted, or outside the expected organization.");
   }
-  const { data: clientLink, error: clientLinkError } = await client
-    .from("client_therapist_links")
+  const { data: sessionRows, error: sessionError } = await client
+    .from("sessions")
     .select("client_id,therapist_id,organization_id")
     .eq("therapist_id", therapistId)
     .eq("organization_id", organizationId)
-    .order("client_id", { ascending: true })
-    .limit(1)
-    .maybeSingle();
-  if (clientLinkError) throw clientLinkError;
-  assertSmokeBcbaClientLinkInvariant(clientLink, { therapistId, organizationId });
-  const clientId = clientLink.client_id;
+    .order("client_id", { ascending: true });
+  if (sessionError) throw sessionError;
+
+  const { data: authorizationRows, error: authorizationLookupError } = await client
+    .from("authorizations")
+    .select("client_id,provider_id,organization_id,status")
+    .eq("provider_id", therapistId)
+    .eq("organization_id", organizationId)
+    .eq("status", "approved")
+    .order("client_id", { ascending: true });
+  if (authorizationLookupError) throw authorizationLookupError;
+
+  const clientId = resolveSmokeBcbaClientId(
+    sessionRows ?? [],
+    authorizationRows ?? [],
+    { therapistId, organizationId },
+  );
 
   const { data: clientRow, error: clientError } = await client
     .from("clients").select("id,organization_id,deleted_at").eq("id", clientId).maybeSingle();

--- a/src/test/__tests__/mswUnhandledRequest.test.ts
+++ b/src/test/__tests__/mswUnhandledRequest.test.ts
@@ -2,13 +2,20 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   handleUnhandledMswRequest,
+  LIVE_SUPABASE_REQUEST_HEADER,
+  LIVE_SUPABASE_REQUEST_HEADER_VALUE,
   shouldBypassUnhandledMswRequest,
 } from '../mswUnhandledRequest';
+
+const liveHeaders = {
+  [LIVE_SUPABASE_REQUEST_HEADER]: LIVE_SUPABASE_REQUEST_HEADER_VALUE,
+};
 
 describe('MSW unhandled request routing', () => {
   it('bypasses configured Supabase live requests when DB integration tests are enabled', () => {
     const request = new Request('https://db.example.supabase.co/auth/v1/admin/users', {
       method: 'POST',
+      headers: liveHeaders,
     });
 
     expect(shouldBypassUnhandledMswRequest(request, {
@@ -26,12 +33,14 @@ describe('MSW unhandled request routing', () => {
     expect(shouldBypassUnhandledMswRequest(
       new Request('https://db.example.supabase.co/rest/v1/rpc/assign_admin_role', {
         method: 'POST',
+        headers: liveHeaders,
       }),
       env,
     )).toBe(true);
     expect(shouldBypassUnhandledMswRequest(
       new Request('https://db.example.supabase.co/auth/v1/token?grant_type=password', {
         method: 'POST',
+        headers: liveHeaders,
       }),
       env,
     )).toBe(true);
@@ -51,6 +60,27 @@ describe('MSW unhandled request routing', () => {
   it('keeps strict unhandled request errors for unrelated hosts', () => {
     const request = new Request('https://api.example.com/auth/v1/admin/users', {
       method: 'POST',
+      headers: liveHeaders,
+    });
+
+    expect(shouldBypassUnhandledMswRequest(request, {
+      RUN_DB_IT: '1',
+      SUPABASE_URL: 'https://db.example.supabase.co',
+    })).toBe(false);
+  });
+
+  it('keeps strict unhandled request errors for unmarked configured-host requests', () => {
+    const request = new Request('https://db.example.supabase.co/rest/v1/widgets');
+
+    expect(shouldBypassUnhandledMswRequest(request, {
+      RUN_DB_IT: '1',
+      SUPABASE_URL: 'https://db.example.supabase.co',
+    })).toBe(false);
+  });
+
+  it('keeps strict unhandled request errors for the wrong internal marker', () => {
+    const request = new Request('https://db.example.supabase.co/rest/v1/widgets', {
+      headers: { [LIVE_SUPABASE_REQUEST_HEADER]: 'not-the-live-suite' },
     });
 
     expect(shouldBypassUnhandledMswRequest(request, {

--- a/src/test/mswUnhandledRequest.ts
+++ b/src/test/mswUnhandledRequest.ts
@@ -7,6 +7,12 @@ type MswUnhandledRequestPrint = {
 
 const truthyFlags = new Set(['1', 'true', 'yes', 'on']);
 
+export const LIVE_SUPABASE_REQUEST_HEADER = 'x-internal-live-supabase-test';
+export const LIVE_SUPABASE_REQUEST_HEADER_VALUE = 'rls-integration';
+export const LIVE_SUPABASE_REQUEST_HEADERS = {
+  [LIVE_SUPABASE_REQUEST_HEADER]: LIVE_SUPABASE_REQUEST_HEADER_VALUE,
+} as const;
+
 const isTruthyFlag = (value: string | undefined): boolean => (
   value ? truthyFlags.has(value.toLowerCase()) : false
 );
@@ -35,6 +41,10 @@ export const shouldBypassUnhandledMswRequest = (
   env: EnvLike = process.env,
 ): boolean => {
   if (!isTruthyFlag(env.RUN_DB_IT)) {
+    return false;
+  }
+
+  if (request.headers.get(LIVE_SUPABASE_REQUEST_HEADER) !== LIVE_SUPABASE_REQUEST_HEADER_VALUE) {
     return false;
   }
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,10 +1,10 @@
 import { vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 import { setupServer } from 'msw/node';
-import { http, HttpResponse } from 'msw';
+import { http, HttpResponse, passthrough } from 'msw';
 import '@testing-library/jest-dom';
 import { installConsoleGuard } from './utils/consoleGuard';
 import { setRuntimeSupabaseConfig } from '../lib/runtimeConfig';
-import { handleUnhandledMswRequest } from './mswUnhandledRequest';
+import { handleUnhandledMswRequest, shouldBypassUnhandledMswRequest } from './mswUnhandledRequest';
 
 const isTestRuntime =
   process.env.VITEST === 'true' ||
@@ -699,6 +699,9 @@ const therapistIdsByOrg: Record<string, string[]> = {
 
 // Setup MSW server for mocking API calls (for integration tests or when Supabase mocks are bypassed)
 export const server = setupServer(
+  http.all('*', ({ request }) => (
+    shouldBypassUnhandledMswRequest(request) ? passthrough() : undefined
+  )),
   http.post('*/rest/v1/rpc/current_user_organization_id', async ({ request }) => {
     const token = getBearerToken(request.headers);
     const orgId = resolveOrgIdForToken(token);

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -114,7 +114,7 @@ if (!environmentResolution.shouldRun && (isCiEnvironment || runDatabaseIntegrati
   });
 }
 
-const SHOULD_RUN_RLS_TESTS = environmentResolution.shouldRun;
+const SHOULD_RUN_RLS_TESTS = environmentResolution.shouldRun && runDatabaseIntegrationTests;
 
 let serviceClient: TypedClient | null = null;
 let runTests = false;
@@ -1038,7 +1038,7 @@ const createGuardianFixture = async (tenant: TenantContext): Promise<GuardianCon
 
 beforeAll(async () => {
   if (!SHOULD_RUN_RLS_TESTS) {
-    console.warn('⏭️  Skipping RLS security tests - environment not configured.');
+    console.warn('⏭️  Skipping hosted RLS security tests - RUN_DB_IT is not explicitly enabled or the environment is incomplete.');
     return;
   }
 

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createClient, type PostgrestError, type SupabaseClient } from '@supabase/supabase-js';
+import { LIVE_SUPABASE_REQUEST_HEADERS } from '../../test/mswUnhandledRequest';
 import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
@@ -400,6 +401,7 @@ const signInWithPassword = async (email: string, password: string): Promise<Type
   if (!accessToken) {
     const authClient = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
       auth: { autoRefreshToken: false, persistSession: false },
+      global: { headers: LIVE_SUPABASE_REQUEST_HEADERS },
     });
     const signInResult = await authClient.auth.signInWithPassword({
       email,
@@ -418,7 +420,7 @@ const signInWithPassword = async (email: string, password: string): Promise<Type
 
   return createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
     auth: { autoRefreshToken: false, persistSession: false },
-    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+    global: { headers: { ...LIVE_SUPABASE_REQUEST_HEADERS, Authorization: `Bearer ${accessToken}` } },
   });
 };
 
@@ -447,8 +449,8 @@ const expectRlsViolation = (error: PostgrestError | null, fallbackRowCount = 0) 
   expect(fallbackRowCount).toBe(0);
 };
 
-const createTextBlob = (text: string): Blob => {
-  return new Blob([text], { type: 'text/plain' });
+const createTextBody = (text: string): Uint8Array => {
+  return new TextEncoder().encode(text);
 };
 
 const buildClientDocumentPath = (clientId: string, label: string): string => {
@@ -1042,6 +1044,7 @@ beforeAll(async () => {
 
   serviceClient = createClient<Database>(SUPABASE_URL, SERVICE_ROLE_KEY, {
     auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: LIVE_SUPABASE_REQUEST_HEADERS },
   });
 
   try {
@@ -2907,6 +2910,7 @@ describe('user_profiles row level security', () => {
 
     const anonymousClient = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
       auth: { autoRefreshToken: false, persistSession: false },
+      global: { headers: LIVE_SUPABASE_REQUEST_HEADERS },
     });
 
     const result = await anonymousClient
@@ -3510,14 +3514,16 @@ describe('admin action logs enforce admin-only access', () => {
           admin_user_id: adminContext.userId,
           action_type: 'rls-test',
           target_user_id: adminContext.userId,
+          organization_id: adminContext.organizationId,
           action_details: { scope: 'rls', message: 'admin verification' },
         })
-        .select('id, admin_user_id')
+        .select('id, admin_user_id, organization_id')
         .single();
 
       expect(insertResult.error).toBeNull();
       const inserted = insertResult.data;
       expect(inserted?.admin_user_id).toBe(adminContext.userId);
+      expect(inserted?.organization_id).toBe(adminContext.organizationId);
 
       if (inserted?.id) {
         insertedActionId = inserted.id;
@@ -3530,12 +3536,13 @@ describe('admin action logs enforce admin-only access', () => {
 
       const selectResult = await adminClient
         .from('admin_actions')
-        .select('id, admin_user_id')
+        .select('id, admin_user_id, organization_id')
         .eq('id', insertedActionId)
         .single();
 
       expect(selectResult.error).toBeNull();
       expect(selectResult.data?.admin_user_id).toBe(adminContext.userId);
+      expect(selectResult.data?.organization_id).toBe(adminContext.organizationId);
     } finally {
       await adminClient.auth.signOut();
     }
@@ -3768,7 +3775,7 @@ describe('storage client document access policies', () => {
     try {
       const uploadResult = await adminClient.storage
         .from('client-documents')
-        .upload(path, createTextBlob('Admin storage test'), {
+        .upload(path, createTextBody('Admin storage test'), {
           contentType: 'text/plain',
           upsert: true,
         });
@@ -3800,7 +3807,7 @@ describe('storage client document access policies', () => {
     try {
       const uploadResult = await therapistClient.storage
         .from('client-documents')
-        .upload(path, createTextBlob('Therapist storage test'), {
+        .upload(path, createTextBody('Therapist storage test'), {
           contentType: 'text/plain',
           upsert: true,
         });
@@ -3832,7 +3839,7 @@ describe('storage client document access policies', () => {
     try {
       const uploadResult = await client.storage
         .from('client-documents')
-        .upload(path, createTextBlob('Client storage test'), {
+        .upload(path, createTextBody('Client storage test'), {
           contentType: 'text/plain',
           upsert: true,
         });
@@ -3864,7 +3871,7 @@ describe('storage client document access policies', () => {
     try {
       const uploadResult = await otherTherapist.storage
         .from('client-documents')
-        .upload(path, createTextBlob('Unauthorized storage test'), {
+        .upload(path, createTextBody('Unauthorized storage test'), {
           contentType: 'text/plain',
           upsert: true,
         });
@@ -3885,7 +3892,7 @@ describe('storage client document access policies', () => {
     const path = buildClientDocumentPath(orgAContext.clientId, 'protected');
     const seedResult = await serviceClient.storage
       .from('client-documents')
-      .upload(path, createTextBlob('Protected content'), {
+      .upload(path, createTextBody('Protected content'), {
         contentType: 'text/plain',
         upsert: true,
       });
@@ -3915,7 +3922,7 @@ describe('storage client document access policies', () => {
     const path = buildClientDocumentPath(orgBContext.clientId, 'restricted');
     const seedResult = await serviceClient.storage
       .from('client-documents')
-      .upload(path, createTextBlob('Restricted content'), {
+      .upload(path, createTextBody('Restricted content'), {
         contentType: 'text/plain',
         upsert: true,
       });

--- a/tests/integration/_helpers/liveRlsHarness.ts
+++ b/tests/integration/_helpers/liveRlsHarness.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "../../../src/lib/generated/database.types";
+import { LIVE_SUPABASE_REQUEST_HEADERS } from "../../../src/test/mswUnhandledRequest";
 import {
   buildCiRlsAppMetadata,
   persistCiRlsAppMetadata,
@@ -295,6 +296,7 @@ const createUserClient = (
 ): TypedClient =>
   createClient<Database>(supabaseUrl, supabaseAnonKey, {
     auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: LIVE_SUPABASE_REQUEST_HEADERS },
   });
 
 export async function setupLiveRlsHarness(): Promise<LiveRlsHarness> {
@@ -341,6 +343,7 @@ export async function setupLiveRlsHarness(): Promise<LiveRlsHarness> {
   const serviceRoleKey = environmentResolution.supabaseServiceRoleKey as string;
   const serviceClient = createClient<Database>(supabaseUrl, serviceRoleKey, {
     auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: LIVE_SUPABASE_REQUEST_HEADERS },
   });
 
   const orgAId = randomUUID();

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -64,6 +64,7 @@ describe("live RLS fixture schema contract", () => {
 
   it("uses the Node transport only for explicitly trusted database integration runs", () => {
     const config = readRepoFile("vitest.config.ts");
+    const securitySuite = readRepoFile("src/tests/security/rls.spec.ts");
 
     expect(config).toContain("const runTrustedDatabaseIntegrationTests = ['1', 'true'].includes(");
     expect(config).toContain(
@@ -71,6 +72,9 @@ describe("live RLS fixture schema contract", () => {
     );
     expect(config).toContain("['src/tests/security/rls.spec.ts', liveRlsEnvironment]");
     expect(config).toContain("['tests/integration/rls.*.test.ts', liveRlsEnvironment]");
+    expect(securitySuite).toContain(
+      "const SHOULD_RUN_RLS_TESTS = environmentResolution.shouldRun && runDatabaseIntegrationTests;",
+    );
   });
 
   it("seeds required therapist names in the shared live RLS harness", () => {

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -62,6 +62,17 @@ describe("live RLS fixture schema contract", () => {
     expect(testMainJob).toContain("RUN_DB_IT: '1'");
   });
 
+  it("uses the Node transport only for explicitly trusted database integration runs", () => {
+    const config = readRepoFile("vitest.config.ts");
+
+    expect(config).toContain("const runTrustedDatabaseIntegrationTests = ['1', 'true'].includes(");
+    expect(config).toContain(
+      "const liveRlsEnvironment = runTrustedDatabaseIntegrationTests ? 'node' : 'jsdom';",
+    );
+    expect(config).toContain("['src/tests/security/rls.spec.ts', liveRlsEnvironment]");
+    expect(config).toContain("['tests/integration/rls.*.test.ts', liveRlsEnvironment]");
+  });
+
   it("seeds required therapist names in the shared live RLS harness", () => {
     const source = readRepoFile("tests/integration/_helpers/liveRlsHarness.ts");
     const inserts = therapistInsertBodies(source);

--- a/tests/scripts/provision-ci-smoke-bcba.test.ts
+++ b/tests/scripts/provision-ci-smoke-bcba.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   assertSmokeBcbaAuthorizationInvariant,
-  assertSmokeBcbaClientLinkInvariant,
   assertDedicatedSmokeBcbaEmail,
   assertSmokeBcbaProfileInvariant,
   buildDefaultSmokeBcbaEmail,
   getMissingBcbaProvisionSecrets,
   shouldSkipSecretlessPullRequest,
+  resolveSmokeBcbaClientId,
   verifySmokeBcbaAuthenticatedReadiness,
 } from "../../scripts/provision-ci-smoke-bcba";
 import type { SupabaseClient } from "@supabase/supabase-js";
@@ -72,22 +72,36 @@ describe("provision-ci-smoke-bcba guards", () => {
     }
   });
 
-  it("requires the resolved client link to match the fixed therapist and tenant", () => {
+  it("resolves the one client shared by same-tenant sessions and approved authorizations", () => {
     const expected = { therapistId: "therapist-1", organizationId: "org-1" };
-    expect(() => assertSmokeBcbaClientLinkInvariant({
-      client_id: "client-1",
-      therapist_id: "therapist-1",
-      organization_id: "org-1",
-    }, expected)).not.toThrow();
+    expect(resolveSmokeBcbaClientId([
+      { client_id: "client-2", therapist_id: "therapist-1", organization_id: "org-1" },
+      { client_id: "client-1", therapist_id: "therapist-1", organization_id: "org-1" },
+    ], [
+      { client_id: "client-1", provider_id: "therapist-1", organization_id: "org-1", status: "approved" },
+    ], expected)).toBe("client-1");
+  });
 
-    for (const link of [
-      null,
-      { client_id: null, therapist_id: "therapist-1", organization_id: "org-1" },
-      { client_id: "client-1", therapist_id: "therapist-2", organization_id: "org-1" },
-      { client_id: "client-1", therapist_id: "therapist-1", organization_id: "org-2" },
-    ]) {
-      expect(() => assertSmokeBcbaClientLinkInvariant(link, expected)).toThrow(/linked client/);
-    }
+  it.each([
+    ["no common client", [{ client_id: "client-1", therapist_id: "therapist-1", organization_id: "org-1" }], []],
+    ["ambiguous clients", [
+      { client_id: "client-1", therapist_id: "therapist-1", organization_id: "org-1" },
+      { client_id: "client-2", therapist_id: "therapist-1", organization_id: "org-1" },
+    ], [
+      { client_id: "client-1", provider_id: "therapist-1", organization_id: "org-1", status: "approved" },
+      { client_id: "client-2", provider_id: "therapist-1", organization_id: "org-1", status: "approved" },
+    ]],
+    ["cross-tenant session", [{ client_id: "client-1", therapist_id: "therapist-1", organization_id: "org-2" }], [
+      { client_id: "client-1", provider_id: "therapist-1", organization_id: "org-1", status: "approved" },
+    ]],
+    ["wrong provider", [{ client_id: "client-1", therapist_id: "therapist-1", organization_id: "org-1" }], [
+      { client_id: "client-1", provider_id: "therapist-2", organization_id: "org-1", status: "approved" },
+    ]],
+  ])("fails closed for %s", (_label, sessions, authorizations) => {
+    expect(() => resolveSmokeBcbaClientId(sessions, authorizations, {
+      therapistId: "therapist-1",
+      organizationId: "org-1",
+    })).toThrow(/exactly one active tenant-bound client/);
   });
 
   it("proves authenticated organization resolution and the bounded sessions RPC", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,6 +69,8 @@ export default defineConfig({
       ['src/scripts/**', 'node'],
       ['tests/edge/**', 'node'],
       ['src/lib/__tests__/schedulingOrchestrator.test.ts', 'node'],
+      ['src/tests/security/rls.spec.ts', 'node'],
+      ['tests/integration/rls.*.test.ts', 'node'],
     ],
     define: {
       'process.env.NODE_ENV': JSON.stringify('test'),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,11 @@ process.env.NODE_ENV = 'development';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
+const runTrustedDatabaseIntegrationTests = ['1', 'true'].includes(
+  (process.env.RUN_DB_IT ?? '').toLowerCase(),
+);
+const liveRlsEnvironment = runTrustedDatabaseIntegrationTests ? 'node' : 'jsdom';
+
 export default defineConfig({
   plugins: [react()],
   // Keep local verification deterministic by preventing Vitest from
@@ -69,8 +74,8 @@ export default defineConfig({
       ['src/scripts/**', 'node'],
       ['tests/edge/**', 'node'],
       ['src/lib/__tests__/schedulingOrchestrator.test.ts', 'node'],
-      ['src/tests/security/rls.spec.ts', 'node'],
-      ['tests/integration/rls.*.test.ts', 'node'],
+      ['src/tests/security/rls.spec.ts', liveRlsEnvironment],
+      ['tests/integration/rls.*.test.ts', liveRlsEnvironment],
     ],
     define: {
       'process.env.NODE_ENV': JSON.stringify('test'),


### PR DESCRIPTION
## Summary
- resolve the synthetic BCBA client deterministically from same-tenant sessions and approved authorizations
- repair trusted RLS fixtures and isolate marked live Supabase traffic from MSW mocks
- run live RLS storage coverage under Node with native Uint8Array upload bodies

## Routing
- Issue: WIN-217
- Classification: high-risk human-reviewed
- Lane: critical
- No migrations, production RLS policies, grants, workflows, or runtime auth behavior changed

## Verification
- RED: 2 files / 7 tests failed before implementation
- GREEN: 3 focused files / 28 tests passed
- secretless RLS load paths: 124 security tests + 16 integration tests passed
- ci:check-focused, lint, typecheck, validate:tenant, build passed
- independent code, security, and Supabase reviews: no actionable findings
- test:ci: 2710 passed; blocked locally by two existing Windows-only failures (CRLF workflow parser and jsdom Blob.text)
- tier-0: 212 passed; blocked by two transient preview-server 404s in routes_client

## Required hosted proof
- trusted Supabase Validate must pass Auth/REST/Storage live suites
- main auth-browser-smoke must pass BCBA provisioning, lifecycle, and cleanup
- human review is required before merge