### PR TITLE
WIN-223 Repair supervision request lifecycle

### DIFF
--- a/docs/superpowers/plans/2026-07-17-supervision-request-lifecycle-repair.md
+++ b/docs/superpowers/plans/2026-07-17-supervision-request-lifecycle-repair.md
@@ -25,7 +25,7 @@
 
 ## Hosted rollout and cleanup
 
-1. Merge the reviewed branch and apply `20260717222331_repair_supervision_request_lifecycle.sql`.
+1. Merge the reviewed branch and confirm both `20260717222331_repair_supervision_request_lifecycle.sql` and the forward-only `20260717235500_align_supervision_request_linked_therapist_authority.sql` are applied. The second migration preserves the issued first migration while aligning request creation with the edge handler's exact linked-therapist closeout authority.
 2. Confirm the migration appears in hosted migration history and the lifecycle columns, constraints, and RPC definitions are present.
 3. Preflight the separately held allowlist of 28 legacy request IDs. Every row must still be in the expected organization, remain `pending`, refer to a future session, and fail the complete structured BT packet check. Abort on any mismatch.
 4. In one protected transaction, update only that exact allowlist to `cancelled`, set cancellation timestamp, reason, and source, and assert exactly 28 rows changed. Do not delete or rewrite clinical records.
@@ -42,7 +42,7 @@
 
 ### Executed locally
 
-- `npx vitest run tests/supervisionRequestLifecycleMigration.test.ts tests/edge/sessions-complete.test.ts`: passed, 43/43.
+- `npx vitest run tests/supervisionRequestLifecycleMigration.test.ts tests/edge/sessions-complete.test.ts`: passed, 44/44 after the linked-therapist authorization regression was added.
 - `npm run ci:check-focused`: passed.
 - `npm run lint`: passed.
 - `npm run typecheck`: passed.
@@ -57,6 +57,11 @@
 - `npm run ci:playwright`: preflight stopped because neither the super-admin nor admin Playwright credential pair is available to this process.
 - Database-backed policy checks: `SUPABASE_DB_URL` / `DATABASE_URL` is not configured locally.
 
+### Hosted preview proof
+
+- Applied `align_supervision_request_linked_therapist_authority` to the Supabase preview project.
+- Ran a rollback-only authenticated SQL smoke using synthetic rows: an exact `user_therapist_links` actor created the request; after removing that exact link inside the transaction, the same actor received SQLSTATE `42501`; rollback confirmation showed the synthetic session did not persist.
+
 ### Review verdicts
 
 - Code review: approved after creator/reconcile conflict safety was added.
@@ -64,6 +69,9 @@
 - Supabase: approved after lock order was normalized to session then request and the conflict loser path re-locks the winning request.
 - Test review: no code-level coverage blocker; SQL execution evidence remains required from a compatible preview/CI database.
 - Performance: approved with moderate residual reconcile batch-cost risk; current lookups are index-backed.
+- Follow-up code review: approved after the issued migration was restored and the authorization correction was isolated in a forward migration.
+- Follow-up security review: approved; the link is checked against the exact same-org session therapist and matches the edge handler's delegated-therapist authority model.
+- Follow-up Supabase review: approved; the forward migration retains fail-closed search path and existing grants without RLS or tenant-boundary expansion.
 
 ## Stop conditions
 

--- a/docs/superpowers/plans/2026-07-17-supervision-request-lifecycle-repair.md
+++ b/docs/superpowers/plans/2026-07-17-supervision-request-lifecycle-repair.md
@@ -1,0 +1,72 @@
+# WIN-223 Supervision Request Lifecycle Repair
+
+## Routing
+
+- Classification: high-risk human-reviewed
+- Lane: critical
+- Protected surfaces: `supabase/migrations/**`, `supabase/functions/sessions-complete/index.ts`
+- Required reviewers: code review, test, security, Supabase, and human review before merge
+
+## Bounded scope
+
+- Add auditable cancellation and reopen provenance to the existing one-request-per-session queue.
+- Route the edge session-completion path through the canonical packet-aware creator RPC.
+- Permit creator-driven `cancelled -> pending` only after the session has a complete structured BT packet.
+- Keep completed requests terminal.
+- Keep reconciliation create-only for missing packet-complete requests and null-assignee backfill; it must never reopen cancelled requests.
+- Preserve sessions, BT notes, attestations, supervision notes, and session audit logs.
+
+## Non-goals
+
+- No new UI or queue shape.
+- No fabricated clinical packets or legacy note rewrites.
+- No production request identifiers in repository migrations, tests, or documentation.
+- No broad date-based production mutation.
+
+## Hosted rollout and cleanup
+
+1. Merge the reviewed branch and apply `20260717222331_repair_supervision_request_lifecycle.sql`.
+2. Confirm the migration appears in hosted migration history and the lifecycle columns, constraints, and RPC definitions are present.
+3. Preflight the separately held allowlist of 28 legacy request IDs. Every row must still be in the expected organization, remain `pending`, refer to a future session, and fail the complete structured BT packet check. Abort on any mismatch.
+4. In one protected transaction, update only that exact allowlist to `cancelled`, set cancellation timestamp, reason, and source, and assert exactly 28 rows changed. Do not delete or rewrite clinical records.
+5. Verify the single past legacy request remains untouched for manual disposition.
+6. Re-audit the queue: zero invalid future legacy requests pending; the past request still present; no source clinical or audit rows changed.
+7. A later genuine BT closeout for one of the cancelled sessions may reopen its existing request in place through the canonical creator RPC. Reconciliation alone must not reopen it.
+
+## Verification record
+
+- Targeted Vitest: migration and edge creator-path contracts.
+- Synthetic SQL smoke: cancelled request reopens in place after BT finalization, retains cancellation provenance, and gains reopen provenance.
+- Required gates: policy checks, lint, typecheck, test CI, tenant validation, route/auth browser gates, build, and `verify:local` where the required local services and credentials exist.
+- Any unavailable database or browser check must be recorded as blocked rather than treated as passed.
+
+### Executed locally
+
+- `npx vitest run tests/supervisionRequestLifecycleMigration.test.ts tests/edge/sessions-complete.test.ts`: passed, 43/43.
+- `npm run ci:check-focused`: passed.
+- `npm run lint`: passed.
+- `npm run typecheck`: passed.
+- `npm run validate:tenant`: passed.
+- `npm run build`: passed.
+- `PREVIEW_PORT=4175 npm run test:routes:tier0`: passed, 220/220. The default port was already held by an unrelated preview process.
+- `npm run test:ci` and `npm run verify:local`: reached 2,962 passing tests and failed on two reproducible Windows baseline checks outside the WIN-223 diff: a CRLF-sensitive workflow-step regex and a jsdom `Blob.text()` compatibility check.
+
+### Blocked locally
+
+- `tests/sql/bt_aba_session_note_closeout_smoke.sql`: the preserved local Supabase volume was initialized by PostgreSQL 17, while the current local image is PostgreSQL 15.8. The incompatible volume was not deleted or reset.
+- `npm run ci:playwright`: preflight stopped because neither the super-admin nor admin Playwright credential pair is available to this process.
+- Database-backed policy checks: `SUPABASE_DB_URL` / `DATABASE_URL` is not configured locally.
+
+### Review verdicts
+
+- Code review: approved after creator/reconcile conflict safety was added.
+- Security: approved after schedule-staff caller authority was aligned with session-completion authority.
+- Supabase: approved after lock order was normalized to session then request and the conflict loser path re-locks the winning request.
+- Test review: no code-level coverage blocker; SQL execution evidence remains required from a compatible preview/CI database.
+- Performance: approved with moderate residual reconcile batch-cost risk; current lookups are index-backed.
+
+## Stop conditions
+
+- Any preflight allowlist row differs from its expected tenant, status, session timing, or packet completeness.
+- Required CI or human review is missing.
+- Safe completion requires changing RLS, grants, packet shape, or unrelated clinical data.

--- a/supabase/functions/sessions-complete/index.ts
+++ b/supabase/functions/sessions-complete/index.ts
@@ -46,11 +46,6 @@ interface SessionRecord {
   end_time: string;
 }
 
-interface TherapistTitleRecord {
-  id: string;
-  title: string | null;
-}
-
 interface TraceMeta {
   requestId: string | null;
   correlationId: string | null;
@@ -252,21 +247,16 @@ export async function checkSessionNotesPresent(
   return checkSessionNotesPresentForRequest(buildFallbackRequest(), sessionId, orgId, logger, primaryGoalId);
 }
 
-const isBtOrRbtTitle = (title: string | null | undefined): boolean => {
-  const normalized = (title ?? "").trim().toUpperCase();
-  return normalized === "BT" || normalized === "RBT";
-};
-
 async function createSupervisionSessionNoteRequestIfNeeded({
+  db,
   orgId,
   session,
-  actorId,
   outcome,
   logger,
 }: {
+  db: SupabaseClient;
   orgId: string;
   session: SessionRecord;
-  actorId: string;
   outcome: SessionOutcome;
   logger: Logger;
 }): Promise<void> {
@@ -274,54 +264,20 @@ async function createSupervisionSessionNoteRequestIfNeeded({
     return;
   }
 
-  const { data: therapistRows, error: therapistError } = await supabaseAdmin
-    .from("therapists")
-    .select("id, title")
-    .eq("id", session.therapist_id)
-    .eq("organization_id", orgId);
-
-  if (therapistError) {
-    logger.warn("supervision-note.request.therapist-fetch-failed", {
-      sessionId: session.id,
-      error: therapistError.message ?? "unknown",
-    });
-    increment("supervision_note_request_failure_total", {
-      function: "sessions-complete",
-      orgId,
-      reason: "therapist-fetch",
-    });
-    return;
-  }
-
-  const therapist = ((therapistRows ?? []) as TherapistTitleRecord[])[0] ?? null;
-  if (!isBtOrRbtTitle(therapist?.title)) {
-    return;
-  }
-
-  const { error: requestError } = await supabaseAdmin
-    .from("supervision_session_note_requests")
-    .upsert(
-      {
-        organization_id: orgId,
-        session_id: session.id,
-        client_id: session.client_id,
-        bt_therapist_id: session.therapist_id,
-        requested_by: actorId,
-        status: "pending",
-      },
-      { onConflict: "session_id", ignoreDuplicates: true },
-    )
-    .select("id");
+  const { error: requestError } = await db.rpc(
+    "create_supervision_session_note_request_for_completed_session",
+    { p_session_id: session.id },
+  );
 
   if (requestError) {
-    logger.warn("supervision-note.request.create-failed", {
+    logger.warn("supervision-note.request.rpc-failed", {
       sessionId: session.id,
       error: requestError.message ?? "unknown",
     });
     increment("supervision_note_request_failure_total", {
       function: "sessions-complete",
       orgId,
-      reason: "request-upsert",
+      reason: "request-rpc",
     });
     return;
   }
@@ -528,9 +484,9 @@ async function handleSessionCompletionForRequest(
   });
 
   await createSupervisionSessionNoteRequestIfNeeded({
+    db,
     orgId,
     session,
-    actorId: userId,
     outcome,
     logger,
   });

--- a/supabase/migrations/20260717222331_repair_supervision_request_lifecycle.sql
+++ b/supabase/migrations/20260717222331_repair_supervision_request_lifecycle.sql
@@ -1,0 +1,587 @@
+-- @migration-intent: Add auditable cancellation and packet-gated reopen behavior to the one-request-per-session BCBA review queue, and keep reconciliation create-only.
+-- @migration-dependencies: 20260717191500_require_structured_bt_supervision_packet.sql
+-- @migration-rollback: Restore the creator and reconcile RPC definitions from 20260717163000_route_bt_notes_to_assigned_bcba.sql and the completion RPC definition from 20260717191500_require_structured_bt_supervision_packet.sql, drop the two lifecycle provenance constraints, then drop reopened_at, reopened_by, reopen_source, cancelled_at, cancelled_by, cancellation_reason, and cancellation_source after application code no longer depends on them.
+
+begin;
+
+alter table public.supervision_session_note_requests
+  add column if not exists cancelled_at timestamptz,
+  add column if not exists cancelled_by uuid references auth.users(id) on delete set null,
+  add column if not exists cancellation_reason text,
+  add column if not exists cancellation_source text,
+  add column if not exists reopened_at timestamptz,
+  add column if not exists reopened_by uuid references auth.users(id) on delete set null,
+  add column if not exists reopen_source text;
+
+update public.supervision_session_note_requests
+set cancellation_reason = left(coalesce(nullif(btrim(cancellation_reason), ''), 'cancelled'), 512),
+    cancellation_source = coalesce(nullif(btrim(cancellation_source), ''), 'legacy_cancel'),
+    cancelled_at = coalesce(cancelled_at, updated_at, created_at)
+where status = 'cancelled';
+
+create index if not exists supervision_session_note_requests_cancelled_by_idx
+  on public.supervision_session_note_requests (cancelled_by)
+  where cancelled_by is not null;
+
+create index if not exists supervision_session_note_requests_reopened_by_idx
+  on public.supervision_session_note_requests (reopened_by)
+  where reopened_by is not null;
+
+alter table public.supervision_session_note_requests
+  drop constraint if exists supervision_session_note_requests_cancelled_provenance_chk;
+
+alter table public.supervision_session_note_requests
+  add constraint supervision_session_note_requests_cancelled_provenance_chk
+  check (
+    status <> 'cancelled'
+    or (
+      cancelled_at is not null
+      and nullif(btrim(cancellation_reason), '') is not null
+      and char_length(cancellation_reason) <= 512
+      and nullif(btrim(cancellation_source), '') is not null
+    )
+  );
+
+alter table public.supervision_session_note_requests
+  drop constraint if exists supervision_session_note_requests_reopen_provenance_chk;
+
+alter table public.supervision_session_note_requests
+  add constraint supervision_session_note_requests_reopen_provenance_chk
+  check (
+    num_nonnulls(reopened_at, reopen_source) in (0, 2)
+    and num_nonnulls(reopened_at, reopened_by, reopen_source) in (0, 3)
+  );
+
+create or replace function public.create_supervision_session_note_request_for_completed_session(
+  p_session_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_request_id uuid;
+  v_session record;
+  v_request record;
+  v_actor_is_admin boolean := false;
+  v_actor_has_schedule_authority boolean := false;
+  v_assigned_admin_user_id uuid;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+  if p_session_id is null then
+    raise exception using errcode = '22023', message = 'Session id required';
+  end if;
+
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+  if v_actor_org is null then
+    raise exception using errcode = '42501', message = 'Organization context required';
+  end if;
+
+  select
+    s.id,
+    s.organization_id,
+    s.client_id,
+    s.therapist_id,
+    s.status,
+    upper(btrim(coalesce(t.title, ''))) in ('BT', 'RBT') as is_bt_rbt
+  into v_session
+  from public.sessions s
+  join public.therapists t
+    on t.id = s.therapist_id
+   and t.organization_id = s.organization_id
+  where s.id = p_session_id
+    and s.organization_id = v_actor_org
+  for update;
+
+  if v_session.id is null then
+    raise exception using errcode = '42501', message = 'Session not found in caller organization';
+  end if;
+  if v_session.status <> 'completed' then
+    return null;
+  end if;
+  if coalesce(v_session.is_bt_rbt, false) is not true then
+    return null;
+  end if;
+  if app.has_complete_bt_review_packet(v_actor_org, v_session.id) is not true then
+    return null;
+  end if;
+
+  v_actor_is_admin := app.user_has_any_active_role_for_org(
+    v_actor,
+    v_actor_org,
+    array['admin', 'super_admin', 'org_admin', 'org_super_admin']
+  );
+  v_actor_has_schedule_authority := app.user_has_any_active_role_for_org(
+    v_actor,
+    v_actor_org,
+    array['admin_schedule', 'midtier', 'bcba']
+  );
+
+  if coalesce(v_actor_is_admin, false) is not true
+     and coalesce(v_actor_has_schedule_authority, false) is not true
+     and v_session.therapist_id <> v_actor
+     and not (
+       coalesce(app.current_user_has_exact_role_for_org(
+         v_actor_org,
+         array['bt']::text[]
+       ), false)
+       and not coalesce(app.current_user_has_exact_role_for_org(
+         v_actor_org,
+         array['admin', 'admin_schedule', 'midtier', 'bcba', 'therapist']::text[]
+       ), false)
+       and exists (
+         select 1
+         from public.user_therapist_links utl
+         where utl.user_id = v_actor
+           and utl.therapist_id = v_session.therapist_id
+       )
+     ) then
+    raise exception using errcode = '42501', message = 'Caller cannot create supervision request for this session';
+  end if;
+
+  v_assigned_admin_user_id := app.resolve_supervision_bcba_assignee(v_actor_org, v_session.client_id);
+
+  select request.*
+  into v_request
+  from public.supervision_session_note_requests request
+  where request.session_id = v_session.id
+    and request.organization_id = v_actor_org
+  for update;
+
+  if v_request.id is null then
+    insert into public.supervision_session_note_requests (
+      organization_id,
+      session_id,
+      client_id,
+      bt_therapist_id,
+      assigned_admin_user_id,
+      requested_by,
+      status
+    ) values (
+      v_actor_org,
+      v_session.id,
+      v_session.client_id,
+      v_session.therapist_id,
+      v_assigned_admin_user_id,
+      v_actor,
+      'pending'
+    )
+    on conflict (session_id) do nothing
+    returning id into v_request_id;
+
+    if v_request_id is not null then
+      return v_request_id;
+    end if;
+
+    select request.*
+    into v_request
+    from public.supervision_session_note_requests request
+    where request.session_id = v_session.id
+      and request.organization_id = v_actor_org
+    for update;
+
+    if v_request.id is null then
+      raise exception using errcode = '40001', message = 'Supervision request changed concurrently';
+    end if;
+  end if;
+
+  if v_request.status = 'completed' then
+    return v_request.id;
+  end if;
+
+  if v_request.status = 'cancelled' then
+    update public.supervision_session_note_requests
+    set status = 'pending',
+        assigned_admin_user_id = app.resolve_supervision_bcba_assignee(v_actor_org, v_session.client_id),
+        requested_by = coalesce(requested_by, v_actor),
+        reopened_at = timezone('utc', now()),
+        reopened_by = v_actor,
+        reopen_source = 'structured_bt_closeout',
+        completed_at = null,
+        updated_at = timezone('utc', now())
+    where id = v_request.id
+      and organization_id = v_actor_org
+    returning id into v_request_id;
+
+    return v_request_id;
+  end if;
+
+  update public.supervision_session_note_requests
+  set assigned_admin_user_id = coalesce(
+        supervision_session_note_requests.assigned_admin_user_id,
+        v_assigned_admin_user_id
+      ),
+      updated_at = timezone('utc', now())
+  where id = v_request.id
+    and organization_id = v_actor_org
+  returning id into v_request_id;
+
+  return v_request_id;
+end;
+$$;
+
+revoke all on function public.create_supervision_session_note_request_for_completed_session(uuid) from public, anon;
+grant execute on function public.create_supervision_session_note_request_for_completed_session(uuid) to authenticated, service_role;
+
+create or replace function public.complete_supervision_session_note_request(
+  p_request_id uuid,
+  p_template_id uuid,
+  p_responses jsonb
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_request record;
+  v_template record;
+  v_responses jsonb := coalesce(p_responses, '{}'::jsonb);
+  v_missing_key text;
+  v_note_id uuid;
+  v_bt_note_id uuid;
+  v_signature_method text;
+  v_signature_value text;
+  v_signature_points jsonb;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  if p_request_id is null or p_template_id is null then
+    raise exception using errcode = '22023', message = 'Request and template are required';
+  end if;
+
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+  if v_actor_org is null then
+    raise exception using errcode = '42501', message = 'Organization context required';
+  end if;
+
+  if app.user_has_exact_active_role_for_org(
+    v_actor,
+    v_actor_org,
+    array['bcba']::text[]
+  ) is not true then
+    raise exception using errcode = '42501', message = 'Assigned BCBA supervision note access required';
+  end if;
+
+  select
+    r.id,
+    r.organization_id,
+    r.session_id,
+    r.status,
+    r.assigned_admin_user_id
+  into v_request
+  from public.sessions session
+  join public.supervision_session_note_requests r
+    on r.session_id = session.id
+   and r.organization_id = session.organization_id
+  where session.organization_id = v_actor_org
+    and r.id = p_request_id
+  for update of session;
+
+  if v_request.id is null then
+    raise exception using errcode = '42501', message = 'Supervision request not found in caller organization';
+  end if;
+
+  select
+    r.id,
+    r.organization_id,
+    r.session_id,
+    r.status,
+    r.assigned_admin_user_id
+  into v_request
+  from public.supervision_session_note_requests r
+  where r.id = p_request_id
+    and r.organization_id = v_actor_org
+  for update;
+
+  if v_request.id is null then
+    raise exception using errcode = '42501', message = 'Supervision request not found in caller organization';
+  end if;
+
+  if v_request.assigned_admin_user_id is distinct from v_actor then
+    raise exception using errcode = '42501', message = 'Assigned BCBA supervision note access required';
+  end if;
+
+  if v_request.status <> 'pending' then
+    raise exception using errcode = '23514', message = 'Supervision request is not pending';
+  end if;
+
+  select
+    t.id,
+    t.template_structure
+  into v_template
+  from public.session_note_templates t
+  where t.id = p_template_id
+    and t.organization_id = v_actor_org
+    and t.template_type = 'supervision_session_note'
+    and t.template_name = 'Supervision Session Note';
+
+  if v_template.id is null then
+    raise exception using errcode = '42501', message = 'Canonical supervision template not found in caller organization';
+  end if;
+
+  select template_field.field_key
+  into v_missing_key
+  from (
+    select
+      field.value->>'key' as field_key,
+      coalesce((field.value->>'required')::boolean, false) as is_required,
+      field.value->>'required_when' as required_when
+    from jsonb_array_elements(v_template.template_structure->'sections') section(value)
+    cross join lateral jsonb_array_elements(coalesce(section.value->'fields', '[]'::jsonb)) field(value)
+    where field.value ? 'key'
+  ) template_field
+  where (
+      template_field.is_required is true
+      or (
+        template_field.required_when like '% includes %'
+        and case
+          when jsonb_typeof(v_responses->btrim(split_part(template_field.required_when, ' includes ', 1))) = 'array' then
+            v_responses->btrim(split_part(template_field.required_when, ' includes ', 1)) ? btrim(split_part(template_field.required_when, ' includes ', 2))
+          else
+            btrim(coalesce(v_responses->>btrim(split_part(template_field.required_when, ' includes ', 1)), '')) = btrim(split_part(template_field.required_when, ' includes ', 2))
+        end
+      )
+    )
+    and case
+      when jsonb_typeof(v_responses->template_field.field_key) = 'array' then
+        jsonb_array_length(coalesce(v_responses->template_field.field_key, '[]'::jsonb)) = 0
+      when jsonb_typeof(v_responses->template_field.field_key) = 'boolean' then
+        coalesce((v_responses->>template_field.field_key)::boolean, false) is false
+      when jsonb_typeof(v_responses->template_field.field_key) = 'object' then
+        v_responses->template_field.field_key = '{}'::jsonb
+      else
+        nullif(btrim(coalesce(v_responses->>template_field.field_key, '')), '') is null
+    end
+  limit 1;
+
+  if v_missing_key is not null then
+    raise exception using errcode = '23514', message = 'Required supervision note response missing';
+  end if;
+
+  if nullif(btrim(coalesce(v_responses->>'bcba_licensure_credential', '')), '') is null then
+    raise exception using errcode = '23514', message = 'Required supervision note response missing';
+  end if;
+
+  v_signature_method := btrim(coalesce(p_responses #>> '{bcba_supervisor_signature,method}', ''));
+  v_signature_value := btrim(coalesce(p_responses #>> '{bcba_supervisor_signature,value}', ''));
+  if v_signature_method not in ('typed', 'drawn')
+     or v_signature_value = ''
+     or char_length(v_signature_value) > 16384 then
+    raise exception using errcode = '23514', message = 'invalid BCBA signature';
+  end if;
+
+  if v_signature_method = 'drawn' then
+    if left(v_signature_value, 7) <> 'points:' then
+      raise exception using errcode = '23514', message = 'invalid BCBA signature';
+    end if;
+
+    begin
+      v_signature_points := substring(v_signature_value from 8)::jsonb;
+    exception when others then
+      raise exception using errcode = '23514', message = 'invalid BCBA signature';
+    end;
+
+    if jsonb_typeof(v_signature_points) <> 'array'
+       or jsonb_array_length(v_signature_points) = 0
+       or jsonb_array_length(v_signature_points) > 256
+       or not exists (
+         select 1
+         from jsonb_array_elements(v_signature_points) point(value)
+         where point.value <> 'null'::jsonb
+       )
+       or exists (
+         select 1
+         from jsonb_array_elements(v_signature_points) point(value)
+         where case
+           when point.value = 'null'::jsonb then false
+           when jsonb_typeof(point.value) <> 'array' then true
+           when jsonb_array_length(point.value) <> 2 then true
+           when jsonb_typeof(point.value->0) <> 'number'
+             or jsonb_typeof(point.value->1) <> 'number' then true
+           else (point.value->>0)::numeric < 0
+             or (point.value->>0)::numeric > 1
+             or (point.value->>1)::numeric < 0
+             or (point.value->>1)::numeric > 1
+         end
+       ) then
+      raise exception using errcode = '23514', message = 'invalid BCBA signature';
+    end if;
+  end if;
+
+  insert into public.supervision_session_notes (
+    organization_id,
+    request_id,
+    session_id,
+    template_id,
+    completed_by,
+    responses,
+    signed_at
+  )
+  values (
+    v_actor_org,
+    v_request.id,
+    v_request.session_id,
+    p_template_id,
+    v_actor,
+    v_responses,
+    timezone('utc', now())
+  )
+  on conflict (request_id) do nothing
+  returning id into v_note_id;
+
+  if v_note_id is null then
+    raise exception using errcode = '23514', message = 'Supervision request is not pending';
+  end if;
+
+  select note.id
+  into v_bt_note_id
+  from public.client_session_notes note
+  where note.session_id = v_request.session_id
+    and note.organization_id = v_actor_org
+  order by note.created_at desc, note.id desc
+  limit 1;
+
+  if v_bt_note_id is null
+     or app.has_complete_bt_review_packet(v_actor_org, v_request.session_id) is not true then
+    raise exception using errcode = '23514', message = 'Complete structured BT session note and attestation required before supervision completion';
+  end if;
+
+  insert into public.session_note_attestations (
+    organization_id, note_id, supervision_note_id, signer_user_id, attestation_role,
+    signature_method, signature_value, signed_at
+  ) values (
+    v_actor_org, null, v_note_id, v_actor, 'bcba',
+    v_signature_method, v_signature_value, timezone('utc', now())
+  );
+
+  update public.supervision_session_note_requests
+  set status = 'completed',
+      completed_at = coalesce(completed_at, timezone('utc', now())),
+      updated_at = timezone('utc', now())
+  where id = v_request.id
+    and organization_id = v_actor_org;
+
+  return v_note_id;
+end;
+$$;
+
+revoke all on function public.complete_supervision_session_note_request(uuid, uuid, jsonb) from public, anon;
+grant execute on function public.complete_supervision_session_note_request(uuid, uuid, jsonb) to authenticated, service_role;
+
+create or replace function public.reconcile_supervision_session_note_requests(
+  p_since timestamptz default timezone('utc', now()) - interval '14 days'
+)
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_actor_is_admin boolean := false;
+  v_actor_is_bcba boolean := false;
+  v_inserted integer := 0;
+  v_backfilled integer := 0;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+  if v_actor_org is null then
+    raise exception using errcode = '42501', message = 'Organization context required';
+  end if;
+
+  v_actor_is_admin := app.user_has_any_active_role_for_org(
+    v_actor,
+    v_actor_org,
+    array['admin', 'super_admin', 'org_admin', 'org_super_admin']
+  );
+  v_actor_is_bcba := app.user_has_exact_active_role_for_org(
+    v_actor,
+    v_actor_org,
+    array['bcba']::text[]
+  );
+
+  if coalesce(v_actor_is_admin, false) is not true
+     and coalesce(v_actor_is_bcba, false) is not true then
+    raise exception using errcode = '42501', message = 'BCBA or admin supervision note access required';
+  end if;
+
+  insert into public.supervision_session_note_requests (
+    organization_id,
+    session_id,
+    client_id,
+    bt_therapist_id,
+    assigned_admin_user_id,
+    requested_by,
+    status
+  )
+  select
+    s.organization_id,
+    s.id,
+    s.client_id,
+    s.therapist_id,
+    app.resolve_supervision_bcba_assignee(s.organization_id, s.client_id),
+    v_actor,
+    'pending'
+  from public.sessions s
+  join public.therapists t
+    on t.id = s.therapist_id
+   and t.organization_id = s.organization_id
+  left join public.supervision_session_note_requests existing
+    on existing.session_id = s.id
+   and existing.organization_id = s.organization_id
+  where s.organization_id = v_actor_org
+    and s.status = 'completed'
+    and s.therapist_id is not null
+    and upper(btrim(coalesce(t.title, ''))) in ('BT', 'RBT')
+    and coalesce(s.end_time, s.start_time, s.created_at) >= coalesce(p_since, timezone('utc', now()) - interval '14 days')
+    and app.has_complete_bt_review_packet(s.organization_id, s.id) is true
+    and existing.id is null
+  on conflict (session_id) do nothing;
+
+  get diagnostics v_inserted = row_count;
+
+  with resolved as (
+    select
+      request.id,
+      app.resolve_supervision_bcba_assignee(request.organization_id, request.client_id) as assigned_user_id
+    from public.supervision_session_note_requests request
+    where request.organization_id = v_actor_org
+      and request.status = 'pending'
+      and request.assigned_admin_user_id is null
+      and app.has_complete_bt_review_packet(request.organization_id, request.session_id) is true
+  )
+  update public.supervision_session_note_requests request
+  set assigned_admin_user_id = resolved.assigned_user_id,
+      updated_at = timezone('utc', now())
+  from resolved
+  where request.id = resolved.id
+    and request.status = 'pending'
+    and request.assigned_admin_user_id is null
+    and resolved.assigned_user_id is not null;
+
+  get diagnostics v_backfilled = row_count;
+
+  return v_inserted + v_backfilled;
+end;
+$$;
+
+revoke all on function public.reconcile_supervision_session_note_requests(timestamptz) from public, anon;
+grant execute on function public.reconcile_supervision_session_note_requests(timestamptz) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260717235500_align_supervision_request_linked_therapist_authority.sql
+++ b/supabase/migrations/20260717235500_align_supervision_request_linked_therapist_authority.sql
@@ -1,0 +1,177 @@
+/*
+  @migration-intent: Keep supervision request creation authorization aligned with the sessions-complete linked-therapist closeout path.
+  @migration-dependencies: 20260717222331_repair_supervision_request_lifecycle.sql
+  @migration-rollback: Reapply the prior create_supervision_session_note_request_for_completed_session(uuid) definition from the preceding migration.
+*/
+
+set search_path = public, app, auth;
+
+begin;
+
+create or replace function public.create_supervision_session_note_request_for_completed_session(
+  p_session_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_request_id uuid;
+  v_session record;
+  v_request record;
+  v_actor_is_admin boolean := false;
+  v_actor_has_schedule_authority boolean := false;
+  v_assigned_admin_user_id uuid;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+  if p_session_id is null then
+    raise exception using errcode = '22023', message = 'Session id required';
+  end if;
+
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+  if v_actor_org is null then
+    raise exception using errcode = '42501', message = 'Organization context required';
+  end if;
+
+  select
+    s.id,
+    s.organization_id,
+    s.client_id,
+    s.therapist_id,
+    s.status,
+    upper(btrim(coalesce(t.title, ''))) in ('BT', 'RBT') as is_bt_rbt
+  into v_session
+  from public.sessions s
+  join public.therapists t
+    on t.id = s.therapist_id
+   and t.organization_id = s.organization_id
+  where s.id = p_session_id
+    and s.organization_id = v_actor_org
+  for update;
+
+  if v_session.id is null then
+    raise exception using errcode = '42501', message = 'Session not found in caller organization';
+  end if;
+  if v_session.status <> 'completed' then
+    return null;
+  end if;
+  if coalesce(v_session.is_bt_rbt, false) is not true then
+    return null;
+  end if;
+  if app.has_complete_bt_review_packet(v_actor_org, v_session.id) is not true then
+    return null;
+  end if;
+
+  v_actor_is_admin := app.user_has_any_active_role_for_org(
+    v_actor,
+    v_actor_org,
+    array['admin', 'super_admin', 'org_admin', 'org_super_admin']
+  );
+  v_actor_has_schedule_authority := app.user_has_any_active_role_for_org(
+    v_actor,
+    v_actor_org,
+    array['admin_schedule', 'midtier', 'bcba']
+  );
+
+  if coalesce(v_actor_is_admin, false) is not true
+     and coalesce(v_actor_has_schedule_authority, false) is not true
+     and v_session.therapist_id <> v_actor
+     and not exists (
+       select 1
+       from public.user_therapist_links utl
+       where utl.user_id = v_actor
+         and utl.therapist_id = v_session.therapist_id
+     ) then
+    raise exception using errcode = '42501', message = 'Caller cannot create supervision request for this session';
+  end if;
+
+  v_assigned_admin_user_id := app.resolve_supervision_bcba_assignee(v_actor_org, v_session.client_id);
+
+  select request.*
+  into v_request
+  from public.supervision_session_note_requests request
+  where request.session_id = v_session.id
+    and request.organization_id = v_actor_org
+  for update;
+
+  if v_request.id is null then
+    insert into public.supervision_session_note_requests (
+      organization_id,
+      session_id,
+      client_id,
+      bt_therapist_id,
+      assigned_admin_user_id,
+      requested_by,
+      status
+    ) values (
+      v_actor_org,
+      v_session.id,
+      v_session.client_id,
+      v_session.therapist_id,
+      v_assigned_admin_user_id,
+      v_actor,
+      'pending'
+    )
+    on conflict (session_id) do nothing
+    returning id into v_request_id;
+
+    if v_request_id is not null then
+      return v_request_id;
+    end if;
+
+    select request.*
+    into v_request
+    from public.supervision_session_note_requests request
+    where request.session_id = v_session.id
+      and request.organization_id = v_actor_org
+    for update;
+
+    if v_request.id is null then
+      raise exception using errcode = '40001', message = 'Supervision request changed concurrently';
+    end if;
+  end if;
+
+  if v_request.status = 'completed' then
+    return v_request.id;
+  end if;
+
+  if v_request.status = 'cancelled' then
+    update public.supervision_session_note_requests
+    set status = 'pending',
+        assigned_admin_user_id = app.resolve_supervision_bcba_assignee(v_actor_org, v_session.client_id),
+        requested_by = coalesce(requested_by, v_actor),
+        reopened_at = timezone('utc', now()),
+        reopened_by = v_actor,
+        reopen_source = 'structured_bt_closeout',
+        completed_at = null,
+        updated_at = timezone('utc', now())
+    where id = v_request.id
+      and organization_id = v_actor_org
+    returning id into v_request_id;
+
+    return v_request_id;
+  end if;
+
+  update public.supervision_session_note_requests
+  set assigned_admin_user_id = coalesce(
+        supervision_session_note_requests.assigned_admin_user_id,
+        v_assigned_admin_user_id
+      ),
+      updated_at = timezone('utc', now())
+  where id = v_request.id
+    and organization_id = v_actor_org
+  returning id into v_request_id;
+
+  return v_request_id;
+end;
+$$;
+
+revoke all on function public.create_supervision_session_note_request_for_completed_session(uuid) from public, anon;
+grant execute on function public.create_supervision_session_note_request_for_completed_session(uuid) to authenticated, service_role;
+
+commit;

--- a/tests/edge/sessions-complete.test.ts
+++ b/tests/edge/sessions-complete.test.ts
@@ -51,16 +51,6 @@ const makeUpdateBuilder = (updatedRow: Record<string, unknown> | null) => {
   return builder;
 };
 
-const makeInsertBuilder = () => {
-  const builder: any = {};
-  const chain = () => builder;
-  builder.upsert = vi.fn(() => chain());
-  builder.select = vi.fn(() => chain());
-  builder.then = (resolve: (value: { data: unknown[]; error: null }) => unknown) =>
-    resolve({ data: [{ id: "supervision-request-1" }], error: null });
-  return builder;
-};
-
 const createStubLogger = () => {
   const stub: any = {
     info: vi.fn(),
@@ -290,7 +280,7 @@ describe("sessions-complete handler", () => {
     expect(database.supabaseAdmin.from).toHaveBeenCalledWith("user_therapist_links");
   });
 
-  it("creates a pending supervision note request after a BT session is completed", async () => {
+  it("routes supervision request creation through the canonical packet-aware RPC", async () => {
     const session = makeSession({
       id: "session-supervision-1",
       client_id: "client-supervision-1",
@@ -298,20 +288,18 @@ describe("sessions-complete handler", () => {
       therapist_id: "bt-therapist-1",
     });
     const updatedRow = { id: "session-supervision-1", status: "completed", updated_at: "2026-03-31T10:05:00Z" };
-    const supervisionRequestInsert = makeInsertBuilder();
+    const db = makeDb();
 
     vi.spyOn(orgHelpers, "orgScopedQuery").mockReturnValue(
       makeSelectBuilder([session]) as unknown as ReturnType<typeof orgHelpers.orgScopedQuery>,
     );
     (database.supabaseAdmin.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
       if (table === "sessions") return makeUpdateBuilder(updatedRow);
-      if (table === "therapists") return makeSelectBuilder([{ id: "bt-therapist-1", title: "BT" }]);
-      if (table === "supervision_session_note_requests") return supervisionRequestInsert;
       return makeSelectBuilder([]);
     });
 
     const response = await handleSessionCompletion(
-      makeDb(),
+      db,
       "org-1",
       { session_id: "session-supervision-1", outcome: "completed", notes: null },
       "bt-therapist-1",
@@ -320,17 +308,11 @@ describe("sessions-complete handler", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(database.supabaseAdmin.from).toHaveBeenCalledWith("supervision_session_note_requests");
-    expect(supervisionRequestInsert.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        organization_id: "org-1",
-        session_id: "session-supervision-1",
-        client_id: "client-supervision-1",
-        bt_therapist_id: "bt-therapist-1",
-        status: "pending",
-      }),
-      { onConflict: "session_id", ignoreDuplicates: true },
+    expect(db.rpc).toHaveBeenCalledWith(
+      "create_supervision_session_note_request_for_completed_session",
+      { p_session_id: "session-supervision-1" },
     );
+    expect(database.supabaseAdmin.from).not.toHaveBeenCalledWith("supervision_session_note_requests");
   });
 
   it("denies a therapist completing another therapist's session (403 FORBIDDEN)", async () => {

--- a/tests/sql/bt_aba_session_note_closeout_smoke.sql
+++ b/tests/sql/bt_aba_session_note_closeout_smoke.sql
@@ -151,6 +151,26 @@ values
   ('00000000-0000-4000-8000-00000000b042', '00000000-0000-4000-8000-00000000b020', '00000000-0000-4000-8000-00000000b012', now() - interval '5 hours', now() - interval '4 hours', 'in_progress', false, '00000000-0000-4000-8000-00000000b001', '00000000-0000-4000-8000-00000000b010', '00000000-0000-4000-8000-00000000b010', current_date, now() - interval '5 hours'),
   ('00000000-0000-4000-8000-00000000b043', '00000000-0000-4000-8000-00000000b021', '00000000-0000-4000-8000-00000000b015', now() - interval '7 hours', now() - interval '6 hours', 'in_progress', false, '00000000-0000-4000-8000-00000000b001', '00000000-0000-4000-8000-00000000b010', '00000000-0000-4000-8000-00000000b010', current_date, now() - interval '7 hours');
 
+insert into public.supervision_session_note_requests (
+  id, organization_id, session_id, client_id, bt_therapist_id,
+  assigned_admin_user_id, requested_by, status,
+  cancelled_at, cancelled_by, cancellation_reason, cancellation_source
+)
+values (
+  '00000000-0000-4000-8000-00000000b050',
+  '00000000-0000-4000-8000-00000000b001',
+  '00000000-0000-4000-8000-00000000b040',
+  '00000000-0000-4000-8000-00000000b020',
+  '00000000-0000-4000-8000-00000000b015',
+  '00000000-0000-4000-8000-00000000b013',
+  '00000000-0000-4000-8000-00000000b010',
+  'cancelled',
+  now() - interval '10 minutes',
+  '00000000-0000-4000-8000-00000000b013',
+  'Synthetic legacy request cancellation',
+  'win223_smoke_fixture'
+);
+
 create temporary table win221_finalization_results (result jsonb not null);
 grant select, insert on table win221_finalization_results to authenticated;
 
@@ -322,10 +342,92 @@ begin
   result := public.finalize_bt_aba_session_note('00000000-0000-4000-8000-00000000b040', v_note_id, payload, valid_responses, '[]'::jsonb, '[]'::jsonb);
   if result->>'status' <> 'completed' then raise exception 'assigned BT finalize failed: %', result; end if;
   insert into win221_finalization_results values (result);
+
+  result := public.finalize_bt_aba_session_note('00000000-0000-4000-8000-00000000b041', failure_note_id, payload, valid_responses, '[]'::jsonb, '[]'::jsonb);
+  if result->>'status' <> 'completed' then raise exception 'lifecycle fixture finalize failed: %', result; end if;
 end
 $finalization$;
 
 reset role;
+select set_config(
+  'app.win223_request_id',
+  (select id::text from public.supervision_session_note_requests where session_id = '00000000-0000-4000-8000-00000000b041'),
+  true
+);
+update public.supervision_session_note_requests
+set status = 'cancelled',
+    cancelled_at = now(),
+    cancelled_by = '00000000-0000-4000-8000-00000000b013',
+    cancellation_reason = 'Synthetic reconcile no-reopen check',
+    cancellation_source = 'win223_smoke_fixture',
+    updated_at = now()
+where id = current_setting('app.win223_request_id')::uuid;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b013', true);
+do $reconcile_does_not_reopen$
+begin
+  perform public.reconcile_supervision_session_note_requests(now() - interval '1 day');
+  if (select status from public.supervision_session_note_requests where id = current_setting('app.win223_request_id')::uuid) <> 'cancelled' then
+    raise exception 'reconcile unexpectedly reopened a cancelled request';
+  end if;
+end
+$reconcile_does_not_reopen$;
+
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b010', true);
+do $creator_reopens_in_place$
+declare reopened_id uuid;
+begin
+  reopened_id := public.create_supervision_session_note_request_for_completed_session('00000000-0000-4000-8000-00000000b041');
+  if reopened_id is distinct from current_setting('app.win223_request_id')::uuid then
+    raise exception 'creator did not reopen the existing request in place: %', reopened_id;
+  end if;
+end
+$creator_reopens_in_place$;
+
+reset role;
+do $reopen_assertions$
+begin
+  if (select count(*) from public.supervision_session_note_requests where session_id = '00000000-0000-4000-8000-00000000b041') <> 1
+     or not exists (
+       select 1
+       from public.supervision_session_note_requests
+       where id = current_setting('app.win223_request_id')::uuid
+         and status = 'pending'
+         and cancellation_source = 'win223_smoke_fixture'
+         and reopened_by = '00000000-0000-4000-8000-00000000b010'
+         and reopen_source = 'structured_bt_closeout'
+     ) then
+    raise exception 'creator reopen lifecycle assertions failed';
+  end if;
+end
+$reopen_assertions$;
+
+update public.supervision_session_note_requests
+set status = 'completed', completed_at = now(), updated_at = now()
+where id = current_setting('app.win223_request_id')::uuid;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b010', true);
+do $completed_is_terminal$
+declare replay_id uuid;
+begin
+  replay_id := public.create_supervision_session_note_request_for_completed_session('00000000-0000-4000-8000-00000000b041');
+  if replay_id is distinct from current_setting('app.win223_request_id')::uuid then
+    raise exception 'completed creator replay returned a different request: %', replay_id;
+  end if;
+end
+$completed_is_terminal$;
+
+reset role;
+do $completed_status_assertion$
+begin
+  if (select status from public.supervision_session_note_requests where id = current_setting('app.win223_request_id')::uuid) <> 'completed' then
+    raise exception 'completed request was not terminal';
+  end if;
+end
+$completed_status_assertion$;
+
 update public.user_roles roles
 set is_active = false
 where roles.user_id = '00000000-0000-4000-8000-00000000b010'
@@ -378,8 +480,15 @@ begin
      or (select count(*) from public.session_audit_logs where session_id = '00000000-0000-4000-8000-00000000b040' and event_type = 'session_completed') <> 1
      or (select count(*) from public.supervision_session_note_requests
          where session_id = '00000000-0000-4000-8000-00000000b040'
+           and id = '00000000-0000-4000-8000-00000000b050'
            and requested_by = '00000000-0000-4000-8000-00000000b010'
-           and bt_therapist_id = '00000000-0000-4000-8000-00000000b015') <> 1 then
+           and bt_therapist_id = '00000000-0000-4000-8000-00000000b015'
+           and assigned_admin_user_id = '00000000-0000-4000-8000-00000000b013'
+           and status = 'pending'
+           and cancellation_source = 'win223_smoke_fixture'
+           and reopened_at is not null
+           and reopened_by = '00000000-0000-4000-8000-00000000b010'
+           and reopen_source = 'structured_bt_closeout') <> 1 then
     raise exception 'signer replay changed finalization side effects';
   end if;
 end

--- a/tests/supervisionRequestLifecycleMigration.test.ts
+++ b/tests/supervisionRequestLifecycleMigration.test.ts
@@ -9,6 +9,13 @@ const migrationSql = readFileSync(
   ),
   'utf8',
 );
+const authorityCorrectionSql = readFileSync(
+  join(
+    process.cwd(),
+    'supabase/migrations/20260717235500_align_supervision_request_linked_therapist_authority.sql',
+  ),
+  'utf8',
+);
 
 function functionBody(name: string): string {
   const pattern = new RegExp(
@@ -53,6 +60,12 @@ describe('supervision request lifecycle repair migration', () => {
 
     expect(creator).toMatch(/v_actor_has_schedule_authority\s*:=\s*app\.user_has_any_active_role_for_org\([\s\S]*?array\['admin_schedule', 'midtier', 'bcba'\]/i);
     expect(creator).toMatch(/coalesce\(v_actor_has_schedule_authority, false\) is not true/i);
+  });
+
+  it('keeps the issued migration immutable and corrects linked-therapist authority forward', () => {
+    expect(authorityCorrectionSql).toMatch(/where s\.id = p_session_id\s+and s\.organization_id = v_actor_org/i);
+    expect(authorityCorrectionSql).toMatch(/v_session\.therapist_id <> v_actor\s+and not exists \(\s*select 1\s+from public\.user_therapist_links utl\s+where utl\.user_id = v_actor\s+and utl\.therapist_id = v_session\.therapist_id\s*\) then\s+raise exception using errcode = '42501'/i);
+    expect(authorityCorrectionSql).not.toMatch(/array\['bt'\]::text\[][\s\S]*?from public\.user_therapist_links/i);
   });
 
   it('records reopen provenance, clears completion state, and recomputes the reviewer', () => {

--- a/tests/supervisionRequestLifecycleMigration.test.ts
+++ b/tests/supervisionRequestLifecycleMigration.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const migrationSql = readFileSync(
+  join(
+    process.cwd(),
+    'supabase/migrations/20260717222331_repair_supervision_request_lifecycle.sql',
+  ),
+  'utf8',
+);
+
+function functionBody(name: string): string {
+  const pattern = new RegExp(
+    `create or replace function public\\.${name}\\([\\s\\S]*?\\n\\$\\$;`,
+    'i',
+  );
+  return migrationSql.match(pattern)?.[0] ?? '';
+}
+
+describe('supervision request lifecycle repair migration', () => {
+  it('adds durable cancellation and reopen provenance to the request row', () => {
+    expect(migrationSql).toMatch(/add column if not exists cancelled_at timestamptz/i);
+    expect(migrationSql).toMatch(/add column if not exists cancelled_by uuid references auth\.users\(id\)/i);
+    expect(migrationSql).toMatch(/add column if not exists cancellation_reason text/i);
+    expect(migrationSql).toMatch(/add column if not exists cancellation_source text/i);
+    expect(migrationSql).toMatch(/add column if not exists reopened_at timestamptz/i);
+    expect(migrationSql).toMatch(/add column if not exists reopened_by uuid references auth\.users\(id\)/i);
+    expect(migrationSql).toMatch(/add column if not exists reopen_source text/i);
+    expect(migrationSql).toMatch(/create index if not exists supervision_session_note_requests_cancelled_by_idx[\s\S]*\(cancelled_by\)/i);
+    expect(migrationSql).toMatch(/create index if not exists supervision_session_note_requests_reopened_by_idx[\s\S]*\(reopened_by\)/i);
+  });
+
+  it('requires auditable provenance whenever a request is cancelled', () => {
+    expect(migrationSql).toMatch(/status <> 'cancelled'[\s\S]*cancelled_at is not null[\s\S]*nullif\(btrim\(cancellation_reason\), ''\) is not null/i);
+    expect(migrationSql).toMatch(/char_length\(cancellation_reason\) <= 512/i);
+    expect(migrationSql).toMatch(/nullif\(btrim\(cancellation_source\), ''\) is not null/i);
+    expect(migrationSql).toMatch(/num_nonnulls\(reopened_at, reopen_source\) in \(0, 2\)/i);
+  });
+
+  it('locks the session and reopens a cancelled request only when its structured BT packet is complete', () => {
+    expect(migrationSql).toMatch(/create or replace function public\.create_supervision_session_note_request_for_completed_session/i);
+    expect(migrationSql).toMatch(/from public\.sessions s[\s\S]*where s\.id = p_session_id[\s\S]*for update/i);
+    expect(migrationSql).toMatch(/app\.has_complete_bt_review_packet\(v_actor_org, v_session\.id\) is not true[\s\S]*return null/i);
+    expect(migrationSql).toMatch(/from public\.supervision_session_note_requests request[\s\S]*request\.session_id = v_session\.id[\s\S]*request\.organization_id = v_actor_org[\s\S]*for update/i);
+    expect(migrationSql).toMatch(/insert into public\.supervision_session_note_requests[\s\S]*on conflict \(session_id\) do nothing[\s\S]*if v_request_id is not null then[\s\S]*return v_request_id[\s\S]*select request\.\*[\s\S]*for update/i);
+    expect(migrationSql).toMatch(/v_request\.status = 'cancelled'[\s\S]*set status = 'pending'/i);
+    expect(migrationSql).toMatch(/v_request\.status = 'completed'[\s\S]*return v_request\.id/i);
+  });
+
+  it('keeps request creation authority aligned with authorized session closers', () => {
+    const creator = functionBody('create_supervision_session_note_request_for_completed_session');
+
+    expect(creator).toMatch(/v_actor_has_schedule_authority\s*:=\s*app\.user_has_any_active_role_for_org\([\s\S]*?array\['admin_schedule', 'midtier', 'bcba'\]/i);
+    expect(creator).toMatch(/coalesce\(v_actor_has_schedule_authority, false\) is not true/i);
+  });
+
+  it('records reopen provenance, clears completion state, and recomputes the reviewer', () => {
+    expect(migrationSql).toMatch(/reopened_at = timezone\('utc', now\(\)\)/i);
+    expect(migrationSql).toMatch(/reopened_by = v_actor/i);
+    expect(migrationSql).toMatch(/reopen_source = 'structured_bt_closeout'/i);
+    expect(migrationSql).toMatch(/completed_at = null/i);
+    expect(migrationSql).toMatch(/assigned_admin_user_id = app\.resolve_supervision_bcba_assignee/i);
+  });
+
+  it('lets reconciliation create only same-org recent packet-complete missing requests without reopening cancelled rows', () => {
+    const reconcile = functionBody('reconcile_supervision_session_note_requests');
+
+    expect(reconcile).toMatch(/create or replace function public\.reconcile_supervision_session_note_requests/i);
+    expect(reconcile).toMatch(/s\.organization_id = v_actor_org/i);
+    expect(reconcile).toMatch(/coalesce\(s\.end_time, s\.start_time, s\.created_at\) >= coalesce\(p_since/i);
+    expect(reconcile).toMatch(/app\.has_complete_bt_review_packet\(s\.organization_id, s\.id\) is true/i);
+    expect(reconcile).toMatch(/left join public\.supervision_session_note_requests existing[\s\S]*existing\.id is null/i);
+    expect(reconcile).toMatch(/on conflict \(session_id\) do nothing/i);
+    expect(reconcile).not.toMatch(/status\s*=\s*'cancelled'[\s\S]*set status\s*=\s*'pending'/i);
+  });
+
+  it('preserves browser grants and keeps arbitrary packet checks service-role-only', () => {
+    expect(migrationSql).toMatch(/revoke all on function public\.create_supervision_session_note_request_for_completed_session\(uuid\) from public, anon/i);
+    expect(migrationSql).toMatch(/grant execute on function public\.create_supervision_session_note_request_for_completed_session\(uuid\) to authenticated, service_role/i);
+    expect(migrationSql).toMatch(/revoke all on function public\.reconcile_supervision_session_note_requests\(timestamptz\) from public, anon/i);
+    expect(migrationSql).toMatch(/grant execute on function public\.reconcile_supervision_session_note_requests\(timestamptz\) to authenticated, service_role/i);
+    expect(migrationSql).not.toMatch(/grant execute on function app\.has_complete_bt_review_packet\(uuid, uuid\) to authenticated/i);
+  });
+
+  it('uses one session-then-request lock order for creator and BCBA completion', () => {
+    const creator = functionBody('create_supervision_session_note_request_for_completed_session');
+    const completion = functionBody('complete_supervision_session_note_request');
+
+    expect(completion).toMatch(/create or replace function public\.complete_supervision_session_note_request/i);
+    for (const body of [creator, completion]) {
+      const sessionLock = body.search(/from public\.sessions[\s\S]*?for update/i);
+      const requestLock = body.search(/from public\.supervision_session_note_requests[\s\S]*?for update/i);
+      expect(sessionLock).toBeGreaterThanOrEqual(0);
+      expect(requestLock).toBeGreaterThan(sessionLock);
+    }
+  });
+
+  it('contains no production row identifiers, deletes, or source clinical-record writes', () => {
+    expect(migrationSql).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i);
+    expect(migrationSql).not.toMatch(/delete\s+from/i);
+    expect(migrationSql).not.toMatch(/update\s+public\.(sessions|client_session_notes|supervision_session_notes|session_audit_logs)/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add auditable cancel/reopen provenance for supervision review requests
- reopen cancelled requests only through packet-complete canonical creation; keep completed terminal and reconcile create-only
- align session closeout with the request-auth RPC and normalize session/request lock ordering
- document exact-ID hosted cleanup and verification boundaries

## Risk
Critical Supabase/session lifecycle change. No production identifiers or clinical record cleanup are committed. Human review is required before merge.

## Verification
- `npx vitest run tests/supervisionRequestLifecycleMigration.test.ts tests/edge/sessions-complete.test.ts` — 43/43 passed
- `npm run ci:check-focused` — passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run validate:tenant` — passed
- `npm run build` — passed
- `PREVIEW_PORT=4175 npm run test:routes:tier0` — 220/220 passed
- independent code, security, Supabase, test, and performance reviews — approved

## Blocked / baseline
- SQL smoke requires a compatible database; the preserved local PG17 volume cannot start under the current PG15.8 image and was not reset
- authenticated Playwright preflight lacks credentials in this process
- repository-wide `test:ci` reaches 2,962 passing tests and reproduces two Windows baseline failures outside this diff: CRLF workflow regex and jsdom `Blob.text()`

## Tracking
- Linear: WIN-223