### PR TITLE
fix(scheduling): authorize Mid Tier session holds

### DIFF
--- a/docs/ai/WIN-255-midtier-hold-auth-handoff.md
+++ b/docs/ai/WIN-255-midtier-hold-auth-handoff.md
@@ -1,0 +1,58 @@
+# WIN-255 Midtier Hold Auth Handoff
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- branch: `codex/win-255-midtier-hold-auth`
+- scope:
+  - `tests/integration/acquire-session-hold-bcba-migration.test.ts`
+  - `supabase/migrations/20260727004500_acquire_session_hold_schedule_staff_authorization.sql`
+  - `docs/ai/WIN-255-midtier-hold-auth-handoff.md`
+
+## Change summary
+
+- Added a focused migration contract that now requires exact `admin_schedule` and `midtier` authorization branches in the privileged seven-argument `public.acquire_session_hold` RPC.
+- Added one forward-only migration that copies the current active-status `acquire_session_hold` body and changes only the authorization predicate to admit exact `admin_schedule` and `midtier` alongside the existing `therapist`, `admin`, `super_admin`, and `bcba` checks.
+- Preserved the active therapist/client boundary, optional session organization boundary, fail-closed denial behavior, and service-role-only execute grants.
+
+## TDD evidence
+
+- RED:
+  - focused migration contract failed because the current SQL did not contain exact `midtier` or `admin_schedule` role checks.
+- GREEN:
+  - the same focused migration contract passed after the forward migration was added and the test was pointed at the new reviewed migration file.
+
+## Verification
+
+- `npx vitest run tests/integration/acquire-session-hold-bcba-migration.test.ts tests/edge/scheduling-authorization.bcba.test.ts` -> pass, 10/10.
+- `npm run ci:check-focused` -> pass; database-backed checks explicitly skipped because no local database URL is configured.
+- `npm run lint` -> pass.
+- `npm run typecheck` -> pass.
+- `npm run validate:tenant` -> pass.
+- `npm run build` -> pass.
+- `npm run test:routes:tier0` -> pass, 220/220.
+- `npm run ci:playwright` -> blocked at credential preflight because neither the super-admin nor admin Playwright credential pair is available locally.
+- `npm run test:ci` -> failed on the five pre-existing baseline failures outside this slice:
+  - Windows newline assertion in `tests/authorizations/authorization-bcba-readonly.test.ts`
+  - synthetic BCBA workflow contract in `tests/ci/check-e2e-reliability-gates.test.ts`
+  - generated super-admin/cleanup workflow contract in `tests/scripts/playwright-iehp-assessment-import-smoke.test.ts`
+  - managed proof branch workflow contract in `tests/workflows/bt-aba-disposable-browser-proof.test.ts`
+  - Node 24 `blob.text` incompatibility in `src/lib/__tests__/supabase.edge.test.ts`
+- `npm run verify:local` -> reached the same five pre-existing `test:ci` failures after policy, lint, and typecheck passed; later aggregate stages did not run. Build and Tier-0 route verification were run separately and passed.
+
+## Verification card
+
+- lane: `critical`
+- required checks: focused migration/authorization contracts, policy checks, lint, typecheck, tenant validation, test suite, build, Tier-0 routes, auth/session browser gate, independent security/Supabase/code review, hosted migration application, and live production reproof
+- executed checks: focused contracts, policy checks, lint, typecheck, tenant validation, test suite, build, Tier-0 routes, and three independent reviews
+- blocked checks: local auth/session browser gate lacks the required protected Playwright credentials
+- result: `review-ready with known unrelated baseline failures`; all executable checks specific to this migration passed
+- independent review:
+  - security review: approved
+  - Supabase review: approved
+  - code review: approved
+- residual verification: CI, human review, hosted migration application, and live Mid Tier booking reproof
+
+## Residual risk
+
+- This is a protected migration/auth change. Human review and hosted migration application are still required before merge.
+- Production behavior remains unchanged until the migration is merged and applied through the reviewed deployment path.

--- a/supabase/migrations/20260727004500_acquire_session_hold_schedule_staff_authorization.sql
+++ b/supabase/migrations/20260727004500_acquire_session_hold_schedule_staff_authorization.sql
@@ -1,0 +1,220 @@
+-- @migration-intent: Carry exact persisted schedule-staff booking authority through the privileged session-hold RPC after the edge authorization check.
+-- @migration-dependencies: 20260713183443_acquire_session_hold_active_status.sql
+-- @migration-rollback: Reapply this function without the exact admin_schedule and midtier user_has_role_for_org branches.
+
+begin;
+
+create or replace function public.acquire_session_hold(
+  p_therapist_id uuid,
+  p_client_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz,
+  p_session_id uuid default null,
+  p_hold_seconds integer default 300,
+  p_actor_id uuid default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_hold session_holds;
+  v_constraint_name text;
+  v_original_sub text;
+  v_original_role text;
+  v_actor_is_authorized boolean;
+  v_target_organization_id uuid;
+begin
+  delete from session_holds where expires_at <= timezone('utc', now());
+
+  if p_actor_id is null then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'FORBIDDEN',
+      'error_message', 'Actor is required to manage session holds.'
+    );
+  end if;
+
+  v_original_sub := current_setting('request.jwt.claim.sub', true);
+  v_original_role := current_setting('request.jwt.claim.role', true);
+
+  perform set_config('request.jwt.claim.sub', p_actor_id::text, true);
+  perform set_config('request.jwt.claim.role', 'authenticated', true);
+
+  v_actor_is_authorized := (
+    app.user_has_role_for_org('therapist', null, p_therapist_id, null, p_session_id)
+    or app.user_has_role_for_org('admin', null, p_therapist_id, null, p_session_id)
+    or app.user_has_role_for_org('super_admin', null, p_therapist_id, null, p_session_id)
+    or app.user_has_role_for_org('bcba', null, p_therapist_id, null, p_session_id)
+    or app.user_has_role_for_org('admin_schedule', null, p_therapist_id, null, p_session_id)
+    or app.user_has_role_for_org('midtier', null, p_therapist_id, null, p_session_id)
+  );
+
+  perform set_config('request.jwt.claim.sub', coalesce(v_original_sub, ''), true);
+  perform set_config('request.jwt.claim.role', coalesce(v_original_role, ''), true);
+
+  if not v_actor_is_authorized then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'FORBIDDEN',
+      'error_message', 'Actor is not permitted to manage holds for this therapist.'
+    );
+  end if;
+
+  select t.organization_id into v_target_organization_id
+  from therapists t
+  where t.id = p_therapist_id
+    and t.status = 'active'
+    and t.deleted_at is null;
+
+  if v_target_organization_id is null
+     or not exists (
+       select 1
+       from clients c
+       where c.id = p_client_id
+         and c.organization_id = v_target_organization_id
+         and c.status = 'active'
+         and c.deleted_at is null
+     ) then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'FORBIDDEN',
+      'error_message', 'Therapist and client must share an active organization boundary.'
+    );
+  end if;
+
+  if p_session_id is not null
+     and not exists (
+       select 1
+       from sessions s
+       where s.id = p_session_id
+         and s.organization_id = v_target_organization_id
+     ) then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'FORBIDDEN',
+      'error_message', 'Session does not match the active organization boundary.'
+    );
+  end if;
+
+  if p_start_time >= p_end_time then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'INVALID_RANGE',
+      'error_message', 'End time must be after start time.'
+    );
+  end if;
+
+  if exists (
+    select 1
+    from sessions s
+    where s.therapist_id = p_therapist_id
+      and (p_session_id is null or s.id <> p_session_id)
+      and s.status <> 'cancelled'
+      and tstzrange(s.start_time, s.end_time, '[)') && tstzrange(p_start_time, p_end_time, '[)')
+  ) then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'THERAPIST_CONFLICT',
+      'error_message', 'Therapist already has a session during this time.'
+    );
+  end if;
+
+  if exists (
+    select 1
+    from sessions s
+    where s.client_id = p_client_id
+      and (p_session_id is null or s.id <> p_session_id)
+      and s.status <> 'cancelled'
+      and tstzrange(s.start_time, s.end_time, '[)') && tstzrange(p_start_time, p_end_time, '[)')
+  ) then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'CLIENT_CONFLICT',
+      'error_message', 'Client already has a session during this time.'
+    );
+  end if;
+
+  if exists (
+    select 1
+    from session_holds h
+    where h.therapist_id = p_therapist_id
+      and h.expires_at > timezone('utc', now())
+      and tstzrange(h.start_time, h.end_time, '[)') && tstzrange(p_start_time, p_end_time, '[)')
+  ) then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'THERAPIST_HOLD_CONFLICT',
+      'error_message', 'Therapist already has a hold during this time.'
+    );
+  end if;
+
+  if exists (
+    select 1
+    from session_holds h
+    where h.client_id = p_client_id
+      and h.expires_at > timezone('utc', now())
+      and tstzrange(h.start_time, h.end_time, '[)') && tstzrange(p_start_time, p_end_time, '[)')
+  ) then
+    return jsonb_build_object(
+      'success', false,
+      'error_code', 'CLIENT_HOLD_CONFLICT',
+      'error_message', 'Client already has a hold during this time.'
+    );
+  end if;
+
+  begin
+    insert into session_holds (
+      therapist_id,
+      client_id,
+      start_time,
+      end_time,
+      session_id,
+      expires_at
+    )
+    values (
+      p_therapist_id,
+      p_client_id,
+      p_start_time,
+      p_end_time,
+      p_session_id,
+      timezone('utc', now()) + make_interval(secs => coalesce(p_hold_seconds, 300))
+    )
+    returning * into v_hold;
+  exception
+    when unique_violation then
+      return jsonb_build_object(
+        'success', false,
+        'error_code', 'HOLD_EXISTS',
+        'error_message', 'A hold already exists for this time.'
+      );
+    when exclusion_violation then
+      get stacked diagnostics v_constraint_name = constraint_name;
+      if v_constraint_name = 'session_holds_therapist_time_excl' then
+        return jsonb_build_object(
+          'success', false,
+          'error_code', 'THERAPIST_HOLD_CONFLICT',
+          'error_message', 'Therapist already has a hold during this time.'
+        );
+      elsif v_constraint_name = 'session_holds_client_time_excl' then
+        return jsonb_build_object(
+          'success', false,
+          'error_code', 'CLIENT_HOLD_CONFLICT',
+          'error_message', 'Client already has a hold during this time.'
+        );
+      else
+        raise;
+      end if;
+  end;
+
+  return jsonb_build_object(
+    'success', true,
+    'hold', row_to_json(v_hold)
+  );
+end;
+$$;
+
+revoke execute on function public.acquire_session_hold(uuid, uuid, timestamptz, timestamptz, uuid, integer, uuid) from public, anon, authenticated;
+grant execute on function public.acquire_session_hold(uuid, uuid, timestamptz, timestamptz, uuid, integer, uuid) to service_role;
+
+commit;

--- a/tests/integration/acquire-session-hold-bcba-migration.test.ts
+++ b/tests/integration/acquire-session-hold-bcba-migration.test.ts
@@ -4,15 +4,21 @@ import { describe, expect, it } from "vitest";
 
 const migrationPath = resolve(
   process.cwd(),
-  "supabase/migrations/20260713183443_acquire_session_hold_active_status.sql",
+  "supabase/migrations/20260727004500_acquire_session_hold_schedule_staff_authorization.sql",
 );
 
-describe("acquire_session_hold BCBA authorization migration", () => {
+describe("acquire_session_hold scheduling authorization migration", () => {
   const sql = readFileSync(migrationPath, "utf8").toLowerCase();
 
-  it("adds exact persisted BCBA authorization for the target therapist organization", () => {
+  it("adds exact persisted schedule-staff authorization for the target therapist organization", () => {
     expect(sql).toContain(
       "app.user_has_role_for_org('bcba', null, p_therapist_id, null, p_session_id)",
+    );
+    expect(sql).toContain(
+      "app.user_has_role_for_org('midtier', null, p_therapist_id, null, p_session_id)",
+    );
+    expect(sql).toContain(
+      "app.user_has_role_for_org('admin_schedule', null, p_therapist_id, null, p_session_id)",
     );
   });
 


### PR DESCRIPTION
## Summary
- authorize exact persisted `midtier` and `admin_schedule` roles in the privileged seven-argument `acquire_session_hold` RPC
- preserve the existing therapist, admin, super-admin, BCBA, active-record, organization-boundary, conflict, and service-role-only protections
- add a focused migration contract and critical-lane verification handoff

## Production defect
A synthetic Mid Tier booking reached `sessions-hold`, passed outer authorization (`authorization.ok=true`), then received RPC `FORBIDDEN`: `Actor is not permitted to manage holds for this therapist.` The live RPC lacked exact Mid Tier/scheduling-staff authorization branches.

## Verification
- focused migration/edge contracts: 10/10 pass
- `npm run ci:check-focused`: pass
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run validate:tenant`: pass
- `npm run build`: pass
- `npm run test:routes:tier0`: 220/220 pass
- independent code, security, and Supabase reviews: approved
- `npm run ci:playwright`: locally blocked by unavailable protected Playwright credential pair
- `npm run test:ci` / `npm run verify:local`: five documented pre-existing baseline failures outside this slice

## Risk
Critical protected database/auth boundary. Human review is required. Production reproof will occur only after the reviewed migration is deployed.

Linear: WIN-255