### PR TITLE
WIN-217: repair trusted RLS authorization boundaries

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -467,7 +467,8 @@ PR #791 follow-up:
   - restore the checked-in therapist-certification contract: same-org admins and the owning active therapist may manage a certification; cross-org actors remain denied.
   - repair live fixture foreign keys, program/goal links, guardian/observer profiles, stale service-only expectations, Edge error status assertions, and marked live transport.
   - update `assign-therapist-user` to use the deployed therapist `status`/`deleted_at` schema and server-controlled caller/target profiles instead of nonexistent `is_active` and mutable auth metadata.
-- non-goals: no workflow changes, generic authenticated storage access, broad role-helper rewrite, production data backfill, or weakening of the unresolved cross-org `manage_admin_users` denial contract.
+  - classify `assign-therapist-user` changes as an admin/auth browser surface so the trusted main workflow executes BCBA provision, acceptance, and cleanup instead of scope-skipping them.
+- non-goals: no workflow job changes, generic authenticated storage access, broad role-helper rewrite, production data backfill, or weakening of the unresolved cross-org `manage_admin_users` denial contract.
 
 Verification card:
 
@@ -476,7 +477,7 @@ Verification card:
 - change type: database/RLS/migration/tenant isolation, Edge integration, and trusted hosted test harness
 - required checks: focused contracts; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run validate:tenant`; `npm run build`; `npm run test:routes:tier0`; `npm run ci:playwright`; `npm run verify:local`; independent critical-lane review; fresh hosted Supabase Validate; non-skipped main BCBA acceptance.
 - executed checks:
-  - focused contracts -> pass, 4 files / 30 tests, including active-role, assigned-therapist, client create/read, session/org consistency, and canonical-profile assertions.
+  - focused contracts -> pass, 5 files / 41 tests, including active-role, assigned-therapist, client create/read, session/org consistency, canonical-profile assertions, and exact BCBA auth-smoke selector coverage.
   - `npm run ci:check-focused` -> pass, with DB-URL-backed advisor/grant checks explicitly skipped locally.
   - `npm run lint` -> pass.
   - `npm run typecheck` -> pass.
@@ -484,6 +485,7 @@ Verification card:
   - `npm run build` -> pass.
   - `npm run test:ci` -> fail locally after 2,721 passes on two unchanged Windows/Node 24 portability assertions: CRLF-sensitive workflow step extraction and jsdom Blob without `text()`.
   - `npm run test:routes:tier0` -> fail locally after 212 passes because the preview server returned transient 404 responses during two `routes_client.cy.ts` session setup visits; the other six specs passed.
-- blocked checks: `npm run ci:playwright`, trusted Supabase validation, migration/runtime parity, deployed Edge parity, and non-skipped BCBA acceptance require protected hosted CI. Full `verify:local` remains failed because it includes the two recorded `test:ci` failures.
+- live PR evidence: PR #792 CI run `29376998559` correctly failed `runtime-migration-parity` because migration `20260714230523_repair_trusted_rls_authorization_boundaries` has not yet been promoted to the hosted migration ledger; the exact reviewed migration must be promoted before that required PR gate can pass.
+- blocked checks: `npm run ci:playwright`, trusted Supabase validation, migration/runtime parity, deployed Edge parity, and non-skipped BCBA acceptance require protected hosted CI. Full `verify:local` remains failed because it includes the two recorded `test:ci` failures. The Edge Function is not in the automatic session bundle and requires reviewed post-merge deployment with `verify_jwt=true` readback.
 - result: `pass-with-blocked-checks` for the bounded local implementation; PR CI, human approval, hosted promotion, fresh green Supabase Validate, and non-skipped BCBA acceptance remain required before completion.
 - residual risk: the forward migration changes live tenant boundaries and the Edge repair is not proven until reviewed code is deployed; `manage_admin_users` remains strict in the test because neither checked-in nor live SQL supports weakening the cross-org denial contract.

--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -454,3 +454,36 @@ PR #791 follow-up:
 - suite execution, Node routing, and MSW passthrough now all require explicit `RUN_DB_IT`. Ordinary CI keeps static contracts but does not create hosted fixtures; the trusted main-only Supabase workflow already sets `RUN_DB_IT: '1'` and therefore retains real Node Auth/REST/Storage transport.
 - the workflow/config contract asserts all three gates share the explicit trust predicate. The four focused helper/contract files pass 38/38; lint, typecheck, and policy pass. Trusted hosted proof remains pending.
 - the PR `auth-browser-smoke` job was green only because change-scope deliberately skipped provisioning and acceptance. It is not counted as BCBA proof; the main push job remains decisive after human merge.
+
+### WIN-217 trusted RLS authorization-boundary follow-up
+
+- branch: `codex/win-217-trusted-rls-followup`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- current hosted evidence: main CI run `29374337742` is green but scope-skipped BCBA provision/acceptance/cleanup; Supabase Validate run `29374337756` exposed fixture drift plus real client-authorization and session-CPT tenant leaks after the original admin-action and Storage timeout failures were repaired.
+- bounded fix:
+  - bind client authorization reads to the requested client and add client-owned document create-and-read access only for the caller's canonical client path; overwrite remains out of scope.
+  - replace every permissive `session_cpt_entries` policy with organization/session-scoped admin, super-admin, therapist, and service-role policies.
+  - restore the checked-in therapist-certification contract: same-org admins and the owning active therapist may manage a certification; cross-org actors remain denied.
+  - repair live fixture foreign keys, program/goal links, guardian/observer profiles, stale service-only expectations, Edge error status assertions, and marked live transport.
+  - update `assign-therapist-user` to use the deployed therapist `status`/`deleted_at` schema and server-controlled caller/target profiles instead of nonexistent `is_active` and mutable auth metadata.
+- non-goals: no workflow changes, generic authenticated storage access, broad role-helper rewrite, production data backfill, or weakening of the unresolved cross-org `manage_admin_users` denial contract.
+
+Verification card:
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- change type: database/RLS/migration/tenant isolation, Edge integration, and trusted hosted test harness
+- required checks: focused contracts; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run validate:tenant`; `npm run build`; `npm run test:routes:tier0`; `npm run ci:playwright`; `npm run verify:local`; independent critical-lane review; fresh hosted Supabase Validate; non-skipped main BCBA acceptance.
+- executed checks:
+  - focused contracts -> pass, 4 files / 30 tests, including active-role, assigned-therapist, client create/read, session/org consistency, and canonical-profile assertions.
+  - `npm run ci:check-focused` -> pass, with DB-URL-backed advisor/grant checks explicitly skipped locally.
+  - `npm run lint` -> pass.
+  - `npm run typecheck` -> pass.
+  - `npm run validate:tenant` -> pass.
+  - `npm run build` -> pass.
+  - `npm run test:ci` -> fail locally after 2,721 passes on two unchanged Windows/Node 24 portability assertions: CRLF-sensitive workflow step extraction and jsdom Blob without `text()`.
+  - `npm run test:routes:tier0` -> fail locally after 212 passes because the preview server returned transient 404 responses during two `routes_client.cy.ts` session setup visits; the other six specs passed.
+- blocked checks: `npm run ci:playwright`, trusted Supabase validation, migration/runtime parity, deployed Edge parity, and non-skipped BCBA acceptance require protected hosted CI. Full `verify:local` remains failed because it includes the two recorded `test:ci` failures.
+- result: `pass-with-blocked-checks` for the bounded local implementation; PR CI, human approval, hosted promotion, fresh green Supabase Validate, and non-skipped BCBA acceptance remain required before completion.
+- residual risk: the forward migration changes live tenant boundaries and the Edge repair is not proven until reviewed code is deployed; `manage_admin_users` remains strict in the test because neither checked-in nor live SQL supports weakening the cross-org denial contract.

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -123,6 +123,10 @@ const classifyFile = (file) => {
     return { specs: ["schedule", "auth"], authSmoke: false, reason: "session cancellation edge flow" };
   }
 
+  if (/^supabase\/functions\/assign-therapist-user\//.test(file)) {
+    return { specs: ["admin", "auth"], authSmoke: true, reason: "therapist provisioning auth flow" };
+  }
+
   if (matchAny(file, [
     /^cypress\/e2e\/routes_auth\.cy\.ts$/,
     /^scripts\/playwright-/,

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -43,6 +43,8 @@ interface TenantContext {
   clientUserId: string;
   clientEmail: string;
   clientPassword: string;
+  programId: string;
+  goalId: string;
   sessionId: string;
   organizationId: string;
 }
@@ -290,6 +292,40 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
   }
   await provisionCiRlsProfile(clientUserId, organizationId, 'client');
 
+  const programResult = await serviceClient
+    .from('programs')
+    .insert({
+      client_id: clientUserId,
+      name: `${label.toUpperCase()} RLS Program`,
+      description: 'Synthetic program for hosted RLS tests',
+      organization_id: organizationId,
+      created_by: therapistId,
+    })
+    .select('id')
+    .single();
+  if (programResult.error || !programResult.data) {
+    throw programResult.error ?? new Error('Program fixture creation failed');
+  }
+  const programId = programResult.data.id;
+
+  const goalResult = await serviceClient
+    .from('goals')
+    .insert({
+      client_id: clientUserId,
+      program_id: programId,
+      title: `${label.toUpperCase()} RLS Goal`,
+      description: 'Synthetic goal for hosted RLS tests',
+      original_text: 'Synthetic goal for hosted RLS tests',
+      organization_id: organizationId,
+      created_by: therapistId,
+    })
+    .select('id')
+    .single();
+  if (goalResult.error || !goalResult.data) {
+    throw goalResult.error ?? new Error('Goal fixture creation failed');
+  }
+  const goalId = goalResult.data.id;
+
   const sessionId = randomUUID();
   const start = new Date(Date.now() - 60 * 60 * 1000);
   const end = new Date(Date.now());
@@ -302,6 +338,8 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
     end_time: end.toISOString(),
     status: 'completed',
     organization_id: organizationId,
+    program_id: programId,
+    goal_id: goalId,
     has_transcription_consent: true,
   });
 
@@ -318,6 +356,8 @@ const createTenantFixture = async (label: string, organizationId: string): Promi
     clientUserId,
     clientEmail,
     clientPassword,
+    programId,
+    goalId,
     sessionId,
     organizationId,
   };
@@ -447,6 +487,11 @@ const expectRlsViolation = (error: PostgrestError | null, fallbackRowCount = 0) 
   }
 
   expect(fallbackRowCount).toBe(0);
+};
+
+const getFunctionErrorStatus = (error: unknown): number | undefined => {
+  const context = (error as { context?: { status?: number } } | null)?.context;
+  return context?.status;
 };
 
 const createTextBody = (text: string): Uint8Array => {
@@ -925,11 +970,11 @@ const ensureSessionTranscriptSegmentsSeeded = async (): Promise<void> => {
     throw new Error('Session transcripts must be seeded before segments');
   }
 
-  const insertSegmentForTranscript = async (transcriptId: string, offset: number) => {
+  const insertSegmentForContext = async (context: TenantContext, offset: number) => {
     const { data, error } = await serviceClient
       .from('session_transcript_segments')
       .insert({
-        session_id: transcriptId,
+        session_id: context.sessionId,
         start_time: offset,
         end_time: offset + 10,
         speaker: 'therapist',
@@ -948,8 +993,8 @@ const ensureSessionTranscriptSegmentsSeeded = async (): Promise<void> => {
     return data.id;
   };
 
-  const orgASegmentId = await insertSegmentForTranscript(sessionTranscriptIdsByOrg.orgA, 0);
-  const orgBSegmentId = await insertSegmentForTranscript(sessionTranscriptIdsByOrg.orgB, 0);
+  const orgASegmentId = await insertSegmentForContext(orgAContext, 0);
+  const orgBSegmentId = await insertSegmentForContext(orgBContext, 0);
 
   sessionTranscriptSegmentIdsByOrg = { orgA: orgASegmentId, orgB: orgBSegmentId };
 };
@@ -1007,6 +1052,20 @@ const createGuardianFixture = async (tenant: TenantContext): Promise<GuardianCon
 
   if (roleInsert.error) {
     throw roleInsert.error;
+  }
+
+  const guardianProfileResult = await serviceClient
+    .from('profiles')
+    .update({
+      organization_id: tenant.organizationId,
+      role: 'client',
+      is_active: true,
+    })
+    .eq('id', guardianId)
+    .select('id')
+    .single();
+  if (guardianProfileResult.error || !guardianProfileResult.data) {
+    throw guardianProfileResult.error ?? new Error('Synthetic guardian profile provisioning failed');
   }
 
   const { data: insertedGuardian, error: guardianInsertError } = await serviceClient
@@ -1210,7 +1269,7 @@ describe('admin organization scoping', () => {
       });
 
       expect(error).toBeTruthy();
-      expect(error?.message.toLowerCase()).toMatch(/organization/);
+      expect(error?.message.toLowerCase()).toMatch(/permission|assign_admin_role/);
     } finally {
       await adminClient.auth.signOut();
     }
@@ -1665,6 +1724,8 @@ afterAll(async () => {
     }
 
     await serviceClient.from('sessions').delete().eq('id', context.sessionId);
+    await serviceClient.from('goals').delete().eq('id', context.goalId);
+    await serviceClient.from('programs').delete().eq('id', context.programId);
     await serviceClient.from('clients').delete().eq('id', context.clientId);
     await serviceClient.from('user_therapist_links').delete().eq('user_id', context.userId);
     await serviceClient.from('therapists').delete().eq('id', context.therapistId);
@@ -2237,37 +2298,29 @@ describe('row level security for multi-tenant tables', () => {
     }
   });
 
-  it('allows clients to manage only sessions that belong to them', async () => {
+  it('prevents clients from directly reading or updating sessions', async () => {
     if (!runTests || !orgAContext || !orgBContext) {
       console.log('⏭️  Skipping RLS test - setup incomplete.');
       return;
     }
 
     const client = await signInClient(orgAContext);
-    let originalNotes: string | null = null;
     try {
       const ownSession = await client
         .from('sessions')
-        .select('id, client_id, notes')
-        .eq('id', orgAContext.sessionId)
-        .maybeSingle();
+        .select('id, client_id')
+        .eq('id', orgAContext.sessionId);
 
       expect(ownSession.error).toBeNull();
-      expect(ownSession.data?.id).toBe(orgAContext.sessionId);
-      expect(ownSession.data?.client_id).toBe(orgAContext.clientId);
-
-      originalNotes = ownSession.data?.notes ?? null;
-      const updatedNotes = `Client note ${randomSuffix()}`;
+      expect(ownSession.data).toHaveLength(0);
 
       const updateResult = await client
         .from('sessions')
-        .update({ notes: updatedNotes })
+        .update({ notes: `Unauthorized client note ${randomSuffix()}` })
         .eq('id', orgAContext.sessionId)
-        .select('notes')
-        .maybeSingle();
+        .select('id');
 
-      expect(updateResult.error).toBeNull();
-      expect(updateResult.data?.notes).toBe(updatedNotes);
+      expectRlsViolation(updateResult.error, updateResult.data?.length ?? 0);
 
       const crossRead = await client
         .from('sessions')
@@ -2287,16 +2340,72 @@ describe('row level security for multi-tenant tables', () => {
       const crossCount = Array.isArray(crossUpdate.data) ? crossUpdate.data.length : 0;
       expectRlsViolation(crossUpdate.error, crossCount);
     } finally {
-      await client
-        .from('sessions')
-        .update({ notes: originalNotes })
-        .eq('id', orgAContext.sessionId);
-
       await client.auth.signOut();
     }
   });
 
-  it('restricts billing records to the authenticated client session scope', async () => {
+  it('allows clients to read their own authorization rows', async () => {
+    if (!runTests || !orgAContext || !serviceClient) {
+      console.log('⏭️  Skipping RLS test - setup incomplete.');
+      return;
+    }
+
+    const { data: authorizationRow, error: authorizationError } = await serviceClient
+      .from('authorizations')
+      .insert({
+        authorization_number: `AUTH-OWN-${Date.now()}-${randomSuffix()}`,
+        client_id: orgAContext.clientId,
+        provider_id: orgAContext.therapistId,
+        diagnosis_code: 'F84.0',
+        start_date: '2026-01-01',
+        end_date: '2026-12-31',
+        organization_id: orgAContext.organizationId,
+        created_by: orgAContext.userId,
+      })
+      .select('id')
+      .single();
+    if (authorizationError || !authorizationRow) {
+      throw authorizationError ?? new Error('Failed to insert own authorization fixture');
+    }
+    createdAuthorizationIds.push(authorizationRow.id);
+
+    const client = await signInClient(orgAContext);
+    try {
+      const ownRead = await client
+        .from('authorizations')
+        .select('id, client_id')
+        .eq('id', authorizationRow.id)
+        .single();
+      expect(ownRead.error).toBeNull();
+      expect(ownRead.data?.client_id).toBe(orgAContext.clientId);
+    } finally {
+      await client.auth.signOut();
+    }
+  });
+
+  it('prevents admins from assigning cross-organization users or therapists', async () => {
+    if (!runTests || !adminContext || !orgBContext) {
+      console.log('⏭️  Skipping cross-organization edge function test - setup incomplete.');
+      return;
+    }
+
+    const adminClient = await signInAdmin(adminContext);
+    try {
+      const { error } = await adminClient.functions.invoke('assign-therapist-user', {
+        body: {
+          userId: orgBContext.clientUserId,
+          therapistId: orgBContext.therapistId,
+        },
+      });
+
+      expect(error).toBeTruthy();
+      expect(getFunctionErrorStatus(error)).toBe(403);
+    } finally {
+      await adminClient.auth.signOut();
+    }
+  });
+
+  it('prevents clients from directly reading or updating billing records', async () => {
     if (!runTests || !orgAContext || !orgBContext) {
       console.log('⏭️  Skipping RLS test - setup incomplete.');
       return;
@@ -2308,8 +2417,6 @@ describe('row level security for multi-tenant tables', () => {
     }
 
     const client = await signInClient(orgAContext);
-    let originalStatus: string | null = null;
-    let targetRecordId: string | null = null;
     try {
       const ownRecords = await client
         .from('billing_records')
@@ -2317,29 +2424,15 @@ describe('row level security for multi-tenant tables', () => {
         .eq('session_id', orgAContext.sessionId);
 
       expect(ownRecords.error).toBeNull();
-      const ownRows = Array.isArray(ownRecords.data) ? ownRecords.data : [];
-      expect(ownRows.length).toBeGreaterThan(0);
-      ownRows.forEach(row => {
-        expect(row.session_id).toBe(orgAContext.sessionId);
-      });
-
-      targetRecordId = ownRows[0]?.id ?? null;
-      if (!targetRecordId) {
-        throw new Error('Expected at least one billing record id for the client session');
-      }
-
-      originalStatus = ownRows[0]?.status ?? null;
-      const newStatus = originalStatus === 'pending' ? 'review' : 'pending';
+      expect(ownRecords.data).toHaveLength(0);
 
       const updateResult = await client
         .from('billing_records')
-        .update({ status: newStatus })
-        .eq('id', targetRecordId)
-        .select('status')
-        .maybeSingle();
+        .update({ status: 'unauthorized' })
+        .eq('id', billingRecordIdsByOrg.orgA)
+        .select('id');
 
-      expect(updateResult.error).toBeNull();
-      expect(updateResult.data?.status).toBe(newStatus);
+      expectRlsViolation(updateResult.error, updateResult.data?.length ?? 0);
 
       const crossRead = await client
         .from('billing_records')
@@ -2359,13 +2452,6 @@ describe('row level security for multi-tenant tables', () => {
       const crossCount = Array.isArray(crossUpdate.data) ? crossUpdate.data.length : 0;
       expectRlsViolation(crossUpdate.error, crossCount);
     } finally {
-      if (targetRecordId) {
-        await client
-          .from('billing_records')
-          .update({ status: originalStatus })
-          .eq('id', targetRecordId);
-      }
-
       await client.auth.signOut();
     }
   });
@@ -2895,6 +2981,40 @@ describe('row level security for multi-tenant tables', () => {
       expect(error).toBeNull();
       expect(Array.isArray(data)).toBe(true);
       expect(data).toHaveLength(0);
+
+      const ownRead = await supabaseAdmin
+        .from('session_cpt_entries')
+        .select('id, cpt_code_id, session_id')
+        .eq('id', sessionCptEntryIdsByOrg.orgA)
+        .single();
+      expect(ownRead.error).toBeNull();
+      expect(ownRead.data?.session_id).toBe(orgAContext.sessionId);
+
+      if (!ownRead.data?.cpt_code_id) {
+        throw new Error('Expected same-organization CPT entry fixture');
+      }
+
+      const mismatchedInsert = await supabaseAdmin
+        .from('session_cpt_entries')
+        .insert({
+          session_id: orgBContext.sessionId,
+          cpt_code_id: ownRead.data.cpt_code_id,
+          line_number: 99,
+          units: 1,
+          billed_minutes: 15,
+          rate: 1,
+          is_primary: false,
+          organization_id: orgAContext.organizationId,
+        })
+        .select('id');
+      expectRlsViolation(mismatchedInsert.error, mismatchedInsert.data?.length ?? 0);
+
+      const mismatchedUpdate = await supabaseAdmin
+        .from('session_cpt_entries')
+        .update({ session_id: orgBContext.sessionId })
+        .eq('id', sessionCptEntryIdsByOrg.orgA)
+        .select('id');
+      expectRlsViolation(mismatchedUpdate.error, mismatchedUpdate.data?.length ?? 0);
     } finally {
       await supabaseAdmin.auth.signOut();
     }
@@ -2972,7 +3092,7 @@ describe('session holds enforce role-scoped access', () => {
     await ensureSessionHoldsSeeded();
   });
 
-  it('allows admins to manage session holds for any therapist', async () => {
+  it('allows admins to manage session holds only within their organization', async () => {
     if (!runTests || !adminContext || !orgAContext || !orgBContext || !sessionHoldIdsByOrg) {
       console.log('⏭️  Skipping RLS test - setup incomplete.');
       return;
@@ -2985,11 +3105,10 @@ describe('session holds enforce role-scoped access', () => {
       const existingHoldResult = await adminClient
         .from('session_holds')
         .select('id, therapist_id')
-        .eq('id', sessionHoldIdsByOrg.orgB)
-        .single();
+        .eq('id', sessionHoldIdsByOrg.orgB);
 
       expect(existingHoldResult.error).toBeNull();
-      expect(existingHoldResult.data?.therapist_id).toBe(orgBContext.therapistId);
+      expect(existingHoldResult.data).toHaveLength(0);
 
       const { start, end, expires } = generateHoldWindow(240);
       const insertResult = await adminClient
@@ -3247,8 +3366,7 @@ describe('session hold edge function authorization', () => {
       });
 
       expect(error).toBeTruthy();
-      const typedError = error as { status?: number; message?: string } | null;
-      expect(typedError?.status).toBe(403);
+      expect(getFunctionErrorStatus(error)).toBe(403);
 
       if (data) {
         const responseBody = data as { success?: boolean; error?: string };
@@ -3297,8 +3415,7 @@ describe('session hold edge function authorization', () => {
       });
 
       expect(error).toBeTruthy();
-      const typedError = error as { status?: number; message?: string } | null;
-      expect(typedError?.status).toBe(403);
+      expect(getFunctionErrorStatus(error)).toBe(403);
 
       if (data) {
         const responseBody = data as { success?: boolean; error?: string };
@@ -3841,7 +3958,7 @@ describe('storage client document access policies', () => {
         .from('client-documents')
         .upload(path, createTextBody('Client storage test'), {
           contentType: 'text/plain',
-          upsert: true,
+          upsert: false,
         });
 
       expect(uploadResult.error).toBeNull();
@@ -3855,6 +3972,28 @@ describe('storage client document access policies', () => {
 
       const downloadedText = await downloadResult.data.text();
       expect(downloadedText).toBe('Client storage test');
+    } finally {
+      await client.auth.signOut();
+    }
+  });
+
+  it('prevents clients from uploading documents into another client path', async () => {
+    if (!runTests || !orgAContext || !orgBContext) {
+      console.log('⏭️  Skipping RLS test - setup incomplete.');
+      return;
+    }
+
+    const client = await signInClient(orgAContext);
+    const path = buildClientDocumentPath(orgBContext.clientId, 'cross-client');
+    try {
+      const uploadResult = await client.storage
+        .from('client-documents')
+        .upload(path, createTextBody('Unauthorized client storage test'), {
+          contentType: 'text/plain',
+          upsert: false,
+        });
+
+      expect(uploadResult.error).toBeTruthy();
     } finally {
       await client.auth.signOut();
     }

--- a/supabase/functions/assign-therapist-user/index.ts
+++ b/supabase/functions/assign-therapist-user/index.ts
@@ -4,18 +4,6 @@ import { assertAdminOrSuperAdmin } from "../_shared/auth.ts";
 
 interface AssignTherapistRequest { userId: string; therapistId: string; }
 
-const extractOrganizationId = (source: Record<string, unknown> | null | undefined): string | null => {
-  if (!source) return null;
-  const possibleKeys = ['organization_id', 'organizationId'] as const;
-  for (const key of possibleKeys) {
-    const value = source[key];
-    if (typeof value === 'string' && value.length > 0) {
-      return value;
-    }
-  }
-  return null;
-};
-
 export default createProtectedRoute(async (req: Request, userContext) => {
   if (req.method !== 'POST') return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   try {
@@ -25,21 +13,32 @@ export default createProtectedRoute(async (req: Request, userContext) => {
     const { userId, therapistId }: AssignTherapistRequest = await req.json();
     if (!userId || !therapistId) return new Response(JSON.stringify({ error: 'User ID and therapist ID are required' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
-    const { data: authUserResult, error: authUserError } = await adminClient.auth.getUser();
-    if (authUserError || !authUserResult?.user) {
-      console.error('Error resolving authenticated admin:', authUserError);
-      logApiAccess('POST', '/assign-therapist-user', userContext, 401);
-      return new Response(JSON.stringify({ error: 'Unable to verify admin context' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    // Profile organization is server-controlled; auth user_metadata is user-editable
+    // and must never authorize tenant-scoped assignment.
+    const serviceRoleClient = supabaseAdmin;
+    const { data: profileRows, error: profileError } = await serviceRoleClient
+      .from('profiles')
+      .select('id, organization_id, is_active')
+      .in('id', [userContext.user.id, userId]);
+    if (profileError) {
+      console.error('Error resolving assignment profiles:', profileError);
+      logApiAccess('POST', '/assign-therapist-user', userContext, 500);
+      return new Response(JSON.stringify({ error: 'Unable to verify organization context' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
-    const callerOrganizationId = extractOrganizationId(authUserResult.user.user_metadata as Record<string, unknown> | null | undefined);
-    if (!callerOrganizationId) {
+    const callerProfile = profileRows?.find((profile) => profile.id === userContext.user.id);
+    const targetProfile = profileRows?.find((profile) => profile.id === userId);
+    const callerOrganizationId = callerProfile?.organization_id ?? null;
+    if (!callerOrganizationId || callerProfile?.is_active !== true) {
       logApiAccess('POST', '/assign-therapist-user', userContext, 403);
       return new Response(JSON.stringify({ error: 'Admin organization context is required' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
+    if (!targetProfile?.organization_id || targetProfile.is_active !== true || targetProfile.organization_id !== callerOrganizationId) {
+      logApiAccess('POST', '/assign-therapist-user', userContext, 403);
+      return new Response(JSON.stringify({ error: 'Cannot assign therapists for users outside your organization' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
 
     // Service role access is required for Supabase auth.admin endpoints; we scope results to the caller's organization before use.
-    const serviceRoleClient = supabaseAdmin;
     const { data: userData, error: userError } = await serviceRoleClient.auth.admin.getUserById(userId);
     if (userError || !userData.user) {
       console.error('Error fetching user:', userError);
@@ -48,12 +47,6 @@ export default createProtectedRoute(async (req: Request, userContext) => {
     }
 
     const targetUser = userData.user;
-    const targetOrganizationId = extractOrganizationId(targetUser.user_metadata as Record<string, unknown> | null | undefined);
-    if (!targetOrganizationId || targetOrganizationId !== callerOrganizationId) {
-      logApiAccess('POST', '/assign-therapist-user', userContext, 403);
-      return new Response(JSON.stringify({ error: 'Cannot assign therapists for users outside your organization' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    }
-
     const userEmail = targetUser.email;
     if (!userEmail) {
       return new Response(JSON.stringify({ error: 'Target user email is missing' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
@@ -61,7 +54,7 @@ export default createProtectedRoute(async (req: Request, userContext) => {
 
     const { data: therapistData, error: therapistError } = await adminClient
       .from('therapists')
-      .select('id, full_name, is_active, deleted_at')
+      .select('id, full_name, status, organization_id, deleted_at')
       .eq('id', therapistId)
       .single();
     if (therapistError || !therapistData) {
@@ -75,13 +68,12 @@ export default createProtectedRoute(async (req: Request, userContext) => {
       return new Response(JSON.stringify({ error: 'Cannot assign archived therapist' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
-    const therapistOrganizationId = extractOrganizationId(therapistData as unknown as Record<string, unknown>);
-    if (therapistOrganizationId && therapistOrganizationId !== callerOrganizationId) {
+    if (!therapistData.organization_id || therapistData.organization_id !== callerOrganizationId) {
       logApiAccess('POST', '/assign-therapist-user', userContext, 403);
       return new Response(JSON.stringify({ error: 'Cannot assign therapists from a different organization' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
-    if (!therapistData.is_active) return new Response(JSON.stringify({ error: 'Cannot assign to inactive therapist' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    if (therapistData.status !== 'active') return new Response(JSON.stringify({ error: 'Cannot assign to inactive therapist' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
     const { data: existingClient } = await adminClient
       .from('clients')

--- a/supabase/migrations/20260714230523_repair_trusted_rls_authorization_boundaries.sql
+++ b/supabase/migrations/20260714230523_repair_trusted_rls_authorization_boundaries.sql
@@ -1,0 +1,397 @@
+-- @migration-intent: Repair authorization boundaries proven by the trusted hosted RLS suite for client documents, authorization rows, session CPT entries, and therapist certifications.
+-- @migration-dependencies: storage.objects,public.clients,public.sessions,public.session_cpt_entries,public.therapist_certifications,app.user_has_role_for_org,app.current_user_can_read_authorization_row
+-- @migration-rollback: Forward recovery only. Apply a later corrective migration that recreates the explicit policies and function below; do not restore dynamically dropped permissive policies.
+-- This migration intentionally changes only the authorization boundaries named above.
+
+drop policy if exists client_documents_org_insert on storage.objects;
+create policy client_documents_org_insert
+  on storage.objects
+  for insert
+  to authenticated
+  with check (
+    bucket_id = 'client-documents'
+    and split_part(name, '/', 1) = 'clients'
+    and (
+      app.user_has_role_for_org(
+        app.current_user_id(),
+        (
+          select c.organization_id
+          from public.clients c
+          where c.id::text = split_part(name, '/', 2)
+          limit 1
+        ),
+        array['org_admin', 'org_super_admin']
+      )
+      or (
+        app.user_has_role_for_org(
+          app.current_user_id(),
+          (
+            select c.organization_id
+            from public.clients c
+            where c.id::text = split_part(name, '/', 2)
+            limit 1
+          ),
+          array['therapist']
+        )
+        and exists (
+          select 1
+          from public.sessions s
+          where s.therapist_id = auth.uid()
+            and split_part(name, '/', 2) = s.client_id::text
+            and s.organization_id = app.current_user_organization_id()
+        )
+      )
+      or (
+        split_part(name, '/', 2) = auth.uid()::text
+        and app.user_has_role_for_org(
+          app.current_user_id(),
+          (
+            select c.organization_id
+            from public.clients c
+            where c.id::text = split_part(name, '/', 2)
+            limit 1
+          ),
+          array['client']
+        )
+        and app.user_has_role_for_org(
+          'client',
+          (
+            select c.organization_id
+            from public.clients c
+            where c.id::text = split_part(name, '/', 2)
+            limit 1
+          ),
+          null,
+          split_part(name, '/', 2)::uuid,
+          null
+        )
+      )
+    )
+  );
+
+drop policy if exists client_documents_org_read on storage.objects;
+create policy client_documents_org_read
+  on storage.objects
+  for select
+  to authenticated
+  using (
+    bucket_id = 'client-documents'
+    and split_part(name, '/', 1) = 'clients'
+    and (
+      app.user_has_role_for_org(
+        app.current_user_id(),
+        (
+          select c.organization_id
+          from public.clients c
+          where c.id::text = split_part(name, '/', 2)
+          limit 1
+        ),
+        array['org_admin', 'org_super_admin']
+      )
+      or (
+        app.user_has_role_for_org(
+          app.current_user_id(),
+          (
+            select c.organization_id
+            from public.clients c
+            where c.id::text = split_part(name, '/', 2)
+            limit 1
+          ),
+          array['therapist']
+        )
+        and exists (
+          select 1
+          from public.sessions s
+          where s.therapist_id = auth.uid()
+            and split_part(name, '/', 2) = s.client_id::text
+            and s.organization_id = app.current_user_organization_id()
+        )
+      )
+      or (
+        split_part(name, '/', 2) = auth.uid()::text
+        and app.user_has_role_for_org(
+          app.current_user_id(),
+          (
+            select c.organization_id
+            from public.clients c
+            where c.id::text = split_part(name, '/', 2)
+            limit 1
+          ),
+          array['client']
+        )
+        and app.user_has_role_for_org(
+          'client',
+          (
+            select c.organization_id
+            from public.clients c
+            where c.id::text = split_part(name, '/', 2)
+            limit 1
+          ),
+          null,
+          split_part(name, '/', 2)::uuid,
+          null
+        )
+      )
+    )
+  );
+
+create or replace function app.current_user_can_read_authorization_row(
+  p_organization_id uuid,
+  p_client_id uuid,
+  p_provider_id uuid
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public, app, auth
+as $$
+begin
+  if p_organization_id is null or p_client_id is null then
+    return false;
+  end if;
+
+  if p_organization_id is distinct from app.current_user_organization_id() then
+    return false;
+  end if;
+
+  if app.current_user_can_manage_authorizations(p_organization_id) then
+    return true;
+  end if;
+
+  if app.user_has_role_for_org(
+    app.current_user_id(),
+    p_organization_id,
+    array['client']
+  ) and app.user_has_role_for_org(
+      'client',
+      p_organization_id,
+      null,
+      p_client_id,
+      null
+    ) then
+    return true;
+  end if;
+
+  if app.user_has_role_for_org(
+    app.current_user_id(),
+    p_organization_id,
+    array['therapist']
+  ) then
+    if p_provider_id is not distinct from app.current_user_id() then
+      return true;
+    end if;
+
+    return app.current_user_has_assigned_client(p_organization_id, p_client_id);
+  end if;
+
+  return false;
+end;
+$$;
+
+grant execute on function app.current_user_can_read_authorization_row(uuid, uuid, uuid)
+  to authenticated, service_role;
+
+-- Multiple permissive policies currently include an unscoped `true`/admin
+-- branch. Remove every policy on this table before recreating the canonical
+-- organization-aware set so no legacy permissive policy can bypass it.
+do $$
+declare
+  policy_record record;
+begin
+  for policy_record in
+    select policyname
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'session_cpt_entries'
+  loop
+    execute format(
+      'drop policy if exists %I on public.session_cpt_entries',
+      policy_record.policyname
+    );
+  end loop;
+end;
+$$;
+
+create policy "Session CPT entries scoped select"
+  on public.session_cpt_entries
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.sessions scoped_session
+      where scoped_session.id = session_cpt_entries.session_id
+        and scoped_session.organization_id = session_cpt_entries.organization_id
+    )
+    and (
+      app.user_has_role_for_org('admin', organization_id, null, null, session_id)
+      or app.user_has_role_for_org('super_admin', organization_id, null, null, session_id)
+      or (
+        app.user_has_role_for_org('therapist', organization_id, null, null, session_id)
+        and exists (
+          select 1
+          from public.sessions assigned_session
+          where assigned_session.id = session_cpt_entries.session_id
+            and assigned_session.therapist_id = auth.uid()
+        )
+      )
+    )
+  );
+
+create policy "Session CPT entries scoped insert"
+  on public.session_cpt_entries
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from public.sessions scoped_session
+      where scoped_session.id = session_cpt_entries.session_id
+        and scoped_session.organization_id = session_cpt_entries.organization_id
+    )
+    and (
+      app.user_has_role_for_org('admin', organization_id, null, null, session_id)
+      or app.user_has_role_for_org('super_admin', organization_id, null, null, session_id)
+      or (
+        app.user_has_role_for_org('therapist', organization_id, null, null, session_id)
+        and exists (
+          select 1
+          from public.sessions assigned_session
+          where assigned_session.id = session_cpt_entries.session_id
+            and assigned_session.therapist_id = auth.uid()
+        )
+      )
+    )
+  );
+
+create policy "Session CPT entries scoped update"
+  on public.session_cpt_entries
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.sessions scoped_session
+      where scoped_session.id = session_cpt_entries.session_id
+        and scoped_session.organization_id = session_cpt_entries.organization_id
+    )
+    and (
+      app.user_has_role_for_org('admin', organization_id, null, null, session_id)
+      or app.user_has_role_for_org('super_admin', organization_id, null, null, session_id)
+      or (
+        app.user_has_role_for_org('therapist', organization_id, null, null, session_id)
+        and exists (
+          select 1
+          from public.sessions assigned_session
+          where assigned_session.id = session_cpt_entries.session_id
+            and assigned_session.therapist_id = auth.uid()
+        )
+      )
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.sessions scoped_session
+      where scoped_session.id = session_cpt_entries.session_id
+        and scoped_session.organization_id = session_cpt_entries.organization_id
+    )
+    and (
+      app.user_has_role_for_org('admin', organization_id, null, null, session_id)
+      or app.user_has_role_for_org('super_admin', organization_id, null, null, session_id)
+      or (
+        app.user_has_role_for_org('therapist', organization_id, null, null, session_id)
+        and exists (
+          select 1
+          from public.sessions assigned_session
+          where assigned_session.id = session_cpt_entries.session_id
+            and assigned_session.therapist_id = auth.uid()
+        )
+      )
+    )
+  );
+
+create policy "Session CPT entries scoped delete"
+  on public.session_cpt_entries
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.sessions scoped_session
+      where scoped_session.id = session_cpt_entries.session_id
+        and scoped_session.organization_id = session_cpt_entries.organization_id
+    )
+    and (
+      app.user_has_role_for_org('admin', organization_id, null, null, session_id)
+      or app.user_has_role_for_org('super_admin', organization_id, null, null, session_id)
+      or (
+        app.user_has_role_for_org('therapist', organization_id, null, null, session_id)
+        and exists (
+          select 1
+          from public.sessions assigned_session
+          where assigned_session.id = session_cpt_entries.session_id
+            and assigned_session.therapist_id = auth.uid()
+        )
+      )
+    )
+  );
+
+create policy "Session CPT entries service role access"
+  on public.session_cpt_entries
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+-- Hosted policy drift removed the intended therapist self-management branch.
+-- Replace all permissive policies so legacy definitions cannot combine with
+-- the canonical same-organization boundary below.
+do $$
+declare
+  policy_record record;
+begin
+  for policy_record in
+    select policyname
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'therapist_certifications'
+  loop
+    execute format(
+      'drop policy if exists %I on public.therapist_certifications',
+      policy_record.policyname
+    );
+  end loop;
+end;
+$$;
+
+create policy "Therapist certifications scoped access"
+  on public.therapist_certifications
+  for all
+  to authenticated
+  using (
+    app.user_has_role_for_org('admin', organization_id, therapist_id, null, null)
+    or app.user_has_role_for_org('super_admin', organization_id, therapist_id, null, null)
+    or (
+      therapist_id = auth.uid()
+      and app.user_has_role_for_org('therapist', organization_id, therapist_id, null, null)
+    )
+  )
+  with check (
+    app.user_has_role_for_org('admin', organization_id, therapist_id, null, null)
+    or app.user_has_role_for_org('super_admin', organization_id, therapist_id, null, null)
+    or (
+      therapist_id = auth.uid()
+      and app.user_has_role_for_org('therapist', organization_id, therapist_id, null, null)
+    )
+  );
+
+create policy "Therapist certifications service role access"
+  on public.therapist_certifications
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+notify pgrst, 'reload schema';

--- a/tests/integration/_helpers/liveRlsHarness.ts
+++ b/tests/integration/_helpers/liveRlsHarness.ts
@@ -290,11 +290,11 @@ const seedOrgData = async (
   };
 };
 
-const createUserClient = (
+export const createLiveRlsClient = (
   supabaseUrl: string,
-  supabaseAnonKey: string,
+  supabaseKey: string,
 ): TypedClient =>
-  createClient<Database>(supabaseUrl, supabaseAnonKey, {
+  createClient<Database>(supabaseUrl, supabaseKey, {
     auth: { autoRefreshToken: false, persistSession: false },
     global: { headers: LIVE_SUPABASE_REQUEST_HEADERS },
   });
@@ -341,10 +341,7 @@ export async function setupLiveRlsHarness(): Promise<LiveRlsHarness> {
   const supabaseUrl = environmentResolution.supabaseUrl as string;
   const supabaseAnonKey = environmentResolution.supabaseAnonKey as string;
   const serviceRoleKey = environmentResolution.supabaseServiceRoleKey as string;
-  const serviceClient = createClient<Database>(supabaseUrl, serviceRoleKey, {
-    auth: { autoRefreshToken: false, persistSession: false },
-    global: { headers: LIVE_SUPABASE_REQUEST_HEADERS },
-  });
+  const serviceClient = createLiveRlsClient(supabaseUrl, serviceRoleKey);
 
   const orgAId = randomUUID();
   const orgBId = randomUUID();
@@ -488,7 +485,7 @@ export async function setupLiveRlsHarness(): Promise<LiveRlsHarness> {
   const { orgAAdmin, orgBAdmin, orgATherapist, orgBTherapist, outsider, orgA, orgB } = resources;
 
   const signInAdmin = async (admin: AdminAuthFixture): Promise<TypedClient> => {
-    const client = createUserClient(supabaseUrl, supabaseAnonKey);
+    const client = createLiveRlsClient(supabaseUrl, supabaseAnonKey);
     const signInResult = await client.auth.signInWithPassword({
       email: admin.email,
       password: admin.password,

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -179,4 +179,42 @@ describe("live RLS fixture schema contract", () => {
       expect(call).not.toMatch(/(^|\n)\s*therapist_id:/);
     }
   });
+
+  it("marks every live message-thread Supabase client and provisions the observer profile", () => {
+    const harnessSource = readRepoFile("tests/integration/_helpers/liveRlsHarness.ts");
+    const messageSource = readRepoFile("tests/integration/rls.message-threads.access.test.ts");
+
+    expect(harnessSource).toContain("export const createLiveRlsClient");
+    expect(messageSource).toContain("createLiveRlsClient(");
+    expect(messageSource).not.toMatch(/\bcreateClient<Database>\(/);
+    expect(messageSource).toContain("app_metadata: observerAppMetadata");
+    expect(messageSource).toContain("persistLiveRlsAppMetadata(");
+    expect(messageSource).toContain("reconcileLiveRlsRole(");
+    expect(messageSource).toContain('"provision_ci_rls_fixture_profile"');
+  });
+
+  it("seeds valid session-linked artifacts and guardian organization context", () => {
+    const source = readRepoFile("src/tests/security/rls.spec.ts");
+
+    expect(source).toContain("session_id: context.sessionId");
+    expect(source).toContain("program_id: programId");
+    expect(source).toContain("goal_id: goalId");
+    expect(source).toContain(".eq('id', context.goalId)");
+    expect(source).toContain(".eq('id', context.programId)");
+    expect(source).toContain("Synthetic guardian profile provisioning failed");
+  });
+
+  it("uses the deployed therapist status schema before assigning a therapist", () => {
+    const source = readRepoFile("supabase/functions/assign-therapist-user/index.ts");
+
+    expect(source).toContain(".select('id, full_name, status, organization_id, deleted_at')");
+    expect(source).toContain("therapistData.status !== 'active'");
+    expect(source).not.toContain("therapistData.is_active");
+    expect(source).toContain(".from('profiles')");
+    expect(source).toContain('callerProfile?.organization_id');
+    expect(source).toContain('targetProfile.organization_id');
+    expect(source).toContain('targetProfile.is_active !== true');
+    expect(source).not.toContain('extractOrganizationId');
+    expect(source).not.toContain('targetUser.user_metadata as');
+  });
 });

--- a/tests/integration/rls.message-threads.access.test.ts
+++ b/tests/integration/rls.message-threads.access.test.ts
@@ -1,12 +1,19 @@
 import { randomUUID } from "node:crypto";
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { type SupabaseClient } from "@supabase/supabase-js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Database } from "../../src/lib/generated/database.types";
 import {
   computeEnvironmentGuidance,
   resolveSupabaseTestEnv,
 } from "../../src/tests/security/supabaseEnv";
-import { setupLiveRlsHarness, type LiveRlsHarness } from "./_helpers/liveRlsHarness.ts";
+import {
+  buildLiveRlsAppMetadata,
+  createLiveRlsClient,
+  persistLiveRlsAppMetadata,
+  reconcileLiveRlsRole,
+  setupLiveRlsHarness,
+  type LiveRlsHarness,
+} from "./_helpers/liveRlsHarness.ts";
 
 type TypedClient = SupabaseClient<Database, "public", Database["public"]>;
 
@@ -48,23 +55,25 @@ beforeAll(async () => {
     return;
   }
 
-  serviceClient = createClient<Database>(
+  serviceClient = createLiveRlsClient(
     environmentResolution.supabaseUrl as string,
     environmentResolution.supabaseServiceRoleKey as string,
-    { auth: { autoRefreshToken: false, persistSession: false } },
   );
 
   const email = `observer.admin.${Date.now()}.${randomUUID().slice(0, 8)}@example.com`;
   const password = `P@ssw0rd-${randomUUID().slice(0, 8)}`;
+  const observerAppMetadata = buildLiveRlsAppMetadata();
   const { data: createdUser, error: createUserError } = await serviceClient.auth.admin.createUser({
     email,
     password,
     email_confirm: true,
     user_metadata: { organization_id: harness.orgAId, role: "admin" },
+    app_metadata: observerAppMetadata,
   });
   if (createUserError || !createdUser?.user) {
     throw createUserError ?? new Error("Observer admin creation failed");
   }
+  orgAObserverAdmin = { userId: createdUser.user.id, email, password };
 
   const assignResult = await serviceClient.rpc("assign_admin_role", {
     user_email: email,
@@ -75,7 +84,15 @@ beforeAll(async () => {
     throw assignResult.error;
   }
 
-  orgAObserverAdmin = { userId: createdUser.user.id, email, password };
+  await persistLiveRlsAppMetadata(serviceClient, createdUser.user.id, observerAppMetadata);
+  await reconcileLiveRlsRole(serviceClient, createdUser.user.id, "admin");
+  const profileResult = await (serviceClient as SupabaseClient).rpc(
+    "provision_ci_rls_fixture_profile",
+    { p_user_id: createdUser.user.id, p_organization_id: harness.orgAId },
+  );
+  if (profileResult.error || profileResult.data !== harness.orgAId) {
+    throw profileResult.error ?? new Error("Observer admin profile provisioning failed");
+  }
 });
 
 afterAll(async () => {
@@ -173,9 +190,10 @@ describe("RLS staff messaging (live Supabase)", () => {
       throw new Error(computeEnvironmentGuidance(env.missing));
     }
 
-    const observerClient = createClient<Database>(env.supabaseUrl as string, env.supabaseAnonKey as string, {
-      auth: { autoRefreshToken: false, persistSession: false },
-    });
+    const observerClient = createLiveRlsClient(
+      env.supabaseUrl as string,
+      env.supabaseAnonKey as string,
+    );
     const signIn = await observerClient.auth.signInWithPassword({
       email: orgAObserverAdmin.email,
       password: orgAObserverAdmin.password,
@@ -240,7 +258,9 @@ describe("RLS staff messaging (live Supabase)", () => {
     });
 
     expect(error).not.toBeNull();
-    expect((error?.message ?? "").toLowerCase()).toMatch(/therapists may only create direct threads|42501/);
+    expect((error?.message ?? "").toLowerCase()).toMatch(
+      /only admins may create group threads|therapists may only create direct threads|42501/,
+    );
   });
 
   it("allows admin group thread creation within active same-org staff", async () => {
@@ -305,9 +325,10 @@ describe("RLS staff messaging (live Supabase)", () => {
       throw new Error(computeEnvironmentGuidance(env.missing));
     }
 
-    const observerClient = createClient<Database>(env.supabaseUrl as string, env.supabaseAnonKey as string, {
-      auth: { autoRefreshToken: false, persistSession: false },
-    });
+    const observerClient = createLiveRlsClient(
+      env.supabaseUrl as string,
+      env.supabaseAnonKey as string,
+    );
     const signIn = await observerClient.auth.signInWithPassword({
       email: orgAObserverAdmin.email,
       password: orgAObserverAdmin.password,

--- a/tests/integration/trusted-rls-token-and-client-storage.contract.test.ts
+++ b/tests/integration/trusted-rls-token-and-client-storage.contract.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..');
+const clientStorageMigration = readFileSync(
+  resolve(
+    repoRoot,
+    'supabase',
+    'migrations',
+    '20260714230523_repair_trusted_rls_authorization_boundaries.sql',
+  ),
+  'utf8',
+).replace(/\s+/g, ' ');
+
+describe('client document self-upload policy', () => {
+  it('retains existing privileged access and adds only active same-org client create-and-read access', () => {
+    expect(clientStorageMigration).toMatch(
+      /drop policy if exists client_documents_org_insert on storage\.objects/i,
+    );
+    expect(clientStorageMigration).toMatch(
+      /create policy client_documents_org_insert on storage\.objects for insert to authenticated with check/i,
+    );
+    expect(clientStorageMigration).toContain("bucket_id = 'client-documents'");
+    expect(clientStorageMigration).toContain("split_part(name, '/', 1) = 'clients'");
+    expect(clientStorageMigration).toContain("array['org_admin', 'org_super_admin']");
+    expect(clientStorageMigration).toContain("array['therapist']");
+    expect(clientStorageMigration).toContain('s.therapist_id = auth.uid()');
+    expect(clientStorageMigration).toContain("array['client']");
+    expect(clientStorageMigration).toContain(
+      "split_part(name, '/', 2) = auth.uid()::text",
+    );
+    expect(clientStorageMigration).toMatch(
+      /app\.user_has_role_for_org\( app\.current_user_id\(\), \( select c\.organization_id from public\.clients c where c\.id::text = split_part\(name, '\/', 2\) limit 1 \), array\['client'\] \)/i,
+    );
+    expect(clientStorageMigration).not.toMatch(
+      /for insert to authenticated with check\s*\(\s*true\s*\)/i,
+    );
+    expect(clientStorageMigration).toMatch(
+      /drop policy if exists client_documents_org_read on storage\.objects/i,
+    );
+    expect(clientStorageMigration).toMatch(
+      /create policy client_documents_org_read on storage\.objects for select to authenticated using/i,
+    );
+    expect(clientStorageMigration).toMatch(
+      /split_part\(name, '\/', 2\) = auth\.uid\(\)::text/i,
+    );
+    expect(clientStorageMigration.match(/array\['client'\]/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('trusted RLS authorization boundary repairs', () => {
+  it('binds client authorization reads to the target client identity', () => {
+    expect(clientStorageMigration).toMatch(
+      /create or replace function app\.current_user_can_read_authorization_row/i,
+    );
+    expect(clientStorageMigration).toMatch(
+      /app\.user_has_role_for_org\( 'client', p_organization_id, null, p_client_id, null \)/i,
+    );
+    expect(clientStorageMigration).not.toContain("array['org_member']");
+    expect(clientStorageMigration).toContain("array['therapist']");
+    expect(clientStorageMigration).not.toMatch(
+      /if p_provider_id is not distinct from app\.current_user_id\(\) then return true; end if; return false/i,
+    );
+  });
+
+  it('removes permissive session CPT policies before recreating org-scoped CRUD policies', () => {
+    expect(clientStorageMigration).toContain("tablename = 'session_cpt_entries'");
+    expect(clientStorageMigration).toContain(
+      'drop policy if exists %I on public.session_cpt_entries',
+    );
+    for (const operation of ['select', 'insert', 'update', 'delete']) {
+      expect(clientStorageMigration).toContain(
+        `create policy "Session CPT entries scoped ${operation}"`,
+      );
+    }
+    expect(clientStorageMigration).toContain(
+      "app.user_has_role_for_org('admin', organization_id, null, null, session_id)",
+    );
+    expect(clientStorageMigration).not.toMatch(/\btrue\s+or\s+true\b/i);
+
+    const outerSessionScopeChecks = clientStorageMigration.match(
+      /(?:using|with check) \( exists \( select 1 from public\.sessions scoped_session where scoped_session\.id = session_cpt_entries\.session_id and scoped_session\.organization_id = session_cpt_entries\.organization_id \) and \(/gi,
+    ) ?? [];
+    expect(outerSessionScopeChecks).toHaveLength(5);
+    expect(
+      clientStorageMigration.match(/assigned_session\.therapist_id = auth\.uid\(\)/g) ?? [],
+    ).toHaveLength(5);
+  });
+
+  it('restores same-org therapist self-management for certifications', () => {
+    expect(clientStorageMigration).toContain("tablename = 'therapist_certifications'");
+    expect(clientStorageMigration).toContain(
+      "app.user_has_role_for_org('therapist', organization_id, therapist_id, null, null)",
+    );
+    expect(clientStorageMigration).toContain('therapist_id = auth.uid()');
+  });
+});

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -120,6 +120,20 @@ describe('select-browser-checks', () => {
     ]);
   });
 
+  it('requires hosted auth smoke for therapist user assignment changes', () => {
+    const selection = runSelector('--changed-file', 'supabase/functions/assign-therapist-user/index.ts');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.authSmokeRequired).toBe(true);
+    expect(selection.tier0Specs).toEqual([
+      'cypress/e2e/routes_admin.cy.ts',
+      'cypress/e2e/routes_auth.cy.ts',
+    ]);
+    expect(selection.reasons).toEqual([
+      'supabase/functions/assign-therapist-user/index.ts: therapist provisioning auth flow',
+    ]);
+  });
+
   it('requires hosted auth smoke when the shared Playwright route helper changes', () => {
     const selection = runSelector('--changed-file', 'scripts/lib/playwright-smoke.ts');
 


### PR DESCRIPTION
## Summary
- repair client document create/read ownership and authorization-row client binding
- replace permissive session CPT policies with active-role, assigned-therapist, and session/org-scoped policies
- restore intended therapist certification self-management and harden assign-therapist-user to canonical active profiles/current schema
- repair trusted hosted RLS fixtures, transport markers, and behavioral assertions
- require BCBA auth smoke when assign-therapist-user changes so main executes provision, acceptance, and cleanup

## Risk
Critical protected-path change: one forward RLS migration, one Edge Function, and exact CI scope selection. Human review is mandatory. Do not merge until required CI is green. Fresh post-merge Supabase Validate and a non-skipped main BCBA provision/acceptance/cleanup run remain decisive.

The strict cross-org manage_admin_users assertion remains intentionally unchanged because both checked-in and live SQL enforce denial; prior hosted success has no safe local reproduction and must be resolved by the fresh trusted run.

## Verification
- focused trusted contracts: 5 files / 41 tests passed, including the red/green browser-selector regression
- npm run ci:check-focused: passed (DB-URL-only subchecks skipped locally)
- npm run lint: passed
- npm run typecheck: passed
- npm run validate:tenant: passed
- npm run build: passed
- npm run test:ci: 2,721 passed; 2 unchanged Windows/Node 24 portability failures (CRLF workflow extraction and jsdom Blob.text)
- npm run test:routes:tier0: 212 passed; routes_client preview server returned two transient 404s
- security, Supabase, architecture, implementation, test, DevOps, and code reviews completed; final reviews approved PR handoff
- current PR CI blocker: runtime-migration-parity fails until reviewed migration 20260714230523_repair_trusted_rls_authorization_boundaries is promoted to the hosted ledger

Linear: WIN-217