### PR TITLE
fix(clients): keep search usable below xl

### DIFF
--- a/docs/ai/WIN-248-clients-search-layout-handoff.md
+++ b/docs/ai/WIN-248-clients-search-layout-handoff.md
@@ -1,0 +1,74 @@
+# WIN-248 Clients Search Layout Handoff
+
+## Route
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- triggering paths:
+  - `src/pages/Clients.tsx`
+  - `src/pages/__tests__/Clients.test.tsx`
+- required agents:
+  - `specification-engineer`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+- reviewer required: yes
+- verify-change required: yes
+- linear: [WIN-248](https://linear.app/winningedgeai/issue/WIN-248/keep-clients-search-usable-below-the-xl-desktop-breakpoint)
+
+## Scope
+
+- Keep the Clients search input usable below Tailwind's 1280px `xl` breakpoint.
+- Allow the search/filter toolbar to wrap until `xl` instead of shrinking the search field.
+- Preserve mobile stacking and all search/filter behavior.
+
+Non-goals:
+
+- No auth, routing, server, database, tenant, or deploy configuration changes.
+- No client data mutation or search-semantic changes.
+
+Stop conditions:
+
+- Reclassify if the fix needs a shared layout abstraction or protected path.
+- Stop if verification identifies a behavior regression outside the local toolbar.
+
+## Live Reproduction
+
+- Environment: `https://app.allincompassing.ai`
+- Production commit: `0ec76305ef6d75e2e8679cb6dd60edf0c8e8096a`
+- Actor role: BCBA
+- App viewport: approximately 1270px wide
+- Result: the search input collapsed to an icon-sized box because its minimum width began at `xl`.
+- Screenshot: `.tmp/live-bcba-route-audit-2026-07-23/40-production-bcba-client-search-apostrophe.jpg`
+
+## Verification Card
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- change type: UI/page responsive layout
+- required checks:
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm test -- --run src/pages/__tests__/Clients.test.tsx`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - focused Clients test before implementation: fail as expected, 1 failed / 6 passed
+  - focused Clients test after implementation: pass, 7 passed
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+  - `npm run test:ci`: local environment-only failure in four unrelated workflow/Blob tests
+  - main CI `unit-tests` for production commit `0ec76305`: pass
+- blocked checks:
+  - `npm run verify:local`: blocked by the same unrelated `test:ci` failures under the desktop's bundled Node 24 runtime; GitHub's Node 20 unit job is green.
+- result: `pass-with-blocked-checks`
+- residual risk: class assertions require deploy-preview and production Computer confirmation at the reproduced viewport.
+
+## Next Action
+
+1. Complete independent code review.
+2. Push and open the WIN-248 PR.
+3. Confirm CI and deploy-preview rendering.
+4. Merge, verify the matching production deploy, and rerun the BCBA Computer walkthrough.

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -423,8 +423,8 @@ const Clients = () => {
 
       <div className="bg-white dark:bg-dark-lighter rounded-lg shadow mb-6">
         <div className="p-4 border-b dark:border-gray-700">
-          <div className="flex flex-col sm:flex-row gap-4">
-            <div className="relative flex-1 xl:flex-[1_0_20rem] 2xl:flex-[1_0_24rem]">
+          <div className="flex flex-col sm:flex-row sm:flex-wrap xl:flex-nowrap gap-4">
+            <div className="relative flex-1 sm:min-w-[16rem] xl:flex-[1_0_20rem] 2xl:flex-[1_0_24rem]">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
               <input
                 type="text"
@@ -432,7 +432,7 @@ const Clients = () => {
                 aria-label="Search clients"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full xl:min-w-[20rem] 2xl:min-w-[24rem] pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-dark dark:text-gray-200"
+                className="w-full sm:min-w-[16rem] xl:min-w-[20rem] 2xl:min-w-[24rem] pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-dark dark:text-gray-200"
               />
             </div>
               <div className="flex flex-wrap gap-2">

--- a/src/pages/__tests__/Clients.test.tsx
+++ b/src/pages/__tests__/Clients.test.tsx
@@ -182,12 +182,17 @@ describe('Clients page filtering', () => {
     });
   });
 
-  it('keeps the search input from collapsing at desktop widths with local responsive classes', () => {
+  it('keeps the search input usable below the xl breakpoint and lets filters wrap', () => {
     renderWithProviders(<Clients />);
 
     const searchInput = screen.getByRole('textbox', { name: /search clients/i });
+    const filterRow = searchInput.parentElement?.parentElement;
+
+    expect(searchInput).toHaveClass('sm:min-w-[16rem]');
     expect(searchInput).toHaveClass('xl:min-w-[20rem]');
     expect(searchInput).toHaveClass('2xl:min-w-[24rem]');
+    expect(filterRow).toHaveClass('sm:flex-wrap');
+    expect(filterRow).toHaveClass('xl:flex-nowrap');
   });
 
   it('invalidates the clients query after successful mutations', () => {


### PR DESCRIPTION
## Summary
- keep the Clients search field at a usable width below Tailwind's `xl` breakpoint
- allow the search/filter row to wrap until `xl` instead of collapsing the search control
- add focused responsive class coverage

## Live QA evidence
- reproduced on production at an approximately 1270px app viewport during the BCBA Computer walkthrough
- tracked in [WIN-248](https://linear.app/winningedgeai/issue/WIN-248/keep-clients-search-usable-below-the-xl-desktop-breakpoint)

## Verification
- focused Clients test: red before implementation, then 7/7 pass
- `npm run ci:check-focused`: pass
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run build`: pass
- independent code review: approved, no findings
- broader local `npm run test:ci`: four unrelated failures under bundled Node 24; authoritative main Node 20 `unit-tests` is green

## Risk
UI-only responsive classes. No auth, server, database, tenant, or deployment configuration changes.