### PR TITLE
WIN-234: align prompt outcomes to session dates

### DIFF
--- a/docs/ai/WIN-234-session-date-outcomes-handoff.md
+++ b/docs/ai/WIN-234-session-date-outcomes-handoff.md
@@ -1,0 +1,46 @@
+# WIN-234 Handoff
+
+## Status
+
+Implementation and integrated specialist review are complete on `codex/win-234-session-date-outcomes`. The slice is ready for a human-reviewed PR with the repository-wide and browser gates called out below.
+
+## Accepted contract
+
+- Clinical analytics select prompt outcomes by session-note date.
+- Capture/audit timestamps remain unchanged.
+- Final event reads remain user-token/RLS backed and tenant scoped.
+- No database or frontend behavior change is authorized.
+
+## Verification card
+
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Change type: server/API integration and tenant-scoped clinical analytics read.
+- Required checks: focused tests, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run validate:tenant`, `npm run test:routes:tier0`, `npm run build`, `npm run ci:playwright`, and `npm run verify:local` when its prerequisites pass.
+- Executed checks:
+  - Baseline focused API/trend tests: pass, 52 tests.
+  - Final focused API/trend tests: pass, 54 tests.
+  - TDD regression: the late-entry/minimum-DTO test failed before the implementation and passed afterward; both non-midnight query tests failed before UTC-boundary validation and passed afterward.
+  - `npm run ci:check-focused`: pass; database-backed subchecks skipped because no local database URL was configured.
+  - `npm run lint`: pass.
+  - `npm run typecheck`: pass.
+  - `npm run validate:tenant`: pass.
+  - `npm run build`: pass.
+  - Read-only hosted Supabase schema, RLS/grant, cardinality, index, and `EXPLAIN` inspection: pass; the existing client/date index is used and no migration is required.
+  - Integrated code, test, security, and performance reviews: approve.
+- Blocked checks:
+  - `npm run test:ci`: fail outside this slice in `tests/scripts/playwright-iehp-assessment-import-smoke.test.ts` (line-ending-sensitive config assertion) and `src/lib/__tests__/supabase.edge.test.ts` (`Blob.text` is unavailable in the test runtime). Neither file is changed by WIN-234.
+  - `npm run test:routes:tier0`: local Cypress harness did not complete; one attempt raced the build, a Node 24 retry ended with `EPIPE`, and a Node 20 retry timed out. Require PR CI.
+  - `npm run ci:playwright`: not run because `npm run ci:playwright:env-readiness` reported all required hosted target/persona/runtime credentials missing. Require PR CI.
+  - `npm run verify:local`: blocked because its `test:ci` and tier-0 constituents are already failing or blocked as described above.
+- Result: `pass-with-blocked-checks` for the bounded WIN-234 behavior; human review and required PR CI remain mandatory.
+- Residual risk: the user-JWT PostgREST nested relationship query is covered by focused transport tests and hosted read-only query-plan inspection, but it has not been exercised end-to-end with a credentialed hosted persona in this worktree.
+
+## Review result
+
+- Specification: go; scope is limited to session-date analytics selection.
+- Architecture: approve; use one user-JWT/RLS-backed nested query and preserve capture timestamps.
+- Code review: approve after UTC day-boundary validation prevented silent datetime truncation.
+- Test review: approve; focused regression coverage is sufficient for the changed contract.
+- Security review: approve; organization, client, and goal validation and minimal response projection remain intact.
+- Performance review: approve after hosted `EXPLAIN` and relationship-cardinality evidence.

--- a/docs/ai/WIN-234-session-date-outcomes-plan.md
+++ b/docs/ai/WIN-234-session-date-outcomes-plan.md
@@ -1,0 +1,41 @@
+# WIN-234 Session-Date Prompt Outcome Selection
+
+## Routing
+
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Linear: [WIN-234](https://linear.app/winningedgeai/issue/WIN-234/align-prompt-outcome-analytics-to-clinical-session-dates)
+- Triggering path: `src/server/api/trial-events.ts`
+- Human approval, `verify-change`, and `pr-hygiene` are mandatory before merge.
+
+## Scope
+
+- Preserve `trial_events.event_timestamp` as capture and audit time.
+- Select `view=prompt_outcomes` rows by authorized `client_session_notes.session_date` membership.
+- Keep the final event read user-token/RLS backed and return the existing minimal DTO.
+- Add focused regressions for late-entered and UTC-boundary sessions.
+
+## Tenant boundary
+
+- The active organization, requested client, and requested goal must remain validated before the analytics read.
+- The final query must constrain both trial events and joined session notes to the same organization and client.
+- Nested session/note relationship data is filter-only and must not be returned.
+
+## Non-goals and stop conditions
+
+- No timestamp rewrite, backfill, capture change, schema, migration, RPC, RLS, grant, role, or index change.
+- No change to existing non-prompt trial-event GET modes, trend bucketing, or graph UI.
+- Stop if session-date selection cannot remain user-token/RLS backed or requires a database change.
+
+## Verification contract
+
+- Focused API and trend tests.
+- `npm run ci:check-focused`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:ci`
+- `npm run validate:tenant`
+- `npm run test:routes:tier0`
+- `npm run build`
+- `npm run ci:playwright` when hosted credentials are available; otherwise require PR CI.
+- Read-only hosted Supabase relationship, index, and query-plan verification.

--- a/src/server/__tests__/trialEventsHandler.test.ts
+++ b/src/server/__tests__/trialEventsHandler.test.ts
@@ -36,6 +36,8 @@ const GOAL_ID = "55555555-5555-4555-8555-555555555555";
 const THERAPIST_ID = "66666666-6666-4666-8666-666666666666";
 const SERVICE_ROLE_KEY = "service-role-key";
 const ORIGINAL_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const PROMPT_OUTCOMES_START_AT = "2026-07-01T00:00:00.000Z";
+const PROMPT_OUTCOMES_END_BEFORE = "2026-07-02T00:00:00.000Z";
 
 const buildPostRequest = () =>
   new Request("http://localhost/api/trial-events", {
@@ -54,7 +56,7 @@ const buildGetRequest = (query = `target_id=${TARGET_ID}`) =>
   });
 
 const buildPromptOutcomesRequest = (
-  query = `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+  query = `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=${PROMPT_OUTCOMES_START_AT}&end_before=${PROMPT_OUTCOMES_END_BEFORE}`,
 ) =>
   new Request(`http://localhost/api/trial-events?${query}`, {
     method: "GET",
@@ -293,6 +295,26 @@ describe("trialEventsHandler", () => {
   });
 
   it.each([
+    ["2026-07-01T12:00:00.000Z", "2026-07-02T00:00:00.000Z"],
+    ["2026-07-01T00:00:00.000Z", "2026-07-02T12:00:00.000Z"],
+  ])("rejects prompt outcome reads whose date range is not aligned to UTC day boundaries", async (startAt, endBefore) => {
+    vi.mocked(currentUserCanCaptureTrialEvent).mockResolvedValue({ allowed: false, upstreamError: false });
+
+    const response = await trialEventsHandler(
+      buildPromptOutcomesRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=${startAt}&end_before=${endBefore}`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "start_at and end_before must be UTC day boundaries at 00:00:00.000Z",
+    });
+    expect(currentUserCanCaptureTrialEvent).not.toHaveBeenCalled();
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it.each([
     [CLIENT_ID, GOAL_ID],
     ["77777777-7777-4777-8777-777777777777", "88888888-8888-4888-8888-888888888888"],
   ])("denies prompt outcome reads before privileged scope lookups regardless of requested ids", async (clientId, goalId) => {
@@ -358,15 +380,23 @@ describe("trialEventsHandler", () => {
           goal_id: GOAL_ID,
           therapist_id: THERAPIST_ID,
           response: "correct",
-          event_timestamp: "2026-07-01T01:00:00.000Z",
+          event_timestamp: "2026-07-02T07:30:00.000Z",
+          sessions: {
+            client_session_notes: [
+              {
+                session_date: "2026-07-01",
+              },
+            ],
+          },
         },
       ],
     });
 
     const response = await trialEventsHandler(buildPromptOutcomesRequest());
+    const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual([
+    expect(payload).toEqual([
       {
         id: "event-1",
         session_id: SESSION_ID,
@@ -374,7 +404,7 @@ describe("trialEventsHandler", () => {
         goal_id: GOAL_ID,
         therapist_id: THERAPIST_ID,
         response: "correct",
-        event_timestamp: "2026-07-01T01:00:00.000Z",
+        event_timestamp: "2026-07-02T07:30:00.000Z",
       },
     ]);
     expect(currentUserCanCaptureTrialEvent).toHaveBeenCalledWith(ACCESS_TOKEN, ORG_ID, CLIENT_ID);
@@ -408,7 +438,7 @@ describe("trialEventsHandler", () => {
     expect(fetchJson).toHaveBeenNthCalledWith(
       3,
       expect.stringContaining(
-        `/rest/v1/trial_events?select=id,session_id,target_id,goal_id,therapist_id,response,event_timestamp`,
+        `/rest/v1/trial_events?select=id,session_id,target_id,goal_id,therapist_id,response,event_timestamp,sessions!inner(client_session_notes!inner(session_date))`,
       ),
       expect.objectContaining({
         method: "GET",
@@ -435,12 +465,22 @@ describe("trialEventsHandler", () => {
     );
     expect(fetchJson).toHaveBeenNthCalledWith(
       3,
-      expect.stringContaining(`event_timestamp=gte.2026-07-01T00%3A00%3A00.000Z`),
+      expect.stringContaining(`sessions.client_session_notes.organization_id=eq.${ORG_ID}`),
       expect.any(Object),
     );
     expect(fetchJson).toHaveBeenNthCalledWith(
       3,
-      expect.stringContaining(`event_timestamp=lt.2026-07-02T00%3A00%3A00.000Z`),
+      expect.stringContaining(`sessions.client_session_notes.client_id=eq.${CLIENT_ID}`),
+      expect.any(Object),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`sessions.client_session_notes.session_date=gte.2026-07-01`),
+      expect.any(Object),
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining(`sessions.client_session_notes.session_date=lt.2026-07-02`),
       expect.any(Object),
     );
     expect(fetchJson).toHaveBeenNthCalledWith(
@@ -458,6 +498,9 @@ describe("trialEventsHandler", () => {
       expect.stringContaining(`limit=5001`),
       expect.any(Object),
     );
+    expect(vi.mocked(fetchJson).mock.calls[2]?.[0]).not.toContain("event_timestamp=gte");
+    expect(vi.mocked(fetchJson).mock.calls[2]?.[0]).not.toContain("event_timestamp=lt");
+    expect(payload[0]).not.toHaveProperty("sessions");
   });
 
   it("returns 422 when prompt outcome reads exceed the 5000 row cap", async () => {

--- a/src/server/api/trial-events.ts
+++ b/src/server/api/trial-events.ts
@@ -70,6 +70,17 @@ const maxPromptOutcomeWindowMs = 366 * 24 * 60 * 60 * 1000;
 const maxPromptOutcomeRows = 5000;
 const promptOutcomeFetchLimit = maxPromptOutcomeRows + 1;
 
+type PromptOutcomeRow = {
+  id: string;
+  session_id: string;
+  target_id: string;
+  goal_id: string;
+  therapist_id: string;
+  response: string | null;
+  event_timestamp: string;
+  sessions?: unknown;
+};
+
 const buildHeaders = (anonKey: string, accessToken: string): Record<string, string> => ({
   "Content-Type": "application/json",
   apikey: anonKey,
@@ -87,6 +98,11 @@ const buildServiceRoleHeaders = (): Record<string, string> | null => {
     Authorization: `Bearer ${serviceRoleKey}`,
   };
 };
+
+const toUtcDateString = (value: string): string => new Date(value).toISOString().slice(0, 10);
+
+const isUtcDayBoundary = (value: string): boolean =>
+  new Date(value).toISOString().endsWith("T00:00:00.000Z");
 
 const validateMeasurementPayload = (
   measurementType: string,
@@ -158,6 +174,9 @@ const parsePromptOutcomesQuery = (url: URL): { value: PromptOutcomesQuery | null
   }
   if (endBeforeMs - startAtMs > maxPromptOutcomeWindowMs) {
     return { value: null, error: "Prompt outcome query window cannot exceed 366 days" };
+  }
+  if (!isUtcDayBoundary(startAt) || !isUtcDayBoundary(endBefore)) {
+    return { value: null, error: "start_at and end_before must be UTC day boundaries at 00:00:00.000Z" };
   }
 
   return {
@@ -311,13 +330,18 @@ export async function trialEventsHandler(request: Request): Promise<Response> {
         return json({ error: "goal_id is not in scope for this client" }, 403);
       }
 
+      const startDate = toUtcDateString(startAt);
+      const endDate = toUtcDateString(endBefore);
+
       const filters = [
-        `select=id,session_id,target_id,goal_id,therapist_id,response,event_timestamp`,
+        `select=id,session_id,target_id,goal_id,therapist_id,response,event_timestamp,sessions!inner(client_session_notes!inner(session_date))`,
         `organization_id=eq.${encodeURIComponent(organizationId)}`,
         `client_id=eq.${encodeURIComponent(clientId)}`,
         `goal_id=eq.${encodeURIComponent(goalId)}`,
-        `event_timestamp=gte.${encodeURIComponent(startAt)}`,
-        `event_timestamp=lt.${encodeURIComponent(endBefore)}`,
+        `sessions.client_session_notes.organization_id=eq.${encodeURIComponent(organizationId)}`,
+        `sessions.client_session_notes.client_id=eq.${encodeURIComponent(clientId)}`,
+        `sessions.client_session_notes.session_date=gte.${encodeURIComponent(startDate)}`,
+        `sessions.client_session_notes.session_date=lt.${encodeURIComponent(endDate)}`,
         "prompt_type=not.is.null",
         `response=in.(${encodeURIComponent(Array.from(promptOutcomeResponseValues).join(","))})`,
         "order=event_timestamp.asc,trial_number.asc",
@@ -332,11 +356,21 @@ export async function trialEventsHandler(request: Request): Promise<Response> {
         return json({ error: "Failed to load prompt outcomes" }, result.status || 500);
       }
 
-      const rows = Array.isArray(result.data) ? result.data : [];
+      const rows = Array.isArray(result.data) ? (result.data as PromptOutcomeRow[]) : [];
       if (rows.length > maxPromptOutcomeRows) {
         return json({ error: "Prompt outcome query exceeds 5000 events" }, 422);
       }
-      return json(rows);
+      return json(
+        rows.map(({ id, session_id, target_id, goal_id, therapist_id, response, event_timestamp }) => ({
+          id,
+          session_id,
+          target_id,
+          goal_id,
+          therapist_id,
+          response,
+          event_timestamp,
+        })),
+      );
     }
 
     if (!sessionId && !targetId) {


### PR DESCRIPTION
## Summary
- select prompt outcomes by the clinical session-note date instead of the trial capture timestamp
- preserve `event_timestamp` as audit metadata and keep the final event read user-JWT/RLS backed
- reject non-UTC-midnight analytics bounds to avoid silently truncating arbitrary datetimes
- strip nested relationship data from the existing minimal response DTO

## Routing and risk
- Linear: WIN-234
- classification: high-risk human-reviewed
- lane: critical (`src/server/api/trial-events.ts`)
- no schema, migration, RLS, grant, RPC, index, capture, or graph UI changes
- human approval is required before merge

## Verification
Passed locally:
- focused API + trends: 54/54
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`
- read-only hosted schema/RLS/index/EXPLAIN inspection
- code, test, security, and performance reviews

Blocked/local-environment evidence:
- `npm run test:ci` reaches two unrelated existing failures: the IEHP Supabase config assertion is line-ending-sensitive, and the PDF edge test runtime lacks `Blob.text`; neither failing file is changed here
- tier-0 Cypress did not complete locally (build race, Node 24 `EPIPE`, then Node 20 timeout); require PR CI
- Playwright readiness reports required hosted target/persona/runtime credentials missing; require PR CI
- `npm run verify:local` is consequently blocked by its `test:ci` and tier-0 constituents

## Hosted query proof
The user-JWT nested PostgREST read remains tenant scoped. A read-only hosted `EXPLAIN` used the existing client/date session-note index plus primary/unique-key lookups; no migration or new index is required.

## Residual risk
The exact hosted JWT-backed REST call could not be exercised locally without a credentialed smoke persona. Focused transport tests and read-only hosted query-plan/RLS evidence cover the bounded contract; PR CI and human review remain mandatory.