### PR TITLE
WIN-251: route Mid Tier session capture authority

### DIFF
--- a/docs/ai/WIN-251-midtier-session-capture-handoff.md
+++ b/docs/ai/WIN-251-midtier-session-capture-handoff.md
@@ -1,0 +1,47 @@
+# WIN-251 Mid Tier Session Capture Handoff
+
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: session-note API authority routing is a protected server boundary.
+- triggering paths: `src/server/api/**`
+
+## Scope
+
+- task intent: allow exact Mid Tier session capture without widening exact-BT assignment authority.
+- files touched: one handler, its focused test, this handoff.
+- single-purpose diff: yes
+
+## Required Agents
+
+- agents used: software architect, implementation engineer, code review engineer, security engineer.
+- reviewer: completed; approved after a BCBA-ordering regression was fixed.
+
+## Verification Card
+
+- required checks: focused handler suite, policy checks, tenant safety, build, full CI and route gates.
+- executed checks:
+  - focused session-notes handler suite: pass, 68 tests.
+  - `npm run ci:check-focused`: pass.
+  - `npm run validate:tenant`: pass.
+  - `npm run build`: pass.
+- blocked checks:
+  - `npm run test:ci`: exceeded the bounded 300-second local window while external-provider tests attempted unavailable network services.
+  - DB-backed policy checks: `SUPABASE_DB_URL` is unavailable locally.
+- result: pass-with-blocked-checks
+- residual risk: CI and deployed exact Mid Tier capture must be observed before live closure.
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: blocked by expired Linear OAuth grant; issue `WIN-251` exists.
+- protected-path drift: only the declared handler.
+- unrelated changes: none.
+- generated artifact drift: none.
+- verification summary: present.
+- pr-ready: yes, human review required before merge.
+
+## Handoff Summary
+
+The handler now probes exact Mid Tier capability only after established BCBA authority and before the exact-BT assignment path. This preserves BCBA behavior and BT assignment limits while routing Mid Tier capture correctly; focused tests, policy, tenant safety, and build passed.

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -157,6 +157,13 @@ describe("sessionNotesUpsertHandler", () => {
       supabaseUrl: BASE_URL,
       anonKey: "anon-key",
     });
+    vi.mocked(fetchJson).mockImplementation(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.endsWith("/rest/v1/rpc/user_has_role_for_org")) {
+        return { ok: true, status: 200, data: false } as never;
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
     process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
   });
 
@@ -544,7 +551,7 @@ describe("sessionNotesUpsertHandler", () => {
     }));
 
     expect(response.status).toBe(502);
-    expect(currentUserIsBcbaForOrg).not.toHaveBeenCalled();
+    expect(currentUserIsBcbaForOrg).toHaveBeenCalledWith(ACCESS_TOKEN, "org-1");
     expect(fetchAuthenticatedUserIdWithStatus).not.toHaveBeenCalled();
   });
 
@@ -629,7 +636,11 @@ describe("sessionNotesUpsertHandler", () => {
     expect(response.status).toBe(403);
     expect(currentUserIsBcbaForOrg).toHaveBeenCalledWith(ACCESS_TOKEN, "org-1");
     expect(fetchAuthenticatedUserIdWithStatus).not.toHaveBeenCalled();
-    expect(fetchJson).not.toHaveBeenCalled();
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+    expect(fetchJson).toHaveBeenCalledWith(`${BASE_URL}/rest/v1/rpc/user_has_role_for_org`, expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ role_name: "midtier", target_organization_id: "org-1" }),
+    }));
   });
 
   it("does not make existing allowed roles depend on BCBA role resolution", async () => {
@@ -657,6 +668,9 @@ describe("sessionNotesUpsertHandler", () => {
     const fetchJsonMock = vi.mocked(fetchJson);
     fetchJsonMock.mockImplementation(async (url, init) => {
       const requestUrl = String(url);
+      if (requestUrl.endsWith("/rest/v1/rpc/user_has_role_for_org")) {
+        return { ok: true, status: 200, data: false };
+      }
       if (requestUrl.includes("/rest/v1/rpc/resolve_assigned_bt_session_capture_billing")) {
         expect(init?.method).toBe("POST");
         expect(JSON.parse(String(init?.body ?? "{}"))).toEqual({ p_session_id: basePayload.sessionId });
@@ -717,6 +731,9 @@ describe("sessionNotesUpsertHandler", () => {
     const fetchJsonMock = vi.mocked(fetchJson);
     fetchJsonMock.mockImplementation(async (url, init) => {
       const requestUrl = String(url);
+      if (requestUrl.endsWith("/rest/v1/rpc/user_has_role_for_org")) {
+        return { ok: true, status: 200, data: false };
+      }
       if (requestUrl.includes("/rest/v1/rpc/resolve_assigned_bt_session_capture_billing")) {
         throw new Error("BCBA capture must not use the assigned-BT resolver");
       }
@@ -758,6 +775,127 @@ describe("sessionNotesUpsertHandler", () => {
     expect(fetchJsonMock.mock.calls.some(([url]) => String(url).includes("/rest/v1/authorizations?"))).toBe(true);
   });
 
+  it("keeps BCBA legacy capture on the existing authorization path when the Mid Tier probe fails", async () => {
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: false,
+      isAdmin: false,
+      isOrgMember: false,
+      isSuperAdmin: false,
+      upstreamError: false,
+    });
+    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: true, upstreamError: false });
+    vi.mocked(currentUserIsBcbaForOrg).mockResolvedValue({ allowed: true, upstreamError: false });
+
+    const fetchJsonMock = vi.mocked(fetchJson);
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.endsWith("/rest/v1/rpc/user_has_role_for_org")) {
+        return { ok: false, status: 500, data: { code: "XX000", message: "Mid Tier role probe failed" } };
+      }
+      if (requestUrl.includes("/rest/v1/rpc/resolve_assigned_bt_session_capture_billing")) {
+        throw new Error("BCBA capture must not use the assigned-BT resolver");
+      }
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl === `${BASE_URL}/rest/v1/client_session_notes` && init?.method === "POST") {
+        return { ok: true, status: 201, data: [{ id: "note-created" }] };
+      }
+      if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes("id=eq.note-created")) {
+        return { ok: true, status: 200, data: [buildSessionNoteRow("note-created")] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(new Request("http://localhost/api/session-notes/upsert", {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify(basePayload),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(currentUserIsBcbaForOrg).toHaveBeenCalledWith(ACCESS_TOKEN, "org-1");
+    expect(fetchJsonMock.mock.calls.some(([url]) => String(url).includes("/rest/v1/authorizations?"))).toBe(true);
+  });
+
+  it("routes an exact Mid Tier caller through the standard authorization path", async () => {
+    vi.mocked(resolveOrgAndRoleWithStatus).mockResolvedValue({
+      organizationId: "org-1",
+      isTherapist: false,
+      isAdmin: false,
+      isOrgMember: false,
+      isSuperAdmin: false,
+      upstreamError: false,
+    });
+    vi.mocked(currentUserCanTakeClientData).mockResolvedValue({ allowed: false, upstreamError: false });
+    vi.mocked(currentUserIsBcbaForOrg).mockResolvedValue({ allowed: false, upstreamError: false });
+
+    const fetchJsonMock = vi.mocked(fetchJson);
+    fetchJsonMock.mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.endsWith("/rest/v1/rpc/user_has_role_for_org")) {
+        const parsedBody = JSON.parse(String(init?.body ?? "{}")) as { role_name?: string };
+        if (parsedBody.role_name === "midtier") {
+          return { ok: true, status: 200, data: true };
+        }
+        return { ok: true, status: 200, data: false };
+      }
+      if (requestUrl.includes("/rest/v1/rpc/resolve_assigned_bt_session_capture_billing")) {
+        throw new Error("Mid Tier capture must not use the assigned-BT resolver");
+      }
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [] };
+      }
+      if (requestUrl === `${BASE_URL}/rest/v1/client_session_notes` && init?.method === "POST") {
+        return { ok: true, status: 201, data: [{ id: "note-created" }] };
+      }
+      if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes("id=eq.note-created")) {
+        return { ok: true, status: 200, data: [buildSessionNoteRow("note-created")] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(new Request("http://localhost/api/session-notes/upsert", {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify(basePayload),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(fetchJsonMock.mock.calls.some(([url]) => String(url).includes("/rest/v1/authorizations?"))).toBe(true);
+  });
+
   it.each([
     { field: "clientId", value: "77777777-7777-4777-8777-777777777777" },
     { field: "therapistId", value: "88888888-8888-4888-8888-888888888888" },
@@ -776,6 +914,9 @@ describe("sessionNotesUpsertHandler", () => {
     let wroteNote = false;
     vi.mocked(fetchJson).mockImplementation(async (url, init) => {
       const requestUrl = String(url);
+      if (requestUrl.endsWith("/rest/v1/rpc/user_has_role_for_org")) {
+        return { ok: true, status: 200, data: false };
+      }
       if (requestUrl.includes("/rest/v1/rpc/resolve_assigned_bt_session_capture_billing")) {
         return {
           ok: true,
@@ -832,6 +973,9 @@ describe("sessionNotesUpsertHandler", () => {
 
     vi.mocked(fetchJson).mockImplementation(async (url, init) => {
       const requestUrl = String(url);
+      if (requestUrl.endsWith("/rest/v1/rpc/user_has_role_for_org")) {
+        return { ok: true, status: 200, data: false };
+      }
       if (requestUrl.includes("/rest/v1/rpc/resolve_assigned_bt_session_capture_billing")) {
         return {
           ok: true,
@@ -907,6 +1051,9 @@ describe("sessionNotesUpsertHandler", () => {
     let wroteNote = false;
     vi.mocked(fetchJson).mockImplementation(async (url, init) => {
       const requestUrl = String(url);
+      if (requestUrl.endsWith("/rest/v1/rpc/user_has_role_for_org")) {
+        return { ok: true, status: 200, data: false };
+      }
       if (requestUrl.includes("/rest/v1/rpc/resolve_assigned_bt_session_capture_billing")) {
         return {
           ok: false,

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -618,6 +618,27 @@ const resolveAssignedBtSessionCaptureBilling = async (args: {
   };
 };
 
+const currentUserHasExactMidTierRoleWithStatus = async (
+  accessToken: string,
+  organizationId: string,
+): Promise<{ allowed: boolean; upstreamError: boolean }> => {
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+  const headers = {
+    "Content-Type": "application/json",
+    apikey: anonKey,
+    Authorization: `Bearer ${accessToken}`,
+  };
+  const result = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/user_has_role_for_org`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ role_name: "midtier", target_organization_id: organizationId }),
+  });
+  return {
+    allowed: result.ok && result.data === true,
+    upstreamError: !result.ok && result.status >= 500,
+  };
+};
+
 const isLegacyGoalIdsTypeError = (payload: unknown): boolean => {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return false;
@@ -1243,6 +1264,17 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
   if (!isBtAbaRequest) {
     const hasResolvedSessionNoteRole = isTherapist || isAdmin || isSuperAdmin || isOrgMember;
     if (!hasResolvedSessionNoteRole) {
+      const bcbaAuthority = await currentUserIsBcbaForOrg(accessToken, organizationId);
+      if (bcbaAuthority.upstreamError) {
+        return errorResponse(request, "upstream_error", "Unable to validate BCBA access", { status: 502 });
+      }
+      const exactMidTierAuthority = !bcbaAuthority.allowed
+        ? await currentUserHasExactMidTierRoleWithStatus(accessToken, organizationId)
+        : { allowed: false, upstreamError: false };
+      if (exactMidTierAuthority.upstreamError) {
+        return errorResponse(request, "upstream_error", "Unable to validate Mid Tier access", { status: 502 });
+      }
+      if (!bcbaAuthority.allowed && !exactMidTierAuthority.allowed) {
       const legacyPayload = requestedAction === undefined
         ? upsertSchema.safeParse(body)
         : { success: false as const };
@@ -1252,15 +1284,11 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
       if (clientDataAuthority.upstreamError) {
         return errorResponse(request, "upstream_error", "Unable to validate client data access", { status: 502 });
       }
-      const bcbaAuthority = await currentUserIsBcbaForOrg(accessToken, organizationId);
-      if (bcbaAuthority.upstreamError) {
-        return errorResponse(request, "upstream_error", "Unable to validate BCBA access", { status: 502 });
-      }
-      hasAssignedBtLegacyCaptureAuthority = legacyPayload.success
-        && clientDataAuthority.allowed
-        && !bcbaAuthority.allowed;
-      if (!hasAssignedBtLegacyCaptureAuthority && !bcbaAuthority.allowed) {
+        hasAssignedBtLegacyCaptureAuthority = legacyPayload.success
+          && clientDataAuthority.allowed;
+        if (!hasAssignedBtLegacyCaptureAuthority) {
         return errorResponse(request, "forbidden", "Forbidden");
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- route exact Mid Tier capture before the exact-BT assignment resolver
- preserve existing BCBA authority ordering and BT assignment limits
- add regression coverage and a critical-lane handoff

## Verification
- focused session-notes handler suite (68 tests)
- npm run ci:check-focused
- npm run validate:tenant
- npm run build

## Risk
Protected server/API boundary. Human review and post-deploy live Mid Tier capture proof are required. Linear: WIN-251 (connector update currently blocked by expired OAuth).