### PR TITLE
WIN-223: allow BCBA session cancellation

### DIFF
--- a/docs/superpowers/plans/2026-07-17-supervision-request-lifecycle-repair.md
+++ b/docs/superpowers/plans/2026-07-17-supervision-request-lifecycle-repair.md
@@ -73,6 +73,14 @@
 - Follow-up security review: approved; the link is checked against the exact same-org session therapist and matches the edge handler's delegated-therapist authority model.
 - Follow-up Supabase review: approved; the forward migration retains fail-closed search path and existing grants without RLS or tenant-boundary expansion.
 
+### Post-merge CI follow-through
+
+- Main CI run `29623168770` passed the booking, start, note-save, measurement, deployment, migration, and hosted database proofs, but its BCBA acceptance cleanup received `403 Forbidden` from `sessions-cancel`.
+- Root cause: `sessions-cancel` recognized super-admin, admin, and exact therapist roles but omitted the exact in-org `bcba` role already used by the acceptance actor.
+- Bounded correction: recognize exact `bcba` authority as admin-scoped for cancellation inside the already-resolved organization. Do not grant cancellation to `admin_schedule` or `midtier`, and do not change schema, RLS, grants, RPCs, or workflow configuration.
+- TDD proof: the focused role-resolution regression failed with `expected null to be 'admin'`, then passed 13/13 after the one-role correction.
+- Required closure proof: targeted edge tests, policy checks, lint, typecheck, test CI, tenant validation, route tier-0, build, and the hosted BCBA session-acceptance browser step.
+
 ## Stop conditions
 
 - Any preflight allowlist row differs from its expected tenant, status, session timing, or packet completeness.

--- a/supabase/functions/sessions-cancel/index.ts
+++ b/supabase/functions/sessions-cancel/index.ts
@@ -218,6 +218,9 @@ async function resolveCancellationRole(
   if (await assertUserHasOrgRole(db, orgId, "admin")) {
     return "admin";
   }
+  if (await assertUserHasOrgRole(db, orgId, "bcba")) {
+    return "admin";
+  }
   if (await assertUserHasOrgRole(db, orgId, "therapist", { targetTherapistId: userId })) {
     return "therapist";
   }

--- a/tests/edge/sessions-cancel.org-scope.test.ts
+++ b/tests/edge/sessions-cancel.org-scope.test.ts
@@ -451,5 +451,25 @@ describe("sessions-cancel org scoping", () => {
       __TESTING__.resolveCancellationRole(mockDb, "org-1", "viewer-user"),
     ).resolves.toBeNull();
   });
+
+  it("treats exact in-org bcba as admin-scoped without granting admin_schedule or midtier", async () => {
+    const assertUserHasOrgRoleSpy = vi
+      .spyOn(orgHelpers, "assertUserHasOrgRole")
+      .mockImplementation(async (_db, _orgId, role) => role === "bcba");
+
+    const mockDb: any = {
+      rpc: vi.fn(),
+    };
+
+    await expect(
+      __TESTING__.resolveCancellationRole(mockDb, "org-1", "bcba-user"),
+    ).resolves.toBe("admin");
+
+    expect(assertUserHasOrgRoleSpy).toHaveBeenNthCalledWith(1, mockDb, "org-1", "super_admin");
+    expect(assertUserHasOrgRoleSpy).toHaveBeenNthCalledWith(2, mockDb, "org-1", "admin");
+    expect(assertUserHasOrgRoleSpy).toHaveBeenNthCalledWith(3, mockDb, "org-1", "bcba");
+    expect(assertUserHasOrgRoleSpy).not.toHaveBeenCalledWith(mockDb, "org-1", "admin_schedule");
+    expect(assertUserHasOrgRoleSpy).not.toHaveBeenCalledWith(mockDb, "org-1", "midtier");
+  });
 });
 


### PR DESCRIPTION
## Summary
- recognize exact in-org BCBA authority in sessions-cancel
- keep admin_schedule and midtier cancellation authority unchanged
- add a focused role-resolution regression and post-merge verification record

## Root cause
Main CI's BCBA acceptance flow completed booking, start, and note measurement, then cleanup failed with 403 because sessions-cancel omitted the exact BCBA role.

## Verification
- focused Vitest: 24/24 passed
- policy checks: passed
- lint: passed
- typecheck: passed
- tenant validation: passed
- build: passed
- tier-0 routes: 220/220 passed
- test:ci: 2964 passed; 2 pre-existing Windows-only baseline failures (CRLF workflow parser and jsdom Blob.text)

## Risk
Critical auth boundary, intentionally narrowed to exact BCBA inside the already-resolved organization. No schema, RLS, grant, RPC, or workflow changes.