### PR TITLE
WIN-218: add BCBA trial prompt controls

### DIFF
--- a/docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md
+++ b/docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md
@@ -1,0 +1,82 @@
+# WIN-218 BCBA Trial Prompt Buttons Handoff
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- issue: [WIN-218](https://linear.app/winningedgeai/issue/WIN-218/add-bcba-prompt-specific-trial-capture-controls)
+- branch: `codex/bcba-trial-prompt-buttons`
+- scope: add seven prompt controls and per-target correctness selection to configured response-based targets in `SessionModal`; extend focused component regressions
+- files touched:
+  - `src/components/SessionModal.tsx`
+  - `src/components/__tests__/SessionModal.test.tsx`
+  - `docs/superpowers/specs/2026-07-16-bcba-trial-prompt-buttons-design.md`
+  - `docs/superpowers/plans/2026-07-16-bcba-trial-prompt-buttons.md`
+  - `docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md`
+- protected paths: none
+- required agents:
+  - `specification-engineer`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+
+## Change Summary
+
+- Added exact prompt controls for Full verbal, Partial verbal, Gesture, Model, Visual, Full physical, and Partial physical.
+- Added a checked-by-default `Prompted response was correct` checkbox with state keyed by configured target ID.
+- Prompt clicks use the existing raw-trial path and persist canonical `response`, `prompt_type`, and `prompt_level` values.
+- Prompt controls render only for configured response-based targets; numeric/value and legacy ad-hoc capture paths remain unchanged.
+- Accessible checkbox, group, and button names include the configured target name to prevent duplicate target-index-only names across goals.
+- No migration or server/API change was required. Supabase plugin readback confirmed hosted `public.trial_events` already has nullable `response`, `prompt_type`, and `prompt_level` columns with RLS enabled.
+
+## TDD Evidence
+
+- RED: prompt-specific regression failed because the checkbox and seven prompt buttons were absent.
+- RED: target-isolation helper regression failed because `setPromptCorrectnessForTarget` was absent.
+- GREEN: direct target-isolation regression passed `1/1`.
+- GREEN: direct prompt and duration regressions passed `2/2` during implementation.
+- GREEN: complete `SessionModal` file passed `72/72` during implementation.
+- implementation commit: `67db3041252e724beb01df009ff3ec85fa77949c`
+
+## Verification Card
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- change type: `UI/component/page`
+- required checks:
+  - direct focused `SessionModal` Vitest regression
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run verify:local`
+  - synthetic browser proof when an authenticated test BCBA session is available
+- executed checks:
+  - `npx vitest run --config vitest.config.ts src/components/__tests__/SessionModal.test.tsx -t "keeps prompt correctness isolated by configured target|records prompt-specific trials as raw trial events|submits configured duration target values as raw trial values with units"` -> PASS (`3` passed, `69` skipped)
+  - complete `SessionModal` file, implementation-engineer run -> PASS (`72/72`)
+  - `npm run ci:check-focused` -> PASS
+  - `npm run lint` -> PASS
+  - `npm run typecheck` -> PASS
+  - `npm run build` -> PASS (`2165` modules transformed)
+  - `npm run test:ci` -> FAIL outside changed files (`2759` passed, `3` skipped, `2` failed)
+  - `npm run verify:local` -> FAIL at its `test:ci` stage on the same two outside-scope tests; its policy, lint, and typecheck stages passed
+  - Chrome Beta local branch navigation -> BLOCKED at login because no authenticated localhost BCBA session or `PW_*`/`CI_SMOKE_BCBA_*` credentials are available to the process
+- blocked/failed checks:
+  - `src/lib/__tests__/supabase.edge.test.ts` `downloads blob from async download endpoint` -> local Windows test Blob lacks `.text()`; this test and implementation match `origin/main`
+  - `tests/ci/check-e2e-reliability-gates.test.ts` synthetic BCBA provision step assertion -> local CRLF checkout prevents the LF-specific regex from matching; the test, workflow, and expected provision step match `origin/main`
+  - authenticated browser mutation/readback -> requires a protected test credential or an existing authenticated localhost session; none was exposed or copied
+- result: `fail` locally until fresh PR CI proves the two unchanged Linux gates and required branch checks
+- residual risk: component behavior and payload construction are directly proven, but visual authenticated BCBA proof remains dependent on trusted browser credentials or preview/CI. No hosted data was mutated during local verification.
+
+## Reviews
+
+- specification-engineer: confirmed the smallest scope is UI-only because existing types, server upsert, migration, and hosted schema already support prompt metadata.
+- test-engineer: confirmed seven mappings, checked/unchecked payloads and counters, saved-history numbering, progression version, numeric-target absence, and direct focused Vitest evidence; authenticated browser proof remains pending.
+- code-review-engineer: spec PASS, quality APPROVED, no Critical/Important/Minor findings, and no protected-path drift.
+
+## PR Readiness
+
+- single purpose: yes
+- unrelated changes: untracked `.tmp/` remains excluded
+- generated artifact drift: none
+- Linear: WIN-218 is `In Progress`; move to `In Review` after PR creation
+- current local verification blocker: fresh PR CI must pass the unchanged Linux-only gates before this handoff can be marked `pr-ready: yes`

--- a/docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md
+++ b/docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md
@@ -80,3 +80,9 @@
 - generated artifact drift: none
 - Linear: WIN-218 is `In Progress`; move to `In Review` after PR creation
 - current local verification blocker: fresh PR CI must pass the unchanged Linux-only gates before this handoff can be marked `pr-ready: yes`
+
+## Review Follow-up: Session Reset
+
+- finding: prompt correctness could remain unchecked when the mounted modal changed session or client while reusing the same target ID.
+- fix: the existing `[session?.id, clientId]` capture reset now also clears `promptCorrectByTargetId`.
+- regression proof: the prompt trial test unchecks the control, rerenders the mounted modal with a new session ID, and requires the checkbox to return to checked before recording the next session's trials.

--- a/docs/superpowers/plans/2026-07-16-bcba-trial-prompt-buttons.md
+++ b/docs/superpowers/plans/2026-07-16-bcba-trial-prompt-buttons.md
@@ -109,7 +109,7 @@ expect(screen.queryByRole('button', {
 Run:
 
 ```powershell
-npm test -- src/components/__tests__/SessionModal.test.tsx -t "records prompt-specific trials"
+npx vitest run src/components/__tests__/SessionModal.test.tsx -t "records prompt-specific trials"
 ```
 
 Expected: FAIL because the `Prompted response was correct` checkbox and prompt buttons do not exist yet. If the selected test name differs after editing, use the exact new test name with `-t` and record it in the task report.
@@ -222,7 +222,7 @@ Keep this block inside `configuredTarget && responseCaptureOptions.length > 0` s
 Run:
 
 ```powershell
-npm test -- src/components/__tests__/SessionModal.test.tsx -t "records prompt-specific trials"
+npx vitest run src/components/__tests__/SessionModal.test.tsx -t "records prompt-specific trials"
 ```
 
 Expected: PASS with both prompt events, counts, and canonical fields proven.
@@ -232,7 +232,7 @@ Expected: PASS with both prompt events, counts, and canonical fields proven.
 Run:
 
 ```powershell
-npm test -- src/components/__tests__/SessionModal.test.tsx
+npx vitest run src/components/__tests__/SessionModal.test.tsx
 ```
 
 Expected: all SessionModal tests PASS without new warnings or unhandled errors.

--- a/docs/superpowers/plans/2026-07-16-bcba-trial-prompt-buttons.md
+++ b/docs/superpowers/plans/2026-07-16-bcba-trial-prompt-buttons.md
@@ -1,0 +1,312 @@
+# BCBA Trial Prompt Buttons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a BCBA record seven canonical prompt types as correct or incorrect raw trials from the existing Schedule session-capture UI.
+
+**Architecture:** Extend `SessionModal` only: keep correctness state keyed by configured target ID, render prompt controls only beside existing response-based target controls, and append prompt metadata through the current pending-trial submission flow. Reuse the existing `SessionCaptureTrialEventInput` contract and protected persistence path without modifying server, Supabase, auth, or tenant code.
+
+**Tech Stack:** React 18, TypeScript, React Hook Form, Vitest, Testing Library, Supabase-backed `trial_events` persistence.
+
+## Global Constraints
+
+- Render exactly `Full verbal`, `Partial verbal`, `Gesture`, `Model`, `Visual`, `Full physical`, and `Partial physical`.
+- Label the per-target checkbox exactly `Prompted response was correct` and default it to checked.
+- Checked records `response: 'correct'`; unchecked records `response: 'incorrect'`.
+- Store correctness independently per configured target ID.
+- Canonical mappings are `verbal/full`, `verbal/partial`, `gesture/null`, `model/null`, `visual/null`, `physical/full`, and `physical/partial`.
+- Render prompt controls only for configured response-based targets; do not render them for numeric/value targets.
+- Reuse `trial_events.response`, `prompt_type`, and `prompt_level`; do not change migrations, Edge Functions, server/API code, authorization, role policy, or tenant behavior.
+- Preserve existing `+`/`-`, response-button, numeric, legacy ad-hoc, save, and progression-version behavior.
+- Use synthetic fixtures only; do not create or expose PHI.
+
+---
+
+### Task 1: Add Prompt-Specific Raw-Trial Capture
+
+**Files:**
+- Modify: `src/components/SessionModal.tsx:101-121`
+- Modify: `src/components/SessionModal.tsx:417-426`
+- Modify: `src/components/SessionModal.tsx:1997-2017`
+- Modify: `src/components/SessionModal.tsx:3771-3803`
+- Test: `src/components/__tests__/SessionModal.test.tsx:2488-2585`
+
+**Interfaces:**
+- Consumes: `SessionCaptureTrialEventInput`, `getNextRawTrialNumber(targetId)`, `getRawTrialCount(targetId, measurementType, field)`, `setPendingTrialEvents`, and React Hook Form `setValue`.
+- Produces: `promptCaptureOptions`, per-target correctness state, and pending events containing `response`, `prompt_type`, and `prompt_level`.
+
+- [ ] **Step 1: Write the failing prompt-capture regression**
+
+Extend the existing configured `taskAnalysis` target test so it first asserts all seven buttons and the checked-by-default checkbox, then records one checked prompt and one unchecked prompt before saving:
+
+```tsx
+const promptLabels = [
+  'Full verbal',
+  'Partial verbal',
+  'Gesture',
+  'Model',
+  'Visual',
+  'Full physical',
+  'Partial physical',
+];
+for (const label of promptLabels) {
+  expect(screen.getByRole('button', {
+    name: new RegExp(`Record ${label.toLowerCase()} prompt for target 1`, 'i'),
+  })).toBeInTheDocument();
+}
+
+const correctness = screen.getByRole('checkbox', {
+  name: /Prompted response was correct for target 1/i,
+});
+expect(correctness).toBeChecked();
+
+await userEvent.click(screen.getByRole('button', {
+  name: /Record full verbal prompt for target 1/i,
+}));
+await userEvent.click(correctness);
+await userEvent.click(screen.getByRole('button', {
+  name: /Record partial physical prompt for target 1/i,
+}));
+expect(screen.getByText('+1 · −1')).toBeInTheDocument();
+```
+
+Assert the submitted raw trials contain sequential trial numbers, both correctness values, and canonical prompt metadata:
+
+```tsx
+expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+  session_note_trial_events: [
+    expect.objectContaining({
+      target_id: targetId,
+      trial_number: 1,
+      response: 'correct',
+      prompt_type: 'verbal',
+      prompt_level: 'full',
+    }),
+    expect.objectContaining({
+      target_id: targetId,
+      trial_number: 2,
+      response: 'incorrect',
+      prompt_type: 'physical',
+      prompt_level: 'partial',
+    }),
+  ],
+}));
+```
+
+In the existing numeric/value-target test, assert the checkbox and a representative prompt button are absent:
+
+```tsx
+expect(screen.queryByRole('checkbox', {
+  name: /Prompted response was correct for target 1/i,
+})).not.toBeInTheDocument();
+expect(screen.queryByRole('button', {
+  name: /Record full verbal prompt for target 1/i,
+})).not.toBeInTheDocument();
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```powershell
+npm test -- src/components/__tests__/SessionModal.test.tsx -t "records prompt-specific trials"
+```
+
+Expected: FAIL because the `Prompted response was correct` checkbox and prompt buttons do not exist yet. If the selected test name differs after editing, use the exact new test name with `-t` and record it in the task report.
+
+- [ ] **Step 3: Define the canonical prompt configuration and per-target state**
+
+Near `responseOptionsByMeasurementType`, add a readonly configuration:
+
+```tsx
+const promptCaptureOptions = [
+  { label: 'Full verbal', promptType: 'verbal', promptLevel: 'full' },
+  { label: 'Partial verbal', promptType: 'verbal', promptLevel: 'partial' },
+  { label: 'Gesture', promptType: 'gesture', promptLevel: null },
+  { label: 'Model', promptType: 'model', promptLevel: null },
+  { label: 'Visual', promptType: 'visual', promptLevel: null },
+  { label: 'Full physical', promptType: 'physical', promptLevel: 'full' },
+  { label: 'Partial physical', promptType: 'physical', promptLevel: 'partial' },
+] as const;
+```
+
+Beside pending trial state, add target-keyed correctness state whose missing value means correct:
+
+```tsx
+const [promptCorrectByTargetId, setPromptCorrectByTargetId] = useState<Record<string, boolean>>({});
+```
+
+- [ ] **Step 4: Extend response recording to accept prompt metadata**
+
+Change `recordResponseTrial` to accept an optional prompt argument and include its fields only when supplied:
+
+```tsx
+const recordResponseTrial = useCallback(
+  (
+    goalId: string,
+    targetIndex: number,
+    configuredTarget: GoalTarget,
+    response: NonNullable<TrialEvent['response']>,
+    prompt?: { promptType: string; promptLevel: string | null },
+  ) => {
+    const field = isPositiveResponse(response) ? 'metric_value' : 'incorrect_trials';
+    const dirtyPath =
+      `session_note_goal_measurements.${goalId}.data.target_trials.${targetIndex}.${field}` as const;
+    const nextDisplayedCount = getRawTrialCount(
+      configuredTarget.id,
+      configuredTarget.measurement_type,
+      field,
+    ) + 1;
+    const newEvent: SessionCaptureTrialEventInput = {
+      target_id: configuredTarget.id,
+      trial_number: getNextRawTrialNumber(configuredTarget.id),
+      response,
+      ...(prompt ? {
+        prompt_type: prompt.promptType,
+        prompt_level: prompt.promptLevel,
+      } : {}),
+      metadata: { source: 'schedule_capture', goal_id: goalId, target_index: targetIndex },
+    };
+    setPendingTrialEvents((current) => [...current, newEvent]);
+    setValue(dirtyPath, nextDisplayedCount, { shouldDirty: true, shouldTouch: true });
+  },
+  [getNextRawTrialNumber, getRawTrialCount, setValue],
+);
+```
+
+- [ ] **Step 5: Render the per-target checkbox and seven buttons**
+
+Inside the configured response-target branch, after the existing response-button row, render:
+
+```tsx
+<div className="mt-3 rounded-md border border-indigo-200 bg-white/80 p-2 dark:border-indigo-800 dark:bg-dark/70">
+  <label className="flex min-h-10 items-center gap-2 text-xs font-medium text-gray-800 dark:text-gray-200">
+    <input
+      type="checkbox"
+      checked={promptCorrectByTargetId[configuredTarget.id] ?? true}
+      onChange={(event) => setPromptCorrectByTargetId((current) => ({
+        ...current,
+        [configuredTarget.id]: event.target.checked,
+      }))}
+      aria-label={`Prompted response was correct for target ${targetIndex + 1}`}
+      className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+    />
+    Prompted response was correct
+  </label>
+  <div className="mt-2 flex flex-wrap gap-2" role="group" aria-label={`Prompt types for target ${targetIndex + 1}`}>
+    {promptCaptureOptions.map((prompt) => (
+      <button
+        key={prompt.label}
+        type="button"
+        aria-label={`Record ${prompt.label.toLowerCase()} prompt for target ${targetIndex + 1}`}
+        className="rounded-md border border-indigo-300 bg-indigo-50 px-3 py-2 text-xs font-semibold text-indigo-900 shadow-sm hover:bg-indigo-100 dark:border-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-100 dark:hover:bg-indigo-900/60"
+        onClick={() => recordResponseTrial(
+          selectedGoalId,
+          sourceIndex,
+          configuredTarget,
+          (promptCorrectByTargetId[configuredTarget.id] ?? true) ? 'correct' : 'incorrect',
+          { promptType: prompt.promptType, promptLevel: prompt.promptLevel },
+        )}
+      >
+        {prompt.label}
+      </button>
+    ))}
+  </div>
+</div>
+```
+
+Keep this block inside `configuredTarget && responseCaptureOptions.length > 0` so numeric/value targets and unconfigured ad-hoc rows cannot render it.
+
+- [ ] **Step 6: Run the focused test and verify GREEN**
+
+Run:
+
+```powershell
+npm test -- src/components/__tests__/SessionModal.test.tsx -t "records prompt-specific trials"
+```
+
+Expected: PASS with both prompt events, counts, and canonical fields proven.
+
+- [ ] **Step 7: Run the complete SessionModal regression file**
+
+Run:
+
+```powershell
+npm test -- src/components/__tests__/SessionModal.test.tsx
+```
+
+Expected: all SessionModal tests PASS without new warnings or unhandled errors.
+
+- [ ] **Step 8: Self-review and commit the implementation**
+
+Inspect only the task diff, confirm no protected paths changed, then commit:
+
+```powershell
+git diff --check
+git diff -- src/components/SessionModal.tsx src/components/__tests__/SessionModal.test.tsx
+git add -- src/components/SessionModal.tsx src/components/__tests__/SessionModal.test.tsx
+git commit -m "feat: add BCBA trial prompt controls"
+```
+
+### Task 2: Verify, Prove, And Prepare The PR
+
+**Files:**
+- Create: `docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md`
+- Verify: `src/components/SessionModal.tsx`
+- Verify: `src/components/__tests__/SessionModal.test.tsx`
+
+**Interfaces:**
+- Consumes: the Task 1 branch diff, test output, browser artifacts, `verify-change`, reviewer findings, and WIN-218.
+- Produces: a verification card, reviewable handoff, PR-hygiene verdict, pushed branch, and GitHub pull request.
+
+- [ ] **Step 1: Run the standard-lane mandatory checks**
+
+Run in this order and preserve exact pass/fail evidence:
+
+```powershell
+npm run ci:check-focused
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run build
+npm run verify:local
+```
+
+Expected: all secret-free checks PASS. If `verify:local` reports a named secret or protected-system prerequisite, record that exact check as blocked rather than claiming it passed.
+
+- [ ] **Step 2: Capture synthetic browser proof**
+
+Use the repository Playwright/browser workflow with a test BCBA identity and synthetic session. Prove all seven buttons render, the checkbox defaults checked, a checked click increments correct, an unchecked click increments incorrect, and the save payload includes canonical prompt metadata. Store screenshots or traces under an ignored artifact path and do not include PHI.
+
+- [ ] **Step 3: Run required specialist review**
+
+Have `code-review-engineer` inspect correctness, accessibility, regression risk, and protected-path drift. Have `test-engineer` confirm the focused regression and browser proof cover every acceptance criterion. Resolve every critical or important finding and rerun affected checks.
+
+- [ ] **Step 4: Create the verification and tracking handoff**
+
+Write `docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md` with:
+
+```markdown
+# WIN-218 BCBA Trial Prompt Buttons Handoff
+
+- classification: low-risk autonomous
+- lane: standard
+- scope: SessionModal prompt controls and focused regression only
+- required checks: ci:check-focused, lint, typecheck, test:ci, build, verify:local, synthetic browser proof
+- executed checks: exact commands and results
+- blocked checks: none, or exact environmental blocker
+- result: pass or fail
+- residual risk: concise remaining browser or hosted-environment risk
+- reviewer: findings and disposition
+- Linear: WIN-218
+```
+
+Commit the handoff after its evidence is complete.
+
+- [ ] **Step 5: Run `verify-change` and `pr-hygiene`**
+
+Use the repo-local skills to emit their required verification card and PR-ready verdict. `pr-ready` must be `yes`; otherwise address the required follow-up before pushing.
+
+- [ ] **Step 6: Push and open the PR**
+
+Push `codex/bcba-trial-prompt-buttons`, create a PR linked to WIN-218, move WIN-218 to `In Review`, and report live required checks and exact merge blockers. Do not merge without the required human review if branch protection requires it.

--- a/docs/superpowers/specs/2026-07-16-bcba-trial-prompt-buttons-design.md
+++ b/docs/superpowers/specs/2026-07-16-bcba-trial-prompt-buttons-design.md
@@ -1,0 +1,104 @@
+# BCBA Trial Prompt Buttons Design
+
+## Summary
+
+Add prompt-specific raw-trial controls to the existing Schedule session-capture UI. For each configured response-based target, a BCBA can choose whether a prompted response was correct and record one of seven prompt types. The resulting trial uses the existing `trial_events` persistence path.
+
+## Routing
+
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Triggering paths: `src/components/SessionModal.tsx`, `src/components/__tests__/SessionModal.test.tsx`
+- Protected paths: none
+- Required agents: `specification-engineer`, `implementation-engineer`, `code-review-engineer`, `test-engineer`
+- Reviewer required: yes
+- `verify-change` required: yes
+- Linear tracking required: yes before implementation
+
+The hosted `public.trial_events` table and current application types already contain nullable `response`, `prompt_type`, and `prompt_level` fields. The existing session-note upsert path already accepts and persists them, so this slice must not change migrations, Edge Functions, or server/API code.
+
+## User Experience
+
+Each configured response-based target in the Trials section will show:
+
+- a checkbox labeled `Prompted response was correct`, checked by default;
+- buttons for `Full verbal`, `Partial verbal`, `Gesture`, `Model`, `Visual`, `Full physical`, and `Partial physical`.
+
+Clicking a prompt button records exactly one pending raw trial. A checked checkbox records `response: "correct"`; an unchecked checkbox records `response: "incorrect"`. The existing correct or incorrect count updates immediately. Correctness is stored independently per configured target so changing one target does not affect another.
+
+Prompt controls appear only for configured targets whose measurement type accepts response trials. Numeric/value-based targets keep their existing value-entry control. Legacy ad-hoc aggregate capture remains unchanged.
+
+## Canonical Prompt Mapping
+
+| Button | `prompt_type` | `prompt_level` |
+| --- | --- | --- |
+| Full verbal | `verbal` | `full` |
+| Partial verbal | `verbal` | `partial` |
+| Gesture | `gesture` | `null` |
+| Model | `model` | `null` |
+| Visual | `visual` | `null` |
+| Full physical | `physical` | `full` |
+| Partial physical | `physical` | `partial` |
+
+## Component And Data Flow
+
+`SessionModal` will define the canonical prompt-button configuration and keep checkbox state keyed by configured target ID. A small prompt-recording callback will reuse the existing next-trial-number, pending-event, dirty-field, and count logic used by response trials.
+
+Each new pending event will contain:
+
+- `target_id` and the next `trial_number`;
+- `response` from the target's correctness checkbox;
+- canonical `prompt_type` and `prompt_level` from the selected button;
+- the existing `schedule_capture` metadata with goal ID and target index.
+
+Saving through `Save skills` or the existing full progress action will submit the event through `session_note_trial_events`. Existing optimistic progression version enrichment remains unchanged.
+
+## Error And State Handling
+
+- Checkbox state defaults to correct when a configured target first renders.
+- Checkbox state is isolated by target ID.
+- Removing a newly added pending trial continues to use the existing decrement behavior and does not alter saved trials.
+- Existing disabled/loading states and save error handling remain authoritative.
+- No prompt button is rendered where the measurement contract rejects response values.
+
+## Tests And Proof
+
+Extend the focused `SessionModal` tests to prove:
+
+1. all seven prompt buttons render for a configured response-based target;
+2. the correctness checkbox defaults to checked;
+3. a checked prompt click increments the correct count and submits the expected prompt fields;
+4. an unchecked prompt click increments the incorrect count and submits the expected prompt fields;
+5. trial numbers remain sequential and progression-version enrichment is preserved;
+6. prompt controls are absent for numeric/value targets.
+
+After the focused regression passes, run the standard-lane verification matrix and capture browser evidence using a synthetic or test BCBA session. Hosted proof must not create or expose real PHI.
+
+## Scope
+
+Allowed production file:
+
+- `src/components/SessionModal.tsx`
+
+Allowed supporting files:
+
+- `src/components/__tests__/SessionModal.test.tsx`
+- the task handoff/tracking document required by repository policy
+
+Non-goals:
+
+- database, migration, Edge Function, or server/API changes;
+- authorization or role-policy changes;
+- prompt analytics, reporting, or graph redesign;
+- changes to numeric trial capture or legacy ad-hoc targets;
+- unrelated SessionModal refactoring.
+
+Stop and re-route if implementation requires a protected path, changes the trial-event schema, modifies auth/tenant behavior, or cannot remain within the listed surfaces.
+
+## Acceptance Criteria
+
+- A BCBA can see and use all seven prompt buttons on eligible configured targets.
+- The per-target checkbox defaults to correct and deterministically controls whether a prompt click records a correct or incorrect response.
+- Saved raw trials contain the canonical prompt fields and are visible through the existing trial-event read path.
+- Existing `+`/`-`, independent/prompted, numeric, and save behavior does not regress.
+- Required local checks, focused browser proof, specialist review, `verify-change`, and `pr-hygiene` complete before PR handoff.

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -864,6 +864,7 @@ export function SessionModal({
 
   useEffect(() => {
     setPendingTrialEvents([]);
+    setPromptCorrectByTargetId({});
     setPendingNumericTrialValues({});
   }, [session?.id, clientId]);
 

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -112,6 +112,22 @@ const responseOptionsByMeasurementType: Record<string, Array<{ response: NonNull
   ],
 };
 
+const promptCaptureOptions = [
+  { label: 'Full verbal', promptType: 'verbal', promptLevel: 'full' },
+  { label: 'Partial verbal', promptType: 'verbal', promptLevel: 'partial' },
+  { label: 'Gesture', promptType: 'gesture', promptLevel: null },
+  { label: 'Model', promptType: 'model', promptLevel: null },
+  { label: 'Visual', promptType: 'visual', promptLevel: null },
+  { label: 'Full physical', promptType: 'physical', promptLevel: 'full' },
+  { label: 'Partial physical', promptType: 'physical', promptLevel: 'partial' },
+] as const;
+
+export const setPromptCorrectnessForTarget = (
+  current: Record<string, boolean>,
+  targetId: string,
+  checked: boolean,
+): Record<string, boolean> => ({ ...current, [targetId]: checked });
+
 const getValueMeasurementMeta = (measurementType: string) =>
   valueRequiredMeasurementTypes.has(measurementType)
     ? valueMeasurementMeta[measurementType] ?? { label: 'Value', unit: 'value', step: 0.1 }
@@ -422,6 +438,7 @@ export function SessionModal({
   const [alternativeTimes, setAlternativeTimes] = useState<AlternativeTime[]>([]);
   const [isLoadingAlternatives, setIsLoadingAlternatives] = useState(false);
   const [pendingTrialEvents, setPendingTrialEvents] = useState<SessionCaptureTrialEventInput[]>([]);
+  const [promptCorrectByTargetId, setPromptCorrectByTargetId] = useState<Record<string, boolean>>({});
   const [pendingNumericTrialValues, setPendingNumericTrialValues] = useState<Record<string, string>>({});
   const [progressionNotices, setProgressionNotices] = useState<string[]>([]);
   const [progressionConflict, setProgressionConflict] = useState<string | null>(null);
@@ -2000,6 +2017,7 @@ export function SessionModal({
       targetIndex: number,
       configuredTarget: GoalTarget,
       response: NonNullable<TrialEvent['response']>,
+      prompt?: { promptType: string; promptLevel: string | null },
     ) => {
       const field = isPositiveResponse(response) ? 'metric_value' : 'incorrect_trials';
       const dirtyPath =
@@ -2009,6 +2027,10 @@ export function SessionModal({
         target_id: configuredTarget.id,
         trial_number: getNextRawTrialNumber(configuredTarget.id),
         response,
+        ...(prompt ? {
+          prompt_type: prompt.promptType,
+          prompt_level: prompt.promptLevel,
+        } : {}),
         metadata: { source: 'schedule_capture', goal_id: goalId, target_index: targetIndex },
       };
       setPendingTrialEvents((current) => [...current, newEvent]);
@@ -3774,32 +3796,74 @@ export function SessionModal({
                                                 + correct or achieved · − incorrect or no response.
                                               </p>
                                               {configuredTarget && responseCaptureOptions.length > 0 ? (
-                                                <div className="mt-3 flex flex-wrap items-center gap-2">
-                                                  {responseCaptureOptions.map((option) => (
-                                                    <button
-                                                      key={option.response}
-                                                      type="button"
-                                                      aria-label={
-                                                        option.response === 'correct'
-                                                          ? `Increase correct trials for target ${targetIndex + 1}`
-                                                          : option.response === 'incorrect'
-                                                            ? `Increase incorrect or no-response trials for target ${targetIndex + 1}`
-                                                            : `Record ${option.label.toLowerCase()} response for target ${targetIndex + 1}`
-                                                      }
-                                                      className={[
-                                                        'rounded-md px-3 py-2 text-xs font-semibold shadow-sm',
-                                                        isPositiveResponse(option.response)
-                                                          ? 'bg-emerald-600 text-white hover:bg-emerald-700'
-                                                          : 'bg-rose-600 text-white hover:bg-rose-700',
-                                                      ].join(' ')}
-                                                      onClick={() => recordResponseTrial(selectedGoalId, sourceIndex, configuredTarget, option.response)}
+                                                <div>
+                                                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                                                    {responseCaptureOptions.map((option) => (
+                                                      <button
+                                                        key={option.response}
+                                                        type="button"
+                                                        aria-label={
+                                                          option.response === 'correct'
+                                                            ? `Increase correct trials for target ${targetIndex + 1}`
+                                                            : option.response === 'incorrect'
+                                                              ? `Increase incorrect or no-response trials for target ${targetIndex + 1}`
+                                                              : `Record ${option.label.toLowerCase()} response for target ${targetIndex + 1}`
+                                                        }
+                                                        className={[
+                                                          'rounded-md px-3 py-2 text-xs font-semibold shadow-sm',
+                                                          isPositiveResponse(option.response)
+                                                            ? 'bg-emerald-600 text-white hover:bg-emerald-700'
+                                                            : 'bg-rose-600 text-white hover:bg-rose-700',
+                                                        ].join(' ')}
+                                                        onClick={() => recordResponseTrial(selectedGoalId, sourceIndex, configuredTarget, option.response)}
+                                                      >
+                                                        {option.label}
+                                                      </button>
+                                                    ))}
+                                                    <span className="text-xs tabular-nums text-gray-600 dark:text-gray-300">
+                                                      +{targetCorrectDisplay} · −{targetIncorrectDisplay}
+                                                    </span>
+                                                  </div>
+                                                  <div className="mt-3 rounded-md border border-indigo-200 bg-white/80 p-2 dark:border-indigo-800 dark:bg-dark/70">
+                                                    <label className="flex min-h-10 items-center gap-2 text-xs font-medium text-gray-800 dark:text-gray-200">
+                                                      <input
+                                                        type="checkbox"
+                                                        checked={promptCorrectByTargetId[configuredTarget.id] ?? true}
+                                                        onChange={(event) => setPromptCorrectByTargetId((current) =>
+                                                          setPromptCorrectnessForTarget(
+                                                            current,
+                                                            configuredTarget.id,
+                                                            event.target.checked,
+                                                          ))}
+                                                        aria-label={`Prompted response was correct for target ${targetIndex + 1}: ${configuredTarget.name}`}
+                                                        className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                                      />
+                                                      Prompted response was correct
+                                                    </label>
+                                                    <div
+                                                      className="mt-2 flex flex-wrap gap-2"
+                                                      role="group"
+                                                      aria-label={`Prompt types for target ${targetIndex + 1}: ${configuredTarget.name}`}
                                                     >
-                                                      {option.label}
-                                                    </button>
-                                                  ))}
-                                                  <span className="text-xs tabular-nums text-gray-600 dark:text-gray-300">
-                                                    +{targetCorrectDisplay} · −{targetIncorrectDisplay}
-                                                  </span>
+                                                      {promptCaptureOptions.map((prompt) => (
+                                                        <button
+                                                          key={prompt.label}
+                                                          type="button"
+                                                          aria-label={`Record ${prompt.label.toLowerCase()} prompt for target ${targetIndex + 1}: ${configuredTarget.name}`}
+                                                          className="rounded-md border border-indigo-300 bg-indigo-50 px-3 py-2 text-xs font-semibold text-indigo-900 shadow-sm hover:bg-indigo-100 dark:border-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-100 dark:hover:bg-indigo-900/60"
+                                                          onClick={() => recordResponseTrial(
+                                                            selectedGoalId,
+                                                            sourceIndex,
+                                                            configuredTarget,
+                                                            (promptCorrectByTargetId[configuredTarget.id] ?? true) ? 'correct' : 'incorrect',
+                                                            { promptType: prompt.promptType, promptLevel: prompt.promptLevel },
+                                                          )}
+                                                        >
+                                                          {prompt.label}
+                                                        </button>
+                                                      ))}
+                                                    </div>
+                                                  </div>
                                                 </div>
                                               ) : (
                                                 <div className="mt-3 flex flex-wrap items-center gap-3">

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/utils';
 import { fireEvent } from '@testing-library/react';
-import { SessionModal, dedupeProgressionNotices, formatProgressionNotices, selectSessionCaptureTargets } from '../SessionModal';
+import { SessionModal, dedupeProgressionNotices, formatProgressionNotices, selectSessionCaptureTargets, setPromptCorrectnessForTarget } from '../SessionModal';
 import { supabase } from '../../lib/supabase';
 import { fetchLinkedClientSessionNoteForSession } from '../../lib/session-note-linked-fetch';
 import type { Session } from '../../types';
@@ -32,6 +32,14 @@ describe('SessionModal', () => {
     const archived = { ...base, id: 'archived', name: 'Archived', status: 'archived', is_current: false };
     expect(selectSessionCaptureTargets([current, stale, archived], new Set())).toEqual([current]);
     expect(selectSessionCaptureTargets([current, stale, archived], new Set(['stale']))).toEqual([current, stale]);
+  });
+
+  it('keeps prompt correctness isolated by configured target', () => {
+    const current = { 'target-1': false, 'target-2': true };
+    expect(setPromptCorrectnessForTarget(current, 'target-1', true)).toEqual({
+      'target-1': true,
+      'target-2': true,
+    });
   });
 
   it('formats every progression outcome and incomplete-criteria warning', () => {
@@ -2219,6 +2227,12 @@ describe('SessionModal', () => {
     );
 
     await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
+    expect(screen.queryByRole('checkbox', {
+      name: /Prompted response was correct for target 1/i,
+    })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {
+      name: /Record full verbal prompt for target 1/i,
+    })).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
       target: { value: 'Duration observed' },
     });
@@ -2470,7 +2484,7 @@ describe('SessionModal', () => {
     expect(onSubmit).not.toHaveBeenCalled();
   }, 15000);
 
-  it('submits task-analysis responses as raw trial events', async () => {
+  it('records prompt-specific trials as raw trial events', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const targetId = '88888888-8888-4888-8888-888888888882';
     const buildChain = (rows: unknown[], singleRow: unknown = null) => {
@@ -2516,6 +2530,9 @@ describe('SessionModal', () => {
             status: 'active',
             sort_order: 0,
             is_current: true,
+            current_phase: 'baseline',
+            evaluation_window_started_at: '2024-01-01T00:00:00Z',
+            progression_version: 7,
             created_by: null,
             updated_by: null,
             created_at: '2024-01-01T00:00:00Z',
@@ -2524,7 +2541,28 @@ describe('SessionModal', () => {
         ]);
       }
       if (table === 'trial_events') {
-        return buildChain([]);
+        return buildChain([
+          {
+            id: 'trial-existing-prompt',
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            session_id: 'session-task-analysis-trials',
+            target_id: targetId,
+            goal_id: 'goal-1',
+            therapist_id: 'test-therapist-1',
+            trial_number: 4,
+            response: 'correct',
+            prompt_type: null,
+            prompt_level: null,
+            value: null,
+            event_timestamp: '2026-03-01T10:05:00.000Z',
+            metadata: {},
+            created_by: null,
+            updated_by: null,
+            created_at: '2026-03-01T10:05:00.000Z',
+            updated_at: '2026-03-01T10:05:00.000Z',
+          },
+        ]);
       }
       return buildChain([]);
     });
@@ -2557,30 +2595,56 @@ describe('SessionModal', () => {
     fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
       target: { value: 'Task analysis observed' },
     });
-    await userEvent.click(screen.getByRole('button', { name: /Record independent response for target 1/i }));
-    await userEvent.click(screen.getByRole('button', { name: /Record prompted response for target 1/i }));
-    expect(screen.getByText('+2 · −0')).toBeInTheDocument();
+    const promptLabels = [
+      'Full verbal',
+      'Partial verbal',
+      'Gesture',
+      'Model',
+      'Visual',
+      'Full physical',
+      'Partial physical',
+    ];
+    for (const label of promptLabels) {
+      expect(screen.getByRole('button', {
+        name: new RegExp(`Record ${label.toLowerCase()} prompt for target 1`, 'i'),
+      })).toBeInTheDocument();
+    }
+
+    const correctness = screen.getByRole('checkbox', {
+      name: /Prompted response was correct for target 1/i,
+    });
+    expect(correctness).toBeChecked();
+
+    for (const label of promptLabels.slice(0, -1)) {
+      await userEvent.click(screen.getByRole('button', {
+        name: new RegExp(`Record ${label.toLowerCase()} prompt for target 1`, 'i'),
+      }));
+    }
+    await userEvent.click(correctness);
+    await userEvent.click(screen.getByRole('button', {
+      name: /Record partial physical prompt for target 1/i,
+    }));
+    expect(screen.getByText('+7 · −1')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: /Save skills/i }));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
-        session_note_trial_events: [
-          expect.objectContaining({
-            target_id: targetId,
-            trial_number: 1,
-            response: 'independent',
-          }),
-          expect.objectContaining({
-            target_id: targetId,
-            trial_number: 2,
-            response: 'prompted',
-          }),
-        ],
+        session_note_trial_events: expect.any(Array),
       }));
     });
     const submitted = onSubmit.mock.calls[0]?.[0] as {
+      session_note_trial_events?: Array<Record<string, unknown>>;
       session_note_goal_measurements?: Record<string, SessionGoalMeasurementEntry>;
     };
+    expect(submitted.session_note_trial_events).toEqual([
+      expect.objectContaining({ target_id: targetId, trial_number: 5, response: 'correct', prompt_type: 'verbal', prompt_level: 'full', expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 6, response: 'correct', prompt_type: 'verbal', prompt_level: 'partial', expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 7, response: 'correct', prompt_type: 'gesture', prompt_level: null, expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 8, response: 'correct', prompt_type: 'model', prompt_level: null, expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 9, response: 'correct', prompt_type: 'visual', prompt_level: null, expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 10, response: 'correct', prompt_type: 'physical', prompt_level: 'full', expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 11, response: 'incorrect', prompt_type: 'physical', prompt_level: 'partial', expected_progression_version: 7 }),
+    ]);
     expect(submitted.session_note_goal_measurements?.['goal-1']?.data.measurement_type).toBe('taskAnalysis');
   }, 15000);
 

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -2567,27 +2567,28 @@ describe('SessionModal', () => {
       return buildChain([]);
     });
 
-    renderWithProviders(
+    const session = {
+      id: 'session-task-analysis-trials',
+      therapist_id: 'test-therapist-1',
+      client_id: 'test-client-1',
+      program_id: 'program-1',
+      goal_id: 'goal-1',
+      start_time: '2026-03-01T10:00:00.000Z',
+      end_time: '2026-03-01T11:00:00.000Z',
+      status: 'in_progress',
+      notes: '',
+      created_at: '2026-03-01T09:00:00.000Z',
+      created_by: null,
+      updated_at: '2026-03-01T09:00:00.000Z',
+      updated_by: null,
+      started_at: null,
+    } satisfies Session;
+    const { rerender } = renderWithProviders(
       <SessionModal
         {...defaultProps}
         onSubmit={onSubmit}
         existingSessions={[]}
-        session={{
-          id: 'session-task-analysis-trials',
-          therapist_id: 'test-therapist-1',
-          client_id: 'test-client-1',
-          program_id: 'program-1',
-          goal_id: 'goal-1',
-          start_time: '2026-03-01T10:00:00.000Z',
-          end_time: '2026-03-01T11:00:00.000Z',
-          status: 'in_progress',
-          notes: '',
-          created_at: '2026-03-01T09:00:00.000Z',
-          created_by: null,
-          updated_at: '2026-03-01T09:00:00.000Z',
-          updated_by: null,
-          started_at: null,
-        } satisfies Session}
+        session={session}
       />,
     );
 
@@ -2614,6 +2615,18 @@ describe('SessionModal', () => {
       name: /Prompted response was correct for target 1/i,
     });
     expect(correctness).toBeChecked();
+
+    await userEvent.click(correctness);
+    expect(correctness).not.toBeChecked();
+    rerender(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        existingSessions={[]}
+        session={{ ...session, id: 'session-task-analysis-trials-next' }}
+      />,
+    );
+    await waitFor(() => expect(correctness).toBeChecked());
 
     await userEvent.click(screen.getByRole('button', { name: /Record independent response for target 1/i }));
     await userEvent.click(screen.getByRole('button', { name: /Record prompted response for target 1/i }));

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -2615,6 +2615,8 @@ describe('SessionModal', () => {
     });
     expect(correctness).toBeChecked();
 
+    await userEvent.click(screen.getByRole('button', { name: /Record independent response for target 1/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Record prompted response for target 1/i }));
     for (const label of promptLabels.slice(0, -1)) {
       await userEvent.click(screen.getByRole('button', {
         name: new RegExp(`Record ${label.toLowerCase()} prompt for target 1`, 'i'),
@@ -2624,7 +2626,7 @@ describe('SessionModal', () => {
     await userEvent.click(screen.getByRole('button', {
       name: /Record partial physical prompt for target 1/i,
     }));
-    expect(screen.getByText('+7 · −1')).toBeInTheDocument();
+    expect(screen.getByText('+9 · −1')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: /Save skills/i }));
 
     await waitFor(() => {
@@ -2637,14 +2639,20 @@ describe('SessionModal', () => {
       session_note_goal_measurements?: Record<string, SessionGoalMeasurementEntry>;
     };
     expect(submitted.session_note_trial_events).toEqual([
-      expect.objectContaining({ target_id: targetId, trial_number: 5, response: 'correct', prompt_type: 'verbal', prompt_level: 'full', expected_progression_version: 7 }),
-      expect.objectContaining({ target_id: targetId, trial_number: 6, response: 'correct', prompt_type: 'verbal', prompt_level: 'partial', expected_progression_version: 7 }),
-      expect.objectContaining({ target_id: targetId, trial_number: 7, response: 'correct', prompt_type: 'gesture', prompt_level: null, expected_progression_version: 7 }),
-      expect.objectContaining({ target_id: targetId, trial_number: 8, response: 'correct', prompt_type: 'model', prompt_level: null, expected_progression_version: 7 }),
-      expect.objectContaining({ target_id: targetId, trial_number: 9, response: 'correct', prompt_type: 'visual', prompt_level: null, expected_progression_version: 7 }),
-      expect.objectContaining({ target_id: targetId, trial_number: 10, response: 'correct', prompt_type: 'physical', prompt_level: 'full', expected_progression_version: 7 }),
-      expect.objectContaining({ target_id: targetId, trial_number: 11, response: 'incorrect', prompt_type: 'physical', prompt_level: 'partial', expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 5, response: 'independent', expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 6, response: 'prompted', expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 7, response: 'correct', prompt_type: 'verbal', prompt_level: 'full', expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 8, response: 'correct', prompt_type: 'verbal', prompt_level: 'partial', expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 9, response: 'correct', prompt_type: 'gesture', prompt_level: null, expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 10, response: 'correct', prompt_type: 'model', prompt_level: null, expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 11, response: 'correct', prompt_type: 'visual', prompt_level: null, expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 12, response: 'correct', prompt_type: 'physical', prompt_level: 'full', expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 13, response: 'incorrect', prompt_type: 'physical', prompt_level: 'partial', expected_progression_version: 7 }),
     ]);
+    expect(submitted.session_note_trial_events?.[0]).not.toHaveProperty('prompt_type');
+    expect(submitted.session_note_trial_events?.[0]).not.toHaveProperty('prompt_level');
+    expect(submitted.session_note_trial_events?.[1]).not.toHaveProperty('prompt_type');
+    expect(submitted.session_note_trial_events?.[1]).not.toHaveProperty('prompt_level');
     expect(submitted.session_note_goal_measurements?.['goal-1']?.data.measurement_type).toBe('taskAnalysis');
   }, 15000);
 


### PR DESCRIPTION
## Summary

- add Full verbal, Partial verbal, Gesture, Model, Visual, Full physical, and Partial physical buttons to eligible configured trial targets
- add a checked-by-default, target-isolated correctness checkbox that records prompt trials as correct or incorrect
- persist canonical `prompt_type` and `prompt_level` through the existing raw `trial_events` path
- keep numeric/value and legacy ad-hoc capture unchanged

## Why

BCBAs need prompt-specific trial capture alongside the existing response controls so saved raw trials retain both prompt type/level and outcome correctness.

## Verification

- focused prompt/isolation/duration regressions: 3 passed
- complete SessionModal suite: 72 passed
- `npm run ci:check-focused`: passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run build`: passed
- independent code review: spec pass, quality approved, no findings, no protected-path drift
- hosted Supabase schema readback: existing RLS-enabled `trial_events` fields support the change; no migration needed

## Local environment limitations

`npm run test:ci` and `npm run verify:local` reached 2,759 passing tests but failed on two unchanged `origin/main` Windows-only surfaces: a Blob `.text()` polyfill mismatch and an LF-specific workflow regex against a CRLF checkout. Fresh Linux PR CI is required before this draft is ready. Authenticated local browser proof is also blocked because no localhost BCBA session or protected `PW_*` credentials were available.

## Tracking

- Linear: [WIN-218](https://linear.app/winningedgeai/issue/WIN-218/add-bcba-prompt-specific-trial-capture-controls)
- Verification handoff: `docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md`