### PR TITLE
WIN-253: restore production Fill Docs generation

### DIFF
--- a/docs/ai/WIN-253-fill-docs-production-handoff.md
+++ b/docs/ai/WIN-253-fill-docs-production-handoff.md
@@ -1,0 +1,93 @@
+# WIN-253 Fill Docs production handoff
+
+## Routing
+
+- Classification: high-risk, human-reviewed
+- Lane: critical
+- Triggering surfaces: `supabase/functions/fill-docs/**` and `supabase/config.toml`
+- Linear: WIN-253
+
+## Scope
+
+Restore the production Mid Tier Fill Docs workflow with the smallest contained
+Edge Function change:
+
+- bundle the three tracked DOCX templates;
+- correct the FBA and PR template filenames;
+- generate the document in memory;
+- return the existing base64 response variant;
+- remove storage uploads, signed URLs, and `therapist_documents` manifest writes.
+
+Non-goals include role-policy changes, shared auth refactors, migrations, RLS or
+storage-policy changes, and deploy-workflow expansion.
+
+## Verification
+
+- Focused Deno test RED: missing handler/template exports before implementation.
+- Focused Deno test GREEN:
+  `deno test --no-check --allow-env --allow-read --allow-net supabase/functions/fill-docs/index.test.ts`
+  (`4 passed`, `0 failed`).
+- `npm run ci:check-focused`: passed.
+- `npm run lint`: passed.
+- `npm run typecheck`: passed.
+- `npm run validate:tenant`: passed; no schema or RLS change was made.
+- `npm run build`: passed.
+- `npm run test:ci`: failed on existing unrelated regressions in
+  `tests/workflows/bt-aba-disposable-browser-proof.test.ts` and
+  `src/lib/__tests__/supabase.edge.test.ts` (`blob.text is not a function`).
+- Production proof remains required after human review, merge, and a dedicated
+  `fill-docs` Edge Function deployment.
+
+### Verification card
+
+- Classification: high-risk human-reviewed
+- Lane: critical
+- Change type: server/API/Edge integration and protected Supabase function
+- Required checks: `npm run ci:check-focused`, `npm run lint`,
+  `npm run typecheck`, focused Deno tests, `npm run test:ci`,
+  `npm run build`, `npm run validate:tenant`,
+  `npm run test:routes:tier0`, `npm run ci:playwright`,
+  and `npm run verify:local`
+- Executed checks:
+  - focused Deno tests: passed (`4 passed`, `0 failed`)
+  - `npm run ci:check-focused`: passed
+  - `npm run lint`: passed
+  - `npm run typecheck`: passed
+  - `npm run build`: passed
+  - `npm run validate:tenant`: passed
+  - `npm run test:routes:tier0`: passed (`220 passed`, `0 failed`)
+  - `npm run test:ci`: failed on the unrelated baseline failures listed above
+  - `npm run ci:playwright`: blocked at preflight because local privileged
+    Playwright credentials are not configured
+- Blocked checks:
+  - `npm run ci:playwright`: missing `PW_SUPERADMIN_*` or `PW_ADMIN_*`
+    credentials in the local process
+  - `npm run verify:local`: cannot complete while the same credential gate and
+    baseline `test:ci` failures remain
+- Result: pass-with-blocked-checks
+- Residual risk: production remains on the stale function until human merge
+  and a dedicated deploy; live ER/FBA/PR proof is mandatory afterward.
+
+## Required agents
+
+Completed: specification engineer, software architect, implementation
+engineer, code review engineer, test engineer, security engineer, and Supabase
+reviewer.
+
+## Deployment and live proof
+
+After merge:
+
+1. Deploy only the production `fill-docs` Edge Function with all three bundled
+   DOCX assets.
+2. Prove `OPTIONS` returns promptly with the expected CORS response.
+3. Generate synthetic ER, FBA, and PR documents as Mid Tier and verify valid
+   DOCX downloads.
+4. Confirm no storage object or `therapist_documents` row is created.
+
+## Residual risk
+
+The largest template produces roughly a 1 MB base64 JSON response. This is
+acceptable for the current low-volume authenticated workflow but should not be
+generalized to large or public document generation. The broader CI/deployment
+gap that allowed the production function bundle to drift is a separate slice.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -265,6 +265,14 @@ verify_jwt = true
 verify_jwt = true
 static_files = [ "./functions/generate-assessment-plan-docx/fill_docs/Updated FBA -IEHP.docx" ]
 
+[functions.fill-docs]
+verify_jwt = true
+static_files = [
+  "./functions/fill-docs/fill_docs/Updated ER - IEHP.docx",
+  "./functions/fill-docs/fill_docs/Updated FBA -IEHP.docx",
+  "./functions/fill-docs/fill_docs/Updated PR -IEHP.docx",
+]
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/fill-docs/index.test.ts
+++ b/supabase/functions/fill-docs/index.test.ts
@@ -1,0 +1,105 @@
+import { expect } from "jsr:@std/expect";
+
+Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+Deno.env.set("SUPABASE_ANON_KEY", "anon-key");
+Deno.env.set("SUPABASE_PUBLISHABLE_KEY", "anon-key");
+
+const {
+  createFillDocsHandler,
+  default: fillDocsRoute,
+  TEMPLATES,
+  TEMPLATE_STATIC_FILES,
+} = await import("./index.ts");
+
+const postRequest = (payload: unknown): Request =>
+  new Request("https://edge.test/fill-docs", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-token",
+      apikey: "anon",
+    },
+    body: JSON.stringify(payload),
+  });
+
+const fillDocsConfigBlock = await (async () => {
+  const configToml = await Deno.readTextFile(
+    new URL("../../config.toml", import.meta.url),
+  );
+  const match = configToml.match(/\[functions\.fill-docs\][\s\S]*?(?=\n\[|$)/);
+  return match?.[0] ?? "";
+})();
+
+Deno.test("fill-docs bundled template references resolve to tracked assets and config static_files", async () => {
+  expect(TEMPLATE_STATIC_FILES).toEqual(
+    Object.values(TEMPLATES).map((template) => template.staticFile),
+  );
+
+  for (const template of Object.values(TEMPLATES)) {
+    await expect(Deno.stat(template.fileUrl)).resolves.toMatchObject({
+      isFile: true,
+    });
+    expect(fillDocsConfigBlock).toContain(template.staticFile);
+  }
+});
+
+Deno.test("fill-docs protected route answers OPTIONS before authentication", async () => {
+  const response = await fillDocsRoute(
+    new Request("https://edge.test/functions/v1/fill-docs", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://app.allincompassing.ai",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "authorization,content-type",
+      },
+    }),
+  );
+
+  expect(response.status).toBe(204);
+  expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+    "https://app.allincompassing.ai",
+  );
+  expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
+    "OPTIONS",
+  );
+  expect(response.headers.get("Access-Control-Allow-Headers")).toContain(
+    "Authorization",
+  );
+});
+
+Deno.test("fillDocsHandler returns backward-compatible base64 JSON without persistence metadata", async () => {
+  const handler = createFillDocsHandler({
+    readTemplateBytes: () => Promise.resolve(new Uint8Array([1, 2, 3])),
+    fillDocxTemplate: () => Promise.resolve(new Uint8Array([4, 5, 6])),
+  });
+
+  const response = await handler(postRequest({
+    template: "FBA",
+    fields: { CLIENT_NAME: "Synthetic Client" },
+    outputFileName: "synthetic-output",
+  }));
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({
+    success: true,
+    template: "FBA",
+    filename: "synthetic-output.docx",
+    contentType:
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    base64: btoa(String.fromCharCode(4, 5, 6)),
+  });
+});
+
+Deno.test("fill-docs source no longer carries storage persistence code paths", async () => {
+  const source = await Deno.readTextFile(
+    new URL("./index.ts", import.meta.url),
+  );
+
+  expect(source).not.toContain("therapist_documents");
+  expect(source).not.toContain(".upload(");
+  expect(source).not.toContain("createSignedUrl");
+  expect(source).not.toContain("requireOrg");
+  expect(source).not.toContain("resolveTherapistIdForUser");
+  expect(source).not.toContain("supabaseAdmin");
+});

--- a/supabase/functions/fill-docs/index.ts
+++ b/supabase/functions/fill-docs/index.ts
@@ -5,13 +5,10 @@ import {
   RouteOptions,
   UserContext,
 } from "../_shared/auth-middleware.ts";
-import { createRequestClient, supabaseAdmin } from "../_shared/database.ts";
-import { getLogger } from "../_shared/logging.ts";
-import { requireOrg } from "../_shared/org.ts";
 
-type TemplateKey = "ER" | "FBA" | "PR";
+export type TemplateKey = "ER" | "FBA" | "PR";
 
-type FillDocsRequest = {
+export type FillDocsRequest = {
   template: TemplateKey;
   fields: Record<string, string>;
   outputFileName?: string;
@@ -22,31 +19,47 @@ type FillDocsResponse = {
   template: TemplateKey;
   filename: string;
   contentType: string;
-  // Prefer signed URL download (keeps responses small and avoids base64 inflation).
-  downloadUrl?: string;
-  bucketId?: string;
-  objectPath?: string;
-  // Legacy fallback (keep for compatibility / debugging).
-  base64?: string;
+  base64: string;
+};
+
+type TemplateMeta = {
+  fileName: string;
+  staticFile: string;
+  fileUrl: URL;
+};
+
+type FillDocsDeps = {
+  readTemplateBytes?: (template: TemplateMeta) => Promise<Uint8Array>;
+  fillDocxTemplate?: (
+    templateBytes: Uint8Array,
+    fields: Record<string, string>,
+  ) => Promise<Uint8Array>;
 };
 
 const CONTENT_TYPE =
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
-const TEMPLATES: Record<TemplateKey, { fileName: string; fileUrl: URL }> = {
+export const TEMPLATES: Record<TemplateKey, TemplateMeta> = {
   ER: {
     fileName: "Updated ER - IEHP.docx",
+    staticFile: "./functions/fill-docs/fill_docs/Updated ER - IEHP.docx",
     fileUrl: new URL("./fill_docs/Updated ER - IEHP.docx", import.meta.url),
   },
   FBA: {
-    fileName: "Updated FBA - IEHP.docx",
-    fileUrl: new URL("./fill_docs/Updated FBA - IEHP.docx", import.meta.url),
+    fileName: "Updated FBA -IEHP.docx",
+    staticFile: "./functions/fill-docs/fill_docs/Updated FBA -IEHP.docx",
+    fileUrl: new URL("./fill_docs/Updated FBA -IEHP.docx", import.meta.url),
   },
   PR: {
-    fileName: "Updated PR - IEHP.docx",
-    fileUrl: new URL("./fill_docs/Updated PR - IEHP.docx", import.meta.url),
+    fileName: "Updated PR -IEHP.docx",
+    staticFile: "./functions/fill-docs/fill_docs/Updated PR -IEHP.docx",
+    fileUrl: new URL("./fill_docs/Updated PR -IEHP.docx", import.meta.url),
   },
 };
+
+export const TEMPLATE_STATIC_FILES = Object.values(TEMPLATES).map((template) =>
+  template.staticFile
+);
 
 function jsonResponse(body: Record<string, unknown>, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -105,7 +118,10 @@ function escapeXmlText(value: string): string {
     .replaceAll("'", "&apos;");
 }
 
-function applyPlaceholdersToXml(xml: string, fields: Record<string, string>): string {
+function applyPlaceholdersToXml(
+  xml: string,
+  fields: Record<string, string>,
+): string {
   let next = xml;
   for (const [key, rawValue] of Object.entries(fields)) {
     const token = `{{${key}}}`;
@@ -114,7 +130,7 @@ function applyPlaceholdersToXml(xml: string, fields: Record<string, string>): st
   return next;
 }
 
-function toBase64(bytes: Uint8Array): string {
+export function toBase64(bytes: Uint8Array): string {
   let binary = "";
   const chunkSize = 0x8000;
   for (let i = 0; i < bytes.length; i += chunkSize) {
@@ -123,31 +139,7 @@ function toBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
-async function resolveTherapistIdForUser(
-  db: ReturnType<typeof createRequestClient>,
-  userId: string,
-): Promise<string> {
-  // Common case: therapist row id == auth uid
-  const direct = await db.from("therapists").select("id").eq("id", userId).maybeSingle();
-  if (direct.data?.id && !direct.error) {
-    return direct.data.id as string;
-  }
-
-  // Fallback: mapping table if present
-  const linked = await db
-    .from("user_therapist_links")
-    .select("therapist_id")
-    .eq("user_id", userId)
-    .maybeSingle();
-  const therapistId = (linked.data as Record<string, unknown> | null)?.therapist_id;
-  if (typeof therapistId === "string" && therapistId.length > 0) {
-    return therapistId;
-  }
-
-  return userId;
-}
-
-async function fillDocxTemplate(
+export async function fillDocxTemplate(
   templateBytes: Uint8Array,
   fields: Record<string, string>,
 ): Promise<Uint8Array> {
@@ -172,106 +164,70 @@ async function fillDocxTemplate(
   return out as Uint8Array;
 }
 
-export default createProtectedRoute(async (req: Request, userContext: UserContext) => {
-  const logger = getLogger(req, {
-    functionName: "fill-docs",
-    userId: userContext.user.id,
-  });
-
-  if (req.method !== "POST") {
-    logApiAccess(req.method, "/fill-docs", userContext, 405);
-    return jsonResponse({ error: "Method not allowed" }, 405);
-  }
-
-  try {
-    const requestClient = createRequestClient(req);
-    const orgId = await requireOrg(requestClient);
-    const therapistId = await resolveTherapistIdForUser(requestClient, userContext.user.id);
-
-    const parsed = parseRequest(await req.json());
-    if (!parsed.ok) {
-      logApiAccess("POST", "/fill-docs", userContext, 400);
-      logger.warn("request.invalid", { reason: parsed.error });
-      return jsonResponse({ error: parsed.error }, 400);
-    }
-
-    const { template, fields, outputFileName } = parsed.value;
-    const templateMeta = TEMPLATES[template];
-    const templateBytes = await Deno.readFile(templateMeta.fileUrl);
-
-    logger.info("fill.start", { template, fieldsCount: Object.keys(fields).length, orgId, therapistId });
-
-    const filledBytes = await fillDocxTemplate(templateBytes, fields);
-
-    const filename = ensureDocxExtension(
-      outputFileName ?? `${templateMeta.fileName.replace(".docx", "")} (filled).docx`,
-    );
-
-    // Persist to Storage so the client can download via signed URL (no huge JSON payloads).
-    const bucketId = "therapist-documents";
-    const documentKey = "fill-docs";
-    const safeName = filename.replaceAll(/[^a-zA-Z0-9._() -]/g, "_");
-    const objectPath = `therapists/${therapistId}/${documentKey}/${crypto.randomUUID()}-${safeName}`;
-
-    const uploadResult = await supabaseAdmin.storage.from(bucketId).upload(
-      objectPath,
-      filledBytes,
-      {
-        contentType: CONTENT_TYPE,
-        upsert: false,
-      },
-    );
-    if (uploadResult.error) {
-      throw new Error(`Storage upload failed: ${uploadResult.error.message}`);
-    }
-
-    // Record in therapist_documents manifest for auditability and reuse of existing conventions.
-    const manifestInsert = await supabaseAdmin.from("therapist_documents").insert({
-      therapist_id: therapistId,
-      organization_id: orgId,
-      document_key: documentKey,
-      bucket_id: bucketId,
-      object_path: objectPath,
-    });
-    if (manifestInsert.error) {
-      logger.warn("manifest.insert_failed", { error: manifestInsert.error.message, bucketId, objectPath });
-      // Non-fatal: file is already uploaded.
-    }
-
-    const signed = await supabaseAdmin.storage.from(bucketId).createSignedUrl(objectPath, 60 * 10);
-    if (signed.error || !signed.data?.signedUrl) {
-      throw new Error(`Signed URL generation failed: ${signed.error?.message ?? "unknown"}`);
-    }
-
-    const response: FillDocsResponse = {
-      success: true,
-      template,
-      filename,
-      contentType: CONTENT_TYPE,
-      downloadUrl: signed.data.signedUrl,
-      bucketId,
-      objectPath,
-    };
-
-    logApiAccess("POST", "/fill-docs", userContext, 200);
-    logger.info("fill.complete", { template, filename, bucketId, objectPath });
-    return new Response(JSON.stringify(response), {
-      status: 200,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Internal server error";
-    logApiAccess("POST", "/fill-docs", userContext, 500);
-    logger.error("fill.failed", { error: message });
-
-    // As a last-resort fallback for debugging (only if we still have the template + payload in scope).
-    return jsonResponse({ error: "Failed to fill document template" }, 500);
-  }
-}, RouteOptions.therapist);
-
 function ensureDocxExtension(name: string): string {
   const trimmed = name.trim();
   if (trimmed.toLowerCase().endsWith(".docx")) return trimmed;
   return `${trimmed}.docx`;
 }
 
+export function createFillDocsHandler(deps: FillDocsDeps = {}) {
+  const readTemplateBytes = deps.readTemplateBytes ??
+    ((template: TemplateMeta) => Deno.readFile(template.fileUrl));
+  const renderDocx = deps.fillDocxTemplate ?? fillDocxTemplate;
+
+  return async (
+    req: Request,
+    userContext: UserContext | null = null,
+  ): Promise<Response> => {
+    if (req.method !== "POST") {
+      logApiAccess(req.method, "/fill-docs", userContext, 405);
+      return jsonResponse({ error: "Method not allowed" }, 405);
+    }
+
+    try {
+      const parsed = parseRequest(await req.json());
+      if (!parsed.ok) {
+        logApiAccess("POST", "/fill-docs", userContext, 400);
+        return jsonResponse({ error: parsed.error }, 400);
+      }
+
+      const { template, fields, outputFileName } = parsed.value;
+      const templateMeta = TEMPLATES[template];
+      const templateBytes = await readTemplateBytes(templateMeta);
+      const filledBytes = await renderDocx(templateBytes, fields);
+      const filename = ensureDocxExtension(
+        outputFileName ??
+          `${templateMeta.fileName.replace(".docx", "")} (filled).docx`,
+      );
+
+      const response: FillDocsResponse = {
+        success: true,
+        template,
+        filename,
+        contentType: CONTENT_TYPE,
+        base64: toBase64(filledBytes),
+      };
+
+      logApiAccess("POST", "/fill-docs", userContext, 200);
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    } catch (error) {
+      const message = error instanceof Error
+        ? error.message
+        : "Internal server error";
+      logApiAccess("POST", "/fill-docs", userContext, 500);
+      console.error("fill-docs error", message);
+      return jsonResponse({ error: "Failed to fill document template" }, 500);
+    }
+  };
+}
+
+const fillDocsHandler = createFillDocsHandler();
+
+export default createProtectedRoute(
+  async (req: Request, userContext: UserContext) =>
+    fillDocsHandler(req, userContext),
+  RouteOptions.therapist,
+);


### PR DESCRIPTION
## Summary
- package the three tracked DOCX templates for the `fill-docs` Edge Function
- correct the FBA/PR asset filenames and return the existing base64 response variant
- remove service-role storage uploads, signed URLs, and `therapist_documents` manifest writes
- add focused asset, OPTIONS/CORS, response-contract, and no-persistence tests

## Routing
- classification: high-risk human-reviewed
- lane: critical
- Linear: https://linear.app/winningedgeai/issue/WIN-253/fix-production-fill-docs-preflight-timeout-and-stale-mid-tier-edge

## Verification
- `deno test --no-lock --no-check --allow-env --allow-read --allow-net supabase/functions/fill-docs/index.test.ts` (4 passed)
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run validate:tenant`
- `npm run test:routes:tier0` (220 passed)
- `npm run test:ci` has unrelated local baseline failures documented in the handoff
- `npm run ci:playwright` is locally blocked by missing privileged Playwright credentials; CI remains authoritative

## Risk and deployment
This is protected Supabase function work and requires human review. After merge, deploy only `fill-docs` to production, then re-run Mid Tier ER/FBA/PR generation and prove no storage or manifest residue.