### PR TITLE
WIN-190: require supervision session note fields

### DIFF
--- a/supabase/migrations/20260717144005_require_supervision_session_note_fields.sql
+++ b/supabase/migrations/20260717144005_require_supervision_session_note_fields.sql
@@ -1,0 +1,102 @@
+/*
+  @migration-intent: Require the supervisor session note fields requested for completed supervision notes across already-seeded tenant templates.
+  @migration-dependencies: 20260629233000_create_supervision_session_note_workflow.sql
+  @migration-rollback: Update public.session_note_templates to restore the prior optional flags for the affected supervision session note fields if this contract is intentionally reverted.
+*/
+
+begin;
+
+do $$
+declare
+  missing_template_count integer;
+begin
+  select count(*)
+  into missing_template_count
+  from public.organizations as organization
+  where not exists (
+    select 1
+    from public.session_note_templates as template
+    where template.organization_id = organization.id
+      and template.template_type = 'supervision_session_note'
+      and template.template_name = 'Supervision Session Note'
+  );
+
+  if missing_template_count > 0 then
+    raise exception 'Missing Supervision Session Note template for % organization rows', missing_template_count;
+  end if;
+end
+$$;
+
+update public.session_note_templates as template
+set
+  template_structure = jsonb_set(
+    template.template_structure,
+    '{sections}',
+    (
+      select jsonb_agg(
+        case
+          when section.value ? 'fields' then jsonb_set(
+            section.value,
+            '{fields}',
+            (
+              select jsonb_agg(
+                case
+                  when field.value->>'key' in (
+                    'rbt_in_attendance',
+                    'skill_strategies_interventions_used',
+                    'behavior_strategies_interventions_used',
+                    'coordination_of_care',
+                    'client_response_to_treatment',
+                    'session_note_description'
+                  ) then jsonb_set(field.value, '{required}', 'true'::jsonb, true)
+                  else field.value
+                end
+                order by field.ordinality
+              )
+              from jsonb_array_elements(coalesce(section.value->'fields', '[]'::jsonb)) with ordinality as field(value, ordinality)
+            ),
+            true
+          )
+          else section.value
+        end
+        order by section.ordinality
+      )
+      from jsonb_array_elements(coalesce(template.template_structure->'sections', '[]'::jsonb)) with ordinality as section(value, ordinality)
+    ),
+    true
+  ),
+  updated_at = timezone('utc', now())
+where template.template_type = 'supervision_session_note'
+  and template.template_name = 'Supervision Session Note';
+
+do $$
+declare
+  missing_required_count integer;
+begin
+  select count(*)
+  into missing_required_count
+  from public.session_note_templates template
+  where template.template_type = 'supervision_session_note'
+    and template.template_name = 'Supervision Session Note'
+    and exists (
+      select 1
+      from jsonb_array_elements(coalesce(template.template_structure->'sections', '[]'::jsonb)) section(value)
+      cross join lateral jsonb_array_elements(coalesce(section.value->'fields', '[]'::jsonb)) field(value)
+      where field.value->>'key' in (
+        'rbt_in_attendance',
+        'skill_strategies_interventions_used',
+        'behavior_strategies_interventions_used',
+        'coordination_of_care',
+        'client_response_to_treatment',
+        'session_note_description'
+      )
+      and coalesce((field.value->>'required')::boolean, false) is false
+    );
+
+  if missing_required_count > 0 then
+    raise exception 'Supervision session note required field backfill incomplete for % template rows', missing_required_count;
+  end if;
+end
+$$;
+
+commit;

--- a/tests/supervisionSessionNoteRequiredFieldsMigration.test.ts
+++ b/tests/supervisionSessionNoteRequiredFieldsMigration.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('supervision session note required fields migration', () => {
+  const migrationSql = readFileSync(
+    join(
+      process.cwd(),
+      'supabase/migrations/20260717144005_require_supervision_session_note_fields.sql',
+    ),
+    'utf-8',
+  );
+
+  it('updates only supervision session note templates', () => {
+    expect(migrationSql).toMatch(/update public\.session_note_templates/i);
+    expect(migrationSql).toMatch(/where template\.(?:template_type|template_name)\s*=\s*'supervision_session_note'/i);
+    expect(migrationSql).toMatch(/template\.template_name\s*=\s*'Supervision Session Note'/i);
+  });
+
+  it('marks the requested supervisor note fields as required', () => {
+    expect(migrationSql).toMatch(/jsonb_set\(field\.value,\s*'\{required\}',\s*'true'::jsonb,\s*true\)/i);
+    [
+      'rbt_in_attendance',
+      'skill_strategies_interventions_used',
+      'behavior_strategies_interventions_used',
+      'coordination_of_care',
+      'client_response_to_treatment',
+      'session_note_description',
+    ].forEach((fieldKey) => {
+      expect(migrationSql).toContain(`'${fieldKey}'`);
+    });
+  });
+
+  it('fails closed when an organization is missing its supervision template', () => {
+    expect(migrationSql).toMatch(/from public\.organizations(?:\s+as)?\s+organization/i);
+    expect(migrationSql).toMatch(/where not exists\s*\([\s\S]*template\.organization_id\s*=\s*organization\.id/i);
+    expect(migrationSql).toMatch(/raise exception 'Missing Supervision Session Note template for % organization rows'/i);
+  });
+});


### PR DESCRIPTION
## Summary
- require six supervision-session-note fields in existing tenant templates
- fail closed when any organization is missing its canonical supervision template
- add a migration contract test for scope, required keys, and tenant-template presence
- use a migration timestamp later than the current production migration ledger

Linear: WIN-190

## Tenant safety
- updates existing `public.session_note_templates` rows only
- changes no RLS policies, grants, RPC exposure, auth, or cross-tenant access
- production read-only preflight: 2 organizations, 2 canonical templates, 0 missing, 0 duplicate

## Verification
Passed:
- targeted migration test: 3/3
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`
- pre-commit policy hook

Blocked baseline:
- `npm run test:ci`: 2938 passed, 3 skipped, 2 unrelated failures
  - `tests/ci/check-e2e-reliability-gates.test.ts` expects a BCBA provisioning workflow step that is absent on current `main`
  - `src/lib/__tests__/supabase.edge.test.ts` receives a Blob without `.text()` in this local test environment
- Both failures reproduce independently and do not touch this two-file diff.
- `npm run verify:local` was not rerun because it includes the already-reproduced failing full-suite gate.

## Risk
Critical-lane migration. Human review is required before merge. The migration has not been applied to production.