### PR TITLE
WIN-217: isolate Supabase RPC contract env

### DIFF
--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -554,3 +554,15 @@ Verification card:
 - local verification: the workflow contract was RED before the split and passes after it, 1 file / 14 tests. `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run validate:tenant`, and `npm run build` pass. `npm run test:ci` reaches 2,730 passing tests and the same two unchanged Windows portability failures: jsdom `Blob.text()` and CRLF-sensitive workflow-step extraction.
 - required hosted sequence: independent critical-lane review -> human review -> merge -> fresh main Supabase Validate -> runtime parity and all six serialized hosted files green -> zero-residue Supabase readback.
 - residual risk: local execution cannot supply protected hosted credentials; the serialized main-only workflow and post-run residue query remain decisive.
+
+### WIN-217 secret-free RPC contract isolation follow-up
+
+- branch: `codex/win-217-isolate-unit-supabase-env`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- hosted evidence: after PR #796 merged, main Supabase Validate run `29430099521` passed runtime migration parity but failed 13 assertions in `orgRoleRpcEquivalence.contract.test.ts` before the serialized hosted phase began.
+- root cause: the contract mocked the exported `getSupabaseConfig`, while functions inside the same module call its original lexical binding. Removing hosted credentials from the ordinary unit phase exposed that hidden ambient-environment dependency.
+- bounded fix: replace the ineffective same-module mock with test-local `.invalid` Supabase URL and synthetic anon-key stubs; reject unexpected fetches by default. Keep the workflow split, production credentials, runtime code, database authority, and hosted test selection unchanged.
+- RED/GREEN proof: with all Supabase URL/key variables removed and the env loader pointed at a nonexistent file, the target produced 13 failures before the fix and passes 14/14 after it.
+- required hosted sequence: independent critical-lane review -> human review -> merge -> fresh main Supabase Validate -> secret-free ordinary suite green -> all six serialized hosted files green -> zero-residue Supabase readback.
+- residual risk: the complete Windows unit suite retains two unrelated local portability failures already recorded above; Linux CI and the fresh main-only hosted phase remain decisive.

--- a/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
+++ b/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
@@ -1,23 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../api/shared", async () => {
-  const actual = await vi.importActual<typeof import("../api/shared")>("../api/shared");
-  return {
-    ...actual,
-    getSupabaseConfig: vi.fn(() => ({
-      supabaseUrl: "https://test.supabase.co",
-      anonKey: "anon-key",
-    })),
-  };
-});
-
 import {
   currentUserCanCaptureTrialEvent,
   currentUserCanManageLockedTrialEvent,
   currentUserCanManageProgramsGoals,
   currentUserCanTakeClientData,
   currentUserIsBcbaForOrg,
-  getSupabaseConfig,
   resolveOrgAndRoleWithStatus,
   resolveSchedulingOrgAndRoleWithStatus,
   sessionHasLockedNote,
@@ -25,7 +13,6 @@ import {
 import type { Database } from "../../lib/generated/database.types";
 
 const accessToken = "header.payload.signature";
-const originalServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 function jsonResponse(data: unknown, status = 200): Response {
   const text = data === "" ? "" : JSON.stringify(data);
@@ -36,20 +23,20 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, "fetch">>;
 
   beforeEach(() => {
-    vi.mocked(getSupabaseConfig).mockReturnValue({
-      supabaseUrl: "https://test.supabase.co",
-      anonKey: "anon-key",
-    });
-    fetchSpy = vi.spyOn(globalThis, "fetch");
+    vi.stubEnv("CODEX_ENV_PATH", ".tmp/nonexistent-rpc-contract-env");
+    vi.stubEnv("SUPABASE_URL", "https://unit-test.supabase.invalid");
+    vi.stubEnv("SUPABASE_PUBLISHABLE_KEY", "unit-test-anon-key");
+    vi.stubEnv("SUPABASE_ANON_KEY", "unit-test-anon-key");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "");
+    vi.stubEnv("SUPABASE_SECRET_KEY", "");
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("Unexpected unmocked fetch"));
   });
 
   afterEach(() => {
     fetchSpy.mockRestore();
-    if (typeof originalServiceRoleKey === "string") {
-      process.env.SUPABASE_SERVICE_ROLE_KEY = originalServiceRoleKey;
-    } else {
-      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
-    }
+    vi.unstubAllEnvs();
   });
 
   it("calls current_user_is_super_admin, current_user_organization_id, then user_has_role_for_org for therapist/admin/org_admin/org_member", async () => {


### PR DESCRIPTION
## Summary
- remove the ineffective same-module `getSupabaseConfig` mock from the RPC equivalence contract
- isolate the suite with reserved `.invalid` Supabase config and cleared service-role aliases
- reject unexpected fetches so unit coverage cannot contact a hosted project
- preserve PR #796's secret-free unit / serialized hosted workflow split unchanged

## Root cause
Fresh main Supabase Validate run 29430099521 passed runtime migration parity, then failed 13 contract assertions because module-local calls bypassed the mocked export and read ambient Supabase config. The hosted phase was skipped.

## Verification
- RED: clean-env target reproduced 13 failures / 1 pass
- GREEN: ambient-env and clean-env targets both pass 14/14
- `npm run ci:check-focused` passed
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run validate:tenant` passed
- `npm run build` passed
- `npm run verify:local` reached 2,730 passes and stopped only on the two unchanged Windows portability baselines (`Blob.text()` and CRLF workflow-step extraction); Linux PR CI passed both on #796
- independent code, test, and Supabase/security reviews: no remaining findings

## Risk
Critical lane because `src/server/**` is protected. Test and handoff only: no runtime code, workflow, secrets, migrations, RLS, grants, RPCs, or hosted Supabase state changed.

Linear: WIN-217