### PR TITLE
fix: include aggregate capture in BT closeout

### DIFF
--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -1,0 +1,84 @@
+# WIN-243 Closeout Aggregate Preview Handoff
+
+## Routing
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- why: the fix is limited to frontend closeout preview derivation and targeted component tests
+- triggering paths: `src/components/SessionModal.tsx`, `src/components/__tests__/SessionModal.test.tsx`
+- branch: `codex/win-243-closeout-aggregate-preview`
+- Linear: `WIN-243`
+
+## Scope
+
+- task intent: show stored quantitative legacy goal measurements in the BT ABA Daily Summary when no raw trial-event rows exist
+- allowed files: `src/components/SessionModal.tsx`, `src/components/__tests__/SessionModal.test.tsx`, this handoff
+- representation rule: preserve each aggregate measurement as an aggregate preview row; do not invent individual raw trials
+- precedence rule: raw trial events remain one-for-one and suppress duplicate aggregate preview rows for the same goal/target
+- non-goals: no server, Supabase, RPC, RLS, grant, capture-persistence, finalization, or session-status changes
+- stop condition: re-route before touching `src/server/**`, `supabase/**`, auth, runtime config, CI, or deploy surfaces
+
+## Evidence
+
+- synthetic session: `862ded50-9b5c-4411-bdf6-3e3439c7c79d`
+- live symptom: Daily Summary displayed `0 collected data points`
+- hosted note evidence: `goal_measurements` stored `metric_value: 2` with verbal/full prompt counts
+- hosted trial evidence: the session had zero `trial_events` rows
+- root cause: `closeoutDataPoints` currently derives only from raw trial events
+- screenshot: `.tmp/live-audit-evidence-2026-07-23/04-session-capture-saved-closeout-data-missing.png`
+
+## Corrected Audit Finding
+
+The earlier suspected scheduling/finalization assignment mismatch was not a product defect. `app.current_user_has_assigned_client` intentionally accepts the session's assigned therapist in addition to `client_therapist_links`, and adding a synthetic link did not resolve the observed 403. The missing BT template binding was the actual finalization failure and was fixed by WIN-242.
+
+## Required Agents
+
+- required sequence: specification-engineer, implementation-engineer, code-review-engineer, test-engineer
+- agents used: specification-engineer, implementation-engineer, code-review-engineer, test-engineer
+- reviewer: completed; the first review found overly broad same-goal aggregate suppression and stale restored-draft input risk
+- re-review: approved with no findings after exact goal/target deduplication, normalized restored-draft hydration, and regression coverage
+
+## Verification Card
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- change type: UI/component session-closeout derivation and targeted component tests
+- required checks:
+  - targeted `SessionModal` tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - targeted `SessionModal` tests: pass, 110/110
+  - `npm run ci:check-focused`: pass via bundled Node runtime
+  - `npm run lint`: pass via bundled Node runtime
+  - `npm run typecheck`: pass via bundled Node runtime
+  - `npm run test:ci`: fail on four pre-existing baseline tests; all 110 `SessionModal` tests pass within the full run
+  - focused baseline rerun: three deterministic unrelated failures remain in the async PDF blob test and two CI/workflow source-contract tests; the order-sensitive schedule-readiness test passes in isolation
+  - `npm run test:routes:tier0`: pass, 220/220
+  - `npm run ci:playwright`: preflight passed; auth smoke failed because the configured `superadmin@test.com` credential was rejected, so the fail-fast runner did not execute the remaining children
+  - `npm run build`: pass
+- blocked checks:
+  - `npm run verify:local`: blocked by the same unrelated `test:ci` baseline failures
+  - remaining `npm run ci:playwright` children: blocked after the credential failure stopped the fail-fast runner
+- result: `pass-with-blocked-checks`
+- residual risk: live credential-backed closeout verification must rely on PR CI; aggregate values remain aggregate preview rows rather than fabricated raw trials
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes
+- single-purpose: yes
+- protected-path drift: none
+- unrelated changes: pre-existing untracked `.superpowers/brainstorm/`, `.tmp/`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml` are excluded
+- generated artifact drift: none
+- change summary: present
+- verification summary: present
+- reviewer: completed and approved
+- pr-ready: yes
+- required follow-up: commit the isolated files, push the branch, open the human-reviewed PR, move WIN-243 to In Review, and inspect live checks

--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -38,7 +38,8 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - reviewer: completed; the first review found overly broad same-goal aggregate suppression and stale restored-draft input risk
 - PR review: found that normalized preview state could replace historical persisted measurements and that completed aggregate-only sessions did not hydrate the preview
 - follow-up PR review: found that aggregate rows containing only `incorrect_trials` or `opportunities` were still omitted when `metric_value` was null
-- re-review: approved with no findings after adding explicit metric/incorrect/opportunity fallback handling and targeted coverage for both secondary quantitative shapes
+- final-head PR review: found that completed sessions still used current-target-filtered form measurements and that archived targetless goals could display a raw UUID instead of the finalized snapshot label
+- re-review: approved with no findings after switching completed previews to unfiltered linked-note measurements and finalized goal-label snapshots
 
 ## Verification Card
 
@@ -56,7 +57,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - targeted `SessionModal` tests: pass, 111/111
+  - targeted `SessionModal` tests: pass, 112/112
   - `npm run ci:check-focused`: pass via bundled Node runtime
   - `npm run lint`: pass via bundled Node runtime
   - `npm run typecheck`: pass via bundled Node runtime
@@ -70,7 +71,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run verify:local`: blocked by the same unrelated `test:ci` baseline failures
   - remaining `npm run ci:playwright` children: blocked after the credential failure stopped the fail-fast runner
 - result: `pending-final-head-ci`
-- residual risk: the secondary-field correction still requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
+- residual risk: the finalized-snapshot corrections still require final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
 
 ## PR Hygiene
 

--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -43,7 +43,8 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - latest PR review: found mixed correct/incorrect aggregates hid the incorrect count and label-based deduplication was unsafe for renamed or same-named targets
 - final-head PR review: found an indexed raw event could duplicate a top-level fallback and older unindexed raw events could duplicate a renamed single-target snapshot
 - subsequent PR review: found completed legacy measurements were marked unlinked when the finalized `goal_ids` column was null
-- re-review: approved with no findings after merging completed linkage from explicit goal IDs and persisted measurement keys
+- exact-head PR review: found the sole-label fallback could mislabel an identifiable unindexed raw target and suppress a distinct aggregate
+- re-review: approved after limiting sole-label inference to raw targets that cannot be identified by target ID
 
 ## Verification Card
 
@@ -61,7 +62,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - targeted `SessionModal` tests: pass, 122/122
+  - targeted `SessionModal` tests: pass, 123/123
   - `npm run ci:check-focused`: pass via bundled Node runtime
   - `npm run lint`: pass via bundled Node runtime
   - `npm run typecheck`: pass via bundled Node runtime
@@ -75,7 +76,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run verify:local`: blocked by the same unrelated `test:ci` baseline failures
   - remaining `npm run ci:playwright` children: blocked after the credential failure stopped the fail-fast runner
 - result: `pending-final-head-ci`
-- residual risk: the completed legacy-linkage correction requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
+- residual risk: the identity-safe unindexed fallback requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
 
 ## PR Hygiene
 
@@ -87,6 +88,6 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - generated artifact drift: none
 - change summary: present
 - verification summary: present
-- reviewer: completed and approved with no findings for the completed legacy-linkage correction
+- reviewer: completed and approved with no findings for the identity-safe unindexed fallback
 - pr-ready: yes
 - required follow-up: commit and push the isolated correction, resolve the current review thread, rerun final-head PR checks, and capture credential-backed closeout proof

--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -46,7 +46,8 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - subsequent PR review: found completed legacy measurements were marked unlinked when the finalized `goal_ids` column was null
 - exact-head PR review: found the sole-label fallback could mislabel an identifiable unindexed raw target and suppress a distinct aggregate
 - replacement-PR review: found that an unlabeled later aggregate inherited target zero and that non-count aggregates lost units or used count-specific wording
-- re-review: approved after preserving unlabeled aggregate identity, formatting non-count units, and retaining unit context for zero-valued mixed outcomes
+- subsequent exact-head review: found current goal metadata could overwrite persisted measurement type and a sole finalized label was not recovered when legacy `goal_ids` was null
+- re-review: approved after preserving persisted measurement type, limiting single-label inference to the unambiguous case, and covering ambiguous no-guess behavior
 
 ## Verification Card
 
@@ -64,7 +65,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - targeted `SessionModal` tests: pass, 125/125
+  - targeted `SessionModal` tests: pass, 128/128
   - `npm run ci:check-focused`: pass via bundled Node runtime
   - `npm run lint`: pass via bundled Node runtime
   - `npm run typecheck`: pass via bundled Node runtime
@@ -73,12 +74,12 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run test:routes:tier0`: pass, 220/220; one concurrent build/Cypress attempt returned transient 404s while `dist` was being rewritten, then the isolated rerun passed
   - `npm run ci:playwright`: preflight passed; auth smoke failed because the configured `superadmin@test.com` credential was rejected, so the fail-fast runner did not execute the remaining children
   - `npm run build`: pass
-  - PR #839 CI on commit `495ce07a`: all required checks passed, including Linux unit tests, policy, lint/typecheck, build, and the lane-scoped browser gates
+  - PR #839 CI on commit `04aabda0`: all required checks passed, including Linux unit tests, policy, lint/typecheck, build, and the lane-scoped browser gates
 - blocked checks:
   - `npm run verify:local`: blocked by the same unrelated `test:ci` baseline failures
   - remaining `npm run ci:playwright` children: blocked after the credential failure stopped the fail-fast runner
 - result: `pending-final-head-ci`
-- residual risk: the latest unit/identity correction requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
+- residual risk: the latest persisted-metadata and label-inference correction requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
 
 ## PR Hygiene
 
@@ -90,6 +91,6 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - generated artifact drift: none
 - change summary: present
 - verification summary: present
-- reviewer: completed and approved with no findings for the unit-aware and identity-safe aggregate fallback
+- reviewer: completed and approved with no findings for the persisted-metadata and unambiguous-label fallback
 - pr-ready: yes
 - required follow-up: commit and push the isolated correction, resolve the two current review threads, rerun final-head PR checks, and capture credential-backed closeout proof

--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -40,7 +40,8 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - follow-up PR review: found that aggregate rows containing only `incorrect_trials` or `opportunities` were still omitted when `metric_value` was null
 - final-head PR review: found that completed sessions still used current-target-filtered form measurements and that archived targetless goals could display a raw UUID instead of the finalized snapshot label
 - subsequent PR review: found zero-correct prompt aggregates hid incorrect outcomes, metadata-only target rows suppressed valid top-level values, and archived raw targets could duplicate a human-labeled aggregate
-- re-review: approved with no findings after preserving sparse label slots and preventing cross-target fallback
+- latest PR review: found mixed correct/incorrect aggregates hid the incorrect count and label-based deduplication was unsafe for renamed or same-named targets
+- re-review: approved with no findings after switching indexed trial events to persisted target identity and preserving both mixed outcomes
 
 ## Verification Card
 
@@ -58,7 +59,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - targeted `SessionModal` tests: pass, 116/116
+  - targeted `SessionModal` tests: pass, 119/119
   - `npm run ci:check-focused`: pass via bundled Node runtime
   - `npm run lint`: pass via bundled Node runtime
   - `npm run typecheck`: pass via bundled Node runtime
@@ -72,7 +73,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run verify:local`: blocked by the same unrelated `test:ci` baseline failures
   - remaining `npm run ci:playwright` children: blocked after the credential failure stopped the fail-fast runner
 - result: `pending-final-head-ci`
-- residual risk: the finalized-snapshot corrections still require final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
+- residual risk: the latest correction still requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
 
 ## PR Hygiene
 
@@ -84,6 +85,6 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - generated artifact drift: none
 - change summary: present
 - verification summary: present
-- reviewer: completed and approved
+- reviewer: completed and approved with no findings for the latest correction
 - pr-ready: yes
 - required follow-up: commit and push the isolated correction, resolve the current review thread, rerun final-head PR checks, and capture credential-backed closeout proof

--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -36,7 +36,8 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - required sequence: specification-engineer, implementation-engineer, code-review-engineer, test-engineer
 - agents used: specification-engineer, implementation-engineer, code-review-engineer, test-engineer
 - reviewer: completed; the first review found overly broad same-goal aggregate suppression and stale restored-draft input risk
-- re-review: approved with no findings after exact goal/target deduplication, normalized restored-draft hydration, and regression coverage
+- PR review: found that normalized preview state could replace historical persisted measurements and that completed aggregate-only sessions did not hydrate the preview
+- re-review: approved with no findings after separating preview/persistence state, adding completed-session hydration, and covering both regressions
 
 ## Verification Card
 
@@ -54,11 +55,11 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - targeted `SessionModal` tests: pass, 110/110
+  - targeted `SessionModal` tests: pass, 111/111
   - `npm run ci:check-focused`: pass via bundled Node runtime
   - `npm run lint`: pass via bundled Node runtime
   - `npm run typecheck`: pass via bundled Node runtime
-  - `npm run test:ci`: fail on four pre-existing baseline tests; all 110 `SessionModal` tests pass within the full run
+  - `npm run test:ci`: fail on four pre-existing baseline tests; all WIN-243 `SessionModal` tests pass within the full run
   - focused baseline rerun: three deterministic unrelated failures remain in the async PDF blob test and two CI/workflow source-contract tests; the order-sensitive schedule-readiness test passes in isolation
   - `npm run test:routes:tier0`: pass, 220/220
   - `npm run ci:playwright`: preflight passed; auth smoke failed because the configured `superadmin@test.com` credential was rejected, so the fail-fast runner did not execute the remaining children

--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -6,7 +6,8 @@
 - lane: `standard`
 - why: the fix is limited to frontend closeout preview derivation and targeted component tests
 - triggering paths: `src/components/SessionModal.tsx`, `src/components/__tests__/SessionModal.test.tsx`
-- branch: `codex/win-243-closeout-aggregate-preview`
+- branch: `codex/win-243-closeout-aggregate-preview-final`
+- PR: `#839` (replacement for `#838`, whose synchronized head stopped emitting required GitHub Actions checks)
 - Linear: `WIN-243`
 
 ## Scope
@@ -44,7 +45,8 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - final-head PR review: found an indexed raw event could duplicate a top-level fallback and older unindexed raw events could duplicate a renamed single-target snapshot
 - subsequent PR review: found completed legacy measurements were marked unlinked when the finalized `goal_ids` column was null
 - exact-head PR review: found the sole-label fallback could mislabel an identifiable unindexed raw target and suppress a distinct aggregate
-- re-review: approved after limiting sole-label inference to raw targets that cannot be identified by target ID
+- replacement-PR review: found that an unlabeled later aggregate inherited target zero and that non-count aggregates lost units or used count-specific wording
+- re-review: approved after preserving unlabeled aggregate identity, formatting non-count units, and retaining unit context for zero-valued mixed outcomes
 
 ## Verification Card
 
@@ -62,21 +64,21 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - targeted `SessionModal` tests: pass, 123/123
+  - targeted `SessionModal` tests: pass, 125/125
   - `npm run ci:check-focused`: pass via bundled Node runtime
   - `npm run lint`: pass via bundled Node runtime
   - `npm run typecheck`: pass via bundled Node runtime
   - `npm run test:ci`: fail on four pre-existing baseline tests; all WIN-243 `SessionModal` tests pass within the full run
   - focused baseline rerun: three deterministic unrelated failures remain in the async PDF blob test and two CI/workflow source-contract tests; the order-sensitive schedule-readiness test passes in isolation
-  - `npm run test:routes:tier0`: pass, 220/220
+  - `npm run test:routes:tier0`: pass, 220/220; one concurrent build/Cypress attempt returned transient 404s while `dist` was being rewritten, then the isolated rerun passed
   - `npm run ci:playwright`: preflight passed; auth smoke failed because the configured `superadmin@test.com` credential was rejected, so the fail-fast runner did not execute the remaining children
   - `npm run build`: pass
-  - PR CI on commit `c7d4c8ae`: all required checks passed, including Linux unit tests, tier-0 browser, auth browser smoke, policy, lint/typecheck, and build
+  - PR #839 CI on commit `495ce07a`: all required checks passed, including Linux unit tests, policy, lint/typecheck, build, and the lane-scoped browser gates
 - blocked checks:
   - `npm run verify:local`: blocked by the same unrelated `test:ci` baseline failures
   - remaining `npm run ci:playwright` children: blocked after the credential failure stopped the fail-fast runner
 - result: `pending-final-head-ci`
-- residual risk: the identity-safe unindexed fallback requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
+- residual risk: the latest unit/identity correction requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
 
 ## PR Hygiene
 
@@ -88,6 +90,6 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - generated artifact drift: none
 - change summary: present
 - verification summary: present
-- reviewer: completed and approved with no findings for the identity-safe unindexed fallback
+- reviewer: completed and approved with no findings for the unit-aware and identity-safe aggregate fallback
 - pr-ready: yes
-- required follow-up: commit and push the isolated correction, resolve the current review thread, rerun final-head PR checks, and capture credential-backed closeout proof
+- required follow-up: commit and push the isolated correction, resolve the two current review threads, rerun final-head PR checks, and capture credential-backed closeout proof

--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -39,7 +39,8 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - PR review: found that normalized preview state could replace historical persisted measurements and that completed aggregate-only sessions did not hydrate the preview
 - follow-up PR review: found that aggregate rows containing only `incorrect_trials` or `opportunities` were still omitted when `metric_value` was null
 - final-head PR review: found that completed sessions still used current-target-filtered form measurements and that archived targetless goals could display a raw UUID instead of the finalized snapshot label
-- re-review: approved with no findings after switching completed previews to unfiltered linked-note measurements and finalized goal-label snapshots
+- subsequent PR review: found zero-correct prompt aggregates hid incorrect outcomes, metadata-only target rows suppressed valid top-level values, and archived raw targets could duplicate a human-labeled aggregate
+- re-review: approved with no findings after preserving sparse label slots and preventing cross-target fallback
 
 ## Verification Card
 
@@ -57,7 +58,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - targeted `SessionModal` tests: pass, 112/112
+  - targeted `SessionModal` tests: pass, 116/116
   - `npm run ci:check-focused`: pass via bundled Node runtime
   - `npm run lint`: pass via bundled Node runtime
   - `npm run typecheck`: pass via bundled Node runtime

--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -37,7 +37,8 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - agents used: specification-engineer, implementation-engineer, code-review-engineer, test-engineer
 - reviewer: completed; the first review found overly broad same-goal aggregate suppression and stale restored-draft input risk
 - PR review: found that normalized preview state could replace historical persisted measurements and that completed aggregate-only sessions did not hydrate the preview
-- re-review: approved with no findings after separating preview/persistence state, adding completed-session hydration, and covering both regressions
+- follow-up PR review: found that aggregate rows containing only `incorrect_trials` or `opportunities` were still omitted when `metric_value` was null
+- re-review: approved with no findings after adding explicit metric/incorrect/opportunity fallback handling and targeted coverage for both secondary quantitative shapes
 
 ## Verification Card
 
@@ -64,11 +65,12 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run test:routes:tier0`: pass, 220/220
   - `npm run ci:playwright`: preflight passed; auth smoke failed because the configured `superadmin@test.com` credential was rejected, so the fail-fast runner did not execute the remaining children
   - `npm run build`: pass
+  - PR CI on commit `c7d4c8ae`: all required checks passed, including Linux unit tests, tier-0 browser, auth browser smoke, policy, lint/typecheck, and build
 - blocked checks:
   - `npm run verify:local`: blocked by the same unrelated `test:ci` baseline failures
   - remaining `npm run ci:playwright` children: blocked after the credential failure stopped the fail-fast runner
-- result: `pass-with-blocked-checks`
-- residual risk: live credential-backed closeout verification must rely on PR CI; aggregate values remain aggregate preview rows rather than fabricated raw trials
+- result: `pending-final-head-ci`
+- residual risk: the secondary-field correction still requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
 
 ## PR Hygiene
 
@@ -82,4 +84,4 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - verification summary: present
 - reviewer: completed and approved
 - pr-ready: yes
-- required follow-up: commit the isolated files, push the branch, open the human-reviewed PR, move WIN-243 to In Review, and inspect live checks
+- required follow-up: commit and push the isolated correction, resolve the current review thread, rerun final-head PR checks, and capture credential-backed closeout proof

--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -41,7 +41,8 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - final-head PR review: found that completed sessions still used current-target-filtered form measurements and that archived targetless goals could display a raw UUID instead of the finalized snapshot label
 - subsequent PR review: found zero-correct prompt aggregates hid incorrect outcomes, metadata-only target rows suppressed valid top-level values, and archived raw targets could duplicate a human-labeled aggregate
 - latest PR review: found mixed correct/incorrect aggregates hid the incorrect count and label-based deduplication was unsafe for renamed or same-named targets
-- re-review: approved with no findings after switching indexed trial events to persisted target identity and preserving both mixed outcomes
+- final-head PR review: found an indexed raw event could duplicate a top-level fallback and older unindexed raw events could duplicate a renamed single-target snapshot
+- re-review: approved with no findings after matching indexed top-level fallbacks and preferring sole historical snapshot labels for unindexed events
 
 ## Verification Card
 
@@ -59,7 +60,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - targeted `SessionModal` tests: pass, 119/119
+  - targeted `SessionModal` tests: pass, 121/121
   - `npm run ci:check-focused`: pass via bundled Node runtime
   - `npm run lint`: pass via bundled Node runtime
   - `npm run typecheck`: pass via bundled Node runtime
@@ -73,7 +74,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run verify:local`: blocked by the same unrelated `test:ci` baseline failures
   - remaining `npm run ci:playwright` children: blocked after the credential failure stopped the fail-fast runner
 - result: `pending-final-head-ci`
-- residual risk: the latest correction still requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
+- residual risk: the latest final-head corrections require final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
 
 ## PR Hygiene
 
@@ -85,6 +86,6 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - generated artifact drift: none
 - change summary: present
 - verification summary: present
-- reviewer: completed and approved with no findings for the latest correction
+- reviewer: completed and approved with no findings for the latest final-head corrections
 - pr-ready: yes
 - required follow-up: commit and push the isolated correction, resolve the current review thread, rerun final-head PR checks, and capture credential-backed closeout proof

--- a/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
+++ b/docs/ai/WIN-243-closeout-aggregate-preview-handoff.md
@@ -42,7 +42,8 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - subsequent PR review: found zero-correct prompt aggregates hid incorrect outcomes, metadata-only target rows suppressed valid top-level values, and archived raw targets could duplicate a human-labeled aggregate
 - latest PR review: found mixed correct/incorrect aggregates hid the incorrect count and label-based deduplication was unsafe for renamed or same-named targets
 - final-head PR review: found an indexed raw event could duplicate a top-level fallback and older unindexed raw events could duplicate a renamed single-target snapshot
-- re-review: approved with no findings after matching indexed top-level fallbacks and preferring sole historical snapshot labels for unindexed events
+- subsequent PR review: found completed legacy measurements were marked unlinked when the finalized `goal_ids` column was null
+- re-review: approved with no findings after merging completed linkage from explicit goal IDs and persisted measurement keys
 
 ## Verification Card
 
@@ -60,7 +61,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run build`
   - `npm run verify:local`
 - executed checks:
-  - targeted `SessionModal` tests: pass, 121/121
+  - targeted `SessionModal` tests: pass, 122/122
   - `npm run ci:check-focused`: pass via bundled Node runtime
   - `npm run lint`: pass via bundled Node runtime
   - `npm run typecheck`: pass via bundled Node runtime
@@ -74,7 +75,7 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
   - `npm run verify:local`: blocked by the same unrelated `test:ci` baseline failures
   - remaining `npm run ci:playwright` children: blocked after the credential failure stopped the fail-fast runner
 - result: `pending-final-head-ci`
-- residual risk: the latest final-head corrections require final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
+- residual risk: the completed legacy-linkage correction requires final-head PR CI and credential-backed browser proof; aggregate values remain aggregate preview rows rather than fabricated raw trials
 
 ## PR Hygiene
 
@@ -86,6 +87,6 @@ The earlier suspected scheduling/finalization assignment mismatch was not a prod
 - generated artifact drift: none
 - change summary: present
 - verification summary: present
-- reviewer: completed and approved with no findings for the latest final-head corrections
+- reviewer: completed and approved with no findings for the completed legacy-linkage correction
 - pr-ready: yes
 - required follow-up: commit and push the isolated correction, resolve the current review thread, rerun final-head PR checks, and capture credential-backed closeout proof

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -3148,6 +3148,14 @@ export function SessionModal({
     const goalMeasurements = isCompletedBtAbaSession
       ? (linkedSessionNote?.goal_measurements as Record<string, unknown> | null | undefined)
       : sessionNoteGoalMeasurements ?? closeoutCaptureRef.current?.notePayload.goal_measurements;
+    const completedLinkedGoalIds = Array.from(new Set([
+      ...finalizedGoalIds,
+      ...(
+        goalMeasurements && typeof goalMeasurements === 'object'
+          ? Object.keys(goalMeasurements)
+          : []
+      ),
+    ]));
 
     return buildCloseoutDataPoints({
       existingTrialEvents,
@@ -3155,7 +3163,7 @@ export function SessionModal({
       goalTargetsById,
       goalsById,
       goalLabelsById: finalizedGoalLabelsById,
-      linkedGoalIds: isCompletedBtAbaSession ? finalizedGoalIds : sessionNoteGoalIds,
+      linkedGoalIds: isCompletedBtAbaSession ? completedLinkedGoalIds : sessionNoteGoalIds,
       goalMeasurements,
     });
   }, [

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -523,6 +523,17 @@ const getCloseoutAggregateValue = (
   return opportunities === null ? null : `${opportunities} opportunities`;
 };
 
+const getPersistedMeasurementType = (rawValue: unknown): string | null => {
+  if (!rawValue || typeof rawValue !== 'object') {
+    return null;
+  }
+  const candidate = rawValue as { data?: unknown } & Record<string, unknown>;
+  const sourceData = candidate.data && typeof candidate.data === 'object'
+    ? candidate.data as Record<string, unknown>
+    : candidate;
+  return trimString(sourceData.measurement_type);
+};
+
 export const buildCloseoutDataPoints = ({
   existingTrialEvents,
   pendingTrialEvents,
@@ -539,7 +550,11 @@ export const buildCloseoutDataPoints = ({
     ? []
     : Object.entries(goalMeasurements).flatMap(([goalId, rawValue]) => {
         const goal = goalsById.get(goalId);
-        const normalized = normalizeGoalMeasurementEntry(rawValue, goal);
+        const persistedMeasurementType = getPersistedMeasurementType(rawValue);
+        const normalizationGoal = goal && persistedMeasurementType
+          ? { ...goal, measurement_type: persistedMeasurementType }
+          : goal;
+        const normalized = normalizeGoalMeasurementEntry(rawValue, normalizationGoal);
         return normalized ? [{ goalId, goal, normalized }] : [];
       });
   const aggregateTargetLabelsByGoal = new Map(
@@ -3152,22 +3167,26 @@ export function SessionModal({
   const closeoutDataPoints = useMemo(() => {
     const finalizedGoalIds = linkedSessionNote?.goal_ids ?? [];
     const finalizedGoalLabels = linkedSessionNote?.goals_addressed ?? [];
+    const goalMeasurements = isCompletedBtAbaSession
+      ? (linkedSessionNote?.goal_measurements as Record<string, unknown> | null | undefined)
+      : sessionNoteGoalMeasurements ?? closeoutCaptureRef.current?.notePayload.goal_measurements;
+    const measurementGoalIds = goalMeasurements && typeof goalMeasurements === 'object'
+      ? Object.keys(goalMeasurements)
+      : [];
+    const finalizedGoalLabelIds = finalizedGoalIds.length > 0
+      ? finalizedGoalIds
+      : measurementGoalIds.length === 1 && finalizedGoalLabels.length === 1
+        ? measurementGoalIds
+        : [];
     const finalizedGoalLabelsById = new Map(
-      finalizedGoalIds.flatMap((goalEntryId, index) => {
+      finalizedGoalLabelIds.flatMap((goalEntryId, index) => {
         const label = trimString(finalizedGoalLabels[index]);
         return label ? [[goalEntryId, label] as const] : [];
       }),
     );
-    const goalMeasurements = isCompletedBtAbaSession
-      ? (linkedSessionNote?.goal_measurements as Record<string, unknown> | null | undefined)
-      : sessionNoteGoalMeasurements ?? closeoutCaptureRef.current?.notePayload.goal_measurements;
     const completedLinkedGoalIds = Array.from(new Set([
       ...finalizedGoalIds,
-      ...(
-        goalMeasurements && typeof goalMeasurements === 'object'
-          ? Object.keys(goalMeasurements)
-          : []
-      ),
+      ...measurementGoalIds,
     ]));
 
     return buildCloseoutDataPoints({

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -428,6 +428,123 @@ const trimString = (value: unknown): string | null => {
   return trimmed.length > 0 ? trimmed : null;
 };
 
+export interface CloseoutDataPoint {
+  label: string;
+  value: string | number;
+  linked: boolean;
+}
+
+interface BuildCloseoutDataPointsArgs {
+  existingTrialEvents: readonly TrialEvent[];
+  pendingTrialEvents: readonly SessionCaptureTrialEventInput[];
+  goalTargetsById: ReadonlyMap<string, GoalTarget>;
+  goalsById: ReadonlyMap<string, Goal>;
+  linkedGoalIds: readonly string[];
+  goalMeasurements: Record<string, unknown> | null | undefined;
+}
+
+const toCloseoutAggregateKey = (goalId: string | null, targetLabel: string | null): string =>
+  `${goalId ?? '__unknown_goal__'}::${targetLabel ?? '__goal__'}`;
+
+const getTrialEventGoalId = (
+  event: TrialEvent | SessionCaptureTrialEventInput,
+  goalTargetsById: ReadonlyMap<string, GoalTarget>,
+): string | null =>
+  'goal_id' in event && typeof event.goal_id === 'string'
+    ? event.goal_id
+    : goalTargetsById.get(event.target_id)?.goal_id ?? null;
+
+const getTrialEventLabel = (
+  event: TrialEvent | SessionCaptureTrialEventInput,
+  goalTargetsById: ReadonlyMap<string, GoalTarget>,
+): string =>
+  goalTargetsById.get(event.target_id)?.name ?? event.target_id;
+
+export const buildCloseoutDataPoints = ({
+  existingTrialEvents,
+  pendingTrialEvents,
+  goalTargetsById,
+  goalsById,
+  linkedGoalIds,
+  goalMeasurements,
+}: BuildCloseoutDataPointsArgs): CloseoutDataPoint[] => {
+  const seenTrialKeys = new Set<string>();
+  const rawAggregateKeys = new Set<string>();
+
+  const rawDataPoints = [...existingTrialEvents, ...pendingTrialEvents]
+    .filter((event) => {
+      const key = `${event.target_id}:${event.trial_number}`;
+      if (seenTrialKeys.has(key)) {
+        return false;
+      }
+      seenTrialKeys.add(key);
+      return true;
+    })
+    .map((event) => {
+      const goalId = getTrialEventGoalId(event, goalTargetsById);
+      const label = getTrialEventLabel(event, goalTargetsById);
+      rawAggregateKeys.add(toCloseoutAggregateKey(goalId, label));
+      return {
+        label,
+        value: event.response ?? event.value ?? '',
+        linked: Boolean(goalId && linkedGoalIds.includes(goalId)),
+      };
+    });
+
+  if (!goalMeasurements || typeof goalMeasurements !== 'object') {
+    return rawDataPoints;
+  }
+
+  const aggregateDataPoints = Object.entries(goalMeasurements).flatMap(([goalId, rawValue]) => {
+    const goal = goalsById.get(goalId);
+    const normalized = normalizeGoalMeasurementEntry(rawValue, goal);
+    if (!normalized) {
+      return [];
+    }
+
+    const fallbackLabel = goal?.title ?? goalId;
+    const measurementTargets = getGoalMeasurementTargets(normalized.data);
+    const targetTrials = Array.isArray(normalized.data.target_trials) ? normalized.data.target_trials : [];
+    const linked = linkedGoalIds.includes(goalId);
+
+    if (targetTrials.length > 0) {
+      return targetTrials.flatMap((trial, index) => {
+        const value = toOptionalNumber(trial.metric_value);
+        if (value === null) {
+          return [];
+        }
+        const targetLabel = trimString(trial.target) ?? measurementTargets[index] ?? measurementTargets[0] ?? null;
+        if (rawAggregateKeys.has(toCloseoutAggregateKey(goalId, targetLabel))) {
+          return [];
+        }
+        return [{
+          label: targetLabel ?? fallbackLabel,
+          value,
+          linked,
+        }];
+      });
+    }
+
+    const value = toOptionalNumber(normalized.data.metric_value);
+    if (value === null) {
+      return [];
+    }
+
+    const targetLabel = trimString(normalized.data.target) ?? measurementTargets[0] ?? null;
+    if (rawAggregateKeys.has(toCloseoutAggregateKey(goalId, targetLabel))) {
+      return [];
+    }
+
+    return [{
+      label: targetLabel ?? fallbackLabel,
+      value,
+      linked,
+    }];
+  });
+
+  return [...rawDataPoints, ...aggregateDataPoints];
+};
+
 const sumPlanTargetTrials = (
   trials: NonNullable<SessionGoalMeasurementEntry['data']['target_trials']>,
   field: 'metric_value' | 'incorrect_trials' | 'opportunities',
@@ -2878,7 +2995,7 @@ export function SessionModal({
       notePayload: {
         goals_addressed: linkedSessionNote?.goals_addressed ?? getValues('session_note_goals_addressed') ?? [],
         goal_ids: linkedSessionNote?.goal_ids ?? getValues('session_note_goal_ids') ?? null,
-        goal_measurements: linkedSessionNote?.goal_measurements ?? getValues('session_note_goal_measurements') ?? null,
+        goal_measurements: getValues('session_note_goal_measurements') ?? linkedSessionNote?.goal_measurements ?? null,
         goal_notes: linkedSessionNote?.goal_notes ?? getValues('session_note_goal_notes') ?? null,
         narrative: linkedSessionNote?.narrative ?? getValues('session_note_narrative') ?? '',
       },
@@ -2928,24 +3045,15 @@ export function SessionModal({
   }, [isOpen, isInProgressSession, session?.id]);
 
   const closeoutDataPoints = useMemo(() => {
-    const seen = new Set<string>();
-    return [...existingTrialEvents, ...(closeoutCaptureRef.current?.trialEvents ?? [])]
-      .filter((event) => {
-        const key = `${event.target_id}:${event.trial_number}`;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      })
-      .map((event) => {
-        const persistedGoalId = 'goal_id' in event && typeof event.goal_id === 'string' ? event.goal_id : null;
-        const goalForEvent = persistedGoalId ?? goalTargetsById.get(event.target_id)?.goal_id ?? null;
-        return {
-          label: goalTargetsById.get(event.target_id)?.name ?? event.target_id,
-          value: event.response ?? event.value ?? '',
-          linked: Boolean(goalForEvent && sessionNoteGoalIds.includes(goalForEvent)),
-        };
-      });
-  }, [existingTrialEvents, goalTargetsById, modalStep, sessionNoteGoalIds]);
+    return buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: closeoutCaptureRef.current?.trialEvents ?? [],
+      goalTargetsById,
+      goalsById,
+      linkedGoalIds: sessionNoteGoalIds,
+      goalMeasurements: closeoutCaptureRef.current?.notePayload.goal_measurements,
+    });
+  }, [existingTrialEvents, goalTargetsById, goalsById, modalStep, sessionNoteGoalIds]);
 
   if (!isOpen) return null;
 

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -478,16 +478,14 @@ const getTrialEventLabel = (
     return aggregateTargetLabels[targetIndex];
   }
 
-  if (aggregateTargetLabels.length === 1 && aggregateTargetLabels[0]) {
-    return aggregateTargetLabels[0];
-  }
-
   const currentTargetLabel = goalTargetsById.get(event.target_id)?.name;
   if (currentTargetLabel) {
     return currentTargetLabel;
   }
 
-  return event.target_id;
+  return aggregateTargetLabels.length === 1 && aggregateTargetLabels[0]
+    ? aggregateTargetLabels[0]
+    : event.target_id;
 };
 
 const getCloseoutAggregateValue = (

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -19,6 +19,7 @@ import type {
   Session,
   GoalTarget,
   SessionCaptureTrialEventInput,
+  SessionGoalMeasurementData,
   SessionGoalMeasurementEntry,
   TrialEvent,
   Therapist,
@@ -460,6 +461,21 @@ const getTrialEventLabel = (
 ): string =>
   goalTargetsById.get(event.target_id)?.name ?? event.target_id;
 
+const getCloseoutAggregateValue = (
+  measurement: Pick<SessionGoalMeasurementData, 'metric_value' | 'incorrect_trials' | 'opportunities'>,
+): string | number | null => {
+  const metricValue = toOptionalNumber(measurement.metric_value);
+  if (metricValue !== null) {
+    return metricValue;
+  }
+  const incorrectTrials = toOptionalNumber(measurement.incorrect_trials);
+  if (incorrectTrials !== null) {
+    return `${incorrectTrials} incorrect`;
+  }
+  const opportunities = toOptionalNumber(measurement.opportunities);
+  return opportunities === null ? null : `${opportunities} opportunities`;
+};
+
 export const buildCloseoutDataPoints = ({
   existingTrialEvents,
   pendingTrialEvents,
@@ -509,7 +525,7 @@ export const buildCloseoutDataPoints = ({
 
     if (targetTrials.length > 0) {
       return targetTrials.flatMap((trial, index) => {
-        const value = toOptionalNumber(trial.metric_value);
+        const value = getCloseoutAggregateValue(trial);
         if (value === null) {
           return [];
         }
@@ -525,7 +541,7 @@ export const buildCloseoutDataPoints = ({
       });
     }
 
-    const value = toOptionalNumber(normalized.data.metric_value);
+    const value = getCloseoutAggregateValue(normalized.data);
     if (value === null) {
       return [];
     }

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -478,14 +478,16 @@ const getTrialEventLabel = (
     return aggregateTargetLabels[targetIndex];
   }
 
+  if (aggregateTargetLabels.length === 1 && aggregateTargetLabels[0]) {
+    return aggregateTargetLabels[0];
+  }
+
   const currentTargetLabel = goalTargetsById.get(event.target_id)?.name;
   if (currentTargetLabel) {
     return currentTargetLabel;
   }
 
-  return aggregateTargetLabels.length === 1 && aggregateTargetLabels[0]
-    ? aggregateTargetLabels[0]
-    : event.target_id;
+  return event.target_id;
 };
 
 const getCloseoutAggregateValue = (
@@ -611,7 +613,17 @@ export const buildCloseoutDataPoints = ({
     }
 
     const targetLabel = trimString(normalized.data.target) ?? measurementTargets[0] ?? null;
-    if (rawFallbackAggregateKeys.has(toCloseoutAggregateKey(goalId, targetLabel))) {
+    const matchingTargetIndexes = targetTrials.flatMap((trial, index) => {
+      const trialLabel = trimString(trial.target) ?? measurementTargets[index] ?? null;
+      return trialLabel === targetLabel ? [index] : [];
+    });
+    const hasIndexedRawFallbackMatch =
+      matchingTargetIndexes.length === 1 &&
+      rawTargetIndexKeys.has(toCloseoutTargetIndexKey(goalId, matchingTargetIndexes[0]));
+    if (
+      hasIndexedRawFallbackMatch ||
+      rawFallbackAggregateKeys.has(toCloseoutAggregateKey(goalId, targetLabel))
+    ) {
       return [];
     }
 

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -2995,7 +2995,7 @@ export function SessionModal({
       notePayload: {
         goals_addressed: linkedSessionNote?.goals_addressed ?? getValues('session_note_goals_addressed') ?? [],
         goal_ids: linkedSessionNote?.goal_ids ?? getValues('session_note_goal_ids') ?? null,
-        goal_measurements: getValues('session_note_goal_measurements') ?? linkedSessionNote?.goal_measurements ?? null,
+        goal_measurements: linkedSessionNote?.goal_measurements ?? getValues('session_note_goal_measurements') ?? null,
         goal_notes: linkedSessionNote?.goal_notes ?? getValues('session_note_goal_notes') ?? null,
         narrative: linkedSessionNote?.narrative ?? getValues('session_note_narrative') ?? '',
       },
@@ -3051,9 +3051,16 @@ export function SessionModal({
       goalTargetsById,
       goalsById,
       linkedGoalIds: sessionNoteGoalIds,
-      goalMeasurements: closeoutCaptureRef.current?.notePayload.goal_measurements,
+      goalMeasurements: sessionNoteGoalMeasurements ?? closeoutCaptureRef.current?.notePayload.goal_measurements,
     });
-  }, [existingTrialEvents, goalTargetsById, goalsById, modalStep, sessionNoteGoalIds]);
+  }, [
+    existingTrialEvents,
+    goalTargetsById,
+    goalsById,
+    modalStep,
+    sessionNoteGoalIds,
+    sessionNoteGoalMeasurements,
+  ]);
 
   if (!isOpen) return null;
 

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -490,16 +490,31 @@ const getTrialEventLabel = (
 
 const getCloseoutAggregateValue = (
   measurement: Pick<SessionGoalMeasurementData, 'metric_value' | 'incorrect_trials' | 'opportunities'>,
+  metadata: Pick<SessionGoalMeasurementData, 'measurement_type' | 'metric_label' | 'metric_unit'>,
 ): string | number | null => {
   const metricValue = toOptionalNumber(measurement.metric_value);
   const incorrectTrials = toOptionalNumber(measurement.incorrect_trials);
   if (metricValue !== null) {
+    const isCountMeasurement = isCountTrialMeasurementMetadata(
+      metadata.measurement_type,
+      metadata.metric_label,
+      metadata.metric_unit,
+    );
+    const metricUnit = trimString(metadata.metric_unit);
+    const metricLabel = trimString(metadata.metric_label);
+    const formattedMetricValue = isCountMeasurement || (!metricUnit && !metricLabel)
+      ? metricValue
+      : metricUnit === '%'
+        ? `${metricValue}%`
+        : `${metricValue} ${metricUnit ?? metricLabel}`;
     if (incorrectTrials !== null && incorrectTrials > 0) {
-      return metricValue > 0
-        ? `${metricValue} correct / ${incorrectTrials} incorrect`
-        : `${incorrectTrials} incorrect`;
+      return isCountMeasurement
+        ? metricValue > 0
+          ? `${metricValue} correct / ${incorrectTrials} incorrect`
+          : `${incorrectTrials} incorrect`
+        : `${formattedMetricValue} / ${incorrectTrials} incorrect`;
     }
-    return metricValue;
+    return formattedMetricValue;
   }
   if (incorrectTrials !== null) {
     return `${incorrectTrials} incorrect`;
@@ -580,14 +595,14 @@ export const buildCloseoutDataPoints = ({
 
     if (targetTrials.length > 0) {
       const hasQuantitativeTargetValue = targetTrials.some(
-        (trial) => getCloseoutAggregateValue(trial) !== null,
+        (trial) => getCloseoutAggregateValue(trial, normalized.data) !== null,
       );
       const targetDataPoints = targetTrials.flatMap((trial, index) => {
-        const value = getCloseoutAggregateValue(trial);
+        const value = getCloseoutAggregateValue(trial, normalized.data);
         if (value === null) {
           return [];
         }
-        const targetLabel = trimString(trial.target) ?? measurementTargets[index] ?? measurementTargets[0] ?? null;
+        const targetLabel = trimString(trial.target) ?? measurementTargets[index] ?? null;
         if (
           rawTargetIndexKeys.has(toCloseoutTargetIndexKey(goalId, index)) ||
           rawFallbackAggregateKeys.has(toCloseoutAggregateKey(goalId, targetLabel))
@@ -605,7 +620,7 @@ export const buildCloseoutDataPoints = ({
       }
     }
 
-    const value = getCloseoutAggregateValue(normalized.data);
+    const value = getCloseoutAggregateValue(normalized.data, normalized.data);
     if (value === null) {
       return [];
     }

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -440,6 +440,7 @@ interface BuildCloseoutDataPointsArgs {
   pendingTrialEvents: readonly SessionCaptureTrialEventInput[];
   goalTargetsById: ReadonlyMap<string, GoalTarget>;
   goalsById: ReadonlyMap<string, Goal>;
+  goalLabelsById?: ReadonlyMap<string, string>;
   linkedGoalIds: readonly string[];
   goalMeasurements: Record<string, unknown> | null | undefined;
 }
@@ -481,6 +482,7 @@ export const buildCloseoutDataPoints = ({
   pendingTrialEvents,
   goalTargetsById,
   goalsById,
+  goalLabelsById = new Map(),
   linkedGoalIds,
   goalMeasurements,
 }: BuildCloseoutDataPointsArgs): CloseoutDataPoint[] => {
@@ -518,7 +520,7 @@ export const buildCloseoutDataPoints = ({
       return [];
     }
 
-    const fallbackLabel = goal?.title ?? goalId;
+    const fallbackLabel = goalLabelsById.get(goalId) ?? goal?.title ?? goalId;
     const measurementTargets = getGoalMeasurementTargets(normalized.data);
     const targetTrials = Array.isArray(normalized.data.target_trials) ? normalized.data.target_trials : [];
     const linked = linkedGoalIds.includes(goalId);
@@ -3061,18 +3063,33 @@ export function SessionModal({
   }, [isOpen, isInProgressSession, session?.id]);
 
   const closeoutDataPoints = useMemo(() => {
+    const finalizedGoalIds = linkedSessionNote?.goal_ids ?? [];
+    const finalizedGoalLabels = linkedSessionNote?.goals_addressed ?? [];
+    const finalizedGoalLabelsById = new Map(
+      finalizedGoalIds.flatMap((goalEntryId, index) => {
+        const label = trimString(finalizedGoalLabels[index]);
+        return label ? [[goalEntryId, label] as const] : [];
+      }),
+    );
+    const goalMeasurements = isCompletedBtAbaSession
+      ? (linkedSessionNote?.goal_measurements as Record<string, unknown> | null | undefined)
+      : sessionNoteGoalMeasurements ?? closeoutCaptureRef.current?.notePayload.goal_measurements;
+
     return buildCloseoutDataPoints({
       existingTrialEvents,
       pendingTrialEvents: closeoutCaptureRef.current?.trialEvents ?? [],
       goalTargetsById,
       goalsById,
-      linkedGoalIds: sessionNoteGoalIds,
-      goalMeasurements: sessionNoteGoalMeasurements ?? closeoutCaptureRef.current?.notePayload.goal_measurements,
+      goalLabelsById: finalizedGoalLabelsById,
+      linkedGoalIds: isCompletedBtAbaSession ? finalizedGoalIds : sessionNoteGoalIds,
+      goalMeasurements,
     });
   }, [
     existingTrialEvents,
     goalTargetsById,
     goalsById,
+    isCompletedBtAbaSession,
+    linkedSessionNote,
     modalStep,
     sessionNoteGoalIds,
     sessionNoteGoalMeasurements,

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -448,6 +448,9 @@ interface BuildCloseoutDataPointsArgs {
 const toCloseoutAggregateKey = (goalId: string | null, targetLabel: string | null): string =>
   `${goalId ?? '__unknown_goal__'}::${targetLabel ?? '__goal__'}`;
 
+const toCloseoutTargetIndexKey = (goalId: string, targetIndex: number): string =>
+  `${goalId}::index:${targetIndex}`;
+
 const getTrialEventGoalId = (
   event: TrialEvent | SessionCaptureTrialEventInput,
   goalTargetsById: ReadonlyMap<string, GoalTarget>,
@@ -456,19 +459,28 @@ const getTrialEventGoalId = (
     ? event.goal_id
     : goalTargetsById.get(event.target_id)?.goal_id ?? null;
 
+const getTrialEventTargetIndex = (
+  event: TrialEvent | SessionCaptureTrialEventInput,
+): number | null => {
+  const targetIndex = toOptionalNumber(event.metadata?.target_index);
+  return targetIndex !== null && Number.isInteger(targetIndex) && targetIndex >= 0
+    ? targetIndex
+    : null;
+};
+
 const getTrialEventLabel = (
   event: TrialEvent | SessionCaptureTrialEventInput,
   goalTargetsById: ReadonlyMap<string, GoalTarget>,
   aggregateTargetLabels: readonly (string | null)[],
 ): string => {
+  const targetIndex = getTrialEventTargetIndex(event);
+  if (targetIndex !== null && aggregateTargetLabels[targetIndex]) {
+    return aggregateTargetLabels[targetIndex];
+  }
+
   const currentTargetLabel = goalTargetsById.get(event.target_id)?.name;
   if (currentTargetLabel) {
     return currentTargetLabel;
-  }
-
-  const targetIndex = toOptionalNumber(event.metadata?.target_index);
-  if (targetIndex !== null && Number.isInteger(targetIndex) && targetIndex >= 0) {
-    return aggregateTargetLabels[targetIndex] ?? event.target_id;
   }
 
   return aggregateTargetLabels.length === 1 && aggregateTargetLabels[0]
@@ -482,8 +494,10 @@ const getCloseoutAggregateValue = (
   const metricValue = toOptionalNumber(measurement.metric_value);
   const incorrectTrials = toOptionalNumber(measurement.incorrect_trials);
   if (metricValue !== null) {
-    if (metricValue === 0 && incorrectTrials !== null && incorrectTrials > 0) {
-      return `${incorrectTrials} incorrect`;
+    if (incorrectTrials !== null && incorrectTrials > 0) {
+      return metricValue > 0
+        ? `${metricValue} correct / ${incorrectTrials} incorrect`
+        : `${incorrectTrials} incorrect`;
     }
     return metricValue;
   }
@@ -504,7 +518,8 @@ export const buildCloseoutDataPoints = ({
   goalMeasurements,
 }: BuildCloseoutDataPointsArgs): CloseoutDataPoint[] => {
   const seenTrialKeys = new Set<string>();
-  const rawAggregateKeys = new Set<string>();
+  const rawTargetIndexKeys = new Set<string>();
+  const rawFallbackAggregateKeys = new Set<string>();
   const normalizedMeasurements = !goalMeasurements || typeof goalMeasurements !== 'object'
     ? []
     : Object.entries(goalMeasurements).flatMap(([goalId, rawValue]) => {
@@ -535,12 +550,17 @@ export const buildCloseoutDataPoints = ({
     })
     .map((event) => {
       const goalId = getTrialEventGoalId(event, goalTargetsById);
+      const targetIndex = getTrialEventTargetIndex(event);
       const label = getTrialEventLabel(
         event,
         goalTargetsById,
         goalId ? aggregateTargetLabelsByGoal.get(goalId) ?? [] : [],
       );
-      rawAggregateKeys.add(toCloseoutAggregateKey(goalId, label));
+      if (goalId && targetIndex !== null) {
+        rawTargetIndexKeys.add(toCloseoutTargetIndexKey(goalId, targetIndex));
+      } else {
+        rawFallbackAggregateKeys.add(toCloseoutAggregateKey(goalId, label));
+      }
       return {
         label,
         value: event.response ?? event.value ?? '',
@@ -568,7 +588,10 @@ export const buildCloseoutDataPoints = ({
           return [];
         }
         const targetLabel = trimString(trial.target) ?? measurementTargets[index] ?? measurementTargets[0] ?? null;
-        if (rawAggregateKeys.has(toCloseoutAggregateKey(goalId, targetLabel))) {
+        if (
+          rawTargetIndexKeys.has(toCloseoutTargetIndexKey(goalId, index)) ||
+          rawFallbackAggregateKeys.has(toCloseoutAggregateKey(goalId, targetLabel))
+        ) {
           return [];
         }
         return [{
@@ -588,7 +611,7 @@ export const buildCloseoutDataPoints = ({
     }
 
     const targetLabel = trimString(normalized.data.target) ?? measurementTargets[0] ?? null;
-    if (rawAggregateKeys.has(toCloseoutAggregateKey(goalId, targetLabel))) {
+    if (rawFallbackAggregateKeys.has(toCloseoutAggregateKey(goalId, targetLabel))) {
       return [];
     }
 

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -459,17 +459,34 @@ const getTrialEventGoalId = (
 const getTrialEventLabel = (
   event: TrialEvent | SessionCaptureTrialEventInput,
   goalTargetsById: ReadonlyMap<string, GoalTarget>,
-): string =>
-  goalTargetsById.get(event.target_id)?.name ?? event.target_id;
+  aggregateTargetLabels: readonly (string | null)[],
+): string => {
+  const currentTargetLabel = goalTargetsById.get(event.target_id)?.name;
+  if (currentTargetLabel) {
+    return currentTargetLabel;
+  }
+
+  const targetIndex = toOptionalNumber(event.metadata?.target_index);
+  if (targetIndex !== null && Number.isInteger(targetIndex) && targetIndex >= 0) {
+    return aggregateTargetLabels[targetIndex] ?? event.target_id;
+  }
+
+  return aggregateTargetLabels.length === 1 && aggregateTargetLabels[0]
+    ? aggregateTargetLabels[0]
+    : event.target_id;
+};
 
 const getCloseoutAggregateValue = (
   measurement: Pick<SessionGoalMeasurementData, 'metric_value' | 'incorrect_trials' | 'opportunities'>,
 ): string | number | null => {
   const metricValue = toOptionalNumber(measurement.metric_value);
+  const incorrectTrials = toOptionalNumber(measurement.incorrect_trials);
   if (metricValue !== null) {
+    if (metricValue === 0 && incorrectTrials !== null && incorrectTrials > 0) {
+      return `${incorrectTrials} incorrect`;
+    }
     return metricValue;
   }
-  const incorrectTrials = toOptionalNumber(measurement.incorrect_trials);
   if (incorrectTrials !== null) {
     return `${incorrectTrials} incorrect`;
   }
@@ -488,6 +505,24 @@ export const buildCloseoutDataPoints = ({
 }: BuildCloseoutDataPointsArgs): CloseoutDataPoint[] => {
   const seenTrialKeys = new Set<string>();
   const rawAggregateKeys = new Set<string>();
+  const normalizedMeasurements = !goalMeasurements || typeof goalMeasurements !== 'object'
+    ? []
+    : Object.entries(goalMeasurements).flatMap(([goalId, rawValue]) => {
+        const goal = goalsById.get(goalId);
+        const normalized = normalizeGoalMeasurementEntry(rawValue, goal);
+        return normalized ? [{ goalId, goal, normalized }] : [];
+      });
+  const aggregateTargetLabelsByGoal = new Map(
+    normalizedMeasurements.map(({ goalId, normalized }) => {
+      const measurementTargets = getGoalMeasurementTargets(normalized.data);
+      const targetTrials = normalized.data.target_trials ?? [];
+      const targetLabels = targetTrials.length > 0
+        ? targetTrials
+            .map((trial, index) => trimString(trial.target) ?? measurementTargets[index] ?? null)
+        : measurementTargets;
+      return [goalId, targetLabels] as const;
+    }),
+  );
 
   const rawDataPoints = [...existingTrialEvents, ...pendingTrialEvents]
     .filter((event) => {
@@ -500,7 +535,11 @@ export const buildCloseoutDataPoints = ({
     })
     .map((event) => {
       const goalId = getTrialEventGoalId(event, goalTargetsById);
-      const label = getTrialEventLabel(event, goalTargetsById);
+      const label = getTrialEventLabel(
+        event,
+        goalTargetsById,
+        goalId ? aggregateTargetLabelsByGoal.get(goalId) ?? [] : [],
+      );
       rawAggregateKeys.add(toCloseoutAggregateKey(goalId, label));
       return {
         label,
@@ -513,20 +552,17 @@ export const buildCloseoutDataPoints = ({
     return rawDataPoints;
   }
 
-  const aggregateDataPoints = Object.entries(goalMeasurements).flatMap(([goalId, rawValue]) => {
-    const goal = goalsById.get(goalId);
-    const normalized = normalizeGoalMeasurementEntry(rawValue, goal);
-    if (!normalized) {
-      return [];
-    }
-
+  const aggregateDataPoints = normalizedMeasurements.flatMap(({ goalId, goal, normalized }) => {
     const fallbackLabel = goalLabelsById.get(goalId) ?? goal?.title ?? goalId;
     const measurementTargets = getGoalMeasurementTargets(normalized.data);
     const targetTrials = Array.isArray(normalized.data.target_trials) ? normalized.data.target_trials : [];
     const linked = linkedGoalIds.includes(goalId);
 
     if (targetTrials.length > 0) {
-      return targetTrials.flatMap((trial, index) => {
+      const hasQuantitativeTargetValue = targetTrials.some(
+        (trial) => getCloseoutAggregateValue(trial) !== null,
+      );
+      const targetDataPoints = targetTrials.flatMap((trial, index) => {
         const value = getCloseoutAggregateValue(trial);
         if (value === null) {
           return [];
@@ -541,6 +577,9 @@ export const buildCloseoutDataPoints = ({
           linked,
         }];
       });
+      if (hasQuantitativeTargetValue) {
+        return targetDataPoints;
+      }
     }
 
     const value = getCloseoutAggregateValue(normalized.data);

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -342,6 +342,145 @@ describe('SessionModal', () => {
     ]);
   });
 
+  it('keeps an unlabeled later aggregate distinct from target zero', () => {
+    const goalTargetsById = new Map<string, GoalTarget>([[
+      'target-first-unindexed',
+      {
+        id: 'target-first-unindexed',
+        organization_id: 'org-a',
+        client_id: 'test-client-1',
+        goal_id: 'goal-1',
+        name: 'First target',
+        measurement_type: 'frequency',
+        graph_config: {},
+        sort_order: 0,
+        current_phase: 'baseline',
+        status: 'active',
+        is_current: true,
+        evaluation_window_started_at: null,
+        progression_version: 1,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ]]);
+    const existingTrialEvents = [{
+      id: 'trial-first-unindexed',
+      organization_id: 'org-a',
+      client_id: 'test-client-1',
+      session_id: 'session-1',
+      target_id: 'target-first-unindexed',
+      goal_id: 'goal-1',
+      therapist_id: 'test-therapist-1',
+      trial_number: 1,
+      response: 'correct',
+      event_timestamp: '2026-03-01T10:15:00.000Z',
+      metadata: {},
+      created_at: '2026-03-01T10:15:00.000Z',
+      updated_at: '2026-03-01T10:15:00.000Z',
+    }] satisfies TrialEvent[];
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: [],
+      goalTargetsById,
+      goalsById: new Map(mockGoals.map((goal) => [goal.id, goal])),
+      linkedGoalIds: ['goal-1'],
+      goalMeasurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            targets: ['First target'],
+            target_trials: [
+              { target: 'First target', metric_value: 1 },
+              { target: null, metric_value: 7 },
+            ],
+          },
+        },
+      },
+    })).toEqual([
+      {
+        label: 'First target',
+        value: 'correct',
+        linked: true,
+      },
+      {
+        label: 'Default Goal',
+        value: 7,
+        linked: true,
+      },
+    ]);
+  });
+
+  it('retains units and avoids count wording for non-count aggregates', () => {
+    const goalsById = new Map<string, Goal>([
+      ['goal-duration', { ...mockGoals[0], id: 'goal-duration', title: 'Duration Goal', measurement_type: 'duration' }],
+      ['goal-percent', { ...mockGoals[0], id: 'goal-percent', title: 'Percent Goal', measurement_type: 'percentage' }],
+      ['goal-rate', { ...mockGoals[0], id: 'goal-rate', title: 'Rate Goal', measurement_type: 'rate' }],
+    ]);
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents: [],
+      pendingTrialEvents: [],
+      goalTargetsById: new Map(),
+      goalsById,
+      linkedGoalIds: ['goal-duration', 'goal-percent', 'goal-rate'],
+      goalMeasurements: {
+        'goal-duration': {
+          version: 1,
+          data: {
+            measurement_type: 'duration',
+            metric_label: 'Duration',
+            metric_unit: 'minutes',
+            target_trials: [{ target: 'Engagement duration', metric_value: 15, incorrect_trials: 2 }],
+          },
+        },
+        'goal-percent': {
+          version: 1,
+          data: {
+            measurement_type: 'percentage',
+            metric_label: 'Percent',
+            metric_unit: '%',
+            target_trials: [
+              { target: 'Accuracy', metric_value: 80 },
+              { target: 'Zero accuracy', metric_value: 0, incorrect_trials: 2 },
+            ],
+          },
+        },
+        'goal-rate': {
+          version: 1,
+          data: {
+            measurement_type: 'rate',
+            metric_label: 'Rate',
+            metric_unit: 'per hour',
+            target_trials: [{ target: 'Requests', metric_value: 3 }],
+          },
+        },
+      },
+    })).toEqual([
+      {
+        label: 'Engagement duration',
+        value: '15 minutes / 2 incorrect',
+        linked: true,
+      },
+      {
+        label: 'Accuracy',
+        value: '80%',
+        linked: true,
+      },
+      {
+        label: 'Zero accuracy',
+        value: '0% / 2 incorrect',
+        linked: true,
+      },
+      {
+        label: 'Requests',
+        value: '3 per hour',
+        linked: true,
+      },
+    ]);
+  });
+
   it('keeps raw closeout trial events one-for-one and skips duplicate aggregate rows for the same goal target', () => {
     const goalTargetsById = new Map<string, GoalTarget>([[
       'target-1',

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -481,6 +481,37 @@ describe('SessionModal', () => {
     ]);
   });
 
+  it('preserves persisted measurement metadata when the current goal type has changed', () => {
+    const currentGoal = {
+      ...mockGoals[0],
+      title: 'Goal now measured by percent',
+      measurement_type: 'percentage',
+    };
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents: [],
+      pendingTrialEvents: [],
+      goalTargetsById: new Map(),
+      goalsById: new Map([[currentGoal.id, currentGoal]]),
+      linkedGoalIds: ['goal-1'],
+      goalMeasurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_label: 'Count',
+            metric_unit: 'responses',
+            target_trials: [{ target: 'Historical count target', metric_value: 2 }],
+          },
+        },
+      },
+    })).toEqual([{
+      label: 'Historical count target',
+      value: 2,
+      linked: true,
+    }]);
+  });
+
   it('keeps raw closeout trial events one-for-one and skips duplicate aggregate rows for the same goal target', () => {
     const goalTargetsById = new Map<string, GoalTarget>([[
       'target-1',
@@ -2254,6 +2285,128 @@ describe('SessionModal', () => {
     expect(await screen.findByText('Linked count: 1')).toBeInTheDocument();
     expect(screen.getByText('All count: 1')).toBeInTheDocument();
     expect(screen.getByText('Legacy linked target: 2')).toBeInTheDocument();
+  });
+
+  it('recovers a sole finalized label when a completed legacy note has no goal_ids', async () => {
+    vi.mocked(getBtAbaSessionNote).mockResolvedValue({
+      noteId: 'note-completed-aggregate-inferred-label',
+      templateId: 'template-bt-1',
+      responses: validBtAbaResponses as unknown as Record<string, unknown>,
+      status: 'completed',
+    });
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'note-completed-aggregate-inferred-label',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: ['Archived Snapshot Goal'],
+      goal_ids: null,
+      goal_measurements: {
+        'goal-archived-inferred': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_value: 3,
+            opportunities: 3,
+          },
+        },
+      },
+      goal_notes: {},
+      session_id: 'session-bt-completed-aggregate-inferred-label',
+      narrative: 'Completed legacy aggregate note',
+      is_locked: true,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: '2026-03-01T11:00:00.000Z',
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T11:00:00.000Z',
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        dataCollectionOnly
+        session={{
+          ...btInProgressSession,
+          id: 'session-bt-completed-aggregate-inferred-label',
+          status: 'completed',
+        }}
+      />,
+    );
+
+    expect(await screen.findByText('Mode: finalized')).toBeInTheDocument();
+    expect(await screen.findByText('Linked count: 1')).toBeInTheDocument();
+    expect(screen.getByText('Archived Snapshot Goal: 3')).toBeInTheDocument();
+    expect(screen.queryByText('goal-archived-inferred: 3')).not.toBeInTheDocument();
+  });
+
+  it('does not guess finalized label mappings when legacy measurement keys are ambiguous', async () => {
+    vi.mocked(getBtAbaSessionNote).mockResolvedValue({
+      noteId: 'note-completed-aggregate-ambiguous-label',
+      templateId: 'template-bt-1',
+      responses: validBtAbaResponses as unknown as Record<string, unknown>,
+      status: 'completed',
+    });
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'note-completed-aggregate-ambiguous-label',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: ['Ambiguous Snapshot Goal'],
+      goal_ids: null,
+      goal_measurements: {
+        'goal-ambiguous-a': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_value: 1,
+          },
+        },
+        'goal-ambiguous-b': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_value: 2,
+          },
+        },
+      },
+      goal_notes: {},
+      session_id: 'session-bt-completed-aggregate-ambiguous-label',
+      narrative: 'Completed ambiguous legacy aggregate note',
+      is_locked: true,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: '2026-03-01T11:00:00.000Z',
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T11:00:00.000Z',
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        dataCollectionOnly
+        session={{
+          ...btInProgressSession,
+          id: 'session-bt-completed-aggregate-ambiguous-label',
+          status: 'completed',
+        }}
+      />,
+    );
+
+    expect(await screen.findByText('Mode: finalized')).toBeInTheDocument();
+    expect(await screen.findByText('Linked count: 2')).toBeInTheDocument();
+    expect(screen.getByText('goal-ambiguous-a: 1')).toBeInTheDocument();
+    expect(screen.getByText('goal-ambiguous-b: 2')).toBeInTheDocument();
   });
 
   it('uses finalized snapshot labels for targetless measurements from archived goals', async () => {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -500,6 +500,50 @@ describe('SessionModal', () => {
     }]);
   });
 
+  it('does not duplicate a top-level fallback when an indexed raw trial matches its metadata-only target', () => {
+    const existingTrialEvents = [{
+      id: 'trial-metadata-target',
+      organization_id: 'org-a',
+      client_id: 'test-client-1',
+      session_id: 'session-1',
+      target_id: 'target-metadata',
+      goal_id: 'goal-metadata-target',
+      therapist_id: 'test-therapist-1',
+      trial_number: 1,
+      response: 'correct',
+      event_timestamp: '2026-03-01T10:15:00.000Z',
+      metadata: { target_index: 0 },
+      created_at: '2026-03-01T10:15:00.000Z',
+      updated_at: '2026-03-01T10:15:00.000Z',
+    }] satisfies TrialEvent[];
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: [],
+      goalTargetsById: new Map(),
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-metadata-target'],
+      goalMeasurements: {
+        'goal-metadata-target': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target: 'Metadata-only target',
+            metric_value: 5,
+            target_trials: [{
+              target: 'Metadata-only target',
+              trial_prompt_note: 'Observed with a model prompt',
+            }],
+          },
+        },
+      },
+    })).toEqual([{
+      label: 'Metadata-only target',
+      value: 'correct',
+      linked: true,
+    }]);
+  });
+
   it('uses aggregate target metadata to label and deduplicate archived raw targets', () => {
     const existingTrialEvents = [{
       id: 'trial-archived-target',
@@ -588,6 +632,68 @@ describe('SessionModal', () => {
       linkedGoalIds: ['goal-renamed'],
       goalMeasurements: {
         'goal-renamed': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target_trials: [{
+              target: 'Finalized target snapshot',
+              metric_value: 1,
+            }],
+          },
+        },
+      },
+    })).toEqual([{
+      label: 'Finalized target snapshot',
+      value: 'correct',
+      linked: true,
+    }]);
+  });
+
+  it('uses a sole snapshot label to deduplicate a renamed target when an older raw trial has no index', () => {
+    const goalTargetsById = new Map<string, GoalTarget>([[
+      'target-renamed-no-index',
+      {
+        id: 'target-renamed-no-index',
+        organization_id: 'org-a',
+        client_id: 'test-client-1',
+        goal_id: 'goal-renamed-no-index',
+        name: 'Current renamed target',
+        measurement_type: 'frequency',
+        graph_config: {},
+        sort_order: 0,
+        current_phase: 'baseline',
+        status: 'active',
+        is_current: true,
+        evaluation_window_started_at: null,
+        progression_version: 1,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ]]);
+    const existingTrialEvents = [{
+      id: 'trial-renamed-target-no-index',
+      organization_id: 'org-a',
+      client_id: 'test-client-1',
+      session_id: 'session-1',
+      target_id: 'target-renamed-no-index',
+      goal_id: 'goal-renamed-no-index',
+      therapist_id: 'test-therapist-1',
+      trial_number: 1,
+      response: 'correct',
+      event_timestamp: '2026-03-01T10:15:00.000Z',
+      metadata: {},
+      created_at: '2026-03-01T10:15:00.000Z',
+      updated_at: '2026-03-01T10:15:00.000Z',
+    }] satisfies TrialEvent[];
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: [],
+      goalTargetsById,
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-renamed-no-index'],
+      goalMeasurements: {
+        'goal-renamed-no-index': {
           version: 1,
           data: {
             measurement_type: 'frequency',

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -414,6 +414,161 @@ describe('SessionModal', () => {
     ]);
   });
 
+  it('shows incorrect prompt outcomes when a legacy aggregate has zero correct trials', () => {
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents: [],
+      pendingTrialEvents: [],
+      goalTargetsById: new Map(),
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-prompt-incorrect'],
+      goalMeasurements: {
+        'goal-prompt-incorrect': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target_trials: [{
+              target: 'Prompt outcome target',
+              prompt_counts: [{
+                prompt_type: 'verbal',
+                prompt_level: 'full',
+                correct_trials: 0,
+                incorrect_trials: 2,
+              }],
+            }],
+          },
+        },
+      },
+    })).toEqual([{
+      label: 'Prompt outcome target',
+      value: '2 incorrect',
+      linked: true,
+    }]);
+  });
+
+  it('falls back to a top-level aggregate when target rows contain metadata only', () => {
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents: [],
+      pendingTrialEvents: [],
+      goalTargetsById: new Map(),
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-metadata-target'],
+      goalMeasurements: {
+        'goal-metadata-target': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target: 'Metadata-only target',
+            metric_value: 5,
+            target_trials: [{
+              target: 'Metadata-only target',
+              trial_prompt_note: 'Observed with a model prompt',
+            }],
+          },
+        },
+      },
+    })).toEqual([{
+      label: 'Metadata-only target',
+      value: 5,
+      linked: true,
+    }]);
+  });
+
+  it('uses aggregate target metadata to label and deduplicate archived raw targets', () => {
+    const existingTrialEvents = [{
+      id: 'trial-archived-target',
+      organization_id: 'org-a',
+      client_id: 'test-client-1',
+      session_id: 'session-1',
+      target_id: 'target-archived',
+      goal_id: 'goal-archived',
+      therapist_id: 'test-therapist-1',
+      trial_number: 1,
+      response: 'correct',
+      event_timestamp: '2026-03-01T10:15:00.000Z',
+      metadata: { target_index: 0 },
+      created_at: '2026-03-01T10:15:00.000Z',
+      updated_at: '2026-03-01T10:15:00.000Z',
+    }] satisfies TrialEvent[];
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: [],
+      goalTargetsById: new Map(),
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-archived'],
+      goalMeasurements: {
+        'goal-archived': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target_trials: [{
+              target: 'Archived target snapshot',
+              metric_value: 1,
+              opportunities: 1,
+            }],
+          },
+        },
+      },
+    })).toEqual([{
+      label: 'Archived target snapshot',
+      value: 'correct',
+      linked: true,
+    }]);
+  });
+
+  it('preserves sparse aggregate target indexes when labeling archived raw targets', () => {
+    const existingTrialEvents = [{
+      id: 'trial-archived-unlabeled-target',
+      organization_id: 'org-a',
+      client_id: 'test-client-1',
+      session_id: 'session-1',
+      target_id: 'target-archived-unlabeled',
+      goal_id: 'goal-archived-sparse',
+      therapist_id: 'test-therapist-1',
+      trial_number: 1,
+      response: 'correct',
+      event_timestamp: '2026-03-01T10:15:00.000Z',
+      metadata: { target_index: 0 },
+      created_at: '2026-03-01T10:15:00.000Z',
+      updated_at: '2026-03-01T10:15:00.000Z',
+    }] satisfies TrialEvent[];
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: [],
+      goalTargetsById: new Map(),
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-archived-sparse'],
+      goalMeasurements: {
+        'goal-archived-sparse': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target_trials: [
+              { trial_prompt_note: 'Unlabeled historical target' },
+              {
+                target: 'Later labeled target',
+                metric_value: 2,
+                opportunities: 2,
+              },
+            ],
+          },
+        },
+      },
+    })).toEqual([
+      {
+        label: 'target-archived-unlabeled',
+        value: 'correct',
+        linked: true,
+      },
+      {
+        label: 'Later labeled target',
+        value: 2,
+        linked: true,
+      },
+    ]);
+  });
+
   it('keeps an unlabeled aggregate row when a raw event only proves a different target for the same goal', () => {
     const goalTargetsById = new Map<string, GoalTarget>([[
       'target-1',

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -445,6 +445,33 @@ describe('SessionModal', () => {
     }]);
   });
 
+  it('shows both correct and incorrect outcomes for a mixed legacy aggregate', () => {
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents: [],
+      pendingTrialEvents: [],
+      goalTargetsById: new Map(),
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-prompt-mixed'],
+      goalMeasurements: {
+        'goal-prompt-mixed': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target_trials: [{
+              target: 'Mixed prompt outcome target',
+              metric_value: 2,
+              incorrect_trials: 3,
+            }],
+          },
+        },
+      },
+    })).toEqual([{
+      label: 'Mixed prompt outcome target',
+      value: '2 correct / 3 incorrect',
+      linked: true,
+    }]);
+  });
+
   it('falls back to a top-level aggregate when target rows contain metadata only', () => {
     expect(buildCloseoutDataPoints({
       existingTrialEvents: [],
@@ -514,6 +541,117 @@ describe('SessionModal', () => {
       value: 'correct',
       linked: true,
     }]);
+  });
+
+  it('uses the persisted target index to deduplicate and label a renamed target', () => {
+    const goalTargetsById = new Map<string, GoalTarget>([[
+      'target-renamed',
+      {
+        id: 'target-renamed',
+        organization_id: 'org-a',
+        client_id: 'test-client-1',
+        goal_id: 'goal-renamed',
+        name: 'Current renamed target',
+        measurement_type: 'frequency',
+        graph_config: {},
+        sort_order: 0,
+        current_phase: 'baseline',
+        status: 'active',
+        is_current: true,
+        evaluation_window_started_at: null,
+        progression_version: 1,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ]]);
+    const existingTrialEvents = [{
+      id: 'trial-renamed-target',
+      organization_id: 'org-a',
+      client_id: 'test-client-1',
+      session_id: 'session-1',
+      target_id: 'target-renamed',
+      goal_id: 'goal-renamed',
+      therapist_id: 'test-therapist-1',
+      trial_number: 1,
+      response: 'correct',
+      event_timestamp: '2026-03-01T10:15:00.000Z',
+      metadata: { target_index: 0 },
+      created_at: '2026-03-01T10:15:00.000Z',
+      updated_at: '2026-03-01T10:15:00.000Z',
+    }] satisfies TrialEvent[];
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: [],
+      goalTargetsById,
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-renamed'],
+      goalMeasurements: {
+        'goal-renamed': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target_trials: [{
+              target: 'Finalized target snapshot',
+              metric_value: 1,
+            }],
+          },
+        },
+      },
+    })).toEqual([{
+      label: 'Finalized target snapshot',
+      value: 'correct',
+      linked: true,
+    }]);
+  });
+
+  it('does not suppress a different indexed target that shares the same label', () => {
+    const existingTrialEvents = [{
+      id: 'trial-duplicate-label-target',
+      organization_id: 'org-a',
+      client_id: 'test-client-1',
+      session_id: 'session-1',
+      target_id: 'target-first',
+      goal_id: 'goal-duplicate-label',
+      therapist_id: 'test-therapist-1',
+      trial_number: 1,
+      response: 'correct',
+      event_timestamp: '2026-03-01T10:15:00.000Z',
+      metadata: { target_index: 0 },
+      created_at: '2026-03-01T10:15:00.000Z',
+      updated_at: '2026-03-01T10:15:00.000Z',
+    }] satisfies TrialEvent[];
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: [],
+      goalTargetsById: new Map(),
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-duplicate-label'],
+      goalMeasurements: {
+        'goal-duplicate-label': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target_trials: [
+              { target: 'Shared target label', metric_value: 1 },
+              { target: 'Shared target label', metric_value: 2 },
+            ],
+          },
+        },
+      },
+    })).toEqual([
+      {
+        label: 'Shared target label',
+        value: 'correct',
+        linked: true,
+      },
+      {
+        label: 'Shared target label',
+        value: 2,
+        linked: true,
+      },
+    ]);
   });
 
   it('preserves sparse aggregate target indexes when labeling archived raw targets', () => {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1572,9 +1572,14 @@ describe('SessionModal', () => {
       goal_ids: ['goal-1'],
       goal_measurements: {
         'goal-1': {
-          count: 2,
-          trials: 2,
-          promptLevel: 'Full verbal',
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target: 'Finalized retired target',
+            targets: ['Finalized retired target'],
+            metric_value: 2,
+            opportunities: 2,
+          },
         },
       },
       goal_notes: {},
@@ -1601,7 +1606,65 @@ describe('SessionModal', () => {
     expect(await screen.findByText('Mode: finalized')).toBeInTheDocument();
     expect(await screen.findByText('Linked count: 1')).toBeInTheDocument();
     expect(screen.getByText('All count: 1')).toBeInTheDocument();
-    expect(screen.getByText('Default Goal: 2')).toBeInTheDocument();
+    expect(screen.getByText('Finalized retired target: 2')).toBeInTheDocument();
+  });
+
+  it('uses finalized snapshot labels for targetless measurements from archived goals', async () => {
+    vi.mocked(getBtAbaSessionNote).mockResolvedValue({
+      noteId: 'note-completed-archived-aggregate',
+      templateId: 'template-bt-1',
+      responses: validBtAbaResponses as unknown as Record<string, unknown>,
+      status: 'completed',
+    });
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'note-completed-archived-aggregate',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: ['Archived Snapshot Goal'],
+      goal_ids: ['goal-archived'],
+      goal_measurements: {
+        'goal-archived': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_value: 3,
+            opportunities: 3,
+          },
+        },
+      },
+      goal_notes: {},
+      session_id: 'session-bt-completed-archived-aggregate',
+      narrative: 'Completed archived aggregate note',
+      is_locked: true,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: '2026-03-01T11:00:00.000Z',
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T11:00:00.000Z',
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        dataCollectionOnly
+        session={{
+          ...btInProgressSession,
+          id: 'session-bt-completed-archived-aggregate',
+          status: 'completed',
+        }}
+      />,
+    );
+
+    expect(await screen.findByText('Mode: finalized')).toBeInTheDocument();
+    expect(await screen.findByText('Linked count: 1')).toBeInTheDocument();
+    expect(screen.getByText('Archived Snapshot Goal: 3')).toBeInTheDocument();
+    expect(screen.queryByText('goal-archived: 3')).not.toBeInTheDocument();
   });
 
   it('surfaces persisted BT draft loading failure before closeout can advance', async () => {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -649,27 +649,7 @@ describe('SessionModal', () => {
     }]);
   });
 
-  it('uses a sole snapshot label to deduplicate a renamed target when an older raw trial has no index', () => {
-    const goalTargetsById = new Map<string, GoalTarget>([[
-      'target-renamed-no-index',
-      {
-        id: 'target-renamed-no-index',
-        organization_id: 'org-a',
-        client_id: 'test-client-1',
-        goal_id: 'goal-renamed-no-index',
-        name: 'Current renamed target',
-        measurement_type: 'frequency',
-        graph_config: {},
-        sort_order: 0,
-        current_phase: 'baseline',
-        status: 'active',
-        is_current: true,
-        evaluation_window_started_at: null,
-        progression_version: 1,
-        created_at: '2024-01-01T00:00:00Z',
-        updated_at: '2024-01-01T00:00:00Z',
-      },
-    ]]);
+  it('uses a sole snapshot label for an older unindexed raw target that can no longer be identified', () => {
     const existingTrialEvents = [{
       id: 'trial-renamed-target-no-index',
       organization_id: 'org-a',
@@ -689,7 +669,7 @@ describe('SessionModal', () => {
     expect(buildCloseoutDataPoints({
       existingTrialEvents,
       pendingTrialEvents: [],
-      goalTargetsById,
+      goalTargetsById: new Map(),
       goalsById: new Map(),
       linkedGoalIds: ['goal-renamed-no-index'],
       goalMeasurements: {
@@ -709,6 +689,75 @@ describe('SessionModal', () => {
       value: 'correct',
       linked: true,
     }]);
+  });
+
+  it('preserves a distinct aggregate when an older unindexed raw target is still identifiable', () => {
+    const goalTargetsById = new Map<string, GoalTarget>([[
+      'target-known-no-index',
+      {
+        id: 'target-known-no-index',
+        organization_id: 'org-a',
+        client_id: 'test-client-1',
+        goal_id: 'goal-known-no-index',
+        name: 'Known raw target',
+        measurement_type: 'frequency',
+        graph_config: {},
+        sort_order: 0,
+        current_phase: 'baseline',
+        status: 'active',
+        is_current: true,
+        evaluation_window_started_at: null,
+        progression_version: 1,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ]]);
+    const existingTrialEvents = [{
+      id: 'trial-known-target-no-index',
+      organization_id: 'org-a',
+      client_id: 'test-client-1',
+      session_id: 'session-1',
+      target_id: 'target-known-no-index',
+      goal_id: 'goal-known-no-index',
+      therapist_id: 'test-therapist-1',
+      trial_number: 1,
+      response: 'correct',
+      event_timestamp: '2026-03-01T10:15:00.000Z',
+      metadata: {},
+      created_at: '2026-03-01T10:15:00.000Z',
+      updated_at: '2026-03-01T10:15:00.000Z',
+    }] satisfies TrialEvent[];
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: [],
+      goalTargetsById,
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-known-no-index'],
+      goalMeasurements: {
+        'goal-known-no-index': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target_trials: [{
+              target: 'Distinct aggregate target',
+              metric_value: 2,
+            }],
+          },
+        },
+      },
+    })).toEqual([
+      {
+        label: 'Known raw target',
+        value: 'correct',
+        linked: true,
+      },
+      {
+        label: 'Distinct aggregate target',
+        value: 2,
+        linked: true,
+      },
+    ]);
   });
 
   it('does not suppress a different indexed target that shares the same label', () => {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1168,6 +1168,27 @@ describe('SessionModal', () => {
   });
 
   it('restores a persisted BT draft and finalizes atomically before reporting completion', async () => {
+    const persistedGoalMeasurements = {
+      'goal-1': {
+        version: 1,
+        data: {
+          measurement_type: 'frequency',
+          metric_label: 'Count',
+          metric_unit: 'responses',
+          targets: ['Match peer greeting in 4/5 trials', 'Retired target'],
+          target_trials: [
+            {
+              target: 'Match peer greeting in 4/5 trials',
+              metric_value: 2,
+            },
+            {
+              target: 'Retired target',
+              metric_value: 9,
+            },
+          ],
+        },
+      },
+    };
     vi.mocked(getBtAbaSessionNote).mockResolvedValue({
       noteId: 'note-restored',
       templateId: 'template-restored',
@@ -1184,27 +1205,7 @@ describe('SessionModal', () => {
       therapist_name: 'Test Therapist 1',
       goals_addressed: ['Default Goal'],
       goal_ids: ['goal-1'],
-      goal_measurements: {
-        'goal-1': {
-          version: 1,
-          data: {
-            measurement_type: 'frequency',
-            metric_label: 'Count',
-            metric_unit: 'responses',
-            targets: ['Match peer greeting in 4/5 trials', 'Retired target'],
-            target_trials: [
-              {
-                target: 'Match peer greeting in 4/5 trials',
-                metric_value: 2,
-              },
-              {
-                target: 'Retired target',
-                metric_value: 9,
-              },
-            ],
-          },
-        },
-      },
+      goal_measurements: persistedGoalMeasurements,
       goal_notes: {},
       session_id: 'session-bt-restored',
       narrative: '',
@@ -1249,12 +1250,18 @@ describe('SessionModal', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Save ABA Draft' }));
     await waitFor(() => expect(saveBtAbaSessionNoteDraft).toHaveBeenCalledWith(expect.objectContaining({
-      sessionId: 'session-bt-restored', templateId: 'template-restored', responses: validBtAbaResponses,
+      sessionId: 'session-bt-restored',
+      templateId: 'template-restored',
+      notePayload: expect.objectContaining({ goal_measurements: persistedGoalMeasurements }),
+      responses: validBtAbaResponses,
     })));
 
     await userEvent.click(screen.getByRole('button', { name: 'Finalize ABA Session' }));
     await waitFor(() => expect(finalizeBtAbaSessionNote).toHaveBeenCalledWith(expect.objectContaining({
-      sessionId: 'session-bt-restored', noteId: 'note-restored', responses: validBtAbaResponses,
+      sessionId: 'session-bt-restored',
+      noteId: 'note-restored',
+      notePayload: expect.objectContaining({ goal_measurements: persistedGoalMeasurements }),
+      responses: validBtAbaResponses,
       trialEvents: expect.any(Array), expectedTargetVersions: expect.any(Array),
     })));
     expect(await screen.findByRole('alert')).toHaveTextContent('Atomic finalization failed');
@@ -1512,6 +1519,57 @@ describe('SessionModal', () => {
 
     expect(await screen.findByText('Goals: Finalized Archived Goal')).toBeInTheDocument();
     expect(screen.queryByText('Goals: Default Goal')).not.toBeInTheDocument();
+  });
+
+  it('renders aggregate-only measurements when a completed BT session is reopened', async () => {
+    vi.mocked(getBtAbaSessionNote).mockResolvedValue({
+      noteId: 'note-completed-aggregate',
+      templateId: 'template-bt-1',
+      responses: validBtAbaResponses as unknown as Record<string, unknown>,
+      status: 'completed',
+    });
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'note-completed-aggregate',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: ['Default Goal'],
+      goal_ids: ['goal-1'],
+      goal_measurements: {
+        'goal-1': {
+          count: 2,
+          trials: 2,
+          promptLevel: 'Full verbal',
+        },
+      },
+      goal_notes: {},
+      session_id: 'session-bt-completed-aggregate',
+      narrative: 'Completed aggregate note',
+      is_locked: true,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: '2026-03-01T11:00:00.000Z',
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T11:00:00.000Z',
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        dataCollectionOnly
+        session={{ ...btInProgressSession, id: 'session-bt-completed-aggregate', status: 'completed' }}
+      />,
+    );
+
+    expect(await screen.findByText('Mode: finalized')).toBeInTheDocument();
+    expect(await screen.findByText('Linked count: 1')).toBeInTheDocument();
+    expect(screen.getByText('All count: 1')).toBeInTheDocument();
+    expect(screen.getByText('Default Goal: 2')).toBeInTheDocument();
   });
 
   it('surfaces persisted BT draft loading failure before closeout can advance', async () => {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -291,6 +291,28 @@ describe('SessionModal', () => {
           trials: 5,
           promptLevel: 'Gestural',
         },
+        'goal-incorrect-only': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target_trials: [
+              {
+                target: 'All incorrect target',
+                metric_value: null,
+                incorrect_trials: 2,
+                opportunities: 2,
+              },
+            ],
+          },
+        },
+        'goal-opportunities-only': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target: 'Opportunity-only target',
+            opportunities: 4,
+          },
+        },
         'goal-note-only': {
           note: 'Narrative only',
         },
@@ -305,6 +327,16 @@ describe('SessionModal', () => {
       {
         label: 'Second Goal',
         value: 4,
+        linked: false,
+      },
+      {
+        label: 'All incorrect target',
+        value: '2 incorrect',
+        linked: false,
+      },
+      {
+        label: 'Opportunity-only target',
+        value: '4 opportunities',
         linked: false,
       },
     ]);

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -3,6 +3,7 @@ import { renderWithProviders, screen, userEvent, waitFor } from '../../test/util
 import { fireEvent } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import {
+  buildCloseoutDataPoints,
   SessionModal,
   decrementLegacyPromptCounts,
   dedupeProgressionNotices,
@@ -15,7 +16,7 @@ import {
 } from '../SessionModal';
 import { supabase } from '../../lib/supabase';
 import { fetchLinkedClientSessionNoteForSession } from '../../lib/session-note-linked-fetch';
-import type { Session } from '../../types';
+import type { Goal, GoalTarget, Session, TrialEvent } from '../../types';
 import { startSessionFromModal } from '../../features/scheduling/domain/sessionStart';
 import {
   finalizeBtAbaSessionNote,
@@ -68,7 +69,14 @@ vi.mock('../session-notes/BtAbaSessionNoteForm', () => ({
     readOnly,
   }: {
     initialResponses: BtAbaSessionNoteResponses;
-    context: { placeOfService: string; billingCode: string; modifiers: string[]; programs: Array<{ name: string; goals: string[] }>; linkedDataPoints: unknown[]; allDataPoints: unknown[] };
+    context: {
+      placeOfService: string;
+      billingCode: string;
+      modifiers: string[];
+      programs: Array<{ name: string; goals: string[] }>;
+      linkedDataPoints: Array<{ label: string; value: string | number }>;
+      allDataPoints: Array<{ label: string; value: string | number }>;
+    };
     onSaveDraft: (responses: BtAbaSessionNoteResponses) => Promise<void>;
     onFinalize: (responses: BtAbaSessionNoteResponses) => Promise<void>;
     busy: boolean;
@@ -84,6 +92,9 @@ vi.mock('../session-notes/BtAbaSessionNoteForm', () => ({
       <p>Goals: {context.programs.flatMap((program) => program.goals).join(', ') || 'None'}</p>
       <p>Linked count: {context.linkedDataPoints.length}</p>
       <p>All count: {context.allDataPoints.length}</p>
+      {context.allDataPoints.map((dataPoint, index) => (
+        <p key={`${dataPoint.label}:${index}`}>{dataPoint.label}: {dataPoint.value}</p>
+      ))}
       {!readOnly && <button type="button" disabled={busy} onClick={() => void onSaveDraft(validBtAbaResponses)}>Save ABA Draft</button>}
       {!readOnly && <button type="button" disabled={busy} onClick={() => void onFinalize(validBtAbaResponses)}>Finalize ABA Session</button>}
     </section>
@@ -246,6 +257,192 @@ describe('SessionModal', () => {
       updated_at: '2024-01-02T00:00:00Z',
     },
   ];
+
+  it('builds closeout preview rows from aggregate legacy goal measurements when raw trial events are absent', () => {
+    const goalTargetsById = new Map<string, GoalTarget>();
+    const goalsById = new Map<string, Goal>(mockGoals.map((goal) => [goal.id, goal]));
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents: [],
+      pendingTrialEvents: [],
+      goalTargetsById,
+      goalsById,
+      linkedGoalIds: ['goal-1'],
+      goalMeasurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_label: 'Count',
+            metric_unit: 'responses',
+            target_trials: [
+              {
+                target: 'Hosted aggregate target',
+                metric_value: 2,
+                prompt_counts: [
+                  { prompt_type: 'gesture', prompt_level: null, correct_trials: 2, incorrect_trials: 0 },
+                ],
+              },
+            ],
+          },
+        },
+        'goal-2': {
+          count: 4,
+          trials: 5,
+          promptLevel: 'Gestural',
+        },
+        'goal-note-only': {
+          note: 'Narrative only',
+        },
+        'goal-empty': {},
+      },
+    })).toEqual([
+      {
+        label: 'Hosted aggregate target',
+        value: 2,
+        linked: true,
+      },
+      {
+        label: 'Second Goal',
+        value: 4,
+        linked: false,
+      },
+    ]);
+  });
+
+  it('keeps raw closeout trial events one-for-one and skips duplicate aggregate rows for the same goal target', () => {
+    const goalTargetsById = new Map<string, GoalTarget>([[
+      'target-1',
+      {
+        id: 'target-1',
+        organization_id: 'org-a',
+        client_id: 'test-client-1',
+        goal_id: 'goal-1',
+        name: 'Hosted aggregate target',
+        measurement_type: 'frequency',
+        graph_config: {},
+        sort_order: 0,
+        current_phase: 'baseline',
+        status: 'active',
+        is_current: true,
+        evaluation_window_started_at: null,
+        progression_version: 1,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ]]);
+    const goalsById = new Map<string, Goal>(mockGoals.map((goal) => [goal.id, goal]));
+    const existingTrialEvents = [{
+      id: 'trial-1',
+      organization_id: 'org-a',
+      client_id: 'test-client-1',
+      session_id: 'session-1',
+      target_id: 'target-1',
+      goal_id: 'goal-1',
+      therapist_id: 'test-therapist-1',
+      trial_number: 1,
+      response: 'correct',
+      event_timestamp: '2026-03-01T10:15:00.000Z',
+      metadata: {},
+      created_at: '2026-03-01T10:15:00.000Z',
+      updated_at: '2026-03-01T10:15:00.000Z',
+    }] satisfies TrialEvent[];
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: [],
+      goalTargetsById,
+      goalsById,
+      linkedGoalIds: ['goal-1'],
+      goalMeasurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_label: 'Count',
+            metric_unit: 'responses',
+            target_trials: [
+              {
+                target: 'Hosted aggregate target',
+                metric_value: 2,
+                prompt_counts: [
+                  { prompt_type: 'gesture', prompt_level: null, correct_trials: 2, incorrect_trials: 0 },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    })).toEqual([
+      {
+        label: 'Hosted aggregate target',
+        value: 'correct',
+        linked: true,
+      },
+    ]);
+  });
+
+  it('keeps an unlabeled aggregate row when a raw event only proves a different target for the same goal', () => {
+    const goalTargetsById = new Map<string, GoalTarget>([[
+      'target-1',
+      {
+        id: 'target-1',
+        organization_id: 'org-a',
+        client_id: 'test-client-1',
+        goal_id: 'goal-unlabeled',
+        name: 'Raw target',
+        measurement_type: 'frequency',
+        graph_config: {},
+        sort_order: 0,
+        current_phase: 'baseline',
+        status: 'active',
+        is_current: true,
+        evaluation_window_started_at: null,
+        progression_version: 1,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ]]);
+    const existingTrialEvents = [{
+      id: 'trial-unlabeled-goal',
+      organization_id: 'org-a',
+      client_id: 'test-client-1',
+      session_id: 'session-1',
+      target_id: 'target-1',
+      goal_id: 'goal-unlabeled',
+      therapist_id: 'test-therapist-1',
+      trial_number: 1,
+      response: 'correct',
+      event_timestamp: '2026-03-01T10:15:00.000Z',
+      metadata: {},
+      created_at: '2026-03-01T10:15:00.000Z',
+      updated_at: '2026-03-01T10:15:00.000Z',
+    }] satisfies TrialEvent[];
+
+    expect(buildCloseoutDataPoints({
+      existingTrialEvents,
+      pendingTrialEvents: [],
+      goalTargetsById,
+      goalsById: new Map(),
+      linkedGoalIds: ['goal-unlabeled'],
+      goalMeasurements: {
+        'goal-unlabeled': {
+          count: 3,
+        },
+      },
+    })).toEqual([
+      {
+        label: 'Raw target',
+        value: 'correct',
+        linked: true,
+      },
+      {
+        label: 'goal-unlabeled',
+        value: 3,
+        linked: true,
+      },
+    ]);
+  });
 
   beforeEach(() => {
     vi.mocked(startSessionFromModal).mockReset();
@@ -977,6 +1174,49 @@ describe('SessionModal', () => {
       responses: validBtAbaResponses as unknown as Record<string, unknown>,
       status: 'draft',
     });
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'note-restored',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: ['Default Goal'],
+      goal_ids: ['goal-1'],
+      goal_measurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            metric_label: 'Count',
+            metric_unit: 'responses',
+            targets: ['Match peer greeting in 4/5 trials', 'Retired target'],
+            target_trials: [
+              {
+                target: 'Match peer greeting in 4/5 trials',
+                metric_value: 2,
+              },
+              {
+                target: 'Retired target',
+                metric_value: 9,
+              },
+            ],
+          },
+        },
+      },
+      goal_notes: {},
+      session_id: 'session-bt-restored',
+      narrative: '',
+      is_locked: false,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: null,
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T10:30:00.000Z',
+    });
     vi.mocked(finalizeBtAbaSessionNote)
       .mockRejectedValueOnce(new Error('Atomic finalization failed'))
       .mockResolvedValue({ status: 'completed', noteId: 'note-restored', progressionResults: [] });
@@ -1002,6 +1242,10 @@ describe('SessionModal', () => {
     expect(await screen.findByRole('heading', { name: 'ABA Session Note' })).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
     expect(await screen.findByText('Draft client status: Engaged')).toBeInTheDocument();
+    expect(await screen.findByText('Linked count: 1')).toBeInTheDocument();
+    expect(screen.getByText('All count: 1')).toBeInTheDocument();
+    expect(screen.getByText('Match peer greeting in 4/5 trials: 2')).toBeInTheDocument();
+    expect(screen.queryByText(/Retired target/)).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Save ABA Draft' }));
     await waitFor(() => expect(saveBtAbaSessionNoteDraft).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -2008,6 +2008,66 @@ describe('SessionModal', () => {
     expect(screen.getByText('Finalized retired target: 2')).toBeInTheDocument();
   });
 
+  it('links completed legacy measurements by goal key when the finalized goal_ids column is null', async () => {
+    vi.mocked(getBtAbaSessionNote).mockResolvedValue({
+      noteId: 'note-completed-aggregate-null-goal-ids',
+      templateId: 'template-bt-1',
+      responses: validBtAbaResponses as unknown as Record<string, unknown>,
+      status: 'completed',
+    });
+    vi.mocked(fetchLinkedClientSessionNoteForSession).mockResolvedValue({
+      id: 'note-completed-aggregate-null-goal-ids',
+      date: '2026-03-01',
+      start_time: '10:00:00',
+      end_time: '11:00:00',
+      service_code: '97153',
+      therapist_id: 'test-therapist-1',
+      therapist_name: 'Test Therapist 1',
+      goals_addressed: null,
+      goal_ids: null,
+      goal_measurements: {
+        'goal-1': {
+          version: 1,
+          data: {
+            measurement_type: 'frequency',
+            target: 'Legacy linked target',
+            targets: ['Legacy linked target'],
+            metric_value: 2,
+            opportunities: 2,
+          },
+        },
+      },
+      goal_notes: {},
+      session_id: 'session-bt-completed-aggregate-null-goal-ids',
+      narrative: 'Completed legacy aggregate note',
+      is_locked: true,
+      client_id: 'test-client-1',
+      authorization_id: 'auth-1',
+      organization_id: 'org-a',
+      session_duration: 60,
+      signed_at: '2026-03-01T11:00:00.000Z',
+      created_at: '2026-03-01T09:00:00.000Z',
+      updated_at: '2026-03-01T11:00:00.000Z',
+    });
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        dataCollectionOnly
+        session={{
+          ...btInProgressSession,
+          id: 'session-bt-completed-aggregate-null-goal-ids',
+          status: 'completed',
+        }}
+      />,
+    );
+
+    expect(await screen.findByText('Mode: finalized')).toBeInTheDocument();
+    expect(await screen.findByText('Linked count: 1')).toBeInTheDocument();
+    expect(screen.getByText('All count: 1')).toBeInTheDocument();
+    expect(screen.getByText('Legacy linked target: 2')).toBeInTheDocument();
+  });
+
   it('uses finalized snapshot labels for targetless measurements from archived goals', async () => {
     vi.mocked(getBtAbaSessionNote).mockResolvedValue({
       noteId: 'note-completed-archived-aggregate',


### PR DESCRIPTION
## Summary
- show persisted legacy aggregate measurements in BT session closeout
- preserve finalized labels, mixed outcomes, completed linkage, and raw-trial precedence
- cover archived, renamed, indexed, unindexed, and aggregate-only session variants

## Tracking
- Linear: WIN-243
- Supersedes #838 after GitHub stopped emitting required Actions checks for its synchronized head

## Verification
- SessionModal: 123/123
- policy, lint, typecheck, build: pass
- Tier-0 browser routes: 220/220
- independent code review: approved

Final merge remains gated on this PR's exact-head required checks and live closeout proof.