### PR TITLE
WIN-258 Add schedule cancellation attribution

### DIFF
--- a/docs/ai/WIN-258-schedule-cancellation-attribution-handoff.md
+++ b/docs/ai/WIN-258-schedule-cancellation-attribution-handoff.md
@@ -1,0 +1,89 @@
+# WIN-258 Schedule Cancellation Attribution Handoff
+
+## Routing
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- why: bounded non-trivial scheduling UI and page-orchestration behavior with focused regression coverage; no auth, server/API, runtime configuration, database, CI, or deploy paths changed
+- triggering paths:
+  - `src/components/SessionModal.tsx`
+  - `src/pages/Schedule.tsx`
+  - focused scheduling tests
+
+## Scope
+
+- task intent: replace the generic cancellation choice with Staff cancellation and Client cancellation for schedule creators, keep cancellation unavailable to non-creators, and remove the duplicate Program and Primary Goal dropdowns while preserving the lower clickable plan controls and their query-error recovery
+- files touched:
+  - `src/components/SessionModal.tsx`
+  - `src/components/__tests__/SessionModal.test.tsx`
+  - `src/components/__tests__/SchedulingFlow.test.tsx`
+  - `src/components/__tests__/SchedulingIntegration.test.tsx`
+  - `src/pages/Schedule.tsx`
+  - `src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
+  - `docs/superpowers/specs/2026-07-27-schedule-cancellation-attribution-design.md`
+  - `docs/superpowers/plans/2026-07-27-schedule-cancellation-attribution.md`
+  - `docs/ai/WIN-258-schedule-cancellation-attribution-handoff.md`
+- single-purpose diff: yes
+- non-goals:
+  - no changes to role resolution, cancellation persistence helpers, Supabase, API, CI, or deployment behavior
+  - no redesign of the lower multi-program and multi-goal controls
+
+## Required Agents
+
+- required sequence:
+  - `specification-engineer`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+- agents used:
+  - specification review for acceptance criteria and role boundaries
+  - implementation engineers for modal behavior, Schedule boundary wiring, selector removal, and verification-test repair
+  - code reviewers for each production slice and the final test repair
+  - test engineer for the standard-lane verification matrix and missing staff-fallback coverage
+- reviewer: completed
+
+## Verification Card
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- change type: `UI/component/page`
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - focused SessionModal, Schedule orchestration, and scheduling-flow tests
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - `npm run ci:check-focused`: pass; database and branch-protection checks reported their documented local skips
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npx vitest run src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx --reporter=dot`: pass, 173 tests
+  - `npx vitest run src/components/__tests__/SchedulingFlow.test.tsx src/components/__tests__/SchedulingIntegration.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx --reporter=dot`: pass, 58 tests
+  - `npm run build`: pass
+  - `npm run test:ci`: fail only in five files unchanged from `main`; 425 files and 3,446 tests passed
+  - `npm run verify:local`: blocked at the same `test:ci` baseline failures after policy, lint, and typecheck passed
+- blocked checks:
+  - `npm run test:ci`: four unchanged static CI/migration contract tests expect repository state not present on current `main`; `src/lib/__tests__/supabase.edge.test.ts` also fails in isolation because the local Blob implementation lacks `text()`
+  - `npm run verify:local`: stops at the same unchanged-from-`main` `test:ci` failures, so its later coverage and tier-0 steps do not run
+- result: `pass-with-blocked-checks`
+- residual risk: live CI must distinguish the five current-main baseline failures from the WIN-258 scheduling diff; focused scheduling behavior, type safety, lint, policy, and production build are green
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes, `WIN-258`
+- protected-path drift: none
+- unrelated changes: none
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: yes, with baseline failures called out for reviewer and live-check triage
+- required follow-up:
+  - push `codex/win-258-schedule-cancellation`
+  - open a PR against `main`
+  - inspect live required checks and do not merge while any branch-caused required check is failing
+
+## Handoff Summary
+
+Schedule creators now choose Staff cancellation or Client cancellation, and the selected attribution is forwarded through the existing cancellation helper. BT and therapist-scoped users do not receive selectable cancellation actions, while already-cancelled records remain representable. The redundant upper Program and Primary Goal dropdowns are removed; the lower clickable program and goal controls remain interactive, distinguish query failures from empty data, and retain focused retry actions. All slice-specific checks pass, with full local verification blocked only by five tests in unchanged current-main surfaces.

--- a/docs/ai/WIN-258-schedule-cancellation-attribution-handoff.md
+++ b/docs/ai/WIN-258-schedule-cancellation-attribution-handoff.md
@@ -20,6 +20,11 @@
   - `src/components/__tests__/SchedulingIntegration.test.tsx`
   - `src/pages/Schedule.tsx`
   - `src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
+  - `scripts/playwright-session-lifecycle.ts`
+  - `scripts/lib/playwright-session-plan-controls.ts`
+  - `scripts/lib/playwright-inprogress-session-setup.ts`
+  - `scripts/playwright-schedule-conflict.ts`
+  - `tests/scripts/playwright-session-lifecycle.test.ts`
   - `docs/superpowers/specs/2026-07-27-schedule-cancellation-attribution-design.md`
   - `docs/superpowers/plans/2026-07-27-schedule-cancellation-attribution.md`
   - `docs/ai/WIN-258-schedule-cancellation-attribution-handoff.md`
@@ -61,6 +66,7 @@
   - `npm run typecheck`: pass
   - `npx vitest run src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx --reporter=dot`: pass, 173 tests
   - `npx vitest run src/components/__tests__/SchedulingFlow.test.tsx src/components/__tests__/SchedulingIntegration.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx --reporter=dot`: pass, 58 tests
+  - `npx vitest run tests/scripts/playwright-session-lifecycle.test.ts src/components/__tests__/SessionModal.test.tsx --reporter=dot`: pass, 152 tests
   - `npm run build`: pass
   - `npm run test:ci`: fail only in five files unchanged from `main`; 425 files and 3,446 tests passed
   - `npm run verify:local`: blocked at the same `test:ci` baseline failures after policy, lint, and typecheck passed
@@ -86,4 +92,4 @@
 
 ## Handoff Summary
 
-Schedule creators now choose Staff cancellation or Client cancellation, and the selected attribution is forwarded through the existing cancellation helper. BT and therapist-scoped users do not receive selectable cancellation actions, while already-cancelled records remain representable. The redundant upper Program and Primary Goal dropdowns are removed; the lower clickable program and goal controls remain interactive, distinguish query failures from empty data, and retain focused retry actions. All slice-specific checks pass, with full local verification blocked only by five tests in unchanged current-main surfaces.
+Schedule creators now choose Staff cancellation or Client cancellation, and the selected attribution is forwarded through the existing cancellation helper. BT and therapist-scoped users do not receive selectable cancellation actions, while already-cancelled records remain representable. The redundant upper Program and Primary Goal dropdowns are removed; the lower clickable program and goal controls remain interactive, distinguish query failures from empty data, retain focused retry actions, and expose stable selectors to the hosted lifecycle smoke. All slice-specific checks pass, with full local verification blocked only by five tests in unchanged current-main surfaces.

--- a/docs/superpowers/plans/2026-07-27-schedule-cancellation-attribution.md
+++ b/docs/superpowers/plans/2026-07-27-schedule-cancellation-attribution.md
@@ -1,0 +1,338 @@
+# Schedule Cancellation Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add staff/client cancellation attribution for schedule creators and remove the redundant Program and Primary Goal dropdowns without changing canonical session or plan-link persistence.
+
+**Architecture:** Keep authorization and role resolution in `Schedule`, passing the existing create-schedule boundary into `SessionModal` as a boolean prop. `SessionModal` owns UI-only status values and normalizes them to the existing `Session` fields before submission; `Schedule` forwards the normalized attribution through the existing `cancelSessions` client. The lower program/goal controls remain the only visible plan selectors while hidden registered fields preserve the existing payload contract.
+
+**Tech Stack:** React 18, TypeScript, react-hook-form, TanStack Query, Vitest, Testing Library.
+
+## Global Constraints
+
+- Linear issue: `WIN-258`.
+- Classification: `low-risk autonomous`.
+- Lane: `standard`.
+- Allowed production files: `src/components/SessionModal.tsx`, `src/pages/Schedule.tsx`.
+- Allowed focused tests: `src/components/__tests__/SessionModal.test.tsx`, `src/pages/__tests__/Schedule.orchestration.integration.test.tsx`.
+- Do not touch migrations, Supabase functions, server code, auth/role resolution, CI, or deploy configuration.
+- Keep canonical persisted status exactly `cancelled`.
+- Keep cancellation attribution limited to `staff` and `client`.
+- Preserve `program_id`, `goal_id`, and `goal_ids` synchronization and existing BT data-collection behavior.
+
+---
+
+### Task 1: Direct cancellation choices in SessionModal
+
+**Files:**
+- Modify: `src/components/SessionModal.tsx`
+- Test: `src/components/__tests__/SessionModal.test.tsx`
+
+**Interfaces:**
+- Consumes: `Session["status"]`, `Session["cancellation_attribution"]`, and the existing `onSubmit(SessionModalSubmitData)` callback.
+- Produces: optional `canCreateSchedules?: boolean` prop, defaulting to `true` for existing direct component consumers; creator selections submit `{ status: "cancelled", cancellation_attribution: "staff" | "client" }`.
+
+- [ ] **Step 1: Write failing creator and non-creator visibility tests**
+
+Add focused tests that render the real `SessionModal` and assert:
+
+```tsx
+expect(screen.getByRole('option', { name: 'Staff cancellation' })).toBeInTheDocument();
+expect(screen.getByRole('option', { name: 'Client cancellation' })).toBeInTheDocument();
+expect(screen.queryByRole('option', { name: /^Cancelled$/ })).not.toBeInTheDocument();
+```
+
+Then render with `canCreateSchedules={false}` and assert the two attribution choices are absent while the legacy generic cancelled choice remains available for backward-compatible non-creator editing.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+npm test -- src/components/__tests__/SessionModal.test.tsx -t "cancellation"
+```
+
+Expected: FAIL because `canCreateSchedules` and the two direct options do not exist.
+
+- [ ] **Step 3: Write failing submission normalization tests**
+
+For each direct option, select it, submit the real modal form, and assert the literal consumer payload:
+
+```tsx
+expect(defaultProps.onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+  status: 'cancelled',
+  cancellation_attribution: expectedAttribution,
+}));
+```
+
+Use literal cases for `staff` and `client`; do not calculate the expected attribution from production helpers.
+
+- [ ] **Step 4: Run the submission tests and verify RED**
+
+Run:
+
+```powershell
+npm test -- src/components/__tests__/SessionModal.test.tsx -t "cancellation"
+```
+
+Expected: FAIL because the current generic option cannot encode the selected attribution.
+
+- [ ] **Step 5: Implement controlled UI status normalization**
+
+In `SessionModal`:
+
+1. Add `canCreateSchedules?: boolean` to `SessionModalProps` and default it to `true`.
+2. Initialize `cancellation_attribution` from the session; for a legacy cancelled session, use `client` only when explicitly stored and otherwise display `staff`.
+3. Watch `status` and `cancellation_attribution`.
+4. Replace direct `register('status')` ownership of the visible select with a controlled value:
+   - creator `cancelled + staff` -> `cancelled:staff`
+   - creator `cancelled + client` -> `cancelled:client`
+   - other statuses -> their canonical value
+5. On change:
+   - `cancelled:staff` sets `status="cancelled"` and `cancellation_attribution="staff"`
+   - `cancelled:client` sets `status="cancelled"` and `cancellation_attribution="client"`
+   - any canonical status sets that status and clears stale cancellation attribution
+6. Register hidden `status` and `cancellation_attribution` inputs so react-hook-form submits canonical values.
+7. For creators, render only `Staff cancellation` and `Client cancellation`; for non-creators, retain the legacy `Cancelled` option and render neither new choice.
+
+- [ ] **Step 6: Run the focused tests and verify GREEN**
+
+Run:
+
+```powershell
+npm test -- src/components/__tests__/SessionModal.test.tsx -t "cancellation"
+```
+
+Expected: PASS with both visibility and literal payload assertions green.
+
+- [ ] **Step 7: Commit Task 1**
+
+```powershell
+git add -- src/components/SessionModal.tsx src/components/__tests__/SessionModal.test.tsx
+git commit -m "feat(schedule): classify appointment cancellations"
+```
+
+---
+
+### Task 2: Schedule role boundary and cancellation forwarding
+
+**Files:**
+- Modify: `src/pages/Schedule.tsx`
+- Test: `src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
+
+**Interfaces:**
+- Consumes: `SessionModal` prop `canCreateSchedules` and `SessionModalSubmitData.cancellation_attribution`.
+- Produces: `cancelSessions({ sessionIds, reason, cancellationAttribution })` using the selected literal `staff` or `client` value.
+
+- [ ] **Step 1: Extend the real Schedule modal mock boundary**
+
+Update the test’s `SessionModal` test double to capture `canCreateSchedules` and expose a button that submits a literal cancelled payload:
+
+```tsx
+onSubmit({
+  id: session?.id,
+  status: 'cancelled',
+  cancellation_attribution: 'client',
+})
+```
+
+The double exists only to cross the Schedule orchestration boundary; assertions must target Schedule output (`cancelSessions` arguments), not the existence of the mock itself.
+
+- [ ] **Step 2: Write failing role-boundary tests**
+
+Use literal expectations to prove:
+
+- `midtier`, `admin_schedule`, `admin`, `bcba`, and `super_admin` receive `canCreateSchedules=true`;
+- `bt` and `therapist` receive `canCreateSchedules=false`.
+
+Reuse the existing role fixture mechanism in `Schedule.orchestration.integration.test.tsx`.
+
+- [ ] **Step 3: Write the failing cancellation-forwarding test**
+
+Submit the client-cancellation payload through the Schedule modal boundary and assert:
+
+```tsx
+expect(cancelSessionsMock).toHaveBeenCalledWith({
+  sessionIds: [expectedSessionId],
+  reason: undefined,
+  cancellationAttribution: 'client',
+});
+```
+
+- [ ] **Step 4: Run the focused Schedule tests and verify RED**
+
+Run:
+
+```powershell
+npm test -- src/pages/__tests__/Schedule.orchestration.integration.test.tsx -t "create schedules|cancellation attribution"
+```
+
+Expected: FAIL because Schedule neither passes the permission prop nor forwards attribution.
+
+- [ ] **Step 5: Implement the Schedule boundary**
+
+In `Schedule.tsx`:
+
+1. Reuse `!therapistScopedView` as `canCreateSchedules`; do not add or change global role capabilities.
+2. Pass `canCreateSchedules={!therapistScopedView}` to `SessionModal`.
+3. Extend the cancellation mutation variables with optional `cancellationAttribution`.
+4. Pass that value to the existing `cancelSessions` helper.
+5. In the `edit-cancel` submit branch, normalize the submitted value to `client` only when it is exactly `client`; otherwise use `staff`.
+6. Leave the legacy direct-delete path unchanged so its existing helper default remains `staff`.
+
+- [ ] **Step 6: Run the focused Schedule tests and verify GREEN**
+
+Run:
+
+```powershell
+npm test -- src/pages/__tests__/Schedule.orchestration.integration.test.tsx -t "create schedules|cancellation attribution"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 2**
+
+```powershell
+git add -- src/pages/Schedule.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+git commit -m "feat(schedule): forward cancellation attribution"
+```
+
+---
+
+### Task 3: Remove duplicate plan dropdowns and preserve primary IDs
+
+**Files:**
+- Modify: `src/components/SessionModal.tsx`
+- Test: `src/components/__tests__/SessionModal.test.tsx`
+
+**Interfaces:**
+- Consumes: existing `toggleProgramSelection`, `toggleGoalSelection`, `updateProgramSelection`, and react-hook-form `program_id`, `goal_id`, `goal_ids`.
+- Produces: the same submission fields with no visible `Program` or `Primary Goal` comboboxes.
+
+- [ ] **Step 1: Write the failing UI-removal test**
+
+Render with active program/goal fixtures and assert:
+
+```tsx
+expect(screen.queryByRole('combobox', { name: /^Program$/i })).not.toBeInTheDocument();
+expect(screen.queryByRole('combobox', { name: /^Primary Goal$/i })).not.toBeInTheDocument();
+expect(screen.getByRole('button', { name: /Default Program/i })).toBeInTheDocument();
+```
+
+Assert the lower goal checkbox is available after selecting the program.
+
+- [ ] **Step 2: Write the failing payload-preservation test**
+
+Use only the lower controls:
+
+1. click the `Default Program` button;
+2. select the `Default Goal` checkbox;
+3. submit the modal;
+4. assert literal `program_id: "program-1"`, `goal_id: "goal-1"`, and `goal_ids` containing `"goal-1"`.
+
+This test catches removal of hidden registration or broken primary synchronization.
+
+- [ ] **Step 3: Run the focused plan-selector tests and verify RED**
+
+Run:
+
+```powershell
+npm test -- src/components/__tests__/SessionModal.test.tsx -t "redundant plan|lower plan"
+```
+
+Expected: FAIL because the two top-row comboboxes still render.
+
+- [ ] **Step 4: Remove only the duplicate visible row**
+
+In `SessionModal.tsx`:
+
+1. Remove the visible Program and Primary Goal `<select>` row and its dropdown-only loading/error blocks.
+2. Keep hidden registered inputs for `program_id` and `goal_id` in both visible-plan and scheduler-only modes.
+3. Keep the empty-plan warnings, lower program controls, lower goal controls, selection summaries, and all synchronization effects.
+4. Do not change plan persistence or Start Session validation.
+
+- [ ] **Step 5: Update obsolete test interactions**
+
+In `SessionModal.test.tsx`, replace interactions that select the removed Program/Primary Goal comboboxes with clicks on the real lower program buttons and goal checkboxes. Preserve each test’s original behavioral assertion; delete assertions whose only purpose was the removed dropdown implementation.
+
+- [ ] **Step 6: Run the complete SessionModal suite and verify GREEN**
+
+Run:
+
+```powershell
+npm test -- src/components/__tests__/SessionModal.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+```powershell
+git add -- src/components/SessionModal.tsx src/components/__tests__/SessionModal.test.tsx
+git commit -m "refactor(schedule): remove duplicate plan selectors"
+```
+
+---
+
+### Task 4: Standard-lane verification and handoff
+
+**Files:**
+- Create: `docs/ai/WIN-258-schedule-cancellation-attribution-handoff.md`
+- Verify: all files changed by Tasks 1-3
+
+**Interfaces:**
+- Consumes: completed implementation commits and `WIN-258`.
+- Produces: verification card, reviewer verdict, PR hygiene verdict, pushed branch, and review-ready PR.
+
+- [ ] **Step 1: Run the focused regression pair**
+
+```powershell
+npm test -- src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the mandatory standard-lane checks**
+
+```powershell
+npm run ci:check-focused
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run build
+npm run verify:local
+```
+
+Record each actual result. If `verify:local` duplicates checks or requires unavailable protected systems, record the exact output rather than claiming it passed.
+
+- [ ] **Step 3: Run required independent reviews**
+
+Use:
+
+- `code-review-engineer` for correctness, role-boundary drift, and protected-path review;
+- `test-engineer` for regression coverage and verification sufficiency.
+
+Resolve all in-scope findings and rerun affected checks.
+
+- [ ] **Step 4: Produce repo-required artifacts**
+
+Use the repo-local `verify-change` skill to write the verification card and `pr-hygiene` to produce `pr-ready: yes|no`. Include:
+
+- classification and lane;
+- explicit files touched;
+- required and executed checks;
+- blocked checks;
+- reviewer result;
+- residual risk;
+- `WIN-258` tracking state.
+
+- [ ] **Step 5: Commit the handoff artifact**
+
+```powershell
+git add -- docs/ai/WIN-258-schedule-cancellation-attribution-handoff.md
+git commit -m "docs(win-258): record schedule cancellation verification"
+```
+
+- [ ] **Step 6: Push and open the PR**
+
+Push `codex/removegoalsandprograms`, create a PR linked to `WIN-258`, and report live required checks and blockers. Move `WIN-258` to `In Review` and add the PR/check-status comment.

--- a/docs/superpowers/plans/2026-07-27-schedule-cancellation-attribution.md
+++ b/docs/superpowers/plans/2026-07-27-schedule-cancellation-attribution.md
@@ -42,7 +42,7 @@ expect(screen.getByRole('option', { name: 'Client cancellation' })).toBeInTheDoc
 expect(screen.queryByRole('option', { name: /^Cancelled$/ })).not.toBeInTheDocument();
 ```
 
-Then render with `canCreateSchedules={false}` and assert the two attribution choices are absent while the legacy generic cancelled choice remains available for backward-compatible non-creator editing.
+Then render a scheduled session with `canCreateSchedules={false}` and assert that neither attribution choice nor a generic selectable cancelled choice is present. For an already-cancelled session, a disabled `Cancelled` option may render only to represent the persisted terminal state.
 
 - [ ] **Step 2: Run the focused tests and verify RED**
 
@@ -93,7 +93,7 @@ In `SessionModal`:
    - `cancelled:client` sets `status="cancelled"` and `cancellation_attribution="client"`
    - any canonical status sets that status and clears stale cancellation attribution
 6. Register hidden `status` and `cancellation_attribution` inputs so react-hook-form submits canonical values.
-7. For creators, render only `Staff cancellation` and `Client cancellation`; for non-creators, retain the legacy `Cancelled` option and render neither new choice.
+7. For creators, render only `Staff cancellation` and `Client cancellation`. For non-creators, render no selectable cancellation option; when the loaded session is already cancelled, render a disabled `Cancelled` option only to represent its persisted terminal state.
 
 - [ ] **Step 6: Run the focused tests and verify GREEN**
 

--- a/docs/superpowers/specs/2026-07-27-schedule-cancellation-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-27-schedule-cancellation-attribution-design.md
@@ -1,0 +1,101 @@
+# Schedule Cancellation Attribution and Plan Selector Cleanup
+
+## Goal
+
+Make appointment cancellation attribution explicit for staff who can create schedules, and remove the redundant Program and Primary Goal dropdowns from the session modal while preserving the existing clickable program and goal controls.
+
+## User-visible behavior
+
+- In the session modal Status control, replace the single `Cancelled` choice with:
+  - `Staff cancellation`
+  - `Client cancellation`
+- Show those two cancellation choices only when the caller can create schedules. In the current Schedule page, that means midtier, admin schedule, admin, BCBA, and super admin. BT and therapist users remain excluded.
+- Either cancellation choice submits the canonical session status `cancelled`.
+- `Staff cancellation` submits `cancellation_attribution: "staff"`.
+- `Client cancellation` submits `cancellation_attribution: "client"`.
+- Remove the visible Program and Primary Goal dropdown row shown above the existing program and goal controls.
+- Keep the existing program buttons/mobile checkboxes and goal checkboxes as the user-facing selection controls.
+
+## Data flow
+
+`Schedule` remains the authority for whether the current user can create appointments. It passes that permission into `SessionModal`.
+
+`SessionModal` represents the two cancellation choices as UI-only status values, then normalizes either choice before invoking `onSubmit`:
+
+- status becomes `cancelled`
+- cancellation attribution becomes `staff` or `client`
+
+The existing `Schedule` cancellation mutation forwards the normalized attribution to `cancelSessions`. The existing client and edge-function contract already accepts this field, so no database, migration, edge-function, or API contract change is required.
+
+The removed plan dropdowns do not remove the registered `program_id` or `goal_id` form values. Existing program and goal selection logic continues to synchronize:
+
+- selected programs
+- the internal primary program
+- selected goals
+- the internal primary goal
+
+This preserves create, edit, and Start Session payload compatibility.
+
+## Scope
+
+Expected production files:
+
+- `src/components/SessionModal.tsx`
+- `src/pages/Schedule.tsx`
+
+Expected focused tests:
+
+- `src/components/__tests__/SessionModal.test.tsx`
+- a focused Schedule test only if needed to prove permission or mutation forwarding at the page boundary
+
+The implementation may add a small scheduling-domain helper and focused unit test if keeping UI-value normalization out of the component materially improves test clarity. It must not touch protected backend, auth, database, CI, or deploy paths.
+
+## Non-goals
+
+- Changing who is authorized by the backend to cancel a session
+- Adding new cancellation attribution values
+- Changing cancellation reasons or notes
+- Changing session lifecycle transitions
+- Changing program or goal persistence semantics
+- Refactoring the broader session modal
+- Modifying Supabase migrations, functions, RLS, grants, or generated database types
+
+## Error handling
+
+- A cancellation option must never submit without a matching attribution.
+- Existing cancelled sessions with missing or legacy `unknown` attribution may render a neutral cancelled state for review, but selecting a new cancellation action must resolve to `staff` or `client`.
+- Existing cancellation API errors continue through the current Schedule mutation error path.
+
+## Verification
+
+Use test-driven development with focused tests that prove:
+
+1. schedule creators see both direct cancellation choices and not the generic `Cancelled` choice;
+2. non-creators do not receive the new cancellation choices;
+3. each choice submits `status: "cancelled"` with the matching attribution;
+4. Schedule forwards the attribution to `cancelSessions`;
+5. the Program and Primary Goal comboboxes are absent while the clickable program and goal controls remain usable;
+6. selected programs and goals still populate the expected internal primary IDs.
+
+Because this is non-trivial UI/state work outside protected paths, route it as `standard` unless implementation requires a protected-path change. Required verification is the union of the standard lane and UI/component matrix:
+
+- `npm run ci:check-focused`
+- `npm run lint`
+- `npm run typecheck`
+- focused tests during TDD
+- `npm run test:ci`
+- `npm run build`
+- `npm run verify:local` when the local environment supports its secret-free checks
+
+## Stop conditions
+
+Stop and re-route before implementation widens into any of these areas:
+
+- `supabase/migrations/**`
+- `supabase/functions/**`
+- `src/server/**`
+- auth, role-resolution, tenant, RLS, grant, or RPC behavior
+- CI/workflow or deployment configuration
+- a change to the canonical session status or cancellation API contract
+
+Also stop if the lower clickable program and goal controls cannot preserve the existing primary IDs without changing persistence semantics.

--- a/scripts/lib/playwright-inprogress-session-setup.ts
+++ b/scripts/lib/playwright-inprogress-session-setup.ts
@@ -15,6 +15,7 @@ import {
   type LifecycleTargetPair,
 } from "../../src/scripts/playwrightSessionLifecycleTargets";
 import { waitForSelectOptions } from "./playwright-smoke";
+import { selectSessionPlanControls } from "./playwright-session-plan-controls";
 
 export interface LifecycleIds {
   sessionId: string;
@@ -709,13 +710,8 @@ async function chooseSessionTargets(
     await page.selectOption("#client-select", "");
     const seeded = await ensureProgramAndGoalForPair(therapistId, clientId);
     await page.selectOption("#client-select", clientId);
-    const selectedProgram = await selectOptionWhenAvailable(page, "#program-select", seeded.programId);
-    if (!selectedProgram) {
-      await archiveCreatedProgramGoalFixtures(seeded);
-      continue;
-    }
-    const selectedGoal = await selectOptionWhenAvailable(page, "#goal-select", seeded.goalId);
-    if (selectedGoal) {
+    const selectedPlan = await selectSessionPlanControls(page, seeded.programId, seeded.goalId);
+    if (selectedPlan) {
       return {
         therapistId,
         clientId,

--- a/scripts/lib/playwright-session-plan-controls.ts
+++ b/scripts/lib/playwright-session-plan-controls.ts
@@ -1,0 +1,102 @@
+import type { Page } from "playwright";
+
+type PlanControlKind = "program" | "goal";
+
+const buildPlanControlSelector = (kind: PlanControlKind, id: string): string =>
+  `[data-${kind}-id=${JSON.stringify(id)}]:visible`;
+
+export const buildSessionPlanControlSelectors = (
+  programId: string,
+  goalId: string,
+): { programSelector: string; goalSelector: string } => ({
+  programSelector: buildPlanControlSelector("program", programId),
+  goalSelector: buildPlanControlSelector("goal", goalId),
+});
+
+const isControlSelected = async (
+  page: Page,
+  selector: string,
+): Promise<boolean> => page.locator(selector).first().evaluate((element) =>
+  element instanceof HTMLInputElement
+    ? element.checked
+    : element.getAttribute("aria-pressed") === "true");
+
+const selectPlanControl = async (
+  page: Page,
+  selector: string,
+  timeoutMs: number,
+): Promise<boolean> => {
+  const control = page.locator(selector).first();
+  const visible = await control
+    .waitFor({ state: "visible", timeout: timeoutMs })
+    .then(() => true)
+    .catch(() => false);
+  if (!visible) {
+    return false;
+  }
+  if (!(await isControlSelected(page, selector))) {
+    await control.click();
+  }
+  return isControlSelected(page, selector);
+};
+
+export const selectSessionProgramControl = (
+  page: Page,
+  programId: string,
+  timeoutMs = 10_000,
+): Promise<boolean> =>
+  selectPlanControl(page, buildPlanControlSelector("program", programId), timeoutMs);
+
+export const selectSessionGoalControl = (
+  page: Page,
+  goalId: string,
+  timeoutMs = 10_000,
+): Promise<boolean> =>
+  selectPlanControl(page, buildPlanControlSelector("goal", goalId), timeoutMs);
+
+export const selectSessionPlanControls = async (
+  page: Page,
+  programId: string,
+  goalId: string,
+  timeoutMs = 10_000,
+): Promise<boolean> =>
+  (await selectSessionProgramControl(page, programId, timeoutMs)) &&
+  (await selectSessionGoalControl(page, goalId, timeoutMs));
+
+export const waitForSessionPlanControlIds = async (
+  page: Page,
+  kind: PlanControlKind,
+  timeoutMs = 10_000,
+): Promise<string[]> => {
+  const attribute = `data-${kind}-id`;
+  await page.waitForFunction(
+    (name) => document.querySelector(`[${name}]`) !== null,
+    attribute,
+    { timeout: timeoutMs },
+  );
+  return page.locator(`[${attribute}]`).evaluateAll((elements, name) =>
+    Array.from(new Set(
+      elements
+        .map((element) => element.getAttribute(name))
+        .filter((value): value is string => Boolean(value)),
+    )), attribute);
+};
+
+export const readSelectedSessionPlanIds = async (
+  page: Page,
+): Promise<{ programIds: string[]; goalIds: string[] }> => page.evaluate(() => {
+  const selectedIds = (attribute: "data-program-id" | "data-goal-id") =>
+    Array.from(new Set(
+      Array.from(document.querySelectorAll<HTMLElement>(`[${attribute}]`))
+        .filter((element) =>
+          element instanceof HTMLInputElement
+            ? element.checked
+            : element.getAttribute("aria-pressed") === "true")
+        .map((element) => element.getAttribute(attribute))
+        .filter((value): value is string => Boolean(value)),
+    ));
+  return {
+    programIds: selectedIds("data-program-id"),
+    goalIds: selectedIds("data-goal-id"),
+  };
+});

--- a/scripts/playwright-schedule-conflict.ts
+++ b/scripts/playwright-schedule-conflict.ts
@@ -11,6 +11,12 @@ import {
   loginAndAssertSession,
   waitForSelectOptions,
 } from "./lib/playwright-smoke";
+import {
+  readSelectedSessionPlanIds,
+  selectSessionPlanControls,
+  selectSessionProgramControl,
+  waitForSessionPlanControlIds,
+} from "./lib/playwright-session-plan-controls";
 
 type ConflictMode = "mock" | "real";
 
@@ -129,8 +135,9 @@ async function chooseSessionTargets(page: Page): Promise<ConflictTargets> {
   if (preferred.therapistId && preferred.clientId && preferred.programId && preferred.goalId) {
     await selectValueOrThrow(page, "#therapist-select", preferred.therapistId, "Therapist");
     await selectValueOrThrow(page, "#client-select", preferred.clientId, "Client");
-    await selectValueOrThrow(page, "#program-select", preferred.programId, "Program");
-    await selectValueOrThrow(page, "#goal-select", preferred.goalId, "Goal");
+    if (!(await selectSessionPlanControls(page, preferred.programId, preferred.goalId))) {
+      throw new Error("Preferred program/goal is not currently selectable in the lower plan controls.");
+    }
     return {
       therapistId: preferred.therapistId,
       clientId: preferred.clientId,
@@ -157,16 +164,20 @@ async function chooseSessionTargets(page: Page): Promise<ConflictTargets> {
         break;
       }
       await page.selectOption("#client-select", clientId);
-      const programValues = await waitForSelectOptions(page, "#program-select", { timeoutMs: 1_500 }).catch(() => []);
+      const programValues = await waitForSessionPlanControlIds(page, "program", 1_500).catch(() => []);
       if (programValues.length === 0) {
         continue;
       }
-      await page.selectOption("#program-select", programValues[0]);
-      const goalValues = await waitForSelectOptions(page, "#goal-select", { timeoutMs: 1_500 }).catch(() => []);
+      if (!(await selectSessionProgramControl(page, programValues[0], 1_500))) {
+        continue;
+      }
+      const goalValues = await waitForSessionPlanControlIds(page, "goal", 1_500).catch(() => []);
       if (goalValues.length === 0) {
         continue;
       }
-      await page.selectOption("#goal-select", goalValues[0]);
+      if (!(await selectSessionPlanControls(page, programValues[0], goalValues[0], 1_500))) {
+        continue;
+      }
       return {
         therapistId,
         clientId,
@@ -188,15 +199,19 @@ async function chooseSessionTargets(page: Page): Promise<ConflictTargets> {
     await page.selectOption("#therapist-select", fallbackTherapistId);
     await page.selectOption("#client-select", fallbackClientId);
     await page.waitForTimeout(500);
-    await selectValueOrThrow(page, "#program-select", seeded.programId, "Seeded program");
-    const availableGoals = await waitForSelectOptions(page, "#goal-select", { timeoutMs: 12_000 }).catch(() => []);
+    if (!(await selectSessionProgramControl(page, seeded.programId, 12_000))) {
+      throw new Error("Seeded program is not available in the lower plan controls.");
+    }
+    const availableGoals = await waitForSessionPlanControlIds(page, "goal", 12_000).catch(() => []);
     const selectedGoalId = availableGoals.includes(seeded.goalId)
       ? seeded.goalId
       : availableGoals[0];
     if (!selectedGoalId) {
       throw new Error("No goals available after auto-seeding program/goal fixture.");
     }
-    await page.selectOption("#goal-select", selectedGoalId);
+    if (!(await selectSessionPlanControls(page, seeded.programId, selectedGoalId, 12_000))) {
+      throw new Error("Seeded goal is not available in the lower plan controls.");
+    }
     return {
       therapistId: fallbackTherapistId,
       clientId: fallbackClientId,
@@ -564,8 +579,9 @@ async function run() {
 
     const therapistValue = await page.locator("#therapist-select").inputValue();
     const clientValue = await page.locator("#client-select").inputValue();
-    const programValue = await page.locator("#program-select").inputValue();
-    const goalValue = await page.locator("#goal-select").inputValue();
+    const selectedPlan = await readSelectedSessionPlanIds(page);
+    const programValue = selectedPlan.programIds[0] ?? "";
+    const goalValue = selectedPlan.goalIds[0] ?? "";
     const currentStartValue = await startTimeInput.inputValue();
     const currentEndValue = await endTimeInput.inputValue();
 

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -22,6 +22,12 @@ import {
   classifyScheduleReadinessFailure,
   openScheduleSessionModalFromCalendar,
 } from "./lib/playwright-schedule-session-modal";
+import {
+  buildSessionPlanControlSelectors,
+  selectSessionPlanControls,
+} from "./lib/playwright-session-plan-controls";
+
+export { buildSessionPlanControlSelectors } from "./lib/playwright-session-plan-controls";
 
 /** Canonical /schedule + SessionModal regression: book → Start Session → terminal close (no-show/completed). */
 
@@ -902,13 +908,8 @@ async function chooseSessionTargetsExcluding(
       await cleanupCreatedProgramGoal(seeded);
       continue;
     }
-    const selectedProgram = await selectOptionWhenAvailable(page, "#program-select", seeded.programId);
-    if (!selectedProgram) {
-      await cleanupCreatedProgramGoal(seeded);
-      continue;
-    }
-    const selectedGoal = await selectOptionWhenAvailable(page, "#goal-select", seeded.goalId);
-    if (!selectedGoal) {
+    const selectedPlan = await selectSessionPlanControls(page, seeded.programId, seeded.goalId);
+    if (!selectedPlan) {
       await cleanupCreatedProgramGoal(seeded);
       continue;
     }

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -779,6 +779,7 @@ interface SessionModalProps {
   onSessionStarted?: () => void | Promise<void>;
   dataCollectionOnly?: boolean;
   allowStartSession?: boolean;
+  canCreateSchedules?: boolean;
   hideGoalCaptureFields?: boolean;
   onBtAbaSessionFinalized?: (result: BtAbaFinalizeResult & { sessionId: string }) => void | Promise<void>;
 }
@@ -803,6 +804,7 @@ export function SessionModal({
   onSessionStarted,
   dataCollectionOnly = false,
   allowStartSession = false,
+  canCreateSchedules = true,
   hideGoalCaptureFields = false,
   onBtAbaSessionFinalized,
 }: SessionModalProps) {
@@ -892,6 +894,14 @@ export function SessionModal({
     return '';
   };
 
+  const getInitialCancellationAttribution = (): Session['cancellation_attribution'] | '' => {
+    if (session?.status !== 'cancelled') {
+      return '';
+    }
+
+    return session.cancellation_attribution === 'client' ? 'client' : 'staff';
+  };
+
   type SessionModalFormValues = Partial<Session> & SessionModalClinicalNotesPayload;
   
   const {
@@ -918,6 +928,7 @@ export function SessionModal({
             : ''),
       notes: session?.notes || '',
       status: session?.status || 'scheduled',
+      cancellation_attribution: getInitialCancellationAttribution(),
       session_note_narrative: '',
       session_note_goal_notes: {},
       session_note_goal_measurements: {},
@@ -935,6 +946,8 @@ export function SessionModal({
   const programId = watch('program_id');
   const goalId = watch('goal_id');
   const goalIds = watch('goal_ids') as string[] | undefined;
+  const sessionStatus = watch('status');
+  const cancellationAttribution = watch('cancellation_attribution');
   const sessionNoteGoalNotes = watch('session_note_goal_notes') as Record<string, string> | undefined;
   const sessionNoteStoredGoalIds = watch('session_note_goal_ids') as string[] | undefined;
   const sessionNoteGoalsAddressed = watch('session_note_goals_addressed') as string[] | undefined;
@@ -2426,6 +2439,41 @@ export function SessionModal({
     const toLocalInput = (iso: string) => formatSessionLocalInput(iso, resolvedTimeZone);
     setValue('start_time', toLocalInput(newStartTime));
     setValue('end_time', toLocalInput(newEndTime));
+  };
+
+  useEffect(() => {
+    if (sessionStatus === 'cancelled') {
+      if (cancellationAttribution !== 'staff' && cancellationAttribution !== 'client') {
+        setValue('cancellation_attribution', 'staff', { shouldDirty: false, shouldTouch: false });
+      }
+      return;
+    }
+
+    if (cancellationAttribution) {
+      setValue('cancellation_attribution', '', { shouldDirty: false, shouldTouch: false });
+    }
+  }, [cancellationAttribution, sessionStatus, setValue]);
+
+  const resolvedCancellationAttribution =
+    cancellationAttribution === 'client' ? 'client' : 'staff';
+  const statusSelectValue =
+    sessionStatus === 'cancelled'
+      ? (canCreateSchedules ? `cancelled:${resolvedCancellationAttribution}` : 'cancelled')
+      : (sessionStatus ?? 'scheduled');
+
+  const handleStatusChange = (value: string) => {
+    if (value === 'cancelled:staff' || value === 'cancelled:client') {
+      setValue('status', 'cancelled', { shouldDirty: true, shouldTouch: true });
+      setValue(
+        'cancellation_attribution',
+        value === 'cancelled:client' ? 'client' : 'staff',
+        { shouldDirty: true, shouldTouch: true },
+      );
+      return;
+    }
+
+    setValue('status', value as Session['status'], { shouldDirty: true, shouldTouch: true });
+    setValue('cancellation_attribution', '', { shouldDirty: true, shouldTouch: true });
   };
 
   const hasStartedSession = Boolean(sessionDetails?.started_at ?? session?.started_at);
@@ -4023,16 +4071,31 @@ export function SessionModal({
               >
                 Status
               </label>
+              <input type="hidden" {...register('status')} value={sessionStatus ?? ''} readOnly />
+              <input
+                type="hidden"
+                {...register('cancellation_attribution')}
+                value={cancellationAttribution ?? ''}
+                readOnly
+              />
               <select
                 id="status-select"
-                {...register('status')}
+                value={statusSelectValue}
+                onChange={(event) => handleStatusChange(event.target.value)}
                 disabled={isDataCollectionOnly}
                 className="min-h-11 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
               >
                 <option value="scheduled">Scheduled</option>
                 <option value="in_progress" disabled>In Progress</option>
                 <option value="completed" disabled={!session}>Completed</option>
-                <option value="cancelled">Cancelled</option>
+                {canCreateSchedules ? (
+                  <>
+                    <option value="cancelled:staff">Staff cancellation</option>
+                    <option value="cancelled:client">Client cancellation</option>
+                  </>
+                ) : sessionStatus === 'cancelled' ? (
+                  <option value="cancelled" disabled>Cancelled</option>
+                ) : null}
                 <option value="no-show" disabled={!session}>No Show</option>
               </select>
             </div>

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -1008,6 +1008,8 @@ export function SessionModal({
     data: programs = [],
     isFetched: isProgramsFetched,
     isFetching: isProgramsFetching,
+    isError: isProgramsError,
+    refetch: refetchPrograms,
   } = useQuery({
     queryKey: ['client-programs', clientId, activeOrganizationId ?? 'MISSING_ORG'],
     queryFn: async () => {
@@ -1032,6 +1034,8 @@ export function SessionModal({
     data: goals = [],
     isFetched: isGoalsFetched,
     isFetching: isGoalsFetching,
+    isError: isGoalsError,
+    refetch: refetchGoals,
   } = useQuery({
     queryKey: ['client-goals', clientId, activeOrganizationId ?? 'MISSING_ORG'],
     queryFn: async () => {
@@ -3668,7 +3672,45 @@ export function SessionModal({
               </div>
             )}
 
-            {!shouldHideGoalCaptureFields && (programs.length === 0 || activePrograms.length === 0 || availableProgramGroups.length === 0) && (
+            {!shouldHideGoalCaptureFields && (isProgramsError || isGoalsError) && (
+              <div className="space-y-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-200 sm:p-4">
+                {isProgramsError && (
+                  <div className="flex items-center justify-between gap-3">
+                    <span>Could not load programs.</span>
+                    <button
+                      type="button"
+                      aria-label="Retry programs"
+                      onClick={() => {
+                        void refetchPrograms();
+                      }}
+                      className="font-semibold underline underline-offset-2"
+                    >
+                      Retry
+                    </button>
+                  </div>
+                )}
+                {isGoalsError && (
+                  <div className="flex items-center justify-between gap-3">
+                    <span>Could not load goals.</span>
+                    <button
+                      type="button"
+                      aria-label="Retry goals"
+                      onClick={() => {
+                        void refetchGoals();
+                      }}
+                      className="font-semibold underline underline-offset-2"
+                    >
+                      Retry
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {!shouldHideGoalCaptureFields &&
+              !isProgramsError &&
+              !isGoalsError &&
+              (programs.length === 0 || activePrograms.length === 0 || availableProgramGroups.length === 0) && (
               <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200 sm:p-4">
                 {programs.length === 0 || activePrograms.length === 0
                   ? 'No active programs found for this client. Create or activate a program before starting a session.'

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -1008,8 +1008,6 @@ export function SessionModal({
     data: programs = [],
     isFetched: isProgramsFetched,
     isFetching: isProgramsFetching,
-    isError: isProgramsError,
-    refetch: refetchPrograms,
   } = useQuery({
     queryKey: ['client-programs', clientId, activeOrganizationId ?? 'MISSING_ORG'],
     queryFn: async () => {
@@ -1034,8 +1032,6 @@ export function SessionModal({
     data: goals = [],
     isFetched: isGoalsFetched,
     isFetching: isGoalsFetching,
-    isError: isGoalsError,
-    refetch: refetchGoals,
   } = useQuery({
     queryKey: ['client-goals', clientId, activeOrganizationId ?? 'MISSING_ORG'],
     queryFn: async () => {
@@ -3686,113 +3682,8 @@ export function SessionModal({
               <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 sm:sr-only">
                 Program &amp; goals
               </p>
-              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-4">
-              <div>
-                <label
-                  htmlFor="program-select"
-                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-                >
-                  Program
-                </label>
-                <select
-                  id="program-select"
-                  {...register('program_id')}
-                  disabled={isDataCollectionOnly || isProgramsFetching || !clientId}
-                  onChange={(event) => {
-                    if (isDataCollectionOnly) {
-                      return;
-                    }
-                    const nextProgramId = event.target.value;
-                    setValue('program_id', nextProgramId, { shouldDirty: true, shouldTouch: true });
-                    if (!nextProgramId) {
-                      updateProgramSelection([]);
-                      return;
-                    }
-                    updateProgramSelection([nextProgramId, ...selectedProgramIds.filter((id) => id !== nextProgramId)]);
-                  }}
-                  className="min-h-11 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
-                >
-                  <option value="">Select a program</option>
-                  {session?.id && programId && !hasProgramOptionForValue && (
-                    <option value={programId}>
-                      Current program (unavailable in active list)
-                    </option>
-                  )}
-                  {activePrograms.map((program) => (
-                    <option key={program.id} value={program.id}>
-                      {program.name}
-                    </option>
-                  ))}
-                </select>
-                {errors.program_id && (
-                  <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.program_id.message}</p>
-                )}
-                {isProgramsFetching && (
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Loading programs...</p>
-                )}
-                {isProgramsError && (
-                  <div className="mt-1 flex items-center gap-2 text-xs text-red-600 dark:text-red-300">
-                    <span>Could not load programs.</span>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        void refetchPrograms();
-                      }}
-                      className="font-semibold underline underline-offset-2"
-                    >
-                      Retry
-                    </button>
-                  </div>
-                )}
-              </div>
-
-              <div>
-                <label
-                  htmlFor="goal-select"
-                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-                >
-                  Primary Goal
-                </label>
-                <select
-                  id="goal-select"
-                  {...register('goal_id')}
-                  disabled={isDataCollectionOnly || isGoalsFetching || selectedProgramGoals.length === 0}
-                  className="min-h-11 w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-dark dark:text-gray-200"
-                >
-                  <option value="">Select a goal</option>
-                  {session?.id && goalId && !hasGoalOptionForValue && (
-                    <option value={goalId}>
-                      Current goal (unavailable in active list)
-                    </option>
-                  )}
-                  {selectedProgramGoals.map((goal) => (
-                    <option key={goal.id} value={goal.id}>
-                      {goal.title}
-                    </option>
-                  ))}
-                </select>
-                {errors.goal_id && (
-                  <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.goal_id.message}</p>
-                )}
-                {isGoalsFetching && (
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Loading goals...</p>
-                )}
-                {isGoalsError && (
-                  <div className="mt-1 flex items-center gap-2 text-xs text-red-600 dark:text-red-300">
-                    <span>Could not load goals.</span>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        void refetchGoals();
-                      }}
-                      className="font-semibold underline underline-offset-2"
-                    >
-                      Retry
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
+              <input type="hidden" {...register('program_id')} />
+              <input type="hidden" {...register('goal_id')} />
 
             {availableProgramGroups.length > 0 && (
               <div className="space-y-3 rounded-lg border border-gray-200 p-3 dark:border-gray-700">

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -3684,6 +3684,12 @@ export function SessionModal({
               </p>
               <input type="hidden" {...register('program_id')} />
               <input type="hidden" {...register('goal_id')} />
+              {errors.program_id && (
+                <p className="text-sm text-red-600 dark:text-red-400">{errors.program_id.message}</p>
+              )}
+              {errors.goal_id && (
+                <p className="text-sm text-red-600 dark:text-red-400">{errors.goal_id.message}</p>
+              )}
 
             {availableProgramGroups.length > 0 && (
               <div className="space-y-3 rounded-lg border border-gray-200 p-3 dark:border-gray-700">

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -3753,6 +3753,8 @@ export function SessionModal({
                       <button
                         key={program.id}
                         type="button"
+                        data-program-id={program.id}
+                        aria-pressed={isSelected}
                         onClick={() => toggleProgramSelection(program.id)}
                         disabled={isDataCollectionOnly}
                         className={`rounded-full border px-3 py-2 text-sm font-medium transition ${
@@ -3791,6 +3793,7 @@ export function SessionModal({
                         >
                         <input
                           type="checkbox"
+                          data-program-id={program.id}
                           checked={selectedProgramSet.has(program.id)}
                           onChange={() => toggleProgramSelection(program.id)}
                           disabled={isDataCollectionOnly}
@@ -3844,6 +3847,7 @@ export function SessionModal({
                               >
                                 <input
                                   type="checkbox"
+                                  data-goal-id={goal.id}
                                   checked={Array.isArray(goalIds) && goalIds.includes(goal.id)}
                                   onChange={() => toggleGoalSelection(goal.id)}
                                   disabled={isDataCollectionOnly}
@@ -3894,6 +3898,7 @@ export function SessionModal({
                               <label key={goal.id} className="flex min-w-0 items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
                                 <input
                                   type="checkbox"
+                                  data-goal-id={goal.id}
                                   checked={Array.isArray(goalIds) && goalIds.includes(goal.id)}
                                   onChange={() => toggleGoalSelection(goal.id)}
                                   disabled={isDataCollectionOnly}

--- a/src/components/__tests__/SchedulingFlow.test.tsx
+++ b/src/components/__tests__/SchedulingFlow.test.tsx
@@ -146,6 +146,16 @@ const mockGoals = [
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
   },
+  {
+    id: 'goal-2',
+    organization_id: 'org-a',
+    client_id: 'client-1',
+    program_id: 'program-1',
+    title: 'Request a break',
+    status: 'active',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
 ];
 
 const baseFrom = supabase.from;
@@ -160,6 +170,9 @@ const buildProgramGoalQuery = (data: unknown[]) => {
   };
   return chain;
 };
+
+const getSessionGoalCheckboxes = (name: RegExp) =>
+  screen.getAllByRole('checkbox', { name }) as HTMLInputElement[];
 
 describe('Scheduling Flow - Client with Therapist', () => {
   beforeEach(() => {
@@ -396,12 +409,18 @@ describe('Scheduling Flow - Client with Therapist', () => {
 
       const clientSelect = screen.getByRole('combobox', { name: /client/i });
       await userEvent.selectOptions(clientSelect, 'client-2');
+      const programButton = await screen.findByRole('button', { name: /Behavior Plan/i });
+      await userEvent.click(programButton);
 
-      const programSelect = screen.getByRole('combobox', { name: /program/i });
-      await userEvent.selectOptions(programSelect, 'program-1');
-
-      const goalSelect = screen.getByRole('combobox', { name: /primary goal/i });
-      await userEvent.selectOptions(goalSelect, 'goal-1');
+      const goalCheckboxes = await screen.findAllByRole('checkbox', { name: /Increase communication/i });
+      expect(goalCheckboxes).not.toHaveLength(0);
+      goalCheckboxes.forEach((checkbox) => expect(checkbox).toBeChecked());
+      const additionalGoalCheckboxes = screen.getAllByRole('checkbox', { name: /Request a break/i });
+      additionalGoalCheckboxes.forEach((checkbox) => expect(checkbox).not.toBeChecked());
+      await userEvent.click(additionalGoalCheckboxes[0]);
+      await waitFor(() => {
+        getSessionGoalCheckboxes(/Request a break/i).forEach((checkbox) => expect(checkbox).toBeChecked());
+      });
 
       const notesInput = screen.getByRole('textbox', { name: /notes/i });
       await userEvent.type(notesInput, 'Test session');
@@ -584,17 +603,13 @@ describe('Scheduling Flow - Client with Therapist', () => {
 
       expect(screen.getByText('Edit Session')).toBeInTheDocument();
       expect(screen.getByDisplayValue('Regular session')).toBeInTheDocument();
+      expect(await screen.findByText(/Tracking: Behavior Plan/i)).toBeInTheDocument();
+      getSessionGoalCheckboxes(/Increase communication/i).forEach((checkbox) => expect(checkbox).toBeChecked());
 
       // Update notes
       const notesInput = screen.getByRole('textbox', { name: /notes/i });
       await userEvent.clear(notesInput);
       await userEvent.type(notesInput, 'Updated session notes');
-
-      const programSelect = screen.getByRole('combobox', { name: /program/i });
-      await userEvent.selectOptions(programSelect, 'program-1');
-
-      const goalSelect = screen.getByRole('combobox', { name: /primary goal/i });
-      await userEvent.selectOptions(goalSelect, 'goal-1');
 
       // Submit form
       const submitButton = screen.getByRole('button', { name: /update session/i });

--- a/src/components/__tests__/SchedulingIntegration.test.tsx
+++ b/src/components/__tests__/SchedulingIntegration.test.tsx
@@ -63,16 +63,28 @@ const mockProgram = {
   updated_at: '2024-01-01T00:00:00Z',
 };
 
-const mockGoal = {
-  id: 'goal-1',
-  organization_id: 'org-a',
-  client_id: 'client-1',
-  program_id: 'program-1',
-  title: 'Increase communication',
-  status: 'active',
-  created_at: '2024-01-01T00:00:00Z',
-  updated_at: '2024-01-01T00:00:00Z',
-};
+const mockGoals = [
+  {
+    id: 'goal-1',
+    organization_id: 'org-a',
+    client_id: 'client-1',
+    program_id: 'program-1',
+    title: 'Increase communication',
+    status: 'active',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 'goal-2',
+    organization_id: 'org-a',
+    client_id: 'client-1',
+    program_id: 'program-1',
+    title: 'Request a break',
+    status: 'active',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+];
 
 const baseFrom = supabase.from;
 const mockRpc = vi.mocked(supabase.rpc);
@@ -85,6 +97,9 @@ const buildProgramGoalQuery = (data: unknown[]) => {
   };
   return chain;
 };
+
+const getScheduleGoalCheckboxes = (name: RegExp) =>
+  screen.getAllByRole('checkbox', { name }) as HTMLInputElement[];
 
 describe('Scheduling Integration - End-to-End Flow', () => {
   beforeEach(() => {
@@ -99,7 +114,7 @@ describe('Scheduling Integration - End-to-End Flow', () => {
         return buildProgramGoalQuery([mockProgram]) as ReturnType<typeof baseFrom>;
       }
       if (table === 'goals') {
-        return buildProgramGoalQuery([mockGoal]) as ReturnType<typeof baseFrom>;
+        return buildProgramGoalQuery(mockGoals) as ReturnType<typeof baseFrom>;
       }
       return baseFrom(table);
     });
@@ -142,7 +157,7 @@ describe('Scheduling Integration - End-to-End Flow', () => {
         return HttpResponse.json([mockProgram]);
       }),
       http.get('*/rest/v1/goals*', () => {
-        return HttpResponse.json([mockGoal]);
+        return HttpResponse.json(mockGoals);
       }),
       http.post('*/api/book', async ({ request }) => {
         sessionCreated = true;
@@ -213,12 +228,18 @@ describe('Scheduling Integration - End-to-End Flow', () => {
 
     const clientSelect = document.getElementById('client-select') as HTMLSelectElement;
     await userEvent.selectOptions(clientSelect, 'client-1');
+    const programButton = await screen.findByRole('button', { name: /Behavior Plan/i });
+    await userEvent.click(programButton);
 
-    const programSelect = document.getElementById('program-select') as HTMLSelectElement;
-    await userEvent.selectOptions(programSelect, 'program-1');
-
-    const goalSelect = document.getElementById('goal-select') as HTMLSelectElement;
-    await userEvent.selectOptions(goalSelect, 'goal-1');
+    const goalCheckboxes = await screen.findAllByRole('checkbox', { name: /Increase communication/i });
+    expect(goalCheckboxes).not.toHaveLength(0);
+    goalCheckboxes.forEach((checkbox) => expect(checkbox).toBeChecked());
+    const additionalGoalCheckboxes = screen.getAllByRole('checkbox', { name: /Request a break/i });
+    additionalGoalCheckboxes.forEach((checkbox) => expect(checkbox).not.toBeChecked());
+    await userEvent.click(additionalGoalCheckboxes[0]);
+    await waitFor(() => {
+      getScheduleGoalCheckboxes(/Request a break/i).forEach((checkbox) => expect(checkbox).toBeChecked());
+    });
 
     // Add session notes
     const notesInput = screen.getByRole('textbox', { name: /notes/i });

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -3936,6 +3936,44 @@ describe('SessionModal', () => {
     expect(screen.queryByText(/Primary goal is required/i)).not.toBeInTheDocument();
   });
 
+  it('keeps plan query failures distinct from empty data and offers focused retries', async () => {
+    const programOrder = vi.fn(async () => ({ data: null, error: new Error('program fetch failed') }));
+    const goalOrder = vi.fn(async () => ({ data: null, error: new Error('goal fetch failed') }));
+    const buildErrorChain = (order: SupabaseQueryChain['order']) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order,
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') {
+        return buildErrorChain(programOrder);
+      }
+      if (table === 'goals') {
+        return buildErrorChain(goalOrder);
+      }
+      return buildErrorChain(vi.fn(async () => ({ data: [], error: null })));
+    });
+
+    renderWithProviders(<SessionModal {...defaultProps} />);
+    await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
+
+    expect(await screen.findByText('Could not load programs.')).toBeInTheDocument();
+    expect(await screen.findByText('Could not load goals.')).toBeInTheDocument();
+    expect(screen.queryByText(/No active programs found for this client/i)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry programs' }));
+    await waitFor(() => expect(programOrder).toHaveBeenCalledTimes(2));
+    await userEvent.click(screen.getByRole('button', { name: 'Retry goals' }));
+    await waitFor(() => expect(goalOrder).toHaveBeenCalledTimes(2));
+  });
+
   it('shows saved state after successful update for edit sessions', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     renderWithProviders(

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -3321,10 +3321,11 @@ describe('SessionModal', () => {
       expect(option.disabled).toBe(false);
     });
 
-    it('keeps cancelled enabled in create mode', () => {
+    it('shows direct cancellation choices for creators in create mode', () => {
       renderWithProviders(<SessionModal {...defaultProps} />);
-      const option = screen.getByRole('option', { name: /^Cancelled$/i }) as HTMLOptionElement;
-      expect(option.disabled).toBe(false);
+      expect(screen.getByRole('option', { name: 'Staff cancellation' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Client cancellation' })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /^Cancelled$/ })).not.toBeInTheDocument();
     });
   });
 
@@ -3373,6 +3374,58 @@ describe('SessionModal', () => {
       );
       const select = screen.getByRole('combobox', { name: /Status/i }) as HTMLSelectElement;
       expect(select.value).toBe('in_progress');
+    });
+
+    it('hides selectable cancellation options for non-creators', () => {
+      renderWithProviders(
+        <SessionModal
+          {...defaultProps}
+          session={editSession}
+          canCreateSchedules={false}
+        />
+      );
+
+      expect(screen.queryByRole('option', { name: 'Staff cancellation' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: 'Client cancellation' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /^Cancelled$/ })).not.toBeInTheDocument();
+    });
+
+    it('shows a disabled cancelled option only for persisted cancelled sessions without creator access', () => {
+      renderWithProviders(
+        <SessionModal
+          {...defaultProps}
+          session={{ ...editSession, status: 'cancelled' }}
+          canCreateSchedules={false}
+        />
+      );
+
+      const option = screen.getByRole('option', { name: /^Cancelled$/i }) as HTMLOptionElement;
+      expect(option.disabled).toBe(true);
+    });
+
+    it.each([
+      ['Staff cancellation', 'staff'],
+      ['Client cancellation', 'client'],
+    ] as const)('submits %s with literal cancellation attribution', async (optionLabel, expectedAttribution) => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+      renderWithProviders(
+        <SessionModal
+          {...defaultProps}
+          onSubmit={onSubmit}
+          session={editSession}
+        />
+      );
+
+      await userEvent.selectOptions(screen.getByRole('combobox', { name: /Status/i }), optionLabel);
+      await userEvent.click(screen.getByRole('button', { name: /Update Session/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+          status: 'cancelled',
+          cancellation_attribution: expectedAttribution,
+        }));
+      });
     });
 
     it('locks scheduled-session metadata while allowing BT clinical capture to be edited and saved', async () => {

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1196,6 +1196,22 @@ describe('SessionModal', () => {
     existingSessions: [],
     timeZone: "America/New_York",
   };
+
+  const expectVisiblePlanSelectorsRemoved = () => {
+    expect(screen.queryByRole('combobox', { name: /^Program$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /^Primary Goal$/i })).not.toBeInTheDocument();
+  };
+
+  const getGoalCheckbox = (name: RegExp) =>
+    screen.getAllByRole('checkbox', { name })[0] as HTMLInputElement;
+
+  const selectGoalFromLowerControls = async (name: RegExp) => {
+    const checkbox = getGoalCheckbox(name);
+    if (!checkbox.checked) {
+      await userEvent.click(checkbox);
+    }
+  };
+
   const btInProgressSession = {
     id: 'session-bt-review', therapist_id: 'test-therapist-1', client_id: 'test-client-1',
     program_id: 'program-1', goal_id: 'goal-1', goal_ids: ['goal-1'],
@@ -1255,6 +1271,45 @@ describe('SessionModal', () => {
     }));
   }, 15000);
 
+  it('removes redundant plan comboboxes while keeping lower plan controls', async () => {
+    renderWithProviders(<SessionModal {...defaultProps} />);
+
+    await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
+    await screen.findByRole('button', { name: /Default Program/i });
+
+    expectVisiblePlanSelectorsRemoved();
+    expect(screen.getByRole('button', { name: /Default Program/i })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+
+    await waitFor(() => {
+      expect(getGoalCheckbox(/Default Goal/i)).toBeInTheDocument();
+    });
+  });
+
+  it('preserves primary ids from lower plan controls on submit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(<SessionModal {...defaultProps} onSubmit={onSubmit} />);
+
+    await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
+    await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
+    await screen.findByRole('button', { name: /Default Program/i });
+    await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+    await selectGoalFromLowerControls(/Default Goal/i);
+
+    fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2025-03-18T10:00' } });
+    fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2025-03-18T11:00' } });
+
+    await userEvent.click(screen.getByRole('button', { name: /Create Session/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        program_id: 'program-1',
+        goal_id: 'goal-1',
+        goal_ids: expect.arrayContaining(['goal-1']),
+      }));
+    });
+  }, 15000);
+
   it('calls onSubmit with form data when valid', async () => {
     renderWithProviders(<SessionModal {...defaultProps} />);
 
@@ -1267,16 +1322,9 @@ describe('SessionModal', () => {
       screen.getByLabelText(/Client/i),
       'test-client-1'
     );
-    await screen.findByRole('option', { name: /Default Program/i });
-    await userEvent.selectOptions(
-      screen.getByRole('combobox', { name: /^Program$/i }),
-      'program-1'
-    );
-    await screen.findByRole('option', { name: /Default Goal/i });
-    await userEvent.selectOptions(
-      screen.getByLabelText(/Primary Goal/i),
-      'goal-1'
-    );
+    await screen.findByRole('button', { name: /Default Program/i });
+    await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+    await selectGoalFromLowerControls(/Default Goal/i);
 
     // Set start and end times
     const startTime = screen.getByLabelText(/Start Time/i);
@@ -1306,11 +1354,13 @@ describe('SessionModal', () => {
     renderWithProviders(<SessionModal {...defaultProps} />);
 
     await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
-    await screen.findByRole('option', { name: /Default Program/i });
+    await screen.findByRole('button', { name: /Default Program/i });
     const goalFetchCountBeforeSwitch = vi.mocked(supabase.from).mock.calls.filter(([table]) => table === 'goals').length;
 
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: /^Program$/i }), 'program-2');
-    await screen.findByRole('option', { name: /Second Goal/i });
+    await userEvent.click(screen.getByRole('button', { name: /Second Program/i }));
+    await waitFor(() => {
+      expect(getGoalCheckbox(/Second Goal/i)).toBeInTheDocument();
+    });
 
     const goalFetchCountAfterSwitch = vi.mocked(supabase.from).mock.calls.filter(([table]) => table === 'goals').length;
     expect(goalFetchCountAfterSwitch).toBe(goalFetchCountBeforeSwitch);
@@ -1320,13 +1370,12 @@ describe('SessionModal', () => {
     renderWithProviders(<SessionModal {...defaultProps} />);
 
     await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
-    await screen.findByRole('option', { name: /Default Program/i });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: /^Program$/i }), 'program-1');
-    await screen.findByRole('option', { name: /Default Goal/i });
-    await userEvent.selectOptions(screen.getByLabelText(/Primary Goal/i), 'goal-1');
+    await screen.findByRole('button', { name: /Default Program/i });
+    await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+    await selectGoalFromLowerControls(/Default Goal/i);
 
     await userEvent.click(screen.getByRole('button', { name: /Second Program/i }));
-    await userEvent.click(screen.getAllByLabelText(/Second Goal/i)[0]);
+    await selectGoalFromLowerControls(/Second Goal/i);
 
     expect(screen.getAllByText(/Selected goals: Default Goal, Second Goal/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Tracking: Default Program, Second Program/i).length).toBeGreaterThan(0);
@@ -1361,10 +1410,9 @@ describe('SessionModal', () => {
     // Fill out the form
     await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
     await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
-    await screen.findByRole('option', { name: /Default Program/i });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: /^Program$/i }), 'program-1');
-    await screen.findByRole('option', { name: /Default Goal/i });
-    await userEvent.selectOptions(screen.getByLabelText(/Primary Goal/i), 'goal-1');
+    await screen.findByRole('button', { name: /Default Program/i });
+    await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+    await selectGoalFromLowerControls(/Default Goal/i);
     // Use change events for datetime-local inputs to ensure value is set reliably
     const startInput = screen.getByLabelText(/Start Time/i);
     const endInput = screen.getByLabelText(/End Time/i);
@@ -1415,10 +1463,9 @@ describe('SessionModal', () => {
 
     await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
     await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
-    await screen.findByRole('option', { name: /Default Program/i });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: /^Program$/i }), 'program-1');
-    await screen.findByRole('option', { name: /Default Goal/i });
-    await userEvent.selectOptions(screen.getByLabelText(/Primary Goal/i), 'goal-1');
+    await screen.findByRole('button', { name: /Default Program/i });
+    await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+    await selectGoalFromLowerControls(/Default Goal/i);
     fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2025-03-18T10:00' } });
     fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2025-03-18T11:00' } });
 
@@ -2941,13 +2988,12 @@ describe('SessionModal', () => {
         />
       );
 
-      const programSelect = await screen.findByRole('combobox', { name: /Program/i });
-      await screen.findByRole('option', { name: 'Second Program' });
-      await userEvent.selectOptions(programSelect, 'program-2');
-
-      const goalSelect = screen.getByRole('combobox', { name: /Primary Goal/i });
-      await screen.findByRole('option', { name: 'Second Goal' });
-      await userEvent.selectOptions(goalSelect, 'goal-2');
+      await screen.findByRole('button', { name: /Default Program/i });
+      await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+      await userEvent.click(screen.getByRole('button', { name: /Second Program/i }));
+      await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+      await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+      await selectGoalFromLowerControls(/Default Goal/i);
       const startButton = screen.getByRole('button', { name: /Start Session/i });
       await waitFor(() => expect(startButton).not.toBeDisabled());
       await userEvent.click(startButton);
@@ -2957,7 +3003,7 @@ describe('SessionModal', () => {
           sessionId: 'session-edit',
           programId: 'program-2',
           goalId: 'goal-2',
-          goalIds: ['goal-1', 'goal-2'],
+          goalIds: expect.arrayContaining(['goal-1', 'goal-2']),
         });
       });
   });
@@ -3096,15 +3142,14 @@ describe('SessionModal', () => {
       />
     );
 
-    expect(await screen.findByText(/Current program \(unavailable in active list\)/i)).toBeInTheDocument();
-    expect(screen.getByText(/Current goal \(unavailable in active list\)/i)).toBeInTheDocument();
+    expect(await screen.findByText(/No active programs found for this client/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Default Program/i })).not.toBeInTheDocument();
     const unavailableUpdateButton = screen.getByRole('button', { name: /Update Session/i });
     await waitFor(() => expect(unavailableUpdateButton).not.toBeDisabled());
     await userEvent.click(unavailableUpdateButton);
 
     await waitFor(() => {
       expect(onSubmit).not.toHaveBeenCalled();
-      expect(screen.getByText(/Select an active program before saving this scheduled session/i)).toBeInTheDocument();
     });
   });
 
@@ -3163,15 +3208,14 @@ describe('SessionModal', () => {
       />
     );
 
-    expect(await screen.findByRole('option', { name: 'Default Program' })).toBeInTheDocument();
-    expect(screen.getByText(/Current goal \(unavailable in active list\)/i)).toBeInTheDocument();
+    expect(await screen.findByText(/No active goals found for this client/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Default Program/i })).not.toBeInTheDocument();
     const unavailableGoalUpdateButton = screen.getByRole('button', { name: /Update Session/i });
     await waitFor(() => expect(unavailableGoalUpdateButton).not.toBeDisabled());
     await userEvent.click(unavailableGoalUpdateButton);
 
     await waitFor(() => {
       expect(onSubmit).not.toHaveBeenCalled();
-      expect(screen.getByText(/Select an active primary goal before saving this scheduled session/i)).toBeInTheDocument();
     });
   });
 
@@ -3281,7 +3325,8 @@ describe('SessionModal', () => {
       />
     );
 
-    expect(await screen.findByRole('option', { name: 'Default Program' })).toBeInTheDocument();
+    expect(await screen.findByText(/No active goals found for this client/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Default Program/i })).not.toBeInTheDocument();
     const legacyNoGoalUpdateButton = screen.getByRole('button', { name: /Update Session/i });
     await waitFor(() => expect(legacyNoGoalUpdateButton).not.toBeDisabled());
     await userEvent.click(legacyNoGoalUpdateButton);
@@ -3469,8 +3514,7 @@ describe('SessionModal', () => {
 
       expect(screen.getByRole('combobox', { name: /Therapist/i })).toBeDisabled();
       expect(screen.getByRole('combobox', { name: /Client/i })).toBeDisabled();
-      expect(screen.getByRole('combobox', { name: /Program/i })).toBeDisabled();
-      expect(screen.getByRole('combobox', { name: /Primary Goal/i })).toBeDisabled();
+      expectVisiblePlanSelectorsRemoved();
       expect(screen.getByRole('combobox', { name: /Status/i })).toBeDisabled();
       expect(screen.getByLabelText(/Start Time/i)).toBeDisabled();
       expect(screen.getByLabelText(/End Time/i)).toBeDisabled();
@@ -3509,7 +3553,6 @@ describe('SessionModal', () => {
         />
       );
 
-      await screen.findByRole('option', { name: /Default Goal/i });
       expect(screen.queryByRole('button', { name: /Start Session/i })).not.toBeInTheDocument();
     });
 
@@ -3716,7 +3759,6 @@ describe('SessionModal', () => {
         />
       );
 
-      await screen.findByRole('option', { name: /Default Goal/i });
       expect(screen.queryByRole('button', { name: /Start Session/i })).not.toBeInTheDocument();
       expect(vi.mocked(startSessionFromModal)).not.toHaveBeenCalled();
     });
@@ -3737,19 +3779,15 @@ describe('SessionModal', () => {
 
       expect(screen.getByRole('combobox', { name: /Therapist/i })).toBeDisabled();
       expect(screen.getByRole('combobox', { name: /Client/i })).toBeDisabled();
-      expect(screen.getByRole('combobox', { name: /Program/i })).toBeDisabled();
-      expect(screen.getByRole('combobox', { name: /Primary Goal/i })).toBeDisabled();
+      expectVisiblePlanSelectorsRemoved();
       expect(screen.getByRole('combobox', { name: /Status/i })).toBeDisabled();
       expect(screen.getByLabelText(/Start Time/i)).toBeDisabled();
       expect(screen.getByLabelText(/End Time/i)).toBeDisabled();
       expect(screen.getByLabelText(/Schedule Notes/i)).toBeDisabled();
-      await screen.findByRole('option', { name: /Default Goal/i });
-      expect(screen.getByRole('button', { name: /Default Program/i })).toBeDisabled();
-      expect(screen.getByRole('button', { name: /Second Program/i })).toBeDisabled();
-      expect(screen.getByRole('checkbox', { name: /Second Program/i })).toBeDisabled();
-      for (const goalCheckbox of screen.getAllByRole('checkbox', { name: /Default Goal/i })) {
-        expect(goalCheckbox).toBeDisabled();
-      }
+      expect(screen.queryByRole('button', { name: /Default Program/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Second Program/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: /Second Program/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: /Default Goal/i })).not.toBeInTheDocument();
 
       const startButton = await screen.findByRole('button', { name: /Start Session/i });
       await waitFor(() => expect(startButton).not.toBeDisabled());
@@ -3869,15 +3907,14 @@ describe('SessionModal', () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     renderWithProviders(<SessionModal {...defaultProps} onSubmit={onSubmit} />);
 
-    const programSelect = await screen.findByRole('combobox', { name: /Program/i }) as HTMLSelectElement;
-    const goalSelect = screen.getByRole('combobox', { name: /Primary Goal/i }) as HTMLSelectElement;
     await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
     await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
 
     await waitFor(() => {
-      expect(programSelect.value).toBe('');
-      expect(goalSelect.value).toBe('');
+      expectVisiblePlanSelectorsRemoved();
+      expect(screen.queryByRole('button', { name: /Default Program/i })).not.toBeInTheDocument();
     });
+    expect(screen.getByText(/No active programs found for this client/i)).toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'Inactive Published Program' })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'Paused Published Goal' })).not.toBeInTheDocument();
 
@@ -4059,10 +4096,9 @@ describe('SessionModal', () => {
 
     await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
     await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
-    await screen.findByRole('option', { name: /Default Program/i });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: /^Program$/i }), 'program-1');
-    await screen.findByRole('option', { name: /Default Goal/i });
-    await userEvent.selectOptions(screen.getByLabelText(/Primary Goal/i), 'goal-1');
+    await screen.findByRole('button', { name: /Default Program/i });
+    await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+    await selectGoalFromLowerControls(/Default Goal/i);
     fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2026-03-02T10:00' } });
     fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2026-03-02T11:00' } });
 
@@ -4128,10 +4164,9 @@ describe('SessionModal', () => {
 
     await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
     await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
-    await screen.findByRole('option', { name: /Default Program/i });
-    await userEvent.selectOptions(screen.getByRole('combobox', { name: /^Program$/i }), 'program-1');
-    await screen.findByRole('option', { name: /Default Goal/i });
-    await userEvent.selectOptions(screen.getByLabelText(/Primary Goal/i), 'goal-1');
+    await screen.findByRole('button', { name: /Default Program/i });
+    await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+    await selectGoalFromLowerControls(/Default Goal/i);
     fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2026-03-01T10:00' } });
     fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2026-03-01T11:00' } });
 

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -3150,6 +3150,7 @@ describe('SessionModal', () => {
 
     await waitFor(() => {
       expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByText(/Select an active program before saving this scheduled session\./i)).toBeInTheDocument();
     });
   });
 
@@ -3216,6 +3217,7 @@ describe('SessionModal', () => {
 
     await waitFor(() => {
       expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByText(/Select an active primary goal before saving this scheduled session\./i)).toBeInTheDocument();
     });
   });
 
@@ -3784,10 +3786,12 @@ describe('SessionModal', () => {
       expect(screen.getByLabelText(/Start Time/i)).toBeDisabled();
       expect(screen.getByLabelText(/End Time/i)).toBeDisabled();
       expect(screen.getByLabelText(/Schedule Notes/i)).toBeDisabled();
-      expect(screen.queryByRole('button', { name: /Default Program/i })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /Second Program/i })).not.toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: /Second Program/i })).not.toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: /Default Goal/i })).not.toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: /Default Program/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Second Program/i })).toBeDisabled();
+      expect(screen.getByRole('checkbox', { name: /Default Program/i })).toBeDisabled();
+      for (const goalCheckbox of screen.getAllByRole('checkbox', { name: /Default Goal/i })) {
+        expect(goalCheckbox).toBeDisabled();
+      }
 
       const startButton = await screen.findByRole('button', { name: /Start Session/i });
       await waitFor(() => expect(startButton).not.toBeDisabled());

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1227,13 +1227,16 @@ export const Schedule = React.memo(() => {
     mutationFn: async ({
       sessionId,
       reason,
+      cancellationAttribution,
     }: {
       sessionId: string;
       reason?: string | null;
+      cancellationAttribution?: "staff" | "client";
     }) => {
       const result = await cancelSessions({
         sessionIds: [sessionId],
         reason,
+        cancellationAttribution,
       });
 
       return result;
@@ -1648,9 +1651,11 @@ export const Schedule = React.memo(() => {
 
       switch (decision.kind) {
         case "edit-cancel": {
+          const cancellationAttribution = data.cancellation_attribution === "client" ? "client" : "staff";
           const result = await cancelSessionMutation.mutateAsync({
             sessionId: decision.selectedSessionId,
             reason: decision.cancellationReason,
+            cancellationAttribution,
           });
 
           showSuccess(
@@ -1995,6 +2000,7 @@ export const Schedule = React.memo(() => {
           selectedSession?.status === "scheduled" &&
           !selectedSession.started_at
         }
+        canCreateSchedules={!therapistScopedView}
         hideGoalCaptureFields={effectiveRole === "admin" || effectiveRole === "admin_schedule"}
         defaultTherapistId={selectedTherapist}
         defaultClientId={selectedClient}

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -134,6 +134,7 @@ vi.mock("../../components/SessionModal", () => ({
     retryHint,
     dataCollectionOnly,
     allowStartSession,
+    canCreateSchedules,
     hideGoalCaptureFields,
     onBtAbaSessionFinalized,
   }: {
@@ -144,6 +145,7 @@ vi.mock("../../components/SessionModal", () => ({
     retryHint?: string | null;
     dataCollectionOnly?: boolean;
     allowStartSession?: boolean;
+    canCreateSchedules?: boolean;
     hideGoalCaptureFields?: boolean;
     onBtAbaSessionFinalized?: (result: { sessionId: string; noteId: string; status: 'completed'; progressionResults: [] }) => Promise<void>;
   }) =>
@@ -153,6 +155,7 @@ vi.mock("../../components/SessionModal", () => ({
         <div data-testid="retry-hint">{retryHint ?? ""}</div>
         <div data-testid="data-collection-only">{dataCollectionOnly ? "true" : "false"}</div>
         <div data-testid="allow-start-session">{allowStartSession ? "true" : "false"}</div>
+        <div data-testid="can-create-schedules">{canCreateSchedules ? "true" : "false"}</div>
         <div data-testid="hide-goal-capture-fields">{hideGoalCaptureFields ? "true" : "false"}</div>
         <button
           aria-label="submit-complete-with-stale-trial"
@@ -373,6 +376,21 @@ vi.mock("../../components/SessionModal", () => ({
         >
           submit-cancel
         </button>
+        <button
+          aria-label="submit-cancel-client"
+          onClick={() => {
+            const result = onSubmit({
+              id: session?.id,
+              status: "cancelled",
+              cancellation_attribution: "client",
+            });
+            if (result && typeof (result as Promise<unknown>).catch === "function") {
+              void (result as Promise<unknown>).catch(() => undefined);
+            }
+          }}
+        >
+          submit-cancel-client
+        </button>
         <button aria-label="close-modal" onClick={onClose}>
           close-modal
         </button>
@@ -572,6 +590,46 @@ describe("Schedule orchestration integration hardening", () => {
       }));
     });
     expect(showSuccessMock).toHaveBeenCalled();
+  });
+
+  it.each([
+    ["midtier", "midtier", "true"],
+    ["admin schedule", "admin_schedule", "true"],
+    ["admin", "admin", "true"],
+    ["bcba", "bcba", "true"],
+    ["super admin", "super_admin", "true"],
+    ["bt", "bt", "false"],
+    ["therapist", "therapist", "false"],
+  ] as const)("wires create schedules permission for %s", async (_label, role, expectedCanCreate) => {
+    renderWithProviders(<Schedule />, {
+      auth: { role, organizationId: "org-1" },
+    });
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+
+    expect(screen.getByTestId("can-create-schedules")).toHaveTextContent(expectedCanCreate);
+  });
+
+  it("forwards cancellation attribution through the schedule modal boundary", async () => {
+    renderWithProviders(<Schedule />, {
+      auth: { role: "admin", organizationId: "org-1" },
+    });
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+    fireEvent.click(screen.getByLabelText("submit-cancel-client"));
+
+    await waitFor(() => {
+      expect(cancelSessionsMock).toHaveBeenCalledWith({
+        sessionIds: ["session-1"],
+        reason: undefined,
+        cancellationAttribution: "client",
+      });
+    });
   });
 
   it("manual edit update success path stays distinct from create", async () => {

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -632,6 +632,26 @@ describe("Schedule orchestration integration hardening", () => {
     });
   });
 
+  it("falls back to staff cancellation attribution when the modal does not provide one", async () => {
+    renderWithProviders(<Schedule />, {
+      auth: { role: "admin", organizationId: "org-1" },
+    });
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+    fireEvent.click(screen.getByLabelText("submit-cancel"));
+
+    await waitFor(() => {
+      expect(cancelSessionsMock).toHaveBeenCalledWith({
+        sessionIds: ["session-1"],
+        reason: "cancel reason",
+        cancellationAttribution: "staff",
+      });
+    });
+  });
+
   it("manual edit update success path stays distinct from create", async () => {
     renderWithProviders(<Schedule />);
     await screen.findByRole("heading", { name: /Schedule/i });

--- a/tests/scripts/playwright-session-lifecycle.test.ts
+++ b/tests/scripts/playwright-session-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   buildBookingCandidateStarts,
   buildBookingConflictWindowFilters,
+  buildSessionPlanControlSelectors,
   cleanupBeforeNoResponseFailure,
   filterNonOverlappingBookingStarts,
   hasReachedLifecyclePairAttemptLimit,
@@ -51,6 +52,13 @@ describe("playwright session lifecycle booking starts", () => {
     expect(isCreateSessionButtonReady({ disabled: "", ariaDisabled: null, textContent: "Create Session" })).toBe(false);
     expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: "true", textContent: "Create Session" })).toBe(false);
     expect(isCreateSessionButtonReady({ disabled: null, ariaDisabled: null, textContent: "Saving..." })).toBe(false);
+  });
+
+  it("targets the surviving clickable program and goal controls", () => {
+    expect(buildSessionPlanControlSelectors("program-1", "goal-1")).toEqual({
+      programSelector: '[data-program-id="program-1"]:visible',
+      goalSelector: '[data-goal-id="goal-1"]:visible',
+    });
   });
 
   it("accepts only the explicit hosted ALREADY_STARTED recovery contract", () => {


### PR DESCRIPTION
## Summary
- replace the generic cancelled status with Staff cancellation and Client cancellation for users who can create schedules
- keep cancellation choices hidden for BT and therapist-scoped users while preserving display of already-cancelled sessions
- remove the redundant Program and Primary Goal dropdowns and retain the lower clickable plan controls, including query-error retry handling

## Tracking
- Linear: WIN-258
- Route: low-risk autonomous / standard lane

## Verification
- `npm run ci:check-focused` — pass (documented local DB/branch-protection skips)
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npx vitest run src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx --reporter=dot` — pass, 173 tests
- `npx vitest run src/components/__tests__/SchedulingFlow.test.tsx src/components/__tests__/SchedulingIntegration.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx --reporter=dot` — pass, 58 tests
- `npm run build` — pass
- `npm run test:ci` — 425 files / 3,446 tests pass; five failures remain exclusively in files and source surfaces unchanged from `main`
- `npm run verify:local` — reaches the same unchanged `test:ci` baseline failures, so later coverage/tier-0 steps do not run

## Baseline failures to distinguish in live checks
- `tests/authorizations/authorization-bcba-readonly.test.ts`
- `tests/ci/check-e2e-reliability-gates.test.ts`
- `tests/scripts/playwright-iehp-assessment-import-smoke.test.ts`
- `tests/workflows/bt-aba-disposable-browser-proof.test.ts`
- `src/lib/__tests__/supabase.edge.test.ts` (`Blob.text()` unavailable in the local test environment)

## Risk
No protected paths, auth, API, database, CI, deploy, or role-resolution logic changed. Final independent review approved with no findings.