### PR TITLE
WIN-251: resolve BT self-signup to exact BT role

### DIFF
--- a/docs/ai/WIN-251-signup-bt-handoff.md
+++ b/docs/ai/WIN-251-signup-bt-handoff.md
@@ -1,0 +1,47 @@
+# WIN-251 BT Signup Role Handoff
+
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: signup role resolution is an authentication boundary implemented by a Supabase migration.
+- triggering paths: `supabase/migrations/**`
+
+## Scope
+
+- task intent: resolve public BT signup metadata to exact `bt` while keeping guardian/client mappings and fail-closed unknown roles.
+- non-goal: no backfill or repair of existing user-role rows; this is forward-only signup normalization.
+- files touched: one forward migration, one contract test, this handoff.
+- single-purpose diff: yes
+
+## Required Agents
+
+- agents used: implementation engineer, code review engineer, security engineer.
+- security review: completed; approved.
+
+## Verification Card
+
+- executed checks:
+  - focused signup-role contract test: pass.
+  - `npm run ci:check-focused`: pass.
+  - `npm run validate:tenant`: pass.
+  - `npm run build`: pass.
+- blocked checks:
+  - full `npm run test:ci`: not rerun in this worktree after the guardian-safe parse correction; the shared suite is already failing in unrelated baseline tests on sibling WIN-251 branches.
+  - DB-backed migration checks: `SUPABASE_DB_URL` is unavailable locally.
+- result: pass-with-blocked-checks
+- residual risk: legacy callers sending `therapist` metadata will intentionally receive the lower-privilege `bt` role; execution-level Postgres proof and human DB review remain required.
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: blocked by expired Linear OAuth grant; issue `WIN-251` exists.
+- protected-path drift: none beyond the declared migration.
+- unrelated changes: none.
+- generated artifact drift: none.
+- verification summary: present.
+- pr-ready: yes, human review required.
+
+## Handoff Summary
+
+The resolver now maps both current `bt` and legacy `therapist` public signup metadata to exact `bt`, preserves guardian/client behavior even when guardian signup metadata is sent without an explicit role, safely parses malformed `guardian_signup` values without raising, and rejects unknown or privileged metadata. Policy, tenant-safety, focused contract, security review, and build checks passed.

--- a/supabase/migrations/20260724081000_resolve_bt_signup_role_alias.sql
+++ b/supabase/migrations/20260724081000_resolve_bt_signup_role_alias.sql
@@ -1,0 +1,38 @@
+-- @migration-intent: Canonicalize public signup metadata so BT self-signup resolves to the bt role while guardian signup remains client-only and privileged or unknown metadata remains untrusted.
+-- @migration-dependencies: 20251116093000_signup_role_alignment.sql, 20251116094500_signup_role_trigger_fix.sql, 20260701150000_employee_role_capability_matrix.sql
+-- @migration-rollback: Forward recovery only. Apply a later migration restoring the prior app.resolve_signup_role(jsonb) mapping if signup-role semantics must be changed again.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION app.resolve_signup_role(p_metadata jsonb)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  v_metadata jsonb := COALESCE(p_metadata, '{}'::jsonb);
+  v_role text := lower(btrim(COALESCE(v_metadata->>'role', v_metadata->>'signup_role', '')));
+  v_guardian_raw text := lower(btrim(COALESCE(v_metadata->>'guardian_signup', '')));
+  v_guardian boolean := v_guardian_raw IN ('true', 't', '1', 'yes', 'on');
+BEGIN
+  IF v_guardian OR v_role = 'guardian' THEN
+    RETURN 'client';
+  END IF;
+
+  IF v_role = '' THEN
+    RETURN NULL;
+  END IF;
+
+  IF v_role = 'client' THEN
+    RETURN 'client';
+  END IF;
+
+  IF v_role IN ('bt', 'therapist') THEN
+    RETURN 'bt';
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMIT;

--- a/tests/signupRoleAlignmentMigration.test.ts
+++ b/tests/signupRoleAlignmentMigration.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const migrationsDir = join(process.cwd(), 'supabase', 'migrations');
+
+const signupRoleMigrationPath = readdirSync(migrationsDir)
+  .filter((name) => name.includes('signup_role') && name.endsWith('.sql'))
+  .sort()
+  .at(-1);
+
+if (!signupRoleMigrationPath) {
+  throw new Error('Expected at least one signup role migration');
+}
+
+const signupRoleMigration = readFileSync(join(migrationsDir, signupRoleMigrationPath), 'utf8');
+
+describe('signup role alignment migration contract', () => {
+  it('maps bt and legacy therapist metadata to bt while preserving client/guardian downgrade behavior', () => {
+    expect(signupRoleMigration).toMatch(/create or replace function app\.resolve_signup_role\(p_metadata jsonb\)/i);
+    expect(signupRoleMigration).toMatch(/v_guardian_raw text := lower\(btrim\(coalesce\(v_metadata->>'guardian_signup', ''\)\)\);/i);
+    expect(signupRoleMigration).toMatch(/v_guardian boolean := v_guardian_raw in \('true', 't', '1', 'yes', 'on'\);/i);
+    expect(signupRoleMigration).toMatch(/if v_guardian or v_role = 'guardian' then\s+return 'client';\s+end if;\s+if v_role = '' then\s+return null;/i);
+    expect(signupRoleMigration).toMatch(/if v_role = 'client' then\s+return 'client';/i);
+    expect(signupRoleMigration).toMatch(/if v_role in \('bt', 'therapist'\) then\s+return 'bt';/i);
+  });
+
+  it('rejects privileged or unknown signup metadata roles without unsafe boolean casts', () => {
+    expect(signupRoleMigration).not.toMatch(/::boolean/i);
+    expect(signupRoleMigration).not.toMatch(/if v_role in \('client', 'bt', 'therapist', 'admin', 'super_admin'/i);
+    expect(signupRoleMigration).not.toMatch(/return 'admin';/i);
+    expect(signupRoleMigration).not.toMatch(/return 'super_admin';/i);
+    expect(signupRoleMigration).toMatch(/return null;/i);
+  });
+});


### PR DESCRIPTION
## Summary
- map current bt and legacy therapist signup metadata to exact bt
- preserve guardian/client mappings and fail closed for privileged or unknown roles
- forward-only normalization; no existing user backfill

## Verification
- focused signup role contract
- policy, tenant safety, build
- independent security and code review approved

Protected migration: human DB review and hosted apply are required. Linear WIN-251 update is blocked by expired OAuth.