### PR TITLE
WIN-217: repair post-merge trusted RLS validation

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -489,3 +489,20 @@ Verification card:
 - blocked checks: `npm run ci:playwright`, trusted Supabase validation, migration/runtime parity, deployed Edge parity, and non-skipped BCBA acceptance require protected hosted CI. Full `verify:local` remains failed because it includes the two recorded `test:ci` failures. The Edge Function is not in the automatic session bundle and requires reviewed post-merge deployment with `verify_jwt=true` readback.
 - result: `pass-with-blocked-checks` for the bounded local implementation; PR CI, human approval, hosted promotion, fresh green Supabase Validate, and non-skipped BCBA acceptance remain required before completion.
 - residual risk: the forward migration changes live tenant boundaries and the Edge repair is not proven until reviewed code is deployed; `manage_admin_users` remains strict in the test because neither checked-in nor live SQL supports weakening the cross-org denial contract.
+
+### WIN-217 post-merge trusted validation repair
+
+- branch: `codex/win-217-post-merge-trusted-rls`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- triggering evidence: PR #792 merged and deployed successfully, but main Supabase Validate run `29418796988` failed one cross-org admin RPC assertion, two unbounded Edge invocations, three overlapping session fixtures, one equivalent-timestamp assertion, two tenantless note-template reads, and guardian profile setup.
+- bounded fix:
+  - derive `assign_admin_role` and `manage_admin_users` authority from the current JWT plus active canonical profiles; keep `assign_admin_role` service-only, keep `manage_admin_users` authenticated/service-role callable, and preserve same-org denial.
+  - use signup-generated guardian profile state without mutating protected auth fields.
+  - isolate session time ranges, write template `organization_id`, normalize equivalent UTC output, and bound/correlate Edge requests at 15 seconds.
+- local verification:
+  - focused contracts: 3 files / 20 tests passed.
+  - `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run validate:tenant`, and `npm run build` passed.
+  - `npm run test:ci` still has the unchanged local Node/jsdom `Blob.text()` failure; the affected live-fixture contract was updated and passes focused.
+- required hosted sequence: human review -> apply the exact reviewed migration through Supabase -> read back functions/grants/ledger -> green PR runtime parity -> merge -> fresh main Supabase Validate with `RUN_DB_IT=1` -> inspect correlated same-org/cross-org Edge outcomes and zero fixture residue.
+- residual risk: no production migration promotion is authorized until human review; the fresh hosted suite remains the only decisive proof for live RPC, Edge transport, and cleanup behavior.

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -480,6 +480,34 @@ const signInGuardian = async (context: GuardianContext): Promise<TypedClient> =>
   return signInWithPassword(context.email, context.password);
 };
 
+const invokeAssignTherapistUser = async (
+  client: TypedClient,
+  body: { userId: string; therapistId: string },
+  scenario: 'same-org' | 'cross-org',
+) => {
+  const correlationId = `ci-rls-${scenario}-${randomUUID()}`;
+  const startedAt = process.hrtime.bigint();
+  console.info(`[assign-therapist-user:${correlationId}] request started`);
+
+  const result = await client.functions.invoke('assign-therapist-user', {
+    body,
+    headers: { 'x-request-id': correlationId },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+  const errorStatus = getFunctionErrorStatus(result.error);
+  const outcome = result.error
+    ? errorStatus
+      ? `http-${errorStatus}`
+      : `error-${result.error.name}:${result.error.message}`
+    : 'success';
+  console.info(
+    `[assign-therapist-user:${correlationId}] request completed in ${elapsedMs.toFixed(0)}ms with outcome ${outcome}`,
+  );
+  return result;
+};
+
 const expectRlsViolation = (error: PostgrestError | null, fallbackRowCount = 0) => {
   if (error) {
     expect(error.message.toLowerCase()).toMatch(/row-level security|not allowed|permission|violat/);
@@ -552,6 +580,20 @@ const generateHoldWindow = (
     end: endDate.toISOString(),
     expires: expiresDate.toISOString(),
   };
+};
+
+let isolatedSessionWindowOffset = 0;
+
+const generateIsolatedSessionWindow = (
+  baseEndTime: string,
+): { start: string; end: string } => {
+  isolatedSessionWindowOffset += 1;
+  const startDate = new Date(
+    new Date(baseEndTime).getTime() + isolatedSessionWindowOffset * 2 * 60 * 60 * 1000,
+  );
+  const endDate = new Date(startDate.getTime() + 60 * 60 * 1000);
+
+  return { start: startDate.toISOString(), end: endDate.toISOString() };
 };
 
 const ensureSessionCptEntriesSeeded = async (): Promise<void> => {
@@ -941,6 +983,7 @@ const ensureSessionNoteTemplatesSeeded = async (): Promise<void> => {
         template_structure: { sections: ['summary'] },
         created_by: context.therapistId,
         compliance_requirements: { region: 'test' },
+        organization_id: context.organizationId,
       })
       .select('id')
       .single();
@@ -1049,24 +1092,23 @@ const createGuardianFixture = async (tenant: TenantContext): Promise<GuardianCon
   const roleInsert = await serviceClient
     .from('user_roles')
     .insert({ user_id: guardianId, role_id: resolvedRoleId });
-
   if (roleInsert.error) {
     throw roleInsert.error;
   }
 
   const guardianProfileResult = await serviceClient
     .from('profiles')
-    .update({
-      organization_id: tenant.organizationId,
-      role: 'client',
-      is_active: true,
-    })
+    .select('organization_id, role, is_active')
     .eq('id', guardianId)
-    .select('id')
     .single();
   if (guardianProfileResult.error || !guardianProfileResult.data) {
-    throw guardianProfileResult.error ?? new Error('Synthetic guardian profile provisioning failed');
+    throw guardianProfileResult.error ?? new Error('Synthetic guardian profile readback failed');
   }
+  expect(guardianProfileResult.data).toMatchObject({
+    organization_id: tenant.organizationId,
+    role: 'client',
+    is_active: true,
+  });
 
   const { data: insertedGuardian, error: guardianInsertError } = await serviceClient
     .from('client_guardians')
@@ -1303,12 +1345,14 @@ describe('admin organization scoping', () => {
 
     const adminClient = await signInAdmin(adminContext);
     try {
-      const { data, error } = await adminClient.functions.invoke('assign-therapist-user', {
-        body: {
+      const { data, error } = await invokeAssignTherapistUser(
+        adminClient,
+        {
           userId: orgAContext.clientUserId,
           therapistId: orgAContext.therapistId,
         },
-      });
+        'same-org',
+      );
 
       expect(error).toBeNull();
       expect(data?.success).toBe(true);
@@ -2391,12 +2435,14 @@ describe('row level security for multi-tenant tables', () => {
 
     const adminClient = await signInAdmin(adminContext);
     try {
-      const { error } = await adminClient.functions.invoke('assign-therapist-user', {
-        body: {
+      const { error } = await invokeAssignTherapistUser(
+        adminClient,
+        {
           userId: orgBContext.clientUserId,
           therapistId: orgBContext.therapistId,
         },
-      });
+        'cross-org',
+      );
 
       expect(error).toBeTruthy();
       expect(getFunctionErrorStatus(error)).toBe(403);
@@ -2641,7 +2687,7 @@ describe('row level security for multi-tenant tables', () => {
 
     const { data: baseSession, error: baseSessionError } = await serviceClient
       .from('sessions')
-      .select('goal_id, program_id')
+      .select('goal_id, program_id, end_time')
       .eq('id', orgAContext.sessionId)
       .single();
 
@@ -2650,8 +2696,7 @@ describe('row level security for multi-tenant tables', () => {
     }
 
     const targetSessionId = randomUUID();
-    const targetStart = new Date(Date.now() - 45 * 60 * 1000);
-    const targetEnd = new Date(Date.now() + 15 * 60 * 1000);
+    const targetWindow = generateIsolatedSessionWindow(baseSession.end_time);
 
     const { error: insertSessionError } = await serviceClient
       .from('sessions')
@@ -2662,8 +2707,8 @@ describe('row level security for multi-tenant tables', () => {
         organization_id: orgAContext.organizationId,
         program_id: baseSession.program_id,
         goal_id: baseSession.goal_id,
-        start_time: targetStart.toISOString(),
-        end_time: targetEnd.toISOString(),
+        start_time: targetWindow.start,
+        end_time: targetWindow.end,
         status: 'scheduled',
       });
 
@@ -2720,7 +2765,7 @@ describe('row level security for multi-tenant tables', () => {
 
     const { data: baseSession, error: baseSessionError } = await serviceClient
       .from('sessions')
-      .select('goal_id, program_id')
+      .select('goal_id, program_id, end_time')
       .eq('id', orgAContext.sessionId)
       .single();
 
@@ -2729,8 +2774,7 @@ describe('row level security for multi-tenant tables', () => {
     }
 
     const targetSessionId = randomUUID();
-    const targetStart = new Date(Date.now() - 45 * 60 * 1000);
-    const targetEnd = new Date(Date.now() + 15 * 60 * 1000);
+    const targetWindow = generateIsolatedSessionWindow(baseSession.end_time);
 
     const { error: insertSessionError } = await serviceClient
       .from('sessions')
@@ -2741,8 +2785,8 @@ describe('row level security for multi-tenant tables', () => {
         organization_id: orgAContext.organizationId,
         program_id: baseSession.program_id,
         goal_id: baseSession.goal_id,
-        start_time: targetStart.toISOString(),
-        end_time: targetEnd.toISOString(),
+        start_time: targetWindow.start,
+        end_time: targetWindow.end,
         status: 'scheduled',
       });
 
@@ -2799,7 +2843,7 @@ describe('row level security for multi-tenant tables', () => {
 
     const { data: baseSession, error: baseSessionError } = await serviceClient
       .from('sessions')
-      .select('goal_id, program_id')
+      .select('goal_id, program_id, end_time')
       .eq('id', orgAContext.sessionId)
       .single();
 
@@ -2808,8 +2852,7 @@ describe('row level security for multi-tenant tables', () => {
     }
 
     const targetSessionId = randomUUID();
-    const targetStart = new Date(Date.now() - 50 * 60 * 1000);
-    const targetEnd = new Date(Date.now() + 10 * 60 * 1000);
+    const targetWindow = generateIsolatedSessionWindow(baseSession.end_time);
 
     const { error: insertSessionError } = await serviceClient
       .from('sessions')
@@ -2820,8 +2863,8 @@ describe('row level security for multi-tenant tables', () => {
         organization_id: orgAContext.organizationId,
         program_id: baseSession.program_id,
         goal_id: baseSession.goal_id,
-        start_time: targetStart.toISOString(),
-        end_time: targetEnd.toISOString(),
+        start_time: targetWindow.start,
+        end_time: targetWindow.end,
         status: 'scheduled',
       });
 
@@ -3142,7 +3185,7 @@ describe('session holds enforce role-scoped access', () => {
         .single();
 
       expect(updateResult.error).toBeNull();
-      expect(updateResult.data?.end_time).toBe(newEndTime);
+      expect(new Date(updateResult.data?.end_time ?? '').toISOString()).toBe(newEndTime);
 
       const deleteResult = await adminClient
         .from('session_holds')

--- a/supabase/migrations/20260715134500_repair_manage_admin_users_tenant_boundary.sql
+++ b/supabase/migrations/20260715134500_repair_manage_admin_users_tenant_boundary.sql
@@ -1,0 +1,328 @@
+-- @migration-intent: Fail closed on the current JWT and canonical tenant identity when authenticated admins manage admin roles.
+-- @migration-dependencies: 20260506170000_super_admin_admin_management_authz.sql,20260709172500_harden_admin_users_rpc_exposure.sql,20260714153227_decompose_ci_rls_fixture_profile_guard.sql
+-- @migration-rollback: Forward recovery only. Do not restore metadata-derived tenant authorization; replace these functions with a reviewed canonical-profile implementation.
+
+begin;
+
+create or replace function public.assign_admin_role(
+  user_email text,
+  organization_id uuid,
+  reason text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_request_role text := coalesce(auth.jwt() ->> 'role', '');
+  v_is_service_role boolean := v_request_role = 'service_role';
+  v_is_super_admin boolean := public.current_user_is_super_admin();
+  v_caller_id uuid := auth.uid();
+  v_caller_org uuid;
+  v_caller_active boolean;
+  v_target_id uuid;
+  v_target_org uuid;
+  v_target_active boolean;
+  v_target_metadata jsonb;
+  v_admin_role_id uuid;
+  v_role_rows integer := 0;
+begin
+  if organization_id is null then
+    raise exception using errcode = '22023', message = 'Organization ID is required';
+  end if;
+
+  if not v_is_service_role then
+    if v_caller_id is null then
+      raise exception using errcode = '28000', message = 'Authentication required';
+    end if;
+
+    select p.organization_id, p.is_active
+    into v_caller_org, v_caller_active
+    from public.profiles p
+    where p.id = v_caller_id;
+
+    if coalesce(v_caller_active, false) is not true then
+      raise exception using errcode = '42501', message = 'Active caller profile is required';
+    end if;
+
+    if not v_is_super_admin and not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_caller_id
+        and r.name = 'admin'
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+    ) then
+      raise exception using errcode = '42501', message = 'Only active administrators can assign admin role';
+    end if;
+
+    if not v_is_super_admin and v_caller_org is distinct from organization_id then
+      raise exception using errcode = '42501', message = 'Caller organization mismatch';
+    end if;
+  end if;
+
+  select u.id, p.organization_id, p.is_active, u.raw_user_meta_data
+  into v_target_id, v_target_org, v_target_active, v_target_metadata
+  from auth.users u
+  left join public.profiles p on p.id = u.id
+  where u.email = user_email;
+
+  if v_target_id is null then
+    raise exception using errcode = 'P0002', message = format('User with email %s not found', user_email);
+  end if;
+
+  if not v_is_service_role and coalesce(v_target_active, false) is not true then
+    raise exception using errcode = '42501', message = 'Active target profile is required';
+  end if;
+
+  if v_target_org is distinct from organization_id then
+    raise exception using errcode = '42501', message = 'Target user canonical organization mismatch';
+  end if;
+
+  select id into v_admin_role_id
+  from public.roles
+  where name = 'admin';
+
+  if v_admin_role_id is null then
+    insert into public.roles (name, description)
+    values ('admin', 'Administrator role with full access')
+    returning id into v_admin_role_id;
+  end if;
+
+  insert into public.user_roles (user_id, role_id, is_active, expires_at)
+  values (v_target_id, v_admin_role_id, true, null)
+  on conflict (user_id, role_id) do update
+  set is_active = true,
+      expires_at = null;
+
+  get diagnostics v_role_rows = row_count;
+
+  v_target_metadata := coalesce(v_target_metadata, '{}'::jsonb);
+  v_target_metadata := jsonb_set(v_target_metadata, '{organization_id}', to_jsonb(organization_id::text), true);
+  v_target_metadata := jsonb_set(v_target_metadata, '{organizationId}', to_jsonb(organization_id::text), true);
+  v_target_metadata := jsonb_set(v_target_metadata, '{is_admin}', 'true'::jsonb, true);
+
+  update auth.users
+  set raw_user_meta_data = v_target_metadata
+  where id = v_target_id;
+
+  begin
+    insert into public.admin_actions (
+      admin_user_id,
+      target_user_id,
+      organization_id,
+      action_type,
+      action_details
+    ) values (
+      v_caller_id,
+      v_target_id,
+      organization_id,
+      'admin_role_added',
+      jsonb_build_object(
+        'operation', 'add',
+        'target_email', user_email,
+        'service_role', v_is_service_role,
+        'role_upserted', v_role_rows > 0,
+        'reason', nullif(reason, '')
+      )
+    );
+  exception
+    when others then
+      raise warning 'Failed to log admin add action via assign_admin_role: %', sqlerrm;
+  end;
+end;
+$$;
+
+revoke execute on function public.assign_admin_role(text, uuid, text) from public;
+revoke execute on function public.assign_admin_role(text, uuid, text) from anon;
+revoke execute on function public.assign_admin_role(text, uuid, text) from authenticated;
+grant execute on function public.assign_admin_role(text, uuid, text) to service_role;
+
+create or replace function public.manage_admin_users(
+  operation text,
+  target_user_id text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_request_role text := coalesce(auth.jwt() ->> 'role', '');
+  v_is_service_role boolean := v_request_role = 'service_role';
+  v_is_super_admin boolean := public.current_user_is_super_admin();
+  v_admin_role_id uuid;
+  v_caller_id uuid := auth.uid();
+  v_caller_org uuid;
+  v_caller_active boolean;
+  v_target_id uuid;
+  v_target_email text;
+  v_target_org uuid;
+  v_admin_count integer;
+  v_effective_org uuid;
+begin
+  select id into v_admin_role_id
+  from public.roles
+  where name = 'admin';
+
+  if not v_is_service_role then
+    if v_caller_id is null then
+      raise exception using errcode = '28000', message = 'Authentication required';
+    end if;
+
+    select p.organization_id, p.is_active
+    into v_caller_org, v_caller_active
+    from public.profiles p
+    where p.id = v_caller_id;
+
+    if coalesce(v_caller_active, false) is not true then
+      raise exception using errcode = '42501', message = 'Active caller profile is required';
+    end if;
+
+    if not v_is_super_admin and not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_caller_id
+        and r.name = 'admin'
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+    ) then
+      raise exception using errcode = '42501', message = 'Only active administrators can manage admin users';
+    end if;
+
+    if not v_is_super_admin then
+      if v_caller_org is null then
+        raise exception using errcode = '42501', message = 'Caller organization context is required';
+      end if;
+    end if;
+  end if;
+
+  begin
+    v_target_id := target_user_id::uuid;
+  exception
+    when others then
+      select id into v_target_id
+      from auth.users
+      where email = target_user_id;
+  end;
+
+  select email into v_target_email
+  from auth.users
+  where id = v_target_id;
+
+  if v_target_id is null or v_target_email is null then
+    raise exception using errcode = 'P0002', message = format('User with ID/email %s not found', target_user_id);
+  end if;
+
+  v_target_org := app.resolve_user_organization_id(v_target_id);
+
+  if not v_is_service_role and not v_is_super_admin then
+    if v_target_org is null then
+      raise exception using errcode = '42501', message = 'Target user organization context is required';
+    end if;
+
+    if v_caller_org <> v_target_org then
+      raise exception using errcode = '42501', message = 'Target user does not belong to the caller organization';
+    end if;
+  end if;
+
+  if v_admin_role_id is null then
+    insert into public.roles (name, description)
+    values ('admin', 'Administrator role with full access')
+    returning id into v_admin_role_id;
+  end if;
+
+  case operation
+    when 'add' then
+      if coalesce(v_target_org, v_caller_org) is null then
+        raise exception using errcode = '42501', message = 'Organization context is required to add an admin';
+      end if;
+
+      v_effective_org := coalesce(v_target_org, v_caller_org);
+      perform public.assign_admin_role(v_target_email, v_effective_org, 'manage_admin_users:add');
+
+      begin
+        insert into public.admin_actions (
+          admin_user_id,
+          target_user_id,
+          organization_id,
+          action_type,
+          action_details
+        ) values (
+          v_caller_id,
+          v_target_id,
+          v_effective_org,
+          'admin_role_added',
+          jsonb_build_object(
+            'operation', 'add',
+            'target_email', v_target_email,
+            'service_role', v_is_service_role
+          )
+        );
+      exception
+        when others then
+          raise warning 'Failed to log admin add action: %', sqlerrm;
+      end;
+
+    when 'remove' then
+      if not v_is_service_role and not v_is_super_admin then
+        select count(*) into v_admin_count
+        from public.user_roles ur
+        where ur.role_id = v_admin_role_id
+          and app.resolve_user_organization_id(ur.user_id) = v_caller_org
+          and coalesce(ur.is_active, true) = true
+          and (ur.expires_at is null or ur.expires_at > now());
+
+        if v_admin_count <= 1 and v_target_id = v_caller_id then
+          raise exception using errcode = '42501', message = 'Cannot remove the last active administrator for the organization';
+        end if;
+      end if;
+
+      delete from public.user_roles
+      where user_id = v_target_id
+        and role_id = v_admin_role_id;
+
+      update auth.users
+      set raw_user_meta_data = coalesce(raw_user_meta_data, '{}'::jsonb) - 'is_admin'
+      where id = v_target_id;
+
+      v_effective_org := coalesce(v_target_org, v_caller_org);
+
+      begin
+        insert into public.admin_actions (
+          admin_user_id,
+          target_user_id,
+          organization_id,
+          action_type,
+          action_details
+        ) values (
+          v_caller_id,
+          v_target_id,
+          v_effective_org,
+          'admin_role_removed',
+          jsonb_build_object(
+            'operation', 'remove',
+            'target_email', v_target_email,
+            'service_role', v_is_service_role
+          )
+        );
+      exception
+        when others then
+          raise warning 'Failed to log admin remove action: %', sqlerrm;
+      end;
+
+    else
+      raise exception using errcode = '22023', message = format('Invalid operation: %s', operation);
+  end case;
+end;
+$$;
+
+revoke execute on function public.manage_admin_users(text, text) from public;
+revoke execute on function public.manage_admin_users(text, text) from anon;
+grant execute on function public.manage_admin_users(text, text) to authenticated;
+grant execute on function public.manage_admin_users(text, text) to service_role;
+
+commit;

--- a/tests/admins/manage_admin_users_tenant_boundary.spec.ts
+++ b/tests/admins/manage_admin_users_tenant_boundary.spec.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const migrationPath = join(
+  process.cwd(),
+  'supabase/migrations/20260715134500_repair_manage_admin_users_tenant_boundary.sql',
+);
+
+describe('manage_admin_users tenant boundary repair', () => {
+  it('derives the caller type and tenant from current authoritative request state', () => {
+    const sql = readFileSync(migrationPath, 'utf8').replace(/\s+/g, ' ');
+
+    expect(sql).toMatch(/coalesce\(auth\.jwt\(\)\s*->>\s*'role',\s*''\)/i);
+    expect(sql).not.toMatch(/current_setting\('request\.jwt\.claim\.role'/i);
+    expect(sql).toMatch(/select p\.organization_id, p\.is_active into v_caller_org, v_caller_active from public\.profiles p where p\.id = v_caller_id/i);
+    expect(sql).toContain('app.resolve_user_organization_id(v_target_id)');
+    expect(sql).toMatch(/if v_caller_org <> v_target_org then\s+raise exception/i);
+    expect(sql.match(/coalesce\(v_caller_active, false\) is not true/g)).toHaveLength(2);
+  });
+
+  it('keeps delegated admin assignment on the same canonical active-profile boundary', () => {
+    const sql = readFileSync(migrationPath, 'utf8').replace(/\s+/g, ' ');
+
+    expect(sql).toMatch(/create or replace function public\.assign_admin_role/i);
+    expect(sql).toMatch(/left join public\.profiles p on p\.id = u\.id/i);
+    expect(sql).toMatch(/if not v_is_service_role and coalesce\(v_target_active, false\) is not true/i);
+    expect(sql).toMatch(/if v_target_org is distinct from organization_id then/i);
+    expect(sql).not.toMatch(/if v_target_org is not null and v_target_org <> organization_id then/i);
+    expect(sql).toMatch(/on conflict \(user_id, role_id\) do update set is_active = true, expires_at = null/i);
+    expect(sql).not.toMatch(/get_organization_id_from_metadata/i);
+  });
+
+  it('keeps the authenticated and service-role grants explicit', () => {
+    const sql = readFileSync(migrationPath, 'utf8').replace(/\s+/g, ' ');
+
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text, text\) from public/i);
+    expect(sql).toMatch(/revoke execute on function public\.manage_admin_users\(text, text\) from anon/i);
+    expect(sql).toMatch(/grant execute on function public\.manage_admin_users\(text, text\) to authenticated/i);
+    expect(sql).toMatch(/grant execute on function public\.manage_admin_users\(text, text\) to service_role/i);
+    expect(sql).toMatch(/revoke execute on function public\.assign_admin_role\(text, uuid, text\) from anon/i);
+    expect(sql).toMatch(/revoke execute on function public\.assign_admin_role\(text, uuid, text\) from authenticated/i);
+    expect(sql).toMatch(/grant execute on function public\.assign_admin_role\(text, uuid, text\) to service_role/i);
+  });
+});

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -201,7 +201,12 @@ describe("live RLS fixture schema contract", () => {
     expect(source).toContain("goal_id: goalId");
     expect(source).toContain(".eq('id', context.goalId)");
     expect(source).toContain(".eq('id', context.programId)");
-    expect(source).toContain("Synthetic guardian profile provisioning failed");
+    expect(source).toContain("Synthetic guardian profile readback failed");
+    expect(source).toContain(".select('organization_id, role, is_active')");
+    expect(source).not.toContain("await provisionCiRlsProfile(guardianId");
+    expect(source).toContain("headers: { 'x-request-id': correlationId }");
+    expect(source).toContain("`error-${result.error.name}:${result.error.message}`");
+    expect(source).not.toContain("'x-correlation-id'");
   });
 
   it("uses the deployed therapist status schema before assigning a therapist", () => {


### PR DESCRIPTION
## Summary
- repair the nine actionable failures from post-merge Supabase Validate run 29418796988 without weakening tenant assertions
- harden `manage_admin_users` and delegated `assign_admin_role` around current JWT state, active canonical profiles, exact target organization equality, and the existing service-only helper ACL
- correct hosted RLS fixtures for guardian profiles, note-template tenancy, collision-free sessions, UTC equivalence, and bounded/correlated Edge invocations

## Route and risk
- Linear: WIN-217
- classification: high-risk human-reviewed
- lane: critical
- protected surfaces: Supabase migration, SECURITY DEFINER RPC authorization/grants, tenant-scoped hosted validation

## Verification
- 3 focused files / 20 tests: pass
- `npm run ci:check-focused`: pass (DB-backed preview/grant checks skipped locally; no DB URL)
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run validate:tenant`: pass
- `npm run build`: pass
- `npm run test:ci`: local known Node/jsdom `Blob.text()` failure remains; affected fixture contract passes focused
- code/security/DevOps review: approved with no remaining code-level findings

## Required protected sequence
1. Human/security review this exact SQL.
2. Apply the exact reviewed migration through the Supabase migration API before merge so runtime parity can pass.
3. Read back the ledger, both function definitions, SECURITY DEFINER/search_path, and ACLs; run advisors and synthetic same-org/cross-org/null-org/inactive probes.
4. Require all PR checks green, then merge.
5. Require a fresh main Supabase Validate run with `RUN_DB_IT=1`, bounded same-org Edge success, cross-org HTTP 403, and zero fixture residue.

No production migration was applied by this branch before review.