### PR TITLE
WIN-264 Fix Windows Blob test CI blocker

### DIFF
--- a/docs/ai/WIN-261-live-program-goal-editing-handoff.md
+++ b/docs/ai/WIN-261-live-program-goal-editing-handoff.md
@@ -84,3 +84,9 @@
 - Human review is mandatory for the migration and protected server changes.
 - Required next action: obtain human review and merge only when live branch protection allows it.
 - Follow-up, separate from WIN-261: make the unchanged workflow/config contract tests line-ending agnostic on Windows.
+
+## CI Baseline Follow-Up
+
+- WIN-262 / PR #872 made the synthetic-BCBA publishable-key contract, the IEHP smoke contract, and the BT/ABA `codex/return-bt-correction` contract line-ending agnostic on Windows.
+- WIN-264 covers the `src/lib/__tests__/supabase.edge.test.ts` Blob-read failure by reading the returned Blob through the jsdom-supported `FileReader` API in the test only; the separate `tests/authorizations/authorization-bcba-readonly.test.ts` Windows CRLF baseline remains out of scope. See `docs/ai/handoffs/WIN-264-windows-blob-test.md`.
+- No migration, hosted Supabase, workflow, CI-script, or program/goal editing implementation changes are part of WIN-264.

--- a/docs/ai/handoffs/WIN-264-windows-blob-test.md
+++ b/docs/ai/handoffs/WIN-264-windows-blob-test.md
@@ -60,7 +60,17 @@
 
 - Specification: completed; scope remains test-only plus tracking artifacts.
 - Implementation: completed.
-- Code review: no code-level defect found; handoff-card request addressed by this artifact.
-- Test review: pending final verification assessment.
-- PR hygiene: pending.
-- PR handoff: pending commit, push, and PR creation.
+- Code review: approved after the handoff-card request was addressed; no code-level defect or protected-path drift found.
+- Test review: `pass-with-blocked-checks`; the focused scope and required static/build checks passed, while aggregate local verification remains blocked by the unchanged authorization CRLF assertion.
+- PR hygiene:
+  - `pr-ready`: yes
+  - `branch-ready`: yes, `codex/sessionnoteshang`
+  - `linear-ready`: yes, WIN-264
+  - `single-purpose`: yes
+  - `unrelated changes`: none
+  - `generated artifact drift`: none
+  - `protected-path drift`: none
+  - `change summary`: present
+  - `verification summary`: present
+  - `reviewer`: completed
+- PR handoff: PR #874, pending required live checks and human review.

--- a/docs/ai/handoffs/WIN-264-windows-blob-test.md
+++ b/docs/ai/handoffs/WIN-264-windows-blob-test.md
@@ -1,0 +1,66 @@
+# WIN-264 Windows Blob Test CI Unblocker
+
+## Scope
+
+- Fix the Windows-local `blob.text is not a function` failure in `src/lib/__tests__/supabase.edge.test.ts`.
+- Confirm the synthetic-BCBA publishable-key and BT/ABA `codex/return-bt-correction` contracts remain green after WIN-262 / PR #872.
+- Do not change migrations, hosted Supabase state, workflows, CI scripts, or program/goal editing implementation.
+
+## Route
+
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Triggering paths:
+  - `src/lib/__tests__/supabase.edge.test.ts`
+  - `docs/ai/WIN-261-live-program-goal-editing-handoff.md`
+  - `docs/ai/handoffs/WIN-264-windows-blob-test.md`
+- Required agents:
+  - `specification-engineer`
+  - `implementation-engineer`
+  - `code-review-engineer`
+  - `test-engineer`
+- Reviewer required: yes
+- Verify-change required: yes
+- Linear: WIN-264
+
+## Implementation
+
+- Replaced the unsupported jsdom `Blob.text()` test call with `FileReader.readAsText`.
+- Preserved the assertion that the downloaded payload equals `pdf-binary`.
+- Left `downloadSessionNotesPdfExport`, workflow sources, CI scripts, migrations, and program/goal editing code unchanged.
+
+## Verification Card
+
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Change type: test harness and documentation
+- Required checks:
+  - `npx vitest run src/lib/__tests__/supabase.edge.test.ts tests/ci/check-e2e-reliability-gates.test.ts tests/workflows/bt-aba-disposable-browser-proof.test.ts`
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run verify:local`
+- Executed checks:
+  - `npx vitest run src/lib/__tests__/supabase.edge.test.ts tests/ci/check-e2e-reliability-gates.test.ts tests/workflows/bt-aba-disposable-browser-proof.test.ts`: pass, 3 files and 26 tests
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+  - `NODE_OPTIONS=--max-old-space-size=8192 npm run test:ci`: fail after 433 files and 3,573 tests passed
+  - `NODE_OPTIONS=--max-old-space-size=8192 npm run verify:local`: fail at its `test:ci` sub-gate after policy, lint, and typecheck passed
+- Blocked checks:
+  - `npm run test:ci`: blocked by the unchanged CRLF-sensitive assertion in `tests/authorizations/authorization-bcba-readonly.test.ts`
+  - `npm run verify:local`: blocked by the same out-of-scope `test:ci` assertion before coverage, build, and Tier-0 sub-gates
+- Result: `pass-with-blocked-checks`
+- Residual risk: low code risk; the requested three failures are green, while one separately documented Windows CRLF baseline remains outside WIN-264.
+
+## Review And PR Handoff
+
+- Specification: completed; scope remains test-only plus tracking artifacts.
+- Implementation: completed.
+- Code review: no code-level defect found; handoff-card request addressed by this artifact.
+- Test review: pending final verification assessment.
+- PR hygiene: pending.
+- PR handoff: pending commit, push, and PR creation.

--- a/docs/ai/handoffs/WIN-264-windows-blob-test.md
+++ b/docs/ai/handoffs/WIN-264-windows-blob-test.md
@@ -25,7 +25,8 @@
 
 ## Implementation
 
-- Replaced the unsupported jsdom `Blob.text()` test call with `FileReader.readAsText`.
+- Read the payload with `Blob.text()` when the Linux CI response exposes the Node/undici Blob implementation.
+- Fall back to `FileReader.readAsText` for the Windows jsdom Blob implementation, where `Blob.text()` is unavailable.
 - Preserved the assertion that the downloaded payload equals `pdf-binary`.
 - Left `downloadSessionNotesPdfExport`, workflow sources, CI scripts, migrations, and program/goal editing code unchanged.
 
@@ -60,7 +61,7 @@
 
 - Specification: completed; scope remains test-only plus tracking artifacts.
 - Implementation: completed.
-- Code review: approved after the handoff-card request was addressed; no code-level defect or protected-path drift found.
+- Code review: approved after the handoff-card update; no code-level defect or protected-path drift found.
 - Test review: `pass-with-blocked-checks`; the focused scope and required static/build checks passed, while aggregate local verification remains blocked by the unchanged authorization CRLF assertion.
 - PR hygiene:
   - `pr-ready`: yes

--- a/src/lib/__tests__/supabase.edge.test.ts
+++ b/src/lib/__tests__/supabase.edge.test.ts
@@ -155,12 +155,17 @@ describe("session notes pdf async edge helpers", () => {
     );
 
     const blob = await downloadSessionNotesPdfExport("export-3");
-    const text = await new Promise<string>((resolve, reject) => {
-      const reader = new FileReader();
-      reader.addEventListener("load", () => resolve(String(reader.result)));
-      reader.addEventListener("error", () => reject(reader.error ?? new Error("Failed to read blob")));
-      reader.readAsText(blob);
-    });
+    const text =
+      typeof blob.text === "function"
+        ? await blob.text()
+        : await new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.addEventListener("load", () => resolve(String(reader.result)));
+            reader.addEventListener("error", () =>
+              reject(reader.error ?? new Error("Failed to read blob")),
+            );
+            reader.readAsText(blob);
+          });
     expect(text).toBe("pdf-binary");
   });
 });

--- a/src/lib/__tests__/supabase.edge.test.ts
+++ b/src/lib/__tests__/supabase.edge.test.ts
@@ -155,7 +155,12 @@ describe("session notes pdf async edge helpers", () => {
     );
 
     const blob = await downloadSessionNotesPdfExport("export-3");
-    const text = await blob.text();
+    const text = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.addEventListener("load", () => resolve(String(reader.result)));
+      reader.addEventListener("error", () => reject(reader.error ?? new Error("Failed to read blob")));
+      reader.readAsText(blob);
+    });
     expect(text).toBe("pdf-binary");
   });
 });


### PR DESCRIPTION
## Summary
- Read the test payload with `Blob.text()` for Linux CI's Node/undici Blob and fall back to `FileReader.readAsText` for Windows jsdom.
- Preserve the exact `pdf-binary` payload assertion and keep the synthetic-BCBA publishable-key and BT/ABA branch contracts green.
- Record the separate Windows authorization CRLF baseline as out of scope.

## CI diagnosis
- Failed run: `30561557799`, `unit-tests` job `90936055257`.
- Root cause: Linux CI returned a Node/undici Blob that jsdom `FileReader` rejects; `ci-gate` failed only as a downstream consequence.

## Verification
- Focused three-file Vitest: 3 files / 26 tests passed.
- `npm run ci:check-focused`: passed.
- `npm run lint`: passed.
- `npm run typecheck`: passed.
- `npm run build`: passed.
- `npm run test:ci`: current Blob test passed; aggregate blocked by unchanged `tests/authorizations/authorization-bcba-readonly.test.ts` Windows CRLF assertion after 433 files / 3,573 tests passed.
- `npm run verify:local`: blocked at the same out-of-scope `test:ci` sub-gate.

Linear: WIN-264

No migrations, hosted Supabase changes, workflows, CI scripts, or program/goal editing implementation changes.