### PR TITLE
WIN-238: remove redundant plan target card

### DIFF
--- a/docs/ai/WIN-238-plan-target-dedup-handoff.md
+++ b/docs/ai/WIN-238-plan-target-dedup-handoff.md
@@ -28,6 +28,7 @@
 - Executed checks:
   - TDD RED confirmed the configured plan target rendered twice before selection.
   - TDD RED confirmed a legacy saved row with blank target text disappeared during the first correction.
+  - The first Linux CI run exposed a no-configured-target placeholder regression that did not reproduce in the earlier ordered local suite; the existing regression test now passes after restoring the empty capture row only when no plan target text exists.
   - Full `SessionModal` suite: pass (103 tests), including selector-to-capture deduplication and legacy saved-row hydration.
   - `npm run ci:check-focused`: pass; database-backed checks were skipped because no database URL is configured, and auth parity is disabled outside CI.
   - `npm run lint`: pass.

--- a/docs/ai/WIN-238-plan-target-dedup-handoff.md
+++ b/docs/ai/WIN-238-plan-target-dedup-handoff.md
@@ -40,11 +40,12 @@
     - `tests/workflows/bt-aba-disposable-browser-proof.test.ts`
     - `src/lib/__tests__/supabase.edge.test.ts`
   - `npm run verify:local`: fail at its `npm run test:ci` constituent for the same four unrelated failures; earlier policy, lint, and typecheck constituents passed.
+  - PR #833 Linux CI after the scoped placeholder correction: pass, including unit tests, build, tier-0 browser, auth smoke, policy, tenant/runtime contracts, Lighthouse, IEHP smoke, and Netlify deploy preview.
 - Blocked checks:
   - `npm run ci:verify-coverage` and `npm run test:routes:tier0`: not reached because `verify:local` stops when `test:ci` fails.
 - Reviewer: `code-review-engineer` approved after the legacy blank-target hydration regression was corrected; `test-engineer` approved the integrated focused coverage.
 - Result: `pass-with-blocked-checks` for the bounded WIN-238 change; repository-wide verification remains red outside this diff.
-- Residual risk: low for the deduplication behavior. CI must confirm the same focused behavior on Linux, while the four unrelated baseline failures require their own bounded follow-up rather than expansion of WIN-238.
+- Residual risk: low for the deduplication behavior. Linux CI confirmed the configured, legacy hydration, and no-configured-target states; the four Windows-local baseline failures remain outside this diff and require their own bounded follow-up.
 
 ## PR handoff
 

--- a/docs/ai/WIN-238-plan-target-dedup-handoff.md
+++ b/docs/ai/WIN-238-plan-target-dedup-handoff.md
@@ -1,0 +1,53 @@
+# WIN-238 Plan-Target Deduplication Handoff
+
+## Routing
+
+- Linear: [WIN-238](https://linear.app/winningedgeai/issue/WIN-238/remove-redundant-plan-target-card-from-bt-session-capture)
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Triggering surface: `src/components/SessionModal.tsx`
+- Required agents: `specification-engineer` -> `implementation-engineer` -> `code-review-engineer` -> `test-engineer`
+
+## Scope
+
+- Before selection, show the configured target once in the actionable `Use plan target` selector.
+- After selection or hydration, hide the selector/status card and show the configured target once in the active capture card.
+- Preserve configured trial controls, prompt capture, numeric capture, saved readback, ad-hoc targets, and goals without configured targets.
+
+## Non-goals and stop conditions
+
+- No capture payload, state-management, Schedule orchestration, API, schema, auth, tenant, graph, CI, or deploy changes.
+- Stop and re-route if the fix requires any protected path or shared measurement contract.
+
+## Verification card
+
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Change type: UI/component behavior
+- Required checks: focused `SessionModal` tests, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, and `npm run verify:local`.
+- Executed checks:
+  - TDD RED confirmed the configured plan target rendered twice before selection.
+  - TDD RED confirmed a legacy saved row with blank target text disappeared during the first correction.
+  - Full `SessionModal` suite: pass (103 tests), including selector-to-capture deduplication and legacy saved-row hydration.
+  - `npm run ci:check-focused`: pass; database-backed checks were skipped because no database URL is configured, and auth parity is disabled outside CI.
+  - `npm run lint`: pass.
+  - `npm run typecheck`: pass.
+  - `npm run build`: pass.
+  - `npm run test:ci`: fail in four unrelated files on the unchanged repository baseline (3,140 tests passed):
+    - `tests/ci/check-e2e-reliability-gates.test.ts`
+    - `tests/scripts/playwright-iehp-assessment-import-smoke.test.ts`
+    - `tests/workflows/bt-aba-disposable-browser-proof.test.ts`
+    - `src/lib/__tests__/supabase.edge.test.ts`
+  - `npm run verify:local`: fail at its `npm run test:ci` constituent for the same four unrelated failures; earlier policy, lint, and typecheck constituents passed.
+- Blocked checks:
+  - `npm run ci:verify-coverage` and `npm run test:routes:tier0`: not reached because `verify:local` stops when `test:ci` fails.
+- Reviewer: `code-review-engineer` approved after the legacy blank-target hydration regression was corrected; `test-engineer` approved the integrated focused coverage.
+- Result: `pass-with-blocked-checks` for the bounded WIN-238 change; repository-wide verification remains red outside this diff.
+- Residual risk: low for the deduplication behavior. CI must confirm the same focused behavior on Linux, while the four unrelated baseline failures require their own bounded follow-up rather than expansion of WIN-238.
+
+## PR handoff
+
+- Single-purpose diff: `SessionModal` display logic, focused regression tests, and this handoff only.
+- Protected-path drift: none.
+- Generated artifact drift: none.
+- Human review: required before merge through the normal PR flow.

--- a/docs/ai/WIN-238-plan-target-dedup-handoff.md
+++ b/docs/ai/WIN-238-plan-target-dedup-handoff.md
@@ -29,7 +29,7 @@
   - TDD RED confirmed the configured plan target rendered twice before selection.
   - TDD RED confirmed a legacy saved row with blank target text disappeared during the first correction.
   - The first Linux CI run exposed a no-configured-target placeholder regression that did not reproduce in the earlier ordered local suite; the existing regression test now passes after restoring the empty capture row only when no plan target text exists.
-  - Full `SessionModal` suite: pass (103 tests), including selector-to-capture deduplication and legacy saved-row hydration.
+  - Full `SessionModal` suite: pass (104 tests), including selector-to-capture deduplication, blank legacy-row rebinding, explicit-zero evidence, and saved-row hydration.
   - `npm run ci:check-focused`: pass; database-backed checks were skipped because no database URL is configured, and auth parity is disabled outside CI.
   - `npm run lint`: pass.
   - `npm run typecheck`: pass.
@@ -41,9 +41,12 @@
     - `src/lib/__tests__/supabase.edge.test.ts`
   - `npm run verify:local`: fail at its `npm run test:ci` constituent for the same four unrelated failures; earlier policy, lint, and typecheck constituents passed.
   - PR #833 Linux CI after the scoped placeholder correction: pass, including unit tests, build, tier-0 browser, auth smoke, policy, tenant/runtime contracts, Lighthouse, IEHP smoke, and Netlify deploy preview.
+  - PR #833 Codex review follow-up:
+    - P1: blank persisted legacy rows retain an in-place `Use plan target` bind action, preserve saved evidence, and unlock configured target controls after binding.
+    - P2: explicit zero numeric fields count as persisted evidence through nullable presence checks.
 - Blocked checks:
   - `npm run ci:verify-coverage` and `npm run test:routes:tier0`: not reached because `verify:local` stops when `test:ci` fails.
-- Reviewer: `code-review-engineer` approved after the legacy blank-target hydration regression was corrected; `test-engineer` approved the integrated focused coverage.
+- Reviewer: `code-review-engineer` and `test-engineer` approved the integrated change and the P1/P2 review follow-up.
 - Result: `pass-with-blocked-checks` for the bounded WIN-238 change; repository-wide verification remains red outside this diff.
 - Residual risk: low for the deduplication behavior. Linux CI confirmed the configured, legacy hydration, and no-configured-target states; the four Windows-local baseline failures remain outside this diff and require their own bounded follow-up.
 

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -4005,16 +4005,15 @@ export function SessionModal({
                               return [];
                             }
                             const hasPersistedEvidence =
-                              getTargetTrialValue(sourceIndex, 'metric_value') > 0 ||
-                              getTargetTrialValue(sourceIndex, 'incorrect_trials') > 0 ||
-                              (getTargetTrialNullableValue(sourceIndex, 'opportunities') ?? 0) > 0 ||
+                              getTargetTrialNullableValue(sourceIndex, 'metric_value') !== null ||
+                              getTargetTrialNullableValue(sourceIndex, 'incorrect_trials') !== null ||
+                              getTargetTrialNullableValue(sourceIndex, 'opportunities') !== null ||
                               getTargetTrialNote(sourceIndex).trim().length > 0;
                             return hasPersistedEvidence ? [{ targetValue, sourceIndex }] : [];
                           });
                           const hasSelectedPlanTarget = Boolean(
                             planTargetText && selectedPlanTargets.length > 0,
                           );
-                          const hasPersistedBlankPlanTargetEvidence = persistedBlankPlanTargetItems.length > 0;
                           const unconfiguredTargetItems = sessionTargets.length > 0
                             ? sessionTargets.map((targetValue, sourceIndex) => ({ targetValue, sourceIndex }))
                             : [{ targetValue: '', sourceIndex: 0 }];
@@ -4178,7 +4177,7 @@ export function SessionModal({
                                 )}
                                 {!isAdhocTarget ? (
                                   <div className="mt-2">
-                                    {planTargetText && !hasSelectedPlanTarget && !hasPersistedBlankPlanTargetEvidence ? (
+                                    {planTargetText && !hasSelectedPlanTarget ? (
                                       <button
                                         type="button"
                                         onClick={() => updateGoalTargets(selectedGoalId, [planTargetText])}
@@ -4309,7 +4308,7 @@ export function SessionModal({
                                               id={`goal-target-${selectedGoalId}-${targetIndex}`}
                                               className="break-words rounded-md border border-indigo-200 bg-white px-3 py-2 text-sm font-medium text-indigo-950 shadow-sm dark:border-indigo-800 dark:bg-dark dark:text-indigo-100"
                                             >
-                                              {targetValue || planTargetText || 'No target selected'}
+                                              {targetValue || 'No target selected'}
                                             </p>
                                             <input
                                               type="hidden"

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -4015,8 +4015,11 @@ export function SessionModal({
                             planTargetText && selectedPlanTargets.length > 0,
                           );
                           const hasPersistedBlankPlanTargetEvidence = persistedBlankPlanTargetItems.length > 0;
-                          const visibleSessionTargetItems = isAdhocTarget || planGoalHasNoConfiguredTarget
+                          const unconfiguredTargetItems = sessionTargets.length > 0
                             ? sessionTargets.map((targetValue, sourceIndex) => ({ targetValue, sourceIndex }))
+                            : [{ targetValue: '', sourceIndex: 0 }];
+                          const visibleSessionTargetItems = isAdhocTarget || planGoalHasNoConfiguredTarget || !planTargetText
+                            ? unconfiguredTargetItems
                             : (selectedPlanTargets.length > 0 ? selectedPlanTargets : persistedBlankPlanTargetItems);
                           const getDisplayedTargetTrialValue = (
                             item: { targetValue: string; sourceIndex: number },

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -4000,12 +4000,24 @@ export function SessionModal({
                               ? [{ targetValue: trimmed, sourceIndex }]
                               : [];
                           });
+                          const persistedBlankPlanTargetItems = sessionTargets.flatMap((targetValue, sourceIndex) => {
+                            if (targetValue.trim().length > 0) {
+                              return [];
+                            }
+                            const hasPersistedEvidence =
+                              getTargetTrialValue(sourceIndex, 'metric_value') > 0 ||
+                              getTargetTrialValue(sourceIndex, 'incorrect_trials') > 0 ||
+                              (getTargetTrialNullableValue(sourceIndex, 'opportunities') ?? 0) > 0 ||
+                              getTargetTrialNote(sourceIndex).trim().length > 0;
+                            return hasPersistedEvidence ? [{ targetValue, sourceIndex }] : [];
+                          });
                           const hasSelectedPlanTarget = Boolean(
                             planTargetText && selectedPlanTargets.length > 0,
                           );
+                          const hasPersistedBlankPlanTargetEvidence = persistedBlankPlanTargetItems.length > 0;
                           const visibleSessionTargetItems = isAdhocTarget || planGoalHasNoConfiguredTarget
                             ? sessionTargets.map((targetValue, sourceIndex) => ({ targetValue, sourceIndex }))
-                            : (selectedPlanTargets.length > 0 ? selectedPlanTargets : [{ targetValue: '', sourceIndex: 0 }]);
+                            : (selectedPlanTargets.length > 0 ? selectedPlanTargets : persistedBlankPlanTargetItems);
                           const getDisplayedTargetTrialValue = (
                             item: { targetValue: string; sourceIndex: number },
                             field: 'metric_value' | 'incorrect_trials',
@@ -4163,24 +4175,23 @@ export function SessionModal({
                                 )}
                                 {!isAdhocTarget ? (
                                   <div className="mt-2">
-                                    {planTargetText ? (
+                                    {planTargetText && !hasSelectedPlanTarget && !hasPersistedBlankPlanTargetEvidence ? (
                                       <button
                                         type="button"
                                         onClick={() => updateGoalTargets(selectedGoalId, [planTargetText])}
-                                        disabled={hasSelectedPlanTarget}
-                                        className="w-full rounded-md border border-indigo-200 bg-white px-3 py-2 text-left text-sm font-medium text-indigo-900 shadow-sm hover:bg-indigo-50 disabled:cursor-default disabled:border-emerald-200 disabled:bg-emerald-50 disabled:text-emerald-900 dark:border-indigo-800 dark:bg-dark dark:text-indigo-100 dark:hover:bg-indigo-950/40 dark:disabled:border-emerald-900/60 dark:disabled:bg-emerald-900/20 dark:disabled:text-emerald-100"
+                                        className="w-full rounded-md border border-indigo-200 bg-white px-3 py-2 text-left text-sm font-medium text-indigo-900 shadow-sm hover:bg-indigo-50 dark:border-indigo-800 dark:bg-dark dark:text-indigo-100 dark:hover:bg-indigo-950/40"
                                       >
                                         <span className="block text-[11px] font-semibold uppercase tracking-wide">
-                                          {hasSelectedPlanTarget ? 'Plan target selected' : 'Use plan target'}
+                                          Use plan target
                                         </span>
                                         <span className="mt-1 block break-words">{planTargetText}</span>
                                       </button>
-                                    ) : (
+                                    ) : !planTargetText ? (
                                       <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-100">
                                         No plan target is set for this goal. Ask an admin to add the target under
                                         Programs &amp; Goals.
                                       </p>
-                                    )}
+                                    ) : null}
                                   </div>
                                 ) : null}
                                 <div className="mt-1 space-y-2">

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -4904,9 +4904,10 @@ describe('SessionModal', () => {
     expect(submitted.session_note_trial_events ?? []).toEqual([]);
   }, 10000);
 
-  it('keeps a blank persisted plan-target evidence row visible when legacy target strings are missing', async () => {
+  it('keeps a blank persisted plan-target evidence row visible and bindable when legacy target strings are missing', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const planTarget = 'Match peer greeting in 4/5 trials';
+    const targetId = '88888888-8888-4888-8888-888888888890';
     const linkedSessionNote = {
       id: 'linked-note-blank-plan-target-evidence',
       authorization_id: 'auth-1',
@@ -4998,6 +4999,35 @@ describe('SessionModal', () => {
         };
         return chain;
       }
+      if (table === 'goal_targets') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({
+            data: [{
+              id: targetId,
+              organization_id: 'org-a',
+              client_id: 'test-client-1',
+              goal_id: 'goal-1',
+              name: planTarget,
+              measurement_type: 'frequency',
+              graph_config: {},
+              status: 'active',
+              sort_order: 0,
+              is_current: true,
+              created_by: null,
+              updated_by: null,
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-01T00:00:00Z',
+            }],
+            error: null,
+          })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
       const chain: SupabaseQueryChain = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
@@ -5036,12 +5066,223 @@ describe('SessionModal', () => {
       expect(screen.getByDisplayValue('Observed saved evidence without a stored target label')).toBeInTheDocument();
     });
 
-    expect(screen.queryByRole('button', { name: /Use plan target/i })).not.toBeInTheDocument();
+    const planTargetButton = screen.getByRole('button', { name: /Use plan target/i });
+    expect(planTargetButton).toHaveTextContent(planTarget);
     expect(screen.queryByRole('button', { name: /Plan target selected/i })).not.toBeInTheDocument();
     expect(screen.getAllByText(planTarget)).toHaveLength(1);
+    expect(screen.getByText('No target selected')).toBeInTheDocument();
     expect(screen.getByText(/\+4 · −1/)).toBeInTheDocument();
     expect(screen.getByLabelText(/Prompts & reactions for target 1/i)).toHaveValue('Persisted blank target row note');
     expect(screen.getByRole('button', { name: /Increase correct trials for target 1/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Frequency value for target 1 \(count\)/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Add frequency trial for target 1/i })).not.toBeInTheDocument();
+
+    await userEvent.click(planTargetButton);
+
+    expect(screen.queryByRole('button', { name: /Use plan target/i })).not.toBeInTheDocument();
+    expect(screen.getAllByText(planTarget)).toHaveLength(1);
+    expect(screen.queryByText('No target selected')).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/Prompts & reactions for target 1/i)).toHaveValue('Persisted blank target row note');
+    expect(screen.getByLabelText(/Frequency value for target 1 \(count\)/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add frequency trial for target 1/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Save progress/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        session_note_persist_requested: true,
+        session_note_goal_measurements: {
+          'goal-1': {
+            version: 1,
+            data: expect.objectContaining({
+              metric_value: 4,
+              incorrect_trials: 1,
+              opportunities: 6,
+              targets: [planTarget],
+              target: planTarget,
+              target_trials: [
+                expect.objectContaining({
+                  target: planTarget,
+                  metric_value: 4,
+                  incorrect_trials: 1,
+                  opportunities: 6,
+                  trial_prompt_note: 'Persisted blank target row note',
+                }),
+              ],
+              trial_prompt_note: 'Persisted blank target row note',
+            }),
+          },
+        },
+      }));
+    });
+  }, 10000);
+
+  it('treats explicit zero blank plan-target trial values as persisted evidence', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const planTarget = 'Match peer greeting in 4/5 trials';
+    const targetId = '88888888-8888-4888-8888-888888888891';
+    const linkedSessionNote = {
+      id: 'linked-note-blank-plan-target-zero-evidence',
+      authorization_id: 'auth-1',
+      service_code: '97153',
+      narrative: '',
+      goal_notes: {
+        'goal-1': 'Observed saved zero evidence without a stored target label',
+      },
+      goal_measurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_label: 'Count',
+            metric_unit: 'responses',
+            target_trials: [
+              {
+                metric_value: 0,
+                incorrect_trials: 0,
+                opportunities: 0,
+              },
+            ],
+          },
+        },
+      },
+      goal_ids: ['goal-1'],
+      goals_addressed: ['Default Goal'],
+    };
+
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'linked-note-blank-plan-target-zero-evidence',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: linkedSessionNote.goals_addressed,
+      goal_ids: linkedSessionNote.goal_ids,
+      goal_measurements: linkedSessionNote.goal_measurements as Record<string, unknown>,
+      goal_notes: linkedSessionNote.goal_notes,
+      session_id: 'session-linked-blank-plan-target-zero-evidence',
+      narrative: linkedSessionNote.narrative,
+      is_locked: false,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: null,
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T09:00:00.000Z',
+    });
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: mockPrograms, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
+      if (table === 'goals') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: mockGoals, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
+      if (table === 'authorizations') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({
+            data: [{ id: 'auth-1', authorization_number: 'AUTH-001', services: [{ service_code: '97153' }] }],
+            error: null,
+          })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
+      if (table === 'goal_targets') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({
+            data: [{
+              id: targetId,
+              organization_id: 'org-a',
+              client_id: 'test-client-1',
+              goal_id: 'goal-1',
+              name: planTarget,
+              measurement_type: 'frequency',
+              graph_config: {},
+              status: 'active',
+              sort_order: 0,
+              is_current: true,
+              created_by: null,
+              updated_by: null,
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-01T00:00:00Z',
+            }],
+            error: null,
+          })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: [], error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-linked-blank-plan-target-zero-evidence',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Observed saved zero evidence without a stored target label')).toBeInTheDocument();
+    });
+
+    const planTargetButton = screen.getByRole('button', { name: /Use plan target/i });
+    expect(planTargetButton).toHaveTextContent(planTarget);
+    expect(screen.getByText('No target selected')).toBeInTheDocument();
+    expect(screen.getByText(/\+0 · −0/)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Frequency value for target 1 \(count\)/i)).not.toBeInTheDocument();
   }, 10000);
 
   it('shows inline trial bounds validation and blocks save progress when correct trials exceed opportunities', async () => {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -3065,6 +3065,105 @@ describe('SessionModal', () => {
     expect(submitted.session_note_goal_measurements?.['goal-1']?.data.incorrect_trials).toBeNull();
   }, 15000);
 
+  it('renders the configured plan target once before and after selection while keeping active capture controls', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const targetId = '88888888-8888-4888-8888-888888888889';
+    const planTarget = 'Match peer greeting in 4/5 trials';
+    const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildChain(mockPrograms);
+      }
+      if (table === 'goals') {
+        return buildChain(mockGoals);
+      }
+      if (table === 'authorizations') {
+        return buildChain([
+          {
+            id: 'auth-1',
+            authorization_number: 'AUTH-001',
+            services: [{ service_code: '97153' }],
+          },
+        ]);
+      }
+      if (table === 'goal_targets') {
+        return buildChain([
+          {
+            id: targetId,
+            organization_id: 'org-a',
+            client_id: 'test-client-1',
+            goal_id: 'goal-1',
+            name: planTarget,
+            measurement_type: 'frequency',
+            graph_config: {},
+            status: 'active',
+            sort_order: 0,
+            is_current: true,
+            created_by: null,
+            updated_by: null,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        ]);
+      }
+      if (table === 'trial_events') {
+        return buildChain([]);
+      }
+      return buildChain([]);
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        existingSessions={[]}
+        session={{
+          id: 'session-plan-target-dedup',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />,
+    );
+
+    const planTargetButton = await screen.findByRole('button', { name: /Use plan target/i });
+    expect(planTargetButton).toHaveTextContent(planTarget);
+    expect(screen.getAllByText(planTarget)).toHaveLength(1);
+    expect(screen.queryByText('No target selected')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Plan target selected/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Increase correct trials for target 1/i })).not.toBeInTheDocument();
+
+    await userEvent.click(planTargetButton);
+
+    expect(screen.queryByRole('button', { name: /Use plan target/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Plan target selected/i })).not.toBeInTheDocument();
+    expect(screen.getAllByText(planTarget)).toHaveLength(1);
+    expect(screen.getByLabelText(/Frequency value for target 1 \(count\)/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add frequency trial for target 1/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Prompts & reactions for target 1/i)).toBeInTheDocument();
+  }, 15000);
+
   it('submits configured duration target values as raw trial values with units', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const targetId = '88888888-8888-4888-8888-888888888881';
@@ -4734,8 +4833,9 @@ describe('SessionModal', () => {
       expect(screen.getByDisplayValue('Observed mixed saved targets')).toBeInTheDocument();
     });
 
-    const planTargetButton = await screen.findByRole('button', { name: /Plan target selected/i });
-    expect(planTargetButton).toHaveTextContent(planTarget);
+    expect(screen.queryByRole('button', { name: /Use plan target/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Plan target selected/i })).not.toBeInTheDocument();
+    expect(screen.getAllByText(planTarget)).toHaveLength(1);
     expect(screen.queryByText(legacyFreeformTarget)).not.toBeInTheDocument();
 
     const noResponseOutcome = screen.getByRole('radio', {
@@ -4802,6 +4902,146 @@ describe('SessionModal', () => {
     });
     const submitted = onSubmit.mock.calls[0]?.[0] as { session_note_trial_events?: unknown[] };
     expect(submitted.session_note_trial_events ?? []).toEqual([]);
+  }, 10000);
+
+  it('keeps a blank persisted plan-target evidence row visible when legacy target strings are missing', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const planTarget = 'Match peer greeting in 4/5 trials';
+    const linkedSessionNote = {
+      id: 'linked-note-blank-plan-target-evidence',
+      authorization_id: 'auth-1',
+      service_code: '97153',
+      narrative: '',
+      goal_notes: {
+        'goal-1': 'Observed saved evidence without a stored target label',
+      },
+      goal_measurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_label: 'Count',
+            metric_unit: 'responses',
+            target_trials: [
+              {
+                metric_value: 4,
+                incorrect_trials: 1,
+                opportunities: 6,
+                trial_prompt_note: 'Persisted blank target row note',
+              },
+            ],
+          },
+        },
+      },
+      goal_ids: ['goal-1'],
+      goals_addressed: ['Default Goal'],
+    };
+
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'linked-note-blank-plan-target-evidence',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: linkedSessionNote.goals_addressed,
+      goal_ids: linkedSessionNote.goal_ids,
+      goal_measurements: linkedSessionNote.goal_measurements as Record<string, unknown>,
+      goal_notes: linkedSessionNote.goal_notes,
+      session_id: 'session-linked-blank-plan-target-evidence',
+      narrative: linkedSessionNote.narrative,
+      is_locked: false,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: null,
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T09:00:00.000Z',
+    });
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: mockPrograms, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
+      if (table === 'goals') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: mockGoals, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
+      if (table === 'authorizations') {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({
+            data: [{ id: 'auth-1', authorization_number: 'AUTH-001', services: [{ service_code: '97153' }] }],
+            error: null,
+          })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      }
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: [], error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        session={{
+          id: 'session-linked-blank-plan-target-evidence',
+          therapist_id: 'test-therapist-1',
+          client_id: 'test-client-1',
+          program_id: 'program-1',
+          goal_id: 'goal-1',
+          start_time: '2026-03-01T10:00:00.000Z',
+          end_time: '2026-03-01T11:00:00.000Z',
+          status: 'in_progress',
+          notes: '',
+          created_at: '2026-03-01T09:00:00.000Z',
+          created_by: null,
+          updated_at: '2026-03-01T09:00:00.000Z',
+          updated_by: null,
+          started_at: null,
+        } satisfies Session}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Observed saved evidence without a stored target label')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: /Use plan target/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Plan target selected/i })).not.toBeInTheDocument();
+    expect(screen.getAllByText(planTarget)).toHaveLength(1);
+    expect(screen.getByText(/\+4 · −1/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Prompts & reactions for target 1/i)).toHaveValue('Persisted blank target row note');
+    expect(screen.getByRole('button', { name: /Increase correct trials for target 1/i })).toBeInTheDocument();
   }, 10000);
 
   it('shows inline trial bounds validation and blocks save progress when correct trials exceed opportunities', async () => {


### PR DESCRIPTION
## Summary
- remove the redundant selected-plan status card after a configured target is activated or hydrated
- keep the configured target visible once in the active capture card
- preserve legacy saved evidence rows that have blank stored target labels

## Routing
- Linear: WIN-238
- classification: low-risk autonomous
- lane: standard
- protected-path drift: none

## Verification
- full `SessionModal` suite: 103 passed
- `npm run ci:check-focused`: passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm run test:ci`: 3,140 passed / 4 unrelated failures in existing CI/workflow contract and Blob environment tests
- `npm run verify:local`: stopped at the same `test:ci` baseline failures; coverage and tier-0 constituents were not reached
- code-review-engineer: approved after legacy hydration correction
- test-engineer: approved

## Risk
Low and limited to SessionModal target-card rendering. Capture payloads, APIs, schemas, auth, and analytics are unchanged. Human review is requested before merge.