### PR TITLE
WIN-266 Preserve populated session-note targets

### DIFF
--- a/docs/ai/handoffs/WIN-266-session-note-target-hydration.md
+++ b/docs/ai/handoffs/WIN-266-session-note-target-hydration.md
@@ -27,7 +27,7 @@
 - Required sequence: `specification-engineer` -> `implementation-engineer` -> `code-review-engineer` -> `test-engineer`
 - Specification: completed.
 - Implementation: completed by the primary agent.
-- Code review: completed; no findings after the legacy target-trial compatibility regression was added.
+- Code review: completed; an automated P2 for partially populated indexed target metadata was fixed with a focused regression.
 - Test review: completed; implementation confidence high, with residual risk limited to blocked broad/browser verification.
 
 ## Verification Card
@@ -49,7 +49,7 @@
 - Executed checks:
   - TDD RED: the new preservation expectation failed because `Legacy freeform target` disappeared after hydration while the other 720 tests passed.
   - Focused target-preservation and blank-evidence regressions: pass (3 tests).
-  - Full `SessionModal` suite: pass (158 tests).
+  - Full `SessionModal` suite: pass (159 tests), including trial-only and partially populated indexed target metadata.
   - `npm run ci:check-focused`: pass; database URL, CI branch-protection, and disabled auth-parity checks reported their expected local skips.
   - `npm run lint`: pass.
   - `npm run typecheck`: pass.
@@ -75,7 +75,7 @@
 - Unrelated changes: none.
 - Generated artifact drift: none.
 - Verification summary: present.
-- Reviewer: completed with no findings.
+- Reviewer: completed; the one actionable P2 was addressed and verified.
 - PR-ready: yes, with blocked checks disclosed.
 - PR: [#875](https://github.com/Jeduardo622/AllIincompassing/pull/875)
 - Live status at open: mergeable, with policy, Lighthouse, and Netlify preview checks pending.

--- a/docs/ai/handoffs/WIN-266-session-note-target-hydration.md
+++ b/docs/ai/handoffs/WIN-266-session-note-target-hydration.md
@@ -77,7 +77,9 @@
 - Verification summary: present.
 - Reviewer: completed with no findings.
 - PR-ready: yes, with blocked checks disclosed.
-- Required follow-up: push, open the PR, and rerun hosted browser proof when valid credentials are available.
+- PR: [#875](https://github.com/Jeduardo622/AllIincompassing/pull/875)
+- Live status at open: mergeable, with policy, Lighthouse, and Netlify preview checks pending.
+- Required follow-up: complete human review and rerun hosted browser proof when valid credentials are available.
 
 ## Handoff Summary
 

--- a/docs/ai/handoffs/WIN-266-session-note-target-hydration.md
+++ b/docs/ai/handoffs/WIN-266-session-note-target-hydration.md
@@ -1,0 +1,84 @@
+# WIN-266 Session-Note Target Hydration Handoff
+
+## Routing
+
+- Linear: [WIN-266](https://linear.app/winningedgeai/issue/WIN-266/preserve-populated-skills-and-behaviors-during-session-note-hydration)
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Why: non-trivial UI state and hydration behavior outside protected auth, server, Supabase, CI, and deploy paths.
+- Triggering paths: `src/components/SessionModal.tsx`, `src/components/__tests__/SessionModal.test.tsx`
+
+## Scope
+
+- Preserve every populated linked-note target row when goal metadata resolves asynchronously.
+- Keep the current plan target as the primary target when it exists without deleting historical target evidence.
+- Render persisted non-empty or evidenced rows while suppressing empty placeholders.
+- Append or bind `Use plan target` without erasing existing target rows.
+- Preserve all target rows in closeout previews and submitted session-note measurements.
+
+## Non-Goals And Stop Conditions
+
+- No API, server, schema, migration, RLS, RPC, auth, billing, tenant, CI, or deploy changes.
+- No shared session-note persistence-contract changes.
+- Stop and re-route if the fix cannot remain within `SessionModal`, focused tests, and this handoff.
+
+## Required Agents
+
+- Required sequence: `specification-engineer` -> `implementation-engineer` -> `code-review-engineer` -> `test-engineer`
+- Specification: completed.
+- Implementation: completed by the primary agent.
+- Code review: completed; no findings after the legacy target-trial compatibility regression was added.
+- Test review: completed; implementation confidence high, with residual risk limited to blocked broad/browser verification.
+
+## Verification Card
+
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Change type: UI/component state hydration and display.
+- Required checks:
+  - focused `SessionModal` regression
+  - full `SessionModal` suite
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run build`
+  - `npm run verify:local`
+- Executed checks:
+  - TDD RED: the new preservation expectation failed because `Legacy freeform target` disappeared after hydration while the other 720 tests passed.
+  - Focused target-preservation and blank-evidence regressions: pass (3 tests).
+  - Full `SessionModal` suite: pass (158 tests).
+  - `npm run ci:check-focused`: pass; database URL, CI branch-protection, and disabled auth-parity checks reported their expected local skips.
+  - `npm run lint`: pass.
+  - `npm run typecheck`: pass.
+  - `npm run build`: pass after the final implementation.
+  - `npm run test:routes:tier0`: partial, 219/220 passed; an unrelated `/authorizations` route assertion timed out. A later attempted isolated rerun was invalid because the npm script appended the argument to its built-in suite and is not counted as verification.
+  - `npm run test:ci`: changed `SessionModal` tests passed, but the command failed on the unchanged Windows CRLF assertion in `tests/authorizations/authorization-bcba-readonly.test.ts` and later exhausted the Node heap.
+  - `npm run verify:local`: policy, lint, and typecheck constituents passed; the command stopped at the same `test:ci` CRLF failure and heap exhaustion.
+  - `npm run ci:playwright`: preflight passed; hosted superadmin authentication rejected the configured credentials before session smoke tests ran.
+- Blocked checks:
+  - Clean `test:ci` / `verify:local`: blocked by an unrelated Windows CRLF assertion and process heap exhaustion.
+  - Clean tier-0 route gate: blocked by an unrelated `/authorizations` timeout.
+  - Hosted session browser proof: blocked by rejected external test credentials.
+- Result: `pass-with-blocked-checks`.
+- Residual risk: no authenticated browser smoke reached the changed session UI; focused component coverage verifies the delayed-hydration and submission behavior.
+
+## PR Hygiene
+
+- Branch: `codex/win-266-preserve-session-note-targets`
+- Branch-ready: yes.
+- Linear-ready: yes, WIN-266 is In Progress.
+- Single-purpose diff: yes.
+- Protected-path drift: none.
+- Unrelated changes: none.
+- Generated artifact drift: none.
+- Verification summary: present.
+- Reviewer: completed with no findings.
+- PR-ready: yes, with blocked checks disclosed.
+- Required follow-up: push, open the PR, and rerun hosted browser proof when valid credentials are available.
+
+## Handoff Summary
+
+The linked-note hydration path no longer collapses populated measurements to the current plan target after goal metadata resolves. Historical and current target evidence now remains visible and saveable, with focused regression coverage preserving blank-placeholder behavior.

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -666,98 +666,42 @@ export const buildCloseoutDataPoints = ({
   return [...rawDataPoints, ...aggregateDataPoints];
 };
 
-const sumPlanTargetTrials = (
-  trials: NonNullable<SessionGoalMeasurementEntry['data']['target_trials']>,
-  field: 'metric_value' | 'incorrect_trials' | 'opportunities',
-): number | null => {
-  let sum = 0;
-  let hasValue = false;
-
-  for (const trial of trials) {
-    const value = trial[field];
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      sum += value;
-      hasValue = true;
-    }
-  }
-
-  return hasValue ? sum : null;
-};
-
-const summarizePlanTargetTrialNotes = (
-  trials: NonNullable<SessionGoalMeasurementEntry['data']['target_trials']>,
-): string | null => {
-  const notes = trials
-    .map((trial) => trial.trial_prompt_note?.trim() ?? '')
-    .filter((note) => note.length > 0);
-  return notes.length > 0 ? notes.join('; ') : null;
-};
-
-const filterPlanGoalMeasurementToTargetCriteria = (
+const reconcileGoalMeasurementTargets = (
   entry: SessionGoalMeasurementEntry | null,
   goal: Goal | undefined,
   goalId: string,
 ): SessionGoalMeasurementEntry | null => {
-  if (!entry || isAdhocSessionTargetId(goalId)) {
-    return entry;
-  }
-  if (!goal) {
+  if (!entry) {
     return entry;
   }
 
-  const planTarget = goal?.target_criteria?.trim() ?? '';
-  if (!planTarget) {
-    return entry;
-  }
   const sourceTargets = Array.isArray(entry.data.targets) ? entry.data.targets : [];
-  const sourceTrials = Array.isArray(entry.data.target_trials) ? entry.data.target_trials : [];
-  const hasSavedTargetData =
-    sourceTargets.length > 0 ||
-    Boolean(entry.data.target?.trim()) ||
-    sourceTrials.some((trial) => Boolean(trial.target?.trim()));
-  if (!hasSavedTargetData) {
+  const trialTargets = Array.isArray(entry.data.target_trials)
+    ? entry.data.target_trials.map((trial) => trial.target?.trim() ?? '')
+    : [];
+  const recoveredTargets =
+    sourceTargets.length > 0
+      ? sourceTargets
+      : (trialTargets.some((target) => target.length > 0) ? trialTargets : []);
+  const planTarget = isAdhocSessionTargetId(goalId) ? '' : goal?.target_criteria?.trim() ?? '';
+  const primaryTarget =
+    (planTarget && recoveredTargets.some((target) => target.trim() === planTarget)
+      ? planTarget
+      : entry.data.target?.trim()) ||
+    recoveredTargets.find((target) => target.trim().length > 0) ||
+    null;
+  if (recoveredTargets.length === 0 && primaryTarget === entry.data.target) {
     return entry;
   }
-  const targetIndex = sourceTargets.findIndex((target) => target.trim() === planTarget);
-  const hasPlanTarget =
-    planTarget.length > 0 &&
-    (targetIndex >= 0 || entry.data.target?.trim() === planTarget);
-  const filteredTrials = planTarget
-    ? sourceTrials
-        .filter((trial, index) => {
-          const trialTarget = trimString(trial.target) ?? trimString(sourceTargets[index]);
-          return trialTarget === planTarget || index === targetIndex;
-        })
-        .map((trial) => ({
-          ...trial,
-          target: planTarget,
-        }))
-    : [];
-  const shouldKeepPlanTarget = hasPlanTarget || filteredTrials.length > 0;
-  const nextTrials = filteredTrials.length > 0 ? filteredTrials : null;
-  const nextEntry: SessionGoalMeasurementEntry = {
-    version: entry.version,
+
+  return {
+    ...entry,
     data: {
       ...entry.data,
-      metric_value: nextTrials
-        ? sumPlanTargetTrials(nextTrials, 'metric_value')
-        : (shouldKeepPlanTarget ? entry.data.metric_value : null),
-      incorrect_trials: nextTrials
-        ? sumPlanTargetTrials(nextTrials, 'incorrect_trials')
-        : (shouldKeepPlanTarget ? entry.data.incorrect_trials : null),
-      opportunities: nextTrials
-        ? sumPlanTargetTrials(nextTrials, 'opportunities')
-        : (shouldKeepPlanTarget ? entry.data.opportunities : null),
-      targets: shouldKeepPlanTarget ? [planTarget] : null,
-      target: shouldKeepPlanTarget ? planTarget : null,
-      target_trials: nextTrials,
-      trial_prompt_note: nextTrials
-        ? summarizePlanTargetTrialNotes(nextTrials)
-        : (shouldKeepPlanTarget ? entry.data.trial_prompt_note : null),
+      targets: recoveredTargets.length > 0 ? recoveredTargets : entry.data.targets,
+      target: primaryTarget,
     },
   };
-
-  return hasMeaningfulGoalMeasurementEntry(nextEntry) ? nextEntry : null;
 };
 
 interface SessionModalProps {
@@ -1998,7 +1942,7 @@ export function SessionModal({
         mergedGoalIds
           .map((goalEntryId) => {
             const goal = goalsById.get(goalEntryId);
-            const entry = filterPlanGoalMeasurementToTargetCriteria(
+            const entry = reconcileGoalMeasurementTargets(
               normalizeGoalMeasurementEntry(
                 working.session_note_goal_measurements?.[goalEntryId],
                 goal,
@@ -2060,7 +2004,7 @@ export function SessionModal({
             }
             const rawValue = working.session_note_goal_measurements?.[goalKey];
             return hasMeaningfulGoalMeasurementEntry(
-              filterPlanGoalMeasurementToTargetCriteria(
+              reconcileGoalMeasurementTargets(
                 normalizeGoalMeasurementEntry(rawValue, goalsById.get(goalKey)),
                 goalsById.get(goalKey),
                 goalKey,
@@ -2072,7 +2016,7 @@ export function SessionModal({
           ) ||
           Object.entries(working.session_note_goal_measurements ?? {}).some(([goalKey, rawValue]) =>
             hasMeaningfulGoalMeasurementEntry(
-              filterPlanGoalMeasurementToTargetCriteria(
+              reconcileGoalMeasurementTargets(
                 normalizeGoalMeasurementEntry(rawValue, goalsById.get(goalKey)),
                 goalsById.get(goalKey),
                 goalKey,
@@ -3303,7 +3247,7 @@ export function SessionModal({
       Object.entries(linkedMeasurements)
         .map(([goalEntryId, rawValue]) => {
           const goal = goalsById.get(goalEntryId);
-          const normalized = filterPlanGoalMeasurementToTargetCriteria(
+          const normalized = reconcileGoalMeasurementTargets(
             normalizeGoalMeasurementEntry(rawValue, goal),
             goal,
             goalEntryId,
@@ -4560,7 +4504,7 @@ export function SessionModal({
                             sessionNoteGoalMeasurements?.[selectedGoalId],
                             selectedGoal,
                           );
-                          const filteredMeasurementEntry = filterPlanGoalMeasurementToTargetCriteria(
+                          const reconciledMeasurementEntry = reconcileGoalMeasurementTargets(
                             existingMeasurementEntry,
                             selectedGoal,
                             selectedGoalId,
@@ -4598,12 +4542,12 @@ export function SessionModal({
                                 return normalizedWatchedTargets;
                               }
                             }
-                            const normalizedExistingTargets = getGoalMeasurementTargets(filteredMeasurementEntry?.data);
+                            const normalizedExistingTargets = getGoalMeasurementTargets(reconciledMeasurementEntry?.data);
                             return normalizedExistingTargets.length > 0 ? normalizedExistingTargets : [''];
                           })();
                           const rawTargetTrialRows = Array.isArray(watchedTargetTrials)
                             ? watchedTargetTrials
-                            : filteredMeasurementEntry?.data.target_trials ?? [];
+                            : reconciledMeasurementEntry?.data.target_trials ?? [];
                           const getTargetTrialNullableValue = (
                             targetIndex: number,
                             field: 'metric_value' | 'incorrect_trials' | 'opportunities',
@@ -4645,26 +4589,25 @@ export function SessionModal({
                               ? [{ targetValue: trimmed, sourceIndex }]
                               : [];
                           });
-                          const persistedBlankPlanTargetItems = sessionTargets.flatMap((targetValue, sourceIndex) => {
-                            if (targetValue.trim().length > 0) {
-                              return [];
-                            }
-                            const hasPersistedEvidence =
-                              getTargetTrialNullableValue(sourceIndex, 'metric_value') !== null ||
-                              getTargetTrialNullableValue(sourceIndex, 'incorrect_trials') !== null ||
-                              getTargetTrialNullableValue(sourceIndex, 'opportunities') !== null ||
-                              getTargetTrialNote(sourceIndex).trim().length > 0;
-                            return hasPersistedEvidence ? [{ targetValue, sourceIndex }] : [];
-                          });
                           const hasSelectedPlanTarget = Boolean(
                             planTargetText && selectedPlanTargets.length > 0,
                           );
                           const unconfiguredTargetItems = sessionTargets.length > 0
                             ? sessionTargets.map((targetValue, sourceIndex) => ({ targetValue, sourceIndex }))
                             : [{ targetValue: '', sourceIndex: 0 }];
-                          const visibleSessionTargetItems = isAdhocTarget || planGoalHasNoConfiguredTarget || !planTargetText
-                            ? unconfiguredTargetItems
-                            : (selectedPlanTargets.length > 0 ? selectedPlanTargets : persistedBlankPlanTargetItems);
+                          const persistedTargetItems = sessionTargets.flatMap((targetValue, sourceIndex) => {
+                            const hasPersistedEvidence =
+                              targetValue.trim().length > 0 ||
+                              getTargetTrialNullableValue(sourceIndex, 'metric_value') !== null ||
+                              getTargetTrialNullableValue(sourceIndex, 'incorrect_trials') !== null ||
+                              getTargetTrialNullableValue(sourceIndex, 'opportunities') !== null ||
+                              getTargetTrialNote(sourceIndex).trim().length > 0;
+                            return hasPersistedEvidence ? [{ targetValue, sourceIndex }] : [];
+                          });
+                          const visibleSessionTargetItems =
+                            isAdhocTarget || planGoalHasNoConfiguredTarget || !planTargetText
+                              ? unconfiguredTargetItems
+                              : persistedTargetItems;
                           const getDisplayedTargetTrialValue = (
                             item: { targetValue: string; sourceIndex: number },
                             field: 'metric_value' | 'incorrect_trials',
@@ -4825,7 +4768,18 @@ export function SessionModal({
                                     {planTargetText && !hasSelectedPlanTarget ? (
                                       <button
                                         type="button"
-                                        onClick={() => updateGoalTargets(selectedGoalId, [planTargetText])}
+                                        onClick={() => {
+                                          const blankTargetIndex = sessionTargets.findIndex(
+                                            (target) => target.trim().length === 0,
+                                          );
+                                          if (blankTargetIndex >= 0) {
+                                            const nextTargets = sessionTargets.slice();
+                                            nextTargets[blankTargetIndex] = planTargetText;
+                                            updateGoalTargets(selectedGoalId, nextTargets);
+                                            return;
+                                          }
+                                          updateGoalTargets(selectedGoalId, [...sessionTargets, planTargetText]);
+                                        }}
                                         className="w-full rounded-md border border-indigo-200 bg-white px-3 py-2 text-left text-sm font-medium text-indigo-900 shadow-sm hover:bg-indigo-50 dark:border-indigo-800 dark:bg-dark dark:text-indigo-100 dark:hover:bg-indigo-950/40"
                                       >
                                         <span className="block text-[11px] font-semibold uppercase tracking-wide">

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -666,7 +666,7 @@ export const buildCloseoutDataPoints = ({
   return [...rawDataPoints, ...aggregateDataPoints];
 };
 
-const reconcileGoalMeasurementTargets = (
+export const reconcileGoalMeasurementTargets = (
   entry: SessionGoalMeasurementEntry | null,
   goal: Goal | undefined,
   goalId: string,
@@ -679,10 +679,14 @@ const reconcileGoalMeasurementTargets = (
   const trialTargets = Array.isArray(entry.data.target_trials)
     ? entry.data.target_trials.map((trial) => trial.target?.trim() ?? '')
     : [];
-  const recoveredTargets =
-    sourceTargets.length > 0
-      ? sourceTargets
-      : (trialTargets.some((target) => target.length > 0) ? trialTargets : []);
+  const recoveredTargetCount =
+    sourceTargets.length > 0 || trialTargets.some((target) => target.length > 0)
+      ? Math.max(sourceTargets.length, trialTargets.length)
+      : 0;
+  const recoveredTargets = Array.from(
+    { length: recoveredTargetCount },
+    (_, index) => sourceTargets[index]?.trim() || trialTargets[index] || '',
+  );
   const planTarget = isAdhocSessionTargetId(goalId) ? '' : goal?.target_criteria?.trim() ?? '';
   const primaryTarget =
     (planTarget && recoveredTargets.some((target) => target.trim() === planTarget)

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -2187,10 +2187,10 @@ describe('SessionModal', () => {
     expect(await screen.findByRole('heading', { name: 'ABA Session Note' })).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
     expect(await screen.findByText('Draft client status: Engaged')).toBeInTheDocument();
-    expect(await screen.findByText('Linked count: 1')).toBeInTheDocument();
-    expect(screen.getByText('All count: 1')).toBeInTheDocument();
+    expect(await screen.findByText('Linked count: 2')).toBeInTheDocument();
+    expect(screen.getByText('All count: 2')).toBeInTheDocument();
     expect(screen.getByText('Match peer greeting in 4/5 trials: 2')).toBeInTheDocument();
-    expect(screen.queryByText(/Retired target/)).not.toBeInTheDocument();
+    expect(screen.getByText('Retired target: 9')).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Save ABA Draft' }));
     await waitFor(() => expect(saveBtAbaSessionNoteDraft).toHaveBeenCalledWith(expect.objectContaining({
@@ -7023,7 +7023,7 @@ describe('SessionModal', () => {
     });
   }, 10000);
 
-  it('filters saved plan-goal targets and persists prompt buttons for legacy capture', async () => {
+  it('preserves all saved plan-goal targets through hydration and submit', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const planTarget = 'Match peer greeting in 4/5 trials';
     const legacyFreeformTarget = 'Legacy freeform target';
@@ -7042,8 +7042,6 @@ describe('SessionModal', () => {
             measurement_type: 'frequency',
             metric_label: 'Count',
             metric_unit: 'responses',
-            targets: [legacyFreeformTarget, planTarget],
-            target: planTarget,
             target_trials: [
               {
                 target: legacyFreeformTarget,
@@ -7091,6 +7089,11 @@ describe('SessionModal', () => {
       updated_at: '2026-03-01T09:00:00.000Z',
     });
 
+    let resolveGoals: ((value: { data: unknown[]; error: null }) => void) | null = null;
+    const goalsPromise = new Promise<{ data: unknown[]; error: null }>((resolve) => {
+      resolveGoals = resolve;
+    });
+
     vi.mocked(supabase.from).mockImplementation((table: string) => {
       if (table === 'programs') {
         const chain: SupabaseQueryChain = {
@@ -7108,7 +7111,7 @@ describe('SessionModal', () => {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
         neq: vi.fn(() => chain),
-          order: vi.fn(async () => ({ data: mockGoals, error: null })),
+          order: vi.fn(() => goalsPromise),
           maybeSingle: vi.fn(async () => ({ data: null, error: null })),
           limit: vi.fn(async () => ({ data: [], error: null })),
         };
@@ -7166,37 +7169,50 @@ describe('SessionModal', () => {
       expect(screen.getByDisplayValue('Observed mixed saved targets')).toBeInTheDocument();
     });
 
+    expect(await screen.findByText(legacyFreeformTarget)).toBeInTheDocument();
+    expect(screen.getByText(planTarget)).toBeInTheDocument();
+
+    await act(async () => {
+      resolveGoals?.({ data: mockGoals, error: null });
+      await goalsPromise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(legacyFreeformTarget)).toBeInTheDocument();
+      expect(screen.getByText(planTarget)).toBeInTheDocument();
+    });
+
     expect(screen.queryByRole('button', { name: /Use plan target/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Plan target selected/i })).not.toBeInTheDocument();
     expect(screen.getAllByText(planTarget)).toHaveLength(1);
-    expect(screen.queryByText(legacyFreeformTarget)).not.toBeInTheDocument();
+    expect(screen.getByText(legacyFreeformTarget)).toBeInTheDocument();
 
     const noResponseOutcome = screen.getByRole('radio', {
-      name: /^No response for target 1:/i,
+      name: /^No response for target 2:/i,
     });
-    expect(screen.getByRole('radio', { name: /^Correct for target 1:/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /^Correct for target 2:/i })).toBeChecked();
     for (const label of ['full verbal', 'partial verbal', 'gesture', 'model', 'visual', 'full physical', 'partial physical']) {
       expect(screen.getByRole('button', {
-        name: new RegExp(`Record ${label} prompt for target 1`, 'i'),
+        name: new RegExp(`Record ${label} prompt for target 2`, 'i'),
       })).toBeInTheDocument();
     }
     await userEvent.click(screen.getByRole('button', {
-      name: /Record full verbal prompt for target 1/i,
+      name: /Record full verbal prompt for target 2/i,
     }));
     const subtractFiveCorrect = screen.getByRole('button', {
-      name: /Subtract 5 correct trials for target 1/i,
+      name: /Subtract 5 correct trials for target 2/i,
     });
     expect(subtractFiveCorrect).toBeEnabled();
     await userEvent.click(subtractFiveCorrect);
     await userEvent.click(screen.getByRole('button', {
-      name: /Record full verbal prompt for target 1/i,
+      name: /Record full verbal prompt for target 2/i,
     }));
     await userEvent.click(noResponseOutcome);
     await userEvent.click(screen.getByRole('button', {
-      name: /Record gesture prompt for target 1/i,
+      name: /Record gesture prompt for target 2/i,
     }));
-    await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 1/i }));
-    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 1/i), {
+    await userEvent.click(screen.getByRole('button', { name: /Increase correct trials for target 2/i }));
+    fireEvent.change(screen.getByLabelText(/Prompts & reactions for target 2/i), {
       target: { value: 'Edited plan target prompt note' },
     });
 
@@ -7209,12 +7225,19 @@ describe('SessionModal', () => {
           'goal-1': {
             version: 1,
             data: expect.objectContaining({
-              metric_value: 2,
-              incorrect_trials: 2,
-              opportunities: 6,
-              targets: [planTarget],
+              metric_value: 7,
+              incorrect_trials: 6,
+              opportunities: 15,
+              targets: [legacyFreeformTarget, planTarget],
               target: planTarget,
               target_trials: [
+                expect.objectContaining({
+                  target: legacyFreeformTarget,
+                  metric_value: 5,
+                  incorrect_trials: 4,
+                  opportunities: 9,
+                  trial_prompt_note: 'Legacy target prompt note',
+                }),
                 expect.objectContaining({
                   target: planTarget,
                   metric_value: 2,
@@ -7227,7 +7250,7 @@ describe('SessionModal', () => {
                   ],
                 }),
               ],
-              trial_prompt_note: 'Edited plan target prompt note',
+              trial_prompt_note: 'Legacy target prompt note; Edited plan target prompt note',
             }),
           },
         },

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -9,6 +9,7 @@ import {
   dedupeProgressionNotices,
   formatProgressionNotices,
   incrementLegacyPromptCount,
+  reconcileGoalMeasurementTargets,
   remapLegacyPromptCorrectnessAfterRemoval,
   sumLegacyPromptCounts,
   selectSessionCaptureTargets,
@@ -111,6 +112,36 @@ type SupabaseQueryChain = {
 };
 
 describe('SessionModal', () => {
+  it('fills missing indexed target labels from persisted trial rows', () => {
+    const currentTarget = 'Current plan target';
+    const retiredTarget = 'Retired target';
+
+    expect(reconcileGoalMeasurementTargets(
+      {
+        version: 1,
+        data: {
+          targets: [currentTarget],
+          target_trials: [
+            { target: currentTarget, metric_value: 2 },
+            { target: retiredTarget, metric_value: 4 },
+          ],
+        },
+      },
+      { target_criteria: currentTarget } as Goal,
+      'goal-1',
+    )).toEqual({
+      version: 1,
+      data: {
+        targets: [currentTarget, retiredTarget],
+        target: currentTarget,
+        target_trials: [
+          { target: currentTarget, metric_value: 2 },
+          { target: retiredTarget, metric_value: 4 },
+        ],
+      },
+    });
+  });
+
   it('selects only current active targets for new capture while retaining hydrated history', () => {
     const base = { organization_id: 'org-a', client_id: 'client-a', goal_id: 'goal-a', measurement_type: 'frequency', graph_config: {}, sort_order: 0, current_phase: 'baseline', evaluation_window_started_at: null, progression_version: 1, created_at: '', updated_at: '' } as const;
     const current = { ...base, id: 'current', name: 'Current', status: 'active', is_current: true };


### PR DESCRIPTION
## Summary
- preserve every populated skill/behavior target row when goal metadata hydrates after linked session-note data
- recover legacy target identities stored only in `target_trials` and keep the current plan target as the primary marker without deleting historical evidence
- retain existing rows when using the plan target and cover delayed hydration, closeout, and submit behavior

## Routing
- Linear: WIN-266
- classification: low-risk autonomous
- lane: standard
- protected-path drift: none

## Verification
- `npm test -- src/components/__tests__/SessionModal.test.tsx` (158/158 passed)
- `npm run lint` (passed)
- `npm run typecheck` (passed)
- `npm run ci:check-focused` (passed with expected local external-system skips)
- `npm run build` (passed)
- `npm run test:routes:tier0` (219/220; unrelated `/authorizations` timeout)
- `npm run test:ci` (changed tests passed; unrelated Windows CRLF assertion then Node heap OOM)
- `npm run verify:local` (stopped at the same `test:ci` failures)
- `npm run ci:playwright` (preflight passed; hosted superadmin credentials rejected before session smoke)

## Residual Risk
Authenticated browser smoke did not reach the changed session UI because the hosted test credentials were rejected. Focused component coverage exercises the reported delayed-hydration failure and verifies preservation through submission.
