### PR TITLE
WIN-233: track BT prompt outcomes and align graphs

### DIFF
--- a/docs/ai/WIN-233-bt-prompt-outcomes-handoff.md
+++ b/docs/ai/WIN-233-bt-prompt-outcomes-handoff.md
@@ -1,0 +1,46 @@
+# WIN-233 Handoff
+
+## Status
+
+Implementation and focused review are complete on `codex/win-233-bt-prompt-outcomes`. Human review remains mandatory before merge.
+
+## Accepted contract
+
+- Prompt outcome: `correct | incorrect | noResponse`.
+- Legacy prompt detail stores incorrect and no response separately; target-level `incorrect_trials` remains their combined total.
+- Existing rows without no-response detail retain their historical meaning.
+- Existing trial-event GET modes remain unchanged.
+- New analytics read mode is bounded to one authorized client, goal, and exclusive date range and returns a minimal DTO.
+
+## Verification evidence
+
+- Baseline focused Vitest run: 238 tests passed before implementation.
+- Final affected-surface Vitest run: 6 files, 264 tests passed.
+- `npm run ci:check-focused`: passed; database-backed policy checks skipped because no database URL is configured.
+- `npm run lint`: passed.
+- `npm run typecheck`: passed.
+- `npm run validate:tenant`: passed.
+- `npm run test:routes:tier0`: passed, 220 Cypress route tests.
+- `npm run build`: passed.
+- `npm run test:ci`: failed outside the WIN-233 surface both before and after rebasing onto `origin/main` at `8478b811`. Two failures were isolated locally:
+  - `tests/scripts/playwright-iehp-assessment-import-smoke.test.ts`: Windows line-ending-sensitive `supabase/config.toml` assertion.
+  - `src/lib/__tests__/supabase.edge.test.ts`: local Blob implementation does not expose `blob.text()`.
+  - The broad run reported one additional failure before verbose output truncation; no affected WIN-233 suite failed.
+- `npm run verify:local`: not repeated because it includes the same failing `test:ci` gate above.
+- `npm run ci:playwright:env-readiness`: readiness report is `fail` because hosted target, persona, and Supabase credentials are not configured locally. Full Playwright remains required in PR CI.
+- Supabase connector `EXPLAIN`: existing `trial_events_org_client_time_idx` is used for the bounded organization/client/time query; no database change is required.
+- Integrated reviews after corrections: code APPROVE, security APPROVE, performance APPROVE.
+
+## Verification card
+
+- Lane: `critical`
+- Required checks: focused tests, policy checks, lint, typecheck, full CI tests, tenant validation, tier-0 routes, build, hosted Playwright when credentials exist.
+- Executed checks: focused tests, policy checks, lint, typecheck, full CI attempt, tenant validation, tier-0 routes, build, Playwright readiness, hosted read-only query plan.
+- Blocked checks: hosted Playwright due missing local target/persona/Supabase credentials.
+- Result: `review-ready with unrelated broad-suite failures`; human approval and green required PR checks are mandatory before merge.
+- Residual risk: local synthetic browser proof of save/reopen and both graph surfaces could not be run without the hosted test environment; focused component/API tests cover the same data contracts.
+
+## Blockers and residual risk
+
+- Human approval is required before merge because this is a critical-lane protected server change.
+- Do not merge while required PR checks are failing. The unrelated local full-suite failures must either pass in CI or be dispositioned separately by the owning lane.

--- a/docs/ai/WIN-233-bt-prompt-outcomes-plan.md
+++ b/docs/ai/WIN-233-bt-prompt-outcomes-plan.md
@@ -1,0 +1,48 @@
+# WIN-233 BT Prompt Outcomes and Graph Alignment
+
+## Routing
+
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Linear: [WIN-233](https://linear.app/winningedgeai/issue/WIN-233/track-bt-prompt-outcomes-and-align-outcome-graphs)
+- Related issues: WIN-218, WIN-183
+- Triggering boundaries: `src/server/api/trial-events.ts` and the persisted `goal_measurements` JSON contract
+- Merge requirement: human approval after required verification and PR hygiene
+
+## Scope
+
+1. Define the shared `PromptOutcome` contract and preserve optional legacy `no_response_trials` values.
+2. Replace prompt correctness checkboxes with a sticky per-target three-outcome radio group in `SessionModal`.
+3. Add the bounded, RLS-backed `view=prompt_outcomes` trial-event read mode.
+4. Add aligned 100% stacked prompt-outcome charts to Programs & Goals and Client Session Trends without changing the existing percent-correct trend.
+5. Preserve combined target-level unsuccessful counts and existing automatic-progression behavior.
+
+## Non-goals and stop conditions
+
+- No schema migration, RPC, RLS, grant, role, index, or progression SQL change.
+- No historical backfill or reinterpretation of legacy unsuccessful trials.
+- No raw metadata, audit identity, or unrelated clinical-field exposure.
+- No PDF or generated-note analytics expansion.
+- Stop and split the work if the hosted query needs a database/index change or the protected boundary cannot remain tenant-scoped and RLS-backed.
+
+## Parallel ownership
+
+- Shared contract gate: `src/types/index.ts`, `src/lib/goal-measurements.ts`, focused tests.
+- Capture lane: `SessionModal` and focused tests.
+- API lane: `trial-events` handler and security-focused tests.
+- Analytics lane: shared outcome helper, both graph surfaces, and focused tests.
+- Integration gate: code, test, security, and performance reviews against the combined diff.
+
+## Verification contract
+
+- Focused Vitest suites for every affected surface.
+- `npm run ci:check-focused`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:ci`
+- `npm run validate:tenant`
+- `npm run test:routes:tier0`
+- `npm run build`
+- `npm run ci:playwright` when local credentials are available; otherwise required in PR CI.
+- `npm run verify:local` when prerequisites are available.
+- Read-only hosted Supabase constraint, index, and query-plan verification.

--- a/src/components/ClientDetails/ClientSessionTrendsTab.tsx
+++ b/src/components/ClientDetails/ClientSessionTrendsTab.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   Chart as ChartJS,
+  BarElement,
   CategoryScale,
   LinearScale,
   PointElement,
@@ -9,19 +10,26 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
-import { Line } from 'react-chartjs-2';
+import { Bar, Line } from 'react-chartjs-2';
 import { AlertTriangle, BarChart3, Download, Inbox, Loader2 } from 'lucide-react';
 import type { Chart as ChartInstance, ChartData, ChartOptions, PointStyle } from 'chart.js';
-import type { Goal } from '../../types';
+import type { Goal, TrialEvent } from '../../types';
+import { callApi } from '../../lib/api';
 import { fetchClientSessionNotes } from '../../lib/session-notes';
 import { useActiveOrganizationId } from '../../lib/organization';
 import { supabase } from '../../lib/supabase';
+import {
+  buildPromptOutcomeModel,
+  PROMPT_OUTCOME_COLORS,
+  PROMPT_OUTCOME_LABELS,
+  PROMPT_OUTCOME_ORDER,
+} from '../../lib/trial-prompt-outcomes';
 import {
   buildSessionTrendModel,
   type SessionTrendDisplayPeriod,
 } from '../../lib/session-trends';
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+ChartJS.register(BarElement, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
 interface ClientSessionTrendsTabProps {
   client: { id: string };
@@ -47,6 +55,14 @@ const defaultStartDate = (): string => {
 };
 
 const todayDate = (): string => toLocalDateInputValue(new Date());
+
+const toUtcStartOfDayIso = (value: string): string => `${value}T00:00:00.000Z`;
+
+const toExclusiveEndDateIso = (value: string): string => {
+  const date = new Date(`${value}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date.toISOString();
+};
 
 const formatPercent = (value: number): string =>
   Number.isInteger(value) ? `${value}%` : `${value.toFixed(1)}%`;
@@ -87,6 +103,7 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
   const [selectedGoalId, setSelectedGoalId] = useState<string | null>(null);
   const [selectedTherapistId, setSelectedTherapistId] = useState<string | null>(null);
   const chartRef = useRef<ChartInstance<'line', Array<number | null>, string> | undefined>(undefined);
+  const outcomeChartRef = useRef<ChartInstance<'bar', Array<number | null>, string> | undefined>(undefined);
 
   const {
     data: sessionNotes = [],
@@ -149,6 +166,43 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
     },
     enabled: Boolean(client.id && organizationId),
   });
+  const {
+    data: goalTargets = [],
+  } = useQuery({
+    queryKey: ['goal-targets', selectedGoalId, 'session-trends'],
+    queryFn: async () => {
+      if (!selectedGoalId) {
+        return [];
+      }
+      const response = await callApi(`/api/goal-targets?goal_id=${encodeURIComponent(selectedGoalId)}`);
+      if (!response.ok) {
+        throw new Error('Failed to load goal targets.');
+      }
+      return await response.json() as Array<{ id: string; name: string }>;
+    },
+    enabled: Boolean(selectedGoalId),
+  });
+  const {
+    data: promptOutcomeEvents = [],
+    error: promptOutcomeError,
+  } = useQuery({
+    queryKey: ['trial-events', 'prompt-outcomes', client.id, selectedGoalId, startDate, endDate],
+    queryFn: async () => {
+      if (!selectedGoalId) {
+        return [];
+      }
+      const startAt = encodeURIComponent(toUtcStartOfDayIso(startDate));
+      const endBefore = encodeURIComponent(toExclusiveEndDateIso(endDate));
+      const response = await callApi(
+        `/api/trial-events?view=prompt_outcomes&client_id=${encodeURIComponent(client.id)}&goal_id=${encodeURIComponent(selectedGoalId)}&start_at=${startAt}&end_before=${endBefore}`,
+      );
+      if (!response.ok) {
+        throw new Error('Prompt outcomes failed to load.');
+      }
+      return await response.json() as TrialEvent[];
+    },
+    enabled: Boolean(selectedGoalId),
+  });
 
   const trendModel = useMemo(() => buildSessionTrendModel(sessionNotes, goals, {
     selectedGoalId,
@@ -156,12 +210,23 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
     displayPeriod,
     dateRange: { startDate, endDate },
   }), [displayPeriod, endDate, goals, selectedGoalId, selectedTherapistId, sessionNotes, startDate]);
+  const availableGoalOptions = useMemo(() => (
+    trendModel.goalOptions.length > 0
+      ? trendModel.goalOptions
+      : goals.map((goal) => ({
+        id: goal.id,
+        label: goal.title,
+        programName: goal.program_name ?? null,
+      }))
+  ), [goals, trendModel.goalOptions]);
 
   useEffect(() => {
-    if (trendModel.selectedGoalId !== selectedGoalId) {
-      setSelectedGoalId(trendModel.selectedGoalId);
+    if (!selectedGoalId && availableGoalOptions.length > 0) {
+      setSelectedGoalId(availableGoalOptions[0].id);
+    } else if (selectedGoalId && !availableGoalOptions.some((goal) => goal.id === selectedGoalId)) {
+      setSelectedGoalId(availableGoalOptions[0]?.id ?? null);
     }
-  }, [selectedGoalId, trendModel.selectedGoalId]);
+  }, [availableGoalOptions, selectedGoalId]);
 
   const isLoading = isLoadingSessionNotes || isLoadingGoals;
   const error = sessionNotesError ?? goalsError;
@@ -196,6 +261,30 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
   const selectedTherapistLabel = trendModel.selectedTherapistId
     ? trendModel.therapistOptions.find((therapist) => therapist.id === trendModel.selectedTherapistId)?.label ?? null
     : null;
+  const targetLabelsById = useMemo(
+    () => Object.fromEntries(goalTargets.map((target) => [target.id, target.name])),
+    [goalTargets],
+  );
+  const promptOutcomeModel = useMemo(() => {
+    if (!selectedGoalId) {
+      return buildPromptOutcomeModel({
+        goalId: '',
+        displayPeriod,
+        rawEvents: [],
+        sessionNotes: [],
+      });
+    }
+    return buildPromptOutcomeModel({
+      goalId: selectedGoalId,
+      displayPeriod,
+      rawEvents: promptOutcomeEvents,
+      sessionNotes,
+      targetLabelsById,
+      selectedTherapistId: trendModel.selectedTherapistId,
+      requireSessionMembership: true,
+      rawEventsArePromptOnly: true,
+    });
+  }, [displayPeriod, promptOutcomeEvents, selectedGoalId, sessionNotes, targetLabelsById, trendModel.selectedTherapistId]);
 
   const chartBuckets = useMemo(() => {
     const bucketsByKey = new Map<string, string>();
@@ -299,6 +388,57 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
     .slice()
     .sort((left, right) => right.sessionDate.localeCompare(left.sessionDate))
     .slice(0, 10);
+  const promptOutcomeChartData = useMemo<ChartData<'bar', Array<number | null>, string>>(() => ({
+    labels: promptOutcomeModel.buckets.map((bucket) => bucket.label),
+    datasets: PROMPT_OUTCOME_ORDER.map((outcome) => ({
+      label: PROMPT_OUTCOME_LABELS[outcome],
+      data: promptOutcomeModel.buckets.map((bucket) => (
+        bucket.segments.find((segment) => segment.outcome === outcome)?.percentage ?? 0
+      )),
+      backgroundColor: PROMPT_OUTCOME_COLORS[outcome],
+      stack: 'outcomes',
+    })),
+  }), [promptOutcomeModel.buckets]);
+  const promptOutcomeChartOptions = useMemo<ChartOptions<'bar'>>(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        position: 'bottom',
+      },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const bucket = promptOutcomeModel.buckets[context.dataIndex];
+            const outcome = PROMPT_OUTCOME_ORDER[context.datasetIndex];
+            const segment = bucket?.segments.find((item) => item.outcome === outcome);
+            return `${context.dataset.label}: ${segment?.value ?? 0} (${segment?.percentage ?? 0}%)`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: { stacked: true },
+      y: {
+        stacked: true,
+        beginAtZero: true,
+        max: 100,
+        ticks: {
+          callback: (value) => `${value}%`,
+        },
+      },
+    },
+  }), [promptOutcomeModel.buckets]);
+  const handleDownloadOutcomeGraph = () => {
+    const imageUrl = outcomeChartRef.current?.toBase64Image('image/png', 1);
+    if (!imageUrl) {
+      return;
+    }
+    const anchor = document.createElement('a');
+    anchor.href = imageUrl;
+    anchor.download = `session-prompt-outcomes-${client.id}-${todayDate()}.png`;
+    anchor.click();
+  };
 
   if (!organizationId) {
     return (
@@ -334,12 +474,12 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
               setSelectedGoalId(event.target.value || null);
             }}
             className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-dark dark:text-white"
-            disabled={trendModel.goalOptions.length === 0}
+            disabled={availableGoalOptions.length === 0}
           >
-            {trendModel.goalOptions.length === 0 ? (
+            {availableGoalOptions.length === 0 ? (
               <option value="">No trial data</option>
             ) : (
-              trendModel.goalOptions.map((goal) => (
+              availableGoalOptions.map((goal) => (
                 <option key={goal.id} value={goal.id}>
                   {goal.programName ? `${goal.programName}: ${goal.label}` : goal.label}
                 </option>
@@ -415,43 +555,73 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
         <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-100">
           {error instanceof Error ? error.message : 'Session trends failed to load.'}
         </div>
-      ) : chartBuckets.length === 0 ? (
-        <div className="rounded-md border border-dashed border-gray-300 p-8 text-center dark:border-gray-700">
-          <Inbox className="mx-auto h-10 w-10 text-gray-400" />
-          <h3 className="mt-3 text-sm font-semibold text-gray-900 dark:text-white">No graphable trial data</h3>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Save session notes with opportunities or percent-based measurements for this client to populate trends.
-          </p>
-        </div>
       ) : (
         <>
+          {chartBuckets.length === 0 ? (
+            <div className="rounded-md border border-dashed border-gray-300 p-8 text-center dark:border-gray-700">
+              <Inbox className="mx-auto h-10 w-10 text-gray-400" />
+              <h3 className="mt-3 text-sm font-semibold text-gray-900 dark:text-white">No graphable trial data</h3>
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Save session notes with opportunities or percent-based measurements for this client to populate trends.
+              </p>
+            </div>
+          ) : (
+            <div className="rounded-md border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-dark-lighter">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {selectedTherapistLabel ? `Therapist: ${selectedTherapistLabel}` : 'All therapists'}
+                </div>
+                <button
+                  type="button"
+                  onClick={handleDownloadGraph}
+                  className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-700 dark:bg-dark dark:text-gray-200 dark:hover:bg-gray-800"
+                >
+                  <Download className="mr-2 h-4 w-4" />
+                  Download graph
+                </button>
+              </div>
+              {overRangeBucketCount > 0 && (
+                <div className="mb-3 flex items-start rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-100">
+                  <AlertTriangle className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0" />
+                  <span>
+                    {overRangeBucketCount} plotted value{overRangeBucketCount === 1 ? ' exceeds' : 's exceed'} 100% because recorded successes are greater than opportunities.
+                  </span>
+                </div>
+              )}
+              <div className="h-80">
+                <Line ref={chartRef} options={chartOptions} data={chartData} />
+              </div>
+            </div>
+          )}
           <div className="rounded-md border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-dark-lighter">
             <div className="mb-3 flex items-center justify-between gap-3">
               <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                {selectedTherapistLabel ? `Therapist: ${selectedTherapistLabel}` : 'All therapists'}
+                Prompt outcomes
               </div>
               <button
                 type="button"
-                onClick={handleDownloadGraph}
+                onClick={handleDownloadOutcomeGraph}
                 className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-700 dark:bg-dark dark:text-gray-200 dark:hover:bg-gray-800"
               >
                 <Download className="mr-2 h-4 w-4" />
-                Download graph
+                Download outcome graph
               </button>
             </div>
-            {overRangeBucketCount > 0 && (
-              <div className="mb-3 flex items-start rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-100">
-                <AlertTriangle className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0" />
-                <span>
-                  {overRangeBucketCount} plotted value{overRangeBucketCount === 1 ? ' exceeds' : 's exceed'} 100% because recorded successes are greater than opportunities.
-                </span>
+            {promptOutcomeError ? (
+              <p className="text-sm text-red-700 dark:text-red-200">
+                {promptOutcomeError instanceof Error ? promptOutcomeError.message : 'Prompt outcomes failed to load.'}
+              </p>
+            ) : promptOutcomeModel.buckets.length === 0 ? (
+              <p className="text-sm text-gray-500 dark:text-gray-400">No prompted outcome data in the selected range.</p>
+            ) : (
+              <div className="h-72">
+                <Bar ref={outcomeChartRef} data={promptOutcomeChartData} options={promptOutcomeChartOptions} />
               </div>
             )}
-            <div className="h-80">
-              <Line ref={chartRef} options={chartOptions} data={chartData} />
-            </div>
           </div>
 
+          {chartBuckets.length > 0 && (
+            <>
           <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
             <div className="rounded-md border border-gray-200 p-4 dark:border-gray-700">
               <div className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">Buckets</div>
@@ -494,6 +664,43 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
                       </td>
                       <td className="whitespace-nowrap px-4 py-2 text-gray-500 dark:text-gray-400">
                         {point.source === 'target_trials' ? 'Target trials' : point.source === 'flat_trials' ? 'Trial summary' : 'Percent'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+            </>
+          )}
+          <div className="overflow-hidden rounded-md border border-gray-200 dark:border-gray-700">
+            <div className="border-b border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800">
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Prompt outcome evidence</h3>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
+                <thead className="bg-gray-50 dark:bg-gray-800">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Date</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Target</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Correct</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Incorrect</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">No response</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100 bg-white dark:divide-gray-800 dark:bg-dark-lighter">
+                  {promptOutcomeModel.evidence.map((row) => (
+                    <tr key={`${row.sessionKey}-${row.targetKey}`}>
+                      <td className="whitespace-nowrap px-4 py-2 text-gray-900 dark:text-white">{row.sessionDate}</td>
+                      <td className="px-4 py-2 text-gray-700 dark:text-gray-300">{row.targetLabel}</td>
+                      <td className="whitespace-nowrap px-4 py-2 text-gray-700 dark:text-gray-300">
+                        {row.correct} ({row.total > 0 ? Math.round((row.correct / row.total) * 100) : 0}%)
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-2 text-gray-700 dark:text-gray-300">
+                        {row.incorrect} ({row.total > 0 ? Math.round((row.incorrect / row.total) * 100) : 0}%)
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-2 text-gray-700 dark:text-gray-300">
+                        {row.noResponse} ({row.total > 0 ? Math.round((row.noResponse / row.total) * 100) : 0}%)
                       </td>
                     </tr>
                   ))}

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -12,6 +12,12 @@ import {
   type AssessmentTemplateType,
 } from "../../lib/assessment-documents";
 import { supabase } from "../../lib/supabase";
+import {
+  buildPromptOutcomeModel,
+  PROMPT_OUTCOME_COLORS,
+  PROMPT_OUTCOME_LABELS,
+  PROMPT_OUTCOME_ORDER,
+} from "../../lib/trial-prompt-outcomes";
 import { IehpFbaLayoutReview } from "./IehpFbaLayoutReview";
 import { canRoleManageGoalTargetProgression, GoalTargetProgressionEditor, type ManualOverrideInput, type SaveCriterionInput } from "./GoalTargetProgressionEditor";
 import { GoalTargetProgressionHistory } from "./GoalTargetProgressionHistory";
@@ -644,6 +650,26 @@ function TargetProgressPanel({ clientId, organizationId, target }: TargetTrialEv
   });
   const graphEvents = latestTrialEventsForGraph(trialEvents);
   const maxGraphScore = Math.max(1, ...graphEvents.map(trialEventGraphScore));
+  const promptOutcomeModel = useMemo(() => buildPromptOutcomeModel({
+    goalId: target.goal_id,
+    displayPeriod: "day",
+    rawEvents: trialEvents,
+    sessionNotes: [],
+    targetLabelsById: { [target.id]: target.name },
+    selectedTargetLabel: target.name,
+  }), [target.goal_id, target.id, target.name, trialEvents]);
+  const promptOutcomeSegments = PROMPT_OUTCOME_ORDER.map((outcome) => {
+    const value = promptOutcomeModel.summary[outcome];
+    return {
+      outcome,
+      label: PROMPT_OUTCOME_LABELS[outcome],
+      value,
+      percentage: promptOutcomeModel.summary.total > 0
+        ? Math.round((value / promptOutcomeModel.summary.total) * 1000) / 10
+        : 0,
+      color: PROMPT_OUTCOME_COLORS[outcome],
+    };
+  });
 
   return (
     <div
@@ -667,6 +693,30 @@ function TargetProgressPanel({ clientId, organizationId, target }: TargetTrialEv
         <p className="text-slate-500">No trial-level data yet.</p>
       ) : (
         <div className="space-y-3">
+          {promptOutcomeModel.summary.total > 0 && (
+            <div className="rounded-md border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-dark">
+              <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+                Prompt outcomes
+              </div>
+              <div className="flex h-3 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700" aria-label={`Prompt outcomes for ${target.name}`}>
+                {promptOutcomeSegments.map((segment) => (
+                  <div
+                    key={segment.outcome}
+                    className="h-full"
+                    style={{ width: `${segment.percentage}%`, backgroundColor: segment.color }}
+                    title={`${segment.label}: ${segment.value} (${segment.percentage}%)`}
+                  />
+                ))}
+              </div>
+              <div className="mt-2 grid grid-cols-1 gap-1 text-xs text-slate-600 dark:text-slate-300 sm:grid-cols-3">
+                {promptOutcomeSegments.map((segment) => (
+                  <span key={segment.outcome}>
+                    {PROMPT_OUTCOME_LABELS[segment.outcome]} {segment.percentage}% ({segment.value})
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
           <div className="space-y-1" aria-label={`Recent graph points for ${target.name}`}>
             {graphEvents.map((event) => {
               const score = trialEventGraphScore(event);

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -27,6 +27,7 @@ import type {
   Program,
   SessionNoteUpsertResult,
   SessionPromptCount,
+  PromptOutcome,
   BtAbaSessionNotePayload,
   BtAbaFinalizeResult,
 } from '../types';
@@ -135,23 +136,50 @@ const promptCaptureOptions = [
   { label: 'Partial physical', promptType: 'physical', promptLevel: 'partial' },
 ] as const;
 
-export const setPromptCorrectnessForTarget = (
-  current: Record<string, boolean>,
+const promptOutcomeOptions: Array<{ value: PromptOutcome; label: string }> = [
+  { value: 'correct', label: 'Correct' },
+  { value: 'incorrect', label: 'Incorrect' },
+  { value: 'noResponse', label: 'No response' },
+];
+
+const getPromptOutcomeSegmentClasses = (selected: boolean, outcome: PromptOutcome): string => {
+  if (selected) {
+    if (outcome === 'correct') {
+      return 'border-emerald-600 bg-emerald-600 text-white';
+    }
+    if (outcome === 'incorrect') {
+      return 'border-rose-600 bg-rose-600 text-white';
+    }
+    return 'border-amber-500 bg-amber-500 text-white';
+  }
+
+  if (outcome === 'correct') {
+    return 'border-emerald-200 bg-white text-emerald-900 hover:bg-emerald-50 dark:border-emerald-800 dark:bg-dark dark:text-emerald-100 dark:hover:bg-emerald-950/40';
+  }
+  if (outcome === 'incorrect') {
+    return 'border-rose-200 bg-white text-rose-900 hover:bg-rose-50 dark:border-rose-800 dark:bg-dark dark:text-rose-100 dark:hover:bg-rose-950/40';
+  }
+  return 'border-amber-200 bg-white text-amber-900 hover:bg-amber-50 dark:border-amber-800 dark:bg-dark dark:text-amber-100 dark:hover:bg-amber-950/40';
+};
+
+export const setPromptOutcomeForTarget = (
+  current: Record<string, PromptOutcome>,
   targetId: string,
-  checked: boolean,
-): Record<string, boolean> => ({ ...current, [targetId]: checked });
+  outcome: PromptOutcome,
+): Record<string, PromptOutcome> => ({ ...current, [targetId]: outcome });
 
 export const incrementLegacyPromptCount = (
   current: SessionPromptCount[] | null | undefined,
   prompt: { promptType: SessionPromptCount['prompt_type']; promptLevel: SessionPromptCount['prompt_level'] },
-  correct: boolean,
+  outcome: PromptOutcome,
 ): SessionPromptCount[] => normalizePromptCounts([
   ...(current ?? []),
   {
     prompt_type: prompt.promptType,
     prompt_level: prompt.promptLevel,
-    correct_trials: correct ? 1 : 0,
-    incorrect_trials: correct ? 0 : 1,
+    correct_trials: outcome === 'correct' ? 1 : 0,
+    incorrect_trials: outcome === 'incorrect' ? 1 : 0,
+    ...(outcome === 'noResponse' ? { no_response_trials: 1 } : {}),
   },
 ]);
 
@@ -159,23 +187,49 @@ export const decrementLegacyPromptCounts = (
   current: SessionPromptCount[] | null | undefined,
   field: 'correct_trials' | 'incorrect_trials',
   amount: number,
+  preferredOutcome: PromptOutcome,
 ): SessionPromptCount[] => {
   const next = normalizePromptCounts(current).map((count) => ({ ...count }));
   let remaining = Math.max(0, amount);
   for (let index = next.length - 1; index >= 0 && remaining > 0; index -= 1) {
-    const removable = Math.min(next[index][field], remaining);
-    next[index][field] -= removable;
-    remaining -= removable;
+    if (field === 'correct_trials') {
+      const removable = Math.min(next[index].correct_trials, remaining);
+      next[index].correct_trials -= removable;
+      remaining -= removable;
+      continue;
+    }
+
+    const unsuccessfulFields: Array<'incorrect_trials' | 'no_response_trials'> = preferredOutcome === 'noResponse'
+      ? ['no_response_trials', 'incorrect_trials']
+      : ['incorrect_trials', 'no_response_trials'];
+    for (const unsuccessfulField of unsuccessfulFields) {
+      const currentValue = unsuccessfulField === 'no_response_trials'
+        ? next[index].no_response_trials ?? 0
+        : next[index].incorrect_trials;
+      if (currentValue <= 0) {
+        continue;
+      }
+      const removable = Math.min(currentValue, remaining);
+      if (unsuccessfulField === 'no_response_trials') {
+        next[index].no_response_trials = currentValue - removable;
+      } else {
+        next[index].incorrect_trials -= removable;
+      }
+      remaining -= removable;
+      if (remaining === 0) {
+        break;
+      }
+    }
   }
   return normalizePromptCounts(next);
 };
 
 export const remapLegacyPromptCorrectnessAfterRemoval = (
-  current: Record<string, boolean>,
+  current: Record<string, PromptOutcome>,
   goalId: string,
   removedIndex: number,
   previousLength: number,
-): Record<string, boolean> => {
+): Record<string, PromptOutcome> => {
   const next = { ...current };
   for (let index = removedIndex; index < previousLength - 1; index += 1) {
     const nextKey = `legacy:${goalId}:${index + 1}`;
@@ -190,11 +244,14 @@ export const remapLegacyPromptCorrectnessAfterRemoval = (
   return next;
 };
 
-const sumLegacyPromptCounts = (
+export const sumLegacyPromptCounts = (
   counts: SessionPromptCount[] | null | undefined,
   field: 'correct_trials' | 'incorrect_trials',
 ): number => normalizePromptCounts(counts).reduce(
-  (total, count) => Math.min(Number.MAX_SAFE_INTEGER, total + count[field]),
+  (total, count) => Math.min(
+    Number.MAX_SAFE_INTEGER,
+    total + count[field] + (field === 'incorrect_trials' ? count.no_response_trials ?? 0 : 0),
+  ),
   0,
 );
 
@@ -512,7 +569,7 @@ export function SessionModal({
   const [alternativeTimes, setAlternativeTimes] = useState<AlternativeTime[]>([]);
   const [isLoadingAlternatives, setIsLoadingAlternatives] = useState(false);
   const [pendingTrialEvents, setPendingTrialEvents] = useState<SessionCaptureTrialEventInput[]>([]);
-  const [promptCorrectByTargetId, setPromptCorrectByTargetId] = useState<Record<string, boolean>>({});
+  const [promptOutcomeByTargetId, setPromptOutcomeByTargetId] = useState<Record<string, PromptOutcome>>({});
   const [pendingNumericTrialValues, setPendingNumericTrialValues] = useState<Record<string, string>>({});
   const [progressionNotices, setProgressionNotices] = useState<string[]>([]);
   const [progressionConflict, setProgressionConflict] = useState<string | null>(null);
@@ -549,7 +606,7 @@ export function SessionModal({
     isDataCollectionOnly && (session?.status === 'scheduled' || session?.status === 'in_progress'),
   );
   const shouldHideGoalCaptureFields = hideGoalCaptureFields;
-  const shouldShowPromptCorrectnessToggle = !isBtClinicalCaptureSession;
+  const shouldShowPromptCorrectnessToggle = true;
 
   const {
     data: btAbaNoteState,
@@ -1020,7 +1077,7 @@ export function SessionModal({
 
   useEffect(() => {
     setPendingTrialEvents([]);
-    setPromptCorrectByTargetId({});
+    setPromptOutcomeByTargetId({});
     setPendingNumericTrialValues({});
   }, [session?.id, clientId]);
 
@@ -1809,6 +1866,7 @@ export function SessionModal({
           return [...current, ...appended];
         });
         void queryClient.invalidateQueries({ queryKey: sessionTrialEventsQueryKey });
+        void queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === 'trial-events' });
       }
       setPendingTrialEvents((current) =>
         trialEventsForSubmit.length > 0
@@ -2241,6 +2299,7 @@ export function SessionModal({
       field: 'metric_value' | 'incorrect_trials',
       delta: number,
       configuredTarget?: GoalTarget | null,
+      preferredPromptOutcome: PromptOutcome = 'correct',
     ) => {
       if (configuredTarget) {
         const dirtyPath =
@@ -2314,7 +2373,7 @@ export function SessionModal({
         if (promptReduction > 0) {
           setValue(
             promptCountsPath,
-            decrementLegacyPromptCounts(currentPromptCounts, promptField, promptReduction),
+            decrementLegacyPromptCounts(currentPromptCounts, promptField, promptReduction, preferredPromptOutcome),
             { shouldDirty: true, shouldTouch: true },
           );
         }
@@ -2358,25 +2417,25 @@ export function SessionModal({
       targetIndex: number,
       configuredTarget: GoalTarget | null,
       prompt: { promptType: SessionPromptCount['prompt_type']; promptLevel: SessionPromptCount['prompt_level'] },
-      correct: boolean,
+      outcome: PromptOutcome,
     ) => {
       if (configuredTarget && responseRequiredMeasurementTypes.has(configuredTarget.measurement_type)) {
         recordResponseTrial(
           goalId,
           targetIndex,
           configuredTarget,
-          correct ? 'correct' : 'incorrect',
+          outcome,
           prompt,
         );
         return;
       }
 
-      const aggregateField = correct ? 'metric_value' : 'incorrect_trials';
-      bumpTrialCount(goalId, targetIndex, aggregateField, 1, null);
+      const aggregateField = outcome === 'correct' ? 'metric_value' : 'incorrect_trials';
+      bumpTrialCount(goalId, targetIndex, aggregateField, 1, null, outcome);
       const promptCountsPath =
         `session_note_goal_measurements.${goalId}.data.target_trials.${targetIndex}.prompt_counts` as const;
       const current = getValues(promptCountsPath) as SessionPromptCount[] | null | undefined;
-      setValue(promptCountsPath, incrementLegacyPromptCount(current, prompt, correct), {
+      setValue(promptCountsPath, incrementLegacyPromptCount(current, prompt, outcome), {
         shouldDirty: true,
         shouldTouch: true,
       });
@@ -2463,7 +2522,7 @@ export function SessionModal({
       const nextTargetTrials = Array.isArray(currentTargetTrials)
         ? currentTargetTrials.filter((_, index) => index !== targetIndex)
         : undefined;
-      setPromptCorrectByTargetId((current) =>
+      setPromptOutcomeByTargetId((current) =>
         remapLegacyPromptCorrectnessAfterRemoval(current, goalId, targetIndex, existingTargets.length));
       updateGoalTargets(goalId, nextTargets.length > 0 ? nextTargets : [''], nextTargetTrials);
     },
@@ -4109,6 +4168,7 @@ export function SessionModal({
                                       : targetIncorrectDisplay;
                                     const promptCorrectnessKey = configuredTarget?.id ??
                                       `legacy:${selectedGoalId}:${sourceIndex}`;
+                                    const promptOutcome = promptOutcomeByTargetId[promptCorrectnessKey] ?? 'correct';
                                     const targetOpportunitiesDisplay = getTargetTrialNullableValue(sourceIndex, 'opportunities');
                                     const targetTrialBoundsError = getCorrectTrialsOpportunityError(
                                       targetCorrectDisplay,
@@ -4262,21 +4322,38 @@ export function SessionModal({
                                                   </div>
                                                   <div className="mt-3 rounded-md border border-indigo-200 bg-white/80 p-2 dark:border-indigo-800 dark:bg-dark/70">
                                                     {shouldShowPromptCorrectnessToggle ? (
-                                                      <label className="flex min-h-10 items-center gap-2 text-xs font-medium text-gray-800 dark:text-gray-200">
-                                                        <input
-                                                          type="checkbox"
-                                                          checked={promptCorrectByTargetId[promptCorrectnessKey] ?? true}
-                                                          onChange={(event) => setPromptCorrectByTargetId((current) =>
-                                                            setPromptCorrectnessForTarget(
-                                                              current,
-                                                              promptCorrectnessKey,
-                                                              event.target.checked,
-                                                            ))}
-                                                          aria-label={`Prompted response was correct for target ${targetIndex + 1}: ${configuredTarget.name}`}
-                                                          className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                                                        />
-                                                        Prompted response was correct
-                                                      </label>
+                                                      <fieldset>
+                                                        <legend className="mb-2 text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-200">
+                                                          Prompt outcome
+                                                        </legend>
+                                                        <div
+                                                          className="flex flex-wrap gap-2"
+                                                          role="radiogroup"
+                                                          aria-label={`Prompt outcome for target ${targetIndex + 1}: ${configuredTarget.name}`}
+                                                        >
+                                                          {promptOutcomeOptions.map((option) => (
+                                                            <label
+                                                              key={option.value}
+                                                              className={[
+                                                                'flex min-h-10 min-w-[7rem] cursor-pointer items-center justify-center rounded-md border px-3 py-2 text-xs font-semibold transition',
+                                                                getPromptOutcomeSegmentClasses(promptOutcome === option.value, option.value),
+                                                              ].join(' ')}
+                                                            >
+                                                              <input
+                                                                type="radio"
+                                                                name={`prompt-outcome-${promptCorrectnessKey}`}
+                                                                value={option.value}
+                                                                checked={promptOutcome === option.value}
+                                                                onChange={() => setPromptOutcomeByTargetId((current) =>
+                                                                  setPromptOutcomeForTarget(current, promptCorrectnessKey, option.value))}
+                                                                aria-label={`${option.label} for target ${targetIndex + 1}: ${configuredTarget.name}`}
+                                                                className="sr-only"
+                                                              />
+                                                              {option.label}
+                                                            </label>
+                                                          ))}
+                                                        </div>
+                                                      </fieldset>
                                                     ) : null}
                                                     <div
                                                       className={`${shouldShowPromptCorrectnessToggle ? 'mt-2' : ''} flex flex-wrap gap-2`}
@@ -4294,7 +4371,7 @@ export function SessionModal({
                                                             sourceIndex,
                                                             configuredTarget,
                                                             { promptType: prompt.promptType, promptLevel: prompt.promptLevel },
-                                                            promptCorrectByTargetId[promptCorrectnessKey] ?? true,
+                                                            promptOutcome,
                                                           )}
                                                         >
                                                           {prompt.label}
@@ -4311,7 +4388,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Increase correct trials for target ${targetIndex + 1}`}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-600 text-lg font-bold text-white shadow-sm hover:bg-emerald-700"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', 1, configuredTarget)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', 1, configuredTarget, promptOutcome)}
                                               >
                                                 +
                                               </button>
@@ -4323,7 +4400,7 @@ export function SessionModal({
                                                 aria-label={`Decrease correct trials for target ${targetIndex + 1}`}
                                                 disabled={pendingCorrectDisplay < 1}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full border border-emerald-700 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-200"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -1, configuredTarget)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -1, configuredTarget, promptOutcome)}
                                               >
                                                 -
                                               </button>
@@ -4331,7 +4408,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Add 5 correct trials for target ${targetIndex + 1}`}
                                                 className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', 5, configuredTarget)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', 5, configuredTarget, promptOutcome)}
                                               >
                                                 +5
                                               </button>
@@ -4340,7 +4417,7 @@ export function SessionModal({
                                                 aria-label={`Subtract 5 correct trials for target ${targetIndex + 1}`}
                                                 disabled={pendingCorrectDisplay < 5}
                                                 className="rounded-md border border-emerald-200 bg-white px-2 py-1 text-[11px] font-semibold text-emerald-800 shadow-sm hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-emerald-800 dark:bg-dark-lighter dark:text-emerald-100 dark:hover:bg-emerald-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -5, configuredTarget)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'metric_value', -5, configuredTarget, promptOutcome)}
                                               >
                                                 -5
                                               </button>
@@ -4351,7 +4428,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Increase incorrect or no-response trials for target ${targetIndex + 1}`}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full bg-rose-600 text-lg font-bold text-white shadow-sm hover:bg-rose-700"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', 1, configuredTarget)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', 1, configuredTarget, promptOutcome)}
                                               >
                                                 +
                                               </button>
@@ -4363,7 +4440,7 @@ export function SessionModal({
                                                 aria-label={`Decrease incorrect trials for target ${targetIndex + 1}`}
                                                 disabled={pendingIncorrectDisplay < 1}
                                                 className="flex h-10 w-10 items-center justify-center rounded-full border border-rose-700 text-rose-700 hover:bg-rose-50 dark:border-rose-400 dark:text-rose-200"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -1, configuredTarget)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -1, configuredTarget, promptOutcome)}
                                               >
                                                 -
                                               </button>
@@ -4371,7 +4448,7 @@ export function SessionModal({
                                                 type="button"
                                                 aria-label={`Add 5 incorrect or no-response trials for target ${targetIndex + 1}`}
                                                 className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', 5, configuredTarget)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', 5, configuredTarget, promptOutcome)}
                                               >
                                                 +5
                                               </button>
@@ -4380,7 +4457,7 @@ export function SessionModal({
                                                 aria-label={`Subtract 5 incorrect trials for target ${targetIndex + 1}`}
                                                 disabled={pendingIncorrectDisplay < 5}
                                                 className="rounded-md border border-rose-200 bg-white px-2 py-1 text-[11px] font-semibold text-rose-800 shadow-sm hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-rose-800 dark:bg-dark-lighter dark:text-rose-100 dark:hover:bg-rose-950/40"
-                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -5, configuredTarget)}
+                                                onClick={() => bumpTrialCount(selectedGoalId, sourceIndex, 'incorrect_trials', -5, configuredTarget, promptOutcome)}
                                               >
                                                 -5
                                               </button>
@@ -4388,21 +4465,38 @@ export function SessionModal({
                                             {!configuredTarget ? (
                                             <div className="w-full rounded-md border border-indigo-200 bg-white/80 p-2 dark:border-indigo-800 dark:bg-dark/70">
                                               {shouldShowPromptCorrectnessToggle ? (
-                                                <label className="flex min-h-10 items-center gap-2 text-xs font-medium text-gray-800 dark:text-gray-200">
-                                                  <input
-                                                    type="checkbox"
-                                                    checked={promptCorrectByTargetId[promptCorrectnessKey] ?? true}
-                                                    onChange={(event) => setPromptCorrectByTargetId((current) =>
-                                                      setPromptCorrectnessForTarget(
-                                                        current,
-                                                        promptCorrectnessKey,
-                                                        event.target.checked,
-                                                      ))}
-                                                    aria-label={`Prompted response was correct for target ${targetIndex + 1}: ${targetValue}`}
-                                                    className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                                                  />
-                                                  Prompted response was correct
-                                                </label>
+                                                <fieldset>
+                                                  <legend className="mb-2 text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-200">
+                                                    Prompt outcome
+                                                  </legend>
+                                                  <div
+                                                    className="flex flex-wrap gap-2"
+                                                    role="radiogroup"
+                                                    aria-label={`Prompt outcome for target ${targetIndex + 1}: ${targetValue}`}
+                                                  >
+                                                    {promptOutcomeOptions.map((option) => (
+                                                      <label
+                                                        key={option.value}
+                                                        className={[
+                                                          'flex min-h-10 min-w-[7rem] cursor-pointer items-center justify-center rounded-md border px-3 py-2 text-xs font-semibold transition',
+                                                          getPromptOutcomeSegmentClasses(promptOutcome === option.value, option.value),
+                                                        ].join(' ')}
+                                                      >
+                                                        <input
+                                                          type="radio"
+                                                          name={`prompt-outcome-${promptCorrectnessKey}`}
+                                                          value={option.value}
+                                                          checked={promptOutcome === option.value}
+                                                          onChange={() => setPromptOutcomeByTargetId((current) =>
+                                                            setPromptOutcomeForTarget(current, promptCorrectnessKey, option.value))}
+                                                          aria-label={`${option.label} for target ${targetIndex + 1}: ${targetValue}`}
+                                                          className="sr-only"
+                                                        />
+                                                        {option.label}
+                                                      </label>
+                                                    ))}
+                                                  </div>
+                                                </fieldset>
                                               ) : null}
                                               <div
                                                 className={`${shouldShowPromptCorrectnessToggle ? 'mt-2' : ''} flex flex-wrap gap-2`}
@@ -4420,7 +4514,7 @@ export function SessionModal({
                                                       sourceIndex,
                                                       configuredTarget,
                                                       { promptType: prompt.promptType, promptLevel: prompt.promptLevel },
-                                                      promptCorrectByTargetId[promptCorrectnessKey] ?? true,
+                                                      promptOutcome,
                                                     )}
                                                   >
                                                     {prompt.label}
@@ -4481,11 +4575,6 @@ export function SessionModal({
                                   })}
                                 </div>
                               </div>
-                              {selectedGoal?.target_criteria?.trim() ? (
-                                <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
-                                  Current plan target: {selectedGoal.target_criteria}
-                                </p>
-                              ) : null}
                               <input
                                 type="hidden"
                                 {...register(targetFieldKey)}

--- a/src/components/__tests__/ClientSessionTrendsTab.test.tsx
+++ b/src/components/__tests__/ClientSessionTrendsTab.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, screen, waitFor } from '../../test/utils';
 import { renderWithProviders } from '../../test/utils';
 import { ClientSessionTrendsTab } from '../ClientDetails/ClientSessionTrendsTab';
 import { fetchClientSessionNotes } from '../../lib/session-notes';
+import { callApi } from '../../lib/api';
 import { supabase } from '../../lib/supabase';
 
 vi.mock('react-chartjs-2', () => ({
@@ -26,6 +27,25 @@ vi.mock('react-chartjs-2', () => ({
       </div>
     );
   }),
+  Bar: React.forwardRef(({
+    data,
+    options,
+  }: {
+    data: { labels: string[]; datasets: Array<{ label: string; data: Array<number | null> }> };
+    options?: { scales?: { y?: { max?: number } } };
+  }, ref) => {
+    if (ref && typeof ref !== 'function') {
+      ref.current = {
+        toBase64Image: vi.fn(() => 'data:image/png;base64,outcome-chart-image'),
+      };
+    }
+
+    return (
+      <div data-testid="prompt-outcomes-chart">
+        {data.labels.join(',')}:{data.datasets.map((dataset) => `${dataset.label}:${dataset.data.join('|')}`).join(';')}:yMax={options?.scales?.y?.max ?? 'unset'}
+      </div>
+    );
+  }),
 }));
 
 vi.mock('../../lib/session-notes', async () => {
@@ -35,6 +55,10 @@ vi.mock('../../lib/session-notes', async () => {
     fetchClientSessionNotes: vi.fn(),
   };
 });
+
+vi.mock('../../lib/api', () => ({
+  callApi: vi.fn(),
+}));
 
 const createGoalsBuilder = () => {
   const builder: any = {};
@@ -99,6 +123,70 @@ describe('ClientSessionTrendsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.setSystemTime(new Date('2025-06-30T12:00:00Z'));
+    vi.mocked(callApi).mockImplementation(async (path: string) => {
+      if (path === '/api/goal-targets?goal_id=goal-1') {
+        return new Response(JSON.stringify([
+          {
+            id: 'target-1',
+            organization_id: '5238e88b-6198-4862-80a2-dbe15bbeabdd',
+            client_id: 'client-1',
+            goal_id: 'goal-1',
+            name: 'lost in community',
+            measurement_type: 'correctIncorrect',
+            graph_config: { defaultChart: 'bar', source: 'trial_events' },
+            status: 'active',
+            sort_order: 0,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+          {
+            id: 'target-2',
+            organization_id: '5238e88b-6198-4862-80a2-dbe15bbeabdd',
+            client_id: 'client-1',
+            goal_id: 'goal-1',
+            name: 'cross street safely',
+            measurement_type: 'correctIncorrect',
+            graph_config: { defaultChart: 'bar', source: 'trial_events' },
+            status: 'active',
+            sort_order: 1,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ]), { status: 200 });
+      }
+      if (path.startsWith('/api/trial-events?view=prompt_outcomes&')) {
+        return new Response(JSON.stringify([
+          {
+            id: 'prompt-event-1',
+            session_id: 'session-1',
+            target_id: 'target-1',
+            goal_id: 'goal-1',
+            therapist_id: 'therapist-1',
+            response: 'correct',
+            event_timestamp: '2025-06-01T17:00:00.000Z',
+          },
+          {
+            id: 'prompt-event-2',
+            session_id: 'session-1',
+            target_id: 'target-2',
+            goal_id: 'goal-1',
+            therapist_id: 'therapist-1',
+            response: 'incorrect',
+            event_timestamp: '2025-06-01T17:05:00.000Z',
+          },
+          {
+            id: 'prompt-event-3',
+            session_id: 'session-2',
+            target_id: 'target-1',
+            goal_id: 'goal-1',
+            therapist_id: 'therapist-1',
+            response: 'noResponse',
+            event_timestamp: '2025-06-08T17:00:00.000Z',
+          },
+        ]), { status: 200 });
+      }
+      throw new Error(`Unhandled API path ${path}`);
+    });
     vi.mocked(fetchClientSessionNotes).mockResolvedValue([
       {
         id: 'note-1',
@@ -188,6 +276,23 @@ describe('ClientSessionTrendsTab', () => {
     expect(screen.getByRole('option', { name: 'Day' })).toBeInTheDocument();
     expect(screen.getByText('4')).toBeInTheDocument();
     expect(screen.getAllByText(/80%|100%/).length).toBeGreaterThan(0);
+    expect(await screen.findByTestId('prompt-outcomes-chart')).toHaveTextContent('Correct:33.3;Incorrect:33.3;No response:33.3:yMax=100');
+  });
+
+  it('fetches prompt outcomes with an exclusive end date and renders compact evidence counts', async () => {
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    await screen.findByTestId('prompt-outcomes-chart');
+
+    expect(callApi).toHaveBeenCalledWith(
+      '/api/trial-events?view=prompt_outcomes&client_id=client-1&goal_id=goal-1&start_at=2024-12-01T00%3A00%3A00.000Z&end_before=2025-07-01T00%3A00%3A00.000Z',
+    );
+    expect(screen.getByRole('button', { name: /Download outcome graph/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Correct' })).toBeInTheDocument();
+    expect(screen.getAllByText('cross street safely').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('1 (100%)').length).toBeGreaterThan(0);
   });
 
   it('renders each target as a separate chart series with distinct point symbols', async () => {
@@ -382,5 +487,49 @@ describe('ClientSessionTrendsTab', () => {
     });
 
     expect(await screen.findByText('No graphable trial data')).toBeInTheDocument();
+  });
+
+  it('renders prompt outcomes when the median chart has no graphable data', async () => {
+    vi.mocked(fetchClientSessionNotes).mockResolvedValue([
+      createSessionNote('1', '2025-06-01', []),
+      createSessionNote('2', '2025-06-08', []),
+    ]);
+
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    expect(await screen.findByText('No graphable trial data')).toBeInTheDocument();
+    expect(await screen.findByTestId('prompt-outcomes-chart')).toBeInTheDocument();
+  });
+
+  it('shows the exact prompt outcome empty copy', async () => {
+    const defaultCallApi = vi.mocked(callApi).getMockImplementation();
+    vi.mocked(callApi).mockImplementation(async (path: string) => (
+      path.startsWith('/api/trial-events?view=prompt_outcomes&')
+        ? new Response(JSON.stringify([]), { status: 200 })
+        : defaultCallApi!(path)
+    ));
+
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    expect(await screen.findByText('No prompted outcome data in the selected range.')).toBeInTheDocument();
+  });
+
+  it('surfaces a prompt outcome fetch error', async () => {
+    const defaultCallApi = vi.mocked(callApi).getMockImplementation();
+    vi.mocked(callApi).mockImplementation(async (path: string) => (
+      path.startsWith('/api/trial-events?view=prompt_outcomes&')
+        ? new Response(null, { status: 500 })
+        : defaultCallApi!(path)
+    ));
+
+    renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
+      auth: { role: 'admin', userId: 'admin-user-id' },
+    });
+
+    expect(await screen.findByText('Prompt outcomes failed to load.')).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -1309,12 +1309,14 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
               id: "trial-event-1",
               organization_id: ORG_ID,
               client_id: "client-1",
-              session_id: "session-1",
+              session_id: "session-2",
               target_id: "target-1",
               goal_id: "goal-1",
               therapist_id: "therapist-1",
               trial_number: 1,
-              response: null,
+              response: "correct",
+              prompt_type: "verbal",
+              prompt_level: "partial",
               value: 3,
               event_timestamp: "2026-02-11T00:30:00.000Z",
               metadata: {},
@@ -1330,12 +1332,14 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
               goal_id: "goal-1",
               therapist_id: "therapist-1",
               trial_number: 2,
-              response: null,
+              response: "noResponse",
+              prompt_type: "gesture",
+              prompt_level: "full",
               value: 5,
-              event_timestamp: "2026-02-11T17:05:00.000Z",
+              event_timestamp: "2026-02-12T17:05:00.000Z",
               metadata: {},
-              created_at: "2026-02-11T17:05:00.000Z",
-              updated_at: "2026-02-11T17:05:00.000Z",
+              created_at: "2026-02-12T17:05:00.000Z",
+              updated_at: "2026-02-12T17:05:00.000Z",
             },
           ]),
           { status: 200 },
@@ -1394,9 +1398,15 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     expect(within(trialTable).getByRole("columnheader", { name: "Result" })).toBeInTheDocument();
     expect(within(trialTable).getByText("1")).toBeInTheDocument();
     expect(within(trialTable).getByText("2")).toBeInTheDocument();
-    expect(within(trialTable).getAllByText("Feb 11")).toHaveLength(2);
+    expect(within(trialTable).getByText("Feb 11")).toBeInTheDocument();
+    expect(within(trialTable).getByText("Feb 12")).toBeInTheDocument();
     expect(within(trialTable).getByText("5")).toBeInTheDocument();
-    expect(within(trialTable).getAllByText("None recorded")).toHaveLength(2);
+    expect(within(trialTable).getByText("verbal / partial")).toBeInTheDocument();
+    expect(within(trialTable).getByText("gesture / full")).toBeInTheDocument();
+    expect(within(mandsProgress).getByText("Prompt outcomes")).toBeInTheDocument();
+    expect(within(mandsProgress).getByText("Correct 50% (1)")).toBeInTheDocument();
+    expect(within(mandsProgress).getByText("No response 50% (1)")).toBeInTheDocument();
+    expect(within(mandsProgress).getByTitle("Correct: 1 (50%)")).toBeInTheDocument();
 
     expect(await screen.findByText("Sustained engagement")).toBeInTheDocument();
     const engagementGraph = await screen.findByLabelText("Trial-event progress for Sustained engagement");

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -6,9 +6,11 @@ import {
   decrementLegacyPromptCounts,
   dedupeProgressionNotices,
   formatProgressionNotices,
+  incrementLegacyPromptCount,
   remapLegacyPromptCorrectnessAfterRemoval,
+  sumLegacyPromptCounts,
   selectSessionCaptureTargets,
-  setPromptCorrectnessForTarget,
+  setPromptOutcomeForTarget,
 } from '../SessionModal';
 import { supabase } from '../../lib/supabase';
 import { fetchLinkedClientSessionNoteForSession } from '../../lib/session-note-linked-fetch';
@@ -102,24 +104,39 @@ describe('SessionModal', () => {
     expect(selectSessionCaptureTargets([current, stale, archived], new Set(['stale']))).toEqual([current, stale]);
   });
 
-  it('keeps prompt correctness isolated by configured target', () => {
-    const current = { 'target-1': false, 'target-2': true };
-    expect(setPromptCorrectnessForTarget(current, 'target-1', true)).toEqual({
-      'target-1': true,
-      'target-2': true,
+  it('keeps prompt outcomes isolated by configured target', () => {
+    const current = { 'target-1': 'incorrect', 'target-2': 'noResponse' } as const;
+    expect(setPromptOutcomeForTarget(current, 'target-1', 'correct')).toEqual({
+      'target-1': 'correct',
+      'target-2': 'noResponse',
     });
+  });
+
+  it('increments legacy prompt counts using exact outcome buckets', () => {
+    expect(incrementLegacyPromptCount([], {
+      promptType: 'gesture',
+      promptLevel: null,
+    }, 'noResponse')).toEqual([
+      {
+        prompt_type: 'gesture',
+        prompt_level: null,
+        correct_trials: 0,
+        incorrect_trials: 0,
+        no_response_trials: 1,
+      },
+    ]);
   });
 
   it('keeps legacy prompt correctness aligned when an earlier target is removed', () => {
     expect(remapLegacyPromptCorrectnessAfterRemoval({
-      'legacy:goal-1:0': true,
-      'legacy:goal-1:1': false,
-      'legacy:goal-1:2': true,
-      configured: false,
+      'legacy:goal-1:0': 'correct',
+      'legacy:goal-1:1': 'incorrect',
+      'legacy:goal-1:2': 'noResponse',
+      configured: 'incorrect',
     }, 'goal-1', 0, 3)).toEqual({
-      'legacy:goal-1:0': false,
-      'legacy:goal-1:1': true,
-      configured: false,
+      'legacy:goal-1:0': 'incorrect',
+      'legacy:goal-1:1': 'noResponse',
+      configured: 'incorrect',
     });
   });
 
@@ -127,10 +144,29 @@ describe('SessionModal', () => {
     expect(decrementLegacyPromptCounts([
       { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 1, incorrect_trials: 0 },
       { prompt_type: 'gesture', prompt_level: null, correct_trials: 2, incorrect_trials: 1 },
-    ], 'correct_trials', 2)).toEqual([
+    ], 'correct_trials', 2, 'correct')).toEqual([
       { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 1, incorrect_trials: 0 },
       { prompt_type: 'gesture', prompt_level: null, correct_trials: 0, incorrect_trials: 1 },
     ]);
+  });
+
+  it('decrements legacy incorrect totals from the selected unsuccessful bucket first', () => {
+    expect(decrementLegacyPromptCounts([
+      { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 0, incorrect_trials: 1, no_response_trials: 1 },
+    ], 'incorrect_trials', 1, 'noResponse')).toEqual([
+      { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 0, incorrect_trials: 1 },
+    ]);
+    expect(decrementLegacyPromptCounts([
+      { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 0, incorrect_trials: 1, no_response_trials: 1 },
+    ], 'incorrect_trials', 1, 'incorrect')).toEqual([
+      { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 0, incorrect_trials: 0, no_response_trials: 1 },
+    ]);
+  });
+
+  it('treats no-response prompt counts as part of the legacy unsuccessful aggregate floor', () => {
+    expect(sumLegacyPromptCounts([
+      { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 0, incorrect_trials: 1, no_response_trials: 2 },
+    ], 'incorrect_trials')).toBe(3);
   });
 
   it('formats every progression outcome and incomplete-criteria warning', () => {
@@ -3340,13 +3376,19 @@ describe('SessionModal', () => {
       })).toBeInTheDocument();
     }
 
-    const correctness = screen.getByRole('checkbox', {
-      name: /Prompted response was correct for target 1/i,
+    const noResponseOutcome = screen.getByRole('radio', {
+      name: /^No response for target 1:/i,
     });
-    expect(correctness).toBeChecked();
+    const correctOutcome = screen.getByRole('radio', {
+      name: /^Correct for target 1:/i,
+    });
+    expect(correctOutcome).toBeChecked();
+    expect(correctOutcome.closest('label')).toHaveClass('bg-emerald-600');
+    expect(screen.getByText('Prompt outcome')).toBeInTheDocument();
 
-    await userEvent.click(correctness);
-    expect(correctness).not.toBeChecked();
+    await userEvent.click(noResponseOutcome);
+    expect(noResponseOutcome).toBeChecked();
+    expect(noResponseOutcome.closest('label')).toHaveClass('bg-amber-500');
     rerender(
       <SessionModal
         {...defaultProps}
@@ -3355,7 +3397,9 @@ describe('SessionModal', () => {
         session={{ ...session, id: 'session-task-analysis-trials-next' }}
       />,
     );
-    await waitFor(() => expect(correctness).toBeChecked());
+    await waitFor(() => expect(screen.getByRole('radio', {
+      name: /^Correct for target 1:/i,
+    })).toBeChecked());
 
     await userEvent.click(screen.getByRole('button', { name: /Record independent response for target 1/i }));
     await userEvent.click(screen.getByRole('button', { name: /Record prompted response for target 1/i }));
@@ -3364,7 +3408,7 @@ describe('SessionModal', () => {
         name: new RegExp(`Record ${label.toLowerCase()} prompt for target 1`, 'i'),
       }));
     }
-    await userEvent.click(correctness);
+    await userEvent.click(noResponseOutcome);
     await userEvent.click(screen.getByRole('button', {
       name: /Record partial physical prompt for target 1/i,
     }));
@@ -3389,7 +3433,7 @@ describe('SessionModal', () => {
       expect.objectContaining({ target_id: targetId, trial_number: 10, response: 'correct', prompt_type: 'model', prompt_level: null, expected_progression_version: 7 }),
       expect.objectContaining({ target_id: targetId, trial_number: 11, response: 'correct', prompt_type: 'visual', prompt_level: null, expected_progression_version: 7 }),
       expect.objectContaining({ target_id: targetId, trial_number: 12, response: 'correct', prompt_type: 'physical', prompt_level: 'full', expected_progression_version: 7 }),
-      expect.objectContaining({ target_id: targetId, trial_number: 13, response: 'incorrect', prompt_type: 'physical', prompt_level: 'partial', expected_progression_version: 7 }),
+      expect.objectContaining({ target_id: targetId, trial_number: 13, response: 'noResponse', prompt_type: 'physical', prompt_level: 'partial', expected_progression_version: 7 }),
     ]);
     expect(submitted.session_note_trial_events?.[0]).not.toHaveProperty('prompt_type');
     expect(submitted.session_note_trial_events?.[0]).not.toHaveProperty('prompt_level');
@@ -3399,7 +3443,7 @@ describe('SessionModal', () => {
   }, 15000);
 
   it.each(['scheduled', 'in_progress'] as const)(
-    'hides prompted response correctness controls during %s BT data-collection capture',
+    'shows prompt outcome controls during %s BT data-collection capture',
     async (status) => {
       const onSubmit = vi.fn().mockResolvedValue(undefined);
       const targetId = '88888888-8888-4888-8888-8888888888bt';
@@ -3490,9 +3534,11 @@ describe('SessionModal', () => {
 
       await userEvent.click(await screen.findByRole('button', { name: /Use plan target/i }));
 
-      expect(screen.queryByRole('checkbox', {
-        name: /Prompted response was correct for target 1/i,
-      })).not.toBeInTheDocument();
+      const correctOutcome = screen.getByRole('radio', {
+        name: /^Correct for target 1:/i,
+      });
+      expect(correctOutcome).toBeChecked();
+      expect(screen.getByText('Prompt outcome')).toBeInTheDocument();
       const promptLabels = [
         'full verbal',
         'partial verbal',
@@ -3520,9 +3566,9 @@ describe('SessionModal', () => {
           session={session}
         />,
       );
-      expect(await screen.findByRole('checkbox', {
-        name: /Prompted response was correct for target 1/i,
-      })).toBeInTheDocument();
+      expect(await screen.findByRole('radio', {
+        name: /^Correct for target 1:/i,
+      })).toBeChecked();
     },
     15000,
   );
@@ -3986,12 +4032,12 @@ describe('SessionModal', () => {
     fireEvent.change(targetFields[targetFields.length - 1], {
       target: { value: 'Target A' },
     });
-    expect(screen.queryByRole('checkbox', {
-      name: /Prompted response was correct for target 1: Target A/i,
-    })).not.toBeInTheDocument();
     expect(await screen.findByRole('button', {
       name: /Record full verbal prompt for target 1: Target A/i,
     })).toBeInTheDocument();
+    expect(screen.getByRole('radio', {
+      name: /^Correct for target 1: Target A$/i,
+    })).toBeChecked();
     const addTargetButtons = screen.getAllByRole('button', { name: /add target/i });
     await userEvent.click(addTargetButtons[addTargetButtons.length - 1]);
     const secondTargetFields = screen.getAllByLabelText(/^Target 2$/i);
@@ -4535,10 +4581,10 @@ describe('SessionModal', () => {
     expect(planTargetButton).toHaveTextContent(planTarget);
     expect(screen.queryByText(legacyFreeformTarget)).not.toBeInTheDocument();
 
-    const promptCorrectness = screen.getByRole('checkbox', {
-      name: /Prompted response was correct for target 1/i,
+    const noResponseOutcome = screen.getByRole('radio', {
+      name: /^No response for target 1:/i,
     });
-    expect(promptCorrectness).toBeChecked();
+    expect(screen.getByRole('radio', { name: /^Correct for target 1:/i })).toBeChecked();
     for (const label of ['full verbal', 'partial verbal', 'gesture', 'model', 'visual', 'full physical', 'partial physical']) {
       expect(screen.getByRole('button', {
         name: new RegExp(`Record ${label} prompt for target 1`, 'i'),
@@ -4555,7 +4601,7 @@ describe('SessionModal', () => {
     await userEvent.click(screen.getByRole('button', {
       name: /Record full verbal prompt for target 1/i,
     }));
-    await userEvent.click(promptCorrectness);
+    await userEvent.click(noResponseOutcome);
     await userEvent.click(screen.getByRole('button', {
       name: /Record gesture prompt for target 1/i,
     }));
@@ -4587,7 +4633,7 @@ describe('SessionModal', () => {
                   trial_prompt_note: 'Edited plan target prompt note',
                   prompt_counts: [
                     { prompt_type: 'verbal', prompt_level: 'full', correct_trials: 1, incorrect_trials: 0 },
-                    { prompt_type: 'gesture', prompt_level: null, correct_trials: 0, incorrect_trials: 1 },
+                    { prompt_type: 'gesture', prompt_level: null, correct_trials: 0, incorrect_trials: 0, no_response_trials: 1 },
                   ],
                 }),
               ],

--- a/src/lib/__tests__/goal-measurements.test.ts
+++ b/src/lib/__tests__/goal-measurements.test.ts
@@ -178,6 +178,61 @@ describe('goal-measurements helpers', () => {
     })]);
   });
 
+  it('preserves positive no-response prompt counts and folds them into derived incorrect totals', () => {
+    const normalized = normalizeGoalMeasurementEntry({
+      targets: ['Target'],
+      target_trials: [{
+        target: 'Target',
+        metric_value: 0,
+        incorrect_trials: 0,
+        prompt_counts: [
+          {
+            prompt_type: 'verbal',
+            prompt_level: 'full',
+            correct_trials: 1,
+            incorrect_trials: 0,
+            no_response_trials: 2,
+          },
+          {
+            prompt_type: 'gesture',
+            prompt_level: null,
+            correct_trials: 0,
+            incorrect_trials: 1,
+            no_response_trials: 0,
+          },
+          {
+            prompt_type: 'model',
+            prompt_level: null,
+            correct_trials: 0,
+            incorrect_trials: 0,
+            no_response_trials: -4,
+          },
+        ],
+      }],
+    });
+
+    expect(normalized?.data.target_trials).toEqual([expect.objectContaining({
+      metric_value: 1,
+      incorrect_trials: 3,
+      prompt_counts: [
+        {
+          prompt_type: 'verbal',
+          prompt_level: 'full',
+          correct_trials: 1,
+          incorrect_trials: 0,
+          no_response_trials: 2,
+        },
+        {
+          prompt_type: 'gesture',
+          prompt_level: null,
+          correct_trials: 0,
+          incorrect_trials: 1,
+        },
+      ],
+    })]);
+    expect(normalized?.data.incorrect_trials).toBe(3);
+  });
+
   it('builds a goal-scoped measurement entry with goal defaults', () => {
     expect(
       buildGoalMeasurementEntry(

--- a/src/lib/__tests__/trial-prompt-outcomes.test.ts
+++ b/src/lib/__tests__/trial-prompt-outcomes.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import type { GoalTarget, SessionNote, TrialEvent } from "../../types";
+import {
+  buildPromptOutcomeModel,
+  PROMPT_OUTCOME_LABELS,
+} from "../trial-prompt-outcomes";
+
+const goalId = "goal-1";
+const configuredTarget: GoalTarget = {
+  id: "target-1",
+  organization_id: "org-1",
+  client_id: "client-1",
+  goal_id: goalId,
+  name: "Mands for help",
+  measurement_type: "correctIncorrect",
+  graph_config: { defaultChart: "bar", source: "trial_events" },
+  status: "active",
+  sort_order: 0,
+  created_at: "2026-07-01T00:00:00.000Z",
+  updated_at: "2026-07-01T00:00:00.000Z",
+};
+
+const rawPromptEvent = (
+  id: string,
+  sessionId: string,
+  timestamp: string,
+  response: TrialEvent["response"],
+): TrialEvent => ({
+  id,
+  organization_id: "org-1",
+  client_id: "client-1",
+  session_id: sessionId,
+  target_id: configuredTarget.id,
+  goal_id: goalId,
+  therapist_id: "therapist-1",
+  trial_number: 1,
+  response,
+  prompt_type: "verbal",
+  prompt_level: "partial",
+  event_timestamp: timestamp,
+  metadata: {},
+  created_at: timestamp,
+  updated_at: timestamp,
+});
+
+const legacyNote = (
+  id: string,
+  date: string,
+  promptCounts: Array<{
+    prompt_type: "verbal" | "gesture" | "model" | "visual" | "physical";
+    prompt_level: "full" | "partial" | null;
+    correct_trials: number;
+    incorrect_trials: number;
+    no_response_trials?: number | null;
+  }>,
+): SessionNote => ({
+  id,
+  date,
+  start_time: "09:00:00",
+  end_time: "10:00:00",
+  service_code: "97153",
+  therapist_name: "Therapist One",
+  therapist_id: "therapist-1",
+  goals_addressed: ["Increase functional communication"],
+  goal_ids: [goalId],
+  goal_notes: null,
+  goal_measurements: {
+    [goalId]: {
+      version: 1,
+      data: {
+        measurement_type: "correctIncorrect",
+        targets: [configuredTarget.name],
+        target_trials: [
+          {
+            target: configuredTarget.name,
+            prompt_counts: promptCounts,
+          },
+        ],
+      },
+    },
+  },
+  session_id: id,
+  narrative: "Session note",
+  is_locked: false,
+  client_id: "client-1",
+  authorization_id: "auth-1",
+  organization_id: "org-1",
+});
+
+describe("buildPromptOutcomeModel", () => {
+  it("prefers raw configured prompt events over legacy prompt counts for the same session and target", () => {
+    const model = buildPromptOutcomeModel({
+      goalId,
+      displayPeriod: "day",
+      rawEvents: [
+        rawPromptEvent("event-1", "session-a", "2026-07-01T18:00:00.000Z", "correct"),
+        rawPromptEvent("event-2", "session-a", "2026-07-01T18:01:00.000Z", "noResponse"),
+      ],
+      sessionNotes: [
+        legacyNote("session-a", "2026-07-01", [
+          { prompt_type: "verbal", prompt_level: "partial", correct_trials: 7, incorrect_trials: 3, no_response_trials: 2 },
+        ]),
+      ],
+      targetLabelsById: { [configuredTarget.id]: configuredTarget.name },
+    });
+
+    expect(model.summary.total).toBe(2);
+    expect(model.summary.correct).toBe(1);
+    expect(model.summary.incorrect).toBe(0);
+    expect(model.summary.noResponse).toBe(1);
+    expect(model.evidence).toEqual([
+      expect.objectContaining({
+        sessionKey: "session-a",
+        targetLabel: "Mands for help",
+        source: "raw",
+        total: 2,
+      }),
+    ]);
+  });
+
+  it("merges legacy prompt counts when no configured prompt events exist and buckets them by week", () => {
+    const model = buildPromptOutcomeModel({
+      goalId,
+      displayPeriod: "week",
+      rawEvents: [],
+      sessionNotes: [
+        legacyNote("session-a", "2026-07-01", [
+          { prompt_type: "verbal", prompt_level: "partial", correct_trials: 2, incorrect_trials: 1, no_response_trials: 1 },
+        ]),
+        legacyNote("session-b", "2026-07-03", [
+          { prompt_type: "model", prompt_level: "full", correct_trials: 1, incorrect_trials: 2, no_response_trials: 0 },
+        ]),
+      ],
+      targetLabelsById: { [configuredTarget.id]: configuredTarget.name },
+    });
+
+    expect(model.buckets).toEqual([
+      expect.objectContaining({
+        key: "2026-06-29",
+        label: "Week of Jun 29",
+        total: 7,
+        correct: 3,
+        incorrect: 3,
+        noResponse: 1,
+      }),
+    ]);
+    expect(model.buckets[0].segments.map((segment) => segment.label)).toEqual([
+      PROMPT_OUTCOME_LABELS.correct,
+      PROMPT_OUTCOME_LABELS.incorrect,
+      PROMPT_OUTCOME_LABELS.noResponse,
+    ]);
+  });
+
+  it("keeps legacy prompt counts for unmatched targets even when another configured target has raw events", () => {
+    const model = buildPromptOutcomeModel({
+      goalId,
+      displayPeriod: "day",
+      rawEvents: [
+        rawPromptEvent("event-1", "session-a", "2026-07-01T18:00:00.000Z", "correct"),
+      ],
+      sessionNotes: [
+        {
+          ...legacyNote("session-a", "2026-07-01", [
+            { prompt_type: "verbal", prompt_level: "partial", correct_trials: 2, incorrect_trials: 0, no_response_trials: 0 },
+          ]),
+          goal_measurements: {
+            [goalId]: {
+              version: 1,
+              data: {
+                measurement_type: "correctIncorrect",
+                targets: [configuredTarget.name, "Cross street safely"],
+                target_trials: [
+                  { target: configuredTarget.name },
+                  {
+                    target: "Cross street safely",
+                    prompt_counts: [
+                      { prompt_type: "gesture", prompt_level: "full", correct_trials: 0, incorrect_trials: 1, no_response_trials: 1 },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+      targetLabelsById: { [configuredTarget.id]: configuredTarget.name },
+    });
+
+    expect(model.summary).toMatchObject({ correct: 1, incorrect: 1, noResponse: 1, total: 3 });
+    expect(model.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: "raw", targetLabel: "Mands for help", total: 1 }),
+        expect.objectContaining({ source: "legacy", targetLabel: "Cross street safely", total: 2 }),
+      ]),
+    );
+  });
+
+  it("drops raw prompt events that do not belong to a loaded session note", () => {
+    const model = buildPromptOutcomeModel({
+      goalId,
+      displayPeriod: "day",
+      rawEvents: [
+        rawPromptEvent("event-1", "missing-session", "2026-07-01T18:00:00.000Z", "correct"),
+      ],
+      sessionNotes: [],
+      targetLabelsById: { [configuredTarget.id]: configuredTarget.name },
+      requireSessionMembership: true,
+    });
+
+    expect(model.summary.total).toBe(0);
+    expect(model.evidence).toEqual([]);
+    expect(model.buckets).toEqual([]);
+  });
+
+  it("keeps raw prompt events when session membership is not required", () => {
+    const model = buildPromptOutcomeModel({
+      goalId,
+      displayPeriod: "day",
+      rawEvents: [
+        rawPromptEvent("event-1", "missing-session", "2026-07-01T18:00:00.000Z", "correct"),
+      ],
+      sessionNotes: [],
+      targetLabelsById: { [configuredTarget.id]: configuredTarget.name },
+    });
+
+    expect(model.summary.total).toBe(1);
+    expect(model.evidence).toEqual([
+      expect.objectContaining({
+        sessionKey: "missing-session",
+        source: "raw",
+        total: 1,
+      }),
+    ]);
+  });
+
+  it("keeps rows without prompt_type when the raw source is already prompt-only", () => {
+    const { prompt_type: _promptType, ...promptOutcomeEvent } = rawPromptEvent(
+      "event-1",
+      "session-1",
+      "2026-07-01T18:00:00.000Z",
+      "correct",
+    );
+    const model = buildPromptOutcomeModel({
+      goalId,
+      displayPeriod: "day",
+      rawEvents: [promptOutcomeEvent],
+      sessionNotes: [],
+      targetLabelsById: { [configuredTarget.id]: configuredTarget.name },
+      rawEventsArePromptOnly: true,
+    });
+
+    expect(model.summary).toMatchObject({ correct: 1, total: 1 });
+    expect(model.evidence).toEqual([
+      expect.objectContaining({ sessionKey: "session-1", source: "raw", total: 1 }),
+    ]);
+  });
+});

--- a/src/lib/goal-measurements.ts
+++ b/src/lib/goal-measurements.ts
@@ -78,12 +78,15 @@ const toNonNegativeSafeInteger = (value: unknown): number => {
 const addSafeCounts = (left: number, right: number): number =>
   Math.min(Number.MAX_SAFE_INTEGER, left + right);
 
+const sumPromptCountIncorrectTrials = (count: Pick<SessionPromptCount, 'incorrect_trials' | 'no_response_trials'>): number =>
+  addSafeCounts(count.incorrect_trials, toNonNegativeSafeInteger(count.no_response_trials));
+
 export const normalizePromptCounts = (value: unknown): SessionPromptCount[] => {
   if (!Array.isArray(value)) {
     return [];
   }
 
-  const totals = new Map<string, { correct: number; incorrect: number }>();
+  const totals = new Map<string, { correct: number; incorrect: number; noResponse: number }>();
   for (const entry of value) {
     if (!entry || typeof entry !== 'object') {
       continue;
@@ -96,16 +99,17 @@ export const normalizePromptCounts = (value: unknown): SessionPromptCount[] => {
       continue;
     }
     const key = `${canonical[0]}:${canonical[1] ?? ''}`;
-    const existing = totals.get(key) ?? { correct: 0, incorrect: 0 };
+    const existing = totals.get(key) ?? { correct: 0, incorrect: 0, noResponse: 0 };
     totals.set(key, {
       correct: addSafeCounts(existing.correct, toNonNegativeSafeInteger(source.correct_trials)),
       incorrect: addSafeCounts(existing.incorrect, toNonNegativeSafeInteger(source.incorrect_trials)),
+      noResponse: addSafeCounts(existing.noResponse, toNonNegativeSafeInteger(source.no_response_trials)),
     });
   }
 
   return canonicalPromptPairs.flatMap(([promptType, promptLevel]) => {
     const total = totals.get(`${promptType}:${promptLevel ?? ''}`);
-    if (!total || (total.correct === 0 && total.incorrect === 0)) {
+    if (!total || (total.correct === 0 && total.incorrect === 0 && total.noResponse === 0)) {
       return [];
     }
     return [{
@@ -113,6 +117,7 @@ export const normalizePromptCounts = (value: unknown): SessionPromptCount[] => {
       prompt_level: promptLevel,
       correct_trials: total.correct,
       incorrect_trials: total.incorrect,
+      ...(total.noResponse > 0 ? { no_response_trials: total.noResponse } : {}),
     }];
   });
 };
@@ -141,7 +146,7 @@ const normalizeTargetTrials = (
       const source = entry && typeof entry === 'object' ? entry as Record<string, unknown> : {};
       const promptCounts = normalizePromptCounts(source.prompt_counts);
       const promptedCorrect = promptCounts.reduce((total, count) => addSafeCounts(total, count.correct_trials), 0);
-      const promptedIncorrect = promptCounts.reduce((total, count) => addSafeCounts(total, count.incorrect_trials), 0);
+      const promptedIncorrect = promptCounts.reduce((total, count) => addSafeCounts(total, sumPromptCountIncorrectTrials(count)), 0);
       const sourceMetricValue = toOptionalNumber(source.metric_value ?? source.count ?? source.value);
       const sourceIncorrectTrials = toOptionalNumber(source.incorrect_trials ?? source.incorrectTrials);
       const trial: SessionTargetTrialData = {
@@ -167,7 +172,7 @@ const buildLegacyTargetTrial = (
 ): SessionTargetTrialData | null => {
   const promptCounts = normalizePromptCounts(sourceData.prompt_counts);
   const promptedCorrect = promptCounts.reduce((total, count) => addSafeCounts(total, count.correct_trials), 0);
-  const promptedIncorrect = promptCounts.reduce((total, count) => addSafeCounts(total, count.incorrect_trials), 0);
+  const promptedIncorrect = promptCounts.reduce((total, count) => addSafeCounts(total, sumPromptCountIncorrectTrials(count)), 0);
   const sourceMetricValue = toOptionalNumber(sourceData.metric_value ?? sourceData.count ?? sourceData.value);
   const sourceIncorrectTrials = toOptionalNumber(sourceData.incorrect_trials ?? sourceData.incorrectTrials);
   const trial: SessionTargetTrialData = {

--- a/src/lib/trial-prompt-outcomes.ts
+++ b/src/lib/trial-prompt-outcomes.ts
@@ -1,0 +1,328 @@
+import type { PromptOutcome, SessionNote, SessionPromptCount, TrialEvent } from "../types";
+import type { SessionTrendDisplayPeriod } from "./session-trends";
+
+export const PROMPT_OUTCOME_ORDER = ["correct", "incorrect", "noResponse"] as const satisfies ReadonlyArray<PromptOutcome>;
+
+export const PROMPT_OUTCOME_LABELS: Record<PromptOutcome, string> = {
+  correct: "Correct",
+  incorrect: "Incorrect",
+  noResponse: "No response",
+};
+
+export const PROMPT_OUTCOME_COLORS: Record<PromptOutcome, string> = {
+  correct: "#16a34a",
+  incorrect: "#dc2626",
+  noResponse: "#d97706",
+};
+
+type PromptOutcomeCounts = Record<PromptOutcome, number>;
+
+export interface PromptOutcomeEvidenceRow extends PromptOutcomeCounts {
+  sessionKey: string;
+  sessionDate: string;
+  therapistId: string | null;
+  therapistName: string;
+  targetKey: string;
+  targetLabel: string;
+  total: number;
+  source: "raw" | "legacy";
+}
+
+export interface PromptOutcomeBucket {
+  key: string;
+  label: string;
+  correct: number;
+  incorrect: number;
+  noResponse: number;
+  total: number;
+  segments: Array<{
+    outcome: PromptOutcome;
+    label: string;
+    value: number;
+    percentage: number;
+    color: string;
+  }>;
+}
+
+export interface PromptOutcomeModel {
+  summary: PromptOutcomeCounts & { total: number };
+  evidence: PromptOutcomeEvidenceRow[];
+  buckets: PromptOutcomeBucket[];
+}
+
+const emptyCounts = (): PromptOutcomeCounts => ({
+  correct: 0,
+  incorrect: 0,
+  noResponse: 0,
+});
+
+const addCount = (counts: PromptOutcomeCounts, outcome: PromptOutcome, value: number): PromptOutcomeCounts => ({
+  ...counts,
+  [outcome]: counts[outcome] + value,
+});
+
+const totalCounts = (counts: PromptOutcomeCounts): number =>
+  counts.correct + counts.incorrect + counts.noResponse;
+
+const toDate = (value: string): Date | null => {
+  const date = new Date(`${value}T00:00:00`);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const toLocalIsoDate = (date: Date): string =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+
+const getWeekStart = (date: Date): Date => {
+  const copy = new Date(date);
+  const day = copy.getDay();
+  const offset = day === 0 ? -6 : 1 - day;
+  copy.setDate(copy.getDate() + offset);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+};
+
+const formatBucketLabel = (date: Date, displayPeriod: SessionTrendDisplayPeriod): string => {
+  if (displayPeriod === "week") {
+    return `Week of ${new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(date)}`;
+  }
+  if (displayPeriod === "day") {
+    return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(date);
+  }
+  return new Intl.DateTimeFormat("en-US", { month: "short", year: "numeric" }).format(date);
+};
+
+const buildBucketParts = (
+  sessionDate: string,
+  displayPeriod: SessionTrendDisplayPeriod,
+): { key: string; label: string } | null => {
+  const date = toDate(sessionDate);
+  if (!date) {
+    return null;
+  }
+  if (displayPeriod === "week") {
+    const weekStart = getWeekStart(date);
+    return { key: toLocalIsoDate(weekStart), label: formatBucketLabel(weekStart, displayPeriod) };
+  }
+  if (displayPeriod === "day") {
+    return { key: toLocalIsoDate(date), label: formatBucketLabel(date, displayPeriod) };
+  }
+  const monthStart = new Date(date.getFullYear(), date.getMonth(), 1);
+  return {
+    key: `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`,
+    label: formatBucketLabel(monthStart, displayPeriod),
+  };
+};
+
+const normalizeTargetLabel = (value: string | null | undefined, fallback: string): string => {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : fallback;
+};
+
+const buildGoalTargetKey = (goalId: string, targetLabel: string): string =>
+  `${goalId}::${targetLabel.trim().toLowerCase()}`;
+
+const sumLegacyPromptCounts = (promptCounts: SessionPromptCount[] | null | undefined): PromptOutcomeCounts => {
+  return (promptCounts ?? []).reduce((counts, promptCount) => {
+    let nextCounts = counts;
+    if (promptCount.correct_trials > 0) {
+      nextCounts = addCount(nextCounts, "correct", promptCount.correct_trials);
+    }
+    if (promptCount.incorrect_trials > 0) {
+      nextCounts = addCount(nextCounts, "incorrect", promptCount.incorrect_trials);
+    }
+    const noResponseTrials = promptCount.no_response_trials ?? 0;
+    if (noResponseTrials > 0) {
+      nextCounts = addCount(nextCounts, "noResponse", noResponseTrials);
+    }
+    return nextCounts;
+  }, emptyCounts());
+};
+
+const formatTherapistName = (therapistId: string | null | undefined, therapistName: string | null | undefined): string => {
+  const trimmedName = therapistName?.trim();
+  if (trimmedName) {
+    return trimmedName;
+  }
+  return therapistId ? `Therapist ${therapistId.slice(0, 8)}` : "Unknown therapist";
+};
+
+const buildLegacyRows = (
+  sessionNotes: SessionNote[],
+  goalId: string,
+  targetLabelsById: Record<string, string>,
+): PromptOutcomeEvidenceRow[] => {
+  const targetIdsByLabel = new Map(
+    Object.entries(targetLabelsById).map(([targetId, targetLabel]) => [targetLabel.trim().toLowerCase(), targetId] as const),
+  );
+  const rows: PromptOutcomeEvidenceRow[] = [];
+
+  sessionNotes.forEach((note) => {
+    const measurement = note.goal_measurements?.[goalId]?.data;
+    const targetTrials = measurement?.target_trials ?? [];
+    targetTrials.forEach((trial, index) => {
+      const counts = sumLegacyPromptCounts(trial.prompt_counts);
+      const total = totalCounts(counts);
+      if (total === 0) {
+        return;
+      }
+      const targetLabel = normalizeTargetLabel(trial.target, measurement?.targets?.[index] ?? measurement?.target ?? "Target");
+      const matchedTargetId = targetIdsByLabel.get(targetLabel.trim().toLowerCase()) ?? null;
+      rows.push({
+        sessionKey: note.session_id ?? note.id,
+        sessionDate: note.date,
+        therapistId: note.therapist_id ?? null,
+        therapistName: formatTherapistName(note.therapist_id, note.therapist_name),
+        targetKey: matchedTargetId ? `target:${matchedTargetId}` : buildGoalTargetKey(goalId, targetLabel),
+        targetLabel,
+        source: "legacy",
+        total,
+        ...counts,
+      });
+    });
+  });
+
+  return rows;
+};
+
+const groupRawRows = (
+  rawEvents: TrialEvent[],
+  goalId: string,
+  sessionNotes: SessionNote[],
+  targetLabelsById: Record<string, string>,
+  requireSessionMembership: boolean,
+  rawEventsArePromptOnly: boolean,
+): PromptOutcomeEvidenceRow[] => {
+  const sessionNotesByKey = new Map(
+    sessionNotes.map((note) => [note.session_id ?? note.id, note] as const),
+  );
+  const grouped = new Map<string, PromptOutcomeEvidenceRow>();
+
+  rawEvents.forEach((event) => {
+    if ((!rawEventsArePromptOnly && !event.prompt_type) || !event.response || !PROMPT_OUTCOME_ORDER.includes(event.response as PromptOutcome)) {
+      return;
+    }
+    const note = sessionNotesByKey.get(event.session_id);
+    if (requireSessionMembership && !note) {
+      return;
+    }
+    const outcome = event.response as PromptOutcome;
+    const targetLabel = normalizeTargetLabel(targetLabelsById[event.target_id], "Configured target");
+    const targetKey = `target:${event.target_id}`;
+    const groupKey = `${event.session_id}:${targetKey}`;
+    const current = grouped.get(groupKey) ?? {
+      sessionKey: event.session_id,
+      sessionDate: note?.date ?? event.event_timestamp.slice(0, 10),
+      therapistId: note?.therapist_id ?? event.therapist_id ?? null,
+      therapistName: formatTherapistName(note?.therapist_id ?? event.therapist_id, note?.therapist_name),
+      targetKey,
+      targetLabel,
+      source: "raw" as const,
+      total: 0,
+      ...emptyCounts(),
+    };
+    const nextCounts = addCount(current, outcome, 1);
+    grouped.set(groupKey, {
+      ...current,
+      ...nextCounts,
+      total: totalCounts(nextCounts),
+    });
+  });
+
+  return Array.from(grouped.values());
+};
+
+export const buildPromptOutcomeModel = ({
+  goalId,
+  displayPeriod,
+  rawEvents,
+  sessionNotes,
+  targetLabelsById,
+  selectedTherapistId,
+  selectedTargetLabel,
+  requireSessionMembership,
+  rawEventsArePromptOnly,
+}: {
+  goalId: string;
+  displayPeriod: SessionTrendDisplayPeriod;
+  rawEvents: TrialEvent[];
+  sessionNotes: SessionNote[];
+  targetLabelsById?: Record<string, string>;
+  selectedTherapistId?: string | null;
+  selectedTargetLabel?: string | null;
+  requireSessionMembership?: boolean;
+  rawEventsArePromptOnly?: boolean;
+}): PromptOutcomeModel => {
+  const normalizedTargetLabels = targetLabelsById ?? {};
+  const rawRows = groupRawRows(
+    rawEvents,
+    goalId,
+    sessionNotes,
+    normalizedTargetLabels,
+    requireSessionMembership ?? false,
+    rawEventsArePromptOnly ?? false,
+  );
+  const rawKeys = new Set(rawRows.map((row) => `${row.sessionKey}:${row.targetKey}`));
+  const legacyRows = buildLegacyRows(sessionNotes, goalId, normalizedTargetLabels).filter((row) => !rawKeys.has(`${row.sessionKey}:${row.targetKey}`));
+
+  const mergedRows = [...rawRows, ...legacyRows]
+    .filter((row) => !selectedTherapistId || row.therapistId === selectedTherapistId)
+    .filter((row) => !selectedTargetLabel || row.targetLabel === selectedTargetLabel)
+    .sort((left, right) => {
+      const dateComparison = left.sessionDate.localeCompare(right.sessionDate);
+      if (dateComparison !== 0) {
+        return dateComparison;
+      }
+      return left.targetLabel.localeCompare(right.targetLabel);
+    });
+
+  const summary = mergedRows.reduce(
+    (counts, row) => ({
+      correct: counts.correct + row.correct,
+      incorrect: counts.incorrect + row.incorrect,
+      noResponse: counts.noResponse + row.noResponse,
+      total: counts.total + row.total,
+    }),
+    { ...emptyCounts(), total: 0 },
+  );
+
+  const groupedBuckets = new Map<string, PromptOutcomeBucket>();
+  mergedRows.forEach((row) => {
+    const bucketParts = buildBucketParts(row.sessionDate, displayPeriod);
+    if (!bucketParts) {
+      return;
+    }
+    const current = groupedBuckets.get(bucketParts.key) ?? {
+      key: bucketParts.key,
+      label: bucketParts.label,
+      correct: 0,
+      incorrect: 0,
+      noResponse: 0,
+      total: 0,
+      segments: [],
+    };
+    current.correct += row.correct;
+    current.incorrect += row.incorrect;
+    current.noResponse += row.noResponse;
+    current.total += row.total;
+    groupedBuckets.set(bucketParts.key, current);
+  });
+
+  const buckets = Array.from(groupedBuckets.values())
+    .sort((left, right) => left.key.localeCompare(right.key))
+    .map((bucket) => ({
+      ...bucket,
+      segments: PROMPT_OUTCOME_ORDER.map((outcome) => ({
+        outcome,
+        label: PROMPT_OUTCOME_LABELS[outcome],
+        value: bucket[outcome],
+        percentage: bucket.total > 0 ? Math.round((bucket[outcome] / bucket.total) * 1000) / 10 : 0,
+        color: PROMPT_OUTCOME_COLORS[outcome],
+      })),
+    }));
+
+  return {
+    summary,
+    evidence: mergedRows,
+    buckets,
+  };
+};

--- a/src/server/__tests__/trialEventsHandler.test.ts
+++ b/src/server/__tests__/trialEventsHandler.test.ts
@@ -53,6 +53,13 @@ const buildGetRequest = (query = `target_id=${TARGET_ID}`) =>
     method: "GET",
   });
 
+const buildPromptOutcomesRequest = (
+  query = `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+) =>
+  new Request(`http://localhost/api/trial-events?${query}`, {
+    method: "GET",
+  });
+
 const mockTargetAndSessionLookups = (measurementType = "frequency") => {
   vi.mocked(fetchJson)
     .mockResolvedValueOnce({
@@ -111,6 +118,20 @@ const mockSessionReadLookup = (clientId = CLIENT_ID) => {
       },
     ],
   });
+};
+
+const mockPromptOutcomesScopeLookups = () => {
+  vi.mocked(fetchJson)
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [{ id: CLIENT_ID }],
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [{ id: GOAL_ID, client_id: CLIENT_ID }],
+    });
 };
 
 describe("trialEventsHandler", () => {
@@ -233,6 +254,233 @@ describe("trialEventsHandler", () => {
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: "session_id and target_id must belong to the same client" });
     expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects client scope mixed with session or target anchors outside prompt outcome mode", async () => {
+    const response = await trialEventsHandler(buildGetRequest(`client_id=${CLIENT_ID}&target_id=${TARGET_ID}`));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "client_id cannot be combined with session_id or target_id unless view=prompt_outcomes",
+    });
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("rejects prompt outcome reads that mix client scope with target or session anchors", async () => {
+    const response = await trialEventsHandler(
+      buildPromptOutcomesRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z&target_id=${TARGET_ID}`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "view=prompt_outcomes cannot be combined with session_id or target_id",
+    });
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("rejects prompt outcome reads with invalid ranges before scope lookups", async () => {
+    const response = await trialEventsHandler(
+      buildPromptOutcomesRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-02T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "start_at must be before end_before" });
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [CLIENT_ID, GOAL_ID],
+    ["77777777-7777-4777-8777-777777777777", "88888888-8888-4888-8888-888888888888"],
+  ])("denies prompt outcome reads before privileged scope lookups regardless of requested ids", async (clientId, goalId) => {
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: false, upstreamError: false });
+
+    const response = await trialEventsHandler(
+      buildPromptOutcomesRequest(
+        `view=prompt_outcomes&client_id=${clientId}&goal_id=${goalId}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+      ),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+    expect(currentUserCanCaptureTrialEvent).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID, clientId);
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("returns a generic access error before privileged prompt outcome scope lookups", async () => {
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: false, upstreamError: true });
+
+    const response = await trialEventsHandler(buildPromptOutcomesRequest());
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "Unable to validate trial-event read access" });
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["nonexistent", []],
+    ["cross-client", [{ id: GOAL_ID, client_id: "77777777-7777-4777-8777-777777777777" }]],
+  ])("returns the same generic response for %s prompt outcome goals", async (_case, goalRows) => {
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: CLIENT_ID }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: goalRows,
+      });
+
+    const response = await trialEventsHandler(buildPromptOutcomesRequest());
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "goal_id is not in scope for this client" });
+    expect(fetchJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("loads prompt outcomes after service-role scope validation and final user-token read", async () => {
+    mockPromptOutcomesScopeLookups();
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [
+        {
+          id: "event-1",
+          session_id: SESSION_ID,
+          target_id: TARGET_ID,
+          goal_id: GOAL_ID,
+          therapist_id: THERAPIST_ID,
+          response: "correct",
+          event_timestamp: "2026-07-01T01:00:00.000Z",
+        },
+      ],
+    });
+
+    const response = await trialEventsHandler(buildPromptOutcomesRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([
+      {
+        id: "event-1",
+        session_id: SESSION_ID,
+        target_id: TARGET_ID,
+        goal_id: GOAL_ID,
+        therapist_id: THERAPIST_ID,
+        response: "correct",
+        event_timestamp: "2026-07-01T01:00:00.000Z",
+      },
+    ]);
+    expect(currentUserCanCaptureTrialEvent).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID, CLIENT_ID);
+    expect(vi.mocked(currentUserCanCaptureTrialEvent).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(fetchJson).mock.invocationCallOrder[0],
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining(`/rest/v1/clients?select=id&id=eq.${CLIENT_ID}&organization_id=eq.${ORG_ID}`),
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        }),
+      }),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining(
+        `/rest/v1/goals?select=id,client_id&id=eq.${GOAL_ID}&organization_id=eq.${ORG_ID}&client_id=eq.${CLIENT_ID}`,
+      ),
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        }),
+      }),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(
+        `/rest/v1/trial_events?select=id,session_id,target_id,goal_id,therapist_id,response,event_timestamp`,
+      ),
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          apikey: "anon-key",
+          Authorization: `Bearer ${ACCESS_TOKEN}`,
+        }),
+      }),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`organization_id=eq.${ORG_ID}`),
+      expect.any(Object),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`client_id=eq.${CLIENT_ID}`),
+      expect.any(Object),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`goal_id=eq.${GOAL_ID}`),
+      expect.any(Object),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`event_timestamp=gte.2026-07-01T00%3A00%3A00.000Z`),
+      expect.any(Object),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`event_timestamp=lt.2026-07-02T00%3A00%3A00.000Z`),
+      expect.any(Object),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`prompt_type=not.is.null`),
+      expect.any(Object),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`response=in.(correct%2Cincorrect%2CnoResponse)`),
+      expect.any(Object),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`limit=5001`),
+      expect.any(Object),
+    );
+  });
+
+  it("returns 422 when prompt outcome reads exceed the 5000 row cap", async () => {
+    mockPromptOutcomesScopeLookups();
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(fetchJson).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: Array.from({ length: 5001 }, (_, index) => ({
+        id: `event-${index + 1}`,
+        session_id: SESSION_ID,
+        target_id: TARGET_ID,
+        goal_id: GOAL_ID,
+        therapist_id: THERAPIST_ID,
+        response: "correct",
+        event_timestamp: "2026-07-01T01:00:00.000Z",
+      })),
+    });
+
+    const response = await trialEventsHandler(buildPromptOutcomesRequest());
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({ error: "Prompt outcome query exceeds 5000 events" });
   });
 
   it("denies trial-event creation before insert when caller cannot capture data for the client", async () => {

--- a/src/server/api/trial-events.ts
+++ b/src/server/api/trial-events.ts
@@ -58,6 +58,18 @@ type TrialEventReadScope = {
   clientId: string;
 };
 
+type PromptOutcomesQuery = {
+  clientId: string;
+  goalId: string;
+  startAt: string;
+  endBefore: string;
+};
+
+const promptOutcomeResponseValues = new Set(["correct", "incorrect", "noResponse"]);
+const maxPromptOutcomeWindowMs = 366 * 24 * 60 * 60 * 1000;
+const maxPromptOutcomeRows = 5000;
+const promptOutcomeFetchLimit = maxPromptOutcomeRows + 1;
+
 const buildHeaders = (anonKey: string, accessToken: string): Record<string, string> => ({
   "Content-Type": "application/json",
   apikey: anonKey,
@@ -100,6 +112,62 @@ const validateMeasurementPayload = (
   }
 
   return null;
+};
+
+const parsePromptOutcomesQuery = (url: URL): { value: PromptOutcomesQuery | null; error?: string } => {
+  const clientId = url.searchParams.get("client_id");
+  const goalId = url.searchParams.get("goal_id");
+  const startAt = url.searchParams.get("start_at");
+  const endBefore = url.searchParams.get("end_before");
+
+  if (!clientId) {
+    return { value: null, error: "client_id is required for view=prompt_outcomes" };
+  }
+  if (!goalId) {
+    return { value: null, error: "goal_id is required for view=prompt_outcomes" };
+  }
+  if (!startAt) {
+    return { value: null, error: "start_at is required for view=prompt_outcomes" };
+  }
+  if (!endBefore) {
+    return { value: null, error: "end_before is required for view=prompt_outcomes" };
+  }
+  if (!isUuid(clientId)) {
+    return { value: null, error: "client_id must be a valid UUID" };
+  }
+  if (!isUuid(goalId)) {
+    return { value: null, error: "goal_id must be a valid UUID" };
+  }
+
+  const startAtResult = z.string().datetime().safeParse(startAt);
+  if (!startAtResult.success) {
+    return { value: null, error: "start_at must be a valid ISO 8601 datetime" };
+  }
+  const endBeforeResult = z.string().datetime().safeParse(endBefore);
+  if (!endBeforeResult.success) {
+    return { value: null, error: "end_before must be a valid ISO 8601 datetime" };
+  }
+
+  const startAtMs = Date.parse(startAt);
+  const endBeforeMs = Date.parse(endBefore);
+  if (!Number.isFinite(startAtMs) || !Number.isFinite(endBeforeMs)) {
+    return { value: null, error: "start_at and end_before must be valid datetimes" };
+  }
+  if (startAtMs >= endBeforeMs) {
+    return { value: null, error: "start_at must be before end_before" };
+  }
+  if (endBeforeMs - startAtMs > maxPromptOutcomeWindowMs) {
+    return { value: null, error: "Prompt outcome query window cannot exceed 366 days" };
+  }
+
+  return {
+    value: {
+      clientId,
+      goalId,
+      startAt,
+      endBefore,
+    },
+  };
 };
 
 const resolveTrialEventReadScope = async (
@@ -184,8 +252,93 @@ export async function trialEventsHandler(request: Request): Promise<Response> {
 
   if (request.method === "GET") {
     const url = new URL(request.url);
+    const view = url.searchParams.get("view");
+    const clientId = url.searchParams.get("client_id");
     const sessionId = url.searchParams.get("session_id");
     const targetId = url.searchParams.get("target_id");
+
+    if (clientId && (sessionId || targetId) && view !== "prompt_outcomes") {
+      return json({ error: "client_id cannot be combined with session_id or target_id unless view=prompt_outcomes" }, 400);
+    }
+
+    if (view === "prompt_outcomes") {
+      if (sessionId || targetId) {
+        return json({ error: "view=prompt_outcomes cannot be combined with session_id or target_id" }, 400);
+      }
+
+      const promptOutcomesQuery = parsePromptOutcomesQuery(url);
+      if (!promptOutcomesQuery.value) {
+        return json({ error: promptOutcomesQuery.error ?? "Invalid prompt outcomes query" }, 400);
+      }
+
+      const { clientId, goalId, startAt, endBefore } = promptOutcomesQuery.value;
+      const canRead = await currentUserCanCaptureTrialEvent(accessToken, organizationId, clientId);
+      if (canRead.upstreamError) {
+        return json({ error: "Unable to validate trial-event read access" }, 502);
+      }
+      if (!canRead.allowed) {
+        return json({ error: "Forbidden" }, 403);
+      }
+      if (!serviceRoleHeaders) {
+        return json({ error: "Unable to validate trial-event read scope" }, 502);
+      }
+
+      const clientScopeResult = await fetchJson<Array<{ id: string }>>(
+        `${supabaseUrl}/rest/v1/clients?select=id&id=eq.${encodeURIComponent(
+          clientId,
+        )}&organization_id=eq.${encodeURIComponent(organizationId)}&limit=1`,
+        { method: "GET", headers: serviceRoleHeaders },
+      );
+      if (!clientScopeResult.ok) {
+        return json({ error: "Unable to validate trial-event client access" }, clientScopeResult.status || 500);
+      }
+      const clientInScope = Array.isArray(clientScopeResult.data) ? clientScopeResult.data[0] ?? null : null;
+      if (!clientInScope) {
+        return json({ error: "client_id is not in scope for this organization" }, 403);
+      }
+
+      const goalScopeResult = await fetchJson<Array<{ id: string; client_id: string }>>(
+        `${supabaseUrl}/rest/v1/goals?select=id,client_id&id=eq.${encodeURIComponent(
+          goalId,
+        )}&organization_id=eq.${encodeURIComponent(organizationId)}&client_id=eq.${encodeURIComponent(clientId)}&limit=1`,
+        { method: "GET", headers: serviceRoleHeaders },
+      );
+      if (!goalScopeResult.ok) {
+        return json({ error: "Unable to validate trial-event goal access" }, goalScopeResult.status || 500);
+      }
+      const goalInScope = Array.isArray(goalScopeResult.data) ? goalScopeResult.data[0] ?? null : null;
+      if (!goalInScope || goalInScope.client_id !== clientId) {
+        return json({ error: "goal_id is not in scope for this client" }, 403);
+      }
+
+      const filters = [
+        `select=id,session_id,target_id,goal_id,therapist_id,response,event_timestamp`,
+        `organization_id=eq.${encodeURIComponent(organizationId)}`,
+        `client_id=eq.${encodeURIComponent(clientId)}`,
+        `goal_id=eq.${encodeURIComponent(goalId)}`,
+        `event_timestamp=gte.${encodeURIComponent(startAt)}`,
+        `event_timestamp=lt.${encodeURIComponent(endBefore)}`,
+        "prompt_type=not.is.null",
+        `response=in.(${encodeURIComponent(Array.from(promptOutcomeResponseValues).join(","))})`,
+        "order=event_timestamp.asc,trial_number.asc",
+        `limit=${promptOutcomeFetchLimit}`,
+      ].join("&");
+
+      const result = await fetchJson(`${supabaseUrl}/rest/v1/trial_events?${filters}`, {
+        method: "GET",
+        headers,
+      });
+      if (!result.ok) {
+        return json({ error: "Failed to load prompt outcomes" }, result.status || 500);
+      }
+
+      const rows = Array.isArray(result.data) ? result.data : [];
+      if (rows.length > maxPromptOutcomeRows) {
+        return json({ error: "Prompt outcome query exceeds 5000 events" }, 422);
+      }
+      return json(rows);
+    }
+
     if (!sessionId && !targetId) {
       return json({ error: "session_id or target_id is required" }, 400);
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -538,12 +538,14 @@ export interface SessionTargetTrialData {
 
 export type SessionPromptType = 'verbal' | 'gesture' | 'model' | 'visual' | 'physical';
 export type SessionPromptLevel = 'full' | 'partial' | null;
+export type PromptOutcome = 'correct' | 'incorrect' | 'noResponse';
 
 export interface SessionPromptCount {
   prompt_type: SessionPromptType;
   prompt_level: SessionPromptLevel;
   correct_trials: number;
   incorrect_trials: number;
+  no_response_trials?: number | null;
 }
 
 export interface SessionGoalMeasurementEntry {


### PR DESCRIPTION
## Summary
- replace the BT prompt correctness checkbox with a sticky per-target Correct / Incorrect / No response radio selector
- preserve legacy combined unsuccessful counts while adding optional no_response_trials detail
- add a bounded, authorized, RLS-backed prompt-outcome read mode
- add aligned 100% stacked outcome charts to Programs & Goals and Client Session Trends

## Routing and safety
- Linear: WIN-233 (related to WIN-218 and WIN-183)
- classification: high-risk human-reviewed
- lane: critical
- no migration, RPC, RLS, role, grant, index, or progression SQL change
- hosted read-only EXPLAIN confirmed trial_events_org_client_time_idx is used
- code, security, and performance reviews: APPROVE

## Verification
Passed:
- affected Vitest suites: 6 files / 264 tests
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run validate:tenant
- npm run test:routes:tier0 (220 Cypress route tests)
- npm run build

Attempted / blocked:
- npm run test:ci fails outside the WIN-233 surface both before and after rebase: a Windows line-ending assertion, a local Blob.text() environment mismatch, and one additional broad-run failure hidden by verbose truncation. No affected WIN-233 suite failed.
- hosted Playwright is blocked locally because the target/persona/Supabase test credentials are unavailable; it remains required in PR CI.

## Human-review gate
This is a critical-lane protected server/API change. Do not merge without human approval and green required PR checks.