### PR TITLE
fix: authorize Mid Tier legacy session booking

### DIFF
--- a/docs/ai/WIN-254-midtier-booking-auth-handoff.md
+++ b/docs/ai/WIN-254-midtier-booking-auth-handoff.md
@@ -1,0 +1,63 @@
+# WIN-254 Mid Tier Booking Authorization Handoff
+
+- `classification`: high-risk human-reviewed
+- `lane`: critical
+- `issue`: WIN-254
+- `intent`: Allow an active, unexpired exact `midtier` scheduling staff user to book an in-organization therapist through the legacy Node `/api/book` path while preserving therapist self-only and cross-tenant boundaries.
+- `files touched`:
+  - `src/server/api/book.ts`
+  - `src/server/api/shared.ts`
+  - `src/server/__tests__/bookHandler.test.ts`
+  - `src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts`
+- `non-goals`:
+  - No migrations, RLS, grants, RPC, Edge Function, UI, runtime-config, or deployment changes.
+  - No expansion to generic organization members or the broader schedule capability that includes therapists.
+- `stop conditions`: Stop and re-route if the fix requires schema/RPC changes, service-role authorization decisions, Edge Function changes, or a broader employee-role refactor.
+- `required agents`: specification-engineer, software-architect, implementation-engineer, code-review-engineer, test-engineer, security-engineer
+- `required checks`:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - targeted booking and role-RPC tests
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run verify:local`
+- `executed checks`:
+  - `npm run ci:check-focused` -> pass
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - focused Vitest (`bookHandler.test.ts` and `orgRoleRpcEquivalence.contract.test.ts`) -> pass, 47/47
+  - `npm run build` -> pass
+  - `npm run test:routes:tier0` -> pass, 220/220 after the required build
+  - `npm run test:ci` -> fail, 5/3,394 tests; every failing file is unchanged from `origin/main`
+  - `npm run ci:playwright` -> blocked locally because the required Playwright account secrets are unavailable
+  - `npm run verify:local` -> fail at the same five unchanged `test:ci` cases; later coverage/build/route steps did not execute in the aggregate command
+- `blocked checks`:
+  - `npm run ci:playwright` -> requires protected Playwright account credentials not available in this worktree
+- `local baseline failures`:
+  - `tests/authorizations/authorization-bcba-readonly.test.ts` -> Windows checkout text assertion
+  - `tests/ci/check-e2e-reliability-gates.test.ts` -> synthetic BCBA workflow contract assertion
+  - `tests/scripts/playwright-iehp-assessment-import-smoke.test.ts` -> generated super-admin/cleanup workflow contract assertion
+  - `tests/workflows/bt-aba-disposable-browser-proof.test.ts` -> managed proof branch workflow contract assertion
+  - `src/lib/__tests__/supabase.edge.test.ts` -> Node 24 `Blob.text` environment mismatch
+- `reviewer`: code review approved; final security review approved after repo and hosted RPC contract verification
+- `residual risk`: The local Node 24/Windows environment has unrelated baseline test failures; required GitHub Node 20/Linux CI and post-merge production reproof must pass before the live defect is considered closed.
+- `pr handoff`: Ready after the final fresh verification pass and PR-hygiene inspection.
+
+## Root Cause
+
+The production UI posts to the legacy Node `/api/book` fallback. Its authorization logic recognized administrator, therapist self-booking, organization-member aliases, and exact BCBA, but omitted the already-established narrow scheduling staff roles `admin_schedule` and `midtier`. The Edge authorization path had already been updated, leaving a parity gap in the Node fallback.
+
+## Bounded Fix
+
+The server now checks the existing public `user_has_role_for_org` RPC, using the caller's bearer token, for the exact schedule-staff set `admin_schedule`, `midtier`, then `bcba`. Transport and server failures remain fail-closed. Existing organization/entity validation and therapist self-only behavior remain in place.
+
+## TDD Evidence
+
+The new Mid Tier cross-therapist booking regression failed with HTTP 403 before the implementation and passes with HTTP 200 after the bounded fix. A separate regression proves an upstream exact-role verification failure returns HTTP 502 without invoking the booking write.
+
+## Live Closure Gate
+
+After human merge and production deployment, repeat the synthetic Mid Tier client-to-first-session workflow through the real UI, capture redacted screenshot proof, verify the session rows through hosted Supabase, and remove all marker-owned synthetic rows transactionally.

--- a/src/server/__tests__/bookHandler.test.ts
+++ b/src/server/__tests__/bookHandler.test.ts
@@ -538,6 +538,58 @@ describe("bookHandler", () => {
     expect(bookSessionMock).toHaveBeenCalledTimes(1);
   });
 
+  it("allows exact midtier scheduling staff to book another in-org therapist row", async () => {
+    server.use(
+      http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/user_has_role_for_org`, async ({ request }) => {
+        const body = await request.json() as { role_name?: string };
+        return HttpResponse.json(body.role_name === "midtier");
+      }),
+      http.get(`${TEST_SUPABASE_URL}/auth/v1/user`, () => HttpResponse.json({ id: "midtier-user" })),
+    );
+    bookSessionMock.mockResolvedValueOnce(createSuccessfulBookResult({
+      sessionId: "session-midtier",
+      createdBy: "midtier-user",
+    }));
+
+    const bookHandler = await importBookHandler();
+    const response = await bookHandler(createRequest({
+      ...validPayload,
+      session: {
+        ...validPayload.session,
+        therapist_id: "therapist-2",
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(bookSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when exact scheduling staff authority cannot be verified", async () => {
+    server.use(
+      http.post(`${TEST_SUPABASE_URL}/rest/v1/rpc/user_has_role_for_org`, async ({ request }) => {
+        const body = await request.json() as { role_name?: string };
+        if (body.role_name === "midtier") {
+          return new HttpResponse(null, { status: 503 });
+        }
+        return HttpResponse.json(false);
+      }),
+      http.get(`${TEST_SUPABASE_URL}/auth/v1/user`, () => HttpResponse.json({ id: "midtier-user" })),
+    );
+
+    const bookHandler = await importBookHandler();
+    const response = await bookHandler(createRequest({
+      ...validPayload,
+      session: {
+        ...validPayload.session,
+        therapist_id: "therapist-2",
+      },
+    }));
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({ code: "upstream_error" });
+    expect(bookSessionMock).not.toHaveBeenCalled();
+  });
+
   it("does not depend on BCBA authority when a therapist books their own row", async () => {
     let bcbaRoleChecks = 0;
     server.use(

--- a/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
+++ b/src/server/__tests__/orgRoleRpcEquivalence.contract.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  currentUserHasScheduleStaffRoleForOrg,
   currentUserCanCaptureTrialEvent,
   currentUserCanManageLockedTrialEvent,
   currentUserCanManageProgramsGoals,
@@ -106,6 +107,28 @@ describe("P05 resolveOrgAndRoleWithStatus (untargeted RPC equivalence)", () => {
       target_organization_id: "org-1",
     });
     expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${accessToken}`);
+  });
+
+  it("checks exact schedule-staff authority through admin_schedule, midtier, then bcba role RPCs", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(currentUserHasScheduleStaffRoleForOrg(accessToken, "org-1")).resolves.toEqual({
+      allowed: true,
+      upstreamError: false,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/rest/v1/rpc/user_has_role_for_org");
+    expect(JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body))).toEqual({
+      role_name: "admin_schedule",
+      target_organization_id: "org-1",
+    });
+    expect(JSON.parse(String((fetchSpy.mock.calls[1]?.[1] as RequestInit).body))).toEqual({
+      role_name: "midtier",
+      target_organization_id: "org-1",
+    });
   });
 
   it("checks trial-event capture and lock helpers through exposed public RPC wrappers", async () => {

--- a/src/server/api/book.ts
+++ b/src/server/api/book.ts
@@ -3,7 +3,7 @@ import { bookSession, deriveBookSessionOccurrences } from "../bookSession";
 import {
   consumeRateLimit,
   corsHeadersForRequest,
-  currentUserIsBcbaForOrg,
+  currentUserHasScheduleStaffRoleForOrg,
   errorResponse,
   fetchAuthenticatedUserIdWithStatus,
   fetchJson,
@@ -135,25 +135,25 @@ async function assertBookRequestScope(
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 
-  let isBcba = false;
-  const requiresBcbaAuthority =
+  let hasScheduleStaffAuthority = false;
+  const requiresScheduleStaffAuthority =
     !isAdmin &&
     !isSuperAdmin &&
     ((!isTherapist && !isOrgMember) ||
       (isTherapist && body.session.therapist_id !== currentUserId));
-  if (requiresBcbaAuthority) {
-    const bcbaAuthority = await currentUserIsBcbaForOrg(accessToken, organizationId);
-    if (bcbaAuthority.upstreamError) {
-      return errorResponse(request, "upstream_error", "Unable to validate BCBA booking access", { status: 502 });
+  if (requiresScheduleStaffAuthority) {
+    const scheduleStaffAuthority = await currentUserHasScheduleStaffRoleForOrg(accessToken, organizationId);
+    if (scheduleStaffAuthority.upstreamError) {
+      return errorResponse(request, "upstream_error", "Unable to validate scheduling staff booking access", { status: 502 });
     }
-    isBcba = bcbaAuthority.allowed;
+    hasScheduleStaffAuthority = scheduleStaffAuthority.allowed;
   }
 
-  if (!isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember && !isBcba) {
+  if (!isTherapist && !isAdmin && !isSuperAdmin && !isOrgMember && !hasScheduleStaffAuthority) {
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 
-  if (isTherapist && !isAdmin && !isSuperAdmin && !isBcba && body.session.therapist_id !== currentUserId) {
+  if (isTherapist && !isAdmin && !isSuperAdmin && !hasScheduleStaffAuthority && body.session.therapist_id !== currentUserId) {
     return errorResponse(request, "forbidden", "Forbidden", { status: 403 });
   }
 

--- a/src/server/api/shared.ts
+++ b/src/server/api/shared.ts
@@ -284,6 +284,35 @@ export async function currentUserIsBcbaForOrg(
   };
 }
 
+export async function currentUserHasScheduleStaffRoleForOrg(
+  accessToken: string,
+  organizationId: string,
+): Promise<{ allowed: boolean; upstreamError: boolean }> {
+  const { supabaseUrl, anonKey } = getSupabaseConfig();
+
+  for (const roleName of ["admin_schedule", "midtier", "bcba"] as const) {
+    const result = await fetchJson<boolean>(`${supabaseUrl}/rest/v1/rpc/user_has_role_for_org`, {
+      method: "POST",
+      headers: {
+        ...JSON_HEADERS,
+        apikey: anonKey,
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ role_name: roleName, target_organization_id: organizationId }),
+    });
+
+    if (!result.ok && (result.status >= 500 || result.status === 0)) {
+      return { allowed: false, upstreamError: true };
+    }
+
+    if (result.ok && result.data === true) {
+      return { allowed: true, upstreamError: false };
+    }
+  }
+
+  return { allowed: false, upstreamError: false };
+}
+
 export async function currentUserCanDeleteGoalTargets(
   accessToken: string,
   organizationId: string,


### PR DESCRIPTION
## Summary
- align the legacy Node `/api/book` fallback with the established exact schedule-staff roles (`admin_schedule`, `midtier`, `bcba`)
- preserve therapist self-only, organization/entity validation, and fail-closed upstream handling
- add Mid Tier success, upstream failure, and exact-role RPC contract coverage
- link the critical-lane handoff for WIN-254

## Risk
Critical protected-path authorization change in `src/server/**`. No schema, RLS, RPC, Edge Function, runtime-config, UI, or service-role authorization changes.

## Verification
- `npm run ci:check-focused` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- focused Vitest — pass, 47/47
- `npm run build` — pass
- `npm run test:routes:tier0` — pass, 220/220
- `npm run test:ci` — local Windows/Node 24 baseline: 5 failures in files unchanged from `origin/main`; GitHub Node 20/Linux CI is authoritative
- `npm run verify:local` — stops at the same unchanged `test:ci` failures
- `npm run ci:playwright` — locally blocked by unavailable protected Playwright account credentials; required CI gate

## Reviews
- code-review-engineer: approved
- security-engineer: approved after repo and hosted RPC contract verification

## Tracking
- Linear: WIN-254
- Parent audit: WIN-251
- Live production reproof remains required after merge/deploy.