### PR TITLE
fix(clients): explain onboarding ID conflicts

### DIFF
--- a/docs/ai/WIN-257-client-onboarding-conflict-handoff.md
+++ b/docs/ai/WIN-257-client-onboarding-conflict-handoff.md
@@ -1,0 +1,84 @@
+# WIN-257 Client Onboarding Conflict Handoff
+
+- Date: 2026-07-27
+- Route classification: standard
+- Lane rationale: low-risk autonomous UI and client-side mutation handling limited to onboarding conflict mapping; no schema, RPC, or deploy changes
+
+## Scope
+
+- `src/lib/clients/mutations.ts`
+- `src/lib/clients/__tests__/mutations.test.ts`
+- `src/components/ClientOnboarding.tsx`
+- `src/components/__tests__/ClientOnboarding.test.tsx`
+
+## Non-goals
+
+- No Supabase migrations, RPC edits, or preflight uniqueness queries beyond the existing email check
+- No onboarding flow redesign outside duplicate-conflict handling
+- No changes to unrelated onboarding validation, auth, routing, or storage behavior
+
+## Implementation Summary
+
+- Added client-layer mapping for `23505` / `409` unique conflicts during client creation.
+- Mapped `clients_org_client_id_idx` to an actionable client-ID conflict error.
+- Kept global `clients_email_key` conflicts generic so onboarding does not reveal
+  whether an email exists in another organization.
+- Mapped unknown unique conflicts to a generic duplicate-record error.
+- Updated onboarding submit error handling so client-ID conflicts return the user to Basic Info, preserve form state, and surface the field error inline.
+
+## Evidence
+
+- RED command attempted first:
+  - `npx vitest run src/lib/clients/__tests__/mutations.test.ts src/components/__tests__/ClientOnboarding.test.tsx`
+  - Result: blocked locally because `node.exe` was not available on PATH in the shell
+- Reviewer follow-up RED command:
+  - `C:\Users\test\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\vitest\vitest.mjs run src/lib/clients/__tests__/mutations.test.ts`
+  - Result: failed as expected before the mapper fix because `{ status: 409, code: '23503' }` was incorrectly rewritten as a duplicate-record conflict
+- GREEN command:
+  - `C:\Users\test\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\vitest\vitest.mjs run src/lib/clients/__tests__/mutations.test.ts src/components/__tests__/ClientOnboarding.test.tsx`
+  - Result: passed with `2` files / `23` tests
+- Security follow-up RED command:
+  - `npm run test -- src/lib/clients/__tests__/mutations.test.ts`
+  - Result: failed as expected because the initial mapper exposed an email-specific
+    message for the globally unique `clients_email_key`.
+- Final GREEN command:
+  - `npm run test -- src/lib/clients/__tests__/mutations.test.ts src/components/__tests__/ClientOnboarding.test.tsx`
+  - Result: passed with `2` files / `24` tests
+
+## Verification Card
+
+- Lane: `standard`
+- Required checks:
+  - focused mutation and onboarding tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run validate:tenant`
+  - `npm run build`
+- Executed checks:
+  - focused tests: passed, `2` files / `24` tests
+  - `npm run ci:check-focused`: passed; protected-service checks without a
+    configured database URL were explicitly skipped by the policy runner
+  - `npm run lint`: passed
+  - `npm run typecheck`: passed
+  - `npm run validate:tenant`: passed
+  - `npm run build`: passed
+  - `npm run test:routes:tier0`: passed, `7` specs / `220` tests
+  - `npm run test:ci`: failed in `5` unrelated baseline tests outside the changed
+    onboarding surfaces, including authorization migration text drift, disposable
+    browser-proof workflow drift, synthetic BCBA provisioning workflow drift, and
+    the async PDF blob test (`blob.text is not a function`)
+- Blocked checks:
+  - `npm run ci:playwright`: preflight stopped because neither supported
+    admin credential pair is available in this local environment
+- Result: focused onboarding verification passed; repository-wide closure remains
+  blocked by the unrelated `test:ci` failures and unavailable Playwright credentials.
+
+## Residual Risk
+
+- Hosted `create_client` responses that report unique conflicts without SQLSTATE `23505` will only map when the code is absent and the payload still clearly states `duplicate key value violates unique constraint`.
+- No migration, function deploy, RLS, grant, or production-data change is part of
+  this fix.

--- a/src/components/ClientOnboarding.tsx
+++ b/src/components/ClientOnboarding.tsx
@@ -20,6 +20,7 @@ import { prepareFormData } from '../lib/validation';
 import { logger } from '../lib/logger/logger';
 import { clientSchema, type ClientFormData } from '../lib/validationSchemas';
 import {
+  ClientCreateConflictError,
   checkClientEmailExists,
   createClient as createClientRecord,
   updateClientDocuments,
@@ -374,7 +375,18 @@ export function ClientOnboarding({ onComplete }: ClientOnboardingProps) {
         context: { component: 'ClientOnboarding', operation: 'createClientMutation' },
         track: false
       });
-      showError(error);
+
+      if (error instanceof ClientCreateConflictError) {
+        if (error.conflict === 'client_id') {
+          setError('client_id', { type: 'manual', message: error.message });
+          setCurrentStep(1);
+        }
+
+        showError(error.message);
+      } else {
+        showError(error);
+      }
+
       setIsSubmitting(false);
     }
   });
@@ -715,6 +727,9 @@ export function ClientOnboarding({ onComplete }: ClientOnboardingProps) {
                 <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                   Optional: Enter existing client ID if available
                 </p>
+                {errors.client_id && (
+                  <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.client_id.message}</p>
+                )}
               </div>
 
               <div>

--- a/src/components/__tests__/ClientOnboarding.test.tsx
+++ b/src/components/__tests__/ClientOnboarding.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
 import { ClientOnboarding } from '../ClientOnboarding';
+import { ClientCreateConflictError } from '../../lib/clients/mutations';
 import { showError } from '../../lib/toast';
 
 const mockNavigate = vi.fn();
@@ -33,8 +34,24 @@ vi.mock('../../lib/organization', () => ({
 
 vi.mock('../../lib/supabase', () => {
   const uploadMock = vi.fn().mockResolvedValue({ error: null });
+  const orderMock = vi.fn().mockResolvedValue({
+    data: [
+      { code: 'H0031', short_description: 'Direct treatment' },
+      { code: 'S5110', short_description: 'Parent consultation' },
+    ],
+    error: null,
+  });
+  const eqMock = vi.fn(() => ({
+    order: orderMock,
+  }));
+  const selectMock = vi.fn(() => ({
+    eq: eqMock,
+  }));
   return {
     supabase: {
+      from: vi.fn(() => ({
+        select: selectMock,
+      })),
       storage: {
         from: vi.fn(() => ({
           upload: uploadMock,
@@ -48,10 +65,16 @@ const checkClientEmailExistsMock = vi.fn();
 const createClientMock = vi.fn();
 const callEdgeFunctionHttpMock = vi.fn();
 
-vi.mock('../../lib/clients/mutations', () => ({
-  checkClientEmailExists: (...args: unknown[]) => checkClientEmailExistsMock(...args),
-  createClient: (...args: unknown[]) => createClientMock(...args),
-}));
+vi.mock('../../lib/clients/mutations', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/clients/mutations')>(
+    '../../lib/clients/mutations',
+  );
+  return {
+    ...actual,
+    checkClientEmailExists: (...args: unknown[]) => checkClientEmailExistsMock(...args),
+    createClient: (...args: unknown[]) => createClientMock(...args),
+  };
+});
 
 vi.mock('../../lib/api', () => ({
   callEdgeFunctionHttp: (...args: unknown[]) => callEdgeFunctionHttpMock(...args),
@@ -96,10 +119,16 @@ describe('ClientOnboarding step progression', () => {
     return { user, onComplete };
   };
 
-  const advanceToServiceStep = async (user: ReturnType<typeof userEvent.setup>) => {
+  const fillBasicInfo = async (
+    user: ReturnType<typeof userEvent.setup>,
+    overrides: { clientId?: string } = {},
+  ) => {
     await user.type(screen.getByLabelText('First Name'), 'Ada');
     await user.type(screen.getByLabelText('Last Name'), 'Lovelace');
     await user.type(screen.getByLabelText('Date of Birth'), '2010-01-01');
+    if (overrides.clientId) {
+      await user.type(screen.getByLabelText('Client ID'), overrides.clientId);
+    }
     const emailInput = screen.getByLabelText('Email');
     await user.type(emailInput, 'ada@example.com');
     await user.tab();
@@ -107,6 +136,13 @@ describe('ClientOnboarding step progression', () => {
     await waitFor(() => {
       expect(checkClientEmailExistsMock).toHaveBeenCalled();
     });
+  };
+
+  const advanceToServiceStep = async (
+    user: ReturnType<typeof userEvent.setup>,
+    overrides: { clientId?: string } = {},
+  ) => {
+    await fillBasicInfo(user, overrides);
 
     const nextButton = () => screen.getByRole('button', { name: 'Next' });
 
@@ -118,6 +154,21 @@ describe('ClientOnboarding step progression', () => {
 
     await user.click(nextButton());
     await screen.findByText('Service Information');
+  };
+
+  const advanceToDocumentsStep = async (
+    user: ReturnType<typeof userEvent.setup>,
+    overrides: { clientId?: string } = {},
+  ) => {
+    await advanceToServiceStep(user, overrides);
+
+    await user.click(screen.getByRole('button', { name: 'Add Insurance' }));
+    await user.clear(screen.getByLabelText('Contract Units'));
+    await user.type(screen.getByLabelText('Contract Units'), '8');
+    await user.selectOptions(screen.getByLabelText('Select Codes'), ['H0031']);
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    await screen.findByText('Documents & Consent');
   };
 
   it('blocks advancing from service step when insurance contracts are missing', async () => {
@@ -288,5 +339,34 @@ describe('ClientOnboarding step progression', () => {
     expect(screen.getByLabelText('First Name')).toHaveValue('');
     expect(screen.getByLabelText('Email')).toHaveValue('');
   });
+
+  it('returns to Basic Info with a client ID field error when submit hits a duplicate client ID conflict', async () => {
+    createClientMock.mockRejectedValueOnce(
+      new ClientCreateConflictError(
+        'client_id',
+        'This client ID is already in use for this organization. Enter a different client ID.',
+        { code: '23505', status: 409 },
+      ),
+    );
+
+    const { user, onComplete } = setup();
+
+    await advanceToDocumentsStep(user, { clientId: 'CLIENT-42' });
+    await user.click(screen.getByLabelText('I consent to the collection and processing of this information'));
+    await user.click(screen.getByRole('button', { name: 'Complete Onboarding' }));
+
+    await screen.findByText('Basic Information');
+    expect(screen.getByLabelText('Client ID')).toHaveValue('CLIENT-42');
+    expect(
+      screen.getByText(
+        'This client ID is already in use for this organization. Enter a different client ID.',
+      ),
+    ).toBeInTheDocument();
+    expect(vi.mocked(showError)).toHaveBeenCalledWith(
+      'This client ID is already in use for this organization. Enter a different client ID.',
+    );
+    expect(createClientMock).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
+  }, 20000);
 });
 

--- a/src/lib/clients/__tests__/mutations.test.ts
+++ b/src/lib/clients/__tests__/mutations.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '../../generated/database.types';
-import { checkClientEmailExists, createClient, updateClientDocuments } from '../mutations';
+import {
+  checkClientEmailExists,
+  ClientCreateConflictError,
+  createClient,
+  updateClientDocuments,
+} from '../mutations';
 
 const buildSupabaseMock = () => {
   const selectMock = vi.fn();
@@ -98,6 +103,114 @@ describe('createClient', () => {
       'create_client RPC returned no data',
     );
     expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('maps client ID unique conflicts from the RPC into an actionable conflict error', async () => {
+    const { supabase, rpcMock } = buildSupabaseMock();
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: {
+        code: '23505',
+        status: 409,
+        message: 'duplicate key value violates unique constraint "clients_org_client_id_idx"',
+        details: 'Key (organization_id, client_id)=(org-1, CLIENT-42) already exists.',
+      },
+    });
+
+    await expect(createClient(supabase, { client_id: 'CLIENT-42' })).rejects.toMatchObject({
+      name: 'ClientCreateConflictError',
+      conflict: 'client_id',
+      message: 'This client ID is already in use for this organization. Enter a different client ID.',
+    });
+  });
+
+  it('does not disclose email existence when a global email unique conflict occurs', async () => {
+    const { supabase, rpcMock, insertMock } = buildSupabaseMock();
+    rpcMock.mockResolvedValue({ data: null, error: { code: 'PGRST301', message: 'not found' } });
+    insertMock.mockReturnValue({
+      select: () => ({
+        single: () =>
+          Promise.resolve({
+            data: null,
+            error: {
+              code: '23505',
+              status: 409,
+              message: 'duplicate key value violates unique constraint "clients_email_key"',
+              details: 'Key (email)=(ada@example.com) already exists.',
+            },
+          }),
+      }),
+    });
+
+    await expect(createClient(supabase, { email: 'ada@example.com' })).rejects.toMatchObject({
+      name: 'ClientCreateConflictError',
+      conflict: 'duplicate',
+      message: 'A duplicate client record already exists. Review the client details and try again.',
+    });
+  });
+
+  it('maps unknown unique conflicts into a generic duplicate-record error', async () => {
+    const { supabase, rpcMock } = buildSupabaseMock();
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: {
+        code: '23505',
+        status: 409,
+        message: 'duplicate key value violates unique constraint "clients_some_other_key"',
+        details: 'Key (some_field)=(value) already exists.',
+      },
+    });
+
+    await expect(createClient(supabase, { client_id: 'CLIENT-42' })).rejects.toMatchObject({
+      name: 'ClientCreateConflictError',
+      conflict: 'duplicate',
+      message: 'A duplicate client record already exists. Review the client details and try again.',
+    });
+  });
+
+  it('maps a code-less 409 only when it contains canonical unique-constraint text', async () => {
+    const { supabase, rpcMock } = buildSupabaseMock();
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: {
+        status: 409,
+        message: 'duplicate key value violates unique constraint "clients_org_client_id_idx"',
+        details: 'Key (organization_id, client_id)=(org-1, CLIENT-42) already exists.',
+      },
+    });
+
+    await expect(createClient(supabase, { client_id: 'CLIENT-42' })).rejects.toMatchObject({
+      name: 'ClientCreateConflictError',
+      conflict: 'client_id',
+    });
+  });
+
+  it('preserves non-unique 409 RPC errors even when they use a PostgREST conflict status', async () => {
+    const { supabase, rpcMock } = buildSupabaseMock();
+    const error = {
+      code: '23503',
+      status: 409,
+      message: 'insert or update on table "clients" violates foreign key constraint',
+      details: 'Key (organization_id)=(org-1) is not present in table "organizations".',
+    };
+    rpcMock.mockResolvedValue({
+      data: null,
+      error,
+    });
+
+    await expect(createClient(supabase, { client_id: 'CLIENT-42' })).rejects.toEqual(error);
+  });
+
+  it('exports a dedicated conflict error type for onboarding handling', () => {
+    const error = new ClientCreateConflictError(
+      'client_id',
+      'This client ID is already in use for this organization. Enter a different client ID.',
+      { code: '23505' },
+    );
+
+    expect(error.name).toBe('ClientCreateConflictError');
+    expect(error.conflict).toBe('client_id');
+    expect(error.cause).toEqual({ code: '23505' });
   });
 });
 

--- a/src/lib/clients/mutations.ts
+++ b/src/lib/clients/mutations.ts
@@ -11,7 +11,92 @@ type RpcResponse = { data: ClientsTable | null; error: unknown } | { data: Clien
 
 type ClientSupabase = SupabaseClient<Database>;
 
+type ClientCreateConflict = 'client_id' | 'duplicate';
+
+interface MaybePostgrestConflictError {
+  code?: unknown;
+  status?: unknown;
+  message?: unknown;
+  details?: unknown;
+  hint?: unknown;
+}
+
+export class ClientCreateConflictError extends Error {
+  readonly conflict: ClientCreateConflict;
+  override readonly cause: unknown;
+
+  constructor(conflict: ClientCreateConflict, message: string, cause: unknown) {
+    super(message);
+    this.name = 'ClientCreateConflictError';
+    this.conflict = conflict;
+    this.cause = cause;
+  }
+}
+
 const sanitizeEmailPattern = (email: string): string => email.replace(/[%_]/g, (char) => `\\${char}`);
+
+const toSearchableText = (value: unknown): string => (typeof value === 'string' ? value.trim().toLowerCase() : '');
+
+const getPostgrestConflictError = (error: unknown): MaybePostgrestConflictError => (
+  error && typeof error === 'object'
+    ? (error as MaybePostgrestConflictError)
+    : {}
+);
+
+const isUniqueConflictError = (error: unknown): boolean => {
+  const postgrestError = getPostgrestConflictError(error);
+  const code = toSearchableText(postgrestError.code);
+  if (code) {
+    return code === '23505';
+  }
+
+  const status = typeof postgrestError.status === 'number' ? postgrestError.status : null;
+  if (status !== 409) {
+    return false;
+  }
+
+  const combined = [
+    postgrestError.message,
+    postgrestError.details,
+    postgrestError.hint,
+  ]
+    .map(toSearchableText)
+    .join(' ');
+
+  return combined.includes('duplicate key value violates unique constraint');
+};
+
+const toClientCreateConflictError = (error: unknown): ClientCreateConflictError | null => {
+  if (!isUniqueConflictError(error)) {
+    return null;
+  }
+
+  const postgrestError = getPostgrestConflictError(error);
+  const combined = [
+    postgrestError.message,
+    postgrestError.details,
+    postgrestError.hint,
+  ]
+    .map(toSearchableText)
+    .join(' ');
+
+  if (
+    combined.includes('clients_org_client_id_idx')
+    || combined.includes('(organization_id, client_id)')
+  ) {
+    return new ClientCreateConflictError(
+      'client_id',
+      'This client ID is already in use for this organization. Enter a different client ID.',
+      error,
+    );
+  }
+
+  return new ClientCreateConflictError(
+    'duplicate',
+    'A duplicate client record already exists. Review the client details and try again.',
+    error,
+  );
+};
 
 const fetchClientByEmail = async (
   supabase: ClientSupabase,
@@ -103,6 +188,7 @@ export const createClient = async (
   payload: Partial<ClientInsert>,
 ): Promise<ClientsTable> => {
   const rpcResult = await createClientViaRpc(supabase, payload);
+  const mappedRpcConflictError = toClientCreateConflictError(rpcResult.error);
 
   if (!rpcResult.error) {
     if (rpcResult.data) {
@@ -120,11 +206,14 @@ export const createClient = async (
 
   if (!isMissingRpcFunctionError(rpcResult.error, 'create_client')) {
     logger.error('create_client RPC failed', {
-      error: toError(rpcResult.error, describePostgrestError(rpcResult.error)),
+      error: toError(
+        mappedRpcConflictError ?? rpcResult.error,
+        describePostgrestError(rpcResult.error),
+      ),
       metadata: { providedFields: Object.keys(payload) },
       track: false,
     });
-    throw rpcResult.error;
+    throw mappedRpcConflictError ?? rpcResult.error;
   }
 
   logger.warn('create_client RPC missing; attempting direct insert fallback', {
@@ -135,12 +224,13 @@ export const createClient = async (
   try {
     return await insertClientDirectly(supabase, payload);
   } catch (fallbackError) {
+    const mappedConflictError = toClientCreateConflictError(fallbackError);
     logger.error('Client insert fallback failed', {
-      error: toError(fallbackError, 'Client insert fallback failed'),
+      error: toError(mappedConflictError ?? fallbackError, 'Client insert fallback failed'),
       metadata: { providedFields: Object.keys(payload) },
       track: false,
     });
-    throw fallbackError;
+    throw mappedConflictError ?? fallbackError;
   }
 };
 


### PR DESCRIPTION
## Summary

- translate `create_client` unique violations into safe client-create conflict errors
- return onboarding to Basic Info with an inline Client ID error while preserving entered form values
- keep global email uniqueness conflicts generic to avoid cross-tenant existence disclosure
- add focused mutation and full onboarding-flow regression coverage

## Root cause

The hosted `create_client` RPC correctly rejected a duplicate
`(organization_id, client_id)` under `clients_org_client_id_idx` with PostgreSQL
`23505`, exposed by PostgREST as HTTP 409. The onboarding UI treated that
expected conflict as an unclassified mutation failure, so users received only a
generic error and retried the same submission.

No migration, RPC, RLS, grant, function deployment, or production-data change
is included.

Linear: [WIN-257](https://linear.app/winningedgeai/issue/WIN-257/surface-duplicate-client-id-during-client-onboarding)

## Verification

Passed:

- focused Vitest: 2 files / 24 tests
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`
- `npm run test:routes:tier0`: 7 specs / 220 tests
- independent code review: approved
- independent security review: approved after genericizing global email conflicts

Blocked or failing outside this slice:

- `npm run test:ci`: 5 repository-wide failures in unrelated
  authorization/workflow/PDF-blob tests; the focused onboarding suites pass
- `npm run ci:playwright`: stopped at preflight because no supported local admin
  credential pair is available

The verification card and residual risk are recorded in
`docs/ai/WIN-257-client-onboarding-conflict-handoff.md`.
