### PR TITLE
Fix BCBA date-only displays

### DIFF
--- a/docs/ai/WIN-244-date-only-display-handoff.md
+++ b/docs/ai/WIN-244-date-only-display-handoff.md
@@ -1,0 +1,61 @@
+# WIN-244 Date-Only Display Handoff
+
+## Routing
+
+- classification: low-risk autonomous
+- lane: standard
+- issue: WIN-244
+- scope: preserve calendar dates when rendering date-only client, authorization, preauthorization, report-range, and session-note fields
+- non-goals: no data writes, schema changes, auth changes, routing changes, or timezone conversion for timestamp fields
+- stop condition: any fix requiring persisted-data changes or shared auth/runtime behavior
+
+## Changed Surfaces
+
+- Client profile date of birth
+- Authorization list dates
+- Client report range labels
+- Client session-note date-only fields
+- Client preauthorization date-only fields
+- Focused regression tests, including null and invalid session-note dates
+
+## Verification Card
+
+- classification: low-risk autonomous
+- lane: standard
+- change type: UI/component/page
+- required checks:
+  - `npm run lint`
+  - `npm run typecheck`
+  - focused Vitest coverage
+  - `npm run build`
+- executed checks:
+  - focused Vitest, 5 files and 54 tests: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+- blocked checks: none
+- result: pass
+- residual risk: live production still shows the old date shift until this change is reviewed and deployed
+
+## Review
+
+- code-review-engineer: approve after null/invalid date handling was added
+- test-engineer: required UI checks passed; browser/auth/tenant gates are not meaningful for this display-only slice
+
+## PR Hygiene
+
+- pr-ready: yes
+- lane: standard
+- branch-ready: yes, `codex/win-244-date-time-display`
+- linear-ready: yes, WIN-244
+- single-purpose: yes
+- unrelated changes: none
+- generated artifact drift: none
+- protected-path drift: none
+- change summary: present
+- verification summary: present
+- pr handoff: ready
+- reviewer: completed
+- required follow-up: run hosted browser confirmation on the deployed preview or production release
+
+This branch fixes the live off-by-one-day rendering defects without changing stored values. The diff is limited to display formatting and focused regressions.

--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
 import { 
   ClipboardCheck, Calendar, AlertCircle, 
   FileText, Plus, ArrowRight,
@@ -93,6 +94,7 @@ const AUTHORIZATION_STATUSES: AuthorizationStatus[] = ['approved', 'pending', 'd
 const NO_EMBEDDED_PDF_TEXT_MESSAGE = 'No embedded PDF text was found.';
 const GENERIC_PDF_PREFILL_ERROR_MESSAGE = 'PDF text extraction failed. Enter the authorization fields manually.';
 const createDocumentUploadKey = (sequence: number) => `upload-${sequence}`;
+const formatDateOnly = (value: string, pattern: string) => format(parseISO(value), pattern);
 
 const getFileExtension = (fileName: string) => {
   const extension = fileName.split('.').pop()?.toLowerCase();
@@ -1050,7 +1052,7 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                         <div className="flex items-center">
                           <Calendar className="w-4 h-4 text-gray-400 mr-1" />
                           <div className="text-sm text-gray-900 dark:text-white">
-                            {new Date(auth.start_date).toLocaleDateString()} - {new Date(auth.end_date).toLocaleDateString()}
+                            {formatDateOnly(auth.start_date, 'M/d/yyyy')} - {formatDateOnly(auth.end_date, 'M/d/yyyy')}
                           </div>
                         </div>
                         {isAuthExpiring && (
@@ -1807,8 +1809,8 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
               </p>
               <p>
                 <span className="font-medium">Date range:</span>{' '}
-                {new Date(selectedAuthorizationForView.start_date).toLocaleDateString()} -{' '}
-                {new Date(selectedAuthorizationForView.end_date).toLocaleDateString()}
+                {formatDateOnly(selectedAuthorizationForView.start_date, 'M/d/yyyy')} -{' '}
+                {formatDateOnly(selectedAuthorizationForView.end_date, 'M/d/yyyy')}
               </p>
               <p>
                 <span className="font-medium">Provider:</span>{' '}

--- a/src/components/ClientDetails/ProfileTab.tsx
+++ b/src/components/ClientDetails/ProfileTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
 import {
   User, Mail, Calendar, Phone, MapPin,
   Edit2, Plus, CheckCircle, AlertTriangle, RefreshCw,
@@ -251,7 +252,7 @@ export function ProfileTab({ client, viewerRole }: ProfileTabProps) {
             <div>
               <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Date of Birth</p>
               <p className="text-sm text-gray-900 dark:text-white">
-                {client.date_of_birth ? new Date(client.date_of_birth).toLocaleDateString() : 'N/A'}
+                {client.date_of_birth ? format(parseISO(client.date_of_birth), 'M/d/yyyy') : 'N/A'}
               </p>
             </div>
           </div>

--- a/src/components/ClientDetails/SessionNotesTab.tsx
+++ b/src/components/ClientDetails/SessionNotesTab.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { format } from 'date-fns';
+import { format, isValid, parseISO } from 'date-fns';
 import {
   Calendar, ChevronRight, Plus, Download, Inbox,
   Clock, CheckCircle, AlertTriangle, User, Search
@@ -148,6 +148,16 @@ function GoalNoteEntry({ label, noteText, measurement }: GoalNoteEntryProps) {
 interface SessionNotesTabProps {
   client: { id: string };
 }
+
+const formatDateOnly = (
+  value: string | null | undefined,
+  pattern: string,
+  fallback = 'Date unavailable',
+) => {
+  if (!value) return fallback;
+  const parsed = parseISO(value);
+  return isValid(parsed) ? format(parsed, pattern) : fallback;
+};
 
 function hasMeaningfulNarrative(narrative: string): boolean {
   return narrative.trim().length > 0;
@@ -442,7 +452,7 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
                     Auth #{auth.authorization_number}
                   </div>
                   <div className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                    {new Date(auth.start_date).toLocaleDateString()} - {new Date(auth.end_date).toLocaleDateString()}
+                    {formatDateOnly(auth.start_date, 'M/d/yyyy')} - {formatDateOnly(auth.end_date, 'M/d/yyyy')}
                   </div>
                   <div className="mt-2 space-y-1">
                     {auth.services.map(service => (
@@ -600,7 +610,7 @@ export function SessionNotesTab({ client }: SessionNotesTabProps) {
                           <div className="flex items-center">
                             <Calendar className="w-4 h-4 text-gray-400 mr-1" />
                             <span className="text-sm font-medium text-gray-900 dark:text-white">
-                              {format(new Date(note.date), 'MMMM d, yyyy')}
+                              {formatDateOnly(note.date, 'MMMM d, yyyy')}
                             </span>
                             <Clock className="w-4 h-4 text-gray-400 ml-3 mr-1" />
                             <span className="text-sm text-gray-700 dark:text-gray-300">

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -404,8 +404,11 @@ describe("PreAuthTab manual authorization upload", () => {
 
     renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
 
+    expect(await screen.findByText('6/23/2026 - 12/22/2026')).toBeInTheDocument();
+
     await user.click(await screen.findByRole("button", { name: /view/i }));
     expect(await screen.findByText("Behavioral Referral - IEHP Provider SeAp 6.15.pdf")).toBeInTheDocument();
+    expect(screen.getAllByText('6/23/2026 - 12/22/2026')).toHaveLength(2);
 
     await user.click(screen.getByRole("button", { name: /download/i }));
 

--- a/src/components/__tests__/ProfileTab.test.tsx
+++ b/src/components/__tests__/ProfileTab.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, screen } from '../../test/utils';
+import { ProfileTab } from '../ClientDetails/ProfileTab';
+
+vi.mock('../../lib/clients/hooks', () => ({
+  useClientNotes: () => ({ data: [], isLoading: false }),
+  useClientIssues: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('../../lib/toast', () => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+}));
+
+vi.mock('../ClientModal', () => ({
+  ClientModal: () => null,
+}));
+
+vi.mock('../AddGeneralNoteModal', () => ({
+  AddGeneralNoteModal: () => null,
+}));
+
+describe('ProfileTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders DOB as the stored calendar day for date-only values', () => {
+    renderWithProviders(
+      <ProfileTab
+        client={{
+          id: 'client-1',
+          full_name: 'Alyana Perez',
+          client_id: 'CL-1',
+          date_of_birth: '2015-04-20',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('4/20/2015')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/SessionNotesTab.test.tsx
+++ b/src/components/__tests__/SessionNotesTab.test.tsx
@@ -15,6 +15,65 @@ vi.mock('../../lib/session-notes', async (importOriginal) => {
   return { ...mod, fetchClientSessionNotes: vi.fn() };
 });
 
+const {
+  supabaseFromMock,
+} = vi.hoisted(() => {
+  const createAuthorizationsBuilder = (data: unknown[]) => {
+    const builder = {
+      select: vi.fn(() => builder),
+      eq: vi.fn(() => builder),
+      order: vi.fn(() => builder),
+      then: (resolve: (value: { data: unknown[]; error: null }) => void, reject: (reason?: unknown) => void) =>
+        Promise.resolve({ data, error: null }).then(resolve, reject),
+    };
+
+    return builder;
+  };
+
+  const createTherapistsBuilder = () => {
+    const builder = {
+      select: vi.fn(() => builder),
+      eq: vi.fn(() => builder),
+      order: vi.fn(() => Promise.resolve({ data: [], error: null })),
+    };
+
+    return builder;
+  };
+
+  const supabaseFromMock = vi.fn((table: string) => {
+    if (table === 'authorizations') {
+      return createAuthorizationsBuilder([
+        {
+          id: 'auth-1',
+          authorization_number: 'AUTH-SESSION',
+          start_date: '2026-06-23',
+          end_date: '2026-12-22',
+          services: [],
+        },
+      ]);
+    }
+
+    if (table === 'therapists') {
+      return createTherapistsBuilder();
+    }
+
+    return createAuthorizationsBuilder([]);
+  });
+
+  return { supabaseFromMock };
+});
+
+vi.mock('../../lib/supabase', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../../lib/supabase')>();
+  return {
+    ...mod,
+    supabase: {
+      ...mod.supabase,
+      from: supabaseFromMock,
+    },
+  };
+});
+
 // ---------------------------------------------------------------------------
 // Shared fixtures
 // ---------------------------------------------------------------------------
@@ -156,6 +215,7 @@ describe('SessionNotesTab — goal notes display', () => {
   beforeEach(() => {
     // Default: empty note list so each test can override explicitly.
     vi.mocked(fetchClientSessionNotes).mockResolvedValue([]);
+    supabaseFromMock.mockClear();
   });
 
   // -------------------------------------------------------------------------
@@ -354,5 +414,34 @@ describe('SessionNotesTab — overall narrative visibility', () => {
 
     expect(screen.getByText('Client made excellent progress today.')).toBeInTheDocument();
     expect(screen.getByText('Motor skills')).toBeInTheDocument();
+  });
+
+  it('renders session note and authorization date-only values without shifting the calendar day', async () => {
+    vi.mocked(fetchClientSessionNotes).mockResolvedValue([
+      {
+        ...noteWithNarrativeBody,
+        id: 'note-date-only',
+        date: '2026-06-23',
+      },
+    ]);
+
+    renderWithProviders(<SessionNotesTab client={CLIENT} />, AUTH_OPTS);
+
+    expect(await screen.findByText('June 23, 2026')).toBeInTheDocument();
+    expect(await screen.findByText('6/23/2026 - 12/22/2026')).toBeInTheDocument();
+  });
+
+  it('renders a fallback instead of crashing for a legacy note without a session date', async () => {
+    vi.mocked(fetchClientSessionNotes).mockResolvedValue([
+      {
+        ...noteWithNarrativeBody,
+        id: 'note-without-date',
+        date: null as unknown as string,
+      },
+    ]);
+
+    renderWithProviders(<SessionNotesTab client={CLIENT} />, AUTH_OPTS);
+
+    expect(await screen.findByText('Date unavailable')).toBeInTheDocument();
   });
 });

--- a/src/pages/Authorizations.tsx
+++ b/src/pages/Authorizations.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import { 
   FileText,
   Search,
@@ -477,8 +477,8 @@ export function Authorizations() {
                           </div>
                           <div className="text-xs text-gray-500 dark:text-gray-400 flex items-center">
                             <Calendar className="w-3 h-3 mr-1" />
-                            {format(new Date(auth.start_date), 'MMM d, yyyy')} - 
-                            {format(new Date(auth.end_date), 'MMM d, yyyy')}
+                            {format(parseISO(auth.start_date), 'MMM d, yyyy')} -
+                            {format(parseISO(auth.end_date), 'MMM d, yyyy')}
                           </div>
                         </div>
                       </div>

--- a/src/pages/ClientDetails.tsx
+++ b/src/pages/ClientDetails.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useLocation, useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
 import { User, FileText, ClipboardCheck, Contact as FileContract, ArrowLeft, Calendar, AlertCircle, Clock, BarChart3 } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { fetchClientByIdForViewer } from '../lib/clients/fetchers';
@@ -163,7 +164,7 @@ export function ClientDetails() {
   }), [authorizationReportEndDates, client?.auth_end_date, reportWindow.today]);
 
   const reportEndDateLabel = reportStatus.endDate
-    ? new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(`${reportStatus.endDate}T00:00:00`))
+    ? format(parseISO(reportStatus.endDate), 'MMM d, yyyy')
     : null;
 
   const tabs = useMemo(

--- a/src/pages/__tests__/Authorizations.test.tsx
+++ b/src/pages/__tests__/Authorizations.test.tsx
@@ -212,4 +212,21 @@ describe('Authorizations page query scope', () => {
     expect(therapistsInMock).not.toHaveBeenCalled();
     expect(screen.getByText('Authorizations')).toBeInTheDocument();
   });
+
+  it('renders authorization date-only ranges without shifting the calendar day', async () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      effectiveRole: 'admin',
+      profile: baseProfile({
+        id: 'admin-user',
+        role: 'admin',
+        organization_id: 'org-admin-1',
+      }),
+    });
+
+    renderWithProviders(<Authorizations />, { auth: false });
+
+    const authNumber = await screen.findByText('AUTH-1');
+    expect(authNumber.parentElement).toHaveTextContent(/Jan 1, 2025\s*-\s*Dec 31, 2025/);
+  });
 });

--- a/src/pages/__tests__/ClientDetails.test.tsx
+++ b/src/pages/__tests__/ClientDetails.test.tsx
@@ -251,6 +251,16 @@ describe('ClientDetails page', () => {
     expect(supabase.from).toHaveBeenCalledWith('authorizations');
   });
 
+  it('renders the report upcoming date label from the stored calendar day', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00Z'));
+    mockAuthorizationEndDates = [{ end_date: '2026-07-08' }];
+
+    renderWithProviders(<ClientDetails />);
+
+    expect(await screen.findByText(/Authorization ends Jul 8, 2026/i)).toBeInTheDocument();
+  });
+
   it('does not expose report-upcoming authorization dates to viewers without authorization access', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date('2026-07-07T12:00:00Z'));


### PR DESCRIPTION
## Summary
- preserve date-only calendar values across BCBA client and authorization surfaces
- add null/invalid-safe session-note date rendering
- add focused regressions for every live off-by-one-day surface

## Verification
- focused Vitest: 5 files, 54 tests passed
- lint passed
- typecheck passed
- build passed
- code review approved

## Tracking
- Linear: WIN-244
- Handoff: docs/ai/WIN-244-date-only-display-handoff.md