### PR TITLE
WIN-251: show retryable messaging recipient errors

### DIFF
--- a/docs/ai/WIN-251-messaging-error-state-handoff.md
+++ b/docs/ai/WIN-251-messaging-error-state-handoff.md
@@ -1,0 +1,40 @@
+# WIN-251 Messaging Recipient Error-State Handoff
+
+## Routing
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- why: bounded page-state and test changes; no auth, server, schema, or tenant-boundary modification.
+
+## Scope
+
+- task intent: distinguish recipient loading, empty, and backend failure states and provide retry.
+- files touched: messaging compose page, page tests, this handoff.
+- single-purpose diff: yes
+
+## Verification Card
+
+- executed checks:
+  - focused `MessagesNew` tests: pass.
+  - `npm run ci:check-focused`: pass.
+  - `npm run lint`: pass.
+  - `npm run typecheck`: pass.
+  - `npm run build`: pass.
+- blocked checks:
+  - `npm run verify:local`: repo-wide `test:ci` failed in unrelated `tests/workflows/bt-aba-disposable-browser-proof.test.ts`.
+- result: pass-with-blocked-checks
+- residual risk: the retry UI requires live proof after the paired RPC migration deploys.
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: blocked by expired Linear OAuth grant; issue `WIN-251` exists.
+- protected-path drift: none.
+- unrelated changes: none.
+- generated artifact drift: none.
+- verification summary: present.
+- pr-ready: yes.
+
+## Handoff Summary
+
+The compose page now renders an explicit retryable failure state instead of masking a recipient RPC error as an empty organization. Focused UI tests, policy, lint, typecheck, and build passed.

--- a/src/pages/messages/MessagesNew.tsx
+++ b/src/pages/messages/MessagesNew.tsx
@@ -21,7 +21,12 @@ export function MessagesNew() {
   const [threadType, setThreadType] = useState<MessageThreadType>('direct');
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
-  const { data: recipients = [], isLoading } = useQuery({
+  const {
+    data: recipients = [],
+    isError,
+    isLoading,
+    refetch,
+  } = useQuery({
     queryKey: [MESSAGES_QUERY_KEY, 'recipients', organizationId, profile?.id],
     queryFn: () => fetchStaffRecipients(organizationId!, profile!.id),
     enabled: Boolean(organizationId && profile?.id),
@@ -41,6 +46,9 @@ export function MessagesNew() {
   const effectiveThreadType = canCreateGroup ? threadType : 'direct';
 
   const validationMessage = useMemo(() => {
+    if (isError) {
+      return 'Staff recipients could not be loaded.';
+    }
     if (selectedIds.length === 0) {
       return 'Select at least one recipient.';
     }
@@ -51,7 +59,7 @@ export function MessagesNew() {
       return 'Group conversations require at least two recipients.';
     }
     return null;
-  }, [effectiveThreadType, selectedIds]);
+  }, [effectiveThreadType, isError, selectedIds]);
 
   const handleToggleRecipient = (userId: string) => {
     if (effectiveThreadType === 'direct') {
@@ -108,6 +116,20 @@ export function MessagesNew() {
 
       {isLoading ? (
         <p className="text-sm text-gray-500">Loading staff...</p>
+      ) : isError ? (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
+          <p role="alert">We could not load eligible staff right now.</p>
+          <button
+            type="button"
+            onClick={() => {
+              void refetch();
+            }}
+            className="mt-3 inline-flex items-center rounded-lg border border-amber-300 px-3 py-2 text-sm font-medium text-amber-900 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-100 dark:hover:bg-amber-900/40"
+            data-testid="messages-retry-recipient-load"
+          >
+            Retry
+          </button>
+        </div>
       ) : (
         <StaffRecipientPicker
           recipients={recipients}
@@ -123,7 +145,7 @@ export function MessagesNew() {
       <button
         type="button"
         onClick={handleCreate}
-        disabled={createMutation.isPending || Boolean(validationMessage)}
+        disabled={createMutation.isPending || isLoading || isError || Boolean(validationMessage)}
         className="mt-6 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
         data-testid="messages-create-thread"
       >

--- a/src/pages/messages/__tests__/MessagesNew.test.tsx
+++ b/src/pages/messages/__tests__/MessagesNew.test.tsx
@@ -20,11 +20,10 @@ vi.mock('../../../lib/organization', () => ({
   useActiveOrganizationId: () => 'org-1',
 }));
 
+const mockFetchStaffRecipients = vi.hoisted(() => vi.fn());
+
 vi.mock('../../../lib/messages/fetchStaffRecipients', () => ({
-  fetchStaffRecipients: vi.fn(async () => [
-    { id: 'staff-2', full_name: 'Alex Admin', email: 'alex@test.com', role: 'admin' },
-    { id: 'staff-3', full_name: 'Blake Therapist', email: 'blake@test.com', role: 'therapist' },
-  ]),
+  fetchStaffRecipients: mockFetchStaffRecipients,
 }));
 
 const renderPage = () => {
@@ -41,6 +40,10 @@ const renderPage = () => {
 describe('MessagesNew', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetchStaffRecipients.mockResolvedValue([
+      { id: 'staff-2', full_name: 'Alex Admin', email: 'alex@test.com', role: 'admin' },
+      { id: 'staff-3', full_name: 'Blake Therapist', email: 'blake@test.com', role: 'therapist' },
+    ]);
   });
 
   it('shows PHI policy banner for compose', async () => {
@@ -52,6 +55,50 @@ describe('MessagesNew', () => {
     renderPage();
     await screen.findByTestId('staff-recipient-picker');
     expect(screen.queryByRole('radio', { name: /group/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a loading state while recipients are fetched', async () => {
+    mockFetchStaffRecipients.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve([
+              { id: 'staff-2', full_name: 'Alex Admin', email: 'alex@test.com', role: 'admin' },
+            ]);
+          }, 25);
+        }),
+    );
+
+    renderPage();
+
+    expect(screen.getByText('Loading staff...')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when no eligible staff are returned', async () => {
+    mockFetchStaffRecipients.mockResolvedValueOnce([]);
+
+    renderPage();
+
+    expect(await screen.findByTestId('staff-recipient-empty')).toHaveTextContent(
+      'No eligible staff found in your organization.',
+    );
+  });
+
+  it('shows a retryable error state when recipients cannot be loaded', async () => {
+    const user = userEvent.setup();
+    mockFetchStaffRecipients.mockRejectedValueOnce(new Error('backend details should stay hidden'));
+
+    renderPage();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('We could not load eligible staff right now.');
+    const retryButton = screen.getByTestId('messages-retry-recipient-load');
+    expect(retryButton).toBeEnabled();
+    expect(screen.getByTestId('messages-create-thread')).toBeDisabled();
+
+    await user.click(retryButton);
+
+    expect(await screen.findByTestId('staff-recipient-picker')).toBeInTheDocument();
+    expect(mockFetchStaffRecipients).toHaveBeenCalledTimes(2);
   });
 
   it('allows switching the direct-message recipient after an initial selection', async () => {


### PR DESCRIPTION
## Summary
- distinguish recipient loading, empty, and backend failure states
- provide a tested retry action and disable compose while recipient loading fails
- add standard-lane handoff

## Verification
- focused MessagesNew tests (6)
- policy, lint, typecheck, build

Linear: WIN-251 (connector update blocked by expired OAuth). Paired backend PR required for successful live compose.