### PR TITLE
WIN-241: repair session-note plan-target smoke

### DIFF
--- a/docs/ai/WIN-241-session-note-plan-target-smoke-handoff.md
+++ b/docs/ai/WIN-241-session-note-plan-target-smoke-handoff.md
@@ -13,6 +13,22 @@
 - Triggering surface: Playwright smoke behavior in `scripts/playwright-session-note-measurement-roundtrip.ts`
 - Linear: [WIN-241](https://linear.app/winningedgeai/issue/WIN-241/repair-session-note-measurement-smoke-after-plan-target-dedup)
 
+## Required Handoff Card
+
+- `classification`: low-risk autonomous
+- `lane`: standard
+- `files touched`:
+  - `scripts/playwright-session-note-measurement-roundtrip.ts`
+  - `tests/ci/check-e2e-reliability-gates.test.ts`
+  - `docs/ai/WIN-241-session-note-plan-target-smoke-handoff.md`
+- `required agents`: specification-engineer -> implementation-engineer -> code-review-engineer -> test-engineer
+- `required checks`: focused reliability-gate regression; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run build`; local or hosted session-note browser proof
+- `executed checks`: focused regression -> pass; `npm run ci:check-focused` -> pass; `npm run lint` -> pass; `npm run typecheck` -> pass; `npm run test:ci` -> fail on four unrelated baseline failures; `npm run build` -> pass; local browser proof -> blocked before launch by missing credentials
+- `blocked checks`: local browser proof -> protected Supabase and smoke credentials unavailable; hosted `auth-browser-smoke` -> pending on PR #836
+- `reviewer`: completed; no source-level code finding, handoff completeness finding addressed in this document
+- `residual risk`: secret-backed hosted browser behavior is not proven until PR #836 reports a green `auth-browser-smoke`
+- `pr handoff`: missing prerequisite until hosted `auth-browser-smoke` passes and required PR checks complete
+
 ## Verification Card
 
 - Classification: low-risk autonomous

--- a/docs/ai/WIN-241-session-note-plan-target-smoke-handoff.md
+++ b/docs/ai/WIN-241-session-note-plan-target-smoke-handoff.md
@@ -1,0 +1,46 @@
+# WIN-241 Session Note Plan-Target Smoke Handoff
+
+## Scope
+
+- Update the session-note measurement roundtrip smoke to select the configured plan target when its trial controls are initially hidden.
+- Add a focused reliability-gate regression assertion for the required interaction order.
+- Do not change application behavior, authentication, authorization, database, migration, workflow, or deployment surfaces.
+
+## Routing
+
+- Classification: low-risk autonomous
+- Lane: standard
+- Triggering surface: Playwright smoke behavior in `scripts/playwright-session-note-measurement-roundtrip.ts`
+- Linear: [WIN-241](https://linear.app/winningedgeai/issue/WIN-241/repair-session-note-measurement-smoke-after-plan-target-dedup)
+
+## Verification Card
+
+- Classification: low-risk autonomous
+- Lane: standard
+- Change type: CI/browser smoke script and focused policy regression test
+- Required checks:
+  - `npx vitest run tests/ci/check-e2e-reliability-gates.test.ts -t "selects a configured plan target"`
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run playwright:session-note-measurement-roundtrip`
+  - hosted `auth-browser-smoke`
+- Executed checks:
+  - Focused regression: pass (1 passed, 13 skipped)
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+  - `npm run test:ci`: fail with four pre-existing failures outside this diff, including the synthetic BCBA workflow-fixture assertion, disposable browser-proof branch fixtures, and the Blob test environment mismatch
+  - `npm run playwright:session-note-measurement-roundtrip`: blocked before browser launch by missing Supabase URL/keys and smoke credentials
+- Blocked checks:
+  - Local Playwright roundtrip cannot run without protected hosted credentials.
+  - Hosted `auth-browser-smoke` remains pending until the branch is pushed.
+- Result: fail pending hosted browser proof; required local `test:ci` is not green because of unrelated baseline failures
+- Residual risk: The selector interaction is source-tested locally; the hosted smoke must confirm the current modal behavior with CI-managed credentials.
+
+## PR Handoff
+
+The application now exposes configured target controls only after the operator selects `Use plan target`. The smoke preserves its existing path when controls are already visible and otherwise clicks that action before waiting for the target input. Hosted CI is the decisive end-to-end validation.

--- a/scripts/playwright-session-note-measurement-roundtrip.ts
+++ b/scripts/playwright-session-note-measurement-roundtrip.ts
@@ -242,7 +242,15 @@ const setFirstTargetCorrectTrialCount = async (
   count: number,
 ): Promise<boolean> => {
   await ensureGoalCaptureFieldsVisible(dialog, goalId);
-  await dialog.locator(`#goal-target-${goalId}-0`).waitFor({ state: "visible", timeout: 30_000 });
+  const targetLocator = dialog.locator(`#goal-target-${goalId}-0`);
+  const targetVisible = await targetLocator.isVisible().catch(() => false);
+  if (!targetVisible) {
+    const usePlanTargetButton = dialog.getByRole("button", { name: /^Use plan target/i });
+    if ((await usePlanTargetButton.count()) > 0) {
+      await usePlanTargetButton.first().click();
+    }
+  }
+  await targetLocator.waitFor({ state: "visible", timeout: 30_000 });
 
   const addFiveButton = dialog.getByRole("button", { name: "Add 5 correct trials for target 1" });
   const incrementButton = dialog.getByRole("button", { name: "Increase correct trials for target 1" });

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -211,7 +211,7 @@ describe("check-e2e-reliability-gates", () => {
     expect(content).toContain(targetLocator);
     expect(content).toContain(clickPlanTarget);
     expect(content).toContain(waitForTargetControl);
-    expect(content.indexOf(selectPlanTarget)).toBeLessThan(content.indexOf(waitForTargetControl));
+    expect(content.indexOf(clickPlanTarget)).toBeLessThan(content.indexOf(waitForTargetControl));
   });
 
   test("session note measurement filters the crowded schedule to its booked actor and client", () => {

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -199,6 +199,21 @@ describe("check-e2e-reliability-gates", () => {
     expect(resolveOpportunityCountForMetric(8, Number.NaN)).toBe(8);
   });
 
+  test("session note measurement selects a configured plan target before waiting for trial controls", () => {
+    const scriptPath = path.join(repoRoot, "scripts", "playwright-session-note-measurement-roundtrip.ts");
+    const content = readFileSync(scriptPath, "utf8");
+    const selectPlanTarget = 'getByRole("button", { name: /^Use plan target/i })';
+    const targetLocator = 'const targetLocator = dialog.locator(`#goal-target-${goalId}-0`)';
+    const clickPlanTarget = "await usePlanTargetButton.first().click();";
+    const waitForTargetControl = "await targetLocator.waitFor";
+
+    expect(content).toContain(selectPlanTarget);
+    expect(content).toContain(targetLocator);
+    expect(content).toContain(clickPlanTarget);
+    expect(content).toContain(waitForTargetControl);
+    expect(content.indexOf(selectPlanTarget)).toBeLessThan(content.indexOf(waitForTargetControl));
+  });
+
   test("session note measurement filters the crowded schedule to its booked actor and client", () => {
     const scriptPath = path.join(repoRoot, "scripts", "playwright-session-note-measurement-roundtrip.ts");
     const content = readFileSync(scriptPath, "utf8");


### PR DESCRIPTION
## Summary
- select the configured plan target before the session-note measurement smoke waits for trial controls
- preserve the existing path when target controls are already visible
- add a focused reliability-gate regression and WIN-241 verification handoff

## Routing
- classification: low-risk autonomous
- lane: standard
- Linear: https://linear.app/winningedgeai/issue/WIN-241/repair-session-note-measurement-smoke-after-plan-target-dedup

## Verification
- PASS: focused regression
- PASS: npm run ci:check-focused
- PASS: npm run lint
- PASS: npm run typecheck
- PASS: npm run build
- LOCAL BASELINE FAIL: npm run test:ci (4 failures outside this diff)
- LOCAL BLOCKED: browser roundtrip requires protected Supabase and smoke credentials
- PENDING: hosted auth-browser-smoke

## Context
PR #834 exposed this stale smoke after WIN-238 intentionally changed configured plan targets to require the Use plan target action before measurement controls render.