### PR TITLE
Fix BCBA supervision packet RPC result type

### DIFF
--- a/docs/ai/WIN-244-bcba-supervision-rpc-handoff.md
+++ b/docs/ai/WIN-244-bcba-supervision-rpc-handoff.md
@@ -55,11 +55,18 @@
   - `npm run test:ci`: fail on existing unrelated Windows baseline failures
   - `npm run verify:local`: fail because it includes the same unrelated baseline failures
 - blocked checks:
-  - database-backed preview drift and grant checks: local `SUPABASE_DB_URL` is not configured
-- result: `pass-with-blocked-checks`
-- residual risk: the SQL contract is statically and structurally verified, but
-  the applied function and ACLs still require hosted verification after human
-  review and migration deployment.
+  - local database-backed drift and grant checks: local `SUPABASE_DB_URL` is not configured
+- hosted checks:
+  - Supabase preview migration: pass
+  - production migration promotion: pass; runtime ledger recorded `20260723212535/align_supervision_review_packet_template_name_type`
+  - production function definition: pass; `template.template_name::text as supervision_template_name` is present
+  - production ACL: pass; execute remains granted to `authenticated` and denied to `anon` and `PUBLIC`
+  - authenticated hosted dashboard: pass; Supervision Notes Due loaded three review packets without the prior result-structure error
+  - browser evidence: `.tmp/live-bcba-route-audit-2026-07-23/19-supervision-queue-runtime-fixed.jpg` (local audit artifact, not committed)
+- pending checks:
+  - refreshed GitHub runtime migration parity and aggregate CI gate
+- result: `pass-with-blocked-local-checks`; hosted preview, production runtime, and browser verification passed
+- residual risk: fresh CI must recognize the production ledger entry before auto-merge proceeds
 
 ## Review
 
@@ -77,13 +84,11 @@
 - unrelated changes: `.superpowers/brainstorm/`, `.tmp/`, `pnpm-lock.yaml`, and
   `pnpm-workspace.yaml` remain untracked and excluded
 - protected-path drift: none beyond the routed migration
-- pr handoff: ready after staging only the three files above
+- pr handoff: ready; production runtime and browser verification are documented
 - reviewer: completed
 
 ## Post-Merge Proof
 
-1. Confirm the hosted function definition contains
-   `template.template_name::text as supervision_template_name`.
-2. Confirm execute remains limited to `authenticated` and `service_role`.
-3. Refresh the live BCBA dashboard and capture the supervision queue without the
-   prior result-structure error.
+1. Confirm refreshed runtime migration parity and aggregate CI pass.
+2. Allow the existing auto-merge request to merge only after all required checks pass.
+3. Continue the remaining BCBA route audit from the corrected supervision dashboard.

--- a/docs/ai/WIN-244-bcba-supervision-rpc-handoff.md
+++ b/docs/ai/WIN-244-bcba-supervision-rpc-handoff.md
@@ -1,0 +1,89 @@
+# WIN-244 BCBA Supervision RPC Handoff
+
+## Scope
+
+- Restore the BCBA dashboard supervision queue by aligning
+  `get_pending_supervision_review_packets().supervision_template_name` with its
+  declared `text` return type.
+- Keep the existing return columns, tenant filters, role checks, grants,
+  correction behavior, and frontend contract unchanged.
+- Non-goals: table changes, data backfills, RLS changes, UI changes, or broader
+  supervision workflow changes.
+
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- triggering path: `supabase/migrations/**`
+- Linear: `WIN-244`
+- required agents:
+  - `specification-engineer`
+  - `software-architect`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+  - `security-engineer`
+  - `supabase-reviewer`
+
+## Files Touched
+
+- `supabase/migrations/20260723133526_align_supervision_review_packet_template_name_type.sql`
+- `tests/supervisionReviewPacketTemplateNameTypeMigration.test.ts`
+- `docs/ai/WIN-244-bcba-supervision-rpc-handoff.md`
+
+## Verification Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- change type: database migration, tenant-scoped RPC
+- required checks:
+  - focused migration, workflow, and consumer tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - focused Vitest set: pass, 4 files and 39 tests
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+  - `npm run test:ci`: fail on existing unrelated Windows baseline failures
+  - `npm run verify:local`: fail because it includes the same unrelated baseline failures
+- blocked checks:
+  - database-backed preview drift and grant checks: local `SUPABASE_DB_URL` is not configured
+- result: `pass-with-blocked-checks`
+- residual risk: the SQL contract is statically and structurally verified, but
+  the applied function and ACLs still require hosted verification after human
+  review and migration deployment.
+
+## Review
+
+- code-review-engineer: approve, no findings
+- security-engineer: approve, no auth, tenant, or ACL widening
+- supabase-reviewer: approve, `CREATE OR REPLACE FUNCTION` is compatible and the
+  only function-body change is the explicit `::text` cast
+- test-engineer: targeted coverage is adequate; hosted execution remains required
+
+## PR Hygiene
+
+- branch-ready: yes, `codex/win-244-bcba-supervision-rpc`
+- linear-ready: yes, `WIN-244`
+- single-purpose: yes
+- unrelated changes: `.superpowers/brainstorm/`, `.tmp/`, `pnpm-lock.yaml`, and
+  `pnpm-workspace.yaml` remain untracked and excluded
+- protected-path drift: none beyond the routed migration
+- pr handoff: ready after staging only the three files above
+- reviewer: completed
+
+## Post-Merge Proof
+
+1. Confirm the hosted function definition contains
+   `template.template_name::text as supervision_template_name`.
+2. Confirm execute remains limited to `authenticated` and `service_role`.
+3. Refresh the live BCBA dashboard and capture the supervision queue without the
+   prior result-structure error.

--- a/supabase/migrations/20260723133526_align_supervision_review_packet_template_name_type.sql
+++ b/supabase/migrations/20260723133526_align_supervision_review_packet_template_name_type.sql
@@ -1,0 +1,235 @@
+-- @migration-intent: Align the supervision review packet template name projection with the RPC's declared text return type without changing tenant scope, role checks, or execute boundaries.
+-- @migration-dependencies: 20260718155154_return_bt_supervision_correction.sql
+-- @migration-rollback: Restore public.get_pending_supervision_review_packets() from 20260718155154_return_bt_supervision_correction.sql if this cast-only compatibility fix must be reverted.
+
+begin;
+
+revoke all on function public.get_pending_supervision_review_packets() from public, anon;
+revoke all on function public.get_pending_supervision_review_packets() from authenticated;
+
+create or replace function public.get_pending_supervision_review_packets()
+returns table (
+  request_id uuid,
+  organization_id uuid,
+  session_id uuid,
+  client_id uuid,
+  bt_therapist_id uuid,
+  assigned_reviewer_user_id uuid,
+  request_status text,
+  request_created_at timestamptz,
+  session_start_time timestamptz,
+  session_end_time timestamptz,
+  place_of_service text,
+  client_name text,
+  bt_therapist_name text,
+  bt_therapist_title text,
+  bt_note_id uuid,
+  bt_responses jsonb,
+  bt_template_snapshot jsonb,
+  bt_signature_method text,
+  bt_signed_at timestamptz,
+  supervision_template_id uuid,
+  supervision_template_name text,
+  supervision_template_structure jsonb,
+  can_complete boolean,
+  can_return boolean,
+  correction_id uuid,
+  correction_round integer,
+  correction_reason text,
+  correction_requested_at timestamptz,
+  correction_reviewer_user_id uuid,
+  latest_version_number integer,
+  review_versions jsonb
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+  if v_actor_org is null then
+    raise exception using errcode = '42501', message = 'Organization context required';
+  end if;
+
+  return query
+  select
+    request.id as request_id,
+    request.organization_id,
+    request.session_id,
+    request.client_id,
+    request.bt_therapist_id,
+    request.assigned_admin_user_id as assigned_reviewer_user_id,
+    request.status as request_status,
+    request.created_at as request_created_at,
+    session.start_time as session_start_time,
+    session.end_time as session_end_time,
+    session.location_type as place_of_service,
+    client.full_name as client_name,
+    therapist.full_name as bt_therapist_name,
+    therapist.title as bt_therapist_title,
+    coalesce(latest_amendment.note_id, original_note.id) as bt_note_id,
+    coalesce(latest_amendment.responses, original_note.bt_aba_responses) as bt_responses,
+    coalesce(latest_amendment.template_snapshot, original_note.bt_aba_template_snapshot) as bt_template_snapshot,
+    coalesce(latest_amendment.signature_method, original_attestation.signature_method) as bt_signature_method,
+    coalesce(latest_amendment.signed_at, original_attestation.signed_at) as bt_signed_at,
+    template.id as supervision_template_id,
+    template.template_name::text as supervision_template_name,
+    template.template_structure as supervision_template_structure,
+    (
+      request.assigned_admin_user_id = v_actor
+      and app.user_has_exact_active_role_for_org(
+        v_actor,
+        request.organization_id,
+        array['bcba']::text[]
+      )
+      and request.status in ('pending', 'resubmitted')
+      and jsonb_typeof(coalesce(coalesce(latest_amendment.responses, original_note.bt_aba_responses), '{}'::jsonb)) = 'object'
+      and jsonb_typeof(coalesce(coalesce(latest_amendment.template_snapshot, original_note.bt_aba_template_snapshot), '{}'::jsonb)) = 'object'
+      and coalesce(latest_amendment.signature_method, original_attestation.signature_method) in ('typed', 'drawn')
+    ) as can_complete,
+    (
+      request.assigned_admin_user_id = v_actor
+      and app.user_has_exact_active_role_for_org(
+        v_actor,
+        request.organization_id,
+        array['bcba']::text[]
+      )
+      and request.status in ('pending', 'resubmitted')
+      and request.status <> 'correction_required'
+    ) as can_return,
+    correction.id as correction_id,
+    correction.correction_round,
+    correction.correction_reason,
+    correction.requested_at as correction_requested_at,
+    correction.reviewer_user_id as correction_reviewer_user_id,
+    coalesce(latest_amendment.version_number, 1) as latest_version_number,
+    (
+      case
+        when original_note.id is null then '[]'::jsonb
+        else jsonb_build_array(
+          jsonb_build_object(
+            'version_number', 1,
+            'note_id', original_note.id,
+            'source', 'original',
+            'responses', original_note.bt_aba_responses,
+            'template_snapshot', original_note.bt_aba_template_snapshot,
+            'signature_method', original_attestation.signature_method,
+            'signature_value', original_attestation.signature_value,
+            'signed_at', original_attestation.signed_at
+          )
+        )
+      end
+    ) || coalesce(amendments.amendment_versions, '[]'::jsonb) as review_versions
+  from public.supervision_session_note_requests request
+  join public.sessions session
+    on session.id = request.session_id
+   and session.organization_id = request.organization_id
+  join public.clients client
+    on client.id = request.client_id
+   and client.organization_id = request.organization_id
+  join public.therapists therapist
+    on therapist.id = request.bt_therapist_id
+   and therapist.organization_id = request.organization_id
+  left join lateral (
+    select note.*
+    from public.client_session_notes note
+    where note.session_id = request.session_id
+      and note.organization_id = request.organization_id
+      and note.client_id = request.client_id
+      and note.therapist_id = request.bt_therapist_id
+    order by note.created_at desc, note.id desc
+    limit 1
+  ) original_note on true
+  left join lateral (
+    select attestation.signature_method, attestation.signature_value, attestation.signed_at
+    from public.session_note_attestations attestation
+    where attestation.note_id = original_note.id
+      and attestation.organization_id = request.organization_id
+      and attestation.attestation_role = 'bt'
+      and attestation.supervision_note_id is null
+    order by attestation.signed_at desc, attestation.id desc
+    limit 1
+  ) original_attestation on true
+  left join lateral (
+    select
+      amendment.id as note_id,
+      amendment.version_number,
+      amendment.bt_aba_responses as responses,
+      amendment.bt_aba_template_snapshot as template_snapshot,
+      amendment.signature_method,
+      amendment.signed_at
+    from public.bt_session_note_amendments amendment
+    where amendment.request_id = request.id
+      and amendment.organization_id = request.organization_id
+    order by amendment.version_number desc
+    limit 1
+  ) latest_amendment on true
+  left join lateral (
+    select jsonb_agg(
+             jsonb_build_object(
+               'version_number', amendment.version_number,
+               'note_id', amendment.id,
+               'source', 'amendment',
+               'correction_round', amendment.correction_round,
+               'responses', amendment.bt_aba_responses,
+               'template_snapshot', amendment.bt_aba_template_snapshot,
+               'signature_method', amendment.signature_method,
+               'signature_value', amendment.signature_value,
+               'signed_at', amendment.signed_at
+             )
+             order by amendment.version_number asc
+           ) as amendment_versions
+    from public.bt_session_note_amendments amendment
+    where amendment.request_id = request.id
+      and amendment.organization_id = request.organization_id
+  ) amendments on true
+  left join lateral (
+    select unresolved.*
+    from public.supervision_session_note_corrections unresolved
+    where unresolved.request_id = request.id
+      and unresolved.organization_id = request.organization_id
+      and unresolved.resolved_at is null
+    order by unresolved.correction_round desc
+    limit 1
+  ) correction on true
+  left join lateral (
+    select seeded_template.id, seeded_template.template_name, seeded_template.template_structure
+    from public.session_note_templates seeded_template
+    where seeded_template.organization_id = request.organization_id
+      and seeded_template.template_type = 'supervision_session_note'
+      and seeded_template.template_name = 'Supervision Session Note'
+    order by seeded_template.updated_at desc, seeded_template.id desc
+    limit 1
+  ) template on true
+  where request.organization_id = v_actor_org
+    and request.status in ('pending', 'correction_required', 'resubmitted', 'completed')
+    and (
+      app.user_has_any_active_role_for_org(
+        auth.uid(),
+        request.organization_id,
+        array['admin', 'super_admin', 'org_admin', 'org_super_admin']
+      )
+      or (
+        request.assigned_admin_user_id = auth.uid()
+        and app.user_has_exact_active_role_for_org(
+          auth.uid(),
+          request.organization_id,
+          array['bcba']::text[]
+        )
+      )
+    );
+end;
+$$;
+
+grant execute on function public.get_pending_supervision_review_packets() to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/supervisionReviewPacketTemplateNameTypeMigration.test.ts
+++ b/tests/supervisionReviewPacketTemplateNameTypeMigration.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260723133526_align_supervision_review_packet_template_name_type.sql',
+);
+
+const sql = readFileSync(MIGRATION_PATH, 'utf8');
+
+const extractFunction = (sourceSql: string, name: string): string => {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`create or replace function ${escapedName}\\([\\s\\S]*?\\n\\$\\$;`, 'i');
+  const match = sourceSql.match(pattern);
+  expect(match, `${name} function should exist`).not.toBeNull();
+  return match?.[0] ?? '';
+};
+
+describe('supervision review packet template-name type migration', () => {
+  it('casts the supervision template name to text without widening the rpc contract', () => {
+    const fn = extractFunction(sql, 'public.get_pending_supervision_review_packets');
+
+    expect(fn).toContain('template.template_name::text as supervision_template_name');
+    expect(fn).not.toContain('template.template_name as supervision_template_name');
+    expect(fn).toContain("set search_path = ''");
+    expect(fn).toContain('security definer');
+    expect(sql).not.toMatch(/drop function if exists public\.get_pending_supervision_review_packets/i);
+  });
+
+  it('preserves tenant filters, same-org joins, exact bcba checks, and restricted execute grants', () => {
+    const fn = extractFunction(sql, 'public.get_pending_supervision_review_packets');
+
+    expect(fn).toContain('where request.organization_id = v_actor_org');
+    expect(fn).toContain("request.status in ('pending', 'correction_required', 'resubmitted', 'completed')");
+    expect(fn).toContain('where seeded_template.organization_id = request.organization_id');
+    expect(fn).toContain('and unresolved.organization_id = request.organization_id');
+    expect(fn).toContain("array['admin', 'super_admin', 'org_admin', 'org_super_admin']");
+    expect(fn).toContain("array['bcba']::text[]");
+
+    expect(sql).toContain(
+      'revoke all on function public.get_pending_supervision_review_packets() from public, anon;',
+    );
+    expect(sql).toContain(
+      'revoke all on function public.get_pending_supervision_review_packets() from authenticated;',
+    );
+    expect(sql).toContain(
+      'grant execute on function public.get_pending_supervision_review_packets() to authenticated, service_role;',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- cast the supervision template name to the RPC's declared text return type
- preserve SECURITY DEFINER, empty search_path, tenant filters, role checks, and restricted execute grants
- add a focused migration contract test and WIN-244 verification handoff

## Live reproduction
The BCBA dashboard supervision queue currently fails with \structure of query does not match function result type\. Hosted schema inspection confirmed \session_note_templates.template_name\ is varchar while the RPC declares the returned column as text.

## Verification
- focused migration/workflow/consumer tests: 39 passed
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run validate:tenant
- npm run build
- code, security, Supabase, and test specialist review completed

## Known baseline
\
pm run test:ci\ and \
pm run verify:local\ still hit existing unrelated Windows baseline failures documented in the handoff. No failures were introduced in the targeted scope.

## Tracking
Linear: WIN-244

## Risk
Critical protected-path migration. Human review is required before merge. After merge, verify the hosted function ACL and repeat the live BCBA dashboard flow with screenshot proof.