### PR TITLE
WIN-251: prevent onboarding field leakage between steps

### DIFF
--- a/docs/ai/WIN-251-onboarding-field-leak-handoff.md
+++ b/docs/ai/WIN-251-onboarding-field-leak-handoff.md
@@ -1,0 +1,45 @@
+# WIN-251 Onboarding Field-Leak Handoff
+
+## Routing
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- why: bounded client wizard render behavior and regression coverage.
+
+## Scope
+
+- task intent: prevent uncontrolled DOM input values from leaking between wizard steps.
+- files touched: onboarding component, focused test, this handoff.
+- single-purpose diff: yes
+
+## Required Agents
+
+- agents used: code review engineer, test engineer.
+- reviewer: completed; approved.
+
+## Verification Card
+
+- executed checks:
+  - regression before fix: failed with city value `Grace`.
+  - `npm run ci:check-focused`: pass.
+  - focused onboarding test after keyed remount: pass, 8 tests.
+  - `npm run lint`: pass.
+  - `npm run typecheck`: pass.
+  - `npm run build`: pass.
+- blocked checks: none.
+- result: pass.
+- residual risk: verify restored guardian values when navigating backward; regression now covers this behavior.
+
+## PR Hygiene
+
+- branch-ready: yes.
+- linear-ready: blocked by expired Linear OAuth grant; issue `WIN-251` exists.
+- protected-path drift: none.
+- unrelated changes: none.
+- generated artifact drift: none.
+- verification summary: present.
+- pr-ready: yes.
+
+## Handoff Summary
+
+The wizard now keys rendered step content by step number so React cannot reuse uncontrolled input nodes across semantically different fields. The regression reproduces the live guardian-to-address leak and confirms stored guardian values survive backward navigation.

--- a/src/components/ClientOnboarding.tsx
+++ b/src/components/ClientOnboarding.tsx
@@ -1501,7 +1501,9 @@ export function ClientOnboarding({ onComplete }: ClientOnboardingProps) {
         />
         
         <form onSubmit={handleWizardSubmit} onKeyDownCapture={handleFormKeyDown}>
-          {renderStepContent()}
+          <div key={currentStep}>
+            {renderStepContent()}
+          </div>
           
           <div className="mt-8 flex justify-between">
             <button

--- a/src/components/__tests__/ClientOnboarding.test.tsx
+++ b/src/components/__tests__/ClientOnboarding.test.tsx
@@ -162,6 +162,49 @@ describe('ClientOnboarding step progression', () => {
     expect(onComplete).not.toHaveBeenCalled();
   }, 15000);
 
+  it('does not leak guardian names into address fields when advancing to step 3', async () => {
+    const { user } = setup();
+
+    await user.type(screen.getByLabelText('First Name'), 'Ada');
+    await user.type(screen.getByLabelText('Last Name'), 'Lovelace');
+    await user.type(screen.getByLabelText('Date of Birth'), '2010-01-01');
+    const emailInput = screen.getByLabelText('Email');
+    await user.type(emailInput, 'ada@example.com');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(checkClientEmailExistsMock).toHaveBeenCalled();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await screen.findByText('Parent/Guardian Information');
+
+    await user.type(
+      screen.getByLabelText('First Name', { selector: '#onboarding-parent1-first-name' }),
+      'Grace',
+    );
+    await user.type(
+      screen.getByLabelText('Last Name', { selector: '#onboarding-parent1-last-name' }),
+      'Hopper',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await screen.findByText('Address & Contact Information');
+
+    expect(screen.getByLabelText('City')).toHaveValue('');
+    expect(screen.getByLabelText('State')).toHaveValue('');
+
+    await user.click(screen.getByRole('button', { name: 'Previous' }));
+    await screen.findByText('Parent/Guardian Information');
+
+    expect(
+      screen.getByLabelText('First Name', { selector: '#onboarding-parent1-first-name' }),
+    ).toHaveValue('Grace');
+    expect(
+      screen.getByLabelText('Last Name', { selector: '#onboarding-parent1-last-name' }),
+    ).toHaveValue('Hopper');
+  }, 15000);
+
   it('fails closed when email uniqueness check is unavailable', async () => {
     const { user, onComplete } = setup();
     checkClientEmailExistsMock.mockRejectedValueOnce(new Error('supabase unavailable'));


### PR DESCRIPTION
## Summary
- force wizard step content to remount by step key
- prevent guardian values from leaking into city/state DOM inputs
- preserve guardian form values when navigating backward

## Verification
- red reproduction: city received Grace
- focused onboarding suite (8)
- lint, typecheck, build

Linear: WIN-251 (connector update blocked by expired OAuth).