### PR TITLE
WIN-242: Persist BT draft before direct finalize

### DIFF
--- a/docs/ai/WIN-242-direct-bt-finalize-handoff.md
+++ b/docs/ai/WIN-242-direct-bt-finalize-handoff.md
@@ -1,0 +1,72 @@
+# WIN-242 Direct BT Finalize Handoff
+
+## Routing
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- why: the implementation is contained to frontend orchestration and tests while preserving the existing server, authorization, tenant, signature, and progression contracts
+- triggering paths: `src/components/SessionModal.tsx`, `src/components/__tests__/SessionModal.test.tsx`
+- branch: `codex/win-242-direct-bt-finalize`
+- Linear: `WIN-242`
+
+## Scope
+
+- task intent: make direct BT ABA finalization persist the template-backed draft before calling the existing finalize API
+- files touched: `src/components/SessionModal.tsx`, targeted component tests, this handoff
+- non-goals: no RPC, migration, RLS, grant, billing-policy, assignment-policy, or unrelated audit-finding changes
+- stop condition: re-route before touching `src/server/**` or `supabase/**`
+- single-purpose diff: yes
+
+## Live Reproduction
+
+- synthetic client: `QA Workflow07232026`
+- session: `862ded50-9b5c-4411-bdf6-3e3439c7c79d`
+- note: `36d9d14c-5da3-4739-b34c-bbc3c222a8ac`
+- failure: direct Finalize returned `403 Forbidden`; Postgres logged `BT ABA template is out of scope`
+- root cause: the existing note had `bt_aba_template_id = NULL`; the read RPC still returned the active template as a fallback alongside the generic note ID
+- workaround proof: Save Draft attached template `ce4213af-4c00-4a25-a681-9ae6cf11b9e8`; the next Finalize completed and locked the note
+- evidence: `.tmp/live-audit-evidence-2026-07-23/05-session-finalize-forbidden.png` and `06-session-completed.png`
+
+## Required Agents
+
+- required sequence: specification-engineer, implementation-engineer, code-review-engineer, test-engineer
+- agents used: specification-engineer, software-architect, implementation-engineer, code-review-engineer, test-engineer
+- reviewer: completed with no findings after the fallback-template read contract was clarified
+
+## Verification Card
+
+- required checks:
+  - targeted `SessionModal` tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - targeted `SessionModal` tests: pass, 107/107
+  - `npm run ci:check-focused`: pass via direct bundled-Node invocation
+  - `npm run lint`: pass via direct bundled-Node invocation
+  - `npm run typecheck`: pass via direct bundled-Node invocation
+  - `npm run test:ci`: fail on four unrelated baseline tests; the WIN-242 suite passed within the run
+  - `npm run test:routes:tier0`: pass, 220/220
+  - `npm run ci:playwright`: preflight passed; auth smoke failed because the configured `superadmin@test.com` credential was rejected
+  - `npm run build`: pass
+- blocked checks:
+  - `npm run verify:local`: blocked by the same unrelated `test:ci` baseline failures
+  - remaining `npm run ci:playwright` children: blocked after the auth smoke stopped the fail-fast runner
+- result: `pass-with-blocked-checks`
+- residual risk: the live QA also found schedule/finalize assignment inconsistency and a zero-data-point closeout preview; both remain separate follow-up slices
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes
+- protected-path drift: none
+- unrelated changes: pre-existing untracked `.superpowers/brainstorm/`, `.tmp/`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml` are excluded
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: yes
+- required follow-up: push the isolated branch, open the human-reviewed PR, and rely on CI for the credential-backed Playwright rerun

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -586,7 +586,7 @@ export function SessionModal({
   const [modalStep, setModalStep] = useState<'capture' | 'closeout'>('capture');
   const [btAbaBusy, setBtAbaBusy] = useState(false);
   const [btAbaError, setBtAbaError] = useState<string | null>(null);
-  const [btAbaNoteId, setBtAbaNoteId] = useState<string | null>(null);
+  const [, setBtAbaNoteId] = useState<string | null>(null);
   const [btAbaFinalized, setBtAbaFinalized] = useState(false);
   const btAbaTransitionRef = useRef<'idle' | 'finalizing' | 'finalized'>('idle');
   const closeoutCaptureRef = useRef<{
@@ -2068,24 +2068,32 @@ export function SessionModal({
     })();
   };
 
-  const handleSaveBtAbaDraft = async (responses: BtAbaSessionNoteResponses) => {
+  const persistBtAbaDraft = async (
+    draftResponses: BtAbaSessionNoteResponses,
+    options?: { announceSuccess?: boolean },
+  ) => {
     if (!session?.id || !btAbaNoteState?.templateId || !closeoutCaptureRef.current) {
-      const message = 'The ABA session note is still loading. Please retry.';
-      setBtAbaError(message);
-      showError(message);
-      return;
+      throw new Error('The ABA session note is still loading. Please retry.');
     }
+
+    const result = await saveBtAbaSessionNoteDraft({
+      sessionId: session.id,
+      templateId: btAbaNoteState.templateId,
+      notePayload: closeoutCaptureRef.current.notePayload,
+      responses: draftResponses,
+    });
+    setBtAbaNoteId(result.noteId);
+    if (options?.announceSuccess) {
+      showSuccess('ABA session note draft saved');
+    }
+    return result.noteId;
+  };
+
+  const handleSaveBtAbaDraft = async (responses: BtAbaSessionNoteResponses) => {
     setBtAbaBusy(true);
     setBtAbaError(null);
     try {
-      const result = await saveBtAbaSessionNoteDraft({
-        sessionId: session.id,
-        templateId: btAbaNoteState.templateId,
-        notePayload: closeoutCaptureRef.current.notePayload,
-        responses,
-      });
-      setBtAbaNoteId(result.noteId);
-      showSuccess('ABA session note draft saved');
+      await persistBtAbaDraft(responses, { announceSuccess: true });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to save the ABA session note draft.';
       setBtAbaError(message);
@@ -2097,8 +2105,8 @@ export function SessionModal({
 
   const handleFinalizeBtAba = async (responses: BtAbaSessionNoteResponses) => {
     if (btAbaTransitionRef.current !== 'idle') return;
-    if (!session?.id || !btAbaNoteId || !closeoutCaptureRef.current) {
-      const message = 'Save the ABA session note draft before finalizing.';
+    if (!session?.id || !btAbaNoteState?.templateId || !closeoutCaptureRef.current) {
+      const message = 'The ABA session note is still loading. Please retry.';
       setBtAbaError(message);
       showError(message);
       return;
@@ -2108,9 +2116,10 @@ export function SessionModal({
     setBtAbaError(null);
     let result: BtAbaFinalizeResult;
     try {
+      const noteId = await persistBtAbaDraft(responses);
       result = await finalizeBtAbaSessionNote({
         sessionId: session.id,
-        noteId: btAbaNoteId,
+        noteId,
         notePayload: closeoutCaptureRef.current.notePayload,
         responses,
         trialEvents: closeoutCaptureRef.current.trialEvents,

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1024,6 +1024,100 @@ describe('SessionModal', () => {
     }));
   });
 
+  it('persists a BT draft before direct finalize when the read state has a generic note id and fallback template', async () => {
+    // The read RPC supplies the active template fallback even when the generic row has no persisted template binding.
+    vi.mocked(getBtAbaSessionNote).mockResolvedValue({
+      noteId: '36d9-generic-note',
+      templateId: 'template-direct-finalize',
+      responses: null,
+      status: null,
+    });
+    vi.mocked(saveBtAbaSessionNoteDraft).mockResolvedValue({
+      status: 'draft',
+      noteId: 'note-direct-finalize',
+    });
+    vi.mocked(finalizeBtAbaSessionNote).mockResolvedValue({
+      status: 'completed',
+      noteId: 'note-direct-finalize',
+      progressionResults: [],
+    });
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onBtAbaSessionFinalized = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        onSubmit={onSubmit}
+        onBtAbaSessionFinalized={onBtAbaSessionFinalized}
+        session={btInProgressSession}
+        dataCollectionOnly
+      />,
+    );
+
+    const closeSessionButton = await screen.findByRole('button', { name: /^Close Session$/i });
+    await waitFor(() => expect(closeSessionButton).not.toBeDisabled());
+    await userEvent.click(closeSessionButton);
+
+    expect(await screen.findByRole('heading', { name: 'ABA Session Note' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Finalize ABA Session' }));
+
+    await waitFor(() => expect(saveBtAbaSessionNoteDraft).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: btInProgressSession.id,
+      templateId: 'template-direct-finalize',
+      responses: validBtAbaResponses,
+    })));
+    await waitFor(() => expect(finalizeBtAbaSessionNote).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: btInProgressSession.id,
+      noteId: 'note-direct-finalize',
+      responses: validBtAbaResponses,
+    })));
+    expect(finalizeBtAbaSessionNote).not.toHaveBeenCalledWith(expect.objectContaining({
+      noteId: '36d9-generic-note',
+    }));
+    expect(saveBtAbaSessionNoteDraft.mock.invocationCallOrder[0]).toBeLessThan(
+      finalizeBtAbaSessionNote.mock.invocationCallOrder[0],
+    );
+    await waitFor(() => expect(onBtAbaSessionFinalized).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: btInProgressSession.id,
+      noteId: 'note-direct-finalize',
+      status: 'completed',
+    })));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ status: 'in_progress' }));
+    expect(toastMocks.showSuccess).not.toHaveBeenCalledWith('ABA session note draft saved');
+  });
+
+  it('surfaces BT draft preparation failure and skips direct finalize', async () => {
+    vi.mocked(getBtAbaSessionNote).mockResolvedValue({
+      noteId: null,
+      templateId: 'template-direct-finalize',
+      responses: null,
+      status: null,
+    });
+    vi.mocked(saveBtAbaSessionNoteDraft).mockRejectedValue(new Error('Draft preparation failed'));
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        session={btInProgressSession}
+        dataCollectionOnly
+      />,
+    );
+
+    const closeSessionButton = await screen.findByRole('button', { name: /^Close Session$/i });
+    await waitFor(() => expect(closeSessionButton).not.toBeDisabled());
+    await userEvent.click(closeSessionButton);
+
+    expect(await screen.findByRole('heading', { name: 'ABA Session Note' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Finalize ABA Session' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Draft preparation failed');
+    expect(saveBtAbaSessionNoteDraft).toHaveBeenCalledTimes(1);
+    expect(finalizeBtAbaSessionNote).not.toHaveBeenCalled();
+    expect(toastMocks.showError).toHaveBeenCalledWith('Draft preparation failed');
+  });
+
   it('updates the completed ABA-note cache after successful finalization', async () => {
     const setQueryData = vi.spyOn(QueryClient.prototype, 'setQueryData');
     const invalidateQueries = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
@@ -1278,6 +1372,8 @@ describe('SessionModal', () => {
     vi.mocked(getBtAbaSessionNote).mockResolvedValue({
       noteId: 'note-once', templateId: 'template-bt-1', responses: validBtAbaResponses as unknown as Record<string, unknown>, status: 'draft',
     });
+    let resolveDraft!: (value: Awaited<ReturnType<typeof saveBtAbaSessionNoteDraft>>) => void;
+    vi.mocked(saveBtAbaSessionNoteDraft).mockImplementation(() => new Promise((resolve) => { resolveDraft = resolve; }));
     let resolveFinalize!: (value: Awaited<ReturnType<typeof finalizeBtAbaSessionNote>>) => void;
     vi.mocked(finalizeBtAbaSessionNote).mockImplementation(() => new Promise((resolve) => { resolveFinalize = resolve; }));
     const onBtAbaSessionFinalized = vi.fn().mockResolvedValue(undefined);
@@ -1288,11 +1384,14 @@ describe('SessionModal', () => {
     const finalizeButton = await screen.findByRole('button', { name: 'Finalize ABA Session' });
     fireEvent.click(finalizeButton);
     fireEvent.click(finalizeButton);
-    expect(finalizeBtAbaSessionNote).toHaveBeenCalledTimes(1);
+    expect(saveBtAbaSessionNoteDraft).toHaveBeenCalledTimes(1);
+    expect(finalizeBtAbaSessionNote).not.toHaveBeenCalled();
     expect(screen.getByRole('button', { name: 'Close session modal' })).toBeDisabled();
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(defaultProps.onClose).not.toHaveBeenCalled();
 
+    resolveDraft({ status: 'draft', noteId: 'note-once' });
+    await waitFor(() => expect(finalizeBtAbaSessionNote).toHaveBeenCalledTimes(1));
     resolveFinalize({ status: 'completed', noteId: 'note-once', progressionResults: [] });
     await waitFor(() => expect(onBtAbaSessionFinalized).toHaveBeenCalledTimes(1));
   });


### PR DESCRIPTION
## Summary
- persist the current template-backed BT ABA draft immediately before direct finalization
- finalize the note ID returned by that draft save instead of a generic read-state note ID
- add regressions for fallback-template direct finalize, draft-save failure, and duplicate submission

## Live reproduction
- synthetic session 862ded50-9b5c-4411-bdf6-3e3439c7c79d
- direct Finalize returned 403 with BT ABA template is out of scope
- Save Draft attached the active template; the next Finalize completed and locked the note
- local evidence is documented in docs/ai/WIN-242-direct-bt-finalize-handoff.md

## Verification
- PASS: focused SessionModal tests, 107/107
- PASS: policy checks, lint, typecheck, build
- PASS: tier-0 route gate, 220/220
- PASS: independent code review, no findings
- BLOCKED: full test:ci has four unrelated baseline failures in supabase.edge.test.ts and disposable-browser workflow assertions
- BLOCKED: Playwright preflight passed, then auth smoke rejected the configured superadmin@test.com credential

## Risk
Frontend orchestration only. No server, migration, RLS, grant, auth, tenant, billing, or deployment changes.

Linear: WIN-242