### PR TITLE
Hide BT prompted response correctness control

### DIFF
--- a/docs/superpowers/plans/2026-07-16-hide-bt-prompt-correctness.md
+++ b/docs/superpowers/plans/2026-07-16-hide-bt-prompt-correctness.md
@@ -1,0 +1,49 @@
+# Hide BT Prompt Correctness Toggle
+
+## Scope
+
+- Hide the `Prompted response was correct` checkbox during BT data-collection capture.
+- Keep the prompt-type buttons available to BT users.
+- Preserve the checkbox and existing behavior for non-BT session-note flows.
+- Cover the BT behavior with a focused `SessionModal` regression test.
+
+## Non-goals
+
+- Do not change prompt event persistence or correctness defaults.
+- Do not change auth, route guards, session lifecycle, billing, or tenant behavior.
+- Do not include supervision-note migrations or their tests in this PR.
+
+## Routing
+
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Triggering paths: `src/components/SessionModal.tsx` and `src/components/__tests__/SessionModal.test.tsx`
+- Stop condition: re-route if the change expands into auth, routing, server, migration, or tenant-sensitive behavior.
+
+## Verification
+
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Change type: UI/component and focused component test
+- Required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+- Executed checks:
+  - `npm run ci:check-focused` - passed as part of `npm run verify:local`
+  - `npm run lint` - passed as part of `npm run verify:local`
+  - `npm run typecheck` - passed as part of `npm run verify:local`
+  - `npm run test:ci` - failed on two unrelated tests that reproduce in isolation
+  - `vitest run src/components/__tests__/SessionModal.test.tsx` - passed, 84 tests
+  - `npm run build` - passed
+- Blocked checks:
+  - `npm run verify:local` could not reach coverage verification or tier-0 routes because it stopped at the failing `test:ci` step
+- Result: `fail`
+- Residual risk: the full repository suite remains blocked by two failures outside this PR's files; the complete affected component suite passes.
+
+## Tracking
+
+- Linear: `WIN-221`
+- Residual risk: the visibility rule depends on the existing BT clinical-capture signal supplied by the schedule flow.

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -525,6 +525,7 @@ export function SessionModal({
     isDataCollectionOnly && (session?.status === 'scheduled' || session?.status === 'in_progress'),
   );
   const shouldHideGoalCaptureFields = hideGoalCaptureFields;
+  const shouldShowPromptCorrectnessToggle = !isBtClinicalCaptureSession;
 
   const resolvedTimeZone = useMemo(() => resolveSchedulingTimeZone(timeZone), [timeZone]);
 
@@ -3996,23 +3997,25 @@ export function SessionModal({
                                                     </span>
                                                   </div>
                                                   <div className="mt-3 rounded-md border border-indigo-200 bg-white/80 p-2 dark:border-indigo-800 dark:bg-dark/70">
-                                                    <label className="flex min-h-10 items-center gap-2 text-xs font-medium text-gray-800 dark:text-gray-200">
-                                                      <input
-                                                        type="checkbox"
-                                                        checked={promptCorrectByTargetId[promptCorrectnessKey] ?? true}
-                                                        onChange={(event) => setPromptCorrectByTargetId((current) =>
-                                                          setPromptCorrectnessForTarget(
-                                                            current,
-                                                            promptCorrectnessKey,
-                                                            event.target.checked,
-                                                          ))}
-                                                        aria-label={`Prompted response was correct for target ${targetIndex + 1}: ${configuredTarget.name}`}
-                                                        className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                                                      />
-                                                      Prompted response was correct
-                                                    </label>
+                                                    {shouldShowPromptCorrectnessToggle ? (
+                                                      <label className="flex min-h-10 items-center gap-2 text-xs font-medium text-gray-800 dark:text-gray-200">
+                                                        <input
+                                                          type="checkbox"
+                                                          checked={promptCorrectByTargetId[promptCorrectnessKey] ?? true}
+                                                          onChange={(event) => setPromptCorrectByTargetId((current) =>
+                                                            setPromptCorrectnessForTarget(
+                                                              current,
+                                                              promptCorrectnessKey,
+                                                              event.target.checked,
+                                                            ))}
+                                                          aria-label={`Prompted response was correct for target ${targetIndex + 1}: ${configuredTarget.name}`}
+                                                          className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                                        />
+                                                        Prompted response was correct
+                                                      </label>
+                                                    ) : null}
                                                     <div
-                                                      className="mt-2 flex flex-wrap gap-2"
+                                                      className={`${shouldShowPromptCorrectnessToggle ? 'mt-2' : ''} flex flex-wrap gap-2`}
                                                       role="group"
                                                       aria-label={`Prompt types for target ${targetIndex + 1}: ${configuredTarget.name}`}
                                                     >
@@ -4120,23 +4123,25 @@ export function SessionModal({
                                             </div>
                                             {!configuredTarget ? (
                                             <div className="w-full rounded-md border border-indigo-200 bg-white/80 p-2 dark:border-indigo-800 dark:bg-dark/70">
-                                              <label className="flex min-h-10 items-center gap-2 text-xs font-medium text-gray-800 dark:text-gray-200">
-                                                <input
-                                                  type="checkbox"
-                                                  checked={promptCorrectByTargetId[promptCorrectnessKey] ?? true}
-                                                  onChange={(event) => setPromptCorrectByTargetId((current) =>
-                                                    setPromptCorrectnessForTarget(
-                                                      current,
-                                                      promptCorrectnessKey,
-                                                      event.target.checked,
-                                                    ))}
-                                                  aria-label={`Prompted response was correct for target ${targetIndex + 1}: ${targetValue}`}
-                                                  className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                                                />
-                                                Prompted response was correct
-                                              </label>
+                                              {shouldShowPromptCorrectnessToggle ? (
+                                                <label className="flex min-h-10 items-center gap-2 text-xs font-medium text-gray-800 dark:text-gray-200">
+                                                  <input
+                                                    type="checkbox"
+                                                    checked={promptCorrectByTargetId[promptCorrectnessKey] ?? true}
+                                                    onChange={(event) => setPromptCorrectByTargetId((current) =>
+                                                      setPromptCorrectnessForTarget(
+                                                        current,
+                                                        promptCorrectnessKey,
+                                                        event.target.checked,
+                                                      ))}
+                                                    aria-label={`Prompted response was correct for target ${targetIndex + 1}: ${targetValue}`}
+                                                    className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                                  />
+                                                  Prompted response was correct
+                                                </label>
+                                              ) : null}
                                               <div
-                                                className="mt-2 flex flex-wrap gap-2"
+                                                className={`${shouldShowPromptCorrectnessToggle ? 'mt-2' : ''} flex flex-wrap gap-2`}
                                                 role="group"
                                                 aria-label={`Prompt types for target ${targetIndex + 1}: ${targetValue}`}
                                               >

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -3074,6 +3074,135 @@ describe('SessionModal', () => {
     expect(submitted.session_note_goal_measurements?.['goal-1']?.data.measurement_type).toBe('taskAnalysis');
   }, 15000);
 
+  it.each(['scheduled', 'in_progress'] as const)(
+    'hides prompted response correctness controls during %s BT data-collection capture',
+    async (status) => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      const targetId = '88888888-8888-4888-8888-8888888888bt';
+      const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: rows, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      };
+
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
+        if (table === 'programs') {
+          return buildChain(mockPrograms);
+        }
+        if (table === 'goals') {
+          return buildChain(mockGoals.map((goal) =>
+            goal.id === 'goal-1' ? { ...goal, measurement_type: 'taskAnalysis' } : goal,
+          ));
+        }
+        if (table === 'authorizations') {
+          return buildChain([
+            {
+              id: 'auth-1',
+              authorization_number: 'AUTH-001',
+              services: [{ service_code: '97153' }],
+            },
+          ]);
+        }
+        if (table === 'goal_targets') {
+          return buildChain([
+            {
+              id: targetId,
+              organization_id: 'org-a',
+              client_id: 'test-client-1',
+              goal_id: 'goal-1',
+              name: 'Match peer greeting in 4/5 trials',
+              measurement_type: 'taskAnalysis',
+              graph_config: {},
+              status: 'active',
+              sort_order: 0,
+              is_current: true,
+              current_phase: 'baseline',
+              evaluation_window_started_at: '2024-01-01T00:00:00Z',
+              progression_version: 7,
+              created_by: null,
+              updated_by: null,
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-01T00:00:00Z',
+            },
+          ]);
+        }
+        if (table === 'trial_events') {
+          return buildChain([]);
+        }
+        return buildChain([]);
+      });
+
+      const session = {
+        id: `session-task-analysis-bt-capture-${status}`,
+        therapist_id: 'test-therapist-1',
+        client_id: 'test-client-1',
+        program_id: 'program-1',
+        goal_id: 'goal-1',
+        start_time: '2026-03-01T10:00:00.000Z',
+        end_time: '2026-03-01T11:00:00.000Z',
+        status,
+        notes: '',
+        created_at: '2026-03-01T09:00:00.000Z',
+        created_by: null,
+        updated_at: '2026-03-01T09:00:00.000Z',
+        updated_by: null,
+        started_at: status === 'in_progress' ? '2026-03-01T10:00:00.000Z' : null,
+      } satisfies Session;
+      const { rerender } = renderWithProviders(
+        <SessionModal
+          {...defaultProps}
+          onSubmit={onSubmit}
+          existingSessions={[]}
+          dataCollectionOnly
+          session={session}
+        />,
+      );
+
+      await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
+
+      expect(screen.queryByRole('checkbox', {
+        name: /Prompted response was correct for target 1/i,
+      })).not.toBeInTheDocument();
+      const promptLabels = [
+        'full verbal',
+        'partial verbal',
+        'gesture',
+        'model',
+        'visual',
+        'full physical',
+        'partial physical',
+      ];
+      for (const label of promptLabels) {
+        expect(screen.getByRole('button', {
+          name: new RegExp(`Record ${label} prompt for target 1`, 'i'),
+        })).toBeInTheDocument();
+      }
+      await userEvent.click(screen.getByRole('button', {
+        name: /Record full verbal prompt for target 1/i,
+      }));
+      expect(screen.getByText('+1 · −0')).toBeInTheDocument();
+
+      rerender(
+        <SessionModal
+          {...defaultProps}
+          onSubmit={onSubmit}
+          existingSessions={[]}
+          session={session}
+        />,
+      );
+      expect(await screen.findByRole('checkbox', {
+        name: /Prompted response was correct for target 1/i,
+      })).toBeInTheDocument();
+    },
+    15000,
+  );
+
   it('keeps aggregate counts nulled when reopening a raw-trial-backed target without new trial clicks', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const targetId = '88888888-8888-4888-8888-888888888889';
@@ -3497,6 +3626,7 @@ describe('SessionModal', () => {
       <SessionModal
         {...defaultProps}
         onSubmit={onSubmit}
+        dataCollectionOnly
         session={{
           id: 'session-target-removal',
           therapist_id: 'test-therapist-1',
@@ -3532,6 +3662,12 @@ describe('SessionModal', () => {
     fireEvent.change(targetFields[targetFields.length - 1], {
       target: { value: 'Target A' },
     });
+    expect(screen.queryByRole('checkbox', {
+      name: /Prompted response was correct for target 1: Target A/i,
+    })).not.toBeInTheDocument();
+    expect(await screen.findByRole('button', {
+      name: /Record full verbal prompt for target 1: Target A/i,
+    })).toBeInTheDocument();
     const addTargetButtons = screen.getAllByRole('button', { name: /add target/i });
     await userEvent.click(addTargetButtons[addTargetButtons.length - 1]);
     const secondTargetFields = screen.getAllByLabelText(/^Target 2$/i);


### PR DESCRIPTION
## Summary

- hide the `Prompted response was correct` checkbox during BT data-collection capture
- keep all prompt-type buttons available for configured and legacy/freeform targets
- preserve the checkbox for non-BT session-note flows
- add coverage for scheduled and in-progress BT sessions, non-BT preservation, and the legacy/freeform branch

## Tracking

- Linear: [WIN-221](https://linear.app/winningedgeai/issue/WIN-221/add-mandatory-bt-aba-session-note-to-session-close-workflow)
- Lane: `standard`
- Classification: `low-risk autonomous`

## Verification

Passed:
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `vitest run src/components/__tests__/SessionModal.test.tsx` (84/84)
- `npm run build`
- focused code review: approved with no findings

Blocked:
- `npm run test:ci` reproduces two failures outside this PR:
  - `tests/ci/check-e2e-reliability-gates.test.ts`: missing synthetic BCBA workflow provisioning step
  - `src/lib/__tests__/supabase.edge.test.ts`: `blob.text is not a function`
- `npm run verify:local` stops at the same `test:ci` failures before coverage verification and tier-0 routes

## Scope

This PR does not include the local supervision-note migration or its tests. It does not change auth, routing, server, Supabase, billing, or tenant behavior.