### PR TITLE
WIN-252: make BCBA authorizations read-only

### DIFF
--- a/docs/ai/WIN-252-bcba-authorization-readonly-handoff.md
+++ b/docs/ai/WIN-252-bcba-authorization-readonly-handoff.md
@@ -1,0 +1,102 @@
+# WIN-252 BCBA Authorization Read-Only Handoff
+
+## Task
+
+Make authorization access read-only for exact BCBA profiles. BCBA users keep authorization
+and unit visibility but cannot create, renew, edit, delete, or attach authorization documents.
+
+## Routing
+
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Triggering paths:
+  - `src/lib/roles.ts`
+  - `src/pages/Authorizations.tsx`
+  - `src/components/ClientDetails/PreAuthTab.tsx`
+  - `supabase/migrations/**`
+- Linear: `WIN-252`
+- Human review: required before merge
+
+## Scope
+
+Allowed surfaces:
+
+- Frontend authorization capability matrix
+- Authorization list and client pre-authorization mutation affordances
+- Exact authorization management and read helpers
+- Focused role, UI, migration, and tenant smoke tests
+
+Non-goals:
+
+- Changing BCBA route visibility
+- Changing Mid Tier, admin schedule, admin, or super-admin authorization authority
+- Changing BCBA scheduling, staff, programs/goals, billing, or clinical-review authority
+- Redesigning authorization forms or document-download behavior
+
+Stop conditions:
+
+- Any requirement for assignment-dependent BCBA write access
+- Any broader role-matrix change
+- Any cross-organization read expansion
+
+## Boundary
+
+- `bcba` retains `viewAuthorizations`.
+- `bcba` loses `manageAuthorizations`, including profiles with lower-ranked manager grants.
+- `midtier`, `admin_schedule`, `admin`, and `super_admin` remain authorization managers.
+- The Authorizations page and client Pre-Authorization tab hide mutation controls and guard
+  handlers when `manageAuthorizations` is absent.
+- `app.current_user_can_manage_authorizations` removes exact BCBA authority. Existing table
+  write policies and authorization RPCs already depend on this helper.
+- `app.current_user_can_read_authorization_row` adds an explicit same-organization exact BCBA
+  read branch so the write restriction does not remove authorization visibility.
+- A shared trigger guard blocks exact BCBA writes to `authorizations` and
+  `authorization_services`, including provider-self RLS paths and security-definer RPCs.
+- The hosted SQL smoke gives its BCBA actor a lower `admin_schedule` grant and still expects
+  authorization and authorization-service writes to fail with `42501`.
+- Cross-organization authorization reads remain denied.
+
+## Verification Card
+
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Change type: UI/component, role authorization, database/RLS/migration, tenant isolation
+- Required checks:
+  - focused role, UI, and migration contract tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run test:routes:tier0`
+  - `npm run build`
+  - `npm run ci:playwright`
+  - `npm run verify:local`
+- Executed checks:
+  - focused Vitest: passed, 5 files and 56 tests
+  - `npm run ci:check-focused`: passed; database-backed checks skipped without
+    `SUPABASE_DB_URL`
+  - `npm run lint`: passed
+  - `npm run typecheck`: passed
+  - `npm run validate:tenant`: passed
+  - `npm run ci:verify-coverage`: passed
+  - `npm run test:routes:tier0`: passed, 7 specs and 220 tests
+  - `npm run build`: passed
+  - `npm run test:ci`: failed on four unrelated baseline tests in untouched workflow and PDF
+    helper surfaces
+  - `npm run ci:playwright`: stopped at preflight because no admin or super-admin credentials
+    are configured in the worktree
+  - `npm run verify:local`: policy, lint, and typecheck passed before the same four
+    `test:ci` baseline failures stopped the aggregate
+- Blocked checks:
+  - hosted Playwright smoke requires protected credentials
+  - database-backed migration proof requires the Supabase PR preview
+- Result: focused authorization, tenant, route, and build gates passed; aggregate repository
+  verification remains red on four failures unrelated to this diff
+- Residual risk: hosted migration and exact-role behavior require synthetic branch-preview
+  proof before merge
+
+## Rollback
+
+Forward recovery only. A later migration may restore BCBA to the exact authorization manager
+array if product policy changes. The UI capability must be restored in the same recovery.

--- a/src/components/ClientDetails/PreAuthTab.tsx
+++ b/src/components/ClientDetails/PreAuthTab.tsx
@@ -173,8 +173,9 @@ const isAuthorizationDocumentPath = (args: {
 };
 
 export function PreAuthTab({ client }: PreAuthTabProps) {
-  const { user, isAdmin } = useAuth();
+  const { user, isAdmin, hasCapability } = useAuth();
   const organizationId = useActiveOrganizationId();
+  const canManageAuthorizations = hasCapability('manageAuthorizations');
   const queryClient = useQueryClient();
   const [isWizardOpen, setIsWizardOpen] = useState(false);
   const [selectedAuthorizationForView, setSelectedAuthorizationForView] = useState<Authorization | null>(null);
@@ -562,6 +563,10 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   };
 
   const openNewAuthorizationWizard = () => {
+    if (!canManageAuthorizations) {
+      showError('You have read-only access to authorizations.');
+      return;
+    }
     resetWizardForNewAuthorization();
     setIsWizardOpen(true);
   };
@@ -663,6 +668,11 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   };
   
   const handleWizardSubmit = async () => {
+    if (!canManageAuthorizations) {
+      showError('You have read-only access to authorizations.');
+      return;
+    }
+
     if (!organizationId || !user?.id) {
       showError('You must be signed in with an organization selected to submit.');
       return;
@@ -787,6 +797,10 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
   };
   
   const handleRenewAuthorization = (auth: Authorization) => {
+    if (!canManageAuthorizations) {
+      showError('You have read-only access to authorizations.');
+      return;
+    }
     resetPdfPrefillState();
     setWizardData({
       ...createEmptyWizardData(),
@@ -930,13 +944,17 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
           <h3 className="text-lg font-medium text-gray-900 dark:text-white">
             Authorization Tracker
           </h3>
-          <button
-            onClick={openNewAuthorizationWizard}
-            className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 flex items-center"
-          >
-            <Plus className="w-4 h-4 mr-1" />
-            New Authorization
-          </button>
+          {canManageAuthorizations ? (
+            <button
+              onClick={openNewAuthorizationWizard}
+              className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 flex items-center"
+            >
+              <Plus className="w-4 h-4 mr-1" />
+              New Authorization
+            </button>
+          ) : (
+            <span className="text-sm text-gray-500 dark:text-gray-400">Read-only access</span>
+          )}
         </div>
         
         {isLoading ? (
@@ -1089,12 +1107,14 @@ export function PreAuthTab({ client }: PreAuthTabProps) {
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
                         <div className="flex space-x-2">
-                          <button
-                            onClick={() => handleRenewAuthorization(auth)}
-                            className="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300"
-                          >
-                            Renew
-                          </button>
+                          {canManageAuthorizations ? (
+                            <button
+                              onClick={() => handleRenewAuthorization(auth)}
+                              className="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300"
+                            >
+                              Renew
+                            </button>
+                          ) : null}
                           <button
                             className="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300"
                             onClick={() => setSelectedAuthorizationForView(auth)}

--- a/src/components/__tests__/PreAuthTab.test.tsx
+++ b/src/components/__tests__/PreAuthTab.test.tsx
@@ -229,7 +229,11 @@ describe("PreAuthTab manual authorization upload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authorizationsMockData.splice(0, authorizationsMockData.length);
-    useAuthMock.mockReturnValue({ user: { id: "admin-user-id" }, isAdmin: () => false });
+    useAuthMock.mockReturnValue({
+      user: { id: "admin-user-id" },
+      isAdmin: () => false,
+      hasCapability: () => true,
+    });
     useActiveOrganizationIdMock.mockReturnValue(ORG_ID);
     createAuthorizationWithServicesMock.mockResolvedValue({ id: "auth-created-id" });
     updateAuthorizationDocumentsMock.mockResolvedValue(undefined);
@@ -246,6 +250,42 @@ describe("PreAuthTab manual authorization upload", () => {
         error: null,
       }),
     );
+  });
+
+  it("keeps BCBA authorization data visible without create or renew controls", async () => {
+    authorizationsMockData.push({
+      id: "auth-readonly",
+      authorization_number: "AUTH-READONLY",
+      start_date: "2026-01-01",
+      end_date: "2026-12-31",
+      status: "approved",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-02T00:00:00.000Z",
+      services: [{
+        id: "service-1",
+        service_code: "97153",
+        service_description: "Adaptive behavior treatment by protocol",
+        requested_units: 120,
+        approved_units: 120,
+        unit_type: "Units",
+      }],
+      documents: [],
+    });
+    useAuthMock.mockReturnValue({
+      user: { id: "bcba-user-id" },
+      isAdmin: () => false,
+      hasCapability: (capability: string) => capability === "viewAuthorizations",
+    });
+
+    renderWithProviders(<PreAuthTab client={{ id: "client-1" }} />, { auth: false });
+
+    expect(await screen.findByText(/AUTH-READONLY/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /new authorization/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Renew" })).not.toBeInTheDocument();
+    expect(document.querySelector('input[type="file"]')).not.toBeInTheDocument();
+    expect(updateAuthorizationDocumentsMock).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: "View" }));
+    expect(screen.getByText(/120\/120 Units/)).toBeInTheDocument();
   });
 
   it("creates an authorization from entered notice fields and attaches the uploaded PDF", async () => {
@@ -373,7 +413,11 @@ describe("PreAuthTab manual authorization upload", () => {
 
   it("lets admins download an uploaded authorization notice from the detail view", async () => {
     const { anchorClickSpy, createObjectUrlSpy, revokeObjectUrlSpy } = installDownloadBrowserMocks();
-    useAuthMock.mockReturnValue({ user: { id: "admin-user-id" }, isAdmin: () => true });
+    useAuthMock.mockReturnValue({
+      user: { id: "admin-user-id" },
+      isAdmin: () => true,
+      hasCapability: () => true,
+    });
     authorizationsMockData.push({
       id: "auth-created-id",
       authorization_number: "IEHP-AUTH-DOC",
@@ -423,7 +467,11 @@ describe("PreAuthTab manual authorization upload", () => {
   });
 
   it("blocks admin downloads when stored authorization notice paths do not match the client authorization", async () => {
-    useAuthMock.mockReturnValue({ user: { id: "admin-user-id" }, isAdmin: () => true });
+    useAuthMock.mockReturnValue({
+      user: { id: "admin-user-id" },
+      isAdmin: () => true,
+      hasCapability: () => true,
+    });
     authorizationsMockData.push({
       id: "auth-created-id",
       authorization_number: "IEHP-AUTH-DOC",
@@ -455,7 +503,11 @@ describe("PreAuthTab manual authorization upload", () => {
   it("clears the download loading state when storage download fails", async () => {
     installDownloadBrowserMocks();
     storageDownloadMock.mockResolvedValue({ data: null, error: new Error("Storage download failed") });
-    useAuthMock.mockReturnValue({ user: { id: "admin-user-id" }, isAdmin: () => true });
+    useAuthMock.mockReturnValue({
+      user: { id: "admin-user-id" },
+      isAdmin: () => true,
+      hasCapability: () => true,
+    });
     authorizationsMockData.push({
       id: "auth-created-id",
       authorization_number: "IEHP-AUTH-DOC",
@@ -488,7 +540,11 @@ describe("PreAuthTab manual authorization upload", () => {
 
   it("lets super admins download uploaded authorization notices through the admin role helper", async () => {
     const { anchorClickSpy } = installDownloadBrowserMocks();
-    useAuthMock.mockReturnValue({ user: { id: "super-admin-user-id" }, isAdmin: () => true });
+    useAuthMock.mockReturnValue({
+      user: { id: "super-admin-user-id" },
+      isAdmin: () => true,
+      hasCapability: () => true,
+    });
     authorizationsMockData.push({
       id: "auth-created-id",
       authorization_number: "IEHP-AUTH-DOC",

--- a/src/lib/__tests__/roles.test.ts
+++ b/src/lib/__tests__/roles.test.ts
@@ -13,10 +13,20 @@ describe('role capability matrix', () => {
   it('defines BCBA as clinical and operational admin without super-admin bypass', () => {
     expect(roleHasCapability('bcba', 'manageProgramsGoals')).toBe(true);
     expect(roleHasCapability('bcba', 'manageStaff')).toBe(true);
-    expect(roleHasCapability('bcba', 'manageAuthorizations')).toBe(true);
+    expect(roleHasCapability('bcba', 'manageAuthorizations')).toBe(false);
+    expect(roleHasCapability('bcba', 'viewAuthorizations')).toBe(true);
     expect(roleHasCapability('bcba', 'dataTaking')).toBe(true);
     expect(roleHasCapability('bcba', 'viewMonitoring')).toBe(false);
     expect(roleHasCapability('bcba', 'viewSettings')).toBe(false);
+  });
+
+  it('keeps authorization management with operational managers while BCBA remains read-only', () => {
+    expect(rolesForCapability('manageAuthorizations')).toEqual([
+      'midtier',
+      'admin_schedule',
+      'admin',
+      'super_admin',
+    ]);
   });
 
   it('reserves hard-delete of goal targets for BCBA and super-admin', () => {

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -173,7 +173,6 @@ export const ROLE_CAPABILITIES: Record<AppRole, readonly AppCapability[]> = {
     'dataTaking',
     'deleteGoalTargets',
     'lockSessionNotes',
-    'manageAuthorizations',
     'manageClients',
     'manageProgramsGoals',
     'manageStaff',

--- a/src/pages/Authorizations.tsx
+++ b/src/pages/Authorizations.tsx
@@ -53,9 +53,10 @@ export function Authorizations() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedAuthorization, setSelectedAuthorization] = useState<Authorization | undefined>();
   const queryClient = useQueryClient();
-  const { effectiveRole, profile } = useAuth();
+  const { effectiveRole, profile, hasCapability } = useAuth();
   const resolvedOrganizationId = useActiveOrganizationId();
   const isTherapistViewer = effectiveRole === 'midtier';
+  const canManageAuthorizations = hasCapability('manageAuthorizations');
 
   const { data: authorizations = [], isLoading } = useQuery({
     queryKey: ['authorizations'],
@@ -299,22 +300,39 @@ export function Authorizations() {
   });
 
   const handleCreateAuthorization = () => {
+    if (!canManageAuthorizations) {
+      showError('You have read-only access to authorizations');
+      return;
+    }
     setSelectedAuthorization(undefined);
     setIsModalOpen(true);
   };
 
   const handleEditAuthorization = (authorization: Authorization) => {
+    if (!canManageAuthorizations) {
+      showError('You have read-only access to authorizations');
+      return;
+    }
     setSelectedAuthorization(authorization);
     setIsModalOpen(true);
   };
 
   const handleDeleteAuthorization = async (id: string) => {
+    if (!canManageAuthorizations) {
+      showError('You have read-only access to authorizations');
+      return;
+    }
     if (window.confirm('Are you sure you want to delete this authorization?')) {
       await deleteAuthorizationMutation.mutateAsync(id);
     }
   };
 
   const handleSubmit = async (data: Partial<Authorization> & { services: Partial<AuthorizationService>[] }) => {
+    if (!canManageAuthorizations) {
+      showError('You have read-only access to authorizations');
+      return;
+    }
+
     try {
       logger.debug('Submitting authorization form', {
         metadata: { serviceCount: data.services?.length ?? 0 }
@@ -384,13 +402,17 @@ export function Authorizations() {
     <div className="h-full">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Authorizations</h1>
-        <button
-          onClick={handleCreateAuthorization}
-          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-        >
-          <Plus className="w-5 h-5 mr-2 inline-block" />
-          New Authorization
-        </button>
+        {canManageAuthorizations ? (
+          <button
+            onClick={handleCreateAuthorization}
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            <Plus className="w-5 h-5 mr-2 inline-block" />
+            New Authorization
+          </button>
+        ) : (
+          <span className="text-sm text-gray-500 dark:text-gray-400">Read-only access</span>
+        )}
       </div>
 
       <div className="bg-white dark:bg-dark-lighter rounded-lg shadow mb-6">
@@ -519,22 +541,26 @@ export function Authorizations() {
                       </span>
                     </td>
                     <td className="px-6 py-4">
-                      <div className="flex items-center space-x-3">
-                        <button
-                          onClick={() => handleEditAuthorization(auth)}
-                          className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300"
-                          title="Edit authorization"
-                        >
-                          <Edit2 className="w-4 h-4" />
-                        </button>
-                        <button
-                          onClick={() => handleDeleteAuthorization(auth.id)}
-                          className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
-                          title="Delete authorization"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      </div>
+                      {canManageAuthorizations ? (
+                        <div className="flex items-center space-x-3">
+                          <button
+                            onClick={() => handleEditAuthorization(auth)}
+                            className="text-blue-600 dark:text-blue-400 hover:text-blue-900 dark:hover:text-blue-300"
+                            title="Edit authorization"
+                          >
+                            <Edit2 className="w-4 h-4" />
+                          </button>
+                          <button
+                            onClick={() => handleDeleteAuthorization(auth.id)}
+                            className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-300"
+                            title="Delete authorization"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </button>
+                        </div>
+                      ) : (
+                        <span className="text-xs text-gray-500 dark:text-gray-400">View only</span>
+                      )}
                     </td>
                   </tr>
                 ))
@@ -544,7 +570,7 @@ export function Authorizations() {
         </div>
       </div>
 
-      {isModalOpen && (
+      {isModalOpen && canManageAuthorizations && (
         <AuthorizationModal
           isOpen={isModalOpen}
           onClose={() => {

--- a/src/pages/__tests__/Authorizations.test.tsx
+++ b/src/pages/__tests__/Authorizations.test.tsx
@@ -152,6 +152,7 @@ describe('Authorizations page query scope', () => {
     useAuthMock.mockReturnValue({
       user: null,
       effectiveRole: 'midtier',
+      hasCapability: (capability: string) => capability === 'manageAuthorizations',
       profile: baseProfile({
         id: therapistUserId,
         role: 'midtier',
@@ -192,6 +193,7 @@ describe('Authorizations page query scope', () => {
     useAuthMock.mockReturnValue({
       user: null,
       effectiveRole: 'admin',
+      hasCapability: () => true,
       profile: baseProfile({
         id: 'admin-user',
         role: 'admin',
@@ -211,12 +213,16 @@ describe('Authorizations page query scope', () => {
 
     expect(therapistsInMock).not.toHaveBeenCalled();
     expect(screen.getByText('Authorizations')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'New Authorization' })).toBeInTheDocument();
+    expect(screen.getByTitle('Edit authorization')).toBeInTheDocument();
+    expect(screen.getByTitle('Delete authorization')).toBeInTheDocument();
   });
 
   it('renders authorization date-only ranges without shifting the calendar day', async () => {
     useAuthMock.mockReturnValue({
       user: null,
       effectiveRole: 'admin',
+      hasCapability: () => true,
       profile: baseProfile({
         id: 'admin-user',
         role: 'admin',
@@ -228,5 +234,25 @@ describe('Authorizations page query scope', () => {
 
     const authNumber = await screen.findByText('AUTH-1');
     expect(authNumber.parentElement).toHaveTextContent(/Jan 1, 2025\s*-\s*Dec 31, 2025/);
+  });
+
+  it('keeps authorization records visible but hides mutation controls for BCBA', async () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      effectiveRole: 'bcba',
+      hasCapability: (capability: string) => capability === 'viewAuthorizations',
+      profile: baseProfile({
+        id: 'bcba-user',
+        role: 'bcba',
+        organization_id: 'org-bcba-1',
+      }),
+    });
+
+    renderWithProviders(<Authorizations />, { auth: false });
+
+    expect(await screen.findByText('AUTH-1')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'New Authorization' })).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Edit authorization')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Delete authorization')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/ClientDetails.test.tsx
+++ b/src/pages/__tests__/ClientDetails.test.tsx
@@ -222,6 +222,17 @@ describe('ClientDetails page', () => {
     expect(screen.getByText('PreAuthTabContent')).toBeInTheDocument();
   });
 
+  it('renders the Pre-Authorizations tab for BCBA viewers', async () => {
+    renderWithProviders(<ClientDetails />, {
+      auth: { role: 'bcba', userId: 'bcba-user-id' },
+    });
+
+    await waitFor(() => expect(screen.getByText('ProfileTabContent')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Pre-Authorizations/i }));
+    expect(screen.getByText('PreAuthTabContent')).toBeInTheDocument();
+  });
+
   it('shows a report-upcoming banner when client authorization ends within 30 days', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date('2026-07-07T12:00:00Z'));

--- a/supabase/migrations/20260725000810_forward_fix_bcba_authorization_readonly.sql
+++ b/supabase/migrations/20260725000810_forward_fix_bcba_authorization_readonly.sql
@@ -1,0 +1,150 @@
+/*
+  @migration-intent: Make exact BCBA authorization access read-only while preserving the established authorization managers and org-scoped BCBA reads.
+  @migration-dependencies: 20260714230523_repair_trusted_rls_authorization_boundaries.sql, 20260724154636_forward_fix_midtier_authorization_rpc_parity.sql
+  @migration-rollback: Forward recovery only. Apply a later migration that restores BCBA to the exact authorization manager array if product policy changes.
+*/
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_manage_authorizations(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT
+    app.current_user_is_super_admin()
+    OR (
+      NOT app.current_user_has_exact_role_for_org(
+        target_organization_id,
+        ARRAY['bcba']::text[]
+      )
+      AND app.current_user_has_exact_role_for_org(
+        target_organization_id,
+        ARRAY['admin', 'admin_schedule', 'midtier']::text[]
+      )
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_read_authorization_row(
+  p_organization_id uuid,
+  p_client_id uuid,
+  p_provider_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+BEGIN
+  IF p_organization_id IS NULL OR p_client_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF p_organization_id IS DISTINCT FROM app.current_user_organization_id() THEN
+    RETURN false;
+  END IF;
+
+  IF app.current_user_can_manage_authorizations(p_organization_id) THEN
+    RETURN true;
+  END IF;
+
+  IF app.current_user_has_exact_role_for_org(
+    p_organization_id,
+    ARRAY['bcba']::text[]
+  ) THEN
+    RETURN true;
+  END IF;
+
+  IF app.user_has_role_for_org(
+    app.current_user_id(),
+    p_organization_id,
+    ARRAY['client']
+  ) AND app.user_has_role_for_org(
+      'client',
+      p_organization_id,
+      NULL,
+      p_client_id,
+      NULL
+    ) THEN
+    RETURN true;
+  END IF;
+
+  IF app.user_has_role_for_org(
+    app.current_user_id(),
+    p_organization_id,
+    ARRAY['therapist']
+  ) THEN
+    IF p_provider_id IS NOT DISTINCT FROM app.current_user_id() THEN
+      RETURN true;
+    END IF;
+
+    RETURN app.current_user_has_assigned_client(p_organization_id, p_client_id);
+  END IF;
+
+  RETURN false;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.enforce_bcba_authorization_read_only()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+DECLARE
+  target_organization_id uuid;
+BEGIN
+  target_organization_id := CASE
+    WHEN TG_OP = 'DELETE' THEN OLD.organization_id
+    ELSE NEW.organization_id
+  END;
+
+  IF NOT app.current_user_is_super_admin()
+     AND app.current_user_has_exact_role_for_org(
+       target_organization_id,
+       ARRAY['bcba']::text[]
+     ) THEN
+    RAISE EXCEPTION 'BCBA authorization access is read-only'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_bcba_authorization_read_only
+  ON public.authorizations;
+CREATE TRIGGER enforce_bcba_authorization_read_only
+BEFORE INSERT OR UPDATE OR DELETE
+ON public.authorizations
+FOR EACH ROW
+EXECUTE FUNCTION app.enforce_bcba_authorization_read_only();
+
+DROP TRIGGER IF EXISTS enforce_bcba_authorization_service_read_only
+  ON public.authorization_services;
+CREATE TRIGGER enforce_bcba_authorization_service_read_only
+BEFORE INSERT OR UPDATE OR DELETE
+ON public.authorization_services
+FOR EACH ROW
+EXECUTE FUNCTION app.enforce_bcba_authorization_read_only();
+
+REVOKE EXECUTE ON FUNCTION app.current_user_can_manage_authorizations(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION app.current_user_can_manage_authorizations(uuid) TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION app.current_user_can_read_authorization_row(uuid, uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION app.current_user_can_read_authorization_row(uuid, uuid, uuid)
+  TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION app.enforce_bcba_authorization_read_only() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION app.enforce_bcba_authorization_read_only() TO service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/tests/authorizations/authorization-bcba-readonly.test.ts
+++ b/tests/authorizations/authorization-bcba-readonly.test.ts
@@ -1,0 +1,75 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationsDir = join(process.cwd(), 'supabase', 'migrations');
+const migrationFile = '20260725000810_forward_fix_bcba_authorization_readonly.sql';
+const migrationSql = readFileSync(join(migrationsDir, migrationFile), 'utf8');
+
+describe('BCBA authorization read-only migration', () => {
+  it('tracks a single forward migration for the BCBA authorization boundary', () => {
+    const migrationFiles = readdirSync(migrationsDir).filter((fileName) =>
+      fileName.endsWith('_forward_fix_bcba_authorization_readonly.sql'),
+    );
+
+    expect(migrationFiles).toEqual([migrationFile]);
+  });
+
+  it('removes BCBA while preserving the established authorization managers', () => {
+    expect(migrationSql).toContain('app.current_user_is_super_admin()');
+    expect(migrationSql).toContain(
+      "ARRAY['admin', 'admin_schedule', 'midtier']::text[]",
+    );
+    expect(migrationSql).toContain(
+      "NOT app.current_user_has_exact_role_for_org(\n        target_organization_id,\n        ARRAY['bcba']::text[]",
+    );
+    expect(migrationSql).not.toContain(
+      "ARRAY['admin', 'admin_schedule', 'midtier', 'bcba']::text[]",
+    );
+  });
+
+  it('preserves org-scoped BCBA reads independently from mutation authority', () => {
+    expect(migrationSql).toContain(
+      'CREATE OR REPLACE FUNCTION app.current_user_can_read_authorization_row',
+    );
+    expect(migrationSql).toContain("ARRAY['bcba']::text[]");
+    expect(migrationSql).toContain(
+      'IF p_organization_id IS DISTINCT FROM app.current_user_organization_id()',
+    );
+    expect(migrationSql).toContain(
+      'app.current_user_can_manage_authorizations(p_organization_id)',
+    );
+  });
+
+  it('preserves helper hardening and refreshes the PostgREST schema', () => {
+    expect(migrationSql).toContain('SECURITY DEFINER');
+    expect(migrationSql).toContain('SET search_path = public, app, auth');
+    expect(migrationSql).toContain(
+      'REVOKE EXECUTE ON FUNCTION app.current_user_can_manage_authorizations(uuid) FROM PUBLIC, anon;',
+    );
+    expect(migrationSql).toContain(
+      'GRANT EXECUTE ON FUNCTION app.current_user_can_manage_authorizations(uuid) TO authenticated, service_role;',
+    );
+    expect(migrationSql).toContain(
+      'REVOKE EXECUTE ON FUNCTION app.current_user_can_read_authorization_row(uuid, uuid, uuid) FROM PUBLIC, anon;',
+    );
+    expect(migrationSql).toContain("NOTIFY pgrst, 'reload schema';");
+  });
+
+  it('blocks BCBA writes even through provider-self policies or security-definer RPCs', () => {
+    expect(migrationSql).toContain(
+      'CREATE OR REPLACE FUNCTION app.enforce_bcba_authorization_read_only()',
+    );
+    expect(migrationSql).toContain(
+      "RAISE EXCEPTION 'BCBA authorization access is read-only'",
+    );
+    expect(migrationSql).toContain('BEFORE INSERT OR UPDATE OR DELETE');
+    expect(migrationSql).toContain('ON public.authorizations');
+    expect(migrationSql).toContain('ON public.authorization_services');
+    expect(migrationSql).toContain("USING ERRCODE = '42501'");
+    expect(migrationSql).toContain(
+      'REVOKE EXECUTE ON FUNCTION app.enforce_bcba_authorization_read_only() FROM PUBLIC, anon, authenticated;',
+    );
+  });
+});

--- a/tests/sql/employee_role_capability_smoke.sql
+++ b/tests/sql/employee_role_capability_smoke.sql
@@ -48,7 +48,9 @@ begin
     '00000000-0000-4000-8000-000000000401',
     '00000000-0000-4000-8000-000000000402',
     '00000000-0000-4000-8000-000000000403',
-    '00000000-0000-4000-8000-000000000404'
+    '00000000-0000-4000-8000-000000000404',
+    '00000000-0000-4000-8000-000000000405',
+    '00000000-0000-4000-8000-000000000406'
   );
 
   delete from public.goals
@@ -184,7 +186,8 @@ begin
       ('00000000-0000-4000-8000-000000000011'::uuid, 'admin_schedule'),
       ('00000000-0000-4000-8000-000000000012'::uuid, 'midtier'),
       ('00000000-0000-4000-8000-000000000013'::uuid, 'bt'),
-      ('00000000-0000-4000-8000-000000000014'::uuid, 'bcba')
+      ('00000000-0000-4000-8000-000000000014'::uuid, 'bcba'),
+      ('00000000-0000-4000-8000-000000000014'::uuid, 'admin_schedule')
   ) as v(user_id, role_name)
   join public.roles r on r.name = v.role_name;
 
@@ -220,7 +223,11 @@ begin
   insert into public.authorizations (id, authorization_number, client_id, provider_id, diagnosis_code, start_date, end_date, status, organization_id, created_by)
   values
     ('00000000-0000-4000-8000-000000000401', 'CODEX-SMOKE-AUTH-ASSIGNED', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000021', 'F84.0', current_date, current_date + 30, 'approved', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011'),
-    ('00000000-0000-4000-8000-000000000402', 'CODEX-SMOKE-AUTH-UNASSIGNED', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000021', 'F84.0', current_date, current_date + 30, 'approved', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011');
+    ('00000000-0000-4000-8000-000000000402', 'CODEX-SMOKE-AUTH-UNASSIGNED', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000021', 'F84.0', current_date, current_date + 30, 'approved', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011'),
+    ('00000000-0000-4000-8000-000000000405', 'CODEX-SMOKE-AUTH-BCBA-OWNED', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000014', 'F84.0', current_date, current_date + 30, 'approved', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011');
+
+  insert into public.authorization_services (id, authorization_id, service_code, service_description, from_date, to_date, requested_units, approved_units, unit_type, decision_status, organization_id, created_by)
+  values ('00000000-0000-4000-8000-000000000451', '00000000-0000-4000-8000-000000000405', '97153', 'Codex BCBA-owned service', current_date, current_date + 30, 120, 120, 'Units', 'approved', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011');
 
   insert into role_smoke_results
   values ('seed_synthetic_assignments', true, 'seeded synthetic role assignments and fixtures', current_user);
@@ -406,16 +413,21 @@ $bt$;
 
 select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-000000000014', true);
 do $bcba$
+declare
+  affected_rows integer;
+  visible_authorizations integer;
 begin
   insert into role_smoke_results
   values (
-    'bcba_exact_capability_helpers',
+    'bcba_mixed_role_capability_helpers',
     not app.current_user_is_super_admin()
       and app.current_user_can_manage_staff_clients('00000000-0000-4000-8000-000000000001')
+      and not app.current_user_can_manage_authorizations('00000000-0000-4000-8000-000000000001')
       and app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
       and app.current_user_can_manage_programs_goals('00000000-0000-4000-8000-000000000001'),
     'super=' || app.current_user_is_super_admin()
       || ', staff=' || app.current_user_can_manage_staff_clients('00000000-0000-4000-8000-000000000001')
+      || ', authz=' || app.current_user_can_manage_authorizations('00000000-0000-4000-8000-000000000001')
       || ', schedule=' || app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
       || ', programs=' || app.current_user_can_manage_programs_goals('00000000-0000-4000-8000-000000000001'),
     current_user
@@ -427,6 +439,64 @@ begin
     insert into role_smoke_results values ('bcba_client_write_allowed', true, 'insert clients succeeded', current_user);
   exception when others then
     insert into role_smoke_results values ('bcba_client_write_allowed', false, sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    insert into public.authorizations (id, authorization_number, client_id, provider_id, diagnosis_code, start_date, end_date, status, organization_id, created_by)
+    values ('00000000-0000-4000-8000-000000000406', 'CODEX-SMOKE-BCBA-DENIED', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000014', 'F84.0', current_date, current_date + 30, 'pending', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000014');
+    insert into role_smoke_results values ('bcba_authorization_write_denied', false, 'unexpected insert authorizations succeeded', current_user);
+  exception when others then
+    insert into role_smoke_results values ('bcba_authorization_write_denied', sqlstate = '42501', sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  select count(*)
+    into visible_authorizations
+  from public.authorizations
+  where id = '00000000-0000-4000-8000-000000000401';
+  insert into role_smoke_results
+  values (
+    'bcba_authorization_read_allowed',
+    visible_authorizations = 1,
+    'visible_rows=' || visible_authorizations,
+    current_user
+  );
+
+  begin
+    update public.authorizations
+    set authorization_number = 'CODEX-SMOKE-BCBA-UNEXPECTED-UPDATE'
+    where id = '00000000-0000-4000-8000-000000000405';
+    get diagnostics affected_rows = row_count;
+    insert into role_smoke_results values ('bcba_authorization_update_denied', false, 'unexpected updated_rows=' || affected_rows, current_user);
+  exception when others then
+    insert into role_smoke_results values ('bcba_authorization_update_denied', sqlstate = '42501', sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    delete from public.authorizations
+    where id = '00000000-0000-4000-8000-000000000405';
+    get diagnostics affected_rows = row_count;
+    insert into role_smoke_results values ('bcba_authorization_delete_denied', false, 'unexpected deleted_rows=' || affected_rows, current_user);
+  exception when others then
+    insert into role_smoke_results values ('bcba_authorization_delete_denied', sqlstate = '42501', sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    update public.authorization_services
+    set approved_units = 121
+    where id = '00000000-0000-4000-8000-000000000451';
+    get diagnostics affected_rows = row_count;
+    insert into role_smoke_results values ('bcba_authorization_service_update_denied', false, 'unexpected updated_rows=' || affected_rows, current_user);
+  exception when others then
+    insert into role_smoke_results values ('bcba_authorization_service_update_denied', sqlstate = '42501', sqlstate || ': ' || sqlerrm, current_user);
+  end;
+
+  begin
+    delete from public.authorization_services
+    where id = '00000000-0000-4000-8000-000000000451';
+    get diagnostics affected_rows = row_count;
+    insert into role_smoke_results values ('bcba_authorization_service_delete_denied', false, 'unexpected deleted_rows=' || affected_rows, current_user);
+  exception when others then
+    insert into role_smoke_results values ('bcba_authorization_service_delete_denied', sqlstate = '42501', sqlstate || ': ' || sqlerrm, current_user);
   end;
 end
 $bcba$;
@@ -544,7 +614,7 @@ from (
   union all select id from public.programs where id in ('00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000202', '00000000-0000-4000-8000-000000000203', '00000000-0000-4000-8000-000000000204')
   union all select id from public.goals where id in ('00000000-0000-4000-8000-000000000301', '00000000-0000-4000-8000-000000000302', '00000000-0000-4000-8000-000000000303', '00000000-0000-4000-8000-000000000304')
   union all select id from public.sessions where id in ('00000000-0000-4000-8000-000000000501', '00000000-0000-4000-8000-000000000502', '00000000-0000-4000-8000-000000000503', '00000000-0000-4000-8000-000000000504', '00000000-0000-4000-8000-000000000505')
-  union all select id from public.authorizations where id in ('00000000-0000-4000-8000-000000000401', '00000000-0000-4000-8000-000000000402', '00000000-0000-4000-8000-000000000403', '00000000-0000-4000-8000-000000000404')
+  union all select id from public.authorizations where id in ('00000000-0000-4000-8000-000000000401', '00000000-0000-4000-8000-000000000402', '00000000-0000-4000-8000-000000000403', '00000000-0000-4000-8000-000000000404', '00000000-0000-4000-8000-000000000405', '00000000-0000-4000-8000-000000000406')
   union all select id from public.goal_data_points where id in ('00000000-0000-4000-8000-000000000601', '00000000-0000-4000-8000-000000000602')
 ) residue;
 

--- a/tests/sql/employee_role_capability_smoke.sql
+++ b/tests/sql/employee_role_capability_smoke.sql
@@ -419,7 +419,7 @@ declare
 begin
   insert into role_smoke_results
   values (
-    'bcba_mixed_role_capability_helpers',
+    'bcba_exact_capability_helpers',
     not app.current_user_is_super_admin()
       and app.current_user_can_manage_staff_clients('00000000-0000-4000-8000-000000000001')
       and not app.current_user_can_manage_authorizations('00000000-0000-4000-8000-000000000001')


### PR DESCRIPTION
## Summary
- keep BCBA authorization routes, records, documents, and unit totals readable
- remove BCBA create, edit, delete, renew, upload, and submit controls
- enforce read-only access in Supabase for any active BCBA assignment, including provider-self RLS and security-definer RPC paths; super_admin remains the only override

## Risk
Critical authz/migration change. Production is unchanged. Human review and successful Supabase PR preview are required before merge.

## Verification
- focused Vitest: 5 files, 56 tests passed
- ci:check-focused, lint, typecheck, validate:tenant, ci:verify-coverage, build passed
- Tier-0 route gate: 7 specs, 220 tests passed
- Supabase, security, code, and test specialist reviews approved
- ci:playwright stopped at credential preflight locally
- test:ci has four failures in untouched baseline workflow/PDF helper tests; documented in the WIN-252 handoff

## Tracking
- Linear: WIN-252
- Handoff: docs/ai/WIN-252-bcba-authorization-readonly-handoff.md