### PR TITLE
WIN-236 Add IEHP 300 DPI scan matrix case

### DIFF
--- a/.github/workflows/iehp-pdf-mini-matrix-proof.yml
+++ b/.github/workflows/iehp-pdf-mini-matrix-proof.yml
@@ -373,6 +373,7 @@ jobs:
               'clean-single-page',
               'multi-page-target-content',
               'alternate-document-phone-format',
+              'scan-300dpi-monochrome',
               'skills-behaviors-proof',
             ];
             const matrixCases = objects
@@ -387,8 +388,8 @@ jobs:
               });
             const aggregate = objects.find((entry) => entry?.mode === 'pdf-mini-matrix');
 
-            if (matrixCases.length !== 4) {
-              throw new Error(`Expected exactly four case evidence objects but found ${matrixCases.length}.`);
+            if (matrixCases.length !== 5) {
+              throw new Error(`Expected exactly five case evidence objects but found ${matrixCases.length}.`);
             }
             if (!aggregate) {
               throw new Error('Missing aggregate matrix evidence.');
@@ -413,14 +414,14 @@ jobs:
             if (rawPhonePattern.test(JSON.stringify(matrixCases))) {
               throw new Error('Curated matrix evidence contained a raw phone number.');
             }
-            if (aggregate.totalCases !== 4) {
-              throw new Error(`Expected aggregate totalCases to equal 4 but received ${aggregate.totalCases}.`);
+            if (aggregate.totalCases !== 5) {
+              throw new Error(`Expected aggregate totalCases to equal 5 but received ${aggregate.totalCases}.`);
             }
-            if (aggregate.passedCases !== 4) {
-              throw new Error(`Expected aggregate passedCases to equal 4 but received ${aggregate.passedCases}.`);
+            if (aggregate.passedCases !== 5) {
+              throw new Error(`Expected aggregate passedCases to equal 5 but received ${aggregate.passedCases}.`);
             }
-            if (aggregate.cleanupVerifiedCases !== 4) {
-              throw new Error(`Expected aggregate cleanupVerifiedCases to equal 4 but received ${aggregate.cleanupVerifiedCases}.`);
+            if (aggregate.cleanupVerifiedCases !== 5) {
+              throw new Error(`Expected aggregate cleanupVerifiedCases to equal 5 but received ${aggregate.cleanupVerifiedCases}.`);
             }
             if (aggregate.skillsBehaviorsVerifiedCases !== 1) {
               throw new Error(`Expected aggregate skillsBehaviorsVerifiedCases to equal 1 but received ${aggregate.skillsBehaviorsVerifiedCases}.`);

--- a/docs/ai/WIN-236-iehp-300dpi-scan-handoff.md
+++ b/docs/ai/WIN-236-iehp-300dpi-scan-handoff.md
@@ -25,6 +25,8 @@
 
 - RED: focused tests failed on the missing fourth case, missing raster generation path, and the workflow's four-case evidence contract (`6` slice-specific failures).
 - GREEN: helper/workflow tests passed (`29/29`); runner structure tests passed (`6/6`); `npm run typecheck` passed.
+- Hosted follow-up RED: run `29876647651` reached the scan case and failed before upload with `page.evaluate: ReferenceError: __name is not defined`; a focused regression then failed on the nested helper that `tsx` serialized into the browser context.
+- Hosted follow-up GREEN: the browser callback now uses `HTMLImageElement.decode()` without a nested transpiled helper; runner structure tests passed (`6/6`) and typecheck passed before the immutable rerun.
 - The full runner test file also exposes an unchanged Windows line-ending baseline assertion in `supabase/config.toml`; the narrowed changed-surface runner tests are green.
 
 ## Verification Card
@@ -44,7 +46,7 @@
   - focused rerun of an earlier load-sensitive deployment-bundle timeout -> pass (`1/1`)
   - `npm run verify:local` -> policy, lint, and typecheck passed; stopped at the same aggregate baseline boundary before coverage/build/tier-0 continuation
 - blocked checks:
-  - hosted five-case proof -> pending immutable preview deployment and owner-approved workflow dispatch for PR `#830`
+  - hosted five-case proof -> pending owner-approved rerun against the corrected PR `#830` head
 - result: `pass-with-blocked-checks`
 - residual risk: local tests prove fixture shape and orchestration, but only the hosted run can prove that deployed extraction handles an image-only PDF and still cleans every upload
 

--- a/docs/ai/WIN-236-iehp-300dpi-scan-handoff.md
+++ b/docs/ai/WIN-236-iehp-300dpi-scan-handoff.md
@@ -1,0 +1,90 @@
+# WIN-236 — IEHP 300 DPI scanned PDF mini-matrix handoff
+
+- Date: July 21, 2026
+- Linear: `WIN-236`
+- Branch: `codex/win-236-iehp-300dpi-scan`
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Triggering paths: `.github/workflows/iehp-pdf-mini-matrix-proof.yml`, `scripts/lib/iehp-assessment-import-smoke.ts`, `scripts/playwright-iehp-assessment-import-smoke.ts`, and their focused tests
+- Protected boundary: `.github/workflows/iehp-pdf-mini-matrix-proof.yml`; human review is required before merge
+
+## Route-task Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- rationale: the new scan case widens the hosted PDF mini-matrix contract and therefore touches the protected owner-dispatched workflow and its curated evidence counts
+- allowed files: the IEHP smoke helper, the IEHP Playwright smoke runner, the narrowest focused tests, the hosted matrix workflow contract, and this handoff
+- stop conditions: any parser/OCR/server/API/Supabase/auth/runtime-config/migration/secret/production-data change
+
+## Scope
+
+- Add one deterministic synthetic `scan-300dpi-monochrome` PDF mini-matrix case.
+- Generate that case at runtime as a 2550x3300 rasterized black-and-white JPEG-backed Letter PDF with no live data.
+- Preserve existing assessor-phone snapshot precedence assertions, referral-date assertions, extracted status assertions, zero-draft assertions, and unconditional document/storage cleanup.
+- Widen the hosted matrix workflow and workflow-contract test from four to five total cases so curated evidence stays exact.
+
+## Non-goals
+
+- No parser or OCR changes.
+- No new extraction fields.
+- No server/API/Supabase/auth/workflow-secret changes.
+- No production data, PHI, or real phone numbers.
+- No broad smoke-framework refactor.
+
+## Test-first Evidence
+
+- RED:
+  - `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts` failed `4/26` because `IEHP_PDF_MINI_MATRIX_CASES` still had only three cases and no scan metadata.
+  - `npm test -- tests/scripts/playwright-iehp-assessment-import-smoke.test.ts tests/workflows/iehp-pdf-mini-matrix-proof.test.ts` failed the smoke structure assertion because the `raster-scan` generation branch was missing.
+- GREEN:
+  - `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts` passed `26/26`.
+  - `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts tests/workflows/iehp-pdf-mini-matrix-proof.test.ts` passed `29/29`.
+  - `npm run test -- tests/scripts/playwright-iehp-assessment-import-smoke.test.ts` now passes the new scan-branch structure assertion; the only remaining failure in that file is the unchanged baseline `supabase/config.toml` expectation outside this slice.
+
+## Verification Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- change type:
+  - CI/workflow/policy
+  - test harness / Playwright smoke runner
+- required checks:
+  - focused script/workflow tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run verify:local`
+  - hosted `npm run playwright:iehp-assessment-import-pdf-mini-matrix` against the protected preview workflow
+- executed checks:
+  - `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts` -> pass (`26/26`)
+  - `npm test -- tests/scripts/playwright-iehp-assessment-import-smoke.test.ts` -> fail on one unchanged baseline assertion in `selectConfiguredSmokeClient > keeps both CI IEHP proofs on the generated super-admin and unconditional cleanup path`; the new scan-branch structure assertion passed
+  - `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts tests/workflows/iehp-pdf-mini-matrix-proof.test.ts` -> pass (`29/29`)
+  - `npm run ci:check-focused` -> pass; branch-protection, DB grant, and auth-parity probes skipped outside CI as reported by the command
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm run build` -> pass
+  - `npm run test:ci` -> fail outside this slice on:
+    - `tests/ci/deploy-session-edge-bundle.test.ts` timeout
+    - `src/lib/__tests__/ai-documentation.test.ts` fetch/null-text baseline
+    - Vitest coverage temp-file `ENOENT` under `coverage/.tmp`
+  - `npm run verify:local` -> fail at its `test:ci` stage on the same unrelated `deploy-session-edge-bundle`, `ai-documentation`, and coverage-temp-file failures; upstream policy, lint, and typecheck stages passed
+- blocked checks:
+  - local hosted smoke command -> blocked because `PW_BASE_URL`, `PW_SUPERADMIN_EMAIL`, `PW_SUPERADMIN_PASSWORD`, `PW_ASSESSMENT_CLIENT_ID`, `SUPABASE_URL`, and `SUPABASE_ANON_KEY` are all missing from the current process
+- result: `pass-with-blocked-checks`
+- residual risk: local structure tests prove the new synthetic scan path and workflow contract, but only the hosted workflow can prove the current extraction stack actually handles the rasterized PDF end-to-end
+
+## Review
+
+- `code-review-engineer`: completed; no blocking findings. Noted only a low-severity maintainability follow-up to derive workflow case-count guards from `expectedCaseIds.length`.
+- `test-engineer`: requested but did not return findings before interruption.
+- `security-engineer`: requested but did not return findings before interruption.
+
+## Current Hosted-verification Blocker
+
+This local process has no Playwright or Supabase smoke credentials, so no local hosted smoke was run. The protected GitHub workflow still needs to be exercised from the PR head SHA after push.
+
+## Next action
+
+Push the branch, open the PR, dispatch the protected `iehp-pdf-mini-matrix-proof` workflow against the PR head SHA, and stop for human review if the hosted five-case proof fails or if the rasterized case shows the parser lacks existing OCR support.

--- a/docs/ai/WIN-236-iehp-300dpi-scan-handoff.md
+++ b/docs/ai/WIN-236-iehp-300dpi-scan-handoff.md
@@ -1,90 +1,55 @@
-# WIN-236 — IEHP 300 DPI scanned PDF mini-matrix handoff
+# WIN-236 IEHP 300 DPI Scan Handoff
 
 - Date: July 21, 2026
 - Linear: `WIN-236`
 - Branch: `codex/win-236-iehp-300dpi-scan`
+- PR: `#830` (`https://github.com/Jeduardo622/AllIincompassing/pull/830`)
 - Classification: `high-risk human-reviewed`
 - Lane: `critical`
-- Triggering paths: `.github/workflows/iehp-pdf-mini-matrix-proof.yml`, `scripts/lib/iehp-assessment-import-smoke.ts`, `scripts/playwright-iehp-assessment-import-smoke.ts`, and their focused tests
-- Protected boundary: `.github/workflows/iehp-pdf-mini-matrix-proof.yml`; human review is required before merge
-
-## Route-task Card
-
-- classification: `high-risk human-reviewed`
-- lane: `critical`
-- rationale: the new scan case widens the hosted PDF mini-matrix contract and therefore touches the protected owner-dispatched workflow and its curated evidence counts
-- allowed files: the IEHP smoke helper, the IEHP Playwright smoke runner, the narrowest focused tests, the hosted matrix workflow contract, and this handoff
-- stop conditions: any parser/OCR/server/API/Supabase/auth/runtime-config/migration/secret/production-data change
+- Trigger: the hosted proof's exact evidence contract changes under `.github/workflows/**`
+- Required agents: `specification-engineer` -> `software-architect` -> `implementation-engineer` -> `code-review-engineer` -> `test-engineer` -> `security-engineer`
 
 ## Scope
 
-- Add one deterministic synthetic `scan-300dpi-monochrome` PDF mini-matrix case.
-- Generate that case at runtime as a 2550x3300 rasterized black-and-white JPEG-backed Letter PDF with no live data.
-- Preserve existing assessor-phone snapshot precedence assertions, referral-date assertions, extracted status assertions, zero-draft assertions, and unconditional document/storage cleanup.
-- Widen the hosted matrix workflow and workflow-contract test from four to five total cases so curated evidence stays exact.
+- Add one deterministic synthetic `scan-300dpi-monochrome` case to the on-demand IEHP PDF mini-matrix.
+- Render a 2550 x 3300 black-on-white source image with light JPEG compression and embed only that image in a straight Letter PDF.
+- Reuse the existing authenticated upload, extracted-status, zero-draft, checklist/provenance assertions, per-document cleanup, and synthetic-admin cleanup.
+- Require five ordered, redacted, cleanup-verified hosted evidence objects: four PDF cases plus the existing Skills & Behaviors proof.
 
-## Non-goals
+## Non-goals and Stop Conditions
 
-- No parser or OCR changes.
-- No new extraction fields.
-- No server/API/Supabase/auth/workflow-secret changes.
-- No production data, PHI, or real phone numbers.
-- No broad smoke-framework refactor.
+- No parser, OCR, extraction-field, server/API, Supabase function, migration, auth, secret, or production-data changes.
+- If the hosted extractor cannot process the image-only PDF, stop with that limitation; do not widen this slice into parser/OCR work.
 
 ## Test-first Evidence
 
-- RED:
-  - `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts` failed `4/26` because `IEHP_PDF_MINI_MATRIX_CASES` still had only three cases and no scan metadata.
-  - `npm test -- tests/scripts/playwright-iehp-assessment-import-smoke.test.ts tests/workflows/iehp-pdf-mini-matrix-proof.test.ts` failed the smoke structure assertion because the `raster-scan` generation branch was missing.
-- GREEN:
-  - `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts` passed `26/26`.
-  - `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts tests/workflows/iehp-pdf-mini-matrix-proof.test.ts` passed `29/29`.
-  - `npm run test -- tests/scripts/playwright-iehp-assessment-import-smoke.test.ts` now passes the new scan-branch structure assertion; the only remaining failure in that file is the unchanged baseline `supabase/config.toml` expectation outside this slice.
+- RED: focused tests failed on the missing fourth case, missing raster generation path, and the workflow's four-case evidence contract (`6` slice-specific failures).
+- GREEN: helper/workflow tests passed (`29/29`); runner structure tests passed (`6/6`); `npm run typecheck` passed.
+- The full runner test file also exposes an unchanged Windows line-ending baseline assertion in `supabase/config.toml`; the narrowed changed-surface runner tests are green.
 
 ## Verification Card
 
 - classification: `high-risk human-reviewed`
 - lane: `critical`
-- change type:
-  - CI/workflow/policy
-  - test harness / Playwright smoke runner
-- required checks:
-  - focused script/workflow tests
-  - `npm run ci:check-focused`
-  - `npm run lint`
-  - `npm run typecheck`
-  - `npm run test:ci`
-  - `npm run build`
-  - `npm run verify:local`
-  - hosted `npm run playwright:iehp-assessment-import-pdf-mini-matrix` against the protected preview workflow
+- change type: browser smoke harness plus CI/workflow evidence contract
+- required checks: focused tests; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run build`; `npm run verify:local`; owner-approved hosted IEHP PDF mini-matrix workflow
 - executed checks:
-  - `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts` -> pass (`26/26`)
-  - `npm test -- tests/scripts/playwright-iehp-assessment-import-smoke.test.ts` -> fail on one unchanged baseline assertion in `selectConfiguredSmokeClient > keeps both CI IEHP proofs on the generated super-admin and unconditional cleanup path`; the new scan-branch structure assertion passed
-  - `npm test -- tests/scripts/iehp-assessment-import-smoke.test.ts tests/workflows/iehp-pdf-mini-matrix-proof.test.ts` -> pass (`29/29`)
-  - `npm run ci:check-focused` -> pass; branch-protection, DB grant, and auth-parity probes skipped outside CI as reported by the command
+  - focused helper/workflow tests -> pass (`29/29`)
+  - focused runner structure tests -> pass (`6/6`)
+  - `npm run ci:check-focused` -> pass; environment-dependent database and branch-protection probes skipped as reported
   - `npm run lint` -> pass
   - `npm run typecheck` -> pass
   - `npm run build` -> pass
-  - `npm run test:ci` -> fail outside this slice on:
-    - `tests/ci/deploy-session-edge-bundle.test.ts` timeout
-    - `src/lib/__tests__/ai-documentation.test.ts` fetch/null-text baseline
-    - Vitest coverage temp-file `ENOENT` under `coverage/.tmp`
-  - `npm run verify:local` -> fail at its `test:ci` stage on the same unrelated `deploy-session-edge-bundle`, `ai-documentation`, and coverage-temp-file failures; upstream policy, lint, and typecheck stages passed
+  - isolated `npm run test:ci` -> `3134` pass / `2` unrelated baseline failures: Windows `Blob.text()` behavior and the missing BCBA workflow provision-step expectation
+  - focused rerun of an earlier load-sensitive deployment-bundle timeout -> pass (`1/1`)
+  - `npm run verify:local` -> policy, lint, and typecheck passed; stopped at the same aggregate baseline boundary before coverage/build/tier-0 continuation
 - blocked checks:
-  - local hosted smoke command -> blocked because `PW_BASE_URL`, `PW_SUPERADMIN_EMAIL`, `PW_SUPERADMIN_PASSWORD`, `PW_ASSESSMENT_CLIENT_ID`, `SUPABASE_URL`, and `SUPABASE_ANON_KEY` are all missing from the current process
+  - hosted five-case proof -> pending immutable preview deployment and owner-approved workflow dispatch for PR `#830`
 - result: `pass-with-blocked-checks`
-- residual risk: local structure tests prove the new synthetic scan path and workflow contract, but only the hosted workflow can prove the current extraction stack actually handles the rasterized PDF end-to-end
+- residual risk: local tests prove fixture shape and orchestration, but only the hosted run can prove that deployed extraction handles an image-only PDF and still cleans every upload
 
-## Review
+## Protected-path Review
 
-- `code-review-engineer`: completed; no blocking findings. Noted only a low-severity maintainability follow-up to derive workflow case-count guards from `expectedCaseIds.length`.
-- `test-engineer`: requested but did not return findings before interruption.
-- `security-engineer`: requested but did not return findings before interruption.
-
-## Current Hosted-verification Blocker
-
-This local process has no Playwright or Supabase smoke credentials, so no local hosted smoke was run. The protected GitHub workflow still needs to be exercised from the PR head SHA after push.
-
-## Next action
-
-Push the branch, open the PR, dispatch the protected `iehp-pdf-mini-matrix-proof` workflow against the PR head SHA, and stop for human review if the hosted five-case proof fails or if the rasterized case shows the parser lacks existing OCR support.
+- The workflow change only adds the new ordered case ID and raises exact case/aggregate guards from four to five.
+- Triggers, immutable PR-head validation, Netlify deployment binding, secret names, private environment handling, redaction, and unconditional cleanup are unchanged.
+- Human review is required before merge.

--- a/docs/ai/WIN-236-iehp-300dpi-scan-handoff.md
+++ b/docs/ai/WIN-236-iehp-300dpi-scan-handoff.md
@@ -27,6 +27,7 @@
 - GREEN: helper/workflow tests passed (`29/29`); runner structure tests passed (`6/6`); `npm run typecheck` passed.
 - Hosted follow-up RED: run `29876647651` reached the scan case and failed before upload with `page.evaluate: ReferenceError: __name is not defined`; a focused regression then failed on the nested helper that `tsx` serialized into the browser context.
 - Hosted follow-up GREEN: the browser callback now uses `HTMLImageElement.decode()` without a nested transpiled helper; runner structure tests passed (`6/6`) and typecheck passed before the immutable rerun.
+- Hosted extraction GREEN: workflow run `29877347962` validated implementation commit `83af7083`, bound the exact Netlify deployment, and completed all five smoke cases. The new scan case reached `extracted`, retained zero drafts, matched the synthetic referral date and snapshot-precedence assessor phone with document/client-snapshot provenance, and verified document plus storage cleanup.
 - The full runner test file also exposes an unchanged Windows line-ending baseline assertion in `supabase/config.toml`; the narrowed changed-surface runner tests are green.
 
 ## Verification Card
@@ -45,13 +46,15 @@
   - isolated `npm run test:ci` -> `3134` pass / `2` unrelated baseline failures: Windows `Blob.text()` behavior and the missing BCBA workflow provision-step expectation
   - focused rerun of an earlier load-sensitive deployment-bundle timeout -> pass (`1/1`)
   - `npm run verify:local` -> policy, lint, and typecheck passed; stopped at the same aggregate baseline boundary before coverage/build/tier-0 continuation
+  - hosted workflow run `29877347962` -> immutable head and deployment checks passed; smoke command emitted `5/5` passing cases with `5/5` cleanup verification, including `scan-300dpi-monochrome`
 - blocked checks:
-  - hosted five-case proof -> pending owner-approved rerun against the corrected PR `#830` head
+  - the workflow run's finalizer used the default-branch four-case definition and rejected the otherwise valid five-case artifact (`Expected exactly four case evidence objects but found 5`); the PR changes and focused workflow test update that contract to five, so a post-merge dispatch is required to exercise the promoted finalizer
 - result: `pass-with-blocked-checks`
-- residual risk: local tests prove fixture shape and orchestration, but only the hosted run can prove that deployed extraction handles an image-only PDF and still cleans every upload
+- residual risk: hosted extraction and cleanup are proven, but GitHub cannot exercise the PR version of a `workflow_dispatch` finalizer before that workflow definition reaches the default branch
 
 ## Protected-path Review
 
 - The workflow change only adds the new ordered case ID and raises exact case/aggregate guards from four to five.
 - Triggers, immutable PR-head validation, Netlify deployment binding, secret names, private environment handling, redaction, and unconditional cleanup are unchanged.
+- `code-review-engineer`, `security-engineer`, and deployment review found no required changes; the optional follow-up is a stronger artifact-shape unit assertion.
 - Human review is required before merge.

--- a/scripts/lib/iehp-assessment-import-smoke.ts
+++ b/scripts/lib/iehp-assessment-import-smoke.ts
@@ -1,12 +1,30 @@
 import { readdirSync } from 'node:fs';
 import path from 'node:path';
 
-export type IehpPdfMiniMatrixCase = {
-  id: 'clean-single-page' | 'multi-page-target-content' | 'alternate-document-phone-format';
+type IehpPdfMiniMatrixBaseCase = {
   referralDate: string;
   documentPhone: string;
   pageBreakBeforeTarget: boolean;
 };
+
+type IehpDigitalPdfMiniMatrixCase = IehpPdfMiniMatrixBaseCase & {
+  id: 'clean-single-page' | 'multi-page-target-content' | 'alternate-document-phone-format';
+  renderMode: 'digital-pdf';
+};
+
+type IehpRasterPdfMiniMatrixCase = IehpPdfMiniMatrixBaseCase & {
+  id: 'scan-300dpi-monochrome';
+  renderMode: 'raster-scan';
+  scan: {
+    dpi: 300;
+    colorMode: 'black-and-white';
+    rotationDegrees: 0;
+    compression: 'jpeg';
+    jpegQuality: 85;
+  };
+};
+
+export type IehpPdfMiniMatrixCase = IehpDigitalPdfMiniMatrixCase | IehpRasterPdfMiniMatrixCase;
 
 type DocumentChecklistItem = {
   placeholder_key: string;
@@ -109,18 +127,35 @@ export const IEHP_PDF_MINI_MATRIX_CASES: readonly IehpPdfMiniMatrixCase[] = [
     referralDate: '06/30/2026',
     documentPhone: '(909) 555-0101',
     pageBreakBeforeTarget: false,
+    renderMode: 'digital-pdf',
   },
   {
     id: 'multi-page-target-content',
     referralDate: '07/01/2026',
     documentPhone: '909-555-0102',
     pageBreakBeforeTarget: true,
+    renderMode: 'digital-pdf',
   },
   {
     id: 'alternate-document-phone-format',
     referralDate: '07/02/2026',
     documentPhone: '+1 909 555 0103',
     pageBreakBeforeTarget: false,
+    renderMode: 'digital-pdf',
+  },
+  {
+    id: 'scan-300dpi-monochrome',
+    referralDate: '07/03/2026',
+    documentPhone: '909.555.0104',
+    pageBreakBeforeTarget: false,
+    renderMode: 'raster-scan',
+    scan: {
+      dpi: 300,
+      colorMode: 'black-and-white',
+      rotationDegrees: 0,
+      compression: 'jpeg',
+      jpegQuality: 85,
+    },
   },
 ] as const;
 

--- a/scripts/playwright-iehp-assessment-import-smoke.ts
+++ b/scripts/playwright-iehp-assessment-import-smoke.ts
@@ -138,22 +138,10 @@ const buildMonochromeScanImageDataUrl = async (args: {
 
   return args.page.evaluate(
     async ({ base64, quality }) => {
-      const loadImage = async (): Promise<HTMLImageElement> => {
-        const image = new Image();
-        image.decoding = 'async';
-        image.src = `data:image/png;base64,${base64}`;
-        if ('decode' in image) {
-          await image.decode();
-          return image;
-        }
-        await new Promise<void>((resolve, reject) => {
-          image.onload = () => resolve();
-          image.onerror = () => reject(new Error('Failed to load IEHP scan screenshot into canvas.'));
-        });
-        return image;
-      };
-
-      const image = await loadImage();
+      const image = new Image();
+      image.decoding = 'async';
+      image.src = `data:image/png;base64,${base64}`;
+      await image.decode();
       const canvas = document.createElement('canvas');
       canvas.width = image.naturalWidth;
       canvas.height = image.naturalHeight;

--- a/scripts/playwright-iehp-assessment-import-smoke.ts
+++ b/scripts/playwright-iehp-assessment-import-smoke.ts
@@ -129,6 +129,59 @@ const pause = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms));
 };
 
+const buildMonochromeScanImageDataUrl = async (args: {
+  page: import('playwright').Page;
+  jpegQuality: number;
+}): Promise<string> => {
+  const screenshotBuffer = await args.page.screenshot({ type: 'png' });
+  const screenshotBase64 = screenshotBuffer.toString('base64');
+
+  return args.page.evaluate(
+    async ({ base64, quality }) => {
+      const loadImage = async (): Promise<HTMLImageElement> => {
+        const image = new Image();
+        image.decoding = 'async';
+        image.src = `data:image/png;base64,${base64}`;
+        if ('decode' in image) {
+          await image.decode();
+          return image;
+        }
+        await new Promise<void>((resolve, reject) => {
+          image.onload = () => resolve();
+          image.onerror = () => reject(new Error('Failed to load IEHP scan screenshot into canvas.'));
+        });
+        return image;
+      };
+
+      const image = await loadImage();
+      const canvas = document.createElement('canvas');
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+
+      const context = canvas.getContext('2d', { willReadFrequently: true });
+      if (!context) {
+        throw new Error('Canvas 2d context is unavailable for IEHP scan rendering.');
+      }
+
+      context.drawImage(image, 0, 0);
+      const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+      const { data } = imageData;
+      for (let index = 0; index < data.length; index += 4) {
+        const luminance = Math.round(data[index] * 0.299 + data[index + 1] * 0.587 + data[index + 2] * 0.114);
+        const monochrome = luminance < 192 ? 0 : 255;
+        data[index] = monochrome;
+        data[index + 1] = monochrome;
+        data[index + 2] = monochrome;
+        data[index + 3] = 255;
+      }
+      context.putImageData(imageData, 0, 0);
+
+      return canvas.toDataURL('image/jpeg', quality / 100);
+    },
+    { base64: screenshotBase64, quality: args.jpegQuality },
+  );
+};
+
 const fetchWithRetry = async (url: string, init: RequestInit, label: string): Promise<Response> => {
   let lastError: unknown = null;
   for (let attempt = 1; attempt <= 4; attempt += 1) {
@@ -810,13 +863,101 @@ async function run() {
         const generatorPage = await context.newPage();
         try {
           await generatorPage.setContent(buildIehpPdfMiniMatrixHtml(caseDefinition));
-          const pdfBuffer = await generatorPage.pdf({ format: 'Letter', printBackground: true });
+          let uploadPdfBuffer: Buffer;
+          if (caseDefinition.renderMode === 'raster-scan') {
+            await generatorPage.setViewportSize({ width: 2550, height: 3300 });
+            await generatorPage.setContent(`
+              <!doctype html>
+              <html lang="en">
+                <head>
+                  <meta charset="utf-8" />
+                  <title>${caseDefinition.id}</title>
+                  <style>
+                    html, body {
+                      margin: 0;
+                      padding: 0;
+                      width: 2550px;
+                      height: 3300px;
+                      background: white;
+                    }
+
+                    body {
+                      color: black;
+                      font-family: Arial, sans-serif;
+                      font-size: 54px;
+                      line-height: 1.4;
+                    }
+
+                    main {
+                      box-sizing: border-box;
+                      width: 100%;
+                      min-height: 100%;
+                      padding: 240px 220px;
+                    }
+                  </style>
+                </head>
+                <body>
+                  <main>
+                    <p>Referral Date: ${caseDefinition.referralDate}</p>
+                    <p>Assessor's phone number: ${caseDefinition.documentPhone}</p>
+                  </main>
+                </body>
+              </html>
+            `);
+            const monochromeScanDataUrl = await buildMonochromeScanImageDataUrl({
+              page: generatorPage,
+              jpegQuality: caseDefinition.scan.jpegQuality,
+            });
+            const rasterPdfPage = await context.newPage();
+            try {
+              await rasterPdfPage.setContent(`
+                <!doctype html>
+                <html lang="en">
+                  <head>
+                    <meta charset="utf-8" />
+                    <title>${caseDefinition.id}</title>
+                    <style>
+                      @page {
+                        size: Letter;
+                        margin: 0;
+                      }
+
+                      html, body {
+                        margin: 0;
+                        padding: 0;
+                        width: 8.5in;
+                        height: 11in;
+                        background: white;
+                      }
+
+                      img {
+                        display: block;
+                        width: 8.5in;
+                        height: 11in;
+                      }
+                    </style>
+                  </head>
+                  <body>
+                    <img alt="${caseDefinition.id}" src="${monochromeScanDataUrl}" />
+                  </body>
+                </html>
+              `);
+              uploadPdfBuffer = await rasterPdfPage.pdf({ format: 'Letter', printBackground: true });
+            } finally {
+              if (!rasterPdfPage.isClosed()) {
+                await rasterPdfPage.close().then(() => undefined);
+              }
+            }
+          } else {
+            const pdfBuffer = await generatorPage.pdf({ format: 'Letter', printBackground: true });
+            uploadPdfBuffer = pdfBuffer;
+          }
           await generatorPage.close();
           const caseEvidence = await runSmokeCase({
             caseId: caseDefinition.id,
             uploadFileName: buildIehpSmokeUploadFileName(Date.now(), 'pdf'),
             mimeType: 'application/pdf',
-            sourceFileBuffer: pdfBuffer,
+            sourceFileBuffer: uploadPdfBuffer,
             expectedReferralDate: caseDefinition.referralDate,
           });
           console.log(JSON.stringify(caseEvidence, null, 2));

--- a/tests/scripts/iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/iehp-assessment-import-smoke.test.ts
@@ -71,6 +71,7 @@ describe('IEHP assessment import smoke helpers', () => {
       'clean-single-page',
       'multi-page-target-content',
       'alternate-document-phone-format',
+      'scan-300dpi-monochrome',
     ]);
 
     expect(new Set(IEHP_PDF_MINI_MATRIX_CASES.map((caseDefinition) => caseDefinition.referralDate)).size).toBe(
@@ -83,6 +84,7 @@ describe('IEHP assessment import smoke helpers', () => {
       '(909) 555-0101',
       '909-555-0102',
       '+1 909 555 0103',
+      '909.555.0104',
     ]);
   });
 
@@ -91,11 +93,30 @@ describe('IEHP assessment import smoke helpers', () => {
       '(909) 555-0101',
       '909-555-0102',
       '+1 909 555 0103',
+      '909.555.0104',
     ]);
 
     for (const caseDefinition of IEHP_PDF_MINI_MATRIX_CASES) {
       expect(isValidPhone(caseDefinition.documentPhone)).toBe(true);
     }
+  });
+
+  it('defines one deterministic image-only 300 DPI monochrome scan case', () => {
+    expect(
+      IEHP_PDF_MINI_MATRIX_CASES.find((caseDefinition) => caseDefinition.id === 'scan-300dpi-monochrome'),
+    ).toMatchObject({
+      referralDate: '07/03/2026',
+      documentPhone: '909.555.0104',
+      pageBreakBeforeTarget: false,
+      renderMode: 'raster-scan',
+      scan: {
+        dpi: 300,
+        colorMode: 'black-and-white',
+        rotationDegrees: 0,
+        compression: 'jpeg',
+        jpegQuality: 85,
+      },
+    });
   });
 
   it('renders the referral label and document phone into selectable HTML with a page break only for the multi-page case', () => {
@@ -135,7 +156,7 @@ describe('IEHP assessment import smoke helpers', () => {
   });
 
   it('defines one dedicated opt-in skills behaviors proof case without changing the existing mini matrix cases', () => {
-    expect(IEHP_PDF_MINI_MATRIX_CASES).toHaveLength(3);
+    expect(IEHP_PDF_MINI_MATRIX_CASES).toHaveLength(4);
     expect(IEHP_SKILLS_BEHAVIORS_PROOF_CASE).toMatchObject({
       id: 'skills-behaviors-proof',
       expectedSectionKey: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -454,8 +454,8 @@ describe('selectConfiguredSmokeClient', () => {
     );
     expect(cleanupStepStart).toBeGreaterThanOrEqual(0);
     expect(cleanupStep).toContain('if: always()');
-    expect(supabaseConfig).toMatch(
-      /\[functions\.extract-assessment-fields\]\r?\nverify_jwt = true/,
+    expect(supabaseConfig).toContain(
+      '[functions.extract-assessment-fields]\nverify_jwt = true',
     );
     expect(candidateBlock).toContain('PW_SUPERADMIN_EMAIL');
     expect(candidateBlock).not.toContain('PW_ADMIN_EMAIL');

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -917,6 +917,7 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     expect(scanModeIndex).toBeGreaterThan(setContentIndex);
     expect(scanViewportIndex).toBeGreaterThan(scanModeIndex);
     expect(monochromeHelperIndex).toBeLessThan(setContentIndex);
+    expect(script).not.toContain('const loadImage = async');
     expect(scanScreenshotIndex).toBeGreaterThan(monochromeHelperIndex);
     expect(scanCanvasIndex).toBeGreaterThan(scanScreenshotIndex);
     expect(scanLuminanceIndex).toBeGreaterThan(scanCanvasIndex);

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -454,8 +454,8 @@ describe('selectConfiguredSmokeClient', () => {
     );
     expect(cleanupStepStart).toBeGreaterThanOrEqual(0);
     expect(cleanupStep).toContain('if: always()');
-    expect(supabaseConfig).toContain(
-      '[functions.extract-assessment-fields]\nverify_jwt = true',
+    expect(supabaseConfig).toMatch(
+      /\[functions\.extract-assessment-fields\]\r?\nverify_jwt = true/,
     );
     expect(candidateBlock).toContain('PW_SUPERADMIN_EMAIL');
     expect(candidateBlock).not.toContain('PW_ADMIN_EMAIL');
@@ -875,6 +875,16 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     const generatorPageIndex = script.indexOf('const generatorPage = await context.newPage();');
     const setContentIndex = script.indexOf('await generatorPage.setContent(buildIehpPdfMiniMatrixHtml(caseDefinition));');
     const pagePdfIndex = script.indexOf("const pdfBuffer = await generatorPage.pdf({ format: 'Letter', printBackground: true });");
+    const scanModeIndex = script.indexOf("caseDefinition.renderMode === 'raster-scan'", setContentIndex);
+    const scanViewportIndex = script.indexOf('width: 2550, height: 3300', scanModeIndex);
+    const monochromeHelperIndex = script.indexOf('const buildMonochromeScanImageDataUrl = async');
+    const scanScreenshotIndex = script.indexOf("type: 'png'", monochromeHelperIndex);
+    const scanCanvasIndex = script.indexOf('getImageData(0, 0, canvas.width, canvas.height)', scanScreenshotIndex);
+    const scanLuminanceIndex = script.indexOf('const luminance = Math.round(', scanCanvasIndex);
+    const scanQualityIndex = script.indexOf("canvas.toDataURL('image/jpeg', quality / 100)", scanLuminanceIndex);
+    const rasterPageIndex = script.indexOf('const rasterPdfPage = await context.newPage();', scanQualityIndex);
+    const imageOnlyHtmlIndex = script.indexOf('monochromeScanDataUrl', rasterPageIndex);
+    const rasterPdfIndex = script.indexOf("await rasterPdfPage.pdf({ format: 'Letter', printBackground: true })", imageOnlyHtmlIndex);
     const generatorCloseIndex = script.indexOf('await generatorPage.close();');
     const pdfFileNameIndex = script.indexOf(
       "buildIehpSmokeUploadFileName(Date.now(), 'pdf')",
@@ -904,6 +914,16 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     expect(generatorPageIndex).toBeGreaterThan(matrixCaseLoopIndex);
     expect(setContentIndex).toBeGreaterThan(generatorPageIndex);
     expect(pagePdfIndex).toBeGreaterThan(setContentIndex);
+    expect(scanModeIndex).toBeGreaterThan(setContentIndex);
+    expect(scanViewportIndex).toBeGreaterThan(scanModeIndex);
+    expect(monochromeHelperIndex).toBeLessThan(setContentIndex);
+    expect(scanScreenshotIndex).toBeGreaterThan(monochromeHelperIndex);
+    expect(scanCanvasIndex).toBeGreaterThan(scanScreenshotIndex);
+    expect(scanLuminanceIndex).toBeGreaterThan(scanCanvasIndex);
+    expect(scanQualityIndex).toBeGreaterThan(scanLuminanceIndex);
+    expect(rasterPageIndex).toBeGreaterThan(scanQualityIndex);
+    expect(imageOnlyHtmlIndex).toBeGreaterThan(rasterPageIndex);
+    expect(rasterPdfIndex).toBeGreaterThan(imageOnlyHtmlIndex);
     expect(generatorCloseIndex).toBeGreaterThan(pagePdfIndex);
     expect(pdfFileNameIndex).toBeGreaterThan(generatorCloseIndex);
     expect(pdfMimeIndex).toBeGreaterThan(pdfFileNameIndex);

--- a/tests/workflows/iehp-pdf-mini-matrix-proof.test.ts
+++ b/tests/workflows/iehp-pdf-mini-matrix-proof.test.ts
@@ -151,7 +151,11 @@ describe('protected hosted IEHP PDF mini-matrix workflow', () => {
     expect(cleanup?.run).toContain('npx tsx scripts/provision-ci-smoke-admin.ts --cleanup');
     expect(finalize?.if).toBe('always()');
     expect(finalize?.run).toContain('rmSync(publicDir, { recursive: true, force: true })');
-    expect(finalize?.run).toContain("aggregate.totalCases !== 4");
+    expect(finalize?.run).toContain("'scan-300dpi-monochrome'");
+    expect(finalize?.run).toContain('matrixCases.length !== 5');
+    expect(finalize?.run).toContain('aggregate.totalCases !== 5');
+    expect(finalize?.run).toContain('aggregate.passedCases !== 5');
+    expect(finalize?.run).toContain('aggregate.cleanupVerifiedCases !== 5');
     expect(finalize?.run).toContain('redactedPhonePattern');
     expect(finalize?.run).toContain('rawPhonePattern');
     expect(finalize?.run).toContain("'cases.json'");


### PR DESCRIPTION
## Summary
- add one deterministic synthetic `scan-300dpi-monochrome` IEHP PDF mini-matrix case
- rasterize at 2550×3300, threshold to black/white, lightly JPEG-compress, and embed the image alone in a straight Letter PDF
- keep the existing authenticated extraction, field/provenance assertions, zero-draft checks, and fail-closed cleanup path
- update the protected hosted evidence contract from 4 to 5 ordered cases

## Route
- classification: `high-risk human-reviewed`
- lane: `critical` because `.github/workflows/**` changes
- Linear: WIN-236
- human review required before merge

## Test-first evidence
- RED: 6 slice-specific focused failures for the missing case, raster path, and five-case workflow contract
- hosted RED: run 29876647651 exposed a browser-context `__name` serialization failure; a focused regression reproduced it
- GREEN: helper/workflow `29/29`; runner structure `6/6`; browser callback regression fixed with direct `HTMLImageElement.decode()`

## Verification
- `npm run ci:check-focused` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run build` — pass
- isolated `npm run test:ci` — 3134 pass / 2 unrelated Windows baselines: `Blob.text()` and missing BCBA provision-step expectation
- `npm run verify:local` — policy/lint/typecheck pass, then stops at the same aggregate baseline boundary
- final-head hosted run 29877784012 — immutable SHA/deployment validation passed; all 5 smoke cases passed with 5/5 cleanup, including the image-only scan
- workflow conclusion is red only because GitHub used the default-branch four-case finalizer for `workflow_dispatch`; this PR changes and locally tests that finalizer at five cases

## Safety
- synthetic data only
- no parser, OCR, server/API, Supabase, migration, auth, secret, or production-data changes
- workflow triggers, secret names, immutable PR binding, evidence redaction, and unconditional cleanup are unchanged
- code, security, and deployment reviewers found no required changes
