### PR TITLE
WIN-217: trigger RPC contract validation

### DIFF
--- a/.github/workflows/supabase-validate.yml
+++ b/.github/workflows/supabase-validate.yml
@@ -18,6 +18,7 @@ on:
       - 'tests/integration/live-rls-fixture-schema.contract.test.ts'
       - 'tests/integration/liveRlsHarness.unit.test.ts'
       - 'src/tests/security/ciRlsFixtureMetadata.ts'
+      - 'src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts'
       - 'src/tests/security/rls.spec.ts'
       - 'tests/integration/rls.message-threads.access.test.ts'
       - 'tests/integration/rls.session-holds.access.test.ts'

--- a/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
+++ b/docs/ai/2026-07-10-bcba-session-auth-recovery-handoff.md
@@ -566,3 +566,12 @@ Verification card:
 - RED/GREEN proof: with all Supabase URL/key variables removed and the env loader pointed at a nonexistent file, the target produced 13 failures before the fix and passes 14/14 after it.
 - required hosted sequence: independent critical-lane review -> human review -> merge -> fresh main Supabase Validate -> secret-free ordinary suite green -> all six serialized hosted files green -> zero-residue Supabase readback.
 - residual risk: the complete Windows unit suite retains two unrelated local portability failures already recorded above; Linux CI and the fresh main-only hosted phase remain decisive.
+
+### WIN-217 Supabase Validate trigger closure
+
+- branch: `codex/win-217-trigger-rpc-contract-validation`
+- classification/lane: `high-risk human-reviewed` / `critical` because `.github/workflows/**` is protected.
+- scope: add only the isolated RPC contract to the existing `main` push paths and pin that path in the workflow contract; do not change PR behavior, permissions, secrets, jobs, test selection, timeouts, or database authority.
+- RED/GREEN proof: the workflow contract failed 1/14 before the trigger was added and passes 14/14 after it. Policy, lint, typecheck, tenant validation, and build pass.
+- required hosted sequence: human review -> merge -> fresh main Supabase Validate -> secret-free ordinary suite green -> all six serialized hosted suites green -> zero-residue Supabase readback.
+- residual risk: local checks cannot execute the protected hosted phase; the merge-triggered main run remains decisive.

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -54,6 +54,9 @@ describe("live RLS fixture schema contract", () => {
     expect(pushSection).toContain(
       "      - 'src/tests/security/ciRlsFixtureMetadata.ts'",
     );
+    expect(pushSection).toContain(
+      "      - 'src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts'",
+    );
     expect(pushSection).toContain("      - 'src/tests/security/rls.spec.ts'");
     expect(pushSection).toContain("      - 'tests/integration/rls.message-threads.access.test.ts'");
     expect(pushSection).toContain("      - 'tests/integration/rls.session-holds.access.test.ts'");


### PR DESCRIPTION
## Summary
- include the isolated RPC equivalence contract in Supabase Validate's `main` push paths
- pin the trigger in the existing workflow contract
- leave PR behavior, permissions, secrets, jobs, hosted selection, timeouts, and database authority unchanged

## Why
PR #797 fixed the secret-free unit contract and passed regular Linux CI, but that test path did not trigger the main-only Supabase Validate workflow. This exact path closes the durable trigger gap; merging this PR will launch the decisive ordinary + serialized hosted validation.

## Verification
- RED: workflow contract failed 1/14 before the path was added
- GREEN: workflow contract passes 14/14
- `npm run ci:check-focused` passed
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run validate:tenant` passed
- `npm run build` passed
- independent test and protected-workflow reviews: no remaining findings

## Risk
Critical lane because `.github/workflows/**` is protected. Exact push-path addition only; no secret exposure on PRs and no runtime or Supabase state change.

Linear: WIN-217