### PR TITLE
WIN-217: authorize BCBA session note capture

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -489,3 +489,24 @@ Verification card:
 - blocked checks: `npm run ci:playwright`, trusted Supabase validation, migration/runtime parity, deployed Edge parity, and non-skipped BCBA acceptance require protected hosted CI. Full `verify:local` remains failed because it includes the two recorded `test:ci` failures. The Edge Function is not in the automatic session bundle and requires reviewed post-merge deployment with `verify_jwt=true` readback.
 - result: `pass-with-blocked-checks` for the bounded local implementation; PR CI, human approval, hosted promotion, fresh green Supabase Validate, and non-skipped BCBA acceptance remain required before completion.
 - residual risk: the forward migration changes live tenant boundaries and the Edge repair is not proven until reviewed code is deployed; `manage_admin_users` remains strict in the test because neither checked-in nor live SQL supports weakening the cross-org denial contract.
+
+### WIN-217 BCBA session-note authorization follow-up
+
+- branch: `codex/win-217-bcba-session-note-auth`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- hosted failure: main CI run `29418796830` passed synthetic BCBA provisioning, auth, session smoke, lifecycle acceptance, and cleanup, then the measurement roundtrip received HTTP 403 from `POST /api/session-notes/upsert`.
+- root cause: the endpoint's initial authorization gate recognized therapist, admin, super-admin, and org-member roles but omitted the canonical exact `bcba` role. The downstream production `current_user_can_capture_trial_event` RPC already admits exact BCBA actors for the active organization.
+- bounded fix:
+  - only when the existing role gate has no match, call the canonical organization-scoped BCBA helper.
+  - admit only an exact positive BCBA result; preserve 403 for other roles and fail closed with 502 when BCBA role resolution is unavailable.
+  - keep organization, authorization, client, billing, session, therapist, goal, trial-event, and caller-JWT enforcement unchanged.
+- non-goals: no migration, global role-resolver change, role alias, workflow/provisioner change, service-role bypass, or relaxation of tenant/data checks.
+
+Verification card:
+
+- required checks: RED/GREEN handler tests; generic role-resolution contracts; policy; lint; typecheck; `test:ci`; build; tenant validation; independent code/test/security review; human review; hosted main BCBA acceptance.
+- executed checks: two focused authorization tests failed with the original 403 behavior before implementation; focused handler and role contracts pass, 2 files / 61 tests; policy, lint, typecheck, tenant validation, build, and tier-0 routes (7 specs / 220 tests) pass; independent code/security review found no remaining actionable findings; production Supabase definition readback confirms the downstream capture RPC grants exact BCBA authority through the canonical organization-scoped role helper.
+- blocked checks: local `test:ci` reaches the same two unrelated Windows baseline failures recorded above: jsdom `Blob.text()` and CRLF-sensitive workflow-step extraction. Hosted acceptance requires protected main-only CI credentials and intentionally cannot execute on the PR event.
+- result: `human-review-ready-with-blocked-checks`; the protected server change is not complete until the PR is human-reviewed/merged and a fresh main run passes the measurement roundtrip plus zero-residue cleanup.
+- residual risk: local mocks cannot prove the deployed API adapter and production caller JWT traverse the same path; the trusted main-only BCBA acceptance remains decisive.

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -10,6 +10,7 @@ vi.mock("../api/shared", async () => {
     resolveOrgAndRoleWithStatus: vi.fn(),
     fetchAuthenticatedUserIdWithStatus: vi.fn(),
     currentUserCanCaptureTrialEvent: vi.fn(),
+    currentUserIsBcbaForOrg: vi.fn(),
     getSupabaseConfig: vi.fn(),
     fetchJson: vi.fn(),
   };
@@ -21,6 +22,7 @@ vi.mock("../sessionCaptureBillingGate", () => ({
 
 import {
   currentUserCanCaptureTrialEvent,
+  currentUserIsBcbaForOrg,
   fetchAuthenticatedUserIdWithStatus,
   fetchJson,
   getAccessToken,
@@ -137,11 +139,92 @@ describe("sessionNotesUpsertHandler", () => {
       allowed: true,
       upstreamError: false,
     });
+    vi.mocked(currentUserIsBcbaForOrg).mockResolvedValue({
+      allowed: false,
+      upstreamError: false,
+    });
     vi.mocked(getSupabaseConfig).mockReturnValue({
       supabaseUrl: BASE_URL,
       anonKey: "anon-key",
     });
     process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+  });
+
+  it("admits an organization-scoped BCBA through the session-note authorization gate", async () => {
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: false,
+      isAdmin: false,
+      isOrgMember: false,
+      isSuperAdmin: false,
+      upstreamError: false,
+    });
+    vi.mocked(currentUserIsBcbaForOrg).mockResolvedValue({ allowed: true, upstreamError: false });
+
+    const response = await sessionNotesUpsertHandler(new Request("http://localhost/api/session-notes/upsert", {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({}),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(currentUserIsBcbaForOrg).toHaveBeenCalledWith(ACCESS_TOKEN, "org-1");
+    expect(fetchAuthenticatedUserIdWithStatus).toHaveBeenCalledWith(ACCESS_TOKEN);
+  });
+
+  it("fails closed when BCBA role resolution has an upstream error", async () => {
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: false,
+      isAdmin: false,
+      isOrgMember: false,
+      isSuperAdmin: false,
+      upstreamError: false,
+    });
+    vi.mocked(currentUserIsBcbaForOrg).mockResolvedValue({ allowed: false, upstreamError: true });
+
+    const response = await sessionNotesUpsertHandler(new Request("http://localhost/api/session-notes/upsert", {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({}),
+    }));
+
+    expect(response.status).toBe(502);
+    expect(fetchAuthenticatedUserIdWithStatus).not.toHaveBeenCalled();
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("preserves forbidden for users without an existing session-note role or BCBA authority", async () => {
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: false,
+      isAdmin: false,
+      isOrgMember: false,
+      isSuperAdmin: false,
+      upstreamError: false,
+    });
+
+    const response = await sessionNotesUpsertHandler(new Request("http://localhost/api/session-notes/upsert", {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({}),
+    }));
+
+    expect(response.status).toBe(403);
+    expect(currentUserIsBcbaForOrg).toHaveBeenCalledWith(ACCESS_TOKEN, "org-1");
+    expect(fetchAuthenticatedUserIdWithStatus).not.toHaveBeenCalled();
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("does not make existing allowed roles depend on BCBA role resolution", async () => {
+    const response = await sessionNotesUpsertHandler(new Request("http://localhost/api/session-notes/upsert", {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({}),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(currentUserIsBcbaForOrg).not.toHaveBeenCalled();
   });
 
   afterEach(() => {

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -6,6 +6,7 @@ import { getOptionalServerEnv } from "../env";
 import {
   corsHeadersForRequest,
   currentUserCanCaptureTrialEvent,
+  currentUserIsBcbaForOrg,
   errorResponse,
   fetchAuthenticatedUserIdWithStatus,
   fetchJson,
@@ -954,8 +955,19 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
   if (roleUpstreamError) {
     return errorResponse(request, "upstream_error", "Unable to validate organization access", { status: 502 });
   }
-  if (!organizationId || (!isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember)) {
+  if (!organizationId) {
     return errorResponse(request, "forbidden", "Forbidden");
+  }
+
+  const hasResolvedSessionNoteRole = isTherapist || isAdmin || isSuperAdmin || isOrgMember;
+  if (!hasResolvedSessionNoteRole) {
+    const bcbaAuthority = await currentUserIsBcbaForOrg(accessToken, organizationId);
+    if (bcbaAuthority.upstreamError) {
+      return errorResponse(request, "upstream_error", "Unable to validate BCBA access", { status: 502 });
+    }
+    if (!bcbaAuthority.allowed) {
+      return errorResponse(request, "forbidden", "Forbidden");
+    }
   }
 
   const { userId: actorUserId, upstreamError: actorUpstreamError } = await fetchAuthenticatedUserIdWithStatus(accessToken);


### PR DESCRIPTION
## Summary
- authorize exact, organization-scoped BCBA actors at the session-note upsert boundary
- preserve the existing therapist/admin/super-admin/org-member path
- keep non-BCBA denial and fail closed when BCBA role resolution is unavailable
- document the protected verification and hosted acceptance requirements

## Root cause
Main CI run 29418796830 passed synthetic BCBA provisioning, auth/session smoke, lifecycle acceptance, and cleanup. The measurement roundtrip then received HTTP 403 from POST /api/session-notes/upsert because the endpoint's initial role gate omitted the canonical bcba role. Production Supabase readback confirmed the downstream trial-capture RPC already authorizes exact BCBA actors for the active organization.

## Verification
- RED: 2 focused authorization tests failed with the original 403 behavior
- GREEN: handler + generic role contracts, 2 files / 61 tests
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run validate:tenant
- npm run build
- npm run test:routes:tier0 — 7 specs / 220 tests
- independent code/security review — approved, no findings
- npm run test:ci — blocked only by the two recorded Windows baseline failures: jsdom Blob.text() and CRLF-sensitive workflow-step extraction

## Risk
Critical protected server/auth boundary. No migration, global resolver change, role alias, workflow/provisioner change, service-role bypass, or relaxation of organization/client/authorization/session/billing checks.

## Hosted gate
After human review and merge, a fresh main-only run must pass BCBA lifecycle, session-note measurement roundtrip, and zero-residue cleanup.

Linear: https://linear.app/winningedgeai/issue/WIN-217/recover-bcba-session-auth-and-idempotent-start-conflicts