### PR TITLE
WIN-230: block ABA closeout on failed note preflight

### DIFF
--- a/docs/ai/WIN-230-aba-closeout-preflight-handoff.md
+++ b/docs/ai/WIN-230-aba-closeout-preflight-handoff.md
@@ -40,11 +40,12 @@ Linear: [WIN-230](https://linear.app/winningedgeai/issue/WIN-230/block-aba-close
   - `PREVIEW_PORT=4187 npm run test:routes:tier0`: pass, 220/220
   - `npm run ci:playwright`: blocked safely at credential preflight before browser launch
   - `npm run verify:local`: fail at the chained `test:ci` step with the same two out-of-scope failures after policy, lint, and typecheck passed
+  - PR #824 live CI at commit `ac28fffb`: pass, including Linux unit tests, policy, lint/typecheck, build, tenant safety, runtime migration parity, Tier-0 browser, auth browser smoke, optional Playwright smoke, IEHP import smoke, deploy preview, and final `ci-gate`
 - blocked checks:
   - `npm run ci:playwright`: missing synthetic `PW_SUPERADMIN_*` or `PW_ADMIN_*` credentials
   - database-backed policy checks: no `SUPABASE_DB_URL` / `DATABASE_URL`; no database surface changed
-- result: fail
-- residual risk: The focused closeout behavior and route surface are green. Human review and live Linux CI remain required because local aggregate testing has two unrelated Windows/runtime failures and credentialed end-to-end smoke could not run.
+- result: pass-with-blocked-checks
+- residual risk: The focused closeout behavior, route surface, and live Linux CI are green. Human review remains required, and the exact credentialed closeout smoke could not run locally because synthetic credentials were unavailable.
 
 ## PR Hygiene
 
@@ -55,8 +56,8 @@ Linear: [WIN-230](https://linear.app/winningedgeai/issue/WIN-230/block-aba-close
 - generated artifact drift: none
 - verification summary: present
 - pr-ready: yes for human review; not merge-ready until required live checks and human approval are complete
-- required follow-up: Push the isolated branch, open the PR, inspect live Linux checks, and keep the critical-lane human approval gate.
+- required follow-up: Obtain the mandatory critical-lane human approval before merge.
 
 ## Handoff Summary
 
-The modal now enters ABA closeout only after a fresh note lookup succeeds with a usable template; a forbidden lookup or missing template leaves the session in capture and surfaces the lookup error. Persisted draft restoration applies the same readiness rule, and the focused component suite passes 93/93 without changing backend authorization. Local policy, lint, typecheck, build, coverage, and Tier-0 routes pass; two unrelated aggregate-test failures and credentialed Playwright remain for live CI/human review.
+The modal now enters ABA closeout only after a fresh note lookup succeeds with a usable template; a forbidden lookup or missing template leaves the session in capture and surfaces the lookup error. Persisted draft restoration applies the same readiness rule, and the focused component suite passes 93/93 without changing backend authorization. Local policy, lint, typecheck, build, coverage, and Tier-0 routes pass, and PR #824's complete Linux CI matrix is green; credentialed local smoke remains blocked and critical-lane human approval is still required.

--- a/docs/ai/WIN-230-aba-closeout-preflight-handoff.md
+++ b/docs/ai/WIN-230-aba-closeout-preflight-handoff.md
@@ -1,0 +1,62 @@
+# WIN-230: ABA Closeout Preflight Guard
+
+Linear: [WIN-230](https://linear.app/winningedgeai/issue/WIN-230/block-aba-closeout-when-assigned-bt-preflight-fails)
+
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: The change controls an authenticated session-lifecycle transition after the assigned-BT note lookup. The implementation is UI-contained, but authorization failure must remain fail-closed.
+- triggering paths: `src/components/SessionModal.tsx`, with behavioral dependency on `/api/session-notes/upsert` and `get_bt_aba_session_note` authorization.
+
+## Scope
+
+- task intent: Keep BT capture open when the fresh ABA note preflight fails or lacks a usable template, and surface the preflight failure instead of downstream loading/finalization errors.
+- files touched: `src/components/SessionModal.tsx`, `src/components/__tests__/SessionModal.test.tsx`, `docs/ai/WIN-230-aba-closeout-preflight-handoff.md`
+- non-goals: No server, RPC, migration, RLS, role, assignment, deployment, production-data, auto-save, or auto-finalize changes.
+- stop conditions: Stop if containment requires a backend error-contract or authorization-policy change.
+- single-purpose diff: yes
+
+## Required Agents
+
+- required sequence: `specification-engineer` -> `software-architect` -> `implementation-engineer` -> `code-review-engineer` -> `test-engineer` -> `security-engineer`
+- agents used: specification, architecture, implementation, code review, test review, and security review complete
+- reviewer: completed; code and security verdicts approve after the restore-path readiness finding was fixed
+
+## Verification Card
+
+- required checks: focused `SessionModal` regression; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run build`; `npm run test:routes:tier0`; `npm run ci:playwright`; `npm run verify:local`
+- executed checks:
+  - `npm ci`: pass
+  - focused forbidden-refetch regression before implementation: fail as expected because closeout opened
+  - `npx vitest run src/components/__tests__/SessionModal.test.tsx --pool=forks --poolOptions.forks.singleFork`: pass, 93/93
+  - `npm run ci:check-focused`: pass; database-backed and branch-protection checks skipped by the command because their local inputs are unavailable
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run test:ci`: fail with 3071 passed, 5 skipped, and 2 out-of-scope local failures: the Windows CRLF workflow-step parser and `Blob.text()` support in `src/lib/__tests__/supabase.edge.test.ts`
+  - isolated `src/lib/__tests__/supabase.edge.test.ts`: same `blob.text is not a function` failure, confirming it is independent of the closeout suite
+  - `npm run ci:verify-coverage`: pass; line coverage 92.71% exceeds 86%
+  - `npm run build`: pass
+  - `PREVIEW_PORT=4187 npm run test:routes:tier0`: pass, 220/220
+  - `npm run ci:playwright`: blocked safely at credential preflight before browser launch
+  - `npm run verify:local`: fail at the chained `test:ci` step with the same two out-of-scope failures after policy, lint, and typecheck passed
+- blocked checks:
+  - `npm run ci:playwright`: missing synthetic `PW_SUPERADMIN_*` or `PW_ADMIN_*` credentials
+  - database-backed policy checks: no `SUPABASE_DB_URL` / `DATABASE_URL`; no database surface changed
+- result: fail
+- residual risk: The focused closeout behavior and route surface are green. Human review and live Linux CI remain required because local aggregate testing has two unrelated Windows/runtime failures and credentialed end-to-end smoke could not run.
+
+## PR Hygiene
+
+- branch-ready: yes, `codex/fix-aba-closeout-preflight`
+- linear-ready: yes, WIN-230 is In Progress
+- protected-path drift: none; implementation is UI/test only
+- unrelated changes: none in the isolated worktree
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: yes for human review; not merge-ready until required live checks and human approval are complete
+- required follow-up: Push the isolated branch, open the PR, inspect live Linux checks, and keep the critical-lane human approval gate.
+
+## Handoff Summary
+
+The modal now enters ABA closeout only after a fresh note lookup succeeds with a usable template; a forbidden lookup or missing template leaves the session in capture and surfaces the lookup error. Persisted draft restoration applies the same readiness rule, and the focused component suite passes 93/93 without changing backend authorization. Local policy, lint, typecheck, build, coverage, and Tier-0 routes pass; two unrelated aggregate-test failures and credentialed Playwright remain for live CI/human review.

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -1901,7 +1901,19 @@ export function SessionModal({
         });
         if (!transformed) return;
         const refreshedBtAbaNote = await refetchBtAbaNoteState();
-        setBtAbaNoteId(refreshedBtAbaNote.data?.noteId ?? null);
+        if (refreshedBtAbaNote.error || !refreshedBtAbaNote.data?.templateId) {
+          closeoutCaptureRef.current = null;
+          setModalStep('capture');
+          setBtAbaNoteId(null);
+          const message = refreshedBtAbaNote.error instanceof Error
+            ? refreshedBtAbaNote.error.message
+            : 'Unable to load the saved ABA session note draft.';
+          setBtAbaError(message);
+          showError(message);
+          return;
+        }
+
+        setBtAbaNoteId(refreshedBtAbaNote.data.noteId ?? null);
         const trialEvents = transformed.session_note_trial_events ?? [];
         closeoutCaptureRef.current = {
           notePayload: {
@@ -2703,6 +2715,7 @@ export function SessionModal({
       !isBtClinicalCaptureSession ||
       session?.status !== 'in_progress' ||
       btAbaNoteState?.status !== 'draft' ||
+      !btAbaNoteState.templateId ||
       !btAbaNoteState.responses ||
       !btAbaNoteState.noteId
     ) {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -978,6 +978,77 @@ describe('SessionModal', () => {
     expect(screen.getByRole('button', { name: /^Close Session$/i })).toBeDisabled();
   });
 
+  it('keeps capture open when the closeout note refetch is forbidden', async () => {
+    vi.mocked(getBtAbaSessionNote)
+      .mockResolvedValueOnce({
+        noteId: null,
+        templateId: 'template-bt-1',
+        responses: null,
+        status: null,
+      })
+      .mockRejectedValueOnce(new Error('Forbidden'));
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={btInProgressSession}
+        dataCollectionOnly
+      />,
+    );
+
+    const closeSessionButton = await screen.findByRole('button', { name: /^Close Session$/i });
+    await waitFor(() => expect(closeSessionButton).not.toBeDisabled());
+    await userEvent.click(closeSessionButton);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Forbidden');
+    expect(screen.queryByRole('heading', { name: 'ABA Session Note' })).not.toBeInTheDocument();
+    expect(toastMocks.showError).toHaveBeenCalledWith('Forbidden');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ status: 'in_progress' }));
+  });
+
+  it('keeps capture open when the closeout note refetch has no template', async () => {
+    vi.mocked(getBtAbaSessionNote)
+      .mockResolvedValueOnce({
+        noteId: null,
+        templateId: 'template-bt-1',
+        responses: null,
+        status: null,
+      })
+      .mockResolvedValueOnce({
+        noteId: null,
+        templateId: null,
+        responses: null,
+        status: null,
+      });
+    renderWithProviders(
+      <SessionModal {...defaultProps} session={btInProgressSession} dataCollectionOnly />,
+    );
+
+    const closeSessionButton = await screen.findByRole('button', { name: /^Close Session$/i });
+    await waitFor(() => expect(closeSessionButton).not.toBeDisabled());
+    await userEvent.click(closeSessionButton);
+
+    expect(screen.queryByRole('heading', { name: 'ABA Session Note' })).not.toBeInTheDocument();
+    expect(toastMocks.showError).toHaveBeenCalledWith('Unable to load the saved ABA session note draft.');
+  });
+
+  it('does not restore a persisted BT draft without its template', async () => {
+    vi.mocked(getBtAbaSessionNote).mockResolvedValue({
+      noteId: 'note-without-template',
+      templateId: null,
+      responses: validBtAbaResponses as unknown as Record<string, unknown>,
+      status: 'draft',
+    });
+    renderWithProviders(
+      <SessionModal {...defaultProps} session={btInProgressSession} dataCollectionOnly />,
+    );
+
+    await waitFor(() => expect(getBtAbaSessionNote).toHaveBeenCalled());
+    expect(screen.queryByRole('heading', { name: 'ABA Session Note' })).not.toBeInTheDocument();
+  });
+
   it('does not reinterpret completed RPC success as finalization failure when refresh callback rejects', async () => {
     vi.mocked(getBtAbaSessionNote).mockResolvedValue({
       noteId: 'note-completed', templateId: 'template-bt-1', responses: validBtAbaResponses as unknown as Record<string, unknown>, status: 'draft',


### PR DESCRIPTION
## Summary
- fail closed when the fresh BT ABA note preflight is forbidden or has no usable template
- keep capture open and surface the lookup error instead of entering closeout with missing note state
- apply the same template readiness rule to persisted-draft restoration

## Verification
- `SessionModal.test.tsx`: 93/93 passed
- `npm run ci:check-focused`: passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm run ci:verify-coverage`: passed (92.71% lines)
- `PREVIEW_PORT=4187 npm run test:routes:tier0`: 220/220 passed
- `npm run test:ci`: 3071 passed, 5 skipped, 2 unrelated local failures (`Blob.text()` runtime support and Windows CRLF workflow parsing)
- `npm run ci:playwright`: blocked at credential preflight; no protected browser action ran

## Risk
Critical lane because this controls an authenticated session closeout transition. The diff is UI/test only and does not alter RPC authorization, tenant scope, roles, migrations, server routes, or production data. Human review remains required.

Linear: WIN-230