### PR TITLE
fix(fill-docs): serve edge runtime entrypoint

### DIFF
--- a/docs/ai/WIN-253-fill-docs-production-handoff.md
+++ b/docs/ai/WIN-253-fill-docs-production-handoff.md
@@ -85,6 +85,79 @@ After merge:
    DOCX downloads.
 4. Confirm no storage object or `therapist_documents` row is created.
 
+## Production v15 follow-up
+
+PR #862 was merged and deployed as hosted `fill-docs` version 15 with all
+three static DOCX assets, but live browser-origin `OPTIONS` requests still
+timed out. Control Edge Functions answered preflight normally, and
+unauthenticated `fill-docs` requests were rejected promptly at the gateway,
+isolating the defect to the `fill-docs` runtime entrypoint.
+
+The deployed module exported the protected route without registering it with
+`Deno.serve`. The bounded follow-up on
+`codex/win-253-fill-docs-entrypoint` adds only that served entrypoint and its
+focused regression:
+
+- RED with the module-level serve call removed: `4 passed`, `1 failed`
+  because the main-module process never served the expected `204` preflight.
+- GREEN:
+  `$denoExe = (Get-Command deno).Source; & $denoExe test --no-lock --no-check --allow-env --allow-net --allow-read "--allow-run=$denoExe" supabase/functions/fill-docs/index.test.ts`
+  (`5 passed`, `0 failed`).
+- The child process clears inherited environment variables and receives only
+  synthetic Supabase values plus the non-secret Windows runtime roots required
+  to initialize networking.
+- `deno fmt --check` for the function and focused test: passed.
+- `npm run ci:check-focused`: passed.
+- `npm run lint`: passed.
+- `npm run typecheck`: passed.
+- `npm run validate:tenant`: passed.
+- `npm run build`: passed.
+- `npm run test:routes:tier0`: passed (`220 passed`, `0 failed`).
+- `npm run test:ci`: blocked by unrelated baseline failures also reproduced
+  in the clean PR #862 worktree, including the BCBA migration line-ending
+  assertion, async PDF Blob mock, BT/ABA workflow drift, and synthetic BCBA
+  workflow-contract drift.
+- `npm run ci:playwright`: blocked by missing local privileged Playwright
+  credentials.
+- `deno check`: blocked by the existing `TS2589` deep type-instantiation
+  error in `supabase/functions/_shared/org.ts`.
+
+Independent re-review, human merge, a dedicated version 16 deployment, and
+live Computer proof remain required.
+
+### Follow-up verification card
+
+- Classification: high-risk human-reviewed
+- Lane: critical
+- Change type: Supabase Edge Function runtime entrypoint
+- Required checks: focused Deno entrypoint/preflight test,
+  `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`,
+  `npm run test:ci`, `npm run validate:tenant`, `npm run build`,
+  `npm run test:routes:tier0`, `npm run ci:playwright`, and
+  `npm run verify:local`
+- Executed checks:
+  - focused Deno entrypoint/preflight test: passed (`5 passed`, `0 failed`)
+  - `deno fmt --check`: passed
+  - `npm run ci:check-focused`: passed
+  - `npm run lint`: passed
+  - `npm run typecheck`: passed
+  - `npm run validate:tenant`: passed
+  - `npm run build`: passed
+  - `npm run test:routes:tier0`: passed (`220 passed`, `0 failed`)
+  - `npm run test:ci`: failed only on clean-baseline regressions outside this
+    diff; the affected files were reproduced in the clean PR #862 worktree
+- Blocked checks:
+  - `npm run ci:playwright`: local privileged credentials are unavailable
+  - `npm run verify:local`: cannot complete while the same baseline
+    `test:ci` failures and Playwright credential gate remain
+  - `deno check`: existing shared `org.ts` `TS2589` error
+- Result: pass-with-blocked-checks
+- Review: implementation engineer, code review engineer, security engineer,
+  and Supabase reviewer approved the bounded follow-up
+- Residual risk: production behavior is unproven until CI passes, the exact
+  merged function is deployed, and live preflight plus authenticated Mid Tier
+  document generation succeed
+
 ## Residual risk
 
 The largest template produces roughly a 1 MB base64 JSON response. This is

--- a/supabase/functions/fill-docs/index.test.ts
+++ b/supabase/functions/fill-docs/index.test.ts
@@ -68,6 +68,67 @@ Deno.test("fill-docs protected route answers OPTIONS before authentication", asy
   );
 });
 
+Deno.test("fill-docs main module starts the edge runtime and serves preflight", async () => {
+  const endpoint = "http://127.0.0.1:8000/functions/v1/fill-docs";
+  const child = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--no-lock",
+      "--allow-env",
+      "--allow-net",
+      "--allow-read",
+      new URL("./index.ts", import.meta.url).pathname,
+    ],
+    clearEnv: true,
+    env: {
+      ...(Deno.build.os === "windows"
+        ? {
+          SystemRoot: Deno.env.get("SystemRoot") ?? "C:\\Windows",
+          WINDIR: Deno.env.get("WINDIR") ?? "C:\\Windows",
+        }
+        : {}),
+      SUPABASE_URL: "https://example.supabase.co",
+      SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+      SUPABASE_ANON_KEY: "anon-key",
+      SUPABASE_PUBLISHABLE_KEY: "anon-key",
+    },
+    stdout: "null",
+    stderr: "inherit",
+  }).spawn();
+
+  try {
+    let response: Response | undefined;
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      try {
+        response = await fetch(endpoint, {
+          method: "OPTIONS",
+          signal: AbortSignal.timeout(100),
+          headers: {
+            Origin: "https://app.allincompassing.ai",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+          },
+        });
+        break;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    }
+
+    expect(response?.status).toBe(204);
+    expect(response?.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://app.allincompassing.ai",
+    );
+  } finally {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The child exits on its own when no runtime entrypoint is registered.
+    }
+    await child.status;
+  }
+});
+
 Deno.test("fillDocsHandler returns backward-compatible base64 JSON without persistence metadata", async () => {
   const handler = createFillDocsHandler({
     readTemplateBytes: () => Promise.resolve(new Uint8Array([1, 2, 3])),

--- a/supabase/functions/fill-docs/index.ts
+++ b/supabase/functions/fill-docs/index.ts
@@ -226,8 +226,14 @@ export function createFillDocsHandler(deps: FillDocsDeps = {}) {
 
 const fillDocsHandler = createFillDocsHandler();
 
-export default createProtectedRoute(
+export const fillDocsRoute = createProtectedRoute(
   async (req: Request, userContext: UserContext) =>
     fillDocsHandler(req, userContext),
   RouteOptions.therapist,
 );
+
+if (import.meta.main) {
+  Deno.serve(fillDocsRoute);
+}
+
+export default fillDocsRoute;


### PR DESCRIPTION
## Summary
- register the existing protected `fill-docs` route with `Deno.serve` when the module is the Edge Function entrypoint
- add a child-process regression that executes the real main module and proves browser-origin `OPTIONS` returns `204`
- harden the test child with a cleared, synthetic-only environment and document the critical-lane evidence

## Routing and risk
- Linear: WIN-253
- classification: high-risk human-reviewed
- lane: critical (`supabase/functions/**`)
- no shared auth, JWT config, role policy, schema, RLS, grant, RPC, storage, template-content, or tenant-boundary changes

## Verification
- focused Deno test: 5 passed / 0 failed, including real main-module preflight
- regression mutation: removing the module-level serve call produced 4 passed / 1 failed (`undefined` vs expected `204`)
- `deno fmt --check`: passed
- `npm run ci:check-focused`: passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run validate:tenant`: passed
- `npm run build`: passed
- `npm run test:routes:tier0`: 220 passed / 0 failed
- `npm run test:ci`: blocked by unrelated failures reproduced in the clean PR #862 worktree
- `npm run ci:playwright`: blocked locally by missing privileged Playwright credentials; CI remains authoritative

## Independent review
- implementation engineer: approve
- code review engineer: approve
- security engineer: approve after child environment isolation
- Supabase reviewer: approve

## Required after merge
- deploy only `fill-docs` as the next hosted version
- prove browser-origin `OPTIONS` is prompt and returns expected CORS
- prove unauthenticated calls remain denied and hosted `verify_jwt` remains enabled
- re-run synthetic Mid Tier ER/FBA/PR generation through the live UI and capture screenshots
- confirm no storage object or `therapist_documents` row is created

Closes WIN-253 follow-up; production closure remains contingent on merge, deploy, and live proof.