### PR TITLE
WIN-223: require hosted cancellation browser proof

### DIFF
--- a/docs/superpowers/plans/2026-07-17-supervision-request-lifecycle-repair.md
+++ b/docs/superpowers/plans/2026-07-17-supervision-request-lifecycle-repair.md
@@ -80,6 +80,9 @@
 - Bounded correction: recognize exact `bcba` authority as admin-scoped for cancellation inside the already-resolved organization. Do not grant cancellation to `admin_schedule` or `midtier`, and do not change schema, RLS, grants, RPCs, or workflow configuration.
 - TDD proof: the focused role-resolution regression failed with `expected null to be 'admin'`, then passed 13/13 after the one-role correction.
 - Required closure proof: targeted edge tests, policy checks, lint, typecheck, test CI, tenant validation, route tier-0, build, and the hosted BCBA session-acceptance browser step.
+- PR #817 merged the BCBA-only cancellation fix and main CI deployed it, but the browser selector classified `sessions-cancel` with `authSmoke: false`; therefore the hosted BCBA proof was skipped rather than executed.
+- Final CI correction: require hosted auth/session smoke for `supabase/functions/sessions-cancel/**` while preserving its existing schedule/auth tier-0 selection. This is selector-only and does not change runtime or workflow YAML.
+- Final closure proof: after the selector correction merges, the main push must execute (not skip) `BCBA session acceptance proof` and complete its `sessions-cancel` cleanup without `403`.
 
 ## Stop conditions
 

--- a/docs/superpowers/plans/2026-07-17-supervision-request-lifecycle-repair.md
+++ b/docs/superpowers/plans/2026-07-17-supervision-request-lifecycle-repair.md
@@ -83,6 +83,8 @@
 - PR #817 merged the BCBA-only cancellation fix and main CI deployed it, but the browser selector classified `sessions-cancel` with `authSmoke: false`; therefore the hosted BCBA proof was skipped rather than executed.
 - Final CI correction: require hosted auth/session smoke for `supabase/functions/sessions-cancel/**` while preserving its existing schedule/auth tier-0 selection. This is selector-only and does not change runtime or workflow YAML.
 - Final closure proof: after the selector correction merges, the main push must execute (not skip) `BCBA session acceptance proof` and complete its `sessions-cancel` cleanup without `403`.
+- PR #818's first hosted session-smoke run exposed a pre-existing retry synchronization defect: after `/api/book` returned `409`, the modal submit control remained transiently labeled `Saving...` while the smoke searched only for an element named `Create Session`. The captured screenshot confirmed the modal stayed open and the same submit control was still saving.
+- Bounded harness correction: locate the stable session-form submit control, then wait until it is enabled and labeled `Create Session` before retrying. Focused TDD failed on the unhandled `Saving...` state and passed 26/26 after the fix; no application UI or runtime behavior changed.
 
 ## Stop conditions
 

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -120,7 +120,7 @@ const classifyFile = (file) => {
   if (matchAny(file, [
     /^supabase\/functions\/sessions-cancel\//,
   ])) {
-    return { specs: ["schedule", "auth"], authSmoke: false, reason: "session cancellation edge flow" };
+    return { specs: ["schedule", "auth"], authSmoke: true, reason: "session cancellation edge flow" };
   }
 
   if (/^supabase\/functions\/assign-therapist-user\//.test(file)) {

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -627,10 +627,15 @@ const toDatetimeLocal = (date: Date): string => {
 export const isCreateSessionButtonReady = ({
   disabled,
   ariaDisabled,
+  textContent,
 }: {
   disabled: string | null;
   ariaDisabled: string | null;
-}): boolean => disabled === null && ariaDisabled !== "true";
+  textContent: string | null;
+}): boolean =>
+  disabled === null &&
+  ariaDisabled !== "true" &&
+  /Create Session/i.test(textContent ?? "");
 
 export const shouldTryNextLifecyclePairAfterAttempts = ({
   attemptedStartCount,
@@ -660,16 +665,20 @@ const expectCreateSessionButtonReady = async (
     startIso: string;
   },
 ): Promise<ReturnType<Page["getByRole"]>> => {
-  const createSessionButton = page.getByRole("button", { name: /Create Session/i });
+  const createSessionButton = page
+    .locator('[role="dialog"] button[type="submit"][form="session-form"]')
+    .first();
   await createSessionButton.waitFor({ state: "visible", timeout: 10_000 });
 
   const deadline = Date.now() + 20_000;
   let disabled: string | null = null;
   let ariaDisabled: string | null = null;
+  let textContent: string | null = null;
   while (Date.now() < deadline) {
     disabled = await createSessionButton.getAttribute("disabled");
     ariaDisabled = await createSessionButton.getAttribute("aria-disabled");
-    if (isCreateSessionButtonReady({ disabled, ariaDisabled })) {
+    textContent = await createSessionButton.textContent();
+    if (isCreateSessionButtonReady({ disabled, ariaDisabled, textContent })) {
       return createSessionButton;
     }
     await page.waitForTimeout(250);
@@ -685,7 +694,7 @@ const expectCreateSessionButtonReady = async (
     )
     .catch(() => []);
   throw new Error(
-    `Create Session stayed disabled for lifecycle booking. pair=${context.pairKey} attempt=${context.attempt} startIso=${context.startIso} disabled=${disabled ?? "null"} ariaDisabled=${ariaDisabled ?? "null"} visibleErrors=${JSON.stringify(visibleErrors)}`,
+    `Create Session stayed unavailable for lifecycle booking. pair=${context.pairKey} attempt=${context.attempt} startIso=${context.startIso} disabled=${disabled ?? "null"} ariaDisabled=${ariaDisabled ?? "null"} label=${JSON.stringify(textContent)} visibleErrors=${JSON.stringify(visibleErrors)}`,
   );
 };
 

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -47,9 +47,10 @@ describe("playwright session lifecycle booking starts", () => {
   });
 
   it("treats the Create Session button as ready only when enabled", () => {
-    expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: null })).toBe(true);
-    expect(isCreateSessionButtonReady({ disabled: "", ariaDisabled: null })).toBe(false);
-    expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: "true" })).toBe(false);
+    expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: null, textContent: "Create Session" })).toBe(true);
+    expect(isCreateSessionButtonReady({ disabled: "", ariaDisabled: null, textContent: "Create Session" })).toBe(false);
+    expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: "true", textContent: "Create Session" })).toBe(false);
+    expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: null, textContent: "Saving..." })).toBe(false);
   });
 
   it("accepts only the explicit hosted ALREADY_STARTED recovery contract", () => {

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -92,11 +92,11 @@ describe('select-browser-checks', () => {
     ]);
   });
 
-  it('keeps session cancellation changes out of hosted auth smoke', () => {
+  it('runs hosted auth smoke for session cancellation changes', () => {
     const selection = runSelector('--changed-file', 'supabase/functions/sessions-cancel/index.ts');
 
     expect(selection.tier0Required).toBe(true);
-    expect(selection.authSmokeRequired).toBe(false);
+    expect(selection.authSmokeRequired).toBe(true);
     expect(selection.tier0Specs).toEqual([
       'cypress/e2e/routes_schedule.cy.ts',
       'cypress/e2e/routes_auth.cy.ts',


### PR DESCRIPTION
## Summary
- require the existing hosted auth/session smoke when sessions-cancel changes
- preserve the existing schedule/auth Tier-0 selection
- document why PR #817's main run skipped the decisive BCBA acceptance proof

## Risk
Critical-lane CI-policy change in scripts/ci/**. No runtime, database, workflow YAML, auth, tenant, or clinical-record changes.

## Verification
- focused selector TDD: 11/11 passed
- direct selector: uthSmokeRequired=true, schedule/auth specs preserved
- 
pm run ci:check-focused: passed
- 
pm run ci:check:e2e-reliability: passed
- 
pm run lint: passed
- 
pm run typecheck: passed
- 
pm run build: passed
- 
pm run verify:local: reached 2964 passing tests and stopped on two known Windows-only baseline failures (CRLF workflow parsing; jsdom Blob.text); Ubuntu CI is authoritative
- independent code, architecture, security, test, and devops review: approved

## Closure condition
After merge, the main push must execute (not skip) BCBA session acceptance proof, including its sessions-cancel cleanup without 403.

Linear: WIN-223