### PR TITLE
perf(ci): reduce unnecessary PR browser setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,19 +773,34 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Select IEHP assessment import scope
+        id: browser_scope
+        env:
+          BASE_SHA: ${{ needs.change_scope.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.change_scope.outputs.head_sha }}
+        run: node scripts/ci/select-browser-checks.mjs --format github-output
+
+      - name: Skip IEHP assessment import smoke gate
+        if: steps.browser_scope.outputs.iehp_assessment_import_smoke_required != 'true'
+        run: echo "No IEHP assessment import surface changed; IEHP assessment import smoke required check passes without Playwright."
+
       - name: Install dependencies
+        if: steps.browser_scope.outputs.iehp_assessment_import_smoke_required == 'true'
         run: npm ci
 
       - name: Provision IEHP smoke admin
+        if: steps.browser_scope.outputs.iehp_assessment_import_smoke_required == 'true'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: npx tsx scripts/provision-ci-smoke-admin.ts
 
       - name: Install Playwright browser
+        if: steps.browser_scope.outputs.iehp_assessment_import_smoke_required == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: IEHP assessment import smoke gate
+        if: steps.browser_scope.outputs.iehp_assessment_import_smoke_required == 'true'
         env:
           PW_BASE_URL: ${{ github.event_name == 'pull_request' && format('https://deploy-preview-{0}--velvety-cendol-dae4d6.netlify.app', github.event.pull_request.number) || secrets.PW_BASE_URL }}
           PW_ASSESSMENT_CLIENT_ID: ${{ secrets.PW_ASSESSMENT_CLIENT_ID }}
@@ -820,7 +835,7 @@ jobs:
           npm run playwright:iehp-assessment-import-skills-behaviors
 
       - name: Cleanup IEHP smoke admin
-        if: always()
+        if: always() && steps.browser_scope.outputs.iehp_assessment_import_smoke_required == 'true'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -856,12 +871,6 @@ jobs:
         with:
           node-version: 20
           cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
 
       - name: Optional Playwright smoke secret gate
         id: optional_gate
@@ -943,6 +952,14 @@ jobs:
           fi
 
           echo "run_optional=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Install dependencies
+        if: steps.optional_gate.outputs.run_optional == 'true'
+        run: npm ci
+
+      - name: Install Playwright browser
+        if: steps.optional_gate.outputs.run_optional == 'true'
+        run: npx playwright install --with-deps chromium
 
       - name: Run optional Playwright smoke suite
         if: steps.optional_gate.outputs.run_optional == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,6 +766,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -105,6 +105,8 @@ const classifyFile = (file) => {
     /^scripts\/lib\/(?:iehp-)?assessment-import-smoke\.ts$/,
     /^scripts\/lib\/assessment-import-cleanup\.ts$/,
     /^scripts\/provision-ci-smoke-admin\.ts$/,
+    /^netlify\/functions\/assessment-(?:documents(?:-extract-background)?|drafts|checklist)\.ts$/,
+    /^supabase\/functions\/extract-assessment-fields\//,
     /^src\/components\/ClientDetails\/ProgramsGoalsTab(?:\.helpers)?\.ts(x)?$/,
     /^src\/components\/ClientDetails\/IehpFbaLayoutReview\.tsx$/,
     /^src\/lib\/assessment-documents\.ts$/,

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -83,11 +83,35 @@ const matchAny = (file, patterns) => patterns.some((pattern) => pattern.test(fil
 
 const classifyFile = (file) => {
   if (/^scripts\/ci\/select-browser-checks\.mjs$/.test(file)) {
-    return { specs: allSpecKeys, authSmoke: true, supervisionCorrection: true, reason: "browser CI support script" };
+    return { specs: allSpecKeys, authSmoke: true, iehpAssessmentImportSmoke: true, supervisionCorrection: true, reason: "browser CI support script" };
   }
 
   if (/^\.github\/workflows\/bt-aba-disposable-browser-proof\.yml$/.test(file)) {
     return { specs: allSpecKeys, authSmoke: true, supervisionCorrection: true, reason: "shared route/auth surface" };
+  }
+
+  if (/^\.github\/workflows\/ci\.yml$/.test(file)) {
+    return {
+      specs: allSpecKeys,
+      authSmoke: true,
+      iehpAssessmentImportSmoke: true,
+      supervisionCorrection: true,
+      reason: "shared CI workflow surface",
+    };
+  }
+
+  if (matchAny(file, [
+    /^scripts\/playwright-(?:iehp-)?assessment-import-smoke\.ts$/,
+    /^scripts\/lib\/(?:iehp-)?assessment-import-smoke\.ts$/,
+    /^scripts\/lib\/assessment-import-cleanup\.ts$/,
+    /^scripts\/provision-ci-smoke-admin\.ts$/,
+    /^src\/components\/ClientDetails\/ProgramsGoalsTab(?:\.helpers)?\.ts(x)?$/,
+    /^src\/components\/ClientDetails\/IehpFbaLayoutReview\.tsx$/,
+    /^src\/lib\/assessment-documents\.ts$/,
+    /^src\/server\/(?:assessment|iehp)/,
+    /^src\/server\/api\/assessment-/,
+  ])) {
+    return { specs: ["client"], authSmoke: false, iehpAssessmentImportSmoke: true, reason: "IEHP assessment import surface" };
   }
 
   if (/^scripts\/playwright-supervision-correction\.ts$/.test(file)) {
@@ -203,12 +227,14 @@ const selectBrowserChecks = (files, fallbackFull) => {
   const selectedSpecs = new Set();
   const reasons = [];
   let authSmokeRequired = false;
+  let iehpAssessmentImportSmokeRequired = false;
   let supervisionCorrectionRequired = false;
 
   if (fallbackFull) {
     return {
       tier0Required: true,
       authSmokeRequired: true,
+      iehpAssessmentImportSmokeRequired: true,
       supervisionCorrectionRequired: true,
       tier0Specs: allSpecKeys.map((key) => TIER0_SPECS[key]),
       reasons: ["diff unavailable; running full browser gates"],
@@ -222,8 +248,9 @@ const selectBrowserChecks = (files, fallbackFull) => {
       selectedSpecs.add(spec);
     }
     authSmokeRequired = authSmokeRequired || classification.authSmoke;
+    iehpAssessmentImportSmokeRequired = iehpAssessmentImportSmokeRequired || classification.iehpAssessmentImportSmoke === true;
     supervisionCorrectionRequired = supervisionCorrectionRequired || classification.supervisionCorrection === true;
-    if (classification.specs.length > 0 || classification.authSmoke) {
+    if (classification.specs.length > 0 || classification.authSmoke || classification.iehpAssessmentImportSmoke) {
       reasons.push(`${file}: ${classification.reason}`);
     }
   }
@@ -231,6 +258,7 @@ const selectBrowserChecks = (files, fallbackFull) => {
   return {
     tier0Required: selectedSpecs.size > 0,
     authSmokeRequired,
+    iehpAssessmentImportSmokeRequired,
     supervisionCorrectionRequired,
     tier0Specs: [...selectedSpecs].map((key) => TIER0_SPECS[key]),
     reasons,
@@ -242,6 +270,7 @@ const writeGithubOutput = (selection) => {
   const lines = [
     `tier0_required=${selection.tier0Required ? "true" : "false"}`,
     `auth_smoke_required=${selection.authSmokeRequired ? "true" : "false"}`,
+    `iehp_assessment_import_smoke_required=${selection.iehpAssessmentImportSmokeRequired ? "true" : "false"}`,
     `supervision_correction_required=${selection.supervisionCorrectionRequired ? "true" : "false"}`,
     `tier0_specs=${selection.tier0Specs.join(",")}`,
   ];

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -13,6 +13,7 @@ const runSelector = (...args: string[]) => JSON.parse(execFileSync(process.execP
 })) as {
   tier0Required: boolean;
   authSmokeRequired: boolean;
+  iehpAssessmentImportSmokeRequired: boolean;
   supervisionCorrectionRequired: boolean;
   tier0Specs: string[];
   reasons: string[];
@@ -81,6 +82,26 @@ describe('select-browser-checks', () => {
     expect(selection.reasons).toEqual([
       'scripts/ci/select-browser-checks.mjs: browser CI support script',
     ]);
+    expect(selection.iehpAssessmentImportSmokeRequired).toBe(true);
+  });
+
+  it('requires IEHP assessment import smoke for API and provisioning surfaces', () => {
+    for (const file of [
+      'src/server/api/assessment-documents.ts',
+      'src/server/iehpAssessmentDocx.ts',
+      'scripts/provision-ci-smoke-admin.ts',
+      '.github/workflows/ci.yml',
+    ]) {
+      const selection = runSelector('--changed-file', file);
+
+      expect(selection.iehpAssessmentImportSmokeRequired, file).toBe(true);
+    }
+  });
+
+  it('does not require IEHP assessment import smoke for unrelated client routes', () => {
+    const selection = runSelector('--changed-file', 'src/components/ClientsTable.tsx');
+
+    expect(selection.iehpAssessmentImportSmokeRequired).toBe(false);
   });
 
   it('flags the hosted supervision-correction proof when its workflow changes', () => {

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -87,6 +87,11 @@ describe('select-browser-checks', () => {
 
   it('requires IEHP assessment import smoke for API and provisioning surfaces', () => {
     for (const file of [
+      'netlify/functions/assessment-documents.ts',
+      'netlify/functions/assessment-documents-extract-background.ts',
+      'netlify/functions/assessment-drafts.ts',
+      'netlify/functions/assessment-checklist.ts',
+      'supabase/functions/extract-assessment-fields/iehp-skills-behaviors.ts',
       'src/server/api/assessment-documents.ts',
       'src/server/iehpAssessmentDocx.ts',
       'scripts/provision-ci-smoke-admin.ts',
@@ -96,6 +101,19 @@ describe('select-browser-checks', () => {
 
       expect(selection.iehpAssessmentImportSmokeRequired, file).toBe(true);
     }
+  });
+
+  it('fetches comparison history before selecting IEHP assessment import scope', () => {
+    const workflowSource = readFileSync('.github/workflows/ci.yml', 'utf8');
+    const jobStart = workflowSource.indexOf('  iehp_assessment_import_smoke:');
+    const jobEnd = workflowSource.indexOf('  optional_playwright_smoke:', jobStart);
+    const jobSource = workflowSource.slice(jobStart, jobEnd);
+
+    expect(jobStart).toBeGreaterThanOrEqual(0);
+    expect(jobSource).toContain('fetch-depth: 0');
+    expect(jobSource.indexOf('fetch-depth: 0')).toBeLessThan(
+      jobSource.indexOf('Select IEHP assessment import scope'),
+    );
   });
 
   it('does not require IEHP assessment import smoke for unrelated client routes', () => {


### PR DESCRIPTION
## Summary
- Skip optional Playwright npm/Chromium setup when the optional smoke flag is disabled.
- Scope IEHP assessment import smoke to relevant changed surfaces while preserving the required check.
- Add selector regression coverage for IEHP-required and unrelated paths.

## Verification
- Workflow YAML parse: pass
- Selector Vitest: pass (15 tests)
- ci:check-focused: pass with protected-system skips
- lint: pass
- typecheck: pass
- build: pass
- Full coverage suite: 4 unrelated existing failures in Supabase blob mocking and BT/ABA workflow expectation tests

## Risk
This changes protected CI workflow/script paths. Human review is required. Auth smoke sequencing and standalone tenant-safety duplication remain unchanged for a later slice.

Linear: WIN-246