### PR TITLE
WIN-249: scope AI assistant roles to organization

### DIFF
--- a/docs/ai/WIN-249-ai-assistant-role-resolution-handoff.md
+++ b/docs/ai/WIN-249-ai-assistant-role-resolution-handoff.md
@@ -1,0 +1,114 @@
+# WIN-249 AI Assistant Role Resolution Handoff
+
+## Route
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- triggering paths:
+  - `supabase/functions/ai-agent-optimized/**`
+- risk rationale:
+  - protected Supabase Edge Function
+  - role-based assistant tool authorization
+  - organization-scoped authorization
+- required agents:
+  - `specification-engineer`
+  - `software-architect`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+  - `security-engineer`
+  - `supabase-reviewer`
+- human review required: yes
+- linear: [WIN-249](https://linear.app/winningedgeai/issue/WIN-249/fix-ai-assistant-role-downgrade-and-surface-upstream-quota-failures)
+
+## Scope
+
+- Resolve the AI agent actor role from active, authoritative, organization-scoped role checks.
+- Preserve role precedence as `super_admin > bcba > admin > therapist > client`.
+- Preserve BCBA identity in traces while granting the same current assistant tools as admin.
+- Fail closed to `client` when an authoritative role check fails.
+
+Non-goals:
+
+- No provider key, secret, billing, migration, RLS, grant, or deployment changes.
+- No changes to OpenAI request, retry, or fallback behavior.
+- No changes to client-side routing or role resolution.
+
+Stop conditions:
+
+- Stop if the fix requires schema, RPC, shared auth, or deployment changes.
+- Keep the OpenAI quota outage separate from this role-authorization fix.
+
+## Live Evidence
+
+- Production route: `https://app.allincompassing.ai/schedule`
+- Actor: audited BCBA account
+- Hosted function: `ai-agent-optimized` version 22
+- Live trace before fix:
+  - actor role: `client`
+  - upstream result: OpenAI `429` quota exceeded
+  - function response: HTTP 200 with a technical-difficulties message
+- Hosted account state:
+  - active authoritative roles include `admin` and `bcba`
+  - the prior function used the unscoped `get_user_roles` payload incorrectly
+- Screenshot:
+  - `.tmp/live-bcba-route-audit-2026-07-23/70-production-bcba-chat-assistant-failure-confirmed.jpg`
+
+The OpenAI quota failure remains an external operational blocker. This slice fixes the independently confirmed role downgrade and does not claim to restore generated assistant responses.
+
+## Verification Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- change type:
+  - auth/role handling
+  - Supabase Edge integration
+  - tenant/org-scoped authorization
+- required checks:
+  - focused role/CORS/guardrail tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+- executed checks:
+  - focused role/CORS/guardrail tests: pass, 18 tests
+  - final focused role test: pass, 5 tests
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+  - `npm run test:routes:tier0`: pass, 220 tests
+  - `npm run test:ci`: fail in three reproducible unrelated tests from untouched files
+  - `npm run ci:playwright`: blocked at preflight
+- blocked checks:
+  - `npm run test:ci`: existing failures in `src/lib/__tests__/supabase.edge.test.ts`, `tests/workflows/bt-aba-disposable-browser-proof.test.ts`, and `tests/ci/check-e2e-reliability-gates.test.ts`; this branch does not modify their source or fixtures
+  - `npm run ci:playwright`: missing local `PW_SUPERADMIN_*` or `PW_ADMIN_*` credentials
+  - `npm run verify:local`: blocked by the same `test:ci` failures and Playwright credential prerequisite
+- result: `pass-with-blocked-checks`
+- residual risk:
+  - hosted role behavior is not fixed until the protected Edge Function change is reviewed, merged, and deployed
+  - generated assistant responses remain blocked by the production OpenAI quota
+
+## PR Hygiene
+
+- pr-ready: yes for critical-lane human review; merge remains gated on required CI and human approval
+- lane: `critical`
+- branch-ready: yes
+- linear-ready: yes
+- single-purpose: yes
+- unrelated changes: none
+- generated artifact drift: none
+- protected-path drift: none outside the routed function
+- change summary: present
+- verification summary: present
+- reviewer: implementation, security, Supabase, and code reviews completed with no remaining findings
+- required follow-up:
+  - push and open a human-reviewed PR
+  - rely on secret-backed CI for the Playwright gate
+  - deploy only after required human approval and green required checks
+  - rerun the live BCBA Chat Assistant proof after quota restoration

--- a/supabase/functions/ai-agent-optimized/index.ts
+++ b/supabase/functions/ai-agent-optimized/index.ts
@@ -7,6 +7,10 @@ import { getLogger } from "../_shared/logging.ts";
 import { errorEnvelope, getRequestId, IsoDateSchema } from "../lib/http/error.ts";
 import { persistChatMessage } from "./persistence.ts";
 import { corsHeadersForRequest } from "../_shared/cors.ts";
+import {
+  resolveAgentRole,
+  type AgentRole,
+} from "./roleResolution.ts";
 
 // Initialize OpenAI client
 const openai = new OpenAI({
@@ -34,7 +38,6 @@ interface OptimizedAIResponse {
   }>;
 }
 
-type AgentRole = "client" | "therapist" | "admin" | "super_admin";
 type ToolExecutionMode = "server_execute" | "client_handoff" | "suggestion_only";
 
 type ExecutionGate = {
@@ -104,27 +107,27 @@ const SESSION_TOOL_REGISTRY: Record<
   { roles: AgentRole[]; executionMode: ToolExecutionMode }
 > = {
   schedule_session: {
-    roles: ["therapist", "admin", "super_admin"],
+    roles: ["therapist", "admin", "bcba", "super_admin"],
     executionMode: "client_handoff",
   },
   cancel_sessions: {
-    roles: ["therapist", "admin", "super_admin"],
+    roles: ["therapist", "admin", "bcba", "super_admin"],
     executionMode: "client_handoff",
   },
   start_session: {
-    roles: ["therapist", "admin", "super_admin"],
+    roles: ["therapist", "admin", "bcba", "super_admin"],
     executionMode: "client_handoff",
   },
   predict_conflicts: {
-    roles: ["therapist", "admin", "super_admin"],
+    roles: ["therapist", "admin", "bcba", "super_admin"],
     executionMode: "suggestion_only",
   },
   suggest_optimal_times: {
-    roles: ["therapist", "admin", "super_admin"],
+    roles: ["therapist", "admin", "bcba", "super_admin"],
     executionMode: "suggestion_only",
   },
   get_monthly_session_count: {
-    roles: ["therapist", "admin", "super_admin"],
+    roles: ["therapist", "admin", "bcba", "super_admin"],
     executionMode: "server_execute",
   },
 };
@@ -286,42 +289,34 @@ const parseBoolean = (value: string | null | undefined): boolean => {
   return normalized === "true" || normalized === "1" || normalized === "yes";
 };
 
-const parseRoleList = (data: unknown): string[] => {
-  if (!Array.isArray(data)) {
-    return [];
-  }
-  return data.flatMap((entry) => {
-    if (!entry) return [] as string[];
-    const roleValue = (entry as { roles?: unknown }).roles;
-    if (Array.isArray(roleValue)) {
-      return roleValue.filter((role): role is string => typeof role === "string");
-    }
-    if (typeof roleValue === "string" && roleValue.length > 0) {
-      try {
-        const parsed = JSON.parse(roleValue) as unknown;
-        if (Array.isArray(parsed)) {
-          return parsed.filter((role): role is string => typeof role === "string");
-        }
-      } catch {
-        // fall through to comma separated
+const resolveActorRole = async (
+  db: ReturnType<typeof createRequestClient>,
+  orgId: string | null,
+): Promise<AgentRole> => {
+  return resolveAgentRole(
+    async (role) => {
+      if (role === "super_admin") {
+        const { data, error } = await db.rpc("current_user_is_super_admin");
+        if (error) throw error;
+        return data === true;
       }
-      return roleValue.split(",").map((role) => role.trim()).filter(Boolean);
-    }
-    return [] as string[];
-  });
-};
+      if (!orgId) return false;
 
-const resolveActorRole = async (db: ReturnType<typeof createRequestClient>): Promise<AgentRole> => {
-  const { data, error } = await db.rpc("get_user_roles");
-  if (error) {
-    console.warn("Failed to resolve user roles for agent request", error);
-    return "client";
-  }
-  const roles = parseRoleList(data);
-  if (roles.includes("super_admin")) return "super_admin";
-  if (roles.includes("admin")) return "admin";
-  if (roles.includes("therapist")) return "therapist";
-  return "client";
+      const roleNames = role === "admin" ? ["org_super_admin", "admin"] : [role];
+      for (const roleName of roleNames) {
+        const { data, error } = await db.rpc("user_has_role_for_org", {
+          role_name: roleName,
+          target_organization_id: orgId,
+        });
+        if (error) throw error;
+        if (data === true) return true;
+      }
+      return false;
+    },
+    (error) => {
+      console.warn("Failed to resolve organization-scoped role for agent request", error);
+    },
+  );
 };
 
 const resolveExecutionGate = (role: AgentRole, requestedTools: string[] = []): Omit<ExecutionGate, "killSwitchEnabled" | "killSwitchReason" | "killSwitchSource"> => {
@@ -1017,7 +1012,7 @@ Deno.serve(async (req) => {
       orgId,
     });
 
-    const actorRole = await resolveActorRole(db);
+    const actorRole = await resolveActorRole(db, orgId);
     const requestedTools = Array.isArray(context?.guardrails?.allowedTools)
       ? context?.guardrails?.allowedTools
       : [];

--- a/supabase/functions/ai-agent-optimized/roleResolution.ts
+++ b/supabase/functions/ai-agent-optimized/roleResolution.ts
@@ -1,0 +1,22 @@
+export type AgentRole = "client" | "therapist" | "admin" | "bcba" | "super_admin";
+
+const STAFF_ROLE_PRECEDENCE: readonly Exclude<AgentRole, "client">[] = [
+  "super_admin",
+  "bcba",
+  "admin",
+  "therapist",
+];
+
+export const resolveAgentRole = async (
+  hasRole: (role: Exclude<AgentRole, "client">) => Promise<boolean>,
+  onError: (error: unknown) => void = () => {},
+): Promise<AgentRole> => {
+  try {
+    for (const role of STAFF_ROLE_PRECEDENCE) {
+      if (await hasRole(role)) return role;
+    }
+  } catch (error) {
+    onError(error);
+  }
+  return "client";
+};

--- a/tests/edge/ai-agent-optimized.role-resolution.test.ts
+++ b/tests/edge/ai-agent-optimized.role-resolution.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveAgentRole } from "../../supabase/functions/ai-agent-optimized/roleResolution";
+
+const functionSource = readFileSync(
+  path.join(
+    process.cwd(),
+    "supabase",
+    "functions",
+    "ai-agent-optimized",
+    "index.ts",
+  ),
+  "utf8",
+);
+
+describe("AI agent role resolution", () => {
+  it("preserves BCBA identity above an additional admin assignment", async () => {
+    const checkedRoles: string[] = [];
+    const role = await resolveAgentRole(async (candidate) => {
+      checkedRoles.push(candidate);
+      return candidate === "bcba" || candidate === "admin";
+    });
+
+    expect(role).toBe("bcba");
+    expect(checkedRoles).toEqual(["super_admin", "bcba"]);
+  });
+
+  it("resolves an organization-scoped admin when higher roles are absent", async () => {
+    const role = await resolveAgentRole(async (candidate) => candidate === "admin");
+    expect(role).toBe("admin");
+  });
+
+  it("fails closed when no authoritative organization role matches", async () => {
+    const role = await resolveAgentRole(async () => false);
+    expect(role).toBe("client");
+  });
+
+  it("fails closed and reports an authoritative role lookup error", async () => {
+    const lookupError = new Error("role lookup failed");
+    const onError = vi.fn();
+    const role = await resolveAgentRole(async () => {
+      throw lookupError;
+    }, onError);
+
+    expect(role).toBe("client");
+    expect(onError).toHaveBeenCalledWith(lookupError);
+  });
+
+  it("wires authoritative role checks to the resolved organization", () => {
+    expect(functionSource).toContain("resolveActorRole(db, orgId)");
+    expect(functionSource).toContain('db.rpc("user_has_role_for_org"');
+    expect(functionSource).toContain("target_organization_id: orgId");
+    expect(functionSource).toContain("if (!orgId) return false");
+    expect(functionSource).toContain('["org_super_admin", "admin"]');
+    expect(functionSource).not.toContain('db.rpc("get_user_roles"');
+  });
+});


### PR DESCRIPTION
## Summary
- replace unscoped `get_user_roles` parsing with authoritative organization-scoped role checks
- preserve `super_admin > bcba > admin > therapist > client` precedence and existing org-admin aliases
- fail closed on missing org context or RPC errors
- add focused regression coverage and the critical-lane handoff card

## Live evidence
- BCBA audit trace incorrectly recorded the actor as `client`
- the same production request reached `ai-agent-optimized` but OpenAI returned `429 quota exceeded`
- this PR fixes the role-authorization defect; quota restoration remains an external operational action

## Verification
Passed:
- focused role/CORS/guardrail tests: 18/18
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:routes:tier0`: 220/220

Blocked / unrelated:
- `npm run test:ci`: three reproducible existing failures in untouched PDF/workflow tests
- `npm run ci:playwright`: local preflight requires `PW_SUPERADMIN_*` or `PW_ADMIN_*` credentials

## Risk
Critical protected-path change in `supabase/functions/**`. Security, Supabase, code, architecture, specification, implementation, and test reviews completed. Human approval remains required before merge/deploy.

Linear: WIN-249