### PR TITLE
WIN-217: repair hosted admin fixture bootstrap

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -527,3 +527,16 @@ Verification card:
 - blocked checks: local `test:ci` reaches the same two unrelated Windows baseline failures recorded above: jsdom `Blob.text()` and CRLF-sensitive workflow-step extraction. Hosted acceptance requires protected main-only CI credentials and intentionally cannot execute on the PR event.
 - result: `human-review-ready-with-blocked-checks`; the protected server change is not complete until the PR is human-reviewed/merged and a fresh main run passes the measurement roundtrip plus zero-residue cleanup.
 - residual risk: local mocks cannot prove the deployed API adapter and production caller JWT traverse the same path; the trusted main-only BCBA acceptance remains decisive.
+
+### WIN-217 post-merge admin fixture bootstrap repair
+
+- branch: `codex/win-217-admin-fixture-bootstrap`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- hosted failure: post-merge Supabase Validate run `29424318934` passed runtime migration parity, then six live RLS suites failed during admin fixture setup with SQLSTATE `42501` and `Target user canonical organization mismatch`.
+- root cause: trusted fixtures invoked `assign_admin_role` before the CI-only provisioner established the synthetic user's canonical profile organization. The repaired production RPC correctly rejects null or mismatched canonical tenant state.
+- bounded fix: preserve production SQL and grants; reorder all three synthetic admin bootstrap paths to persist the expiring fixture marker, reconcile exactly one admin role, provision/read back the canonical profile, and only then invoke `assign_admin_role` as an idempotent authorization/audit smoke.
+- regression proof: a new secret-free contract requires the complete bootstrap order and verifies that every call is present; focused fixture and migration contracts pass, 3 files / 23 tests.
+- verification: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run validate:tenant`, and `npm run build` pass. Local `npm run test:ci` reaches the two unchanged baseline failures: jsdom `Blob.text()` and CRLF-sensitive workflow-step extraction.
+- required hosted sequence: human review -> merge the fixture-only follow-up -> fresh main Supabase Validate with all six suites collected and passing -> verify zero marked fixture users/roles remain.
+- residual risk: the decisive live proof is main-only because protected Supabase credentials are unavailable to local and pull-request test jobs.

--- a/src/tests/security/rls.spec.ts
+++ b/src/tests/security/rls.spec.ts
@@ -386,6 +386,8 @@ const createAdminFixture = async (organizationId: string): Promise<AdminContext>
   const userId = createdUser.user.id;
   createdFixtureAuthUserIds.push(userId);
 
+  await provisionCiRlsProfile(userId, organizationId, 'admin');
+
   const assignResult = await serviceClient.rpc('assign_admin_role', {
     user_email: email,
     organization_id: organizationId,
@@ -395,8 +397,6 @@ const createAdminFixture = async (organizationId: string): Promise<AdminContext>
   if (assignResult.error) {
     throw assignResult.error;
   }
-
-  await provisionCiRlsProfile(userId, organizationId, 'admin');
 
   return { email, password, userId, organizationId };
 };

--- a/tests/integration/_helpers/liveRlsHarness.ts
+++ b/tests/integration/_helpers/liveRlsHarness.ts
@@ -145,14 +145,6 @@ const createAuthFixture = async (
       if (!options.organizationId) {
         throw new Error("Admin fixtures require an organization id");
       }
-      const assignResult = await serviceClient.rpc("assign_admin_role", {
-        user_email: email,
-        organization_id: options.organizationId,
-        reason: "integration-test bootstrap",
-      });
-      if (assignResult.error) {
-        throw assignResult.error;
-      }
     } else if (options.role === "therapist") {
       await assignNamedRole(serviceClient, userId, "therapist");
     }
@@ -168,6 +160,15 @@ const createAuthFixture = async (
       );
       if (profileResult.error || profileResult.data !== options.organizationId) {
         throw profileResult.error ?? new Error("Synthetic RLS profile provisioning returned the wrong organization");
+      }
+
+      const assignResult = await serviceClient.rpc("assign_admin_role", {
+        user_email: email,
+        organization_id: options.organizationId,
+        reason: "integration-test bootstrap",
+      });
+      if (assignResult.error) {
+        throw assignResult.error;
       }
     }
 

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -193,6 +193,60 @@ describe("live RLS fixture schema contract", () => {
     expect(messageSource).toContain('"provision_ci_rls_fixture_profile"');
   });
 
+  it("provisions canonical admin profiles before invoking assign_admin_role", () => {
+    const harnessSource = readRepoFile("tests/integration/_helpers/liveRlsHarness.ts");
+    const securitySource = readRepoFile("src/tests/security/rls.spec.ts");
+    const messageSource = readRepoFile("tests/integration/rls.message-threads.access.test.ts");
+
+    const harnessAdminSetup = harnessSource.match(
+      /const createAuthFixture[\s\S]*?\n};\n\nconst seedOrgData/,
+    )?.[0];
+    const securityAdminSetup = securitySource.match(
+      /const createAdminFixture[\s\S]*?\n};\n\nconst createTherapistCertificationFixture/,
+    )?.[0];
+    const securityProvisioner = securitySource.match(
+      /const provisionCiRlsProfile[\s\S]*?\n};\n\nconst createTenantFixture/,
+    )?.[0];
+    const messageAdminSetup = messageSource.match(
+      /beforeAll\(async \(\) => \{[\s\S]*?\n}\);\n\nafterAll/,
+    )?.[0];
+
+    expect(harnessAdminSetup).toBeTruthy();
+    expect(securityAdminSetup).toBeTruthy();
+    expect(securityProvisioner).toBeTruthy();
+    expect(messageAdminSetup).toBeTruthy();
+
+    const expectOrdered = (source: string, tokens: string[]) => {
+      const indexes = tokens.map((token) => source.indexOf(token));
+      for (const index of indexes) {
+        expect(index).toBeGreaterThan(-1);
+      }
+      expect(indexes).toEqual([...indexes].sort((left, right) => left - right));
+    };
+
+    expectOrdered(harnessAdminSetup!, [
+      "await persistLiveRlsAppMetadata(",
+      "await reconcileLiveRlsRole(",
+      '"provision_ci_rls_fixture_profile"',
+      'rpc("assign_admin_role"',
+    ]);
+    expectOrdered(securityProvisioner!, [
+      "await persistCiRlsAppMetadata(",
+      "await reconcileCiRlsFixtureRole(",
+      "rpc('provision_ci_rls_fixture_profile'",
+    ]);
+    expectOrdered(securityAdminSetup!, [
+      "await provisionCiRlsProfile(userId, organizationId, 'admin')",
+      "rpc('assign_admin_role'",
+    ]);
+    expectOrdered(messageAdminSetup!, [
+      "await persistLiveRlsAppMetadata(",
+      "await reconcileLiveRlsRole(",
+      '"provision_ci_rls_fixture_profile"',
+      'rpc("assign_admin_role"',
+    ]);
+  });
+
   it("seeds valid session-linked artifacts and guardian organization context", () => {
     const source = readRepoFile("src/tests/security/rls.spec.ts");
 

--- a/tests/integration/rls.message-threads.access.test.ts
+++ b/tests/integration/rls.message-threads.access.test.ts
@@ -75,15 +75,6 @@ beforeAll(async () => {
   }
   orgAObserverAdmin = { userId: createdUser.user.id, email, password };
 
-  const assignResult = await serviceClient.rpc("assign_admin_role", {
-    user_email: email,
-    organization_id: harness.orgAId,
-    reason: "integration-test observer admin",
-  });
-  if (assignResult.error) {
-    throw assignResult.error;
-  }
-
   await persistLiveRlsAppMetadata(serviceClient, createdUser.user.id, observerAppMetadata);
   await reconcileLiveRlsRole(serviceClient, createdUser.user.id, "admin");
   const profileResult = await (serviceClient as SupabaseClient).rpc(
@@ -92,6 +83,15 @@ beforeAll(async () => {
   );
   if (profileResult.error || profileResult.data !== harness.orgAId) {
     throw profileResult.error ?? new Error("Observer admin profile provisioning failed");
+  }
+
+  const assignResult = await serviceClient.rpc("assign_admin_role", {
+    user_email: email,
+    organization_id: harness.orgAId,
+    reason: "integration-test observer admin",
+  });
+  if (assignResult.error) {
+    throw assignResult.error;
   }
 });
 


### PR DESCRIPTION
## Summary
- reorder all synthetic admin fixture paths so canonical profile provisioning completes before assign_admin_role
- preserve the production fail-closed tenant check and service-role RPC boundaries
- add a secret-free ordering contract covering persist, reconcile, provision, and assignment

## Evidence
- root failure: main Supabase Validate run 29424318934, six setup failures with SQLSTATE 42501
- RED: ordering contract failed before the implementation
- GREEN: 3 focused files / 23 tests passed
- policy, lint, typecheck, tenant validation, and build passed
- local test:ci reaches the two unchanged Windows baseline failures: Blob.text and CRLF-sensitive workflow extraction
- independent tenant/security review: no actionable findings

## Risk
- critical lane because hosted tenant fixtures exercise privileged RPCs
- no production SQL, grants, RLS, Edge Functions, or application authority changed
- decisive acceptance is a fresh main-only Supabase Validate run plus zero fixture residue

Linear: WIN-217