### PR TITLE
fix(dashboard): remove ambiguous session metrics overload

### DIFF
--- a/docs/ai/WIN-244-session-metrics-overload-handoff.md
+++ b/docs/ai/WIN-244-session-metrics-overload-handoff.md
@@ -1,0 +1,73 @@
+# WIN-244 Session Metrics Overload Handoff
+
+## Routing
+
+- classification: high-risk human-reviewed
+- lane: critical
+- issue: WIN-244
+- triggering path: `supabase/migrations/**`
+- scope: remove the legacy text overload of `get_session_metrics`, align generated database types, and add a focused migration contract
+- non-goals: no RPC body, caller, dashboard fallback, RLS, grant, Edge function, auth, or tenant-boundary changes
+- stop condition: any fix requiring a caller contract, function-body, permission, or shared reporting redesign
+
+## Changed Surfaces
+
+- Added a migration that drops only `public.get_session_metrics(text, text, uuid, uuid)`
+- Reloaded the PostgREST schema after removing the ambiguous overload
+- Collapsed the duplicate generated `get_session_metrics` signature
+- Added a focused contract for overload removal, the surviving date-signature grant, and schema reload
+
+## Verification Card
+
+- classification: high-risk human-reviewed
+- lane: critical
+- change type: database migration, generated type artifact, and integration contract
+- required checks:
+  - focused Vitest contract
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run verify:local`
+  - Supabase preview migration and hosted RPC/ACL proof
+- executed checks:
+  - focused Vitest contract, 3 tests: pass
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+- blocked checks:
+  - `npm run test:ci`: blocked by four unrelated baseline failures, including the existing `supabase.edge` Blob mock failure, stale BT browser-proof contract, and synthetic BCBA provisioning key expectation
+  - `npm run verify:local`: reached and failed at the same unrelated `test:ci` baseline failures after policy, lint, and typecheck passed
+- pending checks:
+  - Supabase preview migration and hosted RPC/ACL proof
+- result: pass with blocked local full-suite checks; pending critical-lane hosted verification
+- residual risk: static tests cannot prove the effective preview schema or ACL; hosted preview evidence is required before merge
+
+## Review
+
+- specification-engineer: approved the bounded migration/type/test direction
+- software-architect: approved after requiring generated-type alignment, contract coverage, and hosted preview proof
+- implementation-engineer: completed the bounded three-file implementation
+- code-review-engineer: no SQL correctness defect; approval pending handoff and hosted verification
+- test-engineer: static contract is appropriate but cannot replace hosted PostgREST proof
+- security-engineer: approved; surviving date overload remains tenant-scoped and fail-closed
+- supabase-reviewer: migration is sound; approval pending hosted preview proof
+- human review: mandatory before merge
+
+## PR Hygiene
+
+- pr-ready: yes, for human review and hosted preview verification
+- lane: critical
+- branch-ready: yes, `codex/win-244-session-metrics-overload`
+- linear-ready: yes, WIN-244
+- single-purpose: yes
+- unrelated changes: none
+- protected-path drift: none beyond the routed migration
+- pr handoff: local verification and specialist review documented; hosted preview verification remains mandatory
+- required follow-up: push the branch, open a human-reviewed PR, require Supabase preview success, and verify only the date overload remains
+
+The live production dashboard currently reports zero monthly metrics while the Reports route returns non-zero data. Production schema inspection found both date and text overloads with identical argument names; this slice removes only the legacy text overload that makes PostgREST resolution ambiguous.

--- a/docs/ai/WIN-244-session-metrics-overload-handoff.md
+++ b/docs/ai/WIN-244-session-metrics-overload-handoff.md
@@ -43,13 +43,15 @@
   - preview hosted RPC/ACL proof: pass; only the date overload remained, with execute granted to `authenticated` and denied to `anon`
   - production migration promotion: pass; runtime ledger recorded `20260723163640/remove_session_metrics_text_overload`
   - production hosted RPC/ACL proof: pass; only `get_session_metrics(date,date,uuid,uuid)` remains, with execute granted to `authenticated` and denied to `anon` and `PUBLIC`
+  - refreshed GitHub runtime migration parity and aggregate CI gate: pass on commit `c556c2ae`
+  - authenticated production BCBA dashboard: pass after a full reload; Monthly Report Summary returned 282 total sessions, 54 completed sessions, 8 active clients, and 8 active therapists
+  - browser evidence: `.tmp/live-bcba-route-audit-2026-07-23/18-dashboard-runtime-fixed.jpg` (local audit artifact, not committed)
 - blocked checks:
   - `npm run test:ci`: blocked by four unrelated baseline failures, including the existing `supabase.edge` Blob mock failure, stale BT browser-proof contract, and synthetic BCBA provisioning key expectation
   - `npm run verify:local`: reached and failed at the same unrelated `test:ci` baseline failures after policy, lint, and typecheck passed
-- pending checks:
-  - refreshed GitHub runtime migration parity and aggregate CI gate
-- result: pass with blocked local full-suite checks; hosted preview and production runtime verification passed
-- residual risk: the production dashboard must still be rechecked through the authenticated BCBA UI after the refreshed CI suite passes
+- pending checks: none
+- result: pass with blocked local full-suite checks; hosted preview, production runtime, refreshed CI, and authenticated BCBA UI verification passed
+- residual risk: existing browser sessions can retain the pre-migration React Query result until reload; fresh requests return the corrected metrics
 
 ## Review
 
@@ -72,6 +74,6 @@
 - unrelated changes: none
 - protected-path drift: none beyond the routed migration
 - pr handoff: local verification, specialist review, Supabase preview, production migration promotion, and hosted RPC/ACL proof are documented
-- required follow-up: require refreshed runtime migration parity and aggregate CI gate success, then recheck the authenticated BCBA dashboard metrics
+- required follow-up: complete the required human-reviewed merge flow, then continue the remaining BCBA route audit
 
 The live production dashboard currently reports zero monthly metrics while the Reports route returns non-zero data. Production schema inspection found both date and text overloads with identical argument names; this slice removes only the legacy text overload that makes PostgREST resolution ambiguous.

--- a/docs/ai/WIN-244-session-metrics-overload-handoff.md
+++ b/docs/ai/WIN-244-session-metrics-overload-handoff.md
@@ -39,23 +39,27 @@
   - `npm run typecheck`: pass
   - `npm run validate:tenant`: pass
   - `npm run build`: pass
+  - Supabase preview migration: pass
+  - preview hosted RPC/ACL proof: pass; only the date overload remained, with execute granted to `authenticated` and denied to `anon`
+  - production migration promotion: pass; runtime ledger recorded `20260723163640/remove_session_metrics_text_overload`
+  - production hosted RPC/ACL proof: pass; only `get_session_metrics(date,date,uuid,uuid)` remains, with execute granted to `authenticated` and denied to `anon` and `PUBLIC`
 - blocked checks:
   - `npm run test:ci`: blocked by four unrelated baseline failures, including the existing `supabase.edge` Blob mock failure, stale BT browser-proof contract, and synthetic BCBA provisioning key expectation
   - `npm run verify:local`: reached and failed at the same unrelated `test:ci` baseline failures after policy, lint, and typecheck passed
 - pending checks:
-  - Supabase preview migration and hosted RPC/ACL proof
-- result: pass with blocked local full-suite checks; pending critical-lane hosted verification
-- residual risk: static tests cannot prove the effective preview schema or ACL; hosted preview evidence is required before merge
+  - refreshed GitHub runtime migration parity and aggregate CI gate
+- result: pass with blocked local full-suite checks; hosted preview and production runtime verification passed
+- residual risk: the production dashboard must still be rechecked through the authenticated BCBA UI after the refreshed CI suite passes
 
 ## Review
 
 - specification-engineer: approved the bounded migration/type/test direction
 - software-architect: approved after requiring generated-type alignment, contract coverage, and hosted preview proof
 - implementation-engineer: completed the bounded three-file implementation
-- code-review-engineer: no SQL correctness defect; approval pending handoff and hosted verification
-- test-engineer: static contract is appropriate but cannot replace hosted PostgREST proof
+- code-review-engineer: no SQL correctness defect; hosted verification requirement satisfied
+- test-engineer: static contract and hosted PostgREST proof both passed
 - security-engineer: approved; surviving date overload remains tenant-scoped and fail-closed
-- supabase-reviewer: migration is sound; approval pending hosted preview proof
+- supabase-reviewer: migration is sound; hosted preview proof passed
 - human review: mandatory before merge
 
 ## PR Hygiene
@@ -67,7 +71,7 @@
 - single-purpose: yes
 - unrelated changes: none
 - protected-path drift: none beyond the routed migration
-- pr handoff: local verification and specialist review documented; hosted preview verification remains mandatory
-- required follow-up: push the branch, open a human-reviewed PR, require Supabase preview success, and verify only the date overload remains
+- pr handoff: local verification, specialist review, Supabase preview, production migration promotion, and hosted RPC/ACL proof are documented
+- required follow-up: require refreshed runtime migration parity and aggregate CI gate success, then recheck the authenticated BCBA dashboard metrics
 
 The live production dashboard currently reports zero monthly metrics while the Reports route returns non-zero data. Production schema inspection found both date and text overloads with identical argument names; this slice removes only the legacy text overload that makes PostgREST resolution ambiguous.

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -6891,40 +6891,23 @@ export type Database = {
         Returns: number
       }
       get_session_metrics:
-        | {
-            Args: {
-              p_client_id?: string
-              p_end_date: string
-              p_start_date: string
-              p_therapist_id?: string
-            }
-            Returns: {
-              cancelled_sessions: number
-              completed_sessions: number
-              no_show_sessions: number
-              sessions_by_client: Json
-              sessions_by_day: Json
-              sessions_by_therapist: Json
-              total_sessions: number
-            }[]
+        {
+          Args: {
+            p_client_id?: string
+            p_end_date: string
+            p_start_date: string
+            p_therapist_id?: string
           }
-        | {
-            Args: {
-              p_client_id?: string
-              p_end_date: string
-              p_start_date: string
-              p_therapist_id?: string
-            }
-            Returns: {
-              cancelled_sessions: number
-              completed_sessions: number
-              no_show_sessions: number
-              sessions_by_client: Json
-              sessions_by_day: Json
-              sessions_by_therapist: Json
-              total_sessions: number
-            }[]
-          }
+          Returns: {
+            cancelled_sessions: number
+            completed_sessions: number
+            no_show_sessions: number
+            sessions_by_client: Json
+            sessions_by_day: Json
+            sessions_by_therapist: Json
+            total_sessions: number
+          }[]
+        }
       get_session_notes_with_compliance: {
         Args: { p_client_id: string; p_limit?: number }
         Returns: {

--- a/supabase/migrations/20260723154500_remove_session_metrics_text_overload.sql
+++ b/supabase/migrations/20260723154500_remove_session_metrics_text_overload.sql
@@ -1,0 +1,11 @@
+-- @migration-intent: Remove the legacy text overload so PostgREST resolves session metrics calls to the date signature without ambiguity.
+-- @migration-dependencies: 20251231150000_lock_down_scheduling_rpcs.sql
+-- @migration-rollback: Recreate the reviewed text wrapper from 20251231150000, revoke execute from PUBLIC and anon, grant execute to authenticated, then reload the PostgREST schema.
+
+begin;
+
+drop function if exists public.get_session_metrics(text, text, uuid, uuid);
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/integration/session-metrics-overload-migration.contract.test.ts
+++ b/tests/integration/session-metrics-overload-migration.contract.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const overloadRemovalMigration = readFileSync(
+  path.join(
+    process.cwd(),
+    "supabase",
+    "migrations",
+    "20260723154500_remove_session_metrics_text_overload.sql",
+  ),
+  "utf8",
+);
+
+const schedulingRpcHardeningMigration = readFileSync(
+  path.join(
+    process.cwd(),
+    "supabase",
+    "migrations",
+    "20251231150000_lock_down_scheduling_rpcs.sql",
+  ),
+  "utf8",
+);
+const normalizedSchedulingRpcHardeningMigration =
+  schedulingRpcHardeningMigration.toLowerCase();
+
+describe("session metrics overload removal migration", () => {
+  it("removes only the legacy text overload", () => {
+    expect(overloadRemovalMigration).toContain(
+      "drop function if exists public.get_session_metrics(text, text, uuid, uuid);",
+    );
+    expect(overloadRemovalMigration).not.toContain(
+      "drop function if exists public.get_session_metrics(date, date, uuid, uuid);",
+    );
+  });
+
+  it("preserves the authenticated grant on the surviving date overload", () => {
+    expect(normalizedSchedulingRpcHardeningMigration).toContain(
+      "grant execute on function public.get_session_metrics(date, date, uuid, uuid) to authenticated;",
+    );
+  });
+
+  it("requests a PostgREST schema reload after the overload cleanup", () => {
+    expect(overloadRemovalMigration).toContain("notify pgrst, 'reload schema';");
+  });
+});


### PR DESCRIPTION
## Summary
- remove the legacy `get_session_metrics(text, text, uuid, uuid)` overload that makes PostgREST resolution ambiguous
- retain the tenant-scoped date overload and its existing authenticated grant
- align generated types and add a focused migration contract

## Routing
- Linear: WIN-244
- classification: high-risk human-reviewed
- lane: critical
- protected path: `supabase/migrations/**`
- human review required; do not merge without Supabase preview proof

## Live evidence
The production BCBA dashboard reports zero monthly metrics while the Reports route returns 281. Hosted schema inspection found both date and text overloads with identical argument names, matching PostgREST overload ambiguity.

## Verification
Passed locally:
- focused Vitest contract (3 tests)
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`

Blocked by unrelated baseline failures:
- `npm run test:ci`
- `npm run verify:local` (fails at the same `test:ci` baseline after policy, lint, and typecheck pass)

Required before merge:
- Supabase preview migration succeeds
- hosted schema confirms only the date signature remains with authenticated execute
- PostgREST call using string date inputs no longer returns HTTP 300
- human review

## Scope controls
No RPC body, caller, dashboard fallback, RLS, grant, Edge function, auth, or tenant-boundary logic changed.