### PR TITLE
WIN-249 Surface AI provider quota failures

### DIFF
--- a/docs/ai/WIN-249-ai-assistant-quota-status-handoff.md
+++ b/docs/ai/WIN-249-ai-assistant-quota-status-handoff.md
@@ -113,10 +113,9 @@ does not claim to restore provider availability.
 - protected-path drift: none beyond the routed Edge Function
 - change summary: present
 - verification summary: present
-- pr handoff: ready after rebasing onto current `origin/main`
+- pr handoff: ready; rebased onto current `origin/main`
 - reviewer: completed
 - required follow-up:
-  - rebase onto current `origin/main`
   - require green branch CI and human review
   - verify governed deployment retains `verify_jwt=true`
   - repeat the live BCBA Assistant request with Computer

--- a/docs/ai/WIN-249-ai-assistant-quota-status-handoff.md
+++ b/docs/ai/WIN-249-ai-assistant-quota-status-handoff.md
@@ -1,0 +1,122 @@
+# WIN-249 AI Assistant Quota Status Handoff
+
+## Route
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- triggering paths:
+  - `supabase/functions/ai-agent-optimized/index.ts`
+- risk rationale:
+  - protected Supabase Edge Function
+  - app-to-edge HTTP contract
+- required agents:
+  - `specification-engineer`
+  - `software-architect`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+  - `security-engineer`
+  - `supabase-reviewer`
+- human review required: yes
+- linear: [WIN-249](https://linear.app/winningedgeai/issue/WIN-249/fix-ai-assistant-role-downgrade-and-surface-upstream-quota-failures)
+
+## Scope
+
+- Detect only OpenAI `429` errors identified as `insufficient_quota`.
+- Return the existing `upstream_unavailable` error envelope with HTTP 503.
+- Preserve CORS, request ID, correlation ID, and no-store headers.
+- Prove the production browser client degrades safely after the optimized endpoint retries.
+
+Non-goals:
+
+- No secret, provider key, billing, provider selection, or retry-policy changes.
+- No auth, role, tool, persistence, migration, RLS, grant, or tenant-scope changes.
+- No legacy `process-message` deployment or behavior changes.
+
+Stop conditions:
+
+- Stop if the provider error cannot be distinguished from a generic 429.
+- Stop if the fix requires shared error taxonomy, auth, tenant, or secret changes.
+
+## Live Evidence
+
+- Production route: `https://app.allincompassing.ai/schedule`
+- Hosted function: `ai-agent-optimized` version 23 with `verify_jwt=true`
+- Fresh request/correlation ID: `a5040b7c-03e4-4385-9003-b6429e6b66c6`
+- Trace role: `bcba`
+- Provider failure: OpenAI `429`, code/type `insufficient_quota`
+- Provider request ID: `req_48ff46f705af4a4ca80b8f1c3769bb95`
+- Current hosted response: HTTP 200 with a generic technical-difficulties assistant payload
+- Screenshots:
+  - `.tmp/live-bcba-route-audit-2026-07-23/72-bcba-assistant-fresh-retry-failed.png`
+  - `.tmp/live-bcba-route-audit-2026-07-23/73-bcba-assistant-fresh-retry-quota-log.png`
+
+Restoring generated Assistant responses still requires an account-level OpenAI
+quota or key operation. This code slice makes the transport contract honest but
+does not claim to restore provider availability.
+
+## Verification Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- required checks:
+  - focused edge and caller tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - secret-backed CI browser checks
+- executed checks:
+  - focused edge and caller tests: pass, 19 tests
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+  - `npm run test:routes:tier0`: pass, 220 tests
+  - `npm run test:ci`: fail in four unrelated baseline tests from untouched files
+  - `npm run verify:local`: fail at `npm run test:ci` on the same four
+    unrelated baseline tests; policy, lint, and typecheck passed before the stop
+- blocked or failing checks:
+  - `tests/ci/check-e2e-reliability-gates.test.ts`: expected workflow secret text is absent
+  - `tests/scripts/playwright-iehp-assessment-import-smoke.test.ts`: expected function config text is absent
+  - `tests/workflows/bt-aba-disposable-browser-proof.test.ts`: expected branch-specific workflow text is absent
+  - `src/lib/__tests__/supabase.edge.test.ts`: local Blob implementation has no `text()` method
+  - local secret-backed Playwright: requires CI credentials
+- result: `fail`
+- residual risk:
+  - HTTP 503 behavior is not live until human review, merge, and governed deployment
+  - successful Assistant-response proof remains blocked by external OpenAI quota
+
+## Reviews
+
+- specification: complete
+- architecture: approved
+- implementation: approved
+- code review: approved after production caller coverage
+- security review: approved, no findings
+- Supabase review: approved, no tenant or JWT changes
+- test review: focused contract covers the reproduced provider error shape
+
+## PR Hygiene
+
+- pr-ready: yes, subject to required CI and human review
+- lane: `critical`
+- branch-ready: yes, `codex/win-249-ai-assistant-quota-status`
+- linear-ready: yes, WIN-249 is In Review
+- single-purpose: yes
+- unrelated changes: none
+- generated artifact drift: none
+- protected-path drift: none beyond the routed Edge Function
+- change summary: present
+- verification summary: present
+- pr handoff: ready after rebasing onto current `origin/main`
+- reviewer: completed
+- required follow-up:
+  - rebase onto current `origin/main`
+  - require green branch CI and human review
+  - verify governed deployment retains `verify_jwt=true`
+  - repeat the live BCBA Assistant request with Computer

--- a/src/lib/__tests__/ai-upstream-production.test.ts
+++ b/src/lib/__tests__/ai-upstream-production.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("AI production upstream failure handling", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("DEV", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("degrades safely without calling the legacy endpoint after an optimized 503", async () => {
+    const {
+      resetRuntimeSupabaseConfigForTests,
+      setRuntimeSupabaseConfig,
+    } = await import("../runtimeConfig");
+    setRuntimeSupabaseConfig({
+      supabaseUrl: "https://example.supabase.co",
+      supabaseAnonKey: "anon-key",
+      defaultOrganizationId: "5238e88b-6198-4862-80a2-dbe15bbeabdd",
+      supabaseEdgeUrl: "https://example.supabase.co/functions/v1/",
+    });
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          requestId: "req-quota",
+          code: "upstream_unavailable",
+          message: "AI service is temporarily unavailable",
+        }),
+        {
+          status: 503,
+          headers: {
+            "Content-Type": "application/json",
+            "x-request-id": "req-quota",
+            "x-correlation-id": "corr-quota",
+          },
+        },
+      ),
+    );
+    const consoleErrorMock = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { processMessage } = await import("../ai");
+      const result = await processMessage(
+        "List the scheduling tasks available to a BCBA.",
+        {
+          url: "https://app.allincompassing.ai/schedule",
+          userAgent: "vitest",
+          actor: { id: "user-1", role: "bcba" },
+        },
+        { accessToken: "mock-user-jwt" },
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        "https://example.supabase.co/functions/v1/ai-agent-optimized",
+        expect.any(Object),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        "https://example.supabase.co/functions/v1/ai-agent-optimized",
+        expect.any(Object),
+      );
+      expect(fetchMock.mock.calls).not.toContainEqual([
+        "https://example.supabase.co/functions/v1/process-message",
+        expect.any(Object),
+      ]);
+      expect(result).toMatchObject({
+        response:
+          "I apologize, but I'm having trouble processing your request right now. Please try again in a moment or use the manual interface instead.",
+        responseTime: 0,
+        error: "AI fallback disabled in production (status 503)",
+      });
+      expect(consoleErrorMock).toHaveBeenCalled();
+    } finally {
+      resetRuntimeSupabaseConfigForTests();
+    }
+  });
+});

--- a/supabase/functions/ai-agent-optimized/index.ts
+++ b/supabase/functions/ai-agent-optimized/index.ts
@@ -38,6 +38,33 @@ interface OptimizedAIResponse {
   }>;
 }
 
+class AgentUpstreamUnavailableError extends Error {
+  readonly code = "upstream_unavailable";
+
+  constructor() {
+    super("AI service is temporarily unavailable");
+    this.name = "AgentUpstreamUnavailableError";
+  }
+}
+
+const isInsufficientQuotaError = (error: unknown): boolean => {
+  if (!error || typeof error !== "object") return false;
+
+  const candidate = error as Record<string, unknown>;
+  const nested =
+    candidate.error && typeof candidate.error === "object"
+      ? candidate.error as Record<string, unknown>
+      : null;
+  const providerCodes = [
+    candidate.code,
+    candidate.type,
+    nested?.code,
+    nested?.type,
+  ];
+
+  return candidate.status === 429 && providerCodes.includes("insufficient_quota");
+};
+
 type ToolExecutionMode = "server_execute" | "client_handoff" | "suggestion_only";
 
 type ExecutionGate = {
@@ -921,6 +948,10 @@ async function processOptimizedMessage(
       payload: { error: error?.message ?? String(error) },
     });
 
+    if (isInsufficientQuotaError(error)) {
+      throw new AgentUpstreamUnavailableError();
+    }
+
     return {
       response: "I apologize, but I'm experiencing technical difficulties. Please try again or use the manual interface.",
       conversationId: (context as any).conversationId as string,
@@ -1162,6 +1193,15 @@ Deno.serve(async (req) => {
       }
     );
   } catch (error: any) {
+    if (error instanceof AgentUpstreamUnavailableError) {
+      return errorEnvelope({
+        requestId,
+        code: error.code,
+        message: error.message,
+        headers: responseHeaders,
+      });
+    }
+
     if (error instanceof Response) {
       const body = await error.text().catch(() => "");
       return new Response(body, {

--- a/tests/edge/ai-agent-optimized.quota.contract.test.ts
+++ b/tests/edge/ai-agent-optimized.quota.contract.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stubDenoEnv } from "../utils/stubDeno";
+
+const completionCreateMock = vi.fn();
+const createRequestClientMock = vi.fn();
+const getUserOrThrowMock = vi.fn();
+const resolveOrgIdMock = vi.fn();
+const loggerInfoMock = vi.fn();
+const loggerWarnMock = vi.fn();
+const supabaseRpcMock = vi.fn();
+const supabaseFromMock = vi.fn();
+
+const envValues = new Map<string, string>([
+  ["CORS_ALLOWED_ORIGINS", "https://app.allincompassing.ai"],
+  ["APP_ENV", "production"],
+  ["OPENAI_API_KEY", "test-openai-key"],
+]);
+
+function createMaybeSingleQuery() {
+  const query: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const method of ["select", "eq", "order", "limit"]) {
+    query[method] = vi.fn(() => query);
+  }
+  query.maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+  return query;
+}
+
+async function loadHandler() {
+  let serveHandler: ((req: Request) => Promise<Response>) | undefined;
+  stubDenoEnv((key) => envValues.get(key) ?? "");
+  const denoObject = (
+    globalThis as typeof globalThis & { Deno?: Record<string, unknown> }
+  ).Deno ?? {};
+  vi.stubGlobal("Deno", {
+    ...denoObject,
+    env: {
+      get: (key: string) => envValues.get(key) ?? "",
+    },
+    serve: vi.fn((handler: (req: Request) => Promise<Response>) => {
+      serveHandler = handler;
+      return {};
+    }),
+  });
+
+  vi.doMock("npm:openai@5.5.1", () => ({
+    OpenAI: class {
+      chat = { completions: { create: completionCreateMock } };
+    },
+  }));
+  vi.doMock("npm:zod@3.23.8", async () => {
+    const { z } = await import("zod");
+    return { z };
+  });
+  vi.doMock("../../supabase/functions/_shared/database.ts", () => ({
+    createRequestClient: createRequestClientMock,
+    supabaseAdmin: {
+      from: supabaseFromMock,
+      rpc: supabaseRpcMock,
+    },
+  }));
+  vi.doMock("../../supabase/functions/_shared/auth.ts", () => ({
+    getUserOrThrow: getUserOrThrowMock,
+  }));
+  vi.doMock("../../supabase/functions/_shared/org.ts", () => ({
+    resolveOrgId: resolveOrgIdMock,
+  }));
+  vi.doMock("../../supabase/functions/_shared/logging.ts", () => ({
+    getLogger: vi.fn(() => ({
+      info: loggerInfoMock,
+      warn: loggerWarnMock,
+    })),
+  }));
+  vi.doMock(
+    "../../supabase/functions/ai-agent-optimized/persistence.ts",
+    () => ({
+      persistChatMessage: vi.fn(),
+    }),
+  );
+
+  await import("../../supabase/functions/ai-agent-optimized/index.ts");
+
+  if (!serveHandler) {
+    throw new Error(
+      "Expected ai-agent-optimized to register a Deno.serve handler",
+    );
+  }
+  return serveHandler;
+}
+
+describe("ai-agent-optimized provider quota contract", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+
+    const db = {
+      rpc: vi.fn(async (name: string, args?: Record<string, unknown>) => {
+        if (name === "current_user_is_super_admin") {
+          return { data: false, error: null };
+        }
+        if (name === "user_has_role_for_org") {
+          return { data: args?.role_name === "bcba", error: null };
+        }
+        if (name === "get_dropdown_data") {
+          return { data: {}, error: null };
+        }
+        if (name === "detect_scheduling_conflicts") {
+          return { data: [], error: null };
+        }
+        throw new Error(`Unexpected request RPC: ${name}`);
+      }),
+    };
+    createRequestClientMock.mockReturnValue(db);
+    getUserOrThrowMock.mockResolvedValue({ id: "user-bcba" });
+    resolveOrgIdMock.mockResolvedValue("org-1");
+
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === "agent_execution_traces") {
+        return {
+          insert: vi.fn(async () => ({ error: null })),
+        };
+      }
+      return createMaybeSingleQuery();
+    });
+    supabaseRpcMock.mockImplementation(async (name: string) => {
+      if (name === "generate_semantic_cache_key") {
+        return { data: "cache-key", error: null };
+      }
+      if (name === "get_cached_ai_response") {
+        return { data: [], error: null };
+      }
+      throw new Error(`Unexpected admin RPC: ${name}`);
+    });
+
+    completionCreateMock.mockRejectedValue(
+      Object.assign(new Error("You exceeded your current quota"), {
+        status: 429,
+        code: "insufficient_quota",
+        type: "insufficient_quota",
+        error: {
+          code: "insufficient_quota",
+          type: "insufficient_quota",
+        },
+      }),
+    );
+  });
+
+  it("returns a 503 error envelope when OpenAI reports insufficient quota", async () => {
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request(
+        "https://edge.example.com/functions/v1/ai-agent-optimized",
+        {
+          method: "POST",
+          headers: {
+            Origin: "https://app.allincompassing.ai",
+            Authorization: "Bearer token",
+            "Content-Type": "application/json",
+            "x-request-id": "req-quota",
+            "x-correlation-id": "corr-quota",
+          },
+          body: JSON.stringify({
+            message: "List the scheduling tasks available to a BCBA.",
+          }),
+        },
+      ),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Content-Type")).toContain("application/json");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://app.allincompassing.ai",
+    );
+    expect(response.headers.get("x-request-id")).toBe("req-quota");
+    expect(response.headers.get("x-correlation-id")).toBe("corr-quota");
+
+    const body = await response.json();
+    expect(body).toMatchObject({
+      requestId: "req-quota",
+      code: "upstream_unavailable",
+      message: "AI service is temporarily unavailable",
+      classification: {
+        category: "upstream",
+        retryable: true,
+        httpStatus: 503,
+      },
+    });
+    expect(body).not.toHaveProperty("response");
+    expect(body).not.toHaveProperty("action");
+    expect(body).not.toHaveProperty("conversationId");
+  });
+});


### PR DESCRIPTION
## Summary
- classify OpenAI `429 insufficient_quota` as the existing `upstream_unavailable` contract
- return HTTP 503 with a fixed safe message while preserving CORS, no-store, request ID, and correlation ID headers
- prove the production client retries only the optimized endpoint and degrades safely without the legacy fallback

## Live reproduction
- BCBA role resolved correctly in hosted trace `a5040b7c-03e4-4385-9003-b6429e6b66c6`
- provider returned OpenAI `429 insufficient_quota` (`req_48ff46f705af4a4ca80b8f1c3769bb95`)
- current hosted function v23 incorrectly converts that failure into HTTP 200

## Routing and risk
- classification: high-risk human-reviewed
- lane: critical
- protected path: `supabase/functions/ai-agent-optimized/index.ts`
- Linear: https://linear.app/winningedgeai/issue/WIN-249/fix-ai-assistant-role-downgrade-and-surface-upstream-quota-failures
- human review is mandatory before merge
- no secrets, billing, auth, roles, tools, persistence, migrations, RLS, grants, or tenant scope changed

## Verification
- focused edge/client contracts: 19 passed
- `npm run ci:check-focused`: passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run validate:tenant`: passed
- `npm run build`: passed
- `npm run test:routes:tier0`: 220 passed
- `npm run test:ci`: local Windows run has four unrelated baseline failures in untouched workflow/Blob tests; current main Linux CI is green
- `npm run verify:local`: stops at the same four unrelated `test:ci` failures after policy, lint, and typecheck pass
- secret-backed Playwright is delegated to required CI

## Post-merge proof
The governed main-only deployment must publish `ai-agent-optimized` with `verify_jwt=true`. Then repeat the BCBA Assistant request with Computer and capture the live HTTP 503/safe UI behavior. A successful generated Assistant response still requires restoration of the external OpenAI quota/key.