### PR TITLE
fix(ai): allow assistant trace headers in preflight

### DIFF
--- a/docs/ai/WIN-245-ai-assistant-cors-handoff.md
+++ b/docs/ai/WIN-245-ai-assistant-cors-handoff.md
@@ -1,0 +1,73 @@
+# WIN-245 AI Assistant CORS Handoff
+
+## Routing
+
+- classification: high-risk human-reviewed
+- lane: critical
+- issue: WIN-245
+- triggering path: `supabase/functions/ai-agent-optimized/index.ts`
+- tenant boundary: unchanged; authenticated user and organization resolution still occur after preflight
+- scope: align the function's browser CORS headers with the existing shared helper while preserving its `POST, OPTIONS` method contract
+- non-goals: no client, auth, tenant query, AI prompt/tool, persistence, shared CORS policy, secret, or deploy-config changes
+- stop condition: any fix requiring shared policy changes or changes outside the function and focused contract
+
+## Live Evidence
+
+Chrome DevTools reproduced the production BCBA Assistant failure on the Fill Docs route. The browser blocked the `ai-agent-optimized` preflight because the client sends `x-request-id`, but the function allowed only `Content-Type, Authorization`. The same client request also sends `apikey` and `x-correlation-id`.
+
+## Changed Surfaces
+
+- Use `corsHeadersForRequest(req)` for request-scoped origin and allowed-header handling
+- Preserve the function-specific `POST, OPTIONS` method contract
+- Add a focused contract for helper consumption and the complete browser caller header set
+
+## Verification Card
+
+- required checks:
+  - focused CORS and client-header tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run verify:local`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - Supabase preview deployment and hosted browser preflight proof
+- executed checks:
+  - focused Vitest, 12 tests including runtime `OPTIONS` handler execution: pass
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+  - `npm run test:routes:tier0`: pass, 220 tests
+- blocked checks:
+  - `npm run test:ci`: blocked by four unrelated baseline failures, including the existing async PDF Blob mock, stale BT browser-proof workflow contract, and synthetic BCBA provisioning key expectation
+  - `npm run verify:local`: reached and failed at the same unrelated `test:ci` baseline after policy, lint, and typecheck passed
+  - `npm run ci:playwright`: requires protected browser credentials; defer to CI
+- pending checks:
+  - Supabase preview deployment and hosted browser preflight proof
+- result: pass with blocked local full-suite checks; pending critical-lane hosted verification
+- residual risk: static contracts cannot prove the deployed Edge preflight; hosted browser evidence is required before merge
+
+## Review
+
+- specification-engineer: approved the bounded function-and-contract scope
+- software-architect: approved with the `POST, OPTIONS` containment requirement
+- implementation-engineer: approved the implemented diff with no defect
+- code-review-engineer: approved after executable `OPTIONS` coverage and verification-card corrections
+- test-engineer: local contract coverage is sufficient but hosted proof remains mandatory
+- security-engineer: approved; auth and tenant boundaries are unchanged
+- supabase-reviewer: approved for human review; hosted Edge proof remains mandatory before merge
+- human review: mandatory before merge
+
+## PR Hygiene
+
+- pr-ready: yes, for human review and hosted Edge verification
+- branch: `codex/win-245-ai-cors`
+- linear: WIN-245
+- unrelated changes: none
+- protected-path drift: none beyond the routed Edge function
+- merge: prohibited until hosted preflight proof and human review are complete

--- a/supabase/functions/ai-agent-optimized/index.ts
+++ b/supabase/functions/ai-agent-optimized/index.ts
@@ -6,18 +6,12 @@ import { resolveOrgId } from "../_shared/org.ts";
 import { getLogger } from "../_shared/logging.ts";
 import { errorEnvelope, getRequestId, IsoDateSchema } from "../lib/http/error.ts";
 import { persistChatMessage } from "./persistence.ts";
-import { resolveAllowedOrigin } from "../_shared/cors.ts";
+import { corsHeadersForRequest } from "../_shared/cors.ts";
 
 // Initialize OpenAI client
 const openai = new OpenAI({
   apiKey: Deno.env.get("OPENAI_API_KEY"),
 });
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": resolveAllowedOrigin(),
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization",
-};
 
 interface OptimizedAIResponse {
   response: string;
@@ -974,10 +968,11 @@ Deno.serve(async (req) => {
   const requestId = getRequestId(req);
   const correlationId = req.headers.get("x-correlation-id") ?? requestId;
   const responseHeaders = {
+    ...corsHeadersForRequest(req),
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
     "Content-Type": "application/json",
     "x-request-id": requestId,
     "x-correlation-id": correlationId,
-    ...corsHeaders,
   };
 
   if (req.method === "OPTIONS") {

--- a/tests/edge/ai-agent-optimized.cors.contract.test.ts
+++ b/tests/edge/ai-agent-optimized.cors.contract.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stubDenoEnv } from "../utils/stubDeno";
+
+const functionSource = readFileSync(
+  path.join(
+    process.cwd(),
+    "supabase",
+    "functions",
+    "ai-agent-optimized",
+    "index.ts",
+  ),
+  "utf8",
+);
+
+async function loadHandler() {
+  let serveHandler: ((req: Request) => Promise<Response>) | undefined;
+  stubDenoEnv((key) =>
+    key === "CORS_ALLOWED_ORIGINS"
+      ? "https://app.allincompassing.ai"
+      : "",
+  );
+  const denoObject = (
+    globalThis as typeof globalThis & { Deno?: Record<string, unknown> }
+  ).Deno ?? {};
+  vi.stubGlobal("Deno", {
+    ...denoObject,
+    env: {
+      get: (key: string) =>
+        key === "CORS_ALLOWED_ORIGINS"
+          ? "https://app.allincompassing.ai"
+          : "",
+    },
+    serve: vi.fn((handler: (req: Request) => Promise<Response>) => {
+      serveHandler = handler;
+      return {};
+    }),
+  });
+
+  vi.doMock("npm:openai@5.5.1", () => ({
+    OpenAI: class {
+      chat = { completions: { create: vi.fn() } };
+    },
+  }));
+  vi.doMock("npm:zod@3.23.8", async () => {
+    const { z } = await import("zod");
+    return { z };
+  });
+  vi.doMock("../../supabase/functions/_shared/database.ts", () => ({
+    createRequestClient: vi.fn(),
+    supabaseAdmin: {},
+  }));
+  vi.doMock("../../supabase/functions/_shared/auth.ts", () => ({
+    getUserOrThrow: vi.fn(),
+  }));
+  vi.doMock("../../supabase/functions/_shared/org.ts", () => ({
+    resolveOrgId: vi.fn(),
+  }));
+  vi.doMock("../../supabase/functions/_shared/logging.ts", () => ({
+    getLogger: vi.fn(),
+  }));
+  vi.doMock(
+    "../../supabase/functions/ai-agent-optimized/persistence.ts",
+    () => ({
+      persistChatMessage: vi.fn(),
+    }),
+  );
+
+  await import("../../supabase/functions/ai-agent-optimized/index.ts");
+
+  if (!serveHandler) {
+    throw new Error(
+      "Expected ai-agent-optimized to register a Deno.serve handler",
+    );
+  }
+
+  return serveHandler;
+}
+
+describe("ai-agent-optimized CORS contract", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a browser-readable preflight response for trace headers", async () => {
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request(
+        "https://edge.example.com/functions/v1/ai-agent-optimized",
+        {
+          method: "OPTIONS",
+          headers: {
+            Origin: "https://app.allincompassing.ai",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers":
+              "authorization, apikey, content-type, x-request-id, x-correlation-id",
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://app.allincompassing.ai",
+    );
+    expect(response.headers.get("Access-Control-Allow-Methods")).toBe(
+      "POST, OPTIONS",
+    );
+    const allowedHeaders =
+      response.headers.get("Access-Control-Allow-Headers")?.toLowerCase() ?? "";
+    for (const header of [
+      "authorization",
+      "apikey",
+      "content-type",
+      "x-request-id",
+      "x-correlation-id",
+    ]) {
+      expect(allowedHeaders).toContain(header);
+    }
+    expect(response.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("uses request-scoped shared CORS headers for browser requests", () => {
+    expect(functionSource).toMatch(
+      /import\s+\{\s*corsHeadersForRequest\s*\}\s+from\s+["']\.\.\/_shared\/cors\.ts["']/,
+    );
+    expect(functionSource).toContain("...corsHeadersForRequest(req)");
+    expect(functionSource).not.toContain(
+      '"Access-Control-Allow-Headers": "Content-Type, Authorization"',
+    );
+  });
+
+  it("allows the complete browser caller header set", () => {
+    const sharedCorsSource = readFileSync(
+      path.join(
+        process.cwd(),
+        "supabase",
+        "functions",
+        "_shared",
+        "cors.ts",
+      ),
+      "utf8",
+    ).toLowerCase();
+
+    for (const header of [
+      "authorization",
+      "apikey",
+      "content-type",
+      "x-request-id",
+      "x-correlation-id",
+    ]) {
+      expect(sharedCorsSource).toContain(header);
+    }
+  });
+
+  it("preserves the function-specific POST and OPTIONS method contract", () => {
+    expect(functionSource).toContain(
+      '"Access-Control-Allow-Methods": "POST, OPTIONS"',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- use the repository's request-scoped CORS helper for `ai-agent-optimized`
- preserve the function-specific `POST, OPTIONS` method contract
- add executable `Deno.serve` preflight coverage for the browser caller's trace/auth headers

## Routing
- Linear: WIN-245
- classification: high-risk human-reviewed
- lane: critical
- protected path: `supabase/functions/**`
- human review and hosted Edge proof required before merge

## Live evidence
Chrome DevTools on the production BCBA Fill Docs route showed the Assistant preflight blocked because `x-request-id` was absent from `Access-Control-Allow-Headers`. The request failed with `net::ERR_FAILED`, then the UI displayed a generic processing error.

## Verification
Passed locally:
- focused Vitest: 12 tests, including actual `OPTIONS` handler execution
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:routes:tier0`: 220 tests

Blocked by unrelated baseline failures:
- `npm run test:ci`
- `npm run verify:local` at the same `test:ci` baseline

Protected-env check:
- `npm run ci:playwright` deferred to CI because local protected credentials are unavailable

Required before merge:
- deploy exact reviewed Edge bundle to non-production Supabase preview branch
- confirm deployed `verify_jwt=true`
- Computer/browser proof that real preview-origin preflight returns 204 with origin, POST/OPTIONS, and all requested headers
- authenticated same-tenant preview POST
- human review

## Scope controls
No client, auth, tenant query, AI prompt/tool, persistence, shared CORS policy, secret, migration, or deploy-config behavior changed.