### PR TITLE
Fix session note local times

### DIFF
--- a/docs/ai/WIN-244-session-note-timezone-handoff.md
+++ b/docs/ai/WIN-244-session-note-timezone-handoff.md
@@ -1,0 +1,67 @@
+# WIN-244 Session Note Timezone Handoff
+
+## Routing
+
+- classification: low-risk autonomous
+- lane: standard
+- issue: WIN-244
+- scope: write same-day session-note clock fields in the user's local time while preserving elapsed duration
+- non-goals: no schema, API, auth, routing, RLS, or cross-midnight/DST contract redesign
+- stop condition: any change requiring note API offsets or persisted schema changes
+
+## Changed Surfaces
+
+- Added `formatSessionNoteTiming` to validate session timestamps and localize safe same-day clock values
+- Preserved the legacy UTC representation when DST or local-midnight conversion would distort duration
+- Wired both Schedule note-upsert paths through the shared helper
+- Added normal, DST, local-midnight, invalid, reversed, and dual-call-site regressions
+
+## Verification Card
+
+- classification: low-risk autonomous
+- lane: standard
+- change type: UI/component/page and scheduling domain timing logic
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - focused Vitest coverage
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - focused Vitest, 2 files and 45 tests: pass
+  - `npm run ci:check-focused`: pass inside `verify:local`
+  - `npm run lint`: pass inside `verify:local`
+  - `npm run typecheck`: pass inside `verify:local`
+  - `npm run build`: pass
+  - `npm run test:ci`: fail on unrelated workflow-contract and Blob-environment baseline failures
+  - `npm run verify:local`: fail because it stops at the same unrelated `test:ci` failures
+- blocked checks:
+  - `npm run test:ci`: blocked by failures outside this four-file diff
+  - `npm run verify:local`: blocked transitively by the same repo-wide failures
+- result: pass-with-blocked-checks
+- residual risk: the note API still cannot represent timezone offsets; guarded DST and cross-midnight cases retain legacy UTC clock fields
+
+## Review
+
+- code-review-engineer: approve after DST, midnight, invalid, and reversed timestamp safeguards
+- test-engineer: focused `45/45`, policy, lint, typecheck, and build pass
+
+## PR Hygiene
+
+- pr-ready: yes for human review
+- lane: standard
+- branch-ready: yes, `codex/win-244-session-note-timezone`
+- linear-ready: yes, WIN-244
+- single-purpose: yes
+- unrelated changes: none
+- generated artifact drift: none
+- protected-path drift: none
+- change summary: present
+- verification summary: present with blocked repo-wide gates
+- pr handoff: ready
+- reviewer: completed
+- required follow-up: require fresh PR CI and hosted workflow proof before merge
+
+This branch corrects the exact live Los Angeles session-note clock shift while failing safely for timing cases the current note contract cannot represent.

--- a/src/features/scheduling/domain/__tests__/time.test.ts
+++ b/src/features/scheduling/domain/__tests__/time.test.ts
@@ -3,6 +3,7 @@ import {
   addMinutesToLocalInput,
   diffMinutesBetweenLocalInputs,
   formatSessionLocalInput,
+  formatSessionNoteTiming,
   getDefaultSessionEndTime,
   normalizeQuarterHourLocalInput,
   resolveSchedulingTimeZone,
@@ -38,6 +39,76 @@ describe("scheduling time domain helpers", () => {
 
   it("returns empty default end time when start is missing", () => {
     expect(getDefaultSessionEndTime("")).toBe("");
+  });
+
+  it("formats session-note timing in the scheduling timezone", () => {
+    expect(
+      formatSessionNoteTiming({
+        startTimeIso: "2026-07-23T21:00:00.000Z",
+        endTimeIso: "2026-07-23T22:00:00.000Z",
+        resolvedTimeZone: "America/Los_Angeles",
+      }),
+    ).toEqual({
+      sessionDate: "2026-07-23",
+      startTime: "14:00:00",
+      endTime: "15:00:00",
+    });
+  });
+
+  it("preserves legacy UTC timing across the spring-forward DST gap", () => {
+    expect(
+      formatSessionNoteTiming({
+        startTimeIso: "2026-03-08T09:30:00.000Z",
+        endTimeIso: "2026-03-08T10:30:00.000Z",
+        resolvedTimeZone: "America/Los_Angeles",
+      }),
+    ).toEqual({
+      sessionDate: "2026-03-08",
+      startTime: "09:30:00",
+      endTime: "10:30:00",
+    });
+  });
+
+  it("preserves legacy UTC timing across the fall-back DST overlap", () => {
+    expect(
+      formatSessionNoteTiming({
+        startTimeIso: "2026-11-01T08:30:00.000Z",
+        endTimeIso: "2026-11-01T09:30:00.000Z",
+        resolvedTimeZone: "America/Los_Angeles",
+      }),
+    ).toEqual({
+      sessionDate: "2026-11-01",
+      startTime: "08:30:00",
+      endTime: "09:30:00",
+    });
+  });
+
+  it("preserves legacy UTC timing when local times cross midnight", () => {
+    expect(
+      formatSessionNoteTiming({
+        startTimeIso: "2026-07-24T06:30:00.000Z",
+        endTimeIso: "2026-07-24T08:30:00.000Z",
+        resolvedTimeZone: "America/Los_Angeles",
+      }),
+    ).toEqual({
+      sessionDate: "2026-07-24",
+      startTime: "06:30:00",
+      endTime: "08:30:00",
+    });
+  });
+
+  it("rejects invalid or reversed session-note timing", () => {
+    expect(() => formatSessionNoteTiming({
+      startTimeIso: "not-a-date",
+      endTimeIso: "2026-07-23T22:00:00.000Z",
+      resolvedTimeZone: "America/Los_Angeles",
+    })).toThrow("valid ISO datetimes");
+
+    expect(() => formatSessionNoteTiming({
+      startTimeIso: "2026-07-23T22:00:00.000Z",
+      endTimeIso: "2026-07-23T21:00:00.000Z",
+      resolvedTimeZone: "America/Los_Angeles",
+    })).toThrow("later than start time");
   });
 
   it("resolves explicit and runtime scheduling timezones", () => {

--- a/src/features/scheduling/domain/time.ts
+++ b/src/features/scheduling/domain/time.ts
@@ -1,5 +1,6 @@
 import { addMinutes, differenceInMinutes, format, parseISO } from "date-fns";
 import {
+  formatInTimeZone,
   fromZonedTime as zonedTimeToUtc,
   toZonedTime as utcToZonedTime,
 } from "date-fns-tz";
@@ -54,6 +55,57 @@ export const getDefaultSessionEndTime = (startTimeStr: string): string => {
   const startTime = parseISO(startTimeStr);
   const endTime = addMinutes(startTime, 60);
   return format(endTime, "yyyy-MM-dd'T'HH:mm");
+};
+
+export const formatSessionNoteTiming = ({
+  startTimeIso,
+  endTimeIso,
+  resolvedTimeZone,
+}: {
+  startTimeIso: string;
+  endTimeIso: string;
+  resolvedTimeZone: string;
+}): {
+  sessionDate: string;
+  startTime: string;
+  endTime: string;
+} => {
+  const startUtc = parseISO(startTimeIso);
+  const endUtc = parseISO(endTimeIso);
+  if (Number.isNaN(startUtc.getTime()) || Number.isNaN(endUtc.getTime())) {
+    throw new Error("Session timing must contain valid ISO datetimes.");
+  }
+
+  const actualDurationMinutes = differenceInMinutes(endUtc, startUtc);
+  if (actualDurationMinutes <= 0) {
+    throw new Error("Session end time must be later than start time.");
+  }
+
+  const localStartDate = formatInTimeZone(startUtc, resolvedTimeZone, "yyyy-MM-dd");
+  const localEndDate = formatInTimeZone(endUtc, resolvedTimeZone, "yyyy-MM-dd");
+  const localStartTime = formatInTimeZone(startUtc, resolvedTimeZone, "HH:mm:ss");
+  const localEndTime = formatInTimeZone(endUtc, resolvedTimeZone, "HH:mm:ss");
+  const localStartMinutes = Number(localStartTime.slice(0, 2)) * 60 + Number(localStartTime.slice(3, 5));
+  const localEndMinutes = Number(localEndTime.slice(0, 2)) * 60 + Number(localEndTime.slice(3, 5));
+
+  if (
+    localStartDate === localEndDate
+    && localEndMinutes - localStartMinutes === actualDurationMinutes
+  ) {
+    return {
+      sessionDate: localStartDate,
+      startTime: localStartTime,
+      endTime: localEndTime,
+    };
+  }
+
+  // The note API stores date and times without offsets. Preserve the legacy UTC
+  // representation when local wall-clock values would distort elapsed duration.
+  return {
+    sessionDate: formatInTimeZone(startUtc, "UTC", "yyyy-MM-dd"),
+    startTime: formatInTimeZone(startUtc, "UTC", "HH:mm:ss"),
+    endTime: formatInTimeZone(endUtc, "UTC", "HH:mm:ss"),
+  };
 };
 
 /** Minutes between two local datetime-local values in the scheduling timezone; null if invalid. */

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -73,6 +73,7 @@ import {
 } from "../features/scheduling/domain/sessionScope";
 import { filterSessionsBySelectedScope } from "../features/scheduling/domain/sessionFilters";
 import { shouldClearMissingSelection } from "../features/scheduling/domain/selectionGuard";
+import { formatSessionNoteTiming } from "../features/scheduling/domain/time";
 
 type ScheduleDataErrorCategory =
   | "insufficient_privilege"
@@ -1610,6 +1611,11 @@ export const Schedule = React.memo(() => {
             "An authorization id is required to save session capture (add any authorization for this client).",
           );
         }
+        const sessionTiming = formatSessionNoteTiming({
+          startTimeIso: sessionPayload.start_time ?? sessionToPersist.start_time,
+          endTimeIso: sessionPayload.end_time ?? sessionToPersist.end_time,
+          resolvedTimeZone: userTimeZone,
+        });
         return upsertClientSessionNoteForSession({
           sessionId: sessionToPersist.id,
           clientId: sessionPayload.client_id ?? sessionToPersist.client_id,
@@ -1618,9 +1624,9 @@ export const Schedule = React.memo(() => {
           organizationId: activeOrganizationId,
           actorUserId: user.id,
           serviceCode: clinicalNoteDraft.serviceCode,
-          sessionDate: format(parseISO(sessionPayload.start_time ?? sessionToPersist.start_time), "yyyy-MM-dd"),
-          startTime: format(parseISO(sessionPayload.start_time ?? sessionToPersist.start_time), "HH:mm:ss"),
-          endTime: format(parseISO(sessionPayload.end_time ?? sessionToPersist.end_time), "HH:mm:ss"),
+          sessionDate: sessionTiming.sessionDate,
+          startTime: sessionTiming.startTime,
+          endTime: sessionTiming.endTime,
           goalsAddressed: clinicalNoteDraft.goalsAddressed,
           goalIds: clinicalNoteDraft.goalIds,
           goalMeasurements: clinicalNoteDraft.goalMeasurements,
@@ -1714,6 +1720,11 @@ export const Schedule = React.memo(() => {
           }
           let progressionResult;
           if (clinicalNoteDraft && effectiveSelectedSession && activeOrganizationId && user?.id) {
+            const sessionTiming = formatSessionNoteTiming({
+              startTimeIso: sessionPayload.start_time ?? effectiveSelectedSession.start_time,
+              endTimeIso: sessionPayload.end_time ?? effectiveSelectedSession.end_time,
+              resolvedTimeZone: userTimeZone,
+            });
             progressionResult = await upsertClientSessionNoteForSession({
               sessionId: effectiveSelectedSession.id,
               clientId: sessionPayload.client_id ?? effectiveSelectedSession.client_id,
@@ -1722,9 +1733,9 @@ export const Schedule = React.memo(() => {
               organizationId: activeOrganizationId,
               actorUserId: user.id,
               serviceCode: clinicalNoteDraft.serviceCode,
-              sessionDate: format(parseISO(sessionPayload.start_time ?? effectiveSelectedSession.start_time), "yyyy-MM-dd"),
-              startTime: format(parseISO(sessionPayload.start_time ?? effectiveSelectedSession.start_time), "HH:mm:ss"),
-              endTime: format(parseISO(sessionPayload.end_time ?? effectiveSelectedSession.end_time), "HH:mm:ss"),
+              sessionDate: sessionTiming.sessionDate,
+              startTime: sessionTiming.startTime,
+              endTime: sessionTiming.endTime,
               goalsAddressed: clinicalNoteDraft.goalsAddressed,
               goalIds: clinicalNoteDraft.goalIds,
               goalMeasurements: clinicalNoteDraft.goalMeasurements,

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -12,6 +12,11 @@ const buildBookSessionApiPayloadMock = vi.fn((session: unknown) => session);
 const upsertClientSessionNoteForSessionMock = vi.fn();
 const invalidateSessionNoteCachesAfterSessionWriteMock = vi.fn();
 const completeSessionFromModalMock = vi.fn();
+const formatSessionNoteTimingMock = vi.fn(() => ({
+  sessionDate: "2026-07-23",
+  startTime: "14:00:00",
+  endTime: "15:00:00",
+}));
 
 const currentSessionStart = new Date();
 currentSessionStart.setHours(10, 0, 0, 0);
@@ -21,6 +26,11 @@ currentSessionEnd.setHours(11, 0, 0, 0);
 const originalSessionWindow = {
   start_time: currentSessionStart.toISOString(),
   end_time: currentSessionEnd.toISOString(),
+};
+
+const futureSessionNoteWindow = {
+  start_time: "2026-07-23T21:00:00.000Z",
+  end_time: "2026-07-23T22:00:00.000Z",
 };
 
 const originalSessionFixture = {
@@ -75,6 +85,10 @@ vi.mock("../../lib/optimizedQueries", () => ({
 vi.mock("../../features/scheduling/domain/booking", () => ({
   buildBookSessionApiPayload: (session: unknown) => buildBookSessionApiPayloadMock(session),
   bookSessionViaApi: (...args: unknown[]) => bookSessionViaApiMock(...args),
+}));
+
+vi.mock("../../features/scheduling/domain/time", () => ({
+  formatSessionNoteTiming: (...args: unknown[]) => formatSessionNoteTimingMock(...args),
 }));
 
 vi.mock("../../lib/sessionCancellation", () => ({
@@ -227,8 +241,8 @@ vi.mock("../../components/SessionModal", () => ({
               client_id: "client-1",
               program_id: "program-1",
               goal_id: "goal-1",
-              start_time: originalSessionWindow.start_time,
-              end_time: originalSessionWindow.end_time,
+              start_time: futureSessionNoteWindow.start_time,
+              end_time: futureSessionNoteWindow.end_time,
               status: "in_progress",
               session_note_goal_ids: ["goal-1", "adhoc-skill-550e8400-e29b-41d4-a716-446655440000"],
               session_note_goals_addressed: ["Goal 1", "Session target"],
@@ -315,8 +329,8 @@ vi.mock("../../components/SessionModal", () => ({
               client_id: "client-1",
               program_id: "program-1",
               goal_id: "goal-1",
-              start_time: originalSessionWindow.start_time,
-              end_time: originalSessionWindow.end_time,
+              start_time: futureSessionNoteWindow.start_time,
+              end_time: futureSessionNoteWindow.end_time,
               status: "in_progress",
               session_note_goal_ids: ["goal-1", "adhoc-skill-550e8400-e29b-41d4-a716-446655440000"],
               session_note_goals_addressed: ["Goal 1", "Session target"],
@@ -410,6 +424,11 @@ describe("Schedule orchestration integration hardening", () => {
     localStorage.clear();
     vi.clearAllMocks();
     resetScheduleFixture();
+    formatSessionNoteTimingMock.mockReturnValue({
+      sessionDate: "2026-07-23",
+      startTime: "14:00:00",
+      endTime: "15:00:00",
+    });
     upsertClientSessionNoteForSessionMock.mockResolvedValue({
       id: "linked-note-1",
     });
@@ -657,11 +676,19 @@ describe("Schedule orchestration integration hardening", () => {
       expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1);
       expect(bookSessionViaApiMock).toHaveBeenCalledTimes(1);
     });
+    expect(formatSessionNoteTimingMock).toHaveBeenCalledWith({
+      startTimeIso: futureSessionNoteWindow.start_time,
+      endTimeIso: futureSessionNoteWindow.end_time,
+      resolvedTimeZone: expect.any(String),
+    });
     expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: "session-1",
       clientId: "client-1",
       authorizationId: "auth-1",
       serviceCode: "97153",
+      sessionDate: "2026-07-23",
+      startTime: "14:00:00",
+      endTime: "15:00:00",
       captureMergeGoalIds: [
         "goal-1",
         "adhoc-skill-550e8400-e29b-41d4-a716-446655440000",
@@ -912,11 +939,19 @@ describe("Schedule orchestration integration hardening", () => {
       expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1);
       expect(bookSessionViaApiMock).toHaveBeenCalledTimes(1);
     });
+    expect(formatSessionNoteTimingMock).toHaveBeenCalledWith({
+      startTimeIso: futureSessionNoteWindow.start_time,
+      endTimeIso: futureSessionNoteWindow.end_time,
+      resolvedTimeZone: expect.any(String),
+    });
     expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: "session-1",
       clientId: "client-1",
       authorizationId: "auth-1",
       serviceCode: "97153",
+      sessionDate: "2026-07-23",
+      startTime: "14:00:00",
+      endTime: "15:00:00",
     }));
     expect(invalidateSessionNoteCachesAfterSessionWriteMock).toHaveBeenCalledWith(
       expect.anything(),


### PR DESCRIPTION
## Summary
- localize safe same-day session-note clock fields from Schedule timestamps
- preserve legacy UTC fields when DST or local-midnight conversion would distort duration
- cover normal, DST, midnight, invalid, reversed, and both note-upsert paths

## Verification
- focused Vitest: 2 files, 45 tests passed
- policy, lint, typecheck, and build passed
- reviewer approved after DST/midnight safeguards
- repo-wide test:ci remains red on unrelated workflow/Blob baseline failures

## Tracking
- Linear: WIN-244
- Handoff: docs/ai/WIN-244-session-note-timezone-handoff.md