### PR TITLE
WIN-259 Resolve schedule cancellation review findings

### DIFF
--- a/docs/ai/WIN-259-codex-review-followups-handoff.md
+++ b/docs/ai/WIN-259-codex-review-followups-handoff.md
@@ -48,6 +48,8 @@ Result: 3 tests failed for the expected missing behaviors:
 - persisted client attribution displayed as staff
 - unknown persisted attribution displayed as staff
 
+After PR review identified a stale hydration overwrite, a focused regression was added and failed before the follow-up fix because a user-selected client cancellation reverted to unknown. The hydration effect now skips server reconciliation after either cancellation field becomes dirty. The correction and delayed-response regressions both pass.
+
 ## Verification Card
 
 - classification: `low-risk autonomous`
@@ -65,7 +67,8 @@ Result: 3 tests failed for the expected missing behaviors:
 - executed checks:
   - focused red run: 3 expected failures before implementation
   - focused green run: 3 passed
-  - SessionModal and scheduling regression run: 196 passed
+  - cancellation review follow-up: 2 passed
+  - SessionModal and scheduling regression run: 198 passed
   - `npm run ci:check-focused`: passed; secret-backed database checks and CI-only branch-protection checks skipped by the command as expected
   - `npm run lint`: passed
   - `npm run typecheck`: passed
@@ -83,4 +86,4 @@ Result: 3 tests failed for the expected missing behaviors:
 - Linear: WIN-259
 - branch: `codex/win-258-review-followups`
 - PR: https://github.com/Jeduardo622/AllIincompassing/pull/869
-- reviewer: approved with no required changes
+- reviewer: approved both the original slice and the dirty-field hydration guard with no required changes

--- a/docs/ai/WIN-259-codex-review-followups-handoff.md
+++ b/docs/ai/WIN-259-codex-review-followups-handoff.md
@@ -1,0 +1,86 @@
+# WIN-259 Codex Review Follow-ups
+
+## Scope
+
+Resolve both findings left open on merged PR #868:
+
+1. Let a user explicitly promote a selected lower-control goal to the primary `goal_id`.
+2. Hydrate persisted `cancellation_attribution` before displaying an existing cancellation, preserving missing legacy attribution as unknown.
+
+## Route
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- triggering paths:
+  - `src/components/SessionModal.tsx`
+  - `src/components/__tests__/SessionModal.test.tsx`
+- required agents:
+  - `specification-engineer`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+- protected paths: none
+
+## Non-goals
+
+- No migrations, RPC changes, RLS, grants, auth, server, CI, or deploy changes.
+- No broader Program/Goals redesign.
+- No schedule authorization or cancellation-write contract changes.
+
+## Stop Conditions
+
+- Re-route to `critical` if resolving attribution requires a migration, RPC, server, or tenant-policy change.
+- Stop if primary-goal promotion requires changing the persisted session-write contract outside the existing modal payload.
+
+## TDD Evidence
+
+The focused regression run was executed before production implementation:
+
+```text
+npx vitest run src/components/__tests__/SessionModal.test.tsx \
+  -t "lets the lower goal controls replace|hydrates a persisted client cancellation|preserves an unknown persisted cancellation" \
+  --reporter=dot
+```
+
+Result: 3 tests failed for the expected missing behaviors:
+
+- no accessible lower-control primary-goal action
+- persisted client attribution displayed as staff
+- unknown persisted attribution displayed as staff
+
+## Verification Card
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- change type: UI/component state and tenant-scoped detail hydration
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - focused SessionModal and scheduling tests
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run verify:local`
+  - hosted auth/session browser gate
+- executed checks:
+  - focused red run: 3 expected failures before implementation
+  - focused green run: 3 passed
+  - SessionModal and scheduling regression run: 196 passed
+  - `npm run ci:check-focused`: passed; secret-backed database checks and CI-only branch-protection checks skipped by the command as expected
+  - `npm run lint`: passed
+  - `npm run typecheck`: passed
+  - `npm run build`: passed
+  - `npm run test:ci`: reached 3,446 passing tests and 5 failures on unchanged baseline surfaces
+  - `npm run verify:local`: policy, lint, and typecheck passed; stopped at the same 5 unchanged `test:ci` baseline failures
+- blocked checks:
+  - local full-suite green status is blocked by 5 failures reproduced on surfaces unchanged from `origin/main`
+  - hosted auth/session browser confidence is pending the follow-up PR checks
+- result: `pass-with-blocked-checks`
+- residual risk: low; focused behavior and neighboring scheduling coverage pass, while hosted CI remains the authoritative check for the unchanged local baseline failures
+
+## PR Handoff
+
+- Linear: WIN-259
+- branch: `codex/win-258-review-followups`
+- PR: pending
+- reviewer: approved with no required changes

--- a/docs/ai/WIN-259-codex-review-followups-handoff.md
+++ b/docs/ai/WIN-259-codex-review-followups-handoff.md
@@ -82,5 +82,5 @@ Result: 3 tests failed for the expected missing behaviors:
 
 - Linear: WIN-259
 - branch: `codex/win-258-review-followups`
-- PR: pending
+- PR: https://github.com/Jeduardo622/AllIincompassing/pull/869
 - reviewer: approved with no required changes

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -2508,7 +2508,12 @@ export function SessionModal({
   };
 
   useEffect(() => {
-    if (sessionStatus !== 'cancelled' || !sessionDetails) {
+    if (
+      sessionStatus !== 'cancelled' ||
+      !sessionDetails ||
+      dirtyFields.status ||
+      dirtyFields.cancellation_attribution
+    ) {
       return;
     }
 
@@ -2523,7 +2528,14 @@ export function SessionModal({
         shouldTouch: false,
       });
     }
-  }, [cancellationAttribution, sessionDetails, sessionStatus, setValue]);
+  }, [
+    cancellationAttribution,
+    dirtyFields.cancellation_attribution,
+    dirtyFields.status,
+    sessionDetails,
+    sessionStatus,
+    setValue,
+  ]);
 
   const hasStartedSession = Boolean(sessionDetails?.started_at ?? session?.started_at);
   const hasTerminalSessionStatus =

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -899,7 +899,11 @@ export function SessionModal({
       return '';
     }
 
-    return session.cancellation_attribution === 'client' ? 'client' : 'staff';
+    if (session.cancellation_attribution === 'client' || session.cancellation_attribution === 'staff') {
+      return session.cancellation_attribution;
+    }
+
+    return 'unknown';
   };
 
   type SessionModalFormValues = Partial<Session> & SessionModalClinicalNotesPayload;
@@ -968,7 +972,7 @@ export function SessionModal({
       }
       const { data, error } = await supabase
         .from('sessions')
-        .select('program_id, goal_id, started_at, location_type')
+        .select('program_id, goal_id, started_at, location_type, cancellation_attribution')
         .eq('id', session.id)
         .eq('organization_id', activeOrganizationId)
         .maybeSingle();
@@ -1674,6 +1678,29 @@ export function SessionModal({
     }
     setValue('goal_ids', [...nextGoalIds, targetId]);
   };
+
+  const setPrimaryGoal = useCallback((targetId: string) => {
+    if (isDataCollectionOnly) {
+      return;
+    }
+
+    const nextGoalIds = Array.isArray(goalIds) ? [...goalIds] : [];
+    if (!nextGoalIds.includes(targetId)) {
+      setValue('goal_ids', [...nextGoalIds, targetId]);
+    }
+
+    setValue('goal_id', targetId);
+
+    const nextProgramId = goalsById.get(targetId)?.program_id;
+    if (nextProgramId) {
+      if (programId !== nextProgramId) {
+        setValue('program_id', nextProgramId);
+      }
+      setSelectedProgramIds((current) => (
+        current.includes(nextProgramId) ? current : [nextProgramId, ...current]
+      ));
+    }
+  }, [goalIds, goalsById, isDataCollectionOnly, programId, setValue]);
 
   const previousFormValues = useRef({
     startTime,
@@ -2443,7 +2470,7 @@ export function SessionModal({
 
   useEffect(() => {
     if (sessionStatus === 'cancelled') {
-      if (cancellationAttribution !== 'staff' && cancellationAttribution !== 'client') {
+      if (!cancellationAttribution) {
         setValue('cancellation_attribution', 'staff', { shouldDirty: false, shouldTouch: false });
       }
       return;
@@ -2455,7 +2482,11 @@ export function SessionModal({
   }, [cancellationAttribution, sessionStatus, setValue]);
 
   const resolvedCancellationAttribution =
-    cancellationAttribution === 'client' ? 'client' : 'staff';
+    cancellationAttribution === 'client'
+      ? 'client'
+      : cancellationAttribution === 'staff'
+        ? 'staff'
+        : 'unknown';
   const statusSelectValue =
     sessionStatus === 'cancelled'
       ? (canCreateSchedules ? `cancelled:${resolvedCancellationAttribution}` : 'cancelled')
@@ -2475,6 +2506,24 @@ export function SessionModal({
     setValue('status', value as Session['status'], { shouldDirty: true, shouldTouch: true });
     setValue('cancellation_attribution', '', { shouldDirty: true, shouldTouch: true });
   };
+
+  useEffect(() => {
+    if (sessionStatus !== 'cancelled' || !sessionDetails) {
+      return;
+    }
+
+    const nextCancellationAttribution =
+      sessionDetails.cancellation_attribution === 'client' || sessionDetails.cancellation_attribution === 'staff'
+        ? sessionDetails.cancellation_attribution
+        : 'unknown';
+
+    if (cancellationAttribution !== nextCancellationAttribution) {
+      setValue('cancellation_attribution', nextCancellationAttribution, {
+        shouldDirty: false,
+        shouldTouch: false,
+      });
+    }
+  }, [cancellationAttribution, sessionDetails, sessionStatus, setValue]);
 
   const hasStartedSession = Boolean(sessionDetails?.started_at ?? session?.started_at);
   const hasTerminalSessionStatus =
@@ -3840,25 +3889,48 @@ export function SessionModal({
                             {program.name}
                           </p>
                           <div className="grid grid-cols-1 gap-2">
-                            {groupedGoals.map((goal) => (
-                              <label
-                                key={`m-${goal.id}`}
-                                className="flex min-w-0 items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
-                              >
-                                <input
-                                  type="checkbox"
-                                  data-goal-id={goal.id}
-                                  checked={Array.isArray(goalIds) && goalIds.includes(goal.id)}
-                                  onChange={() => toggleGoalSelection(goal.id)}
-                                  disabled={isDataCollectionOnly}
-                                  className="h-5 w-5 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                                />
-                                <span className="min-w-0 flex-1 truncate">{goal.title}</span>
-                                <span className="shrink-0 text-[11px] text-gray-500 dark:text-gray-400">
-                                  {Array.isArray(goal.objective_data_points) ? goal.objective_data_points.length : 0} pts
-                                </span>
-                              </label>
-                            ))}
+                            {groupedGoals.map((goal) => {
+                              const isPrimaryGoal = goalId === goal.id;
+                              return (
+                                <div
+                                  key={`m-${goal.id}`}
+                                  className="flex min-w-0 items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
+                                >
+                                  <label className="flex min-w-0 flex-1 items-center gap-2">
+                                    <input
+                                      type="checkbox"
+                                      data-goal-id={goal.id}
+                                      checked={Array.isArray(goalIds) && goalIds.includes(goal.id)}
+                                      onChange={() => toggleGoalSelection(goal.id)}
+                                      disabled={isDataCollectionOnly}
+                                      className="h-5 w-5 shrink-0 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                                    />
+                                    <span className="min-w-0 flex-1 truncate">{goal.title}</span>
+                                  </label>
+                                  <button
+                                    type="button"
+                                    aria-pressed={isPrimaryGoal}
+                                    aria-label={
+                                      isPrimaryGoal
+                                        ? `${goal.title} is primary goal`
+                                        : `Set ${goal.title} as primary goal`
+                                    }
+                                    onClick={() => setPrimaryGoal(goal.id)}
+                                    disabled={isDataCollectionOnly}
+                                    className={`shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold transition ${
+                                      isPrimaryGoal
+                                        ? 'bg-blue-600 text-white'
+                                        : 'border border-blue-200 bg-white text-blue-700 hover:bg-blue-50 dark:border-blue-800 dark:bg-dark dark:text-blue-200'
+                                    }`}
+                                  >
+                                    {isPrimaryGoal ? 'Primary goal' : 'Set as primary'}
+                                  </button>
+                                  <span className="shrink-0 text-[11px] text-gray-500 dark:text-gray-400">
+                                    {Array.isArray(goal.objective_data_points) ? goal.objective_data_points.length : 0} pts
+                                  </span>
+                                </div>
+                              );
+                            })}
                           </div>
                         </div>
                       );
@@ -3894,22 +3966,45 @@ export function SessionModal({
                             {program.name}
                           </p>
                           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                            {groupedGoals.map((goal) => (
-                              <label key={goal.id} className="flex min-w-0 items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
-                                <input
-                                  type="checkbox"
-                                  data-goal-id={goal.id}
-                                  checked={Array.isArray(goalIds) && goalIds.includes(goal.id)}
-                                  onChange={() => toggleGoalSelection(goal.id)}
-                                  disabled={isDataCollectionOnly}
-                                  className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                                />
-                                <span className="truncate">{goal.title}</span>
-                                <span className="text-[11px] text-gray-500 dark:text-gray-400">
-                                  ({Array.isArray(goal.objective_data_points) ? goal.objective_data_points.length : 0} data points)
-                                </span>
-                              </label>
-                            ))}
+                            {groupedGoals.map((goal) => {
+                              const isPrimaryGoal = goalId === goal.id;
+                              return (
+                                <div key={goal.id} className="flex min-w-0 items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                                  <label className="flex min-w-0 flex-1 items-center gap-2">
+                                    <input
+                                      type="checkbox"
+                                      data-goal-id={goal.id}
+                                      checked={Array.isArray(goalIds) && goalIds.includes(goal.id)}
+                                      onChange={() => toggleGoalSelection(goal.id)}
+                                      disabled={isDataCollectionOnly}
+                                      className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                                    />
+                                    <span className="truncate">{goal.title}</span>
+                                  </label>
+                                  <button
+                                    type="button"
+                                    aria-pressed={isPrimaryGoal}
+                                    aria-label={
+                                      isPrimaryGoal
+                                        ? `${goal.title} is primary goal`
+                                        : `Set ${goal.title} as primary goal`
+                                    }
+                                    onClick={() => setPrimaryGoal(goal.id)}
+                                    disabled={isDataCollectionOnly}
+                                    className={`shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold transition ${
+                                      isPrimaryGoal
+                                        ? 'bg-blue-600 text-white'
+                                        : 'border border-blue-200 bg-white text-blue-700 hover:bg-blue-50 dark:border-blue-800 dark:bg-dark dark:text-blue-200'
+                                    }`}
+                                  >
+                                    {isPrimaryGoal ? 'Primary goal' : 'Set as primary'}
+                                  </button>
+                                  <span className="text-[11px] text-gray-500 dark:text-gray-400">
+                                    ({Array.isArray(goal.objective_data_points) ? goal.objective_data_points.length : 0} data points)
+                                  </span>
+                                </div>
+                              );
+                            })}
                           </div>
                         </div>
                       );
@@ -4034,6 +4129,9 @@ export function SessionModal({
                 <option value="completed" disabled={!session}>Completed</option>
                 {canCreateSchedules ? (
                   <>
+                    {resolvedCancellationAttribution === 'unknown' ? (
+                      <option value="cancelled:unknown" disabled>Cancelled — attribution unavailable</option>
+                    ) : null}
                     <option value="cancelled:staff">Staff cancellation</option>
                     <option value="cancelled:client">Client cancellation</option>
                   </>

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/utils';
-import { fireEvent } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import {
   buildCloseoutDataPoints,
@@ -3576,6 +3576,129 @@ describe('SessionModal', () => {
       const statusSelect = screen.getByRole('combobox', { name: /Status/i }) as HTMLSelectElement;
       await waitFor(() => expect(statusSelect.value).toBe('cancelled:unknown'));
       expect(statusSelect.selectedOptions[0]?.textContent).toBe('Cancelled — attribution unavailable');
+    });
+
+    it('does not reapply persisted cancellation attribution after the user changes it', async () => {
+      const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: rows, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      };
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
+        if (table === 'sessions') {
+          return buildChain([], {
+            program_id: 'program-1',
+            goal_id: 'goal-1',
+            started_at: null,
+            location_type: null,
+            cancellation_attribution: null,
+          });
+        }
+        if (table === 'programs') return buildChain(mockPrograms);
+        if (table === 'goals') return buildChain(mockGoals);
+        return buildChain([]);
+      });
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+      renderWithProviders(
+        <SessionModal
+          {...defaultProps}
+          onSubmit={onSubmit}
+          session={{ ...editSession, status: 'cancelled', cancellation_attribution: undefined }}
+        />,
+      );
+
+      const statusSelect = screen.getByRole('combobox', { name: /Status/i }) as HTMLSelectElement;
+      await waitFor(() => expect(statusSelect.value).toBe('cancelled:unknown'));
+      await userEvent.selectOptions(statusSelect, 'Client cancellation');
+      await waitFor(() => expect(statusSelect.value).toBe('cancelled:client'));
+      await userEvent.click(screen.getByRole('button', { name: /Update Session/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+          status: 'cancelled',
+          cancellation_attribution: 'client',
+        }));
+      });
+    });
+
+    it('does not overwrite a new cancellation choice when stale session details arrive later', async () => {
+      type SessionDetailsResponse = {
+        data: {
+          program_id: string;
+          goal_id: string;
+          started_at: null;
+          location_type: null;
+          cancellation_attribution: null;
+        };
+        error: null;
+      };
+      let resolveSessionDetails: ((value: SessionDetailsResponse) => void) | undefined;
+      const sessionDetailsPromise = new Promise<SessionDetailsResponse>((resolve) => {
+        resolveSessionDetails = resolve;
+      });
+      const buildChain = (rows: unknown[]) => {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: rows, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      };
+      const sessionChain = buildChain([]);
+      sessionChain.maybeSingle = vi.fn(() => sessionDetailsPromise);
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
+        if (table === 'sessions') return sessionChain;
+        if (table === 'programs') return buildChain(mockPrograms);
+        if (table === 'goals') return buildChain(mockGoals);
+        return buildChain([]);
+      });
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+      renderWithProviders(
+        <SessionModal
+          {...defaultProps}
+          onSubmit={onSubmit}
+          session={editSession}
+        />,
+      );
+
+      const statusSelect = screen.getByRole('combobox', { name: /Status/i }) as HTMLSelectElement;
+      await waitFor(() => expect(sessionChain.maybeSingle).toHaveBeenCalled());
+      await userEvent.selectOptions(statusSelect, 'Client cancellation');
+      expect(statusSelect.value).toBe('cancelled:client');
+
+      await act(async () => {
+        resolveSessionDetails?.({
+          data: {
+            program_id: 'program-1',
+            goal_id: 'goal-1',
+            started_at: null,
+            location_type: null,
+            cancellation_attribution: null,
+          },
+          error: null,
+        });
+        await sessionDetailsPromise;
+      });
+
+      await waitFor(() => expect(statusSelect.value).toBe('cancelled:client'));
+      await userEvent.click(screen.getByRole('button', { name: /Update Session/i }));
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+          status: 'cancelled',
+          cancellation_attribution: 'client',
+        }));
+      });
     });
 
     it.each([

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1310,6 +1310,56 @@ describe('SessionModal', () => {
     });
   }, 15000);
 
+  it('lets the lower goal controls replace the automatically selected primary goal', async () => {
+    const alternateGoal = {
+      ...mockGoals[0],
+      id: 'goal-alternate',
+      title: 'Alternate Goal',
+      created_at: '2024-01-03T00:00:00Z',
+      updated_at: '2024-01-03T00:00:00Z',
+    };
+    const buildChain = (rows: unknown[]) => {
+      const chain: SupabaseQueryChain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        order: vi.fn(async () => ({ data: rows, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+        limit: vi.fn(async () => ({ data: [], error: null })),
+      };
+      return chain;
+    };
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') return buildChain(mockPrograms);
+      if (table === 'goals') return buildChain([...mockGoals, alternateGoal]);
+      return buildChain([]);
+    });
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(<SessionModal {...defaultProps} onSubmit={onSubmit} />);
+
+    await userEvent.selectOptions(screen.getByLabelText(/Therapist/i), 'test-therapist-1');
+    await userEvent.selectOptions(screen.getByLabelText(/Client/i), 'test-client-1');
+    await screen.findByRole('button', { name: /Default Program/i });
+    await userEvent.click(screen.getByRole('button', { name: /Default Program/i }));
+    await selectGoalFromLowerControls(/Alternate Goal/i);
+    await userEvent.click(
+      screen.getAllByRole('button', { name: /Set Alternate Goal as primary goal/i })[0],
+    );
+
+    fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2025-03-18T10:00' } });
+    fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2025-03-18T11:00' } });
+    await userEvent.click(screen.getByRole('button', { name: /Create Session/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        program_id: 'program-1',
+        goal_id: 'goal-alternate',
+        goal_ids: expect.arrayContaining(['goal-1', 'goal-alternate']),
+      }));
+    });
+  }, 15000);
+
   it('calls onSubmit with form data when valid', async () => {
     renderWithProviders(<SessionModal {...defaultProps} />);
 
@@ -3448,6 +3498,84 @@ describe('SessionModal', () => {
 
       const option = screen.getByRole('option', { name: /^Cancelled$/i }) as HTMLOptionElement;
       expect(option.disabled).toBe(true);
+    });
+
+    it('hydrates a persisted client cancellation before displaying its attribution', async () => {
+      const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: rows, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      };
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
+        if (table === 'sessions') {
+          return buildChain([], {
+            program_id: 'program-1',
+            goal_id: 'goal-1',
+            started_at: null,
+            location_type: null,
+            cancellation_attribution: 'client',
+          });
+        }
+        if (table === 'programs') return buildChain(mockPrograms);
+        if (table === 'goals') return buildChain(mockGoals);
+        return buildChain([]);
+      });
+
+      renderWithProviders(
+        <SessionModal
+          {...defaultProps}
+          session={{ ...editSession, status: 'cancelled', cancellation_attribution: undefined }}
+        />,
+      );
+
+      const statusSelect = screen.getByRole('combobox', { name: /Status/i }) as HTMLSelectElement;
+      await waitFor(() => expect(statusSelect.value).toBe('cancelled:client'));
+      expect(statusSelect.selectedOptions[0]?.textContent).toBe('Client cancellation');
+    });
+
+    it('preserves an unknown persisted cancellation attribution instead of defaulting it to staff', async () => {
+      const buildChain = (rows: unknown[], singleRow: unknown = null) => {
+        const chain: SupabaseQueryChain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          neq: vi.fn(() => chain),
+          order: vi.fn(async () => ({ data: rows, error: null })),
+          maybeSingle: vi.fn(async () => ({ data: singleRow, error: null })),
+          limit: vi.fn(async () => ({ data: [], error: null })),
+        };
+        return chain;
+      };
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
+        if (table === 'sessions') {
+          return buildChain([], {
+            program_id: 'program-1',
+            goal_id: 'goal-1',
+            started_at: null,
+            location_type: null,
+            cancellation_attribution: null,
+          });
+        }
+        if (table === 'programs') return buildChain(mockPrograms);
+        if (table === 'goals') return buildChain(mockGoals);
+        return buildChain([]);
+      });
+
+      renderWithProviders(
+        <SessionModal
+          {...defaultProps}
+          session={{ ...editSession, status: 'cancelled', cancellation_attribution: undefined }}
+        />,
+      );
+
+      const statusSelect = screen.getByRole('combobox', { name: /Status/i }) as HTMLSelectElement;
+      await waitFor(() => expect(statusSelect.value).toBe('cancelled:unknown'));
+      expect(statusSelect.selectedOptions[0]?.textContent).toBe('Cancelled — attribution unavailable');
     });
 
     it.each([


### PR DESCRIPTION
## Summary
- let schedule creators promote any selected lower-control goal to the persisted primary `goal_id`
- hydrate `cancellation_attribution` from the tenant-scoped session detail query
- preserve legacy cancellations with missing attribution as unavailable instead of mislabeling them as staff

## Tracking
- Linear: [WIN-259](https://linear.app/winningedgeai/issue/WIN-259/resolve-pr-868-codex-review-findings)
- Follow-up to #868
- Resolves review findings: [primary goal](https://github.com/Jeduardo622/AllIincompassing/pull/868#discussion_r3659320009), [cancellation attribution](https://github.com/Jeduardo622/AllIincompassing/pull/868#discussion_r3659320014)

## Verification
- TDD red: 3 expected regression failures before implementation
- focused green: 3 passed
- scheduling regression set: 196 passed
- `npm run ci:check-focused`: passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm run test:ci`: 3,446 passed, 5 failures on unchanged `origin/main` surfaces
- `npm run verify:local`: policy/lint/typecheck passed, then stopped at those same 5 unchanged baseline failures

## Risk
Standard lane, no protected paths. Hosted PR checks are the authoritative browser/full-suite signal for the unchanged local baseline failures.