### PR TITLE
Fix Session Trends prompt outcome route

### DIFF
--- a/docs/ai/WIN-244-trial-events-edge-handoff.md
+++ b/docs/ai/WIN-244-trial-events-edge-handoff.md
@@ -1,0 +1,71 @@
+# WIN-244 Trial Events Edge Handoff
+
+## Routing
+
+- classification: high-risk human-reviewed
+- lane: critical
+- issue: WIN-244
+- scope: add `GET view=prompt_outcomes` parity to the existing Trial Events Edge Function and route Session Trends through it
+- non-goals: no migration, RLS, grant, RPC, Netlify, CI, or existing Trial Events write-contract changes
+- stop condition: any need to widen beyond the existing server-handler contract or modify tenant policy
+
+## Changed Surfaces
+
+- Session Trends now calls the authenticated `trial-events` Edge Function
+- Edge Function mirrors the existing server prompt-outcome validation, capability, tenant scope, filters, row cap, DTO, and upstream-status behavior
+- Edge contracts cover validation, authz failure, tenant scope, status preservation, row cap, legacy GET anchors, and legacy POST
+
+## Verification Card
+
+- classification: high-risk human-reviewed
+- lane: critical
+- change type: server/API/edge integration and tenant-sensitive Supabase read path
+- required checks:
+  - focused Edge, server, and component tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+- executed checks:
+  - focused Edge, server, and component Vitest, 3 files and 66 tests: pass
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+  - `npm run test:ci`: fail on five unrelated repo-wide workflow, Blob-environment, and Schedule readiness failures
+- blocked checks:
+  - `npm run test:routes:tier0`: deferred to fresh PR CI because the full suite is already red outside this diff
+  - `npm run ci:playwright`: requires the hosted auth/browser environment
+  - hosted positive and negative Edge reads: require a reviewed development/preview deployment
+- result: pass-with-blocked-checks
+- residual risk: hosted Edge behavior is not proven until a preview deployment exercises in-scope and forbidden actors
+
+## Review
+
+- code-review-engineer: approve after status parity and legacy regression coverage
+- security-engineer: approve; capability gate precedes privileged existence checks and final read remains request-scoped
+- supabase-reviewer: approve; no migration, RLS, grant, or tenant-boundary regression
+- human review: mandatory before merge because `supabase/functions/**` is protected
+
+## PR Hygiene
+
+- pr-ready: yes for critical-lane human review
+- lane: critical
+- branch-ready: yes, `codex/win-244-trial-events-route`
+- linear-ready: yes, WIN-244
+- single-purpose: yes
+- unrelated changes: none
+- generated artifact drift: none
+- protected-path drift: intentional Edge Function change, correctly routed critical
+- change summary: present
+- verification summary: present with explicit blocked gates
+- pr handoff: ready
+- reviewer: completed
+- required follow-up: fresh CI, hosted preview proof, and required human approval
+
+This branch replaces the broken SPA fallback request with the existing authenticated Edge boundary and adds the missing prompt-outcomes contract without widening tenant access.

--- a/src/components/ClientDetails/ClientSessionTrendsTab.tsx
+++ b/src/components/ClientDetails/ClientSessionTrendsTab.tsx
@@ -14,7 +14,7 @@ import { Bar, Line } from 'react-chartjs-2';
 import { AlertTriangle, BarChart3, Download, Inbox, Loader2 } from 'lucide-react';
 import type { Chart as ChartInstance, ChartData, ChartOptions, PointStyle } from 'chart.js';
 import type { Goal, TrialEvent } from '../../types';
-import { callApi } from '../../lib/api';
+import { callApi, callEdgeFunctionHttp } from '../../lib/api';
 import { fetchClientSessionNotes } from '../../lib/session-notes';
 import { useActiveOrganizationId } from '../../lib/organization';
 import { supabase } from '../../lib/supabase';
@@ -193,8 +193,8 @@ export function ClientSessionTrendsTab({ client }: ClientSessionTrendsTabProps) 
       }
       const startAt = encodeURIComponent(toUtcStartOfDayIso(startDate));
       const endBefore = encodeURIComponent(toExclusiveEndDateIso(endDate));
-      const response = await callApi(
-        `/api/trial-events?view=prompt_outcomes&client_id=${encodeURIComponent(client.id)}&goal_id=${encodeURIComponent(selectedGoalId)}&start_at=${startAt}&end_before=${endBefore}`,
+      const response = await callEdgeFunctionHttp(
+        `trial-events?view=prompt_outcomes&client_id=${encodeURIComponent(client.id)}&goal_id=${encodeURIComponent(selectedGoalId)}&start_at=${startAt}&end_before=${endBefore}`,
       );
       if (!response.ok) {
         throw new Error('Prompt outcomes failed to load.');

--- a/src/components/__tests__/ClientSessionTrendsTab.test.tsx
+++ b/src/components/__tests__/ClientSessionTrendsTab.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, screen, waitFor } from '../../test/utils';
 import { renderWithProviders } from '../../test/utils';
 import { ClientSessionTrendsTab } from '../ClientDetails/ClientSessionTrendsTab';
 import { fetchClientSessionNotes } from '../../lib/session-notes';
-import { callApi } from '../../lib/api';
+import { callApi, callEdgeFunctionHttp } from '../../lib/api';
 import { supabase } from '../../lib/supabase';
 
 vi.mock('react-chartjs-2', () => ({
@@ -58,6 +58,7 @@ vi.mock('../../lib/session-notes', async () => {
 
 vi.mock('../../lib/api', () => ({
   callApi: vi.fn(),
+  callEdgeFunctionHttp: vi.fn(),
 }));
 
 const createGoalsBuilder = () => {
@@ -154,7 +155,10 @@ describe('ClientSessionTrendsTab', () => {
           },
         ]), { status: 200 });
       }
-      if (path.startsWith('/api/trial-events?view=prompt_outcomes&')) {
+      throw new Error(`Unhandled API path ${path}`);
+    });
+    vi.mocked(callEdgeFunctionHttp).mockImplementation(async (path: string) => {
+      if (path.startsWith('trial-events?view=prompt_outcomes&')) {
         return new Response(JSON.stringify([
           {
             id: 'prompt-event-1',
@@ -185,7 +189,7 @@ describe('ClientSessionTrendsTab', () => {
           },
         ]), { status: 200 });
       }
-      throw new Error(`Unhandled API path ${path}`);
+      throw new Error(`Unhandled edge path ${path}`);
     });
     vi.mocked(fetchClientSessionNotes).mockResolvedValue([
       {
@@ -286,8 +290,9 @@ describe('ClientSessionTrendsTab', () => {
 
     await screen.findByTestId('prompt-outcomes-chart');
 
-    expect(callApi).toHaveBeenCalledWith(
-      '/api/trial-events?view=prompt_outcomes&client_id=client-1&goal_id=goal-1&start_at=2024-12-01T00%3A00%3A00.000Z&end_before=2025-07-01T00%3A00%3A00.000Z',
+    expect(callApi).toHaveBeenCalledWith('/api/goal-targets?goal_id=goal-1');
+    expect(callEdgeFunctionHttp).toHaveBeenCalledWith(
+      'trial-events?view=prompt_outcomes&client_id=client-1&goal_id=goal-1&start_at=2024-12-01T00%3A00%3A00.000Z&end_before=2025-07-01T00%3A00%3A00.000Z',
     );
     expect(screen.getByRole('button', { name: /Download outcome graph/i })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Correct' })).toBeInTheDocument();
@@ -504,11 +509,11 @@ describe('ClientSessionTrendsTab', () => {
   });
 
   it('shows the exact prompt outcome empty copy', async () => {
-    const defaultCallApi = vi.mocked(callApi).getMockImplementation();
-    vi.mocked(callApi).mockImplementation(async (path: string) => (
-      path.startsWith('/api/trial-events?view=prompt_outcomes&')
+    const defaultCallEdgeFunctionHttp = vi.mocked(callEdgeFunctionHttp).getMockImplementation();
+    vi.mocked(callEdgeFunctionHttp).mockImplementation(async (path: string) => (
+      path.startsWith('trial-events?view=prompt_outcomes&')
         ? new Response(JSON.stringify([]), { status: 200 })
-        : defaultCallApi!(path)
+        : defaultCallEdgeFunctionHttp!(path)
     ));
 
     renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
@@ -516,14 +521,15 @@ describe('ClientSessionTrendsTab', () => {
     });
 
     expect(await screen.findByText('No prompted outcome data in the selected range.')).toBeInTheDocument();
+    expect(screen.queryByText('Prompt outcomes failed to load.')).not.toBeInTheDocument();
   });
 
   it('surfaces a prompt outcome fetch error', async () => {
-    const defaultCallApi = vi.mocked(callApi).getMockImplementation();
-    vi.mocked(callApi).mockImplementation(async (path: string) => (
-      path.startsWith('/api/trial-events?view=prompt_outcomes&')
+    const defaultCallEdgeFunctionHttp = vi.mocked(callEdgeFunctionHttp).getMockImplementation();
+    vi.mocked(callEdgeFunctionHttp).mockImplementation(async (path: string) => (
+      path.startsWith('trial-events?view=prompt_outcomes&')
         ? new Response(null, { status: 500 })
-        : defaultCallApi!(path)
+        : defaultCallEdgeFunctionHttp!(path)
     ));
 
     renderWithProviders(<ClientSessionTrendsTab client={{ id: 'client-1' }} />, {
@@ -531,5 +537,6 @@ describe('ClientSessionTrendsTab', () => {
     });
 
     expect(await screen.findByText('Prompt outcomes failed to load.')).toBeInTheDocument();
+    expect(screen.queryByText('No prompted outcome data in the selected range.')).not.toBeInTheDocument();
   });
 });

--- a/supabase/functions/trial-events/index.ts
+++ b/supabase/functions/trial-events/index.ts
@@ -44,6 +44,34 @@ type TrialEventReadScope = {
   clientId: string;
 };
 
+type PromptOutcomesQuery = {
+  clientId: string;
+  goalId: string;
+  startAt: string;
+  endBefore: string;
+};
+
+type GoalScope = {
+  id: string;
+  client_id: string;
+};
+
+type PromptOutcomeRow = {
+  id: string;
+  session_id: string;
+  target_id: string;
+  goal_id: string;
+  therapist_id: string;
+  response: string | null;
+  event_timestamp: string;
+  sessions?: unknown;
+};
+
+const promptOutcomeResponseValues = ["correct", "incorrect", "noResponse"] as const;
+const maxPromptOutcomeWindowMs = 366 * 24 * 60 * 60 * 1000;
+const maxPromptOutcomeRows = 5000;
+const promptOutcomeFetchLimit = maxPromptOutcomeRows + 1;
+
 const json = (req: Request, body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
     status,
@@ -54,6 +82,11 @@ const json = (req: Request, body: unknown, status = 200) =>
   });
 
 const isUuid = (value: string): boolean => z.string().uuid().safeParse(value).success;
+
+const toUtcDateString = (value: string): string => new Date(value).toISOString().slice(0, 10);
+
+const isUtcDayBoundary = (value: string): boolean =>
+  new Date(value).toISOString().endsWith("T00:00:00.000Z");
 
 type CapabilityResult = { allowed: boolean; upstreamError: boolean };
 type LockStateResult = { locked: boolean; upstreamError: boolean };
@@ -177,6 +210,67 @@ const resolveTrialEventReadScope = async (
   return clientId ? { scope: { clientId } } : { scope: null, response: json(req, { error: "session_id or target_id is required" }, 400) };
 };
 
+const parsePromptOutcomesQuery = (
+  url: URL,
+): { value: PromptOutcomesQuery | null; error?: string } => {
+  const clientId = url.searchParams.get("client_id");
+  const goalId = url.searchParams.get("goal_id");
+  const startAt = url.searchParams.get("start_at");
+  const endBefore = url.searchParams.get("end_before");
+
+  if (!clientId) {
+    return { value: null, error: "client_id is required for view=prompt_outcomes" };
+  }
+  if (!goalId) {
+    return { value: null, error: "goal_id is required for view=prompt_outcomes" };
+  }
+  if (!startAt) {
+    return { value: null, error: "start_at is required for view=prompt_outcomes" };
+  }
+  if (!endBefore) {
+    return { value: null, error: "end_before is required for view=prompt_outcomes" };
+  }
+  if (!isUuid(clientId)) {
+    return { value: null, error: "client_id must be a valid UUID" };
+  }
+  if (!isUuid(goalId)) {
+    return { value: null, error: "goal_id must be a valid UUID" };
+  }
+
+  const startAtResult = z.string().datetime().safeParse(startAt);
+  if (!startAtResult.success) {
+    return { value: null, error: "start_at must be a valid ISO 8601 datetime" };
+  }
+  const endBeforeResult = z.string().datetime().safeParse(endBefore);
+  if (!endBeforeResult.success) {
+    return { value: null, error: "end_before must be a valid ISO 8601 datetime" };
+  }
+
+  const startAtMs = Date.parse(startAt);
+  const endBeforeMs = Date.parse(endBefore);
+  if (!Number.isFinite(startAtMs) || !Number.isFinite(endBeforeMs)) {
+    return { value: null, error: "start_at and end_before must be valid datetimes" };
+  }
+  if (startAtMs >= endBeforeMs) {
+    return { value: null, error: "start_at must be before end_before" };
+  }
+  if (endBeforeMs - startAtMs > maxPromptOutcomeWindowMs) {
+    return { value: null, error: "Prompt outcome query window cannot exceed 366 days" };
+  }
+  if (!isUtcDayBoundary(startAt) || !isUtcDayBoundary(endBefore)) {
+    return { value: null, error: "start_at and end_before must be UTC day boundaries at 00:00:00.000Z" };
+  }
+
+  return {
+    value: {
+      clientId,
+      goalId,
+      startAt,
+      endBefore,
+    },
+  };
+};
+
 export const handleTrialEvents = async (req: Request) => {
   const db = createRequestClient(req);
   const scopeDb = supabaseAdmin;
@@ -192,8 +286,91 @@ export const handleTrialEvents = async (req: Request) => {
 
   if (req.method === "GET") {
     const url = new URL(req.url);
+    const view = url.searchParams.get("view");
+    const clientId = url.searchParams.get("client_id");
     const sessionId = url.searchParams.get("session_id");
     const targetId = url.searchParams.get("target_id");
+
+    if (clientId && (sessionId || targetId) && view !== "prompt_outcomes") {
+      return json(req, { error: "client_id cannot be combined with session_id or target_id unless view=prompt_outcomes" }, 400);
+    }
+
+    if (view === "prompt_outcomes") {
+      if (sessionId || targetId) {
+        return json(req, { error: "view=prompt_outcomes cannot be combined with session_id or target_id" }, 400);
+      }
+
+      const promptOutcomesQuery = parsePromptOutcomesQuery(url);
+      if (!promptOutcomesQuery.value) {
+        return json(req, { error: promptOutcomesQuery.error ?? "Invalid prompt outcomes query" }, 400);
+      }
+
+      const { clientId, goalId, startAt, endBefore } = promptOutcomesQuery.value;
+      const canRead = await canCaptureTrialEvent(db, orgId, clientId);
+      if (canRead.upstreamError) return json(req, { error: "Unable to validate trial-event read access" }, 502);
+      if (!canRead.allowed) return json(req, { error: "Forbidden" }, 403);
+
+      const { data: clients, error: clientError, status: clientStatus } = await scopeDb
+        .from("clients")
+        .select("id")
+        .eq("organization_id", orgId)
+        .eq("id", clientId)
+        .limit(1);
+      const client = !clientError && clients && clients.length > 0 ? clients[0] as { id: string } : null;
+      if (clientError) {
+        return json(req, { error: "Unable to validate trial-event client access" }, clientStatus || 500);
+      }
+      if (!client) return json(req, { error: "client_id is not in scope for this organization" }, 403);
+
+      const { data: goals, error: goalError, status: goalStatus } = await scopeDb
+        .from("goals")
+        .select("id,client_id")
+        .eq("organization_id", orgId)
+        .eq("client_id", clientId)
+        .eq("id", goalId)
+        .limit(1);
+      const goal = !goalError && goals && goals.length > 0 ? goals[0] as unknown as GoalScope : null;
+      if (goalError) {
+        return json(req, { error: "Unable to validate trial-event goal access" }, goalStatus || 500);
+      }
+      if (!goal || goal.client_id !== clientId) {
+        return json(req, { error: "goal_id is not in scope for this client" }, 403);
+      }
+
+      const startDate = toUtcDateString(startAt);
+      const endDate = toUtcDateString(endBefore);
+      const { data, error, status } = await db
+        .from("trial_events")
+        .select("id,session_id,target_id,goal_id,therapist_id,response,event_timestamp,sessions!inner(client_session_notes!inner(session_date))")
+        .eq("organization_id", orgId)
+        .eq("client_id", clientId)
+        .eq("goal_id", goalId)
+        .eq("sessions.client_session_notes.organization_id", orgId)
+        .eq("sessions.client_session_notes.client_id", clientId)
+        .gte("sessions.client_session_notes.session_date", startDate)
+        .lt("sessions.client_session_notes.session_date", endDate)
+        .not("prompt_type", "is", null)
+        .in("response", [...promptOutcomeResponseValues])
+        .order("event_timestamp", { ascending: true })
+        .order("trial_number", { ascending: true })
+        .limit(promptOutcomeFetchLimit);
+      if (error) return json(req, { error: "Failed to load prompt outcomes" }, status || 500);
+
+      const rows = (data ?? []) as PromptOutcomeRow[];
+      if (rows.length > maxPromptOutcomeRows) {
+        return json(req, { error: "Prompt outcome query exceeds 5000 events" }, 422);
+      }
+      return json(req, rows.map(({ id, session_id, target_id, goal_id, therapist_id, response, event_timestamp }) => ({
+        id,
+        session_id,
+        target_id,
+        goal_id,
+        therapist_id,
+        response,
+        event_timestamp,
+      })));
+    }
+
     if (!sessionId && !targetId) return json(req, { error: "session_id or target_id is required" }, 400);
     if (sessionId && !isUuid(sessionId)) return json(req, { error: "session_id must be a valid UUID" }, 400);
     if (targetId && !isUuid(targetId)) return json(req, { error: "target_id must be a valid UUID" }, 400);

--- a/tests/edge/trial-events.prompt-outcomes.contract.test.ts
+++ b/tests/edge/trial-events.prompt-outcomes.contract.test.ts
@@ -1,0 +1,458 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createRequestClientMock = vi.fn();
+const supabaseAdminFromMock = vi.fn();
+const denoServeMock = vi.fn();
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const CLIENT_ID = "22222222-2222-4222-8222-222222222222";
+const GOAL_ID = "33333333-3333-4333-8333-333333333333";
+const SESSION_ID = "44444444-4444-4444-8444-444444444444";
+const TARGET_ID = "55555555-5555-4555-8555-555555555555";
+const THERAPIST_ID = "66666666-6666-4666-8666-666666666666";
+
+async function loadTrialEventsModule() {
+  vi.doMock("../../supabase/functions/_shared/database.ts", () => ({
+    createRequestClient: createRequestClientMock,
+    supabaseAdmin: { from: supabaseAdminFromMock },
+  }));
+  vi.doMock("../../supabase/functions/_shared/cors.ts", () => ({
+    corsHeadersForRequest: () => ({}),
+  }));
+  vi.doMock("../../supabase/functions/_shared/auth-middleware.ts", () => ({
+    createProtectedRoute: (handler: (req: Request) => Promise<Response>) => handler,
+    RouteOptions: { programsGoals: {} },
+  }));
+
+  vi.stubGlobal("Deno", {
+    serve: denoServeMock,
+    env: { get: vi.fn(() => "") },
+  });
+
+  return import("../../supabase/functions/trial-events/index.ts");
+}
+
+const buildReadRequest = (query: string) =>
+  new Request(`https://edge.example/functions/v1/trial-events?${query}`, {
+    method: "GET",
+    headers: { Authorization: "Bearer test-token", apikey: "anon-key" },
+  });
+
+const buildSelectBuilder = <TRow>(rows: TRow[], error: unknown = null, status = error ? 500 : 200) => {
+  const builder: any = {};
+  const chain = () => builder;
+  builder.select = vi.fn(() => chain());
+  builder.eq = vi.fn(() => chain());
+  builder.limit = vi.fn(async () => ({ data: rows, error, status }));
+  return builder;
+};
+
+const buildTrialEventsQueryBuilder = (rows: unknown[], error: unknown = null, status = error ? 500 : 200) => {
+  const builder: any = {};
+  const chain = () => builder;
+  builder.select = vi.fn(() => chain());
+  builder.eq = vi.fn(() => chain());
+  builder.gte = vi.fn(() => chain());
+  builder.lt = vi.fn(() => chain());
+  builder.not = vi.fn(() => chain());
+  builder.in = vi.fn(() => chain());
+  builder.order = vi.fn(() => chain());
+  builder.limit = vi.fn(async () => ({ data: rows, error, status }));
+  return builder;
+};
+
+const buildLegacyReadBuilder = (rows: unknown[]) => {
+  const builder: any = {};
+  const chain = () => builder;
+  builder.select = vi.fn(() => chain());
+  builder.eq = vi.fn(() => chain());
+  builder.order = vi.fn(() => chain());
+  builder.then = (resolve: (value: unknown) => unknown) =>
+    Promise.resolve({ data: rows, error: null, status: 200 }).then(resolve);
+  return builder;
+};
+
+const buildInsertBuilder = (rows: unknown[]) => {
+  const builder: any = {};
+  const chain = () => builder;
+  builder.insert = vi.fn(() => chain());
+  builder.select = vi.fn(() => chain());
+  builder.limit = vi.fn(async () => ({ data: rows, error: null, status: 201 }));
+  return builder;
+};
+
+const createBaseRequestClient = () => ({
+  auth: {
+    getUser: vi.fn(async () => ({ data: { user: { id: "actor-user" } }, error: null })),
+  },
+  rpc: vi.fn(async (fn: string) => {
+    if (fn === "current_user_organization_id") {
+      return { data: ORG_ID, error: null };
+    }
+    if (fn === "current_user_can_capture_trial_event") {
+      return { data: true, error: null };
+    }
+    throw new Error(`Unexpected rpc ${fn}`);
+  }),
+  from: vi.fn(),
+});
+
+describe("trial-events edge prompt outcome parity", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects prompt outcome reads that mix session or target anchors", async () => {
+    createRequestClientMock.mockReturnValue(createBaseRequestClient());
+    const mod = await loadTrialEventsModule();
+
+    const response = await mod.handleTrialEvents(
+      buildReadRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z&target_id=${TARGET_ID}`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "view=prompt_outcomes cannot be combined with session_id or target_id",
+    });
+    expect(supabaseAdminFromMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-UTC day boundaries before capability or scope checks", async () => {
+    const db = createBaseRequestClient();
+    createRequestClientMock.mockReturnValue(db);
+    const mod = await loadTrialEventsModule();
+
+    const response = await mod.handleTrialEvents(
+      buildReadRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T12:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "start_at and end_before must be UTC day boundaries at 00:00:00.000Z",
+    });
+    expect(db.rpc).toHaveBeenCalledTimes(1);
+    expect(supabaseAdminFromMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-increasing prompt outcome range", async () => {
+    createRequestClientMock.mockReturnValue(createBaseRequestClient());
+    const mod = await loadTrialEventsModule();
+
+    const response = await mod.handleTrialEvents(
+      buildReadRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-02T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "start_at must be before end_before" });
+    expect(supabaseAdminFromMock).not.toHaveBeenCalled();
+  });
+
+  it("checks capability before privileged client and goal scope lookups", async () => {
+    const db = createBaseRequestClient();
+    db.rpc = vi.fn(async (fn: string) => {
+      if (fn === "current_user_organization_id") {
+        return { data: ORG_ID, error: null };
+      }
+      if (fn === "current_user_can_capture_trial_event") {
+        return { data: false, error: null };
+      }
+      throw new Error(`Unexpected rpc ${fn}`);
+    });
+    createRequestClientMock.mockReturnValue(db);
+    const mod = await loadTrialEventsModule();
+
+    const response = await mod.handleTrialEvents(
+      buildReadRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+      ),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Forbidden" });
+    expect(db.rpc).toHaveBeenNthCalledWith(2, "current_user_can_capture_trial_event", {
+      target_organization_id: ORG_ID,
+      target_client_id: CLIENT_ID,
+    });
+    expect(supabaseAdminFromMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when the prompt outcome capability check fails upstream", async () => {
+    const db = createBaseRequestClient();
+    db.rpc = vi.fn(async (fn: string) => {
+      if (fn === "current_user_organization_id") {
+        return { data: ORG_ID, error: null };
+      }
+      if (fn === "current_user_can_capture_trial_event") {
+        return { data: null, error: { message: "rpc unavailable" } };
+      }
+      throw new Error(`Unexpected rpc ${fn}`);
+    });
+    createRequestClientMock.mockReturnValue(db);
+    const mod = await loadTrialEventsModule();
+
+    const response = await mod.handleTrialEvents(
+      buildReadRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+      ),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "Unable to validate trial-event read access" });
+    expect(supabaseAdminFromMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the generic 403 goal-scope response for a missing or cross-client goal", async () => {
+    createRequestClientMock.mockReturnValue(createBaseRequestClient());
+    supabaseAdminFromMock.mockImplementation((table: string) => {
+      if (table === "clients") {
+        return buildSelectBuilder([{ id: CLIENT_ID }]);
+      }
+      if (table === "goals") {
+        return buildSelectBuilder([]);
+      }
+      throw new Error(`Unexpected admin table ${table}`);
+    });
+    const mod = await loadTrialEventsModule();
+
+    const response = await mod.handleTrialEvents(
+      buildReadRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+      ),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "goal_id is not in scope for this client" });
+  });
+
+  it("preserves upstream status for prompt outcome scope and data failures", async () => {
+    createRequestClientMock.mockReturnValue(createBaseRequestClient());
+    supabaseAdminFromMock.mockReturnValue(buildSelectBuilder([], { message: "unavailable" }, 503));
+    const mod = await loadTrialEventsModule();
+
+    const response = await mod.handleTrialEvents(
+      buildReadRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+      ),
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "Unable to validate trial-event client access" });
+  });
+
+  it("queries prompt outcomes with request-scoped filters and strips joined session payloads", async () => {
+    const trialEventsBuilder = buildTrialEventsQueryBuilder([
+      {
+        id: "event-1",
+        session_id: SESSION_ID,
+        target_id: TARGET_ID,
+        goal_id: GOAL_ID,
+        therapist_id: THERAPIST_ID,
+        response: "correct",
+        event_timestamp: "2026-07-02T07:30:00.000Z",
+        sessions: {
+          client_session_notes: [{ session_date: "2026-07-01" }],
+        },
+      },
+    ]);
+    const db = createBaseRequestClient();
+    db.from.mockImplementation((table: string) => {
+      if (table === "trial_events") {
+        return trialEventsBuilder;
+      }
+      throw new Error(`Unexpected request-scoped table ${table}`);
+    });
+    createRequestClientMock.mockReturnValue(db);
+    supabaseAdminFromMock.mockImplementation((table: string) => {
+      if (table === "clients") {
+        return buildSelectBuilder([{ id: CLIENT_ID }]);
+      }
+      if (table === "goals") {
+        return buildSelectBuilder([{ id: GOAL_ID, client_id: CLIENT_ID }]);
+      }
+      throw new Error(`Unexpected admin table ${table}`);
+    });
+    const mod = await loadTrialEventsModule();
+
+    const response = await mod.handleTrialEvents(
+      buildReadRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([
+      {
+        id: "event-1",
+        session_id: SESSION_ID,
+        target_id: TARGET_ID,
+        goal_id: GOAL_ID,
+        therapist_id: THERAPIST_ID,
+        response: "correct",
+        event_timestamp: "2026-07-02T07:30:00.000Z",
+      },
+    ]);
+    expect(db.from).toHaveBeenCalledWith("trial_events");
+    expect(trialEventsBuilder.select).toHaveBeenCalledWith(
+      "id,session_id,target_id,goal_id,therapist_id,response,event_timestamp,sessions!inner(client_session_notes!inner(session_date))",
+    );
+    expect(trialEventsBuilder.eq).toHaveBeenCalledWith("organization_id", ORG_ID);
+    expect(trialEventsBuilder.eq).toHaveBeenCalledWith("client_id", CLIENT_ID);
+    expect(trialEventsBuilder.eq).toHaveBeenCalledWith("goal_id", GOAL_ID);
+    expect(trialEventsBuilder.eq).toHaveBeenCalledWith("sessions.client_session_notes.organization_id", ORG_ID);
+    expect(trialEventsBuilder.eq).toHaveBeenCalledWith("sessions.client_session_notes.client_id", CLIENT_ID);
+    expect(trialEventsBuilder.gte).toHaveBeenCalledWith("sessions.client_session_notes.session_date", "2026-07-01");
+    expect(trialEventsBuilder.lt).toHaveBeenCalledWith("sessions.client_session_notes.session_date", "2026-07-02");
+    expect(trialEventsBuilder.not).toHaveBeenCalledWith("prompt_type", "is", null);
+    expect(trialEventsBuilder.in).toHaveBeenCalledWith("response", ["correct", "incorrect", "noResponse"]);
+    expect(trialEventsBuilder.order).toHaveBeenNthCalledWith(1, "event_timestamp", { ascending: true });
+    expect(trialEventsBuilder.order).toHaveBeenNthCalledWith(2, "trial_number", { ascending: true });
+    expect(trialEventsBuilder.limit).toHaveBeenCalledWith(5001);
+  });
+
+  it("returns 422 when prompt outcomes exceed the 5000 row cap", async () => {
+    const db = createBaseRequestClient();
+    db.from.mockImplementation((table: string) => {
+      if (table === "trial_events") {
+        return buildTrialEventsQueryBuilder(
+          Array.from({ length: 5001 }, (_, index) => ({
+            id: `event-${index + 1}`,
+            session_id: SESSION_ID,
+            target_id: TARGET_ID,
+            goal_id: GOAL_ID,
+            therapist_id: THERAPIST_ID,
+            response: "correct",
+            event_timestamp: "2026-07-01T00:00:00.000Z",
+          })),
+        );
+      }
+      throw new Error(`Unexpected request-scoped table ${table}`);
+    });
+    createRequestClientMock.mockReturnValue(db);
+    supabaseAdminFromMock.mockImplementation((table: string) => {
+      if (table === "clients") {
+        return buildSelectBuilder([{ id: CLIENT_ID }]);
+      }
+      if (table === "goals") {
+        return buildSelectBuilder([{ id: GOAL_ID, client_id: CLIENT_ID }]);
+      }
+      throw new Error(`Unexpected admin table ${table}`);
+    });
+    const mod = await loadTrialEventsModule();
+
+    const response = await mod.handleTrialEvents(
+      buildReadRequest(
+        `view=prompt_outcomes&client_id=${CLIENT_ID}&goal_id=${GOAL_ID}&start_at=2026-07-01T00:00:00.000Z&end_before=2026-07-02T00:00:00.000Z`,
+      ),
+    );
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({ error: "Prompt outcome query exceeds 5000 events" });
+  });
+
+  it.each([
+    ["session_id", SESSION_ID, "sessions"],
+    ["target_id", TARGET_ID, "goal_targets"],
+  ])("preserves legacy GET by %s", async (parameter, value, scopeTable) => {
+    const legacyRows = [{ id: "legacy-event-1" }];
+    const legacyBuilder = buildLegacyReadBuilder(legacyRows);
+    const db = createBaseRequestClient();
+    db.from.mockImplementation((table: string) => {
+      if (table === "trial_events") {
+        return legacyBuilder;
+      }
+      throw new Error(`Unexpected request-scoped table ${table}`);
+    });
+    createRequestClientMock.mockReturnValue(db);
+    supabaseAdminFromMock.mockImplementation((table: string) => {
+      if (table === scopeTable && table === "sessions") {
+        return buildSelectBuilder([{ id: SESSION_ID, client_id: CLIENT_ID, therapist_id: THERAPIST_ID }]);
+      }
+      if (table === scopeTable && table === "goal_targets") {
+        return buildSelectBuilder([
+          { id: TARGET_ID, client_id: CLIENT_ID, goal_id: GOAL_ID, measurement_type: "correctIncorrect" },
+        ]);
+      }
+      throw new Error(`Unexpected admin table ${table}`);
+    });
+    const mod = await loadTrialEventsModule();
+
+    const response = await mod.handleTrialEvents(buildReadRequest(`${parameter}=${value}`));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(legacyRows);
+    expect(legacyBuilder.eq).toHaveBeenCalledWith(parameter, value);
+  });
+
+  it("preserves legacy POST trial-event creation", async () => {
+    const createdRow = { id: "created-event-1" };
+    const insertBuilder = buildInsertBuilder([createdRow]);
+    const db = createBaseRequestClient();
+    db.rpc = vi.fn(async (fn: string) => {
+      if (fn === "current_user_organization_id") {
+        return { data: ORG_ID, error: null };
+      }
+      if (fn === "current_user_can_capture_trial_event") {
+        return { data: true, error: null };
+      }
+      if (fn === "session_has_locked_note") {
+        return { data: false, error: null };
+      }
+      throw new Error(`Unexpected rpc ${fn}`);
+    });
+    db.from.mockImplementation((table: string) => {
+      if (table === "trial_events") {
+        return insertBuilder;
+      }
+      throw new Error(`Unexpected request-scoped table ${table}`);
+    });
+    createRequestClientMock.mockReturnValue(db);
+    supabaseAdminFromMock.mockImplementation((table: string) => {
+      if (table === "goal_targets") {
+        return buildSelectBuilder([
+          { id: TARGET_ID, client_id: CLIENT_ID, goal_id: GOAL_ID, measurement_type: "correctIncorrect" },
+        ]);
+      }
+      if (table === "sessions") {
+        return buildSelectBuilder([{ id: SESSION_ID, client_id: CLIENT_ID, therapist_id: THERAPIST_ID }]);
+      }
+      throw new Error(`Unexpected admin table ${table}`);
+    });
+    const mod = await loadTrialEventsModule();
+    const request = new Request("https://edge.example/functions/v1/trial-events", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        session_id: SESSION_ID,
+        target_id: TARGET_ID,
+        trial_number: 1,
+        response: "correct",
+      }),
+    });
+
+    const response = await mod.handleTrialEvents(request);
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual(createdRow);
+    expect(insertBuilder.insert).toHaveBeenCalledWith([
+      expect.objectContaining({
+        organization_id: ORG_ID,
+        client_id: CLIENT_ID,
+        session_id: SESSION_ID,
+        target_id: TARGET_ID,
+        goal_id: GOAL_ID,
+        therapist_id: THERAPIST_ID,
+        trial_number: 1,
+        response: "correct",
+        created_by: "actor-user",
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- route Session Trends prompt outcomes through the authenticated Trial Events Edge Function
- add server-contract parity for validation, capability, tenant scope, filtering, row caps, DTOs, and upstream statuses
- protect existing GET and POST behavior with Edge regression contracts

## Verification
- focused Edge/server/component Vitest: 3 files, 66 tests passed
- policy, lint, typecheck, tenant validation, and build passed
- code, security, and Supabase reviews approved
- repo-wide test:ci remains red on five unrelated baseline failures

## Risk
Critical lane: this PR touches supabase/functions/**. Human review and hosted preview proof are required before merge.

## Tracking
- Linear: WIN-244
- Handoff: docs/ai/WIN-244-trial-events-edge-handoff.md