### PR TITLE
Clarify BT clinical capture saves

### DIFF
--- a/docs/ai/WIN-220-bt-clinical-capture-handoff.md
+++ b/docs/ai/WIN-220-bt-clinical-capture-handoff.md
@@ -54,7 +54,7 @@
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - `npx vitest run --config vitest.config.ts src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx --reporter=dot`: pass (`92` passed)
+  - `npx vitest run --config vitest.config.ts src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx --reporter=dot`: pass after rebasing onto `origin/main` (`94` passed)
   - focused scheduled/in-progress BT modal regressions: pass (`3` passed)
   - focused scheduled/in-progress/close BT Schedule orchestration regressions: pass (`3` passed)
   - `npm run ci:check-focused`: pass

--- a/docs/ai/WIN-220-bt-clinical-capture-handoff.md
+++ b/docs/ai/WIN-220-bt-clinical-capture-handoff.md
@@ -1,0 +1,88 @@
+# WIN-220 BT Clinical Capture Handoff
+
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: the visible change is UI-only, but it defines a role-sensitive session-edit boundary and verifies persistence through the existing clinical session-note path
+- triggering paths: `src/components/SessionModal.tsx`, `src/pages/Schedule.tsx`, and the existing session-note orchestration
+- issue: [WIN-220](https://linear.app/winningedgeai/issue/WIN-220/make-bt-scheduled-session-clinical-capture-explicitly-editable-and)
+- branch: `codex/bt-clinical-capture-update`
+
+## Scope
+
+- task intent: let a BT edit and save only clinical capture on an existing scheduled or in-progress session
+- files touched:
+  - `src/components/SessionModal.tsx`
+  - `src/components/__tests__/SessionModal.test.tsx`
+  - `src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
+  - `docs/ai/WIN-220-bt-clinical-capture-handoff.md`
+- single-purpose diff: yes
+- non-goals: no appointment metadata editing, role/API/RLS changes, database changes, billing-gate changes, or session-start permission changes
+- stop condition: any required change outside the modal copy/action label or focused regressions must be re-routed
+
+## Change Summary
+
+- BT data-collection-only mode now says that appointment details are locked and clinical capture can be edited and saved.
+- The BT-only submit action is labeled `Save clinical capture` for existing scheduled and in-progress sessions.
+- The existing locked metadata overlay, authorization requirement, and session-note persistence path remain unchanged.
+- Regression coverage now uses a real per-goal clinical edit on a scheduled session and proves `session_note_persist_requested: true`.
+- Schedule orchestration coverage proves a scheduled BT capture invokes the session-note upsert and never invokes the appointment mutation.
+
+## TDD Evidence
+
+- RED: the scheduled BT component regression could not find a `Save clinical capture` action; the modal exposed `Update Session` instead.
+- GREEN: the scheduled BT component regression submits the edited clinical note while retaining the original locked appointment values.
+- GREEN: scheduled and in-progress Schedule orchestration regressions persist clinical capture without updating appointment metadata.
+
+## Required Agents
+
+- required sequence: specification/test review, implementation, code review, security/auth review
+- agents used: specification/test review, implementation, code review, security/auth review
+- reviewer: completed; no blocking or nonblocking code findings
+
+## Verification Card
+
+- required checks:
+  - focused `SessionModal` and `Schedule` regressions
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - `npx vitest run --config vitest.config.ts src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx --reporter=dot`: pass (`92` passed)
+  - focused scheduled/in-progress BT modal regressions: pass (`3` passed)
+  - focused scheduled/in-progress/close BT Schedule orchestration regressions: pass (`3` passed)
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass (`2165` modules transformed)
+  - `PREVIEW_PORT=4174 npm run test:routes:tier0`: pass (`220/220`)
+  - `npm run test:ci`: fail outside changed files (`2761` passed, `3` skipped, `2` failed)
+  - `npm run verify:local`: fail at its `test:ci` stage on the same two outside-scope tests; policy, lint, and typecheck stages passed
+  - `npm run ci:playwright`: preflight pass, then hosted auth fail because the configured `superadmin@test.com` password was rejected; failure screenshot captured under ignored `artifacts/latest`
+- blocked/failed checks:
+  - `src/lib/__tests__/supabase.edge.test.ts` `downloads blob from async download endpoint`: local Windows test Blob lacks `.text()`; unchanged from `origin/main`
+  - `tests/ci/check-e2e-reliability-gates.test.ts` synthetic BCBA provision assertion: local CRLF checkout prevents its LF-specific workflow regex from finding the step; unchanged from `origin/main`
+  - authenticated Playwright suite: configured protected hosted credential is stale/invalid; fresh PR CI must run its managed credential path
+- result: fail locally until fresh PR CI proves the unchanged Linux gates and hosted auth check
+- residual risk: the focused BT capture behavior, payload, orchestration boundary, and route suite are proven; an authenticated hosted BT mutation/readback remains dependent on a valid protected test credential
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes
+- protected-path drift: none
+- unrelated changes: untracked `.tmp/` excluded
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: no, fresh PR CI pending
+- required follow-up: push, open a draft PR, require fresh CI and human review, then update this verdict from live checks
+
+## Handoff Summary
+
+The bounded change makes the BT's allowed action explicit: appointment fields stay locked while clinical capture remains editable and saveable for scheduled and in-progress sessions. Component and orchestration tests prove clinical edits reach the session-note path without invoking appointment update or completion, and all 220 tier-0 routes pass. Two unchanged Windows-only full-suite failures and a stale hosted Playwright credential require fresh PR CI before this critical slice is review-ready.

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -518,6 +518,9 @@ export function SessionModal({
   const conflictHeadingId = 'session-modal-conflicts-heading';
   const queryClient = useQueryClient();
   const isDataCollectionOnly = Boolean(dataCollectionOnly && session?.id);
+  const isBtClinicalCaptureSession = Boolean(
+    isDataCollectionOnly && (session?.status === 'scheduled' || session?.status === 'in_progress'),
+  );
   const shouldHideGoalCaptureFields = hideGoalCaptureFields;
 
   const resolvedTimeZone = useMemo(() => resolveSchedulingTimeZone(timeZone), [timeZone]);
@@ -1869,13 +1872,16 @@ export function SessionModal({
         ? 'Choose therapist, client, and time before creating this appointment.'
         : 'Choose therapist, client, time, and plan details before creating this appointment.';
     }
+    if (isBtClinicalCaptureSession) {
+      return 'Appointment details are locked. Edit the clinical capture below, then save it with this session.';
+    }
     if (isInProgressSession) {
       return shouldHideGoalCaptureFields
         ? 'Review scheduling details and save updates while the visit is active.'
         : 'Log trials and per-goal notes, then save to sync. Use Close session when the visit ends.';
     }
     return 'Review core details first, then add notes before saving.';
-  }, [session, isInProgressSession, shouldHideGoalCaptureFields]);
+  }, [isBtClinicalCaptureSession, session, isInProgressSession, shouldHideGoalCaptureFields]);
   const sessionNoteGoalIds = useMemo(
     () => mergeUniqueGoalIds(
       Array.isArray(goalIds) ? goalIds : [],
@@ -2651,7 +2657,7 @@ export function SessionModal({
                 <p className="font-medium">Session in progress</p>
                 <p className="mt-1">
                   {isDataCollectionOnly
-                    ? 'Session details are read-only. Save progress to sync data collection.'
+                    ? 'Session details are read-only. Save clinical capture to sync data collection.'
                     : shouldHideGoalCaptureFields
                       ? 'Session details stay focused on scheduling fields while active.'
                       : 'You can adjust program and goals while active; save to keep the plan in sync with the schedule.'}
@@ -4259,7 +4265,7 @@ export function SessionModal({
                   <>
                     <CheckCircle2 className="w-4 h-4 mr-2" />
                     {session
-                      ? (isInProgressSession ? 'Save progress' : 'Update Session')
+                      ? (isBtClinicalCaptureSession ? 'Save clinical capture' : (isInProgressSession ? 'Save progress' : 'Update Session'))
                       : 'Create Session'}
                   </>
                 )}

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1387,13 +1387,34 @@ describe('SessionModal', () => {
       expect(select.value).toBe('in_progress');
     });
 
-    it('locks session metadata while allowing data-only save in edit mode', async () => {
+    it('locks scheduled-session metadata while allowing BT clinical capture to be edited and saved', async () => {
       const onSubmit = vi.fn().mockResolvedValue(undefined);
+      const buildChain = (rows: unknown[]) => {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: rows, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      };
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
+        if (table === 'programs') return buildChain(mockPrograms);
+        if (table === 'goals') return buildChain(mockGoals);
+        if (table === 'authorizations') {
+          return buildChain([{
+            id: 'auth-1',
+            authorization_number: 'AUTH-001',
+            services: [{ service_code: '97153' }],
+          }]);
+        }
+        return buildChain([]);
+      });
       const lockedSession: Session = {
         ...editSession,
-        status: 'in_progress',
         notes: 'Original schedule note',
-        started_at: '2026-03-31T10:05:00.000Z',
       };
 
       renderWithProviders(
@@ -1414,7 +1435,10 @@ describe('SessionModal', () => {
       expect(screen.getByLabelText(/End Time/i)).toBeDisabled();
       expect(screen.getByLabelText(/Schedule Notes/i)).toBeDisabled();
 
-      await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
+      fireEvent.change(await screen.findByLabelText(/^Per-goal note$/i), {
+        target: { value: 'BT clinical capture update' },
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Save clinical capture/i }));
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
@@ -1425,10 +1449,34 @@ describe('SessionModal', () => {
           goal_id: 'goal-1',
           start_time: '2026-03-31T10:00:00.000Z',
           end_time: '2026-03-31T11:00:00.000Z',
-          status: 'in_progress',
+          status: 'scheduled',
           notes: 'Original schedule note',
+          session_note_persist_requested: true,
+          session_note_goal_notes: expect.objectContaining({
+            'goal-1': 'BT clinical capture update',
+          }),
         }));
       });
+    });
+
+    it('labels in-progress BT saves as clinical capture without changing the BCBA save label', () => {
+      const inProgressSession: Session = {
+        ...editSession,
+        status: 'in_progress',
+        started_at: '2026-03-31T10:05:00.000Z',
+      };
+
+      const { rerender } = renderWithProviders(
+        <SessionModal {...defaultProps} session={inProgressSession} dataCollectionOnly />,
+      );
+
+      expect(screen.getByRole('button', { name: /Save clinical capture/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Save progress/i })).not.toBeInTheDocument();
+
+      rerender(<SessionModal {...defaultProps} session={inProgressSession} />);
+
+      expect(screen.getByRole('button', { name: /Save progress/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Save clinical capture/i })).not.toBeInTheDocument();
     });
 
     it('allows BT data-only edit mode to close an in-progress session without unlocking schedule metadata', async () => {

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -643,9 +643,7 @@ describe("Schedule orchestration integration hardening", () => {
     expect(showErrorMock).not.toHaveBeenCalled();
   });
 
-  it("BT live capture persistence saves data collection without updating appointment metadata", async () => {
-    scheduleFixtures.sessions[0].status = "in_progress";
-
+  it("BT scheduled-session capture saves clinical data without updating appointment metadata", async () => {
     renderWithProviders(<Schedule />, {
       auth: { role: "bt", organizationId: "org-1" },
     });
@@ -661,6 +659,7 @@ describe("Schedule orchestration integration hardening", () => {
       expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1);
     });
     expect(bookSessionViaApiMock).not.toHaveBeenCalled();
+    expect(completeSessionFromModalMock).not.toHaveBeenCalled();
     expect(invalidateSessionNoteCachesAfterSessionWriteMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -668,6 +667,28 @@ describe("Schedule orchestration integration hardening", () => {
         clientId: "client-1",
       }),
     );
+    expect(showSuccessMock).toHaveBeenCalledWith("Session data collection saved");
+    expect(showErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("BT in-progress capture saves clinical data without updating or completing the appointment", async () => {
+    scheduleFixtures.sessions[0].status = "in_progress";
+
+    renderWithProviders(<Schedule />, {
+      auth: { role: "bt", organizationId: "org-1" },
+    });
+    await screen.findByRole("heading", { name: /Schedule/i });
+
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+    expect(screen.getByTestId("data-collection-only")).toHaveTextContent("true");
+    fireEvent.click(screen.getByLabelText("submit-capture-persist"));
+
+    await waitFor(() => {
+      expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1);
+    });
+    expect(bookSessionViaApiMock).not.toHaveBeenCalled();
+    expect(completeSessionFromModalMock).not.toHaveBeenCalled();
     expect(showSuccessMock).toHaveBeenCalledWith("Session data collection saved");
     expect(showErrorMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- label the BT-only existing-session action `Save clinical capture` for scheduled and in-progress sessions
- explicitly state that appointment details remain locked while clinical capture is editable
- prove scheduled and in-progress BT clinical saves use the session-note path without updating or completing the appointment
- preserve the BCBA `Save progress` action and all existing authorization/billing gates

## Root cause

The clinical-only BT persistence path already existed, but scheduled sessions exposed it as `Update Session`, while all appointment metadata was intentionally locked. The prior component test also submitted no real clinical change, so it did not prove the user-visible edit/save flow.

## Verification

Passed locally after rebasing onto current `main` (including merged prompt controls from #809):

- focused SessionModal + Schedule integration files: 94/94
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `PREVIEW_PORT=4174 npm run test:routes:tier0`: 220/220
- specification/test, security/auth, and independent code review

Local environment blockers requiring fresh PR CI:

- `npm run test:ci`: 2761 passed, 3 skipped, 2 unchanged Windows-only failures (`Blob.text()` and CRLF workflow-regex fixture)
- `npm run ci:playwright`: preflight passed, then the configured hosted `superadmin@test.com` credential was rejected
- `npm run verify:local`: stopped at the same two unchanged `test:ci` failures

## Risk

Critical/human-reviewed because this documents and tests a role-sensitive session-edit boundary. No server, API, Supabase, RLS, migration, auth, billing-gate, or permission code changed. Human review and green PR CI are required before merge.

Linear: WIN-220