### PR TITLE
WIN-218: complete prompt capture for legacy trial targets

### DIFF
--- a/docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md
+++ b/docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md
@@ -1,31 +1,37 @@
 # WIN-218 BCBA Trial Prompt Buttons Handoff
 
-- classification: `low-risk autonomous`
-- lane: `standard`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
 - issue: [WIN-218](https://linear.app/winningedgeai/issue/WIN-218/add-bcba-prompt-specific-trial-capture-controls)
-- branch: `codex/bcba-trial-prompt-buttons`
-- scope: add seven prompt controls and per-target correctness selection to configured response-based targets in `SessionModal`; extend focused component regressions
+- branch: `codex/bcba-prompt-buttons-all-trials`
+- scope: complete seven prompt controls and per-target correctness selection for configured response targets and legacy plan targets without a `goal_targets` UUID
 - files touched:
   - `src/components/SessionModal.tsx`
   - `src/components/__tests__/SessionModal.test.tsx`
+  - `src/lib/goal-measurements.ts`
+  - `src/lib/__tests__/goal-measurements.test.ts`
+  - `src/server/__tests__/sessionNotesUpsertHandler.test.ts`
+  - `src/types/index.ts`
   - `docs/superpowers/specs/2026-07-16-bcba-trial-prompt-buttons-design.md`
   - `docs/superpowers/plans/2026-07-16-bcba-trial-prompt-buttons.md`
   - `docs/ai/WIN-218-bcba-trial-prompt-buttons-handoff.md`
-- protected paths: none
+- protected boundary: shared server/API goal-measurement normalization; no protected-path production file, schema, RLS, or role edit
 - required agents:
   - `specification-engineer`
   - `implementation-engineer`
   - `code-review-engineer`
   - `test-engineer`
+  - `software-architect`
+  - `security-engineer`
 
 ## Change Summary
 
 - Added exact prompt controls for Full verbal, Partial verbal, Gesture, Model, Visual, Full physical, and Partial physical.
 - Added a checked-by-default `Prompted response was correct` checkbox with state keyed by configured target ID.
 - Prompt clicks use the existing raw-trial path and persist canonical `response`, `prompt_type`, and `prompt_level` values.
-- Prompt controls render only for configured response-based targets; numeric/value and legacy ad-hoc capture paths remain unchanged.
+- Prompt controls render for configured response-based targets and legacy plan/ad-hoc trial targets; numeric/value targets remain unchanged.
 - Accessible checkbox, group, and button names include the configured target name to prevent duplicate target-index-only names across goals.
-- No migration or server/API change was required. Supabase plugin readback confirmed hosted `public.trial_events` already has nullable `response`, `prompt_type`, and `prompt_level` columns with RLS enabled.
+- No migration, server-handler, RLS, or role change was required. The follow-up extends the shared goal-measurement normalizer used by the server/API boundary for legacy JSON aggregates; configured targets continue using hosted `public.trial_events`.
 
 ## TDD Evidence
 
@@ -38,9 +44,9 @@
 
 ## Verification Card
 
-- classification: `low-risk autonomous`
-- lane: `standard`
-- change type: `UI/component/page`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- change type: `UI/component/page`, `server/API shared normalization boundary`
 - required checks:
   - direct focused `SessionModal` Vitest regression
   - `npm run ci:check-focused`
@@ -48,8 +54,10 @@
   - `npm run typecheck`
   - `npm run test:ci`
   - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
   - `npm run verify:local`
-  - synthetic browser proof when an authenticated test BCBA session is available
+  - authenticated browser proof when a test BCBA session is available
 - executed checks:
   - `npx vitest run --config vitest.config.ts src/components/__tests__/SessionModal.test.tsx -t "keeps prompt correctness isolated by configured target|records prompt-specific trials as raw trial events|submits configured duration target values as raw trial values with units"` -> PASS (`3` passed, `69` skipped)
   - complete `SessionModal` file, implementation-engineer run -> PASS (`72/72`)
@@ -57,21 +65,26 @@
   - `npm run lint` -> PASS
   - `npm run typecheck` -> PASS
   - `npm run build` -> PASS (`2165` modules transformed)
-  - `npm run test:ci` -> FAIL outside changed files (`2759` passed, `3` skipped, `2` failed)
-  - `npm run verify:local` -> FAIL at its `test:ci` stage on the same two outside-scope tests; its policy, lint, and typecheck stages passed
+  - follow-up focused suite -> PASS (`132/132`)
+  - `npm run test:ci` -> FAIL outside changed files (`2763` passed, `3` skipped, `2` failed)
+  - `npm run test:routes:tier0` -> BLOCKED locally: first attempt found the existing preview on port 4173; isolated retry on 4174 exceeded the local 120-second command budget and ended with Cypress `EPIPE`
   - Chrome Beta local branch navigation -> BLOCKED at login because no authenticated localhost BCBA session or `PW_*`/`CI_SMOKE_BCBA_*` credentials are available to the process
 - blocked/failed checks:
   - `src/lib/__tests__/supabase.edge.test.ts` `downloads blob from async download endpoint` -> local Windows test Blob lacks `.text()`; this test and implementation match `origin/main`
   - `tests/ci/check-e2e-reliability-gates.test.ts` synthetic BCBA provision step assertion -> local CRLF checkout prevents the LF-specific regex from matching; the test, workflow, and expected provision step match `origin/main`
   - authenticated browser mutation/readback -> requires a protected test credential or an existing authenticated localhost session; none was exposed or copied
-- result: `fail` locally until fresh PR CI proves the two unchanged Linux gates and required branch checks
-- residual risk: component behavior and payload construction are directly proven, but visual authenticated BCBA proof remains dependent on trusted browser credentials or preview/CI. No hosted data was mutated during local verification.
+  - `npm run ci:playwright` -> protected hosted credentials are unavailable locally; rely on PR CI
+  - `npm run verify:local` -> blocked from a meaningful pass by the same two unchanged `test:ci` baseline failures above
+- result: `pass-with-blocked-checks`; fresh PR CI must prove the two unchanged Linux gates and required hosted browser checks
+- residual risk: component behavior, legacy/configured persistence, canonical server merge, prompt undo, and target-removal state are directly proven; authenticated browser proof and unchanged Linux-only gates remain dependent on PR CI. No hosted data was mutated during local verification.
 
 ## Reviews
 
-- specification-engineer: confirmed the smallest scope is UI-only because existing types, server upsert, migration, and hosted schema already support prompt metadata.
+- specification-engineer: confirmed the legacy target requires bounded aggregate persistence without synthetic target UUIDs or raw trial events.
 - test-engineer: confirmed seven mappings, checked/unchecked payloads and counters, saved-history numbering, progression version, numeric-target absence, and direct focused Vitest evidence; authenticated browser proof remains pending.
-- code-review-engineer: spec PASS, quality APPROVED, no Critical/Important/Minor findings, and no protected-path drift.
+- code-review-engineer: initial review found prompt undo and target-removal state issues; both were fixed and the follow-up verdict found no blocking code issues.
+- software-architect: conditionally approved the bounded legacy JSON aggregate design and required critical-lane handling.
+- security-engineer: PASS; canonicalization strips authority-like keys and no tenant/authz or raw-trial validation bypass was found.
 
 ## PR Readiness
 
@@ -79,10 +92,32 @@
 - unrelated changes: untracked `.tmp/` remains excluded
 - generated artifact drift: none
 - Linear: WIN-218 is `In Progress`; move to `In Review` after PR creation
-- current local verification blocker: fresh PR CI must pass the unchanged Linux-only gates before this handoff can be marked `pr-ready: yes`
+- current merge blocker: fresh PR CI and required human review must pass before merge
 
 ## Review Follow-up: Session Reset
 
 - finding: prompt correctness could remain unchecked when the mounted modal changed session or client while reusing the same target ID.
 - fix: the existing `[session?.id, clientId]` capture reset now also clears `promptCorrectByTargetId`.
 - regression proof: the prompt trial test unchecks the control, rerenders the mounted modal with a new session ID, and requires the checkbox to return to checked before recording the next session's trials.
+
+## Review Follow-up: Legacy Plan Targets
+
+- trigger: authenticated Edit Session screenshot showed a legacy plan target with only aggregate `+` / `-` controls and no prompt buttons.
+- root cause: prompt controls were nested behind an exact configured `goal_targets` name match; legacy plan targets have no target UUID and therefore never entered that branch.
+- bounded fix:
+  - keep configured response targets on raw `trial_events` with their real target UUID;
+  - store legacy prompt aggregates in the existing session-note JSON target row as canonical `prompt_counts`;
+  - allow only the seven supported prompt type/level pairs, deduplicate them in UI order, reject unknown buckets, and require nonnegative safe-integer counts;
+  - increment exactly one correct/incorrect aggregate and one prompt bucket per legacy prompt click;
+  - when an aggregate decrement crosses a prompted total, remove the matching prompted aggregate as well so accidental prompt clicks remain undoable;
+  - remap index-keyed legacy checkbox state when an earlier ad-hoc target is removed;
+  - retain the checked-by-default, session/client-reset correctness behavior with collision-resistant legacy keys.
+- protected-boundary rationale: `src/lib/goal-measurements.ts` is shared by `src/server/api/session-notes-upsert.ts`, so the follow-up is routed `critical` even though no server implementation, schema, RLS, role, or tenant query changed.
+- focused proof:
+  - shared normalizer + adversarial canonicalization tests: PASS (`11/11` complete file)
+  - `SessionModal` legacy/configured/numeric, prompt undo, and target-removal state regressions: PASS (`74/74` complete file)
+  - server `captureMergeGoalIds` preservation/canonicalization: PASS (`47/47` complete file)
+  - combined focused suite after review follow-up: PASS (`132/132`)
+  - lint: PASS
+  - typecheck: PASS
+- BT authorization: unchanged. Existing BT edit mode remains schedule-metadata locked and clinical-capture capable; changing that protected role behavior requires a separate explicit product decision.

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -26,6 +26,7 @@ import type {
   Goal,
   Program,
   SessionNoteUpsertResult,
+  SessionPromptCount,
 } from '../types';
 import { checkSchedulingConflicts, suggestAlternativeTimes, type Conflict, type AlternativeTime } from '../lib/conflicts';
 import { logger } from '../lib/logger/logger';
@@ -50,6 +51,7 @@ import {
   hasMeaningfulGoalMeasurementEntry,
   mergeUniqueGoalIds,
   normalizeGoalMeasurementEntry,
+  normalizePromptCounts,
 } from '../lib/goal-measurements';
 import {
   getTherapistMinTrialsTarget,
@@ -127,6 +129,63 @@ export const setPromptCorrectnessForTarget = (
   targetId: string,
   checked: boolean,
 ): Record<string, boolean> => ({ ...current, [targetId]: checked });
+
+export const incrementLegacyPromptCount = (
+  current: SessionPromptCount[] | null | undefined,
+  prompt: { promptType: SessionPromptCount['prompt_type']; promptLevel: SessionPromptCount['prompt_level'] },
+  correct: boolean,
+): SessionPromptCount[] => normalizePromptCounts([
+  ...(current ?? []),
+  {
+    prompt_type: prompt.promptType,
+    prompt_level: prompt.promptLevel,
+    correct_trials: correct ? 1 : 0,
+    incorrect_trials: correct ? 0 : 1,
+  },
+]);
+
+export const decrementLegacyPromptCounts = (
+  current: SessionPromptCount[] | null | undefined,
+  field: 'correct_trials' | 'incorrect_trials',
+  amount: number,
+): SessionPromptCount[] => {
+  const next = normalizePromptCounts(current).map((count) => ({ ...count }));
+  let remaining = Math.max(0, amount);
+  for (let index = next.length - 1; index >= 0 && remaining > 0; index -= 1) {
+    const removable = Math.min(next[index][field], remaining);
+    next[index][field] -= removable;
+    remaining -= removable;
+  }
+  return normalizePromptCounts(next);
+};
+
+export const remapLegacyPromptCorrectnessAfterRemoval = (
+  current: Record<string, boolean>,
+  goalId: string,
+  removedIndex: number,
+  previousLength: number,
+): Record<string, boolean> => {
+  const next = { ...current };
+  for (let index = removedIndex; index < previousLength - 1; index += 1) {
+    const nextKey = `legacy:${goalId}:${index + 1}`;
+    const currentKey = `legacy:${goalId}:${index}`;
+    if (Object.prototype.hasOwnProperty.call(current, nextKey)) {
+      next[currentKey] = current[nextKey];
+    } else {
+      delete next[currentKey];
+    }
+  }
+  delete next[`legacy:${goalId}:${previousLength - 1}`];
+  return next;
+};
+
+const sumLegacyPromptCounts = (
+  counts: SessionPromptCount[] | null | undefined,
+  field: 'correct_trials' | 'incorrect_trials',
+): number => normalizePromptCounts(counts).reduce(
+  (total, count) => Math.min(Number.MAX_SAFE_INTEGER, total + count[field]),
+  0,
+);
 
 const getValueMeasurementMeta = (measurementType: string) =>
   valueRequiredMeasurementTypes.has(measurementType)
@@ -2007,7 +2066,23 @@ export function SessionModal({
             ? Number(raw)
             : 0;
       const safe = Number.isFinite(cur) ? cur : 0;
-      setValue(path, Math.max(0, safe + delta), { shouldDirty: true, shouldTouch: true });
+      const nextCount = Math.max(0, safe + delta);
+      if (delta < 0) {
+        const promptCountsPath =
+          `session_note_goal_measurements.${goalId}.data.target_trials.${targetIndex}.prompt_counts` as const;
+        const promptField = field === 'metric_value' ? 'correct_trials' : 'incorrect_trials';
+        const currentPromptCounts = getValues(promptCountsPath) as SessionPromptCount[] | null | undefined;
+        const promptedTotal = sumLegacyPromptCounts(currentPromptCounts, promptField);
+        const promptReduction = Math.max(0, promptedTotal - nextCount);
+        if (promptReduction > 0) {
+          setValue(
+            promptCountsPath,
+            decrementLegacyPromptCounts(currentPromptCounts, promptField, promptReduction),
+            { shouldDirty: true, shouldTouch: true },
+          );
+        }
+      }
+      setValue(path, nextCount, { shouldDirty: true, shouldTouch: true });
     },
     [getNextRawTrialNumber, getRawTrialCount, getValues, setValue],
   );
@@ -2038,6 +2113,38 @@ export function SessionModal({
       setValue(dirtyPath, nextDisplayedCount, { shouldDirty: true, shouldTouch: true });
     },
     [getNextRawTrialNumber, getRawTrialCount, setValue],
+  );
+
+  const recordPromptTrial = useCallback(
+    (
+      goalId: string,
+      targetIndex: number,
+      configuredTarget: GoalTarget | null,
+      prompt: { promptType: SessionPromptCount['prompt_type']; promptLevel: SessionPromptCount['prompt_level'] },
+      correct: boolean,
+    ) => {
+      if (configuredTarget && responseRequiredMeasurementTypes.has(configuredTarget.measurement_type)) {
+        recordResponseTrial(
+          goalId,
+          targetIndex,
+          configuredTarget,
+          correct ? 'correct' : 'incorrect',
+          prompt,
+        );
+        return;
+      }
+
+      const aggregateField = correct ? 'metric_value' : 'incorrect_trials';
+      bumpTrialCount(goalId, targetIndex, aggregateField, 1, null);
+      const promptCountsPath =
+        `session_note_goal_measurements.${goalId}.data.target_trials.${targetIndex}.prompt_counts` as const;
+      const current = getValues(promptCountsPath) as SessionPromptCount[] | null | undefined;
+      setValue(promptCountsPath, incrementLegacyPromptCount(current, prompt, correct), {
+        shouldDirty: true,
+        shouldTouch: true,
+      });
+    },
+    [bumpTrialCount, getValues, recordResponseTrial, setValue],
   );
 
   const recordNumericTrial = useCallback(
@@ -2119,6 +2226,8 @@ export function SessionModal({
       const nextTargetTrials = Array.isArray(currentTargetTrials)
         ? currentTargetTrials.filter((_, index) => index !== targetIndex)
         : undefined;
+      setPromptCorrectByTargetId((current) =>
+        remapLegacyPromptCorrectnessAfterRemoval(current, goalId, targetIndex, existingTargets.length));
       updateGoalTargets(goalId, nextTargets.length > 0 ? nextTargets : [''], nextTargetTrials);
     },
     [getValues, updateGoalTargets],
@@ -3674,6 +3783,8 @@ export function SessionModal({
                                           ? 0
                                           : getRawTrialCount(configuredTarget.id, configuredTarget.measurement_type, 'incorrect_trials', 'pending'))
                                       : targetIncorrectDisplay;
+                                    const promptCorrectnessKey = configuredTarget?.id ??
+                                      `legacy:${selectedGoalId}:${sourceIndex}`;
                                     const targetOpportunitiesDisplay = getTargetTrialNullableValue(sourceIndex, 'opportunities');
                                     const targetTrialBoundsError = getCorrectTrialsOpportunityError(
                                       targetCorrectDisplay,
@@ -3829,11 +3940,11 @@ export function SessionModal({
                                                     <label className="flex min-h-10 items-center gap-2 text-xs font-medium text-gray-800 dark:text-gray-200">
                                                       <input
                                                         type="checkbox"
-                                                        checked={promptCorrectByTargetId[configuredTarget.id] ?? true}
+                                                        checked={promptCorrectByTargetId[promptCorrectnessKey] ?? true}
                                                         onChange={(event) => setPromptCorrectByTargetId((current) =>
                                                           setPromptCorrectnessForTarget(
                                                             current,
-                                                            configuredTarget.id,
+                                                            promptCorrectnessKey,
                                                             event.target.checked,
                                                           ))}
                                                         aria-label={`Prompted response was correct for target ${targetIndex + 1}: ${configuredTarget.name}`}
@@ -3852,12 +3963,12 @@ export function SessionModal({
                                                           type="button"
                                                           aria-label={`Record ${prompt.label.toLowerCase()} prompt for target ${targetIndex + 1}: ${configuredTarget.name}`}
                                                           className="rounded-md border border-indigo-300 bg-indigo-50 px-3 py-2 text-xs font-semibold text-indigo-900 shadow-sm hover:bg-indigo-100 dark:border-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-100 dark:hover:bg-indigo-900/60"
-                                                          onClick={() => recordResponseTrial(
+                                                          onClick={() => recordPromptTrial(
                                                             selectedGoalId,
                                                             sourceIndex,
                                                             configuredTarget,
-                                                            (promptCorrectByTargetId[configuredTarget.id] ?? true) ? 'correct' : 'incorrect',
                                                             { promptType: prompt.promptType, promptLevel: prompt.promptLevel },
+                                                            promptCorrectByTargetId[promptCorrectnessKey] ?? true,
                                                           )}
                                                         >
                                                           {prompt.label}
@@ -3948,6 +4059,48 @@ export function SessionModal({
                                                 -5
                                               </button>
                                             </div>
+                                            {!configuredTarget ? (
+                                            <div className="w-full rounded-md border border-indigo-200 bg-white/80 p-2 dark:border-indigo-800 dark:bg-dark/70">
+                                              <label className="flex min-h-10 items-center gap-2 text-xs font-medium text-gray-800 dark:text-gray-200">
+                                                <input
+                                                  type="checkbox"
+                                                  checked={promptCorrectByTargetId[promptCorrectnessKey] ?? true}
+                                                  onChange={(event) => setPromptCorrectByTargetId((current) =>
+                                                    setPromptCorrectnessForTarget(
+                                                      current,
+                                                      promptCorrectnessKey,
+                                                      event.target.checked,
+                                                    ))}
+                                                  aria-label={`Prompted response was correct for target ${targetIndex + 1}: ${targetValue}`}
+                                                  className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                                />
+                                                Prompted response was correct
+                                              </label>
+                                              <div
+                                                className="mt-2 flex flex-wrap gap-2"
+                                                role="group"
+                                                aria-label={`Prompt types for target ${targetIndex + 1}: ${targetValue}`}
+                                              >
+                                                {promptCaptureOptions.map((prompt) => (
+                                                  <button
+                                                    key={prompt.label}
+                                                    type="button"
+                                                    aria-label={`Record ${prompt.label.toLowerCase()} prompt for target ${targetIndex + 1}: ${targetValue}`}
+                                                    className="rounded-md border border-indigo-300 bg-indigo-50 px-3 py-2 text-xs font-semibold text-indigo-900 shadow-sm hover:bg-indigo-100 dark:border-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-100 dark:hover:bg-indigo-900/60"
+                                                    onClick={() => recordPromptTrial(
+                                                      selectedGoalId,
+                                                      sourceIndex,
+                                                      configuredTarget,
+                                                      { promptType: prompt.promptType, promptLevel: prompt.promptLevel },
+                                                      promptCorrectByTargetId[promptCorrectnessKey] ?? true,
+                                                    )}
+                                                  >
+                                                    {prompt.label}
+                                                  </button>
+                                                ))}
+                                              </div>
+                                            </div>
+                                            ) : null}
                                           </div>
                                               )}
                                             </>

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1,7 +1,15 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/utils';
 import { fireEvent } from '@testing-library/react';
-import { SessionModal, dedupeProgressionNotices, formatProgressionNotices, selectSessionCaptureTargets, setPromptCorrectnessForTarget } from '../SessionModal';
+import {
+  SessionModal,
+  decrementLegacyPromptCounts,
+  dedupeProgressionNotices,
+  formatProgressionNotices,
+  remapLegacyPromptCorrectnessAfterRemoval,
+  selectSessionCaptureTargets,
+  setPromptCorrectnessForTarget,
+} from '../SessionModal';
 import { supabase } from '../../lib/supabase';
 import { fetchLinkedClientSessionNoteForSession } from '../../lib/session-note-linked-fetch';
 import type { Session } from '../../types';
@@ -40,6 +48,29 @@ describe('SessionModal', () => {
       'target-1': true,
       'target-2': true,
     });
+  });
+
+  it('keeps legacy prompt correctness aligned when an earlier target is removed', () => {
+    expect(remapLegacyPromptCorrectnessAfterRemoval({
+      'legacy:goal-1:0': true,
+      'legacy:goal-1:1': false,
+      'legacy:goal-1:2': true,
+      configured: false,
+    }, 'goal-1', 0, 3)).toEqual({
+      'legacy:goal-1:0': false,
+      'legacy:goal-1:1': true,
+      configured: false,
+    });
+  });
+
+  it('removes prompted aggregates when a legacy decrement crosses the prompt floor', () => {
+    expect(decrementLegacyPromptCounts([
+      { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 1, incorrect_trials: 0 },
+      { prompt_type: 'gesture', prompt_level: null, correct_trials: 2, incorrect_trials: 1 },
+    ], 'correct_trials', 2)).toEqual([
+      { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 1, incorrect_trials: 0 },
+      { prompt_type: 'gesture', prompt_level: null, correct_trials: 0, incorrect_trials: 1 },
+    ]);
   });
 
   it('formats every progression outcome and incomplete-criteria warning', () => {
@@ -3523,7 +3554,7 @@ describe('SessionModal', () => {
     });
   }, 10000);
 
-  it('filters saved plan-goal targets to target_criteria when resaving legacy capture', async () => {
+  it('filters saved plan-goal targets and persists prompt buttons for legacy capture', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const planTarget = 'Match peer greeting in 4/5 trials';
     const legacyFreeformTarget = 'Legacy freeform target';
@@ -3554,9 +3585,9 @@ describe('SessionModal', () => {
               },
               {
                 target: planTarget,
-                metric_value: 2,
+                metric_value: 4,
                 incorrect_trials: 1,
-                opportunities: 3,
+                opportunities: 6,
                 trial_prompt_note: 'Plan target prompt note',
               },
             ],
@@ -3670,6 +3701,30 @@ describe('SessionModal', () => {
     expect(planTargetButton).toHaveTextContent(planTarget);
     expect(screen.queryByText(legacyFreeformTarget)).not.toBeInTheDocument();
 
+    const promptCorrectness = screen.getByRole('checkbox', {
+      name: /Prompted response was correct for target 1/i,
+    });
+    expect(promptCorrectness).toBeChecked();
+    for (const label of ['full verbal', 'partial verbal', 'gesture', 'model', 'visual', 'full physical', 'partial physical']) {
+      expect(screen.getByRole('button', {
+        name: new RegExp(`Record ${label} prompt for target 1`, 'i'),
+      })).toBeInTheDocument();
+    }
+    await userEvent.click(screen.getByRole('button', {
+      name: /Record full verbal prompt for target 1/i,
+    }));
+    const subtractFiveCorrect = screen.getByRole('button', {
+      name: /Subtract 5 correct trials for target 1/i,
+    });
+    expect(subtractFiveCorrect).toBeEnabled();
+    await userEvent.click(subtractFiveCorrect);
+    await userEvent.click(screen.getByRole('button', {
+      name: /Record full verbal prompt for target 1/i,
+    }));
+    await userEvent.click(promptCorrectness);
+    await userEvent.click(screen.getByRole('button', {
+      name: /Record gesture prompt for target 1/i,
+    }));
     await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 1/i }));
     fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 1/i), {
       target: { value: 'Edited plan target prompt note' },
@@ -3684,18 +3739,22 @@ describe('SessionModal', () => {
           'goal-1': {
             version: 1,
             data: expect.objectContaining({
-              metric_value: 3,
-              incorrect_trials: 1,
-              opportunities: 3,
+              metric_value: 2,
+              incorrect_trials: 2,
+              opportunities: 6,
               targets: [planTarget],
               target: planTarget,
               target_trials: [
                 expect.objectContaining({
                   target: planTarget,
-                  metric_value: 3,
-                  incorrect_trials: 1,
-                  opportunities: 3,
+                  metric_value: 2,
+                  incorrect_trials: 2,
+                  opportunities: 6,
                   trial_prompt_note: 'Edited plan target prompt note',
+                  prompt_counts: [
+                    { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 1, incorrect_trials: 0 },
+                    { prompt_type: 'gesture', prompt_level: null, correct_trials: 0, incorrect_trials: 1 },
+                  ],
                 }),
               ],
               trial_prompt_note: 'Edited plan target prompt note',
@@ -3704,6 +3763,8 @@ describe('SessionModal', () => {
         },
       }));
     });
+    const submitted = onSubmit.mock.calls[0]?.[0] as { session_note_trial_events?: unknown[] };
+    expect(submitted.session_note_trial_events ?? []).toEqual([]);
   }, 10000);
 
   it('shows inline trial bounds validation and blocks save progress when correct trials exceed opportunities', async () => {

--- a/src/lib/__tests__/goal-measurements.test.ts
+++ b/src/lib/__tests__/goal-measurements.test.ts
@@ -123,6 +123,61 @@ describe('goal-measurements helpers', () => {
     });
   });
 
+  it('preserves canonical aggregate prompt counts for legacy target trials', () => {
+    expect(
+      normalizeGoalMeasurementEntry({
+        targets: ['Permission to look before touch'],
+        target_trials: [
+          {
+            target: 'Permission to look before touch',
+            metric_value: 2,
+            incorrect_trials: 1,
+            prompt_counts: [
+              { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 1, incorrect_trials: 0 },
+              { prompt_type: 'gesture', prompt_level: null, correct_trials: 0, incorrect_trials: 1 },
+            ],
+          },
+        ],
+      }),
+    ).toEqual(expect.objectContaining({
+      data: expect.objectContaining({
+        target_trials: [expect.objectContaining({
+          prompt_counts: [
+            { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 1, incorrect_trials: 0 },
+            { prompt_type: 'gesture', prompt_level: null, correct_trials: 0, incorrect_trials: 1 },
+          ],
+        })],
+      }),
+    }));
+  });
+
+  it('canonicalizes, bounds, and deduplicates legacy prompt counts', () => {
+    const normalized = normalizeGoalMeasurementEntry({
+      targets: ['Target'],
+      target_trials: [{
+        target: 'Target',
+        metric_value: 0,
+        incorrect_trials: 0,
+        prompt_counts: [
+          { prompt_type: 'gesture', prompt_level: null, correct_trials: 1, incorrect_trials: 0, client_id: 'discard-me' },
+          { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 1, incorrect_trials: -4 },
+          { prompt_type: 'gesture', prompt_level: null, correct_trials: 2, incorrect_trials: 1 },
+          { prompt_type: 'unknown', prompt_level: null, correct_trials: 100, incorrect_trials: 100 },
+          { prompt_type: 'visual', prompt_level: null, correct_trials: 0, incorrect_trials: 0 },
+        ],
+      }],
+    });
+
+    expect(normalized?.data.target_trials).toEqual([expect.objectContaining({
+      metric_value: 4,
+      incorrect_trials: 1,
+      prompt_counts: [
+        { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 1, incorrect_trials: 0 },
+        { prompt_type: 'gesture', prompt_level: null, correct_trials: 3, incorrect_trials: 1 },
+      ],
+    })]);
+  });
+
   it('builds a goal-scoped measurement entry with goal defaults', () => {
     expect(
       buildGoalMeasurementEntry(

--- a/src/lib/goal-measurements.ts
+++ b/src/lib/goal-measurements.ts
@@ -1,4 +1,10 @@
-import type { Goal, SessionGoalMeasurementData, SessionGoalMeasurementEntry, SessionTargetTrialData } from '../types';
+import type {
+  Goal,
+  SessionGoalMeasurementData,
+  SessionGoalMeasurementEntry,
+  SessionPromptCount,
+  SessionTargetTrialData,
+} from '../types';
 
 export const GOAL_MEASUREMENT_VERSION = 1 as const;
 
@@ -54,12 +60,70 @@ const normalizeEditableStringList = (value: unknown): string[] => {
 const getPrimaryNonEmptyTarget = (targets: readonly string[]): string | null =>
   targets.map((target) => toOptionalString(target)).find((target): target is string => Boolean(target)) ?? null;
 
+const canonicalPromptPairs = [
+  ['verbal', 'full'],
+  ['verbal', 'partial'],
+  ['gesture', null],
+  ['model', null],
+  ['visual', null],
+  ['physical', 'full'],
+  ['physical', 'partial'],
+] as const;
+
+const toNonNegativeSafeInteger = (value: unknown): number => {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+};
+
+const addSafeCounts = (left: number, right: number): number =>
+  Math.min(Number.MAX_SAFE_INTEGER, left + right);
+
+export const normalizePromptCounts = (value: unknown): SessionPromptCount[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const totals = new Map<string, { correct: number; incorrect: number }>();
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const source = entry as Record<string, unknown>;
+    const promptType = toOptionalString(source.prompt_type);
+    const promptLevel = source.prompt_level === null ? null : toOptionalString(source.prompt_level);
+    const canonical = canonicalPromptPairs.find(([type, level]) => type === promptType && level === promptLevel);
+    if (!canonical) {
+      continue;
+    }
+    const key = `${canonical[0]}:${canonical[1] ?? ''}`;
+    const existing = totals.get(key) ?? { correct: 0, incorrect: 0 };
+    totals.set(key, {
+      correct: addSafeCounts(existing.correct, toNonNegativeSafeInteger(source.correct_trials)),
+      incorrect: addSafeCounts(existing.incorrect, toNonNegativeSafeInteger(source.incorrect_trials)),
+    });
+  }
+
+  return canonicalPromptPairs.flatMap(([promptType, promptLevel]) => {
+    const total = totals.get(`${promptType}:${promptLevel ?? ''}`);
+    if (!total || (total.correct === 0 && total.incorrect === 0)) {
+      return [];
+    }
+    return [{
+      prompt_type: promptType,
+      prompt_level: promptLevel,
+      correct_trials: total.correct,
+      incorrect_trials: total.incorrect,
+    }];
+  });
+};
+
 const hasTargetTrialData = (trial: SessionTargetTrialData | null | undefined): trial is SessionTargetTrialData =>
   Boolean(
     trial &&
       ((trial.metric_value !== null && trial.metric_value !== undefined) ||
         (trial.incorrect_trials !== null && trial.incorrect_trials !== undefined) ||
         (trial.opportunities !== null && trial.opportunities !== undefined) ||
+        (trial.prompt_counts?.length ?? 0) > 0 ||
         (trial.trial_prompt_note?.trim().length ?? 0) > 0 ||
         (trial.target?.trim().length ?? 0) > 0),
   );
@@ -75,12 +139,22 @@ const normalizeTargetTrials = (
   return value
     .map((entry, index) => {
       const source = entry && typeof entry === 'object' ? entry as Record<string, unknown> : {};
+      const promptCounts = normalizePromptCounts(source.prompt_counts);
+      const promptedCorrect = promptCounts.reduce((total, count) => addSafeCounts(total, count.correct_trials), 0);
+      const promptedIncorrect = promptCounts.reduce((total, count) => addSafeCounts(total, count.incorrect_trials), 0);
+      const sourceMetricValue = toOptionalNumber(source.metric_value ?? source.count ?? source.value);
+      const sourceIncorrectTrials = toOptionalNumber(source.incorrect_trials ?? source.incorrectTrials);
       const trial: SessionTargetTrialData = {
         target: toOptionalString(source.target) ?? toOptionalString(targets[index]) ?? null,
-        metric_value: toOptionalNumber(source.metric_value ?? source.count ?? source.value),
-        incorrect_trials: toOptionalNumber(source.incorrect_trials ?? source.incorrectTrials),
+        metric_value: promptCounts.length > 0
+          ? Math.max(sourceMetricValue ?? 0, promptedCorrect)
+          : sourceMetricValue,
+        incorrect_trials: promptCounts.length > 0
+          ? Math.max(sourceIncorrectTrials ?? 0, promptedIncorrect)
+          : sourceIncorrectTrials,
         opportunities: toOptionalNumber(source.opportunities ?? source.trials),
         trial_prompt_note: toOptionalString(source.trial_prompt_note ?? source.trialPromptNote),
+        ...(promptCounts.length > 0 ? { prompt_counts: promptCounts } : {}),
       };
       return hasTargetTrialData(trial) ? trial : null;
     })
@@ -91,12 +165,20 @@ const buildLegacyTargetTrial = (
   sourceData: Record<string, unknown>,
   targets: readonly string[],
 ): SessionTargetTrialData | null => {
+  const promptCounts = normalizePromptCounts(sourceData.prompt_counts);
+  const promptedCorrect = promptCounts.reduce((total, count) => addSafeCounts(total, count.correct_trials), 0);
+  const promptedIncorrect = promptCounts.reduce((total, count) => addSafeCounts(total, count.incorrect_trials), 0);
+  const sourceMetricValue = toOptionalNumber(sourceData.metric_value ?? sourceData.count ?? sourceData.value);
+  const sourceIncorrectTrials = toOptionalNumber(sourceData.incorrect_trials ?? sourceData.incorrectTrials);
   const trial: SessionTargetTrialData = {
     target: getPrimaryNonEmptyTarget(targets),
-    metric_value: toOptionalNumber(sourceData.metric_value ?? sourceData.count ?? sourceData.value),
-    incorrect_trials: toOptionalNumber(sourceData.incorrect_trials ?? sourceData.incorrectTrials),
+    metric_value: promptCounts.length > 0 ? Math.max(sourceMetricValue ?? 0, promptedCorrect) : sourceMetricValue,
+    incorrect_trials: promptCounts.length > 0
+      ? Math.max(sourceIncorrectTrials ?? 0, promptedIncorrect)
+      : sourceIncorrectTrials,
     opportunities: toOptionalNumber(sourceData.opportunities ?? sourceData.trials),
     trial_prompt_note: toOptionalString(sourceData.trial_prompt_note ?? sourceData.trialPromptNote),
+    ...(promptCounts.length > 0 ? { prompt_counts: promptCounts } : {}),
   };
   return hasTargetTrialData(trial) ? trial : null;
 };

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -1686,6 +1686,19 @@ describe("sessionNotesUpsertHandler", () => {
           prompt_level: null,
           note: null,
           trial_prompt_note: null,
+          targets: ["Legacy A"],
+          target: "Legacy A",
+          target_trials: [{
+            target: "Legacy A",
+            metric_value: 2,
+            incorrect_trials: 1,
+            prompt_counts: [{
+              prompt_type: "verbal",
+              prompt_level: "full",
+              correct_trials: 1,
+              incorrect_trials: 0,
+            }],
+          }],
         },
       },
     };
@@ -1693,6 +1706,31 @@ describe("sessionNotesUpsertHandler", () => {
     const savedAfterPatch = {
       ...existingRow,
       goal_notes: { [gidA]: "server kept skill note", [gidB]: "merged bx from client" },
+      goal_measurements: {
+        ...existingRow.goal_measurements,
+        [gidB]: {
+          version: 1,
+          data: {
+            metric_label: "Count",
+            metric_unit: null,
+            metric_value: 1,
+            incorrect_trials: 1,
+            targets: ["Legacy B"],
+            target: "Legacy B",
+            target_trials: [{
+              target: "Legacy B",
+              metric_value: 1,
+              incorrect_trials: 1,
+              prompt_counts: [{
+                prompt_type: "gesture",
+                prompt_level: null,
+                correct_trials: 1,
+                incorrect_trials: 1,
+              }],
+            }],
+          },
+        },
+      },
     };
 
     let fullNoteSelectGets = 0;
@@ -1736,9 +1774,24 @@ describe("sessionNotesUpsertHandler", () => {
         return { ok: true, status: 200, data: [savedAfterPatch] };
       }
       if (requestUrl.includes("/rest/v1/client_session_notes?id=eq.") && method === "PATCH") {
-        const parsedBody = JSON.parse(String(init.body)) as { goal_notes?: Record<string, string> };
+        const parsedBody = JSON.parse(String(init.body)) as {
+          goal_notes?: Record<string, string>;
+          goal_measurements?: Record<string, { data?: { target_trials?: Array<{ prompt_counts?: unknown[] }> } }>;
+        };
         expect(parsedBody.goal_notes?.[gidA]).toBe("server kept skill note");
         expect(parsedBody.goal_notes?.[gidB]).toBe("merged bx from client");
+        expect(parsedBody.goal_measurements?.[gidA]?.data?.target_trials?.[0]?.prompt_counts).toEqual([{
+          prompt_type: "verbal",
+          prompt_level: "full",
+          correct_trials: 1,
+          incorrect_trials: 0,
+        }]);
+        expect(parsedBody.goal_measurements?.[gidB]?.data?.target_trials?.[0]?.prompt_counts).toEqual([{
+          prompt_type: "gesture",
+          prompt_level: null,
+          correct_trials: 1,
+          incorrect_trials: 1,
+        }]);
         return { ok: true, status: 200, data: [{ id: noteId }] };
       }
       throw new Error(`Unexpected request: ${requestUrl} ${method}`);
@@ -1758,7 +1811,24 @@ describe("sessionNotesUpsertHandler", () => {
             [gidA]: "CLIENT STALE MUST NOT WIN",
             [gidB]: "merged bx from client",
           },
-          goalMeasurements: null,
+          goalMeasurements: {
+            [gidB]: {
+              version: 1,
+              data: {
+                targets: ["Legacy B"],
+                target_trials: [{
+                  target: "Legacy B",
+                  metric_value: 0,
+                  incorrect_trials: 0,
+                  prompt_counts: [
+                    { prompt_type: "gesture", prompt_level: null, correct_trials: 1, incorrect_trials: 0 },
+                    { prompt_type: "gesture", prompt_level: null, correct_trials: 0, incorrect_trials: 1 },
+                    { prompt_type: "unknown", prompt_level: null, correct_trials: 9, incorrect_trials: 9 },
+                  ],
+                }],
+              },
+            },
+          },
           captureMergeGoalIds: [gidB],
         }),
       }),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -500,6 +500,18 @@ export interface SessionTargetTrialData {
   opportunities?: number | null;
   /** Verbal / physical prompts and reactions for this target's trial data. */
   trial_prompt_note?: string | null;
+  /** Bounded aggregate prompt capture for legacy targets without a configured target UUID. */
+  prompt_counts?: SessionPromptCount[] | null;
+}
+
+export type SessionPromptType = 'verbal' | 'gesture' | 'model' | 'visual' | 'physical';
+export type SessionPromptLevel = 'full' | 'partial' | null;
+
+export interface SessionPromptCount {
+  prompt_type: SessionPromptType;
+  prompt_level: SessionPromptLevel;
+  correct_trials: number;
+  incorrect_trials: number;
 }
 
 export interface SessionGoalMeasurementEntry {


### PR DESCRIPTION
## Summary
- render all seven prompt buttons plus the checked-by-default correctness control for legacy plan/ad-hoc trial targets, including the Edit Session path shown in the reported screenshot
- keep configured response targets on UUID-backed raw `trial_events`; persist legacy targets as bounded canonical `prompt_counts` inside existing session-note goal measurements
- preserve prompt correctness across target removal, reset it across session/client changes, and make accidental legacy prompt clicks undoable
- leave BT role permissions unchanged pending an explicit product decision

## Root cause
PR #808 gated prompt controls behind an exact configured `goal_targets` match. Legacy plan targets have no target UUID, so Edit Session fell back to aggregate +/- controls only.

## Safety
- critical / human-reviewed because the shared goal-measurement normalizer is used at the server/API persistence boundary
- no schema, migration, RLS, role, auth, tenant query, or server handler changes
- canonicalizer permits only seven prompt type/level pairs, strips unknown/authority-like keys, deduplicates and safely bounds counts
- architect, code-review, and security reviews passed

## Verification
- focused component/normalizer/server suite: 132/132 passed
- lint: passed
- typecheck: passed
- build: passed
- policy checks: passed
- `test:ci`: 2763 passed, 3 skipped, 2 unchanged Windows-only baseline failures (`Blob.text` and CRLF workflow parsing)
- route gate: local retry exceeded the 120-second budget; hosted CI remains required
- `ci:playwright`: requires protected hosted credentials; CI remains required

Linear: WIN-218
