### PR TITLE
WIN-262 Make workflow contract tests line-ending agnostic

### DIFF
--- a/docs/ai/handoffs/WIN-262-crlf-test-harness.md
+++ b/docs/ai/handoffs/WIN-262-crlf-test-harness.md
@@ -1,0 +1,73 @@
+# WIN-262 CRLF Test Harness Handoff
+
+## Routing
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- why: test-only portability cleanup with no production, workflow, configuration, schema, or runtime changes
+- triggering paths:
+  - `tests/ci/check-e2e-reliability-gates.test.ts`
+  - `tests/scripts/playwright-iehp-assessment-import-smoke.test.ts`
+  - `tests/workflows/bt-aba-disposable-browser-proof.test.ts`
+
+## Scope
+
+- task intent: make three workflow and configuration contract tests insensitive to Windows CRLF checkouts while preserving their existing assertions
+- files touched:
+  - `tests/ci/check-e2e-reliability-gates.test.ts`
+  - `tests/scripts/playwright-iehp-assessment-import-smoke.test.ts`
+  - `tests/workflows/bt-aba-disposable-browser-proof.test.ts`
+  - `docs/ai/handoffs/WIN-262-crlf-test-harness.md`
+- non-goals:
+  - changing workflow or configuration files
+  - weakening contract assertions
+  - fixing unrelated repository-wide test failures
+- stop condition: re-route before touching production code, protected paths, shared helpers, or tests outside the three named files
+- single-purpose diff: yes
+
+## Required Agents
+
+- required sequence: `specification-engineer` -> `implementation-engineer` -> `code-review-engineer` -> `test-engineer`
+- agents used: all required agents completed
+- reviewer: completed with approval and no required fixes
+
+## Verification Card
+
+- required checks:
+  - targeted three-file Vitest run
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run verify:local`
+- executed checks:
+  - targeted three-file Vitest run before changes: expected RED, 3 failed and 56 passed
+  - targeted three-file Vitest run after changes: pass, 59 passed
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+  - `npm run test:ci`: blocked by 2 unchanged Windows baseline failures; 3,526 passed and 5 skipped
+  - `npm run verify:local`: stopped at the same `test:ci` failures after policy, lint, and typecheck passed
+- blocked checks:
+  - `tests/authorizations/authorization-bcba-readonly.test.ts`: unchanged LF-only assertion fails against a CRLF migration checkout
+  - `src/lib/__tests__/supabase.edge.test.ts`: unchanged jsdom Blob implementation does not provide `blob.text()`
+  - later `verify:local` stages did not run because the command is fail-fast
+- result: pass-with-blocked-checks
+- residual risk: low for WIN-262; Linux CI must confirm the complete repository suite, while the two unrelated Windows harness baselines need separate cleanup
+
+## PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes, `WIN-262`
+- protected-path drift: none
+- unrelated changes: none
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: yes
+- required follow-up: confirm live CI and address only failures attributable to this diff
+
+## Handoff Summary
+
+WIN-262 normalizes CRLF to LF only at the three raw file-read boundaries whose exact multiline assertions failed on Windows. The focused tests moved from 3 failures to 59 passing assertions, policy/lint/typecheck/build passed, and independent review approved the unchanged assertion strength. Full local verification remains blocked by two reproducible failures in unchanged files, so live Linux CI is the authoritative full-suite gate for this PR.

--- a/tests/ci/check-e2e-reliability-gates.test.ts
+++ b/tests/ci/check-e2e-reliability-gates.test.ts
@@ -27,6 +27,7 @@ const sessionSmokeRunnerChildren = [
   "playwright:schedule-blocked-close",
   "playwright:session-note-measurement-roundtrip",
 ];
+const normalizeLf = (content: string) => content.replace(/\r\n/g, "\n");
 
 const write = (root: string, relativePath: string, content: string) => {
   const target = path.join(root, relativePath);
@@ -294,7 +295,7 @@ describe("check-e2e-reliability-gates", () => {
   });
 
   test("synthetic BCBA provisioning keeps authenticated preflight and unconditional cleanup contracts", () => {
-    const workflow = readFileSync(path.join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+    const workflow = normalizeLf(readFileSync(path.join(repoRoot, ".github/workflows/ci.yml"), "utf8"));
     const provisionStep = workflow.match(/- name: Provision synthetic BCBA smoke actor[\s\S]*?run: npx tsx scripts\/provision-ci-smoke-bcba\.ts\n/)?.[0] ?? "";
     const cleanupStart = workflow.indexOf("- name: Cleanup synthetic BCBA smoke actor");
     const cleanupEnd = workflow.indexOf("- name: Cleanup auth smoke admin", cleanupStart);

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -15,6 +15,8 @@ import {
 } from '../../scripts/playwright-iehp-assessment-import-smoke';
 import { assertIehpSkillsBehaviorsChecklistSection } from '../../scripts/lib/iehp-assessment-import-smoke';
 
+const normalizeLf = (content: string) => content.replace(/\r\n/g, '\n');
+
 const sliceWorkflowJob = (workflow: string, jobName: string): string => {
   const start = workflow.indexOf(`  ${jobName}:`);
   expect(start).toBeGreaterThanOrEqual(0);
@@ -420,7 +422,7 @@ describe('selectConfiguredSmokeClient', () => {
   it('keeps both CI IEHP proofs on the generated super-admin and unconditional cleanup path', () => {
     const root = process.cwd();
     const workflow = readFileSync(path.join(root, '.github/workflows/ci.yml'), 'utf8');
-    const supabaseConfig = readFileSync(path.join(root, 'supabase/config.toml'), 'utf8');
+    const supabaseConfig = normalizeLf(readFileSync(path.join(root, 'supabase/config.toml'), 'utf8'));
     const script = readFileSync(path.join(root, 'scripts/playwright-iehp-assessment-import-smoke.ts'), 'utf8');
     const iehpJob = sliceWorkflowJob(workflow, 'iehp_assessment_import_smoke');
     const cleanupStepStart = iehpJob.indexOf('- name: Cleanup IEHP smoke admin');

--- a/tests/workflows/bt-aba-disposable-browser-proof.test.ts
+++ b/tests/workflows/bt-aba-disposable-browser-proof.test.ts
@@ -50,9 +50,10 @@ const workflowPath = path.join(
   '.github/workflows/bt-aba-disposable-browser-proof.yml',
 );
 const dispatcherPath = path.join(process.cwd(), '.github/workflows/supabase-preview.yml');
+const normalizeLf = (content: string) => content.replace(/\r\n/g, '\n');
 
 const loadWorkflow = (): { source: string; workflow: ProofWorkflow } => {
-  const source = readFileSync(workflowPath, 'utf8');
+  const source = normalizeLf(readFileSync(workflowPath, 'utf8'));
   return { source, workflow: parse(source) as ProofWorkflow };
 };
 


### PR DESCRIPTION
## Summary
- normalize CRLF to LF at three raw workflow/config test-read boundaries
- preserve every existing exact assertion and ordering contract
- document WIN-262 routing, verification, and the unrelated Windows baseline blockers

## Verification
- targeted RED before: 3 failed, 56 passed
- targeted GREEN after: 59 passed
- `npm run ci:check-focused`: pass
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run build`: pass
- `npm run test:ci`: 3,526 passed / 5 skipped; blocked by two reproducible failures in unchanged files (`authorization-bcba-readonly` CRLF assertion and jsdom `Blob.text` support)
- `npm run verify:local`: reaches the same two unchanged `test:ci` blockers after policy, lint, and typecheck pass

## Risk
Low and test-only. No workflow, configuration, application, schema, runtime, or protected-path files changed.

Linear: WIN-262