### PR TITLE
WIN-217: serialize hosted RLS validation

### DIFF
--- a/.github/workflows/supabase-validate.yml
+++ b/.github/workflows/supabase-validate.yml
@@ -19,6 +19,11 @@ on:
       - 'tests/integration/liveRlsHarness.unit.test.ts'
       - 'src/tests/security/ciRlsFixtureMetadata.ts'
       - 'src/tests/security/rls.spec.ts'
+      - 'tests/integration/rls.message-threads.access.test.ts'
+      - 'tests/integration/rls.session-holds.access.test.ts'
+      - 'tests/integration/rls.sessions.read-write.test.ts'
+      - 'tests/integration/rls.therapists.clients.billing.test.ts'
+      - 'tests/integration/rpc.dashboard.org-scope.test.ts'
 
 jobs:
   lint-migrations:
@@ -59,6 +64,7 @@ jobs:
     if: github.event_name == 'push'
     name: Run application tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -68,7 +74,29 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run unit tests
-        run: npm test -- --run --reporter=verbose
+        run: >-
+          npm test -- --run --reporter=verbose
+          --exclude=src/lib/__tests__/DatabaseIntegration.test.ts
+          --exclude=src/lib/__tests__/multiTenantAccess.test.ts
+          --exclude=src/tests/security/rls.spec.ts
+          --exclude=tests/integration/rls.message-threads.access.test.ts
+          --exclude=tests/integration/rls.session-holds.access.test.ts
+          --exclude=tests/integration/rls.sessions.read-write.test.ts
+          --exclude=tests/integration/rls.therapists.clients.billing.test.ts
+          --exclude=tests/integration/rpc.dashboard.org-scope.test.ts
+      - name: Run hosted database tests serially
+        run: >-
+          npm test -- --run --reporter=verbose
+          --no-file-parallelism
+          --maxWorkers=1
+          --hookTimeout=120000
+          --testTimeout=60000
+          src/tests/security/rls.spec.ts
+          tests/integration/rls.message-threads.access.test.ts
+          tests/integration/rls.session-holds.access.test.ts
+          tests/integration/rls.sessions.read-write.test.ts
+          tests/integration/rls.therapists.clients.billing.test.ts
+          tests/integration/rpc.dashboard.org-scope.test.ts
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -76,6 +104,7 @@ jobs:
           VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY || secrets.SUPABASE_PUBLISHABLE_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || secrets.SUPABASE_SECRET_KEY }}
           RUN_DB_IT: '1'
+          VITEST_HANG_TIMEOUT_MS: '180000'
       - name: Record Supabase validate evidence
         if: always()
         run: npm run ci:write-evidence -- supabase-validate-tests "${{ job.status }}"

--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -540,3 +540,17 @@ Verification card:
 - verification: `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run validate:tenant`, and `npm run build` pass. Local `npm run test:ci` reaches the two unchanged baseline failures: jsdom `Blob.text()` and CRLF-sensitive workflow-step extraction.
 - required hosted sequence: human review -> merge the fixture-only follow-up -> fresh main Supabase Validate with all six suites collected and passing -> verify zero marked fixture users/roles remain.
 - residual risk: the decisive live proof is main-only because protected Supabase credentials are unavailable to local and pull-request test jobs.
+
+### WIN-217 hosted RLS validation serialization follow-up
+
+- branch: `codex/win-217-serialize-hosted-rls`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- hosted evidence: main Supabase Validate run `29426261636` proved the canonical-profile ordering repair in four previously failing live RLS suites, then timed out at exactly 30 seconds in the fifth shared-harness setup, the large security-fixture setup, and one legacy anonymous schema probe.
+- root cause: the main-only workflow ran all 390 test files with production Supabase credentials and `RUN_DB_IT=1`, allowing five full fixture graphs plus the security graph to write concurrently. Historical main runs contain the same unrelated exact-30-second timeout pattern; hosted logs showed no deadlock, lock timeout, statement timeout, cancellation, or Auth rate limit.
+- bounded fix: run the ordinary suite without hosted credentials and explicitly exclude live database files; then run only the six trusted RLS/security files serially with one worker, a 120-second hook limit, a 60-second test limit, and a 180-second no-output watchdog. Exclude the flaky legacy `DatabaseIntegration` and dormant `multiTenantAccess` probes from production-backed execution.
+- production authority: unchanged. No migration, RPC, RLS policy, grant, Edge Function, application runtime, or canonical tenant check changes.
+- residue repair: the timed-out setup left two marked `@example.com` auth users, two UUID-scoped `live-rls-org-*` organizations, and one active fixture role. They were removed through the Supabase plugin using exact IDs selected by the combined fixture marker, synthetic domain, unexpired metadata, and known fixture organization constraints. Readback is zero fixture users, zero fixture organizations, and zero active fixture roles.
+- local verification: the workflow contract was RED before the split and passes after it, 1 file / 14 tests. `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run validate:tenant`, and `npm run build` pass. `npm run test:ci` reaches 2,730 passing tests and the same two unchanged Windows portability failures: jsdom `Blob.text()` and CRLF-sensitive workflow-step extraction.
+- required hosted sequence: independent critical-lane review -> human review -> merge -> fresh main Supabase Validate -> runtime parity and all six serialized hosted files green -> zero-residue Supabase readback.
+- residual risk: local execution cannot supply protected hosted credentials; the serialized main-only workflow and post-run residue query remain decisive.

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -31,6 +31,12 @@ describe("live RLS fixture schema contract", () => {
     const testMainJob = workflow.match(
       /  test-main:\n([\s\S]*?)\n  runtime-migration-parity:/,
     )?.[1];
+    const unitTestStep = testMainJob?.match(
+      /      - name: Run unit tests\n([\s\S]*?)      - name: Run hosted database tests serially/,
+    )?.[1];
+    const hostedTestStep = testMainJob?.match(
+      /      - name: Run hosted database tests serially\n([\s\S]*?)      - name: Record Supabase validate evidence/,
+    )?.[1];
 
     expect(workflow).toContain("permissions:\n  contents: read");
     expect(pushSection).toContain(
@@ -49,6 +55,11 @@ describe("live RLS fixture schema contract", () => {
       "      - 'src/tests/security/ciRlsFixtureMetadata.ts'",
     );
     expect(pushSection).toContain("      - 'src/tests/security/rls.spec.ts'");
+    expect(pushSection).toContain("      - 'tests/integration/rls.message-threads.access.test.ts'");
+    expect(pushSection).toContain("      - 'tests/integration/rls.session-holds.access.test.ts'");
+    expect(pushSection).toContain("      - 'tests/integration/rls.sessions.read-write.test.ts'");
+    expect(pushSection).toContain("      - 'tests/integration/rls.therapists.clients.billing.test.ts'");
+    expect(pushSection).toContain("      - 'tests/integration/rpc.dashboard.org-scope.test.ts'");
     expect(pushSection).toContain("      - main");
     expect(pullRequestSection).not.toContain("liveRlsHarness.ts");
     expect(pullRequestSection).not.toContain(
@@ -56,10 +67,34 @@ describe("live RLS fixture schema contract", () => {
     );
     expect(pullRequestSection).not.toContain("rls.spec.ts");
     expect(testMainJob).toContain("    if: github.event_name == 'push'");
-    expect(testMainJob).toContain(
+    expect(testMainJob).toContain("    timeout-minutes: 30");
+    expect(unitTestStep).not.toContain("SUPABASE_SERVICE_ROLE_KEY");
+    expect(unitTestStep).not.toContain("RUN_DB_IT");
+    expect(unitTestStep).toContain("--exclude=src/lib/__tests__/DatabaseIntegration.test.ts");
+    expect(unitTestStep).toContain("--exclude=src/lib/__tests__/multiTenantAccess.test.ts");
+    expect(unitTestStep).toContain("--exclude=src/tests/security/rls.spec.ts");
+    expect(unitTestStep).toContain("--exclude=tests/integration/rls.message-threads.access.test.ts");
+    expect(unitTestStep).toContain("--exclude=tests/integration/rls.session-holds.access.test.ts");
+    expect(unitTestStep).toContain("--exclude=tests/integration/rls.sessions.read-write.test.ts");
+    expect(unitTestStep).toContain("--exclude=tests/integration/rls.therapists.clients.billing.test.ts");
+    expect(unitTestStep).toContain("--exclude=tests/integration/rpc.dashboard.org-scope.test.ts");
+    expect(hostedTestStep).toContain("--no-file-parallelism");
+    expect(hostedTestStep).toContain("--maxWorkers=1");
+    expect(hostedTestStep).toContain("--hookTimeout=120000");
+    expect(hostedTestStep).toContain("--testTimeout=60000");
+    expect(hostedTestStep).not.toContain("src/lib/__tests__/DatabaseIntegration.test.ts");
+    expect(hostedTestStep).not.toContain("src/lib/__tests__/multiTenantAccess.test.ts");
+    expect(hostedTestStep).toContain("src/tests/security/rls.spec.ts");
+    expect(hostedTestStep).toContain("tests/integration/rls.message-threads.access.test.ts");
+    expect(hostedTestStep).toContain("tests/integration/rls.session-holds.access.test.ts");
+    expect(hostedTestStep).toContain("tests/integration/rls.sessions.read-write.test.ts");
+    expect(hostedTestStep).toContain("tests/integration/rls.therapists.clients.billing.test.ts");
+    expect(hostedTestStep).toContain("tests/integration/rpc.dashboard.org-scope.test.ts");
+    expect(hostedTestStep).toContain(
       "SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || secrets.SUPABASE_SECRET_KEY }}",
     );
-    expect(testMainJob).toContain("RUN_DB_IT: '1'");
+    expect(hostedTestStep).toContain("RUN_DB_IT: '1'");
+    expect(hostedTestStep).toContain("VITEST_HANG_TIMEOUT_MS: '180000'");
   });
 
   it("uses the Node transport only for explicitly trusted database integration runs", () => {


### PR DESCRIPTION
## Summary
- separate secret-free unit tests from the trusted hosted Supabase suites
- run the six hosted RLS/security files serially with bounded worker, hook, test, watchdog, and job timeouts
- trigger hosted validation when any executed live test changes and preserve non-hosted policy coverage
- document the root cause and exact cleanup/readback evidence

## Root cause
Main Supabase Validate run 29426261636 ran 390 files with production credentials and file parallelism. Five full fixture graphs plus the security fixture competed for one hosted project and hit the shared 30-second limit. Four previously failing RLS suites passed after #795; the remaining failures were exact timeout/load failures, not tenant-policy assertions.

## Verification
- workflow contract: 14/14 passed (RED before workflow split)
- npm run ci:check-focused: passed
- npm run lint: passed
- npm run typecheck: passed
- npm run validate:tenant: passed
- npm run build: passed
- npm run test:ci: 2,730 passed; two unchanged Windows baselines remain (Blob.text and CRLF workflow extraction)
- independent root-cause, test, and tenant/security reviews: no remaining blocking findings
- Supabase residue cleanup readback: 0 marked fixture users, 0 fixture organizations, 0 active fixture roles

## Risk
Critical CI path, but no migration, RPC, RLS, grant, secret, Edge Function, or production runtime behavior changes. Decisive proof remains a fresh post-merge main Supabase Validate run plus zero-residue readback.