### PR TITLE
WIN-251: allow Mid Tier session booking

### DIFF
--- a/docs/ai/WIN-251-midtier-session-booking-handoff.md
+++ b/docs/ai/WIN-251-midtier-session-booking-handoff.md
@@ -1,0 +1,87 @@
+# WIN-251 Mid Tier session booking authorization
+
+## Scope
+
+- classification: high-risk human-reviewed
+- lane: critical
+- issue: WIN-251
+- intent: allow exact in-organization `midtier` and `admin_schedule` schedule staff to use the existing session hold-and-confirm booking path
+- non-goals: no schema, RLS, grant, migration, generic organization-member, route, session-note, or cancellation changes
+
+## Root-cause evidence
+
+The live Mid Tier Schedule form returned `Forbidden` after `Create Session`.
+Hosted Supabase Edge logs recorded paired `403` responses from
+`sessions-hold` and `sessions-confirm`. Both handlers call
+`evaluateTherapistAuthorization`, whose exact target-scoped role list omitted
+`midtier` and `admin_schedule` even though the shared schedule-staff contract
+recognizes both roles.
+
+## Files
+
+- `supabase/functions/_shared/authorization.ts`
+- `tests/edge/scheduling-authorization.bcba.test.ts`
+- `docs/ai/WIN-251-midtier-session-booking-handoff.md`
+
+## Verification card
+
+- classification: high-risk human-reviewed
+- lane: critical
+- change type: authz; server/API/edge integration; tenant-scoped scheduling
+- required checks:
+  - `npm ci`
+  - focused booking authorization tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run verify:local`
+- executed checks:
+  - `npm ci` -> pass
+  - focused booking authorization tests -> pass, 11/11
+  - `npm run ci:check-focused` -> pass
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm run validate:tenant` -> pass
+  - `npm run build` -> pass
+  - `npm run test:routes:tier0` -> pass, 220/220
+- blocked checks:
+  - `npm run test:ci` -> local Node 24/Windows run reaches the suite but fails
+    five tests that pass on the exact base commit in GitHub's Node 20/Linux
+    `unit-tests` job; PR CI is required as the authoritative result
+  - `npm run verify:local` -> blocked by the same local `test:ci` runtime
+    mismatch after policy, lint, and typecheck pass
+  - `npm run ci:playwright` -> local preflight lacks
+    `PW_SUPERADMIN_EMAIL`/`PW_SUPERADMIN_PASSWORD` or
+    `PW_ADMIN_EMAIL`/`PW_ADMIN_PASSWORD`; PR CI and live Computer proof are
+    required
+- result: pass-with-blocked-checks pending authoritative PR CI
+- residual risk: the code diff is narrow and independently approved, but the
+  live Mid Tier hold-and-confirm workflow must be re-run after merge/deploy
+
+## Reviews
+
+- specification-engineer: completed
+- software-architect: completed; hosted logs superseded an alternate
+  session-note hypothesis
+- code-review-engineer: approved with no blocking findings
+- test-engineer: focused coverage accepted; direct live hold/confirm proof
+  remains required
+- security-engineer: approved; target-therapist scoping and fail-closed
+  behavior preserved
+
+## PR hygiene
+
+- dedicated branch: `codex/win-251-midtier-session-booking`
+- single purpose: yes
+- unrelated changes: none
+- generated artifact drift: none
+- protected-path drift: none outside the routed shared Edge authorization
+  helper
+- Linear linkage: WIN-251
+- human review: required before merge
+

--- a/supabase/functions/_shared/authorization.ts
+++ b/supabase/functions/_shared/authorization.ts
@@ -1,6 +1,12 @@
 import type { SupabaseClient } from "npm:@supabase/supabase-js@2.50.0";
 
-type RoleName = "therapist" | "admin" | "super_admin" | "bcba";
+type RoleName =
+  | "therapist"
+  | "admin"
+  | "super_admin"
+  | "bcba"
+  | "midtier"
+  | "admin_schedule";
 
 interface AuthorizationFailure {
   status: number;
@@ -23,7 +29,14 @@ export async function evaluateTherapistAuthorization(
   client: SupabaseClient,
   therapistId: string,
 ): Promise<TherapistAuthorizationResult> {
-  const roles: RoleName[] = ["therapist", "admin", "super_admin", "bcba"];
+  const roles: RoleName[] = [
+    "therapist",
+    "admin",
+    "super_admin",
+    "bcba",
+    "midtier",
+    "admin_schedule",
+  ];
 
   for (const role of roles) {
     const { data, error } = await client.rpc("user_has_role_for_org", {

--- a/tests/edge/scheduling-authorization.bcba.test.ts
+++ b/tests/edge/scheduling-authorization.bcba.test.ts
@@ -3,6 +3,27 @@ import { describe, expect, it, vi } from "vitest";
 import { evaluateTherapistAuthorization } from "../../supabase/functions/_shared/authorization";
 
 describe("scheduling edge therapist authorization", () => {
+  it.each(["midtier", "admin_schedule"] as const)(
+    "allows exact %s schedule staff to authorize a target therapist",
+    async (allowedRole) => {
+      const rpc = vi.fn(async (_name: string, args: { role_name?: string }) => ({
+        data: args.role_name === allowedRole,
+        error: null,
+      }));
+
+      const result = await evaluateTherapistAuthorization(
+        { rpc } as never,
+        "therapist-row-1",
+      );
+
+      expect(result).toEqual({ ok: true });
+      expect(rpc).toHaveBeenCalledWith("user_has_role_for_org", {
+        role_name: allowedRole,
+        target_therapist_id: "therapist-row-1",
+      });
+    },
+  );
+
   it("allows an exact BCBA role to authorize a target therapist", async () => {
     const rpc = vi.fn(async (_name: string, args: { role_name?: string }) => ({
       data: args.role_name === "bcba",


### PR DESCRIPTION
## Summary
- add exact Mid Tier and Admin Schedule roles to the existing target-therapist booking authorization helper
- preserve target_therapist_id scoping and fail-closed denial/error behavior
- add regression coverage and a critical-lane handoff

## Production evidence
- Mid Tier Create Session reproduced a Forbidden error
- hosted Supabase logs recorded paired 403 responses from sessions-hold and sessions-confirm

## Verification
- focused booking suites: 11/11
- npm run ci:check-focused
- npm run lint
- npm run typecheck
- npm run validate:tenant
- npm run build
- npm run test:routes:tier0: 220/220
- independent code and security reviews: approved

## Local blocked checks
- npm run test:ci / verify:local: bundled Node 24 on Windows fails five base-branch tests that pass on the exact base commit in GitHub Node 20/Linux; PR CI is authoritative
- npm run ci:playwright: local credential preflight missing; CI/live Computer reproof required

## Risk
Critical protected Edge authorization path. Human review, green CI, merge/deploy, and live Mid Tier hold/confirm reproof are required.

Linear: WIN-251