### PR TITLE
WIN-268 Move GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/auth-verification.yml
+++ b/.github/workflows/auth-verification.yml
@@ -8,5 +8,5 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       # ... existing steps preserved ...

--- a/.github/workflows/bcba-smoke-janitor.yml
+++ b/.github/workflows/bcba-smoke-janitor.yml
@@ -14,10 +14,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/bt-aba-disposable-browser-proof.yml
+++ b/.github/workflows/bt-aba-disposable-browser-proof.yml
@@ -89,7 +89,7 @@ jobs:
           NODE
 
       - name: Checkout validated commit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ steps.approval.outputs.validated_sha }}
           persist-credentials: false
@@ -123,7 +123,7 @@ jobs:
       PW_BASE_URL: http://127.0.0.1:4173
     steps:
       - name: Checkout validated commit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.validate.outputs.validated_sha }}
           persist-credentials: false
@@ -134,7 +134,7 @@ jobs:
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -323,7 +323,7 @@ jobs:
 
       - name: Upload redacted browser evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: bt-aba-disposable-proof-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/bt-aba-public-evidence/**
@@ -344,7 +344,7 @@ jobs:
       SUPABASE_BRANCH_PR_NUMBER: ${{ needs.validate.outputs.validated_pr_number }}
     steps:
       - name: Checkout validated commit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.validate.outputs.validated_sha }}
           persist-credentials: false
@@ -365,7 +365,7 @@ jobs:
           } > "$RUNNER_TEMP/bt-aba-cleanup/deletion-evidence.txt"
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -395,7 +395,7 @@ jobs:
 
       - name: Upload deletion evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: bt-aba-disposable-cleanup-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/bt-aba-cleanup/deletion-evidence.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       ai_agent_changed: ${{ steps.detect.outputs.ai_agent_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
@@ -89,12 +89,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
 
@@ -156,10 +156,10 @@ jobs:
       CI: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -216,10 +216,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -240,12 +240,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -267,10 +267,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -298,10 +298,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -340,10 +340,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -372,10 +372,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -396,10 +396,10 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -429,10 +429,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -444,7 +444,7 @@ jobs:
         run: npm run build
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: dist
           path: dist
@@ -459,12 +459,12 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -523,7 +523,7 @@ jobs:
 
       - name: Upload Cypress artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cypress-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
@@ -543,12 +543,12 @@ jobs:
     timeout-minutes: 35
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -714,7 +714,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: playwright-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/latest
@@ -730,12 +730,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -790,7 +790,7 @@ jobs:
 
       - name: Upload Playwright readiness artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: playwright-env-readiness-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/latest/readiness
@@ -806,12 +806,12 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -890,7 +890,7 @@ jobs:
 
       - name: Upload IEHP Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: iehp-playwright-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/latest
@@ -907,10 +907,10 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -1037,7 +1037,7 @@ jobs:
 
       - name: Upload optional Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: optional-playwright-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/latest

--- a/.github/workflows/database-first-ci.yml
+++ b/.github/workflows/database-first-ci.yml
@@ -8,5 +8,5 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       # ... existing steps preserved ...

--- a/.github/workflows/iehp-pdf-mini-matrix-proof.yml
+++ b/.github/workflows/iehp-pdf-mini-matrix-proof.yml
@@ -90,7 +90,7 @@ jobs:
           NODE
 
       - name: Checkout validated commit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ steps.approval.outputs.validated_sha }}
           persist-credentials: false
@@ -118,7 +118,7 @@ jobs:
       CI_SMOKE_ADMIN_EMAIL: playwright.ci.iehp_pdf_matrix_proof.${{ github.run_id }}.${{ github.run_attempt }}@example.com
     steps:
       - name: Checkout validated commit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ needs.validate.outputs.validated_sha }}
           persist-credentials: false
@@ -134,7 +134,7 @@ jobs:
           }
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -454,7 +454,7 @@ jobs:
 
       - name: Upload redacted matrix evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: iehp-pdf-mini-matrix-proof-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -24,7 +24,7 @@ jobs:
       NETLIFY_SITE: velvety-cendol-dae4d6.netlify.app
       GITHUB_HEAD_REF_SAFE: ${{ github.head_ref || github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
       - name: Resolve preview URL
         id: preview
@@ -56,7 +56,7 @@ jobs:
 
           echo "url=${candidate%/}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
 
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload Lighthouse report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: lighthouse-${{ github.run_id }}
           path: .lighthouseci

--- a/.github/workflows/rollback-drill.yml
+++ b/.github/workflows/rollback-drill.yml
@@ -15,10 +15,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload rollback drill artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: rollback-drill-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/latest

--- a/.github/workflows/supabase-preview.yml
+++ b/.github/workflows/supabase-preview.yml
@@ -38,7 +38,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
       - uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
@@ -58,7 +58,7 @@ jobs:
           supabase status
           echo "Preview DB ready (local run). Use with local dev only."
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -73,7 +73,7 @@ jobs:
         run: npm run ci:write-evidence -- supabase-preview "${{ job.status }}"
       - name: Upload preview artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: supabase-preview-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/supabase-validate.yml
+++ b/.github/workflows/supabase-validate.yml
@@ -35,9 +35,9 @@ jobs:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -55,7 +55,7 @@ jobs:
         run: npm run ci:write-evidence -- supabase-migration-lint "${{ job.status }}"
       - name: Upload migration lint artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: supabase-migration-lint-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/latest
@@ -67,8 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm
@@ -111,7 +111,7 @@ jobs:
         run: npm run ci:write-evidence -- supabase-validate-tests "${{ job.status }}"
       - name: Upload Supabase validate artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: supabase-validate-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/latest
@@ -126,10 +126,10 @@ jobs:
       MIGRATION_PARITY_BASE_SHA: ${{ github.event.before }}
       MIGRATION_PARITY_HEAD_SHA: ${{ github.sha }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/tenant-safety.yml
+++ b/.github/workflows/tenant-safety.yml
@@ -25,8 +25,8 @@ jobs:
   tenant-safety:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
       - name: Install dependencies

--- a/docs/ai/handoffs/WIN-268-node24-actions.md
+++ b/docs/ai/handoffs/WIN-268-node24-actions.md
@@ -1,0 +1,93 @@
+# WIN-268 Node 24 Actions
+
+## Route Task
+
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Triggering paths: `.github/workflows/**`
+- Allowed files:
+  - `.github/workflows/auth-verification.yml`
+  - `.github/workflows/bcba-smoke-janitor.yml`
+  - `.github/workflows/bt-aba-disposable-browser-proof.yml`
+  - `.github/workflows/ci.yml`
+  - `.github/workflows/database-first-ci.yml`
+  - `.github/workflows/iehp-pdf-mini-matrix-proof.yml`
+  - `.github/workflows/lighthouse.yml`
+  - `.github/workflows/rollback-drill.yml`
+  - `.github/workflows/supabase-preview.yml`
+  - `.github/workflows/supabase-validate.yml`
+  - `.github/workflows/tenant-safety.yml`
+  - `tests/workflows/bt-aba-disposable-browser-proof.test.ts`
+  - `tests/workflows/github-actions-node24-runtime.test.ts`
+  - `docs/ai/handoffs/WIN-268-node24-actions.md`
+- Non-goals:
+  - no `node-version` changes
+  - no workflow trigger, permission, secret, artifact, or job-logic changes
+  - no `scripts/ci/**`, app, migration, auth, or deploy-config edits
+- Stop conditions:
+  - any required edit outside the allowed files
+  - any need to change workflow behavior beyond action refs
+
+## Verification
+
+- Required checks:
+  - direct workflow validation via parser-based workflow tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run verify:local`
+- Executed checks:
+  - `node .\node_modules\vitest\vitest.mjs run tests/workflows/github-actions-node24-runtime.test.ts tests/workflows/bt-aba-disposable-browser-proof.test.ts tests/workflows/iehp-pdf-mini-matrix-proof.test.ts tests/workflows/ci-test-memory.test.ts` (pass: `4` files, `10` tests)
+  - workflow diff invariant check (pass: workflow changes are action-ref/comment lines only)
+  - old-ref search (pass: no old action tags or SHAs remain)
+  - `npm run ci:check-focused` (pass)
+  - `npm run lint` (pass)
+  - `npm run typecheck` (pass)
+  - `npm run build` (pass)
+  - `npm run test:ci` (fail: repo-wide Vitest run exhausted the Node heap after unrelated `ai-documentation` test stderr)
+- Blocked checks:
+  - `npm run verify:local` (blocked after `npm run test:ci` failed; aggregate run would also include unrelated `test:routes:tier0`)
+- Result:
+  - `pass-with-blocked-checks`
+- Residual risk:
+  - local targeted workflow coverage is green, but repo-wide `test:ci` is not clean in this environment and GitHub Actions remains the authoritative runtime proof for the workflow execution path
+- Verification card:
+  - classification: `high-risk human-reviewed`
+  - lane: `critical`
+  - change type: CI/workflow/policy
+  - required checks: direct workflow validation, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, `npm run verify:local`
+  - executed checks: direct workflow validation (pass), focused policy (pass), lint (pass), typecheck (pass), build (pass), `test:ci` (environment failure)
+  - blocked checks: clean local `test:ci` and `verify:local` exit due shared Windows Node/Vitest heap instability
+  - result: `pass-with-blocked-checks`
+  - residual risk: upstream action runtime behavior and runner compatibility require hosted GitHub Actions proof
+
+## Required agents and review
+
+- `specification-engineer`: confirmed the critical-lane scope, acceptance criteria, non-goals, and stop conditions.
+- `software-architect`: approved the ref-only design for GitHub-hosted runners, with the upstream runner-version and GHES caveats recorded.
+- `implementation-engineer`: implemented the bounded action-ref and workflow-contract test changes.
+- `code-review-engineer`: approved the current diff; confirmed refs/comments-only workflow changes with no trigger, permission, secret, environment, or job-logic drift.
+- `test-engineer`: selected the focused workflow-contract suite; the final four-file suite passed `10/10`.
+- `security-engineer`: approved the current diff and confirmed no trigger, permission, condition, secret, artifact-path, deploy-logic, or project Node-version drift.
+- `devops-engineer`: approved for PR, not merge; hosted Actions must prove runner/runtime and artifact compatibility.
+
+## PR handoff
+
+- Linear: `WIN-268`
+- PR hygiene:
+  - `pr-ready`: yes
+  - `lane`: critical
+  - `branch-ready`: yes (`codex/win-268-node24-actions`)
+  - `linear-ready`: yes (`WIN-268`)
+  - `single-purpose`: yes
+  - `unrelated changes`: none
+  - `generated artifact drift`: none
+  - `protected-path drift`: intended `.github/workflows/**` action-ref updates only
+  - `change summary`: present
+  - `verification summary`: present, with local aggregate failures explicitly blocked
+  - `pr handoff`: ready
+  - `reviewer`: completed
+  - `required follow-up`: inspect hosted Actions logs for Node 20 runtime warnings and action/runtime regressions; obtain mandatory human review before merge
+- Merge policy: human review is mandatory because `.github/workflows/**` is a critical protected path; this slice must stop at review-ready.

--- a/tests/workflows/bt-aba-disposable-browser-proof.test.ts
+++ b/tests/workflows/bt-aba-disposable-browser-proof.test.ts
@@ -206,7 +206,7 @@ describe('manual disposable BT/ABA browser proof workflow', () => {
     expect(cleanupRun?.run).toContain('npm run bt-aba:disposable-branch -- --verify-managed-preview');
     expect(cleanupRun?.run).not.toContain('--cleanup');
     expect(cleanupUpload?.if).toBe('always()');
-    expect(cleanupUpload?.uses).toContain('actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02');
+    expect(cleanupUpload?.uses).toContain('actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f');
     expect(cleanupUpload?.with?.path).toContain('deletion-evidence.txt');
     expect(source.match(/secrets\.SUPABASE_ACCESS_TOKEN/g)).toHaveLength(2);
     expect(source).not.toContain('BT_ABA_MANAGED_BRANCH_ID');
@@ -218,8 +218,8 @@ describe('manual disposable BT/ABA browser proof workflow', () => {
   it('pins actions and preserves exact migration, preview, browser, and artifact boundaries', () => {
     const { source } = loadWorkflow();
 
-    expect(source).toContain('actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5');
-    expect(source).toContain('actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020');
+    expect(source).toContain('actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09');
+    expect(source).toContain('actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444');
     expect(source).toContain('supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51');
     expect(source).not.toContain('supabase link');
     expect(source).not.toContain('supabase db query');

--- a/tests/workflows/github-actions-node24-runtime.test.ts
+++ b/tests/workflows/github-actions-node24-runtime.test.ts
@@ -1,0 +1,89 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+type ActionStep = {
+  file: string;
+  uses: string;
+  nodeVersion?: unknown;
+};
+
+const workflowDir = path.join(process.cwd(), '.github', 'workflows');
+
+const expectedWorkflowFiles = [
+  'auth-verification.yml',
+  'bcba-smoke-janitor.yml',
+  'bt-aba-disposable-browser-proof.yml',
+  'ci.yml',
+  'database-first-ci.yml',
+  'iehp-pdf-mini-matrix-proof.yml',
+  'lighthouse.yml',
+  'rollback-drill.yml',
+  'supabase-preview.yml',
+  'supabase-validate.yml',
+  'tenant-safety.yml',
+];
+
+const expectedPins = {
+  'actions/checkout': 'fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09',
+  'actions/setup-node': 'a0853c24544627f65ddf259abe73b1d18a591444',
+  'actions/upload-artifact': 'b7c566a772e6b6bfb58ed0dc250532a479d7789f',
+} as const;
+
+const targetActions = new Set(Object.keys(expectedPins));
+
+const collectActionSteps = (value: unknown, file: string, results: ActionStep[] = []): ActionStep[] => {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => collectActionSteps(entry, file, results));
+    return results;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return results;
+  }
+
+  const record = value as Record<string, unknown>;
+  const uses = typeof record.uses === 'string' ? record.uses : undefined;
+
+  if (uses) {
+    const [action] = uses.split('@');
+    if (targetActions.has(action)) {
+      const withBlock =
+        record.with && typeof record.with === 'object' ? (record.with as Record<string, unknown>) : undefined;
+      results.push({
+        file,
+        uses,
+        nodeVersion: withBlock?.['node-version'],
+      });
+    }
+  }
+
+  Object.values(record).forEach((entry) => collectActionSteps(entry, file, results));
+  return results;
+};
+
+describe('GitHub Actions runtime pins', () => {
+  it('pins checkout, setup-node, and upload-artifact to the verified SHAs and keeps Node 20', () => {
+    const workflowFiles = readdirSync(workflowDir).filter((entry) => entry.endsWith('.yml')).sort();
+    const actionSteps = workflowFiles.flatMap((file) => {
+      const source = readFileSync(path.join(workflowDir, file), 'utf8');
+      return collectActionSteps(parse(source), file);
+    });
+
+    const matchedFiles = Array.from(new Set(actionSteps.map((step) => step.file))).sort();
+    expect(matchedFiles).toEqual(expectedWorkflowFiles);
+
+    expect(actionSteps.length).toBeGreaterThan(0);
+
+    for (const step of actionSteps) {
+      const [action, ref] = step.uses.split('@');
+      expect(ref, `${step.file} should pin ${action}`).toBe(expectedPins[action as keyof typeof expectedPins]);
+
+      if (action === 'actions/setup-node') {
+        expect(step.nodeVersion, `${step.file} should keep setup-node on Node 20`).toBe(20);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- pin checkout v5.1.0, setup-node v5.0.0, and upload-artifact v6.0.0 by verified commit SHA across repository workflows
- add a repository-wide contract test for the exact action pins and preservation of project `node-version: 20`
- preserve triggers, permissions, secrets, conditions, artifacts, job logic, and deploy behavior

## Verification
- focused workflow contracts: 4 files / 10 tests passed
- workflow diff invariant: refs/comments only
- no old action tags or SHAs remain
- ci:check-focused: passed
- lint: passed
- typecheck: passed
- build: passed
- test:ci/verify:local: clean local aggregate exit blocked by documented shared Windows Node/Vitest heap instability; hosted Actions is the authoritative runtime proof

## Critical-lane review
Architecture, code, security, test, and DevOps reviews completed. Human review remains mandatory before merge. Hosted checks must confirm runner compatibility, artifact behavior, and removal of Node 20 action-runtime warnings.

## Scope
No migrations, scripts/ci, app code, auth logic, deploy config, or program/goal editing implementation changed.

Linear: WIN-268