### PR TITLE
WIN-265 Repair therapist account onboarding

### DIFF
--- a/.superpowers/sdd/2026-07-30-therapist-onboarding-invite/task-2-report.md
+++ b/.superpowers/sdd/2026-07-30-therapist-onboarding-invite/task-2-report.md
@@ -1,0 +1,12 @@
+## Task 2 Report
+
+- Scope: `supabase/functions/admin-invite/index.ts`, `tests/admins/invite_flow.spec.ts`
+- Status: complete
+- Summary:
+  - `admin-invite` now resolves non-super-admin org scope with `resolveOrgId(adminClient)`.
+  - Targeted invites accept `targetTherapistId`, validate therapist org/email/status/deletion before RPC issuance, and pass `p_target_therapist_id` into the seven-argument service-role RPC.
+  - Email delivery rollback now revokes the invite row with `revoked_at` instead of deleting it, and audit details capture `target_therapist_id`.
+- Verification:
+  - `vitest`: `tests/admins/invite_flow.spec.ts` passed with 18/18 tests.
+- Residual risk:
+  - Validation relies on the edge function and the database RPC staying aligned on target-therapist invariants; broader cross-suite verification remains for the parent flow.

--- a/.superpowers/sdd/2026-07-30-therapist-onboarding-invite/task-2-report.md
+++ b/.superpowers/sdd/2026-07-30-therapist-onboarding-invite/task-2-report.md
@@ -14,5 +14,10 @@
   - Renamed rollback-fixture wording from delete semantics to revoke/update semantics for clarity.
 - Verification update:
   - `vitest`: `tests/admins/invite_flow.spec.ts` passed with 19/19 tests after the review fix.
+- Review fix 2 evidence:
+  - Extended the targeted non-`bt` rejection test to assert the `supabaseAdmin.from("therapists")` lookup path was not touched, proving the guard exits before therapist lookup, RPC issuance, email delivery, or audit insertion.
+  - Command: `$env:PATH = 'C:\Users\test\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin;' + $env:PATH; & 'C:\Users\test\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe' '.\node_modules\vitest\vitest.mjs' run 'tests/admins/invite_flow.spec.ts'`
+  - Output: `PASS tests/admins/invite_flow.spec.ts (19 tests)`
+  - Follow-up commit: `WIN-265 task2 skip therapist lookup proof`
 - Residual risk:
   - Validation relies on the edge function and the database RPC staying aligned on target-therapist invariants; broader cross-suite verification remains for the parent flow.

--- a/.superpowers/sdd/2026-07-30-therapist-onboarding-invite/task-2-report.md
+++ b/.superpowers/sdd/2026-07-30-therapist-onboarding-invite/task-2-report.md
@@ -8,5 +8,11 @@
   - Email delivery rollback now revokes the invite row with `revoked_at` instead of deleting it, and audit details capture `target_therapist_id`.
 - Verification:
   - `vitest`: `tests/admins/invite_flow.spec.ts` passed with 18/18 tests.
+- Review fix evidence:
+  - Added an early fail-closed guard for `targetTherapistId` with any non-`bt` role before therapist lookup, RPC issuance, email delivery, or audit insertion.
+  - Added focused coverage proving targeted non-`bt` invites return `403 target_therapist_role_forbidden` with no side effects.
+  - Renamed rollback-fixture wording from delete semantics to revoke/update semantics for clarity.
+- Verification update:
+  - `vitest`: `tests/admins/invite_flow.spec.ts` passed with 19/19 tests after the review fix.
 - Residual risk:
   - Validation relies on the edge function and the database RPC staying aligned on target-therapist invariants; broader cross-suite verification remains for the parent flow.

--- a/docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md
+++ b/docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md
@@ -83,6 +83,7 @@
 
 - pr-ready: yes, for human review
 - merge-ready: no
+- pull request: #878
 - branch: `codex/therapist-onboarding-invite`
 - linear-ready: yes, WIN-265
 - single-purpose: yes

--- a/docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md
+++ b/docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md
@@ -36,7 +36,7 @@
   - `npm run verify:local`
   - `npm run ci:playwright` when protected credentials are available
 - executed checks:
-  - `npx vitest run tests/admins/invite_flow.spec.ts tests/admins/accept_invite_flow.spec.ts tests/admins/therapist_invite_target_migration.spec.ts src/components/__tests__/TherapistOnboarding.test.tsx src/components/__tests__/TherapistProfileInvite.test.tsx` -> pass, 5 files / 58 tests
+  - `npx vitest run tests/admins/invite_flow.spec.ts tests/admins/accept_invite_flow.spec.ts tests/admins/therapist_invite_target_migration.spec.ts src/components/__tests__/TherapistOnboarding.test.tsx src/components/__tests__/TherapistProfileInvite.test.tsx` -> pass, 5 files / 60 tests after synchronizing `origin/main`
   - `npm run ci:check-focused` -> pass; database-backed grant/RLS checks skipped because `SUPABASE_DB_URL` was unavailable, and auth parity was disabled locally
   - `npm run lint` -> pass
   - `npm run typecheck` -> pass
@@ -69,6 +69,15 @@
 - The aggregate coverage suite did not complete because the local Node process exhausted its heap.
 - Credentialed hosted Playwright remains for CI/human-review follow-through.
 - Production still requires reviewed migration/function deployment and a new invite for the affected therapist; this branch does not mutate the live account.
+
+## Post-Sync Verification
+
+- merged `origin/main` at `b25b59b7`; the two incoming changes touched unrelated session-modal and test-harness paths
+- focused regressions -> pass, 5 files / 60 tests
+- `npm run ci:check-focused` -> pass with the same documented database/auth-parity skips
+- `npm run lint` -> pass
+- `npm run typecheck` -> pass
+- `npm run build` -> pass
 
 ## PR Hygiene
 

--- a/docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md
+++ b/docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md
@@ -7,6 +7,7 @@
 - non-goals: plaintext password storage, immediate admin-created passwords, generic staff-onboarding redesign, unrelated auth or RLS cleanup, and production deployment before human review
 - protected paths:
   - `supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql`
+  - `supabase/migrations/20260730183000_preserve_admin_invite_audit_fks.sql`
   - `supabase/functions/admin-invite/index.ts`
   - `supabase/functions/accept-staff-invite/index.ts`
 - hosted read-only evidence: the linked Supabase project contained a therapist directory row without the corresponding Auth user, profile, role, or therapist link; no production mutation was performed
@@ -18,6 +19,8 @@
 - Invite tokens record target, accepted, and revoked lifecycle state.
 - Acceptance revalidates the target, creates Auth/profile/role/link records, consumes the invite with compare-and-set semantics, and removes the newly created Auth user if protected completion fails.
 - Generic and targeted active invites cannot coexist for the same normalized email and organization.
+- Staff-management roles admitted to therapist onboarding may issue only exact targeted BT invites; generic staff invites remain limited to `admin` and `super_admin`.
+- Deleting an inviter or accepted user preserves the invite audit row by nulling its foreign key. A pending invite whose inviter was deleted fails closed before any acceptance side effect.
 - The legacy six-argument invite RPC remains as a service-role-only wrapper around the targeted seven-argument RPC for rollout-order compatibility.
 - Email-delivery failure revokes the invite without deleting the valid therapist row; the therapist profile provides the retry action.
 
@@ -36,6 +39,7 @@
   - `npm run verify:local`
   - `npm run ci:playwright` when protected credentials are available
 - executed checks:
+  - `npx vitest run tests/admins/invite_flow.spec.ts tests/admins/accept_invite_flow.spec.ts tests/admins/therapist_invite_target_migration.spec.ts tests/admins/therapist_invite_fk_lifecycle_migration.spec.ts tests/security/public-security-definer-rpc-grants.security.spec.ts src/components/__tests__/TherapistOnboarding.test.tsx src/components/__tests__/TherapistProfileInvite.test.tsx` -> pass, 7 files / 81 tests after the PR review fixes
   - `npx vitest run tests/admins/invite_flow.spec.ts tests/admins/accept_invite_flow.spec.ts tests/admins/therapist_invite_target_migration.spec.ts src/components/__tests__/TherapistOnboarding.test.tsx src/components/__tests__/TherapistProfileInvite.test.tsx` -> pass, 5 files / 60 tests after synchronizing `origin/main`
   - `npm run ci:check-focused` -> pass; database-backed grant/RLS checks skipped because `SUPABASE_DB_URL` was unavailable, and auth parity was disabled locally
   - `npm run lint` -> pass
@@ -61,6 +65,18 @@
   - made mixed-order collision tests preserve the stored target shape
   - restored a backward-compatible six-argument RPC wrapper
   - removed mutable Auth metadata from default super-admin organization resolution
+  - aligned the outer invite route with the established staff-management roles while retaining handler-level targeted-BT-only least privilege
+  - made both invite audit foreign keys use `ON DELETE SET NULL`, made `created_by` nullable, and rejected pending invites whose inviter no longer exists
+
+## PR Review Follow-Up
+
+- Automated review found that `admin_schedule` and `bcba` could reach therapist onboarding but were rejected by the invite route wrapper before the targeted-invite authorization check.
+- The route now uses `RouteOptions.staffAdmin`; handler authorization still restricts `admin_schedule` and `bcba` to exact targeted BT invites, while generic invites remain denied.
+- Automated review also found that the existing `created_by` and `accepted_by_user_id` foreign keys could block deletion of inviter or accepted-user Auth records.
+- A forward migration changes both audit foreign keys to `ON DELETE SET NULL`, makes `created_by` nullable, and preserves historical invite rows.
+- Acceptance rejects a pending invite with a null inviter before creating a user, granting a role, writing a profile, linking a therapist, consuming the token, or inserting an admin action.
+- Focused review-fix verification passed, 7 files / 81 tests; the Tier-0 route gate remains passing, 7 Cypress specs / 220 tests.
+- Final code, security, and Supabase rereviews approved the complete review-fix diff with no required changes.
 
 ## Residual Risk
 

--- a/docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md
+++ b/docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md
@@ -1,0 +1,87 @@
+# WIN-265 Therapist Onboarding Invite Handoff
+
+- classification: high-risk human-reviewed
+- lane: critical
+- issue: WIN-265
+- scope: make therapist onboarding issue a therapist-bound BT invite, persist invite lifecycle state, create the Auth/profile/role/link records on acceptance, and preserve a recoverable resend path when delivery fails
+- non-goals: plaintext password storage, immediate admin-created passwords, generic staff-onboarding redesign, unrelated auth or RLS cleanup, and production deployment before human review
+- protected paths:
+  - `supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql`
+  - `supabase/functions/admin-invite/index.ts`
+  - `supabase/functions/accept-staff-invite/index.ts`
+- hosted read-only evidence: the linked Supabase project contained a therapist directory row without the corresponding Auth user, profile, role, or therapist link; no production mutation was performed
+
+## Implemented Behavior
+
+- Therapist onboarding and profile retry pass the exact therapist row ID to `admin-invite`.
+- Targeted invites are restricted to `bt`, use canonical database-backed organization context, and validate therapist organization, normalized email, active status, and deletion state.
+- Invite tokens record target, accepted, and revoked lifecycle state.
+- Acceptance revalidates the target, creates Auth/profile/role/link records, consumes the invite with compare-and-set semantics, and removes the newly created Auth user if protected completion fails.
+- Generic and targeted active invites cannot coexist for the same normalized email and organization.
+- The legacy six-argument invite RPC remains as a service-role-only wrapper around the targeted seven-argument RPC for rollout-order compatibility.
+- Email-delivery failure revokes the invite without deleting the valid therapist row; the therapist profile provides the retry action.
+
+## Verification Card
+
+- lane: critical
+- required checks:
+  - focused invite, acceptance, migration, and component regressions
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run test:routes:tier0`
+  - `npm run build`
+  - `npm run verify:local`
+  - `npm run ci:playwright` when protected credentials are available
+- executed checks:
+  - `npx vitest run tests/admins/invite_flow.spec.ts tests/admins/accept_invite_flow.spec.ts tests/admins/therapist_invite_target_migration.spec.ts src/components/__tests__/TherapistOnboarding.test.tsx src/components/__tests__/TherapistProfileInvite.test.tsx` -> pass, 5 files / 58 tests
+  - `npm run ci:check-focused` -> pass; database-backed grant/RLS checks skipped because `SUPABASE_DB_URL` was unavailable, and auth parity was disabled locally
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm run validate:tenant` -> pass
+  - `npm run build` -> pass
+  - `npm run test:routes:tier0` -> pass, 7 Cypress specs / 220 tests
+- blocked or failed checks:
+  - `npm run test:ci` -> environment failure during coverage execution: Node heap OOM (`Ineffective mark-compacts near heap limit`, `ERR_IPC_CHANNEL_CLOSED`)
+  - `npm run verify:local` -> failed at its inherited `test:ci` phase for the same Node heap OOM
+  - `npm run ci:playwright` -> blocked because neither `PW_SUPERADMIN_EMAIL` + `PW_SUPERADMIN_PASSWORD` nor `PW_ADMIN_EMAIL` + `PW_ADMIN_PASSWORD` was available
+- result: pass-with-blocked-checks; review-ready, not merge-ready
+
+## Independent Reviews
+
+- code-review-engineer: approve; final whole-branch review clean after RPC rollout compatibility and canonical organization routing fixes
+- security-engineer: approve; no authz, token exposure, grant widening, or tenant-isolation regression found
+- supabase-reviewer: approve with verification residual risk; both RPC overloads remain service-role-only and the tenant boundary is preserved
+- test-engineer: required local matrix executed; full coverage was blocked by process heap exhaustion and credentialed Playwright by missing protected credentials
+- resolved review findings:
+  - normalized invite-acceptance therapist status consistently with issuance
+  - prevented generic and targeted active-invite coexistence in both orderings
+  - made mixed-order collision tests preserve the stored target shape
+  - restored a backward-compatible six-argument RPC wrapper
+  - removed mutable Auth metadata from default super-admin organization resolution
+
+## Residual Risk
+
+- The migration contract was checked statically and through focused tests, but was not applied to a live branch database.
+- Database-backed grant/RLS policy checks were skipped without `SUPABASE_DB_URL`.
+- The aggregate coverage suite did not complete because the local Node process exhausted its heap.
+- Credentialed hosted Playwright remains for CI/human-review follow-through.
+- Production still requires reviewed migration/function deployment and a new invite for the affected therapist; this branch does not mutate the live account.
+
+## PR Hygiene
+
+- pr-ready: yes, for human review
+- merge-ready: no
+- branch: `codex/therapist-onboarding-invite`
+- linear-ready: yes, WIN-265
+- single-purpose: yes
+- unrelated changes: none identified
+- protected-path drift: none beyond the routed migration and invite functions
+- reviewer status: code, security, and Supabase reviews complete
+- required merge blockers:
+  - critical-lane human review
+  - live CI evaluation of the full coverage and credentialed browser gates
+  - reviewed Supabase migration and Edge Function deployment sequence
+- post-deploy validation: resend the therapist-bound invite, accept it with a compliant user-chosen password, and verify Auth/profile/role/exact therapist-link creation

--- a/docs/superpowers/plans/2026-07-30-therapist-onboarding-invite.md
+++ b/docs/superpowers/plans/2026-07-30-therapist-onboarding-invite.md
@@ -1,0 +1,314 @@
+# Therapist Onboarding Invite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make therapist onboarding automatically issue a secure, tenant-scoped account invite that deterministically links the accepted Auth user to the intended therapist row.
+
+**Architecture:** Extend the existing staff-invite token with an explicit therapist target and durable lifecycle state. Keep account creation in `accept-staff-invite`, add canonical organization and therapist validation at both privileged boundaries, and make the frontend distinguish directory creation from invite delivery.
+
+**Tech Stack:** React, TypeScript, TanStack Query, Supabase Auth/Postgres/Edge Functions, Zod, Vitest, Playwright.
+
+## Global Constraints
+
+- Linear issue WIN-265 is required.
+- Route classification is `high-risk human-reviewed`; lane is `critical`.
+- `user_roles` remains authoritative and `profiles.role` remains a mirror.
+- The application role for therapist-directory invitations is `bt`.
+- Never persist, log, or expose a plaintext password or raw invite token.
+- Never match a therapist account to a directory row by email alone.
+- No production mutation before review-ready verification.
+- Human review is mandatory before merge.
+
+---
+
+### Task 1: Persist therapist targets and invite lifecycle
+
+**Files:**
+- Create: `supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql`
+- Modify: `src/lib/generated/database.types.ts`
+- Create: `tests/admins/therapist_invite_target_migration.spec.ts`
+
+**Interfaces:**
+- Consumes: `create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, role_type, uuid)`.
+- Produces: `admin_invite_tokens.target_therapist_id`, `accepted_at`, `accepted_by_user_id`, and `revoked_at`.
+
+- [ ] **Step 1: Write the failing migration contract test**
+
+```ts
+expect(migrationSql).toMatch(/add column if not exists target_therapist_id uuid/i);
+expect(migrationSql).toMatch(/references public\.therapists\(id\)/i);
+expect(migrationSql).toMatch(/accepted_at timestamptz/i);
+expect(migrationSql).toMatch(/accepted_by_user_id uuid/i);
+expect(migrationSql).toMatch(/revoked_at timestamptz/i);
+expect(functionSql).toMatch(/p_target_therapist_id uuid/i);
+expect(functionSql).not.toMatch(/auth\.uid\(\)/i);
+expect(migrationSql).toMatch(/grant execute[\s\S]+to service_role/i);
+```
+
+- [ ] **Step 2: Run the migration test and confirm it fails because the forward migration does not exist**
+
+Run: `npx vitest run tests/admins/therapist_invite_target_migration.spec.ts`
+
+Expected: FAIL reading the missing migration.
+
+- [ ] **Step 3: Add the forward migration**
+
+Add nullable lifecycle columns with foreign keys, indexes for active target lookup, and a seven-argument service-role-only RPC. The RPC must validate normalized email, organization, expiration, inviter, role, and, when present, this target predicate:
+
+```sql
+exists (
+  select 1
+  from public.therapists t
+  where t.id = p_target_therapist_id
+    and t.organization_id = p_organization_id
+    and t.deleted_at is null
+    and lower(coalesce(t.status, 'active')) = 'active'
+    and lower(trim(t.email)) = v_normalized_email
+)
+```
+
+Active duplicate checks must include:
+
+```sql
+and t.accepted_at is null
+and t.revoked_at is null
+and t.expires_at > v_now
+```
+
+- [ ] **Step 4: Update generated database types**
+
+Add nullable row/update fields, nullable insert fields, and the `target_therapist_id` relationship to `src/lib/generated/database.types.ts`.
+
+- [ ] **Step 5: Run the migration contract tests**
+
+Run: `npx vitest run tests/admins/therapist_invite_target_migration.spec.ts tests/admins/invite_rate_limit_service_role_migration.spec.ts tests/security/public-security-definer-rpc-grants.security.spec.ts`
+
+Expected: PASS.
+
+### Task 2: Harden and target invite issuance
+
+**Files:**
+- Modify: `supabase/functions/admin-invite/index.ts`
+- Modify: `tests/admins/invite_flow.spec.ts`
+
+**Interfaces:**
+- Consumes: optional request field `targetTherapistId: string`.
+- Produces: an invite whose service-owned record is bound to the validated therapist ID.
+
+- [ ] **Step 1: Add failing issuance tests**
+
+Add cases proving:
+
+```ts
+expect(createAdminRpc).toHaveBeenCalledWith(
+  'create_admin_invite_token_rate_limited',
+  expect.objectContaining({ p_target_therapist_id: 'therapist-1' }),
+);
+expect(resolveOrgId).toHaveBeenCalledWith(expect.anything());
+```
+
+Also cover mismatched organization, email, inactive status, and soft deletion returning 409/403 without invoking the RPC or email provider.
+
+- [ ] **Step 2: Run the focused invite tests and confirm the new cases fail**
+
+Run: `npx vitest run tests/admins/invite_flow.spec.ts`
+
+Expected: FAIL because `targetTherapistId` and canonical organization resolution are not implemented.
+
+- [ ] **Step 3: Implement canonical scope and target validation**
+
+Extend the Zod schema with:
+
+```ts
+targetTherapistId: z.string().uuid().optional(),
+```
+
+Resolve non-super-admin organization with `resolveOrgId(adminClient)`. For a target, query `supabaseAdmin.from("therapists")` for `id,email,organization_id,status,deleted_at`, validate the design predicates, and pass:
+
+```ts
+p_target_therapist_id: payload.targetTherapistId ?? null,
+```
+
+Include the target ID in the audit details without including the raw token.
+
+- [ ] **Step 4: Revoke failed-delivery invites**
+
+Replace hard deletion on email failure with an update that sets `revoked_at` for the exact invite ID and organization. Return `invite_rollback_failed` when revocation cannot be persisted.
+
+- [ ] **Step 5: Run the focused invite tests**
+
+Run: `npx vitest run tests/admins/invite_flow.spec.ts`
+
+Expected: PASS.
+
+### Task 3: Provision the exact therapist link at acceptance
+
+**Files:**
+- Modify: `supabase/functions/accept-staff-invite/index.ts`
+- Modify: `tests/admins/accept_invite_flow.spec.ts`
+
+**Interfaces:**
+- Consumes: an unaccepted, unrevoked invite with optional `target_therapist_id`.
+- Produces: Auth user, authoritative role, mirrored profile, exact `user_therapist_links` row, and durable invite acceptance.
+
+- [ ] **Step 1: Add failing acceptance tests**
+
+Extend the fixture with therapist rows, inserted therapist links, token lifecycle updates, and failure toggles. Assert:
+
+```ts
+expect(insertedTherapistLinks).toEqual([
+  { user_id: 'new-user-1', therapist_id: 'therapist-1' },
+]);
+expect(consumedInvites).toEqual([
+  expect.objectContaining({ id: 'invite-1', accepted_by_user_id: 'new-user-1' }),
+]);
+```
+
+Add cross-org, email-mismatch, inactive, deleted, replay, link-failure, and consumption-failure cases.
+
+- [ ] **Step 2: Run the focused acceptance tests and confirm the new cases fail**
+
+Run: `npx vitest run tests/admins/accept_invite_flow.spec.ts`
+
+Expected: FAIL because target validation, therapist linking, and durable consumption are absent.
+
+- [ ] **Step 3: Validate the target before account creation**
+
+Select lifecycle and target fields with the token. Reject accepted or revoked tokens. When targeted, load the therapist and require exact organization, normalized email, active status, and no `deleted_at`.
+
+- [ ] **Step 4: Insert the link and consume the invite**
+
+After role and profile writes, insert:
+
+```ts
+await supabaseAdmin.from("user_therapist_links").upsert(
+  { user_id: userId, therapist_id: inviteRecord.target_therapist_id },
+  { onConflict: "user_id,therapist_id" },
+);
+```
+
+Then compare-and-set `accepted_at` and `accepted_by_user_id` where `accepted_at` and `revoked_at` are null. Any failure invokes the existing Auth-user cleanup and returns a fail-closed error.
+
+- [ ] **Step 5: Run the focused acceptance tests**
+
+Run: `npx vitest run tests/admins/accept_invite_flow.spec.ts`
+
+Expected: PASS.
+
+### Task 4: Make therapist onboarding send and retry the targeted invite
+
+**Files:**
+- Modify: `src/components/TherapistOnboarding.tsx`
+- Modify: `src/components/__tests__/TherapistOnboarding.test.tsx`
+- Modify: `src/components/TherapistDetails/ProfileTab.tsx`
+- Modify: `src/components/__tests__/TherapistProfileInvite.test.tsx`
+
+**Interfaces:**
+- Consumes: the created therapist row `{ id, email, organization_id }`.
+- Produces: `admin-invite` calls containing `targetTherapistId` and accurate success/failure UI.
+
+- [ ] **Step 1: Add failing component tests**
+
+Mock `supabase.functions.invoke` and assert onboarding sends:
+
+```ts
+expect(invoke).toHaveBeenCalledWith('admin-invite', {
+  body: expect.objectContaining({
+    email: 'avery@example.com',
+    organizationId: 'org-test',
+    role: 'bt',
+    targetTherapistId: 'therapist-1',
+  }),
+});
+```
+
+Add a failure case asserting the completion callback still receives the valid therapist creation result while the UI reports that the invite was not sent. Update the profile retry assertion with the exact therapist ID.
+
+- [ ] **Step 2: Run the component tests and confirm the new assertions fail**
+
+Run: `npx vitest run src/components/__tests__/TherapistOnboarding.test.tsx src/components/__tests__/TherapistProfileInvite.test.tsx`
+
+Expected: FAIL because onboarding does not invoke the Edge Function and profile retry omits the target.
+
+- [ ] **Step 3: Implement targeted invite issuance**
+
+After the therapist insert and document attempts, invoke:
+
+```ts
+await supabase.functions.invoke('admin-invite', {
+  body: {
+    email: therapist.email,
+    organizationId: activeOrganizationId,
+    role: 'bt',
+    reason: `Invite ${therapist.full_name} to access their therapist profile.`,
+    targetTherapistId: therapist.id,
+  },
+});
+```
+
+Return `{ therapist, inviteSent }` from the mutation. Show `Therapist created and invite sent` only when both operations succeed; otherwise show a specific recoverable invite error and navigate to the created therapist record or list.
+
+- [ ] **Step 4: Add the target to profile retry**
+
+Include `targetTherapistId: therapist.id` in `ProfileTab`'s existing `admin-invite` request.
+
+- [ ] **Step 5: Run the focused component tests**
+
+Run: `npx vitest run src/components/__tests__/TherapistOnboarding.test.tsx src/components/__tests__/TherapistProfileInvite.test.tsx`
+
+Expected: PASS.
+
+### Task 5: Critical-lane verification and handoff
+
+**Files:**
+- Create: `docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md`
+- Modify: `docs/superpowers/plans/2026-07-30-therapist-onboarding-invite.md`
+
+**Interfaces:**
+- Consumes: test output, hosted read-only evidence, specialist reviews, and live PR state.
+- Produces: verification card, PR-hygiene verdict, and human-review-ready PR.
+
+- [ ] **Step 1: Run focused regression tests**
+
+Run:
+
+```powershell
+npx vitest run tests/admins/invite_flow.spec.ts tests/admins/accept_invite_flow.spec.ts tests/admins/therapist_invite_target_migration.spec.ts src/components/__tests__/TherapistOnboarding.test.tsx src/components/__tests__/TherapistProfileInvite.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the critical verification matrix**
+
+Run:
+
+```powershell
+npm run ci:check-focused
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run validate:tenant
+npm run test:routes:tier0
+npm run build
+npm run verify:local
+```
+
+Run `npm run ci:playwright` only where its required protected credentials are available; otherwise record the exact blocker.
+
+- [ ] **Step 3: Obtain independent reviews**
+
+Require `code-review-engineer`, `test-engineer`, `security-engineer`, and `supabase-reviewer` verdicts with file/command evidence. Resolve all in-scope findings and rerun affected checks.
+
+- [ ] **Step 4: Write the handoff and run workflow skills**
+
+Record route, scope, files, migration behavior, connector evidence, executed and blocked checks, residual risk, and reviewer verdicts. Run `verify-change` and `pr-hygiene`.
+
+- [ ] **Step 5: Commit, push, and open a human-review PR**
+
+```powershell
+git add docs src supabase tests
+git commit -m "fix: complete therapist account onboarding"
+git push -u origin codex/therapist-onboarding-invite
+```
+
+Create a PR linked to WIN-265 and stop before merge pending required human review.

--- a/docs/superpowers/plans/2026-07-30-therapist-onboarding-invite.md
+++ b/docs/superpowers/plans/2026-07-30-therapist-onboarding-invite.md
@@ -303,7 +303,7 @@ Require `code-review-engineer`, `test-engineer`, `security-engineer`, and `supab
 
 Record route, scope, files, migration behavior, connector evidence, executed and blocked checks, residual risk, and reviewer verdicts. Run `verify-change` and `pr-hygiene`.
 
-- [ ] **Step 5: Commit, push, and open a human-review PR**
+- [x] **Step 5: Commit, push, and open a human-review PR**
 
 ```powershell
 git add docs src supabase tests

--- a/docs/superpowers/plans/2026-07-30-therapist-onboarding-invite.md
+++ b/docs/superpowers/plans/2026-07-30-therapist-onboarding-invite.md
@@ -32,7 +32,7 @@
 - Consumes: `create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, role_type, uuid)`.
 - Produces: `admin_invite_tokens.target_therapist_id`, `accepted_at`, `accepted_by_user_id`, and `revoked_at`.
 
-- [ ] **Step 1: Write the failing migration contract test**
+- [x] **Step 1: Write the failing migration contract test**
 
 ```ts
 expect(migrationSql).toMatch(/add column if not exists target_therapist_id uuid/i);
@@ -45,13 +45,13 @@ expect(functionSql).not.toMatch(/auth\.uid\(\)/i);
 expect(migrationSql).toMatch(/grant execute[\s\S]+to service_role/i);
 ```
 
-- [ ] **Step 2: Run the migration test and confirm it fails because the forward migration does not exist**
+- [x] **Step 2: Run the migration test and confirm it fails because the forward migration does not exist**
 
 Run: `npx vitest run tests/admins/therapist_invite_target_migration.spec.ts`
 
 Expected: FAIL reading the missing migration.
 
-- [ ] **Step 3: Add the forward migration**
+- [x] **Step 3: Add the forward migration**
 
 Add nullable lifecycle columns with foreign keys, indexes for active target lookup, and a seven-argument service-role-only RPC. The RPC must validate normalized email, organization, expiration, inviter, role, and, when present, this target predicate:
 
@@ -75,11 +75,11 @@ and t.revoked_at is null
 and t.expires_at > v_now
 ```
 
-- [ ] **Step 4: Update generated database types**
+- [x] **Step 4: Update generated database types**
 
 Add nullable row/update fields, nullable insert fields, and the `target_therapist_id` relationship to `src/lib/generated/database.types.ts`.
 
-- [ ] **Step 5: Run the migration contract tests**
+- [x] **Step 5: Run the migration contract tests**
 
 Run: `npx vitest run tests/admins/therapist_invite_target_migration.spec.ts tests/admins/invite_rate_limit_service_role_migration.spec.ts tests/security/public-security-definer-rpc-grants.security.spec.ts`
 
@@ -95,7 +95,7 @@ Expected: PASS.
 - Consumes: optional request field `targetTherapistId: string`.
 - Produces: an invite whose service-owned record is bound to the validated therapist ID.
 
-- [ ] **Step 1: Add failing issuance tests**
+- [x] **Step 1: Add failing issuance tests**
 
 Add cases proving:
 
@@ -109,13 +109,13 @@ expect(resolveOrgId).toHaveBeenCalledWith(expect.anything());
 
 Also cover mismatched organization, email, inactive status, and soft deletion returning 409/403 without invoking the RPC or email provider.
 
-- [ ] **Step 2: Run the focused invite tests and confirm the new cases fail**
+- [x] **Step 2: Run the focused invite tests and confirm the new cases fail**
 
 Run: `npx vitest run tests/admins/invite_flow.spec.ts`
 
 Expected: FAIL because `targetTherapistId` and canonical organization resolution are not implemented.
 
-- [ ] **Step 3: Implement canonical scope and target validation**
+- [x] **Step 3: Implement canonical scope and target validation**
 
 Extend the Zod schema with:
 
@@ -131,11 +131,11 @@ p_target_therapist_id: payload.targetTherapistId ?? null,
 
 Include the target ID in the audit details without including the raw token.
 
-- [ ] **Step 4: Revoke failed-delivery invites**
+- [x] **Step 4: Revoke failed-delivery invites**
 
 Replace hard deletion on email failure with an update that sets `revoked_at` for the exact invite ID and organization. Return `invite_rollback_failed` when revocation cannot be persisted.
 
-- [ ] **Step 5: Run the focused invite tests**
+- [x] **Step 5: Run the focused invite tests**
 
 Run: `npx vitest run tests/admins/invite_flow.spec.ts`
 
@@ -151,7 +151,7 @@ Expected: PASS.
 - Consumes: an unaccepted, unrevoked invite with optional `target_therapist_id`.
 - Produces: Auth user, authoritative role, mirrored profile, exact `user_therapist_links` row, and durable invite acceptance.
 
-- [ ] **Step 1: Add failing acceptance tests**
+- [x] **Step 1: Add failing acceptance tests**
 
 Extend the fixture with therapist rows, inserted therapist links, token lifecycle updates, and failure toggles. Assert:
 
@@ -166,17 +166,17 @@ expect(consumedInvites).toEqual([
 
 Add cross-org, email-mismatch, inactive, deleted, replay, link-failure, and consumption-failure cases.
 
-- [ ] **Step 2: Run the focused acceptance tests and confirm the new cases fail**
+- [x] **Step 2: Run the focused acceptance tests and confirm the new cases fail**
 
 Run: `npx vitest run tests/admins/accept_invite_flow.spec.ts`
 
 Expected: FAIL because target validation, therapist linking, and durable consumption are absent.
 
-- [ ] **Step 3: Validate the target before account creation**
+- [x] **Step 3: Validate the target before account creation**
 
 Select lifecycle and target fields with the token. Reject accepted or revoked tokens. When targeted, load the therapist and require exact organization, normalized email, active status, and no `deleted_at`.
 
-- [ ] **Step 4: Insert the link and consume the invite**
+- [x] **Step 4: Insert the link and consume the invite**
 
 After role and profile writes, insert:
 
@@ -189,7 +189,7 @@ await supabaseAdmin.from("user_therapist_links").upsert(
 
 Then compare-and-set `accepted_at` and `accepted_by_user_id` where `accepted_at` and `revoked_at` are null. Any failure invokes the existing Auth-user cleanup and returns a fail-closed error.
 
-- [ ] **Step 5: Run the focused acceptance tests**
+- [x] **Step 5: Run the focused acceptance tests**
 
 Run: `npx vitest run tests/admins/accept_invite_flow.spec.ts`
 
@@ -207,7 +207,7 @@ Expected: PASS.
 - Consumes: the created therapist row `{ id, email, organization_id }`.
 - Produces: `admin-invite` calls containing `targetTherapistId` and accurate success/failure UI.
 
-- [ ] **Step 1: Add failing component tests**
+- [x] **Step 1: Add failing component tests**
 
 Mock `supabase.functions.invoke` and assert onboarding sends:
 
@@ -224,13 +224,13 @@ expect(invoke).toHaveBeenCalledWith('admin-invite', {
 
 Add a failure case asserting the completion callback still receives the valid therapist creation result while the UI reports that the invite was not sent. Update the profile retry assertion with the exact therapist ID.
 
-- [ ] **Step 2: Run the component tests and confirm the new assertions fail**
+- [x] **Step 2: Run the component tests and confirm the new assertions fail**
 
 Run: `npx vitest run src/components/__tests__/TherapistOnboarding.test.tsx src/components/__tests__/TherapistProfileInvite.test.tsx`
 
 Expected: FAIL because onboarding does not invoke the Edge Function and profile retry omits the target.
 
-- [ ] **Step 3: Implement targeted invite issuance**
+- [x] **Step 3: Implement targeted invite issuance**
 
 After the therapist insert and document attempts, invoke:
 
@@ -248,11 +248,11 @@ await supabase.functions.invoke('admin-invite', {
 
 Return `{ therapist, inviteSent }` from the mutation. Show `Therapist created and invite sent` only when both operations succeed; otherwise show a specific recoverable invite error and navigate to the created therapist record or list.
 
-- [ ] **Step 4: Add the target to profile retry**
+- [x] **Step 4: Add the target to profile retry**
 
 Include `targetTherapistId: therapist.id` in `ProfileTab`'s existing `admin-invite` request.
 
-- [ ] **Step 5: Run the focused component tests**
+- [x] **Step 5: Run the focused component tests**
 
 Run: `npx vitest run src/components/__tests__/TherapistOnboarding.test.tsx src/components/__tests__/TherapistProfileInvite.test.tsx`
 
@@ -268,7 +268,7 @@ Expected: PASS.
 - Consumes: test output, hosted read-only evidence, specialist reviews, and live PR state.
 - Produces: verification card, PR-hygiene verdict, and human-review-ready PR.
 
-- [ ] **Step 1: Run focused regression tests**
+- [x] **Step 1: Run focused regression tests**
 
 Run:
 
@@ -295,11 +295,11 @@ npm run verify:local
 
 Run `npm run ci:playwright` only where its required protected credentials are available; otherwise record the exact blocker.
 
-- [ ] **Step 3: Obtain independent reviews**
+- [x] **Step 3: Obtain independent reviews**
 
 Require `code-review-engineer`, `test-engineer`, `security-engineer`, and `supabase-reviewer` verdicts with file/command evidence. Resolve all in-scope findings and rerun affected checks.
 
-- [ ] **Step 4: Write the handoff and run workflow skills**
+- [x] **Step 4: Write the handoff and run workflow skills**
 
 Record route, scope, files, migration behavior, connector evidence, executed and blocked checks, residual risk, and reviewer verdicts. Run `verify-change` and `pr-hygiene`.
 

--- a/docs/superpowers/specs/2026-07-30-therapist-onboarding-invite-design.md
+++ b/docs/superpowers/specs/2026-07-30-therapist-onboarding-invite-design.md
@@ -1,0 +1,88 @@
+# Therapist Onboarding Invite Design
+
+Issue: WIN-265
+
+## Goal
+
+Make therapist onboarding produce a usable, tenant-scoped staff account path instead of stopping after a `therapists` directory row is created.
+
+## Current Failure
+
+`TherapistOnboarding` inserts `public.therapists` and reports success without issuing an account invite. The existing staff invite acceptance path creates an Auth user, `user_roles`, and `profiles`, but it does not bind the new Auth user to the intended therapist row through `user_therapist_links`.
+
+Hosted project `wnnjeqheqxxyrgsjmygy` also has invite RPC drift: `create_admin_invite_token_rate_limited` is executable only by `service_role` while its body still requires `auth.uid() = p_created_by`. `admin-invite` calls the RPC with the service-role client, so the hosted contract cannot succeed.
+
+## Approved Design
+
+The application will use the existing secure invitation model. Administrators will not choose or transmit a bootstrap password.
+
+After a therapist directory row is created, `TherapistOnboarding` will call `admin-invite` with the normalized email, active organization, canonical `bt` application role, and the exact new therapist row ID. A successful response reports that the therapist and invite were created. An invite delivery failure preserves the valid therapist directory row, reports that account access was not provisioned, and directs the administrator to retry from the therapist profile. The existing profile invite action will send the same explicit therapist target so it is the deterministic retry path.
+
+`admin-invite` will resolve the caller's organization through the request-scoped `current_user_organization_id` RPC, not editable Auth metadata. Super admins may supply an explicit target organization under the existing elevated-role rules. When a therapist target is supplied, the Edge Function and service-role RPC will both require:
+
+- the target therapist exists;
+- the target is not soft deleted;
+- the target status is active;
+- the target belongs to the invite organization; and
+- the normalized therapist email equals the normalized invite email.
+
+The invite record will retain an explicit nullable `target_therapist_id` and durable lifecycle fields: `accepted_at`, `accepted_by_user_id`, and `revoked_at`. Generic staff invites remain supported with no therapist target.
+
+`accept-staff-invite` will load only unaccepted, unrevoked invite records. For a therapist-targeted invite it will revalidate therapist organization, active status, deletion state, and email before creating an account. It will then create the Auth user, assign the authoritative `user_roles` entry, mirror the role and organization into `profiles`, and insert the exact `user_therapist_links` row. The invite is marked accepted with a compare-and-set update only after all provisioning writes succeed. If role, profile, therapist-link, or invite-consumption work fails, the newly created Auth user is deleted; cascading foreign keys remove dependent account rows while the existing therapist directory row remains intact and the invite stays retryable.
+
+Failed email delivery will mark the invite revoked rather than leaving an active unusable token. Active-invite checks ignore accepted and revoked records. Expired records remain subject to the existing pruning path.
+
+## Role Contract
+
+The existing therapist-profile invitation path assigns the canonical application role `bt`. This slice preserves that behavior for therapist directory accounts regardless of professional title. Professional titles such as RBT, BCBA, speech therapist, or occupational therapist remain directory attributes and do not independently grant application authorization.
+
+Changing title-to-role mapping or allowing organization admins to grant elevated `bcba` or `super_admin` roles is outside this slice.
+
+## Security Invariants
+
+- `user_roles` is the authorization source of truth; `profiles.role` is a synchronized mirror.
+- Caller organization is resolved from database-backed request context.
+- A caller-provided therapist ID is never trusted without service-side organization and email validation.
+- `user_therapist_links` is written only when the Auth user profile organization and therapist organization match the invite organization.
+- Invite tokens are single-use, expiry checked, revocable, and stored only as SHA-256 hashes.
+- The invite creation RPC remains service-role-only.
+- No plaintext password is stored or handled by the onboarding administrator.
+
+## Scope
+
+- `src/components/TherapistOnboarding.tsx`
+- `src/components/TherapistDetails/ProfileTab.tsx`
+- focused component tests
+- `supabase/functions/admin-invite/index.ts`
+- `supabase/functions/accept-staff-invite/index.ts`
+- focused Edge Function tests
+- one forward migration for invite target/lifecycle state and the service-role RPC
+- generated database types
+- WIN-265 tracking and critical-lane handoff artifacts
+
+## Non-goals
+
+- No direct password provisioning.
+- No email-only therapist matching.
+- No replacement of therapist directory IDs with Auth user IDs.
+- No redesign of generic staff invites.
+- No public-signup policy change.
+- No broad role, RLS, scheduling, or session authorization refactor.
+- No production mutation before the branch is reviewed and the required verification is complete.
+
+## Verification
+
+Use test-first coverage for:
+
+- onboarding sends an invite containing the exact therapist ID;
+- onboarding distinguishes directory creation from invite delivery failure;
+- therapist-profile retry sends the exact therapist ID;
+- inviter organization ignores manipulated Auth metadata;
+- non-super-admin cross-organization targeting fails closed;
+- inactive, deleted, cross-organization, or email-mismatched therapist targets fail closed;
+- invite acceptance creates the exact therapist link;
+- link or consumption failure deletes the newly created Auth user and leaves the invite retryable;
+- accepted and revoked invites cannot be replayed;
+- the forward migration keeps the invite RPC service-role-only and removes the hosted `auth.uid()` contradiction.
+
+Then run the critical auth and tenant verification matrix, obtain security/Supabase/code/test reviews, push the branch, and open a human-review PR.

--- a/src/components/TherapistDetails/ProfileTab.tsx
+++ b/src/components/TherapistDetails/ProfileTab.tsx
@@ -36,7 +36,7 @@ interface Issue {
 }
 
 export function ProfileTab({ therapist }: ProfileTabProps) {
-  const { hasRole, profile, user, effectiveRole } = useAuth();
+  const { hasCapability, hasRole, profile, user, effectiveRole } = useAuth();
   const metadata = user?.user_metadata ?? {};
   const metadataOrganizationId =
     typeof metadata.organization_id === 'string'
@@ -46,7 +46,7 @@ export function ProfileTab({ therapist }: ProfileTabProps) {
         : null;
   const inviteOrganizationId =
     therapist.organization_id ?? profile?.organization_id ?? metadataOrganizationId;
-  const canInviteStaff = effectiveRole === 'admin' || effectiveRole === 'super_admin';
+  const canInviteStaff = hasCapability('manageStaff');
   const isOwnProfile = Boolean(
     effectiveRole === 'therapist' &&
       (profile?.id === therapist.id ||

--- a/src/components/TherapistDetails/ProfileTab.tsx
+++ b/src/components/TherapistDetails/ProfileTab.tsx
@@ -147,6 +147,7 @@ export function ProfileTab({ therapist }: ProfileTabProps) {
           organizationId: data.organization_id,
           role: 'bt',
           reason: trimmedReason,
+          targetTherapistId: therapist.id,
         },
       });
 
@@ -547,7 +548,7 @@ export function ProfileTab({ therapist }: ProfileTabProps) {
           email: therapist.email ?? '',
           organization_id: inviteOrganizationId ?? null,
           role: 'bt',
-          reason: `Invite ${therapist.full_name} to access their BT profile.`,
+          reason: `Invite ${therapist.full_name} to access their therapist profile.`,
         }}
         roleOptions={['bt']}
         title="Invite BT to app"

--- a/src/components/TherapistOnboarding.tsx
+++ b/src/components/TherapistOnboarding.tsx
@@ -29,8 +29,13 @@ import {
 } from '../lib/constants/therapists';
 import { parseTherapistOnboardingPrefill } from '../lib/onboardingPrefill';
 
+export interface TherapistOnboardingResult {
+  therapist: Therapist;
+  inviteSent: boolean;
+}
+
 interface TherapistOnboardingProps {
-  onComplete?: () => void;
+  onComplete?: (result?: TherapistOnboardingResult) => void;
 }
 
 interface OnboardingFormData {
@@ -265,9 +270,10 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
         });
       }
 
-      return { therapist, inviteSent };
+      return { therapist, inviteSent } satisfies TherapistOnboardingResult;
     },
-    onSuccess: ({ inviteSent }) => {
+    onSuccess: (result) => {
+      const { inviteSent } = result;
       queryClient.invalidateQueries({ queryKey: ['therapists'] });
       if (inviteSent) {
         showSuccess('Therapist created and invite sent');
@@ -276,7 +282,7 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
       }
       setIsSubmitting(false);
       if (onComplete) {
-        onComplete();
+        onComplete(result);
       } else {
         navigate('/therapists');
       }

--- a/src/components/TherapistOnboarding.tsx
+++ b/src/components/TherapistOnboarding.tsx
@@ -237,11 +237,44 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
         }
       }
 
-      return therapist;
+      let inviteSent = false;
+      try {
+        const { error: inviteError } = await supabase.functions.invoke('admin-invite', {
+          body: {
+            email: therapist.email,
+            organizationId: activeOrganizationId,
+            role: 'bt',
+            reason: `Invite ${therapist.full_name} to access their therapist profile.`,
+            targetTherapistId: therapist.id,
+          },
+        });
+
+        if (inviteError) {
+          throw inviteError;
+        }
+
+        inviteSent = true;
+      } catch (inviteError) {
+        logger.error('Therapist onboarding invite failed after therapist creation', {
+          error: inviteError,
+          context: { component: 'TherapistOnboarding', operation: 'sendInvite' },
+          metadata: {
+            therapistId: therapist.id,
+            organizationId: activeOrganizationId,
+          },
+        });
+      }
+
+      return { therapist, inviteSent };
     },
-    onSuccess: () => {
+    onSuccess: ({ inviteSent }) => {
       queryClient.invalidateQueries({ queryKey: ['therapists'] });
-      showSuccess('Therapist created successfully');
+      if (inviteSent) {
+        showSuccess('Therapist created and invite sent');
+      } else {
+        showError(new Error('Therapist created, but the invite email was not sent. Open the therapist profile and retry Invite to app.'));
+      }
+      setIsSubmitting(false);
       if (onComplete) {
         onComplete();
       } else {

--- a/src/components/__tests__/TherapistOnboarding.test.tsx
+++ b/src/components/__tests__/TherapistOnboarding.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, screen, waitFor, userEvent } from '../../test/utils';
 import { useActiveOrganizationId } from '../../lib/organization';
-import { showError } from '../../lib/toast';
+import { showError, showSuccess } from '../../lib/toast';
 
 vi.mock('../../lib/organization', () => ({
   useActiveOrganizationId: vi.fn(() => 'org-test'),
@@ -13,8 +13,46 @@ vi.mock('../../lib/toast', () => ({
   showError: vi.fn(),
 }));
 
+const {
+  fromMock,
+  insertMock,
+  insertSelectMock,
+  insertSingleMock,
+  invokeMock,
+} = vi.hoisted(() => {
+  const insertSingleMock = vi.fn();
+  const insertSelectMock = vi.fn(() => ({
+    single: insertSingleMock,
+  }));
+  const insertMock = vi.fn(() => ({
+    select: insertSelectMock,
+  }));
+  const fromMock = vi.fn(() => ({
+    insert: insertMock,
+  }));
+  const invokeMock = vi.fn();
+
+  return {
+    fromMock,
+    insertMock,
+    insertSelectMock,
+    insertSingleMock,
+    invokeMock,
+  };
+});
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: fromMock,
+    functions: {
+      invoke: invokeMock,
+    },
+  },
+}));
+
 const mockUseActiveOrganizationId = vi.mocked(useActiveOrganizationId);
 const mockShowError = vi.mocked(showError);
+const mockShowSuccess = vi.mocked(showSuccess);
 import { TherapistOnboarding } from '../TherapistOnboarding';
 
 describe('TherapistOnboarding validation', () => {
@@ -27,7 +65,38 @@ describe('TherapistOnboarding validation', () => {
   beforeEach(() => {
     mockUseActiveOrganizationId.mockReturnValue('org-test');
     mockShowError.mockClear();
+    mockShowSuccess.mockClear();
+    fromMock.mockClear();
+    insertMock.mockClear();
+    insertSelectMock.mockClear();
+    insertSingleMock.mockReset();
+    insertSingleMock.mockResolvedValue({
+      data: {
+        id: 'therapist-1',
+        email: 'avery@example.com',
+        organization_id: 'org-test',
+        full_name: 'Avery Blake',
+      },
+      error: null,
+    });
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue({ data: null, error: null });
   });
+
+  const advanceToFinalStep = async () => {
+    await userEvent.type(screen.getByLabelText(/first name/i), 'Avery');
+    await userEvent.type(screen.getByLabelText(/last name/i), 'Blake');
+    await userEvent.type(screen.getByLabelText(/email/i), 'avery@example.com');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await userEvent.type(screen.getByLabelText(/license number/i), 'LIC-12345');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(screen.getByText(/documents & certifications/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText(/i consent to the collection/i));
+  };
 
   it('validates basic information before advancing', async () => {
     renderOnboarding();
@@ -62,24 +131,44 @@ describe('TherapistOnboarding validation', () => {
   it('allows submission without any uploaded documents', async () => {
     const { handleComplete } = renderOnboarding();
 
-    await userEvent.type(screen.getByLabelText(/first name/i), 'Avery');
-    await userEvent.type(screen.getByLabelText(/last name/i), 'Blake');
-    await userEvent.type(screen.getByLabelText(/email/i), 'avery@example.com');
-    await userEvent.click(screen.getByRole('button', { name: /next/i }));
-
-    await userEvent.type(screen.getByLabelText(/license number/i), 'LIC-12345');
-    await userEvent.click(screen.getByRole('button', { name: /next/i }));
-    await userEvent.click(screen.getByRole('button', { name: /next/i }));
-    await userEvent.click(screen.getByRole('button', { name: /next/i }));
-
-    expect(screen.getByText(/documents & certifications/i)).toBeInTheDocument();
-    await userEvent.click(screen.getByLabelText(/i consent to the collection/i));
+    await advanceToFinalStep();
 
     await userEvent.click(screen.getByRole('button', { name: /complete onboarding/i }));
 
     await waitFor(() => {
       expect(handleComplete).toHaveBeenCalledTimes(1);
     });
+
+    expect(invokeMock).toHaveBeenCalledWith('admin-invite', {
+      body: expect.objectContaining({
+        email: 'avery@example.com',
+        organizationId: 'org-test',
+        role: 'bt',
+        targetTherapistId: 'therapist-1',
+      }),
+    });
+  }, 20000);
+
+  it('completes onboarding with a recoverable error when invite delivery fails', async () => {
+    const { handleComplete } = renderOnboarding();
+    invokeMock.mockResolvedValueOnce({
+      data: null,
+      error: new Error('Edge function failed'),
+    });
+
+    await advanceToFinalStep();
+    await userEvent.click(screen.getByRole('button', { name: /complete onboarding/i }));
+
+    await waitFor(() => {
+      expect(handleComplete).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockShowError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('invite'),
+      }),
+    );
+    expect(mockShowSuccess).not.toHaveBeenCalledWith('Therapist created successfully');
   }, 20000);
 
   it('shows an error when organization context is unavailable', async () => {

--- a/src/components/__tests__/TherapistOnboarding.test.tsx
+++ b/src/components/__tests__/TherapistOnboarding.test.tsx
@@ -56,6 +56,13 @@ const mockShowSuccess = vi.mocked(showSuccess);
 import { TherapistOnboarding } from '../TherapistOnboarding';
 
 describe('TherapistOnboarding validation', () => {
+  const createdTherapist = {
+    id: 'therapist-1',
+    email: 'avery@example.com',
+    organization_id: 'org-test',
+    full_name: 'Avery Blake',
+  };
+
   const renderOnboarding = () => {
     const handleComplete = vi.fn();
     renderWithProviders(<TherapistOnboarding onComplete={handleComplete} />);
@@ -71,12 +78,7 @@ describe('TherapistOnboarding validation', () => {
     insertSelectMock.mockClear();
     insertSingleMock.mockReset();
     insertSingleMock.mockResolvedValue({
-      data: {
-        id: 'therapist-1',
-        email: 'avery@example.com',
-        organization_id: 'org-test',
-        full_name: 'Avery Blake',
-      },
+      data: createdTherapist,
       error: null,
     });
     invokeMock.mockReset();
@@ -139,6 +141,11 @@ describe('TherapistOnboarding validation', () => {
       expect(handleComplete).toHaveBeenCalledTimes(1);
     });
 
+    expect(handleComplete).toHaveBeenCalledWith({
+      therapist: createdTherapist,
+      inviteSent: true,
+    });
+
     expect(invokeMock).toHaveBeenCalledWith('admin-invite', {
       body: expect.objectContaining({
         email: 'avery@example.com',
@@ -161,6 +168,11 @@ describe('TherapistOnboarding validation', () => {
 
     await waitFor(() => {
       expect(handleComplete).toHaveBeenCalledTimes(1);
+    });
+
+    expect(handleComplete).toHaveBeenCalledWith({
+      therapist: createdTherapist,
+      inviteSent: false,
     });
 
     expect(mockShowError).toHaveBeenCalledWith(

--- a/src/components/__tests__/TherapistProfileInvite.test.tsx
+++ b/src/components/__tests__/TherapistProfileInvite.test.tsx
@@ -27,7 +27,9 @@ const therapist = {
   phone: '555-0100',
 };
 
-const mockAuth = (role: 'client' | 'bt' | 'admin' | 'bcba' | 'super_admin' = 'admin') => {
+const mockAuth = (
+  role: 'client' | 'bt' | 'therapist' | 'midtier' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin' = 'admin',
+) => {
   vi.mocked(useAuth).mockReturnValue({
     user: {
       id: `${role}-user-id`,
@@ -57,7 +59,12 @@ const mockAuth = (role: 'client' | 'bt' | 'admin' | 'bcba' | 'super_admin' = 'ad
       };
       return (ranks[role] ?? 0) >= (ranks[requiredRole] ?? 0);
     }),
-    hasCapability: vi.fn(),
+    hasCapability: vi.fn((capability: string) => {
+      if (capability !== 'manageStaff') {
+        return false;
+      }
+      return ['admin_schedule', 'admin', 'bcba', 'super_admin'].includes(role);
+    }),
     hasAnyCapability: vi.fn(),
     hasAnyRole: vi.fn(),
     isAdmin: vi.fn(() => role === 'admin' || role === 'bcba' || role === 'super_admin'),
@@ -122,19 +129,25 @@ describe('Therapist profile staff invite', () => {
     expect(showSuccess).toHaveBeenCalledWith('Staff invite sent successfully');
   }, 20000);
 
-  it('does not expose the invite action to BT viewers', () => {
-    mockAuth('bt');
+  it.each(['admin_schedule', 'bcba', 'super_admin'] as const)(
+    'exposes the invite action to %s viewers when they can manage staff',
+    (role) => {
+      mockAuth(role);
 
-    renderWithProviders(<ProfileTab therapist={therapist} />);
+      renderWithProviders(<ProfileTab therapist={therapist} />);
 
-    expect(screen.queryByRole('button', { name: /invite to app/i })).not.toBeInTheDocument();
-  });
+      expect(screen.getByRole('button', { name: /invite to app/i })).toBeInTheDocument();
+    },
+  );
 
-  it('does not expose the invite action to BCBA viewers', () => {
-    mockAuth('bcba');
+  it.each(['client', 'bt', 'therapist', 'midtier'] as const)(
+    'does not expose the invite action to %s viewers',
+    (role) => {
+      mockAuth(role);
 
-    renderWithProviders(<ProfileTab therapist={therapist} />);
+      renderWithProviders(<ProfileTab therapist={therapist} />);
 
-    expect(screen.queryByRole('button', { name: /invite to app/i })).not.toBeInTheDocument();
-  });
+      expect(screen.queryByRole('button', { name: /invite to app/i })).not.toBeInTheDocument();
+    },
+  );
 });

--- a/src/components/__tests__/TherapistProfileInvite.test.tsx
+++ b/src/components/__tests__/TherapistProfileInvite.test.tsx
@@ -114,6 +114,7 @@ describe('Therapist profile staff invite', () => {
             organizationId: '11111111-1111-1111-1111-111111111111',
             role: 'bt',
             reason: 'Invite Taylor for BT data collection.',
+            targetTherapistId: 'therapist-1',
           },
         }),
       );

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -75,36 +75,62 @@ export type Database = {
       }
       admin_invite_tokens: {
         Row: {
+          accepted_at: string | null
+          accepted_by_user_id: string | null
           created_at: string
           created_by: string
           email: string
           expires_at: string
           id: string
           organization_id: string
+          revoked_at: string | null
           role: Database["public"]["Enums"]["role_type"]
+          target_therapist_id: string | null
           token_hash: string
         }
         Insert: {
+          accepted_at?: string | null
+          accepted_by_user_id?: string | null
           created_at?: string
           created_by: string
           email: string
           expires_at: string
           id?: string
           organization_id: string
+          revoked_at?: string | null
           role?: Database["public"]["Enums"]["role_type"]
+          target_therapist_id?: string | null
           token_hash: string
         }
         Update: {
+          accepted_at?: string | null
+          accepted_by_user_id?: string | null
           created_at?: string
           created_by?: string
           email?: string
           expires_at?: string
           id?: string
           organization_id?: string
+          revoked_at?: string | null
           role?: Database["public"]["Enums"]["role_type"]
+          target_therapist_id?: string | null
           token_hash?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "admin_invite_tokens_accepted_by_user_id_fkey"
+            columns: ["accepted_by_user_id"]
+            isOneToOne: false
+            referencedRelation: "admin_users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "admin_invite_tokens_accepted_by_user_id_fkey"
+            columns: ["accepted_by_user_id"]
+            isOneToOne: false
+            referencedRelation: "admin_users"
+            referencedColumns: ["user_id"]
+          },
           {
             foreignKeyName: "admin_invite_tokens_created_by_fkey"
             columns: ["created_by"]
@@ -118,6 +144,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "admin_users"
             referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "admin_invite_tokens_target_therapist_id_fkey"
+            columns: ["target_therapist_id"]
+            isOneToOne: false
+            referencedRelation: "therapists"
+            referencedColumns: ["id"]
           },
         ]
       }

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -78,7 +78,7 @@ export type Database = {
           accepted_at: string | null
           accepted_by_user_id: string | null
           created_at: string
-          created_by: string
+          created_by: string | null
           email: string
           expires_at: string
           id: string
@@ -92,7 +92,7 @@ export type Database = {
           accepted_at?: string | null
           accepted_by_user_id?: string | null
           created_at?: string
-          created_by: string
+          created_by?: string | null
           email: string
           expires_at: string
           id?: string
@@ -106,7 +106,7 @@ export type Database = {
           accepted_at?: string | null
           accepted_by_user_id?: string | null
           created_at?: string
-          created_by?: string
+          created_by?: string | null
           email?: string
           expires_at?: string
           id?: string

--- a/supabase/functions/accept-staff-invite/index.ts
+++ b/supabase/functions/accept-staff-invite/index.ts
@@ -65,8 +65,11 @@ const normalizeOptionalName = (value: string | undefined) => {
 const normalizeEmail = (value: string) => value.trim().toLowerCase();
 
 const normalizeTherapistStatus = (value: string | null) => {
-  const normalized = value?.trim().toLowerCase();
-  return normalized && normalized.length > 0 ? normalized : "active";
+  if (value === null) {
+    return "active";
+  }
+
+  return value.trim().toLowerCase();
 };
 
 const deleteInviteToken = async (tokenHash: string) => {

--- a/supabase/functions/accept-staff-invite/index.ts
+++ b/supabase/functions/accept-staff-invite/index.ts
@@ -37,7 +37,7 @@ type TherapistRecord = {
   id: string;
   email: string;
   organization_id: string;
-  status: string;
+  status: string | null;
   deleted_at: string | null;
 };
 
@@ -63,6 +63,11 @@ const normalizeOptionalName = (value: string | undefined) => {
 };
 
 const normalizeEmail = (value: string) => value.trim().toLowerCase();
+
+const normalizeTherapistStatus = (value: string | null) => {
+  const normalized = value?.trim().toLowerCase();
+  return normalized && normalized.length > 0 ? normalized : "active";
+};
 
 const deleteInviteToken = async (tokenHash: string) => {
   const { error } = await supabaseAdmin
@@ -171,7 +176,7 @@ async function handleAcceptStaffInvite(req: Request) {
       return jsonResponse(req, 409, { error: "invite_target_invalid" });
     }
 
-    if (therapistRecord.status !== "active" || therapistRecord.deleted_at) {
+    if (normalizeTherapistStatus(therapistRecord.status) !== "active" || therapistRecord.deleted_at) {
       return jsonResponse(req, 409, { error: "invite_target_invalid" });
     }
   }

--- a/supabase/functions/accept-staff-invite/index.ts
+++ b/supabase/functions/accept-staff-invite/index.ts
@@ -148,6 +148,10 @@ async function handleAcceptStaffInvite(req: Request) {
   }
 
   if (inviteRecord.target_therapist_id) {
+    if (roleResult.data !== "bt") {
+      return jsonResponse(req, 409, { error: "invite_target_role_forbidden" });
+    }
+
     const { data: therapist, error: therapistError } = await supabaseAdmin
       .from("therapists")
       .select("id,email,organization_id,status,deleted_at")

--- a/supabase/functions/accept-staff-invite/index.ts
+++ b/supabase/functions/accept-staff-invite/index.ts
@@ -146,6 +146,10 @@ async function handleAcceptStaffInvite(req: Request) {
     return jsonResponse(req, 404, { error: "invite_not_found" });
   }
 
+  if (inviterUserId === null) {
+    return jsonResponse(req, 404, { error: "invite_not_found" });
+  }
+
   if (new Date(inviteRecord.expires_at).getTime() <= Date.now()) {
     await deleteInviteToken(tokenHash);
     return jsonResponse(req, 410, { error: "invite_expired" });

--- a/supabase/functions/accept-staff-invite/index.ts
+++ b/supabase/functions/accept-staff-invite/index.ts
@@ -25,7 +25,7 @@ type InviteTokenRecord = {
   organization_id: string;
   token_hash: string;
   expires_at: string;
-  created_by: string;
+  created_by: string | null;
   role: string;
   target_therapist_id: string | null;
   accepted_at: string | null;
@@ -83,7 +83,7 @@ const deleteInviteToken = async (tokenHash: string) => {
   }
 };
 
-const createUserRole = async (userId: string, role: StaffRole, grantedBy: string) => {
+const createUserRole = async (userId: string, role: StaffRole, grantedBy: string | null) => {
   const { data: roleRow, error: roleError } = await supabaseAdmin
     .from("roles")
     .select("id,name")
@@ -141,6 +141,7 @@ async function handleAcceptStaffInvite(req: Request) {
   }
 
   const inviteRecord = invite as InviteTokenRecord;
+  const inviterUserId = inviteRecord.created_by ?? null;
   if (inviteRecord.accepted_at || inviteRecord.revoked_at) {
     return jsonResponse(req, 404, { error: "invite_not_found" });
   }
@@ -198,7 +199,7 @@ async function handleAcceptStaffInvite(req: Request) {
       organization_id: inviteRecord.organization_id,
       organizationId: inviteRecord.organization_id,
       role: roleResult.data,
-      invited_by: inviteRecord.created_by,
+      invited_by: inviterUserId,
       accepted_invite_id: inviteRecord.id,
     },
   });
@@ -217,7 +218,7 @@ async function handleAcceptStaffInvite(req: Request) {
     }
   };
 
-  const roleAssignment = await createUserRole(userId, roleResult.data, inviteRecord.created_by);
+  const roleAssignment = await createUserRole(userId, roleResult.data, inviterUserId);
   if (roleAssignment.error) {
     await cleanupCreatedUser();
     return jsonResponse(req, 500, { error: roleAssignment.error });
@@ -281,7 +282,7 @@ async function handleAcceptStaffInvite(req: Request) {
   }
 
   const { error: actionError } = await supabaseAdmin.from("admin_actions").insert({
-    admin_user_id: inviteRecord.created_by,
+    admin_user_id: inviterUserId,
     target_user_id: userId,
     organization_id: inviteRecord.organization_id,
     action_type: "staff_invite_accepted",

--- a/supabase/functions/accept-staff-invite/index.ts
+++ b/supabase/functions/accept-staff-invite/index.ts
@@ -27,6 +27,18 @@ type InviteTokenRecord = {
   expires_at: string;
   created_by: string;
   role: string;
+  target_therapist_id: string | null;
+  accepted_at: string | null;
+  accepted_by_user_id: string | null;
+  revoked_at: string | null;
+};
+
+type TherapistRecord = {
+  id: string;
+  email: string;
+  organization_id: string;
+  status: string;
+  deleted_at: string | null;
 };
 
 const jsonResponse = (req: Request, status: number, body: Record<string, unknown>) =>
@@ -49,6 +61,8 @@ const normalizeOptionalName = (value: string | undefined) => {
   const trimmed = value?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : null;
 };
+
+const normalizeEmail = (value: string) => value.trim().toLowerCase();
 
 const deleteInviteToken = async (tokenHash: string) => {
   const { error } = await supabaseAdmin
@@ -108,7 +122,9 @@ async function handleAcceptStaffInvite(req: Request) {
   const tokenHash = await hashToken(parsed.data.token);
   const { data: invite, error: inviteError } = await supabaseAdmin
     .from("admin_invite_tokens")
-    .select("id,email,organization_id,token_hash,expires_at,created_by,role")
+    .select(
+      "id,email,organization_id,token_hash,expires_at,created_by,role,target_therapist_id,accepted_at,accepted_by_user_id,revoked_at",
+    )
     .eq("token_hash", tokenHash)
     .single();
 
@@ -117,6 +133,10 @@ async function handleAcceptStaffInvite(req: Request) {
   }
 
   const inviteRecord = invite as InviteTokenRecord;
+  if (inviteRecord.accepted_at || inviteRecord.revoked_at) {
+    return jsonResponse(req, 404, { error: "invite_not_found" });
+  }
+
   if (new Date(inviteRecord.expires_at).getTime() <= Date.now()) {
     await deleteInviteToken(tokenHash);
     return jsonResponse(req, 410, { error: "invite_expired" });
@@ -125,6 +145,31 @@ async function handleAcceptStaffInvite(req: Request) {
   const roleResult = StaffRoleSchema.safeParse(inviteRecord.role);
   if (!roleResult.success) {
     return jsonResponse(req, 409, { error: "invite_role_not_supported" });
+  }
+
+  if (inviteRecord.target_therapist_id) {
+    const { data: therapist, error: therapistError } = await supabaseAdmin
+      .from("therapists")
+      .select("id,email,organization_id,status,deleted_at")
+      .eq("id", inviteRecord.target_therapist_id)
+      .single();
+
+    const therapistRecord = therapist as TherapistRecord | null;
+    if (therapistError || !therapistRecord) {
+      return jsonResponse(req, 409, { error: "invite_target_invalid" });
+    }
+
+    if (therapistRecord.organization_id !== inviteRecord.organization_id) {
+      return jsonResponse(req, 409, { error: "invite_target_invalid" });
+    }
+
+    if (normalizeEmail(therapistRecord.email) !== normalizeEmail(inviteRecord.email)) {
+      return jsonResponse(req, 409, { error: "invite_target_invalid" });
+    }
+
+    if (therapistRecord.status !== "active" || therapistRecord.deleted_at) {
+      return jsonResponse(req, 409, { error: "invite_target_invalid" });
+    }
   }
 
   const firstName = normalizeOptionalName(parsed.data.first_name);
@@ -188,6 +233,41 @@ async function handleAcceptStaffInvite(req: Request) {
     return jsonResponse(req, 500, { error: "profile_sync_failed" });
   }
 
+  if (inviteRecord.target_therapist_id) {
+    const { error: therapistLinkError } = await supabaseAdmin
+      .from("user_therapist_links")
+      .upsert(
+        {
+          user_id: userId,
+          therapist_id: inviteRecord.target_therapist_id,
+        },
+        { onConflict: "user_id,therapist_id" },
+      );
+
+    if (therapistLinkError) {
+      await cleanupCreatedUser();
+      return jsonResponse(req, 500, { error: "therapist_link_failed" });
+    }
+  }
+
+  const acceptedAt = new Date().toISOString();
+  const { error: consumeInviteError } = await supabaseAdmin
+    .from("admin_invite_tokens")
+    .update({
+      accepted_at: acceptedAt,
+      accepted_by_user_id: userId,
+    })
+    .eq("id", inviteRecord.id)
+    .is("accepted_at", null)
+    .is("revoked_at", null)
+    .select("id")
+    .single();
+
+  if (consumeInviteError) {
+    await cleanupCreatedUser();
+    return jsonResponse(req, 500, { error: "invite_consumption_failed" });
+  }
+
   const { error: actionError } = await supabaseAdmin.from("admin_actions").insert({
     admin_user_id: inviteRecord.created_by,
     target_user_id: userId,
@@ -204,8 +284,6 @@ async function handleAcceptStaffInvite(req: Request) {
   if (actionError) {
     console.warn("Failed to log staff invite acceptance", { code: "staff_invite_accept_log_failed" });
   }
-
-  await deleteInviteToken(tokenHash);
 
   return jsonResponse(req, 200, {
     email: inviteRecord.email,

--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -194,6 +194,11 @@ async function handleInvite(req: Request, userContext: UserContext) {
       return jsonResponse(403, { error: "insufficient_role_for_target" });
     }
 
+    if (payload.targetTherapistId && desiredRole !== "bt") {
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
+      return jsonResponse(403, { error: "target_therapist_role_forbidden" });
+    }
+
     if (payload.targetTherapistId) {
       const { data: targetTherapist, error: targetTherapistError } = await supabaseAdmin
         .from("therapists")

--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -355,6 +355,6 @@ async function handleInvite(req: Request, userContext: UserContext) {
   }
 }
 
-export const handler = createProtectedRoute(handleInvite, RouteOptions.admin);
+export const handler = createProtectedRoute(handleInvite, RouteOptions.staffAdmin);
 
 export default handler;

--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -8,6 +8,7 @@ import {
 } from "../_shared/auth-middleware.ts";
 import { createRequestClient, supabaseAdmin } from "../_shared/database.ts";
 import { getUserRoles } from "../_shared/auth.ts";
+import { resolveOrgId } from "../_shared/org.ts";
 
 const DEFAULT_EXPIRATION_HOURS = 72;
 const MIN_EXPIRATION_HOURS = 1;
@@ -26,6 +27,7 @@ const InviteRequestSchema = z.object({
     .optional(),
   role: z.enum(["bt", "therapist", "midtier", "admin_schedule", "admin", "bcba", "super_admin"]).optional(),
   reason: z.string().trim().min(10).max(1000).optional(),
+  targetTherapistId: z.string().uuid().optional(),
 });
 
 type InviteRequest = z.infer<typeof InviteRequestSchema>;
@@ -80,10 +82,13 @@ const buildInviteUrl = (baseUrl: string, token: string) => {
   return `${trimmed}/accept-invite?token=${token}`;
 };
 
+const isActiveTherapistStatus = (status: string | null | undefined) =>
+  (status ?? "active").trim().toLowerCase() === "active";
+
 const rollbackInviteToken = async (inviteId: string, organizationId: string) => {
   const { error } = await supabaseAdmin
     .from("admin_invite_tokens")
-    .delete()
+    .update({ revoked_at: new Date().toISOString() })
     .eq("id", inviteId)
     .eq("organization_id", organizationId);
 
@@ -167,7 +172,9 @@ async function handleInvite(req: Request, userContext: UserContext) {
       return jsonResponse(401, { error: "unauthorized" });
     }
 
-    const callerOrganizationId = extractOrganizationId(authResult.user.user_metadata as Record<string, unknown> | undefined);
+    const callerOrganizationId = callerIsSuperAdmin
+      ? extractOrganizationId(authResult.user.user_metadata as Record<string, unknown> | undefined)
+      : await resolveOrgId(adminClient);
     const normalizedEmail = normalizeEmail(payload.email);
     const targetOrganizationId = payload.organizationId ?? callerOrganizationId;
 
@@ -185,6 +192,52 @@ async function handleInvite(req: Request, userContext: UserContext) {
     if ((desiredRole === "super_admin" || desiredRole === "bcba") && !callerIsSuperAdmin) {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
       return jsonResponse(403, { error: "insufficient_role_for_target" });
+    }
+
+    if (payload.targetTherapistId) {
+      const { data: targetTherapist, error: targetTherapistError } = await supabaseAdmin
+        .from("therapists")
+        .select("id,email,organization_id,status,deleted_at")
+        .eq("id", payload.targetTherapistId)
+        .maybeSingle();
+
+      if (targetTherapistError) {
+        console.error("Failed to validate invite target therapist", { code: "target_therapist_lookup_failed" });
+        logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
+        return jsonResponse(500, { error: "invite_target_validation_failed" });
+      }
+
+      if (!targetTherapist) {
+        logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
+        return jsonResponse(409, { error: "target_therapist_not_available" });
+      }
+
+      const therapistRecord = targetTherapist as {
+        email?: string | null;
+        organization_id?: string | null;
+        status?: string | null;
+        deleted_at?: string | null;
+      };
+
+      if (therapistRecord.organization_id !== targetOrganizationId) {
+        logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
+        return jsonResponse(403, { error: "target_therapist_org_mismatch" });
+      }
+
+      if (normalizeEmail(therapistRecord.email ?? "") !== normalizedEmail) {
+        logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
+        return jsonResponse(409, { error: "target_therapist_email_mismatch" });
+      }
+
+      if (!isActiveTherapistStatus(therapistRecord.status)) {
+        logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
+        return jsonResponse(409, { error: "target_therapist_inactive" });
+      }
+
+      if (therapistRecord.deleted_at) {
+        logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
+        return jsonResponse(409, { error: "target_therapist_deleted" });
+      }
     }
 
     const { emailServiceUrl, portalBaseUrl } = ensureEmailServiceConfig();
@@ -213,6 +266,7 @@ async function handleInvite(req: Request, userContext: UserContext) {
       p_expires_at: expiresAt.toISOString(),
       p_created_by: userContext.user.id,
       p_role: desiredRole,
+      p_target_therapist_id: payload.targetTherapistId ?? null,
     })) as InsertInviteResult;
 
     if (insertedInvite.error || !insertedInvite.data?.[0]) {
@@ -266,6 +320,7 @@ async function handleInvite(req: Request, userContext: UserContext) {
         invite_id: inviteResult.id,
         role: desiredRole,
         email_delivery_status: emailResult.status,
+        ...(payload.targetTherapistId ? { target_therapist_id: payload.targetTherapistId } : {}),
         ...(payload.reason ? { reason: payload.reason } : {}),
         ...(emailResult.error ? { email_error: emailResult.error } : {}),
       },

--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -49,12 +49,6 @@ const jsonResponse = (status: number, body: Record<string, unknown>, headers: Re
     headers: { ...corsHeaders, ...headers, "Content-Type": "application/json" },
   });
 
-const extractOrganizationId = (metadata: Record<string, unknown> | null | undefined): string | null => {
-  if (!metadata) return null;
-  const candidate = metadata.organization_id ?? metadata.organizationId;
-  return typeof candidate === "string" && candidate.length > 0 ? candidate : null;
-};
-
 const normalizeEmail = (email: string) => email.trim().toLowerCase();
 
 const toHex = (bytes: ArrayBuffer) =>
@@ -172,9 +166,7 @@ async function handleInvite(req: Request, userContext: UserContext) {
       return jsonResponse(401, { error: "unauthorized" });
     }
 
-    const callerOrganizationId = callerIsSuperAdmin
-      ? extractOrganizationId(authResult.user.user_metadata as Record<string, unknown> | undefined)
-      : await resolveOrgId(adminClient);
+    const callerOrganizationId = await resolveOrgId(adminClient);
     const normalizedEmail = normalizeEmail(payload.email);
     const targetOrganizationId = payload.organizationId ?? callerOrganizationId;
 

--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -145,10 +145,6 @@ async function handleInvite(req: Request, userContext: UserContext) {
     const callerRoles = await getUserRoles(adminClient);
     const callerIsAdmin = callerRoles.includes("admin");
     const callerIsSuperAdmin = callerRoles.includes("super_admin");
-    if (!callerIsAdmin && !callerIsSuperAdmin) {
-      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
-      return jsonResponse(403, { error: "insufficient_role" });
-    }
 
     const payloadResult = InviteRequestSchema.safeParse(await req.json());
     if (!payloadResult.success) {
@@ -159,6 +155,17 @@ async function handleInvite(req: Request, userContext: UserContext) {
     }
 
     const payload: InviteRequest = payloadResult.data;
+    const desiredRole = payload.role ?? "admin";
+    const isTargetedBtInvite = Boolean(
+      payload.targetTherapistId
+      && desiredRole === "bt"
+      && (callerIsAdmin || callerIsSuperAdmin || callerRoles.includes("admin_schedule") || callerRoles.includes("bcba")),
+    );
+
+    if (!callerIsAdmin && !callerIsSuperAdmin && !isTargetedBtInvite) {
+      logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
+      return jsonResponse(403, { error: "insufficient_role" });
+    }
 
     const { data: authResult, error: authError } = await adminClient.auth.getUser();
     if (authError || !authResult?.user) {
@@ -180,7 +187,6 @@ async function handleInvite(req: Request, userContext: UserContext) {
       return jsonResponse(403, { error: "cross_org_invite_forbidden" });
     }
 
-    const desiredRole = payload.role ?? "admin";
     if ((desiredRole === "super_admin" || desiredRole === "bcba") && !callerIsSuperAdmin) {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
       return jsonResponse(403, { error: "insufficient_role_for_target" });

--- a/supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql
+++ b/supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql
@@ -80,6 +80,11 @@ begin
   end if;
 
   if p_target_therapist_id is not null
+    and p_role is distinct from 'bt'::public.role_type then
+    raise exception using errcode = '22023', message = 'Target therapist invites must use the bt role';
+  end if;
+
+  if p_target_therapist_id is not null
     and not exists (
       select 1
       from public.therapists t

--- a/supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql
+++ b/supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql
@@ -25,6 +25,16 @@ drop function if exists public.create_admin_invite_token_rate_limited(
   uuid,
   timestamptz,
   uuid,
+  public.role_type,
+  uuid
+);
+
+drop function if exists public.create_admin_invite_token_rate_limited(
+  text,
+  text,
+  uuid,
+  timestamptz,
+  uuid,
   public.role_type
 );
 
@@ -161,5 +171,33 @@ $$;
 
 revoke all on function public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type, uuid) from public, anon, authenticated;
 grant execute on function public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type, uuid) to service_role;
+
+create or replace function public.create_admin_invite_token_rate_limited(
+  p_email text,
+  p_token_hash text,
+  p_organization_id uuid,
+  p_expires_at timestamptz,
+  p_created_by uuid,
+  p_role public.role_type
+)
+returns table(id uuid, expires_at timestamptz, status text)
+language sql
+security definer
+set search_path = public, app, auth
+as $$
+  select *
+  from public.create_admin_invite_token_rate_limited(
+    p_email,
+    p_token_hash,
+    p_organization_id,
+    p_expires_at,
+    p_created_by,
+    p_role,
+    null
+  );
+$$;
+
+revoke all on function public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type) from public, anon, authenticated;
+grant execute on function public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type) to service_role;
 
 commit;

--- a/supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql
+++ b/supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql
@@ -91,7 +91,7 @@ begin
       where t.id = p_target_therapist_id
         and t.organization_id = p_organization_id
         and t.deleted_at is null
-        and lower(coalesce(t.status, 'active')) = 'active'
+        and lower(trim(coalesce(t.status, 'active'))) = 'active'
         and lower(trim(t.email)) = v_normalized_email
     ) then
     raise exception using errcode = '23503', message = 'Target therapist must be active in the organization and match the invite email';
@@ -105,10 +105,6 @@ begin
   from public.admin_invite_tokens t
   where t.email = v_normalized_email
     and t.organization_id = p_organization_id
-    and (
-      (p_target_therapist_id is null and t.target_therapist_id is null)
-      or t.target_therapist_id = p_target_therapist_id
-    )
     and t.accepted_at is null
     and t.revoked_at is null
     and t.expires_at > v_now
@@ -123,10 +119,6 @@ begin
   delete from public.admin_invite_tokens t
   where t.email = v_normalized_email
     and t.organization_id = p_organization_id
-    and (
-      (p_target_therapist_id is null and t.target_therapist_id is null)
-      or t.target_therapist_id = p_target_therapist_id
-    )
     and t.accepted_at is null
     and t.revoked_at is null
     and t.expires_at <= v_now;

--- a/supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql
+++ b/supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql
@@ -1,0 +1,168 @@
+-- @migration-intent: Persist therapist-targeted admin invite lifecycle state and align invite issuance with therapist-bound service-role validation.
+-- @migration-dependencies: 20260709011818_service_role_admin_invite_token_rpc.sql
+-- @migration-rollback: Drop the added admin_invite_tokens lifecycle columns and restore the six-argument create_admin_invite_token_rate_limited signature if this slice is reverted.
+
+begin;
+
+alter table public.admin_invite_tokens
+  add column if not exists target_therapist_id uuid references public.therapists(id),
+  add column if not exists accepted_at timestamptz,
+  add column if not exists accepted_by_user_id uuid references auth.users(id),
+  add column if not exists revoked_at timestamptz;
+
+create index if not exists admin_invite_tokens_active_target_lookup_idx
+  on public.admin_invite_tokens (organization_id, email, target_therapist_id, expires_at)
+  where accepted_at is null
+    and revoked_at is null;
+
+create index if not exists admin_invite_tokens_accepted_by_user_idx
+  on public.admin_invite_tokens (accepted_by_user_id)
+  where accepted_by_user_id is not null;
+
+drop function if exists public.create_admin_invite_token_rate_limited(
+  text,
+  text,
+  uuid,
+  timestamptz,
+  uuid,
+  public.role_type
+);
+
+create or replace function public.create_admin_invite_token_rate_limited(
+  p_email text,
+  p_token_hash text,
+  p_organization_id uuid,
+  p_expires_at timestamptz,
+  p_created_by uuid,
+  p_role public.role_type,
+  p_target_therapist_id uuid
+)
+returns table(id uuid, expires_at timestamptz, status text)
+language plpgsql
+security definer
+set search_path = public, app, auth
+as $$
+declare
+  v_normalized_email text;
+  v_now timestamptz := timezone('utc', now());
+  v_window_start timestamptz := v_now - interval '1 hour';
+  v_invite_limit integer := 10;
+  v_existing_id uuid;
+  v_existing_expires_at timestamptz;
+  v_recent_invite_count integer;
+  v_inserted public.admin_invite_tokens%rowtype;
+begin
+  -- This function is service-role-only after the June 2026 grant hardening. Caller authorization,
+  -- tenant scope, and elevated-role checks happen in the admin-invite Edge function before this RPC.
+  v_normalized_email := lower(trim(coalesce(p_email, '')));
+  if v_normalized_email = '' then
+    raise exception using errcode = '22023', message = 'Invite email is required';
+  end if;
+
+  if p_created_by is null then
+    raise exception using errcode = '22023', message = 'Inviter user ID is required';
+  end if;
+
+  if p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Organization ID is required';
+  end if;
+
+  if p_token_hash is null or length(trim(p_token_hash)) = 0 then
+    raise exception using errcode = '22023', message = 'Token hash is required';
+  end if;
+
+  if p_expires_at is null or p_expires_at <= v_now then
+    raise exception using errcode = '22023', message = 'Invite expiration must be in the future';
+  end if;
+
+  if p_role is null then
+    raise exception using errcode = '22023', message = 'Invite role is required';
+  end if;
+
+  if p_target_therapist_id is not null
+    and not exists (
+      select 1
+      from public.therapists t
+      where t.id = p_target_therapist_id
+        and t.organization_id = p_organization_id
+        and t.deleted_at is null
+        and lower(coalesce(t.status, 'active')) = 'active'
+        and lower(trim(t.email)) = v_normalized_email
+    ) then
+    raise exception using errcode = '23503', message = 'Target therapist must be active in the organization and match the invite email';
+  end if;
+
+  -- Serialize the full check/prune/count/insert sequence per inviter so bursts cannot share a stale count.
+  perform pg_advisory_xact_lock(hashtextextended('admin-invite:' || p_created_by::text, 0));
+
+  select t.id, t.expires_at
+  into v_existing_id, v_existing_expires_at
+  from public.admin_invite_tokens t
+  where t.email = v_normalized_email
+    and t.organization_id = p_organization_id
+    and (
+      (p_target_therapist_id is null and t.target_therapist_id is null)
+      or t.target_therapist_id = p_target_therapist_id
+    )
+    and t.accepted_at is null
+    and t.revoked_at is null
+    and t.expires_at > v_now
+  order by t.created_at desc
+  limit 1;
+
+  if v_existing_id is not null then
+    return query select v_existing_id, v_existing_expires_at, 'active_invite_exists'::text;
+    return;
+  end if;
+
+  delete from public.admin_invite_tokens t
+  where t.email = v_normalized_email
+    and t.organization_id = p_organization_id
+    and (
+      (p_target_therapist_id is null and t.target_therapist_id is null)
+      or t.target_therapist_id = p_target_therapist_id
+    )
+    and t.accepted_at is null
+    and t.revoked_at is null
+    and t.expires_at <= v_now;
+
+  select count(*)::integer
+  into v_recent_invite_count
+  from public.admin_invite_tokens t
+  where t.created_by = p_created_by
+    and t.created_at >= v_window_start;
+
+  if coalesce(v_recent_invite_count, 0) >= v_invite_limit then
+    return query select null::uuid, null::timestamptz, 'rate_limited'::text;
+    return;
+  end if;
+
+  insert into public.admin_invite_tokens (
+    email,
+    token_hash,
+    organization_id,
+    expires_at,
+    created_by,
+    role,
+    target_therapist_id
+  )
+  values (
+    v_normalized_email,
+    p_token_hash,
+    p_organization_id,
+    p_expires_at,
+    p_created_by,
+    p_role,
+    p_target_therapist_id
+  )
+  returning *
+  into v_inserted;
+
+  return query select v_inserted.id, v_inserted.expires_at, 'created'::text;
+end;
+$$;
+
+revoke all on function public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type, uuid) from public, anon, authenticated;
+grant execute on function public.create_admin_invite_token_rate_limited(text, text, uuid, timestamptz, uuid, public.role_type, uuid) to service_role;
+
+commit;

--- a/supabase/migrations/20260730183000_preserve_admin_invite_audit_fks.sql
+++ b/supabase/migrations/20260730183000_preserve_admin_invite_audit_fks.sql
@@ -1,0 +1,20 @@
+-- @migration-intent: Forward-fix admin_invite_tokens invite audit foreign keys to preserve admin invite audit rows when inviter or accepter auth users are deleted.
+-- @migration-dependencies: 20260730170000_therapist_invite_target_lifecycle.sql
+-- @migration-rollback: restore the prior admin_invite_tokens created_by and accepted_by_user_id foreign keys without ON DELETE SET NULL after reviewed downstream code no longer depends on nullable inviter audit references.
+
+begin;
+
+alter table public.admin_invite_tokens
+  alter column created_by drop not null;
+
+alter table public.admin_invite_tokens
+  drop constraint if exists admin_invite_tokens_created_by_fkey,
+  drop constraint if exists admin_invite_tokens_accepted_by_user_id_fkey;
+
+alter table public.admin_invite_tokens
+  add constraint admin_invite_tokens_created_by_fkey
+    foreign key (created_by) references auth.users(id) on delete set null,
+  add constraint admin_invite_tokens_accepted_by_user_id_fkey
+    foreign key (accepted_by_user_id) references auth.users(id) on delete set null;
+
+commit;

--- a/tests/admins/accept_invite_flow.spec.ts
+++ b/tests/admins/accept_invite_flow.spec.ts
@@ -7,7 +7,7 @@ type StoredInviteToken = {
   organization_id: string;
   token_hash: string;
   expires_at: string;
-  created_by: string;
+  created_by: string | null;
   created_at: string;
   role: string;
   target_therapist_id: string | null;
@@ -372,6 +372,71 @@ describe('accept staff invite edge function', () => {
     expect(inviteTokens[0]).toMatchObject({
       accepted_by_user_id: 'new-user-1',
     });
+  }, 20_000);
+
+  it('accepts invites whose inviter account was deleted while preserving nullable audit fields', async () => {
+    therapists.push({
+      id: 'therapist-null-inviter',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    inviteTokens.push(
+      await buildInvite({
+        id: 'invite-null-inviter',
+        created_by: null,
+        target_therapist_id: 'therapist-null-inviter',
+      }),
+    );
+
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          token: rawToken,
+          password: 'StrongPass123!',
+          first_name: 'Null',
+          last_name: 'Inviter',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      email: 'bt.staff@example.com',
+      role: 'bt',
+    });
+
+    expect(createdUsers).toHaveLength(1);
+    expect(createdUsers[0]).toMatchObject({
+      user_metadata: expect.objectContaining({
+        invited_by: null,
+        accepted_invite_id: 'invite-null-inviter',
+      }),
+    });
+    expect(upsertedUserRoles).toEqual([
+      expect.objectContaining({
+        user_id: 'new-user-1',
+        role_id: 'role-bt',
+        granted_by: null,
+        is_active: true,
+      }),
+    ]);
+    expect(adminActionRows).toEqual([
+      expect.objectContaining({
+        admin_user_id: null,
+        target_user_id: 'new-user-1',
+        organization_id: 'org-123',
+        action_type: 'staff_invite_accepted',
+      }),
+    ]);
+    expect(consumedInvites).toEqual([
+      expect.objectContaining({ id: 'invite-null-inviter', accepted_by_user_id: 'new-user-1' }),
+    ]);
   }, 20_000);
 
   it('rejects replay after a successful invite acceptance', async () => {

--- a/tests/admins/accept_invite_flow.spec.ts
+++ b/tests/admins/accept_invite_flow.spec.ts
@@ -36,6 +36,7 @@ const therapists: TherapistRow[] = [];
 const roleRows = [
   { id: 'role-bt', name: 'bt' },
   { id: 'role-admin', name: 'admin' },
+  { id: 'role-bcba', name: 'bcba' },
 ];
 const createdUsers: Array<Record<string, unknown>> = [];
 const upsertedUserRoles: Array<Record<string, unknown>> = [];
@@ -622,6 +623,67 @@ describe('accept staff invite edge function', () => {
 
     expect(response.status).toBe(404);
     expect(createdUsers).toHaveLength(0);
+  }, 20_000);
+
+  it('rejects already accepted invites before account creation', async () => {
+    inviteTokens.push(
+      await buildInvite({
+        id: 'invite-accepted',
+        accepted_at: new Date().toISOString(),
+        accepted_by_user_id: 'existing-user-1',
+      }),
+    );
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invite_not_found' });
+    expect(createdUsers).toHaveLength(0);
+    expect(insertedTherapistLinks).toHaveLength(0);
+    expect(consumedInvites).toHaveLength(0);
+  }, 20_000);
+
+  it('rejects targeted invites when the stored role is not bt without side effects', async () => {
+    therapists.push({
+      id: 'therapist-role-forbidden',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    inviteTokens.push(
+      await buildInvite({
+        id: 'invite-role-forbidden',
+        role: 'bcba',
+        target_therapist_id: 'therapist-role-forbidden',
+      }),
+    );
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invite_target_role_forbidden' });
+    expect(createdUsers).toHaveLength(0);
+    expect(upsertedUserRoles).toHaveLength(0);
+    expect(upsertedProfiles).toHaveLength(0);
+    expect(insertedTherapistLinks).toHaveLength(0);
+    expect(consumedInvites).toHaveLength(0);
+    expect(deletedAuthUserIds).toHaveLength(0);
+    expect(adminActionRows).toHaveLength(0);
   }, 20_000);
 
   it('deletes the partially created auth user when therapist link creation fails', async () => {

--- a/tests/admins/accept_invite_flow.spec.ts
+++ b/tests/admins/accept_invite_flow.spec.ts
@@ -10,6 +10,18 @@ type StoredInviteToken = {
   created_by: string;
   created_at: string;
   role: string;
+  target_therapist_id: string | null;
+  accepted_at: string | null;
+  accepted_by_user_id: string | null;
+  revoked_at: string | null;
+};
+
+type TherapistRow = {
+  id: string;
+  email: string;
+  organization_id: string;
+  status: string;
+  deleted_at: string | null;
 };
 
 const envValues = new Map<string, string>([
@@ -20,6 +32,7 @@ const envValues = new Map<string, string>([
 stubDenoEnv((key) => envValues.get(key) ?? '');
 
 const inviteTokens: StoredInviteToken[] = [];
+const therapists: TherapistRow[] = [];
 const roleRows = [
   { id: 'role-bt', name: 'bt' },
   { id: 'role-admin', name: 'admin' },
@@ -27,12 +40,16 @@ const roleRows = [
 const createdUsers: Array<Record<string, unknown>> = [];
 const upsertedUserRoles: Array<Record<string, unknown>> = [];
 const upsertedProfiles: Array<Record<string, unknown>> = [];
+const insertedTherapistLinks: Array<Record<string, unknown>> = [];
+const consumedInvites: Array<Record<string, unknown>> = [];
 const adminActionRows: Array<Record<string, unknown>> = [];
 const deletedInviteTokenHashes: string[] = [];
 const deletedAuthUserIds: string[] = [];
 let failCreateUser = false;
 let failUserRoleUpsert = false;
 let failProfileUpsert = false;
+let failTherapistLinkUpsert = false;
+let failInviteConsumeUpdate = false;
 
 const toHex = (bytes: ArrayBuffer) =>
   Array.from(new Uint8Array(bytes))
@@ -48,6 +65,11 @@ const makeSingleQuery = (table: string, filters: Record<string, unknown>) => ({
   single: vi.fn(async () => {
     if (table === 'admin_invite_tokens') {
       const match = inviteTokens.find((token) => token.token_hash === filters.token_hash) ?? null;
+      return match ? { data: match, error: null } : { data: null, error: { code: 'PGRST116', message: 'No rows' } };
+    }
+
+    if (table === 'therapists') {
+      const match = therapists.find((therapist) => therapist.id === filters.id) ?? null;
       return match ? { data: match, error: null } : { data: null, error: { code: 'PGRST116', message: 'No rows' } };
     }
 
@@ -84,8 +106,55 @@ const makeTableClient = (table: string) => ({
       return { error: null };
     }
 
+    if (table === 'user_therapist_links') {
+      if (failTherapistLinkUpsert) {
+        return { error: { message: 'therapist link upsert failed' } };
+      }
+      insertedTherapistLinks.push(payload);
+      return { error: null };
+    }
+
     throw new Error(`Unexpected upsert for ${table}`);
   }),
+  update: vi.fn((payload: Record<string, unknown>) => ({
+    eq: vi.fn((column: string, value: unknown) => ({
+      is: vi.fn((firstNullColumn: string, firstNullValue: unknown) => ({
+        is: vi.fn((secondNullColumn: string, secondNullValue: unknown) => ({
+          select: vi.fn((_columns?: string) => ({
+            single: vi.fn(async () => {
+              if (table !== 'admin_invite_tokens') {
+                throw new Error(`Unexpected update for ${table}`);
+              }
+
+              if (column !== 'id' || firstNullValue !== null || secondNullValue !== null) {
+                throw new Error(`Unexpected compare-and-set for ${table}`);
+              }
+
+              const match = inviteTokens.find(
+                (token) =>
+                  token.id === value &&
+                  token[firstNullColumn as keyof StoredInviteToken] === null &&
+                  token[secondNullColumn as keyof StoredInviteToken] === null,
+              );
+
+              if (!match || failInviteConsumeUpdate) {
+                return { data: null, error: { code: 'PGRST116', message: 'No rows' } };
+              }
+
+              match.accepted_at = String(payload.accepted_at ?? new Date().toISOString());
+              match.accepted_by_user_id = String(payload.accepted_by_user_id ?? '');
+              consumedInvites.push({
+                id: match.id,
+                accepted_at: match.accepted_at,
+                accepted_by_user_id: match.accepted_by_user_id,
+              });
+              return { data: match, error: null };
+            }),
+          })),
+        })),
+      })),
+    })),
+  })),
   insert: vi.fn(async (payload: Record<string, unknown>) => {
     if (table === 'admin_actions') {
       adminActionRows.push(payload);
@@ -179,9 +248,12 @@ describe('accept staff invite edge function', () => {
   beforeEach(async () => {
     vi.resetModules();
     inviteTokens.splice(0, inviteTokens.length);
+    therapists.splice(0, therapists.length);
     createdUsers.splice(0, createdUsers.length);
     upsertedUserRoles.splice(0, upsertedUserRoles.length);
     upsertedProfiles.splice(0, upsertedProfiles.length);
+    insertedTherapistLinks.splice(0, insertedTherapistLinks.length);
+    consumedInvites.splice(0, consumedInvites.length);
     adminActionRows.splice(0, adminActionRows.length);
     deletedInviteTokenHashes.splice(0, deletedInviteTokenHashes.length);
     deletedAuthUserIds.splice(0, deletedAuthUserIds.length);
@@ -191,20 +263,36 @@ describe('accept staff invite edge function', () => {
     failCreateUser = false;
     failUserRoleUpsert = false;
     failProfileUpsert = false;
+    failTherapistLinkUpsert = false;
+    failInviteConsumeUpdate = false;
+  });
+
+  const buildInvite = async (overrides: Partial<StoredInviteToken> = {}) => ({
+    id: 'invite-1',
+    email: 'bt.staff@example.com',
+    organization_id: 'org-123',
+    token_hash: await hashToken(rawToken),
+    expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    created_by: 'admin-1',
+    created_at: new Date().toISOString(),
+    role: 'bt',
+    target_therapist_id: null,
+    accepted_at: null,
+    accepted_by_user_id: null,
+    revoked_at: null,
+    ...overrides,
   });
 
   it('creates the invited BT account, assigns role, updates profile, logs acceptance, and consumes the token', async () => {
-    const tokenHash = await hashToken(rawToken);
-    inviteTokens.push({
-      id: 'invite-1',
+    therapists.push({
+      id: 'therapist-1',
       email: 'bt.staff@example.com',
       organization_id: 'org-123',
-      token_hash: tokenHash,
-      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-      created_by: 'admin-1',
-      created_at: new Date().toISOString(),
-      role: 'bt',
+      status: 'active',
+      deleted_at: null,
     });
+    const invite = await buildInvite({ target_therapist_id: 'therapist-1' });
+    inviteTokens.push(invite);
 
     const handler = await loadHandler();
 
@@ -259,6 +347,12 @@ describe('accept staff invite edge function', () => {
         is_active: true,
       }),
     ]);
+    expect(insertedTherapistLinks).toEqual([
+      { user_id: 'new-user-1', therapist_id: 'therapist-1' },
+    ]);
+    expect(consumedInvites).toEqual([
+      expect.objectContaining({ id: 'invite-1', accepted_by_user_id: 'new-user-1' }),
+    ]);
     expect(adminActionRows).toEqual([
       expect.objectContaining({
         admin_user_id: 'admin-1',
@@ -272,22 +366,22 @@ describe('accept staff invite edge function', () => {
         }),
       }),
     ]);
-    expect(deletedInviteTokenHashes).toEqual([tokenHash]);
-    expect(inviteTokens).toHaveLength(0);
+    expect(deletedInviteTokenHashes).toHaveLength(0);
+    expect(inviteTokens).toHaveLength(1);
+    expect(inviteTokens[0]).toMatchObject({
+      accepted_by_user_id: 'new-user-1',
+    });
   }, 20_000);
 
   it('rejects replay after a successful invite acceptance', async () => {
-    const tokenHash = await hashToken(rawToken);
-    inviteTokens.push({
-      id: 'invite-1',
+    therapists.push({
+      id: 'therapist-1',
       email: 'bt.staff@example.com',
       organization_id: 'org-123',
-      token_hash: tokenHash,
-      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-      created_by: 'admin-1',
-      created_at: new Date().toISOString(),
-      role: 'bt',
+      status: 'active',
+      deleted_at: null,
     });
+    inviteTokens.push(await buildInvite({ target_therapist_id: 'therapist-1' }));
 
     const handler = await loadHandler();
     const requestBody = {
@@ -317,22 +411,12 @@ describe('accept staff invite edge function', () => {
     expect(replayResponse.status).toBe(404);
     await expect(replayResponse.json()).resolves.toMatchObject({ error: 'invite_not_found' });
     expect(createdUsers).toHaveLength(1);
-    expect(deletedInviteTokenHashes).toEqual([tokenHash]);
+    expect(consumedInvites).toHaveLength(1);
   }, 20_000);
 
   it('does not consume the token when account creation fails', async () => {
     failCreateUser = true;
-    const tokenHash = await hashToken(rawToken);
-    inviteTokens.push({
-      id: 'invite-create-fails',
-      email: 'bt.staff@example.com',
-      organization_id: 'org-123',
-      token_hash: tokenHash,
-      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-      created_by: 'admin-1',
-      created_at: new Date().toISOString(),
-      role: 'bt',
-    });
+    inviteTokens.push(await buildInvite({ id: 'invite-create-fails' }));
 
     const handler = await loadHandler();
     const response = await handler(
@@ -351,17 +435,7 @@ describe('accept staff invite edge function', () => {
 
   it('deletes the partially created auth user when role assignment fails', async () => {
     failUserRoleUpsert = true;
-    const tokenHash = await hashToken(rawToken);
-    inviteTokens.push({
-      id: 'invite-role-fails',
-      email: 'bt.staff@example.com',
-      organization_id: 'org-123',
-      token_hash: tokenHash,
-      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-      created_by: 'admin-1',
-      created_at: new Date().toISOString(),
-      role: 'bt',
-    });
+    inviteTokens.push(await buildInvite({ id: 'invite-role-fails' }));
 
     const handler = await loadHandler();
     const response = await handler(
@@ -380,17 +454,7 @@ describe('accept staff invite edge function', () => {
 
   it('deletes the partially created auth user when profile sync fails', async () => {
     failProfileUpsert = true;
-    const tokenHash = await hashToken(rawToken);
-    inviteTokens.push({
-      id: 'invite-profile-fails',
-      email: 'bt.staff@example.com',
-      organization_id: 'org-123',
-      token_hash: tokenHash,
-      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-      created_by: 'admin-1',
-      created_at: new Date().toISOString(),
-      role: 'bt',
-    });
+    inviteTokens.push(await buildInvite({ id: 'invite-profile-fails' }));
 
     const handler = await loadHandler();
     const response = await handler(
@@ -424,17 +488,13 @@ describe('accept staff invite edge function', () => {
   }, 20_000);
 
   it('rejects missing or expired invite tokens without creating a user', async () => {
-    const tokenHash = await hashToken(rawToken);
-    inviteTokens.push({
+    const expiredInvite = await buildInvite({
       id: 'invite-expired',
       email: 'expired@example.com',
-      organization_id: 'org-123',
-      token_hash: tokenHash,
       expires_at: new Date(Date.now() - 60 * 1000).toISOString(),
-      created_by: 'admin-1',
       created_at: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
-      role: 'bt',
     });
+    inviteTokens.push(expiredInvite);
 
     const handler = await loadHandler();
 
@@ -449,6 +509,170 @@ describe('accept staff invite edge function', () => {
     expect(response.status).toBe(410);
     await expect(response.json()).resolves.toMatchObject({ error: 'invite_expired' });
     expect(createdUsers).toHaveLength(0);
-    expect(deletedInviteTokenHashes).toEqual([tokenHash]);
+    expect(deletedInviteTokenHashes).toEqual([expiredInvite.token_hash]);
+  }, 20_000);
+
+  it('rejects targeted invites when the therapist belongs to another organization', async () => {
+    therapists.push({
+      id: 'therapist-org-mismatch',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-999',
+      status: 'active',
+      deleted_at: null,
+    });
+    inviteTokens.push(await buildInvite({ id: 'invite-org-mismatch', target_therapist_id: 'therapist-org-mismatch' }));
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(createdUsers).toHaveLength(0);
+    expect(consumedInvites).toHaveLength(0);
+  }, 20_000);
+
+  it('rejects targeted invites when the therapist email does not match', async () => {
+    therapists.push({
+      id: 'therapist-email-mismatch',
+      email: 'other.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    inviteTokens.push(await buildInvite({ id: 'invite-email-mismatch', target_therapist_id: 'therapist-email-mismatch' }));
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(createdUsers).toHaveLength(0);
+    expect(consumedInvites).toHaveLength(0);
+  }, 20_000);
+
+  it('rejects targeted invites when the therapist is inactive', async () => {
+    therapists.push({
+      id: 'therapist-inactive',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'inactive',
+      deleted_at: null,
+    });
+    inviteTokens.push(await buildInvite({ id: 'invite-inactive', target_therapist_id: 'therapist-inactive' }));
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(createdUsers).toHaveLength(0);
+    expect(consumedInvites).toHaveLength(0);
+  }, 20_000);
+
+  it('rejects targeted invites when the therapist is soft deleted', async () => {
+    therapists.push({
+      id: 'therapist-deleted',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: new Date().toISOString(),
+    });
+    inviteTokens.push(await buildInvite({ id: 'invite-deleted', target_therapist_id: 'therapist-deleted' }));
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(createdUsers).toHaveLength(0);
+    expect(consumedInvites).toHaveLength(0);
+  }, 20_000);
+
+  it('rejects revoked invites before account creation', async () => {
+    inviteTokens.push(await buildInvite({ id: 'invite-revoked', revoked_at: new Date().toISOString() }));
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(createdUsers).toHaveLength(0);
+  }, 20_000);
+
+  it('deletes the partially created auth user when therapist link creation fails', async () => {
+    failTherapistLinkUpsert = true;
+    therapists.push({
+      id: 'therapist-link-fail',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    inviteTokens.push(await buildInvite({ id: 'invite-link-fails', target_therapist_id: 'therapist-link-fail' }));
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ error: 'therapist_link_failed' });
+    expect(deletedAuthUserIds).toEqual(['new-user-1']);
+    expect(consumedInvites).toHaveLength(0);
+  }, 20_000);
+
+  it('deletes the partially created auth user when invite consumption fails', async () => {
+    failInviteConsumeUpdate = true;
+    therapists.push({
+      id: 'therapist-consume-fail',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    inviteTokens.push(await buildInvite({ id: 'invite-consume-fails', target_therapist_id: 'therapist-consume-fail' }));
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invite_consumption_failed' });
+    expect(deletedAuthUserIds).toEqual(['new-user-1']);
+    expect(consumedInvites).toHaveLength(0);
   }, 20_000);
 });

--- a/tests/admins/accept_invite_flow.spec.ts
+++ b/tests/admins/accept_invite_flow.spec.ts
@@ -374,7 +374,7 @@ describe('accept staff invite edge function', () => {
     });
   }, 20_000);
 
-  it('accepts invites whose inviter account was deleted while preserving nullable audit fields', async () => {
+  it('fails closed when the inviter account was deleted before invite acceptance', async () => {
     therapists.push({
       id: 'therapist-null-inviter',
       email: 'bt.staff@example.com',
@@ -405,38 +405,15 @@ describe('accept staff invite edge function', () => {
       }),
     );
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      email: 'bt.staff@example.com',
-      role: 'bt',
-    });
-
-    expect(createdUsers).toHaveLength(1);
-    expect(createdUsers[0]).toMatchObject({
-      user_metadata: expect.objectContaining({
-        invited_by: null,
-        accepted_invite_id: 'invite-null-inviter',
-      }),
-    });
-    expect(upsertedUserRoles).toEqual([
-      expect.objectContaining({
-        user_id: 'new-user-1',
-        role_id: 'role-bt',
-        granted_by: null,
-        is_active: true,
-      }),
-    ]);
-    expect(adminActionRows).toEqual([
-      expect.objectContaining({
-        admin_user_id: null,
-        target_user_id: 'new-user-1',
-        organization_id: 'org-123',
-        action_type: 'staff_invite_accepted',
-      }),
-    ]);
-    expect(consumedInvites).toEqual([
-      expect.objectContaining({ id: 'invite-null-inviter', accepted_by_user_id: 'new-user-1' }),
-    ]);
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invite_not_found' });
+    expect(createdUsers).toHaveLength(0);
+    expect(upsertedUserRoles).toHaveLength(0);
+    expect(upsertedProfiles).toHaveLength(0);
+    expect(insertedTherapistLinks).toHaveLength(0);
+    expect(adminActionRows).toHaveLength(0);
+    expect(consumedInvites).toHaveLength(0);
+    expect(deletedAuthUserIds).toHaveLength(0);
   }, 20_000);
 
   it('rejects replay after a successful invite acceptance', async () => {

--- a/tests/admins/accept_invite_flow.spec.ts
+++ b/tests/admins/accept_invite_flow.spec.ts
@@ -635,6 +635,33 @@ describe('accept staff invite edge function', () => {
     expect(consumedInvites).toHaveLength(1);
   }, 20_000);
 
+  it('rejects targeted invites when therapist status is whitespace-only', async () => {
+    therapists.push({
+      id: 'therapist-whitespace-status',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: '   ',
+      deleted_at: null,
+    });
+    inviteTokens.push(
+      await buildInvite({ id: 'invite-whitespace-status', target_therapist_id: 'therapist-whitespace-status' }),
+    );
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invite_target_invalid' });
+    expect(createdUsers).toHaveLength(0);
+    expect(consumedInvites).toHaveLength(0);
+  }, 20_000);
+
   it('rejects targeted invites when the therapist is soft deleted', async () => {
     therapists.push({
       id: 'therapist-deleted',

--- a/tests/admins/accept_invite_flow.spec.ts
+++ b/tests/admins/accept_invite_flow.spec.ts
@@ -20,7 +20,7 @@ type TherapistRow = {
   id: string;
   email: string;
   organization_id: string;
-  status: string;
+  status: string | null;
   deleted_at: string | null;
 };
 
@@ -583,6 +583,56 @@ describe('accept staff invite edge function', () => {
     expect(response.status).toBe(409);
     expect(createdUsers).toHaveLength(0);
     expect(consumedInvites).toHaveLength(0);
+  }, 20_000);
+
+  it('accepts targeted invites when therapist status is null', async () => {
+    therapists.push({
+      id: 'therapist-null-status',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: null,
+      deleted_at: null,
+    });
+    inviteTokens.push(await buildInvite({ id: 'invite-null-status', target_therapist_id: 'therapist-null-status' }));
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ email: 'bt.staff@example.com', role: 'bt' });
+    expect(consumedInvites).toHaveLength(1);
+  }, 20_000);
+
+  it('accepts targeted invites when therapist status normalizes to active', async () => {
+    therapists.push({
+      id: 'therapist-normalized-status',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: ' Active ',
+      deleted_at: null,
+    });
+    inviteTokens.push(
+      await buildInvite({ id: 'invite-normalized-status', target_therapist_id: 'therapist-normalized-status' }),
+    );
+
+    const handler = await loadHandler();
+    const response = await handler(
+      new Request('https://edge.example.com/accept-staff-invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: rawToken, password: 'StrongPass123!' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ email: 'bt.staff@example.com', role: 'bt' });
+    expect(consumedInvites).toHaveLength(1);
   }, 20_000);
 
   it('rejects targeted invites when the therapist is soft deleted', async () => {

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -27,6 +27,7 @@ interface StoredInviteToken {
   created_by: string;
   created_at: string;
   role: string;
+  target_therapist_id: string | null;
   revoked_at: string | null;
 }
 
@@ -193,6 +194,7 @@ const createAdminRpc = vi.fn(async (functionName: string, params: Record<string,
     created_by: createdBy,
     created_at: new Date().toISOString(),
     role: String(params.p_role ?? 'admin'),
+    target_therapist_id: (params.p_target_therapist_id as string | null | undefined) ?? null,
     revoked_at: null,
   };
   inviteTokens.push(stored);
@@ -409,6 +411,7 @@ describe('admin invite edge function', () => {
       created_by: 'admin-1',
       created_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
       role: 'admin',
+      target_therapist_id: null,
       revoked_at: null,
     };
     inviteTokens.push(expiredToken);
@@ -449,6 +452,7 @@ describe('admin invite edge function', () => {
       created_by: 'admin-1',
       created_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
       role: 'admin',
+      target_therapist_id: null,
       revoked_at: null,
     });
 
@@ -481,6 +485,7 @@ describe('admin invite edge function', () => {
         created_by: 'admin-1',
         created_at: new Date(now - index * 60 * 1000).toISOString(),
         role: 'admin',
+        target_therapist_id: null,
         revoked_at: null,
       });
     }
@@ -564,6 +569,7 @@ describe('admin invite edge function', () => {
       email: 'bt.staff@example.com',
       organization_id: 'org-123',
       role: 'bt',
+      target_therapist_id: null,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -625,6 +631,7 @@ describe('admin invite edge function', () => {
       created_by: 'admin-1',
       created_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
       role: 'bt',
+      target_therapist_id: null,
       revoked_at: null,
     });
     therapists.push({
@@ -656,6 +663,7 @@ describe('admin invite edge function', () => {
       expect.objectContaining({ p_target_therapist_id: '77777777-7777-4777-8777-777777777777' }),
     );
     expect(inviteTokens).toHaveLength(1);
+    expect(inviteTokens[0]).toMatchObject({ target_therapist_id: null });
     expect(fetchMock).not.toHaveBeenCalled();
     expect(adminActionRows).toHaveLength(0);
   }, 20_000);
@@ -670,6 +678,7 @@ describe('admin invite edge function', () => {
       created_by: 'admin-1',
       created_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
       role: 'bt',
+      target_therapist_id: '88888888-8888-4888-8888-888888888888',
       revoked_at: null,
     });
     const handler = await loadHandler();
@@ -693,6 +702,7 @@ describe('admin invite edge function', () => {
     );
     expect(therapistLookupSpy).not.toHaveBeenCalled();
     expect(inviteTokens).toHaveLength(1);
+    expect(inviteTokens[0]).toMatchObject({ target_therapist_id: '88888888-8888-4888-8888-888888888888' });
     expect(fetchMock).not.toHaveBeenCalled();
     expect(adminActionRows).toHaveLength(0);
   }, 20_000);

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -67,6 +67,10 @@ let currentUserContext: TestUserContext = {
 };
 
 let currentUserMetadata: Record<string, unknown> = { organization_id: 'org-123' };
+const wrapperAllowedRolesByName = {
+  admin: ['admin', 'bcba', 'super_admin'],
+  staffAdmin: ['admin_schedule', 'admin', 'bcba', 'super_admin'],
+} as const;
 
 const inviteTokens: StoredInviteToken[] = [];
 const therapists: TherapistRecord[] = [];
@@ -210,10 +214,28 @@ createRequestClient.mockImplementation(() => createMockClient());
 
 vi.mock('../../supabase/functions/_shared/auth-middleware.ts', () => ({
   corsHeaders,
-  RouteOptions: { admin: {} },
+  RouteOptions: {
+    admin: { requireAuth: true, allowedRoles: [...wrapperAllowedRolesByName.admin] },
+    staffAdmin: { requireAuth: true, allowedRoles: [...wrapperAllowedRolesByName.staffAdmin] },
+  },
   logApiAccess,
-  createProtectedRoute: (handler: (req: Request, context: TestUserContext) => Promise<Response>) => {
-    return (req: Request) => handler(req, currentUserContext);
+  createProtectedRoute: (
+    handler: (req: Request, context: TestUserContext) => Promise<Response>,
+    options: { allowedRoles?: readonly TestRole[] } = {},
+  ) => {
+    return (req: Request) => {
+      const allowedRoles = options.allowedRoles ?? [];
+      if (allowedRoles.length > 0 && !allowedRoles.includes(currentUserContext.profile.role)) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'forbidden', message: 'Insufficient permissions' }), {
+            status: 403,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+
+      return handler(req, currentUserContext);
+    };
   },
 }));
 

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -70,6 +70,7 @@ const inviteTokens: StoredInviteToken[] = [];
 const therapists: TherapistRecord[] = [];
 const adminActionRows: Array<Record<string, unknown>> = [];
 let rollbackUpdateError: { message: string } | null = null;
+const therapistLookupSpy = vi.fn();
 
 const fromTable = (table: string) => {
   if (table === 'admin_actions') {
@@ -106,6 +107,7 @@ const fromTable = (table: string) => {
   if (table === 'therapists') {
     return {
       select: vi.fn(() => {
+        therapistLookupSpy();
         const filters: Record<string, unknown> = {};
         return {
           eq: vi.fn((column: string, value: unknown) => {
@@ -256,6 +258,7 @@ describe('admin invite edge function', () => {
     createRequestClient.mockClear();
     createAdminRpc.mockClear();
     resolveOrgId.mockClear();
+    therapistLookupSpy.mockClear();
   });
 
   it('creates a scoped invite token, sends email, and logs the admin action', async () => {
@@ -636,6 +639,7 @@ describe('admin invite edge function', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toMatchObject({ error: 'target_therapist_role_forbidden' });
+    expect(therapistLookupSpy).not.toHaveBeenCalled();
     expect(createAdminRpc).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
     expect(adminActionRows).toHaveLength(0);

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -51,7 +51,8 @@ stubDenoEnv((key) => envValues.get(key) ?? '');
 const logApiAccess = vi.fn();
 const getUserRoles = vi.fn(async () => [currentUserContext.profile.role]);
 const createRequestClient = vi.fn();
-const resolveOrgId = vi.fn(async () => currentUserMetadata.organization_id as string | null);
+let currentResolvedOrgId: string | null = 'org-123';
+const resolveOrgId = vi.fn(async () => currentResolvedOrgId);
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -251,6 +252,7 @@ describe('admin invite edge function', () => {
       profile: { id: 'profile-1', email: 'admin@example.com', role: 'admin', is_active: true },
     };
     currentUserMetadata = { organization_id: 'org-123' };
+    currentResolvedOrgId = 'org-123';
     envValues.set('ADMIN_INVITE_EMAIL_URL', 'https://mailer.example.com');
     envValues.set('ADMIN_PORTAL_URL', 'https://admin.example.com');
     fetchMock = vi.fn(async () => ({ ok: true, status: 202 }));
@@ -619,6 +621,36 @@ describe('admin invite edge function', () => {
     expect(adminActionRows[0]?.action_details).toMatchObject({
       target_therapist_id: '11111111-1111-4111-8111-111111111111',
     });
+  }, 20_000);
+
+  it('uses the canonical resolved org for super-admin invites when no explicit organization override is provided', async () => {
+    currentUserContext = {
+      user: { id: 'super-1', email: 'super@example.com' },
+      profile: { id: 'profile-super-1', email: 'super@example.com', role: 'super_admin', is_active: true },
+    };
+    currentUserMetadata = { organization_id: 'org-stale' };
+    currentResolvedOrgId = 'org-canonical';
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'super-target@example.com',
+          role: 'bcba',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(resolveOrgId).toHaveBeenCalledWith(expect.anything());
+    expect(createAdminRpc).toHaveBeenCalledWith(
+      'create_admin_invite_token_rate_limited',
+      expect.objectContaining({ p_organization_id: 'org-canonical' }),
+    );
+    expect(inviteTokens[0]).toMatchObject({ organization_id: 'org-canonical' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   }, 20_000);
 
   it('rejects a targeted invite when a generic active invite already exists for the same org and email', async () => {

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -368,8 +368,8 @@ describe('admin invite edge function', () => {
     });
   }, 20_000);
 
-  it('surfaces rollback failure when email delivery fails and token cleanup cannot complete', async () => {
-    rollbackUpdateError = { message: 'delete denied' };
+  it('surfaces rollback failure when email delivery fails and invite revocation cannot complete', async () => {
+    rollbackUpdateError = { message: 'revoke update denied' };
     fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
     const handler = await loadHandler();
 
@@ -610,6 +610,36 @@ describe('admin invite edge function', () => {
     expect(adminActionRows[0]?.action_details).toMatchObject({
       target_therapist_id: '11111111-1111-4111-8111-111111111111',
     });
+  }, 20_000);
+
+  it('rejects targeted invites when the requested role is not bt', async () => {
+    therapists.push({
+      id: '66666666-6666-4666-8666-666666666666',
+      email: 'therapist.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'therapist.staff@example.com',
+          role: 'therapist',
+          targetTherapistId: '66666666-6666-4666-8666-666666666666',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: 'target_therapist_role_forbidden' });
+    expect(createAdminRpc).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adminActionRows).toHaveLength(0);
+    expect(inviteTokens).toHaveLength(0);
   }, 20_000);
 
   it('rejects targeted invites when the therapist belongs to another organization', async () => {

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { stubDenoEnv } from '../utils/stubDeno';
 
-type TestRole = 'client' | 'bt' | 'therapist' | 'admin' | 'bcba' | 'super_admin';
+type TestRole = 'client' | 'bt' | 'therapist' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin';
 
 type TestUser = {
   id: string;
@@ -897,6 +897,111 @@ describe('admin invite edge function', () => {
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toMatchObject({ error: 'insufficient_role' });
     expect(getUserRoles).toHaveBeenCalledTimes(1);
+    expect(createAdminRpc).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adminActionRows).toHaveLength(0);
+    expect(inviteTokens).toHaveLength(0);
+  }, 20_000);
+
+  it('allows admin_schedule callers to send targeted BT invites only', async () => {
+    currentUserContext = {
+      user: { id: 'admin-schedule-1', email: 'admin_schedule@example.com' },
+      profile: { id: 'profile-admin-schedule-1', email: 'admin_schedule@example.com', role: 'admin_schedule', is_active: true },
+    };
+    therapists.push({
+      id: '99999999-9999-4999-8999-999999999999',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'bt.staff@example.com',
+          role: 'bt',
+          targetTherapistId: '99999999-9999-4999-8999-999999999999',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(createAdminRpc).toHaveBeenCalledWith(
+      'create_admin_invite_token_rate_limited',
+      expect.objectContaining({
+        p_role: 'bt',
+        p_target_therapist_id: '99999999-9999-4999-8999-999999999999',
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(adminActionRows[0]?.action_details).toMatchObject({
+      role: 'bt',
+      target_therapist_id: '99999999-9999-4999-8999-999999999999',
+    });
+  }, 20_000);
+
+  it('allows BCBA callers to send targeted BT invites only', async () => {
+    currentUserContext = {
+      user: { id: 'bcba-1', email: 'bcba@example.com' },
+      profile: { id: 'profile-bcba-1', email: 'bcba@example.com', role: 'bcba', is_active: true },
+    };
+    therapists.push({
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'bt.staff@example.com',
+          role: 'bt',
+          targetTherapistId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(createAdminRpc).toHaveBeenCalledWith(
+      'create_admin_invite_token_rate_limited',
+      expect.objectContaining({
+        p_role: 'bt',
+        p_target_therapist_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(adminActionRows[0]?.action_details).toMatchObject({
+      role: 'bt',
+      target_therapist_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    });
+  }, 20_000);
+
+  it('keeps generic invites blocked for admin_schedule callers', async () => {
+    currentUserContext = {
+      user: { id: 'admin-schedule-1', email: 'admin_schedule@example.com' },
+      profile: { id: 'profile-admin-schedule-1', email: 'admin_schedule@example.com', role: 'admin_schedule', is_active: true },
+    };
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({ email: 'bt.staff@example.com', role: 'bt' }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: 'insufficient_role' });
     expect(createAdminRpc).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
     expect(adminActionRows).toHaveLength(0);

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -27,6 +27,15 @@ interface StoredInviteToken {
   created_by: string;
   created_at: string;
   role: string;
+  revoked_at: string | null;
+}
+
+interface TherapistRecord {
+  id: string;
+  email: string;
+  organization_id: string;
+  status: string | null;
+  deleted_at: string | null;
 }
 
 const envValues = new Map<string, string>([
@@ -41,6 +50,7 @@ stubDenoEnv((key) => envValues.get(key) ?? '');
 const logApiAccess = vi.fn();
 const getUserRoles = vi.fn(async () => [currentUserContext.profile.role]);
 const createRequestClient = vi.fn();
+const resolveOrgId = vi.fn(async () => currentUserMetadata.organization_id as string | null);
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -57,8 +67,9 @@ let currentUserContext: TestUserContext = {
 let currentUserMetadata: Record<string, unknown> = { organization_id: 'org-123' };
 
 const inviteTokens: StoredInviteToken[] = [];
+const therapists: TherapistRecord[] = [];
 const adminActionRows: Array<Record<string, unknown>> = [];
-let rollbackDeleteError: { message: string } | null = null;
+let rollbackUpdateError: { message: string } | null = null;
 
 const fromTable = (table: string) => {
   if (table === 'admin_actions') {
@@ -71,24 +82,44 @@ const fromTable = (table: string) => {
   }
   if (table === 'admin_invite_tokens') {
     return {
-      delete: vi.fn(() => {
+      update: vi.fn((payload: { revoked_at?: string | null }) => {
         const filters: Record<string, unknown> = {};
         const builder = {
           eq: vi.fn((column: string, value: unknown) => {
             filters[column] = value;
-            if (filters.id && filters.organization_id && !rollbackDeleteError) {
-              const index = inviteTokens.findIndex(token =>
+            if (filters.id && filters.organization_id && !rollbackUpdateError) {
+              const inviteToken = inviteTokens.find(token =>
                 token.id === filters.id && token.organization_id === filters.organization_id,
               );
-              if (index >= 0) {
-                inviteTokens.splice(index, 1);
+              if (inviteToken) {
+                inviteToken.revoked_at = payload.revoked_at ?? null;
               }
             }
             return builder;
           }),
-          then: (resolve: (value: { error: { message: string } | null }) => void) => resolve({ error: rollbackDeleteError }),
+          then: (resolve: (value: { error: { message: string } | null }) => void) => resolve({ error: rollbackUpdateError }),
         };
         return builder;
+      }),
+    };
+  }
+  if (table === 'therapists') {
+    return {
+      select: vi.fn(() => {
+        const filters: Record<string, unknown> = {};
+        return {
+          eq: vi.fn((column: string, value: unknown) => {
+            filters[column] = value;
+            return {
+              maybeSingle: vi.fn(async () => ({
+                data:
+                  therapists.find(therapist => Object.entries(filters).every(([key, filterValue]) => therapist[key as keyof TherapistRecord] === filterValue))
+                  ?? null,
+                error: null,
+              })),
+            };
+          }),
+        };
       }),
     };
   }
@@ -118,6 +149,7 @@ const createAdminRpc = vi.fn(async (functionName: string, params: Record<string,
     .filter(token =>
       token.email === email
       && token.organization_id === organizationId
+      && token.revoked_at === null
       && new Date(token.expires_at).getTime() > now
     )
     .sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
@@ -134,6 +166,7 @@ const createAdminRpc = vi.fn(async (functionName: string, params: Record<string,
     if (
       token.email === email
       && token.organization_id === organizationId
+      && token.revoked_at === null
       && new Date(token.expires_at).getTime() <= now
     ) {
       inviteTokens.splice(index, 1);
@@ -158,6 +191,7 @@ const createAdminRpc = vi.fn(async (functionName: string, params: Record<string,
     created_by: createdBy,
     created_at: new Date().toISOString(),
     role: String(params.p_role ?? 'admin'),
+    revoked_at: null,
   };
   inviteTokens.push(stored);
 
@@ -190,6 +224,10 @@ vi.mock('../../supabase/functions/_shared/auth.ts', () => ({
   getUserRoles,
 }));
 
+vi.mock('../../supabase/functions/_shared/org.ts', () => ({
+  resolveOrgId,
+}));
+
 describe('admin invite edge function', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -201,8 +239,9 @@ describe('admin invite edge function', () => {
   beforeEach(async () => {
     vi.resetModules();
     inviteTokens.splice(0, inviteTokens.length);
+    therapists.splice(0, therapists.length);
     adminActionRows.splice(0, adminActionRows.length);
-    rollbackDeleteError = null;
+    rollbackUpdateError = null;
     currentUserContext = {
       user: { id: 'admin-1', email: 'admin@example.com' },
       profile: { id: 'profile-1', email: 'admin@example.com', role: 'admin', is_active: true },
@@ -216,6 +255,7 @@ describe('admin invite edge function', () => {
     getUserRoles.mockClear();
     createRequestClient.mockClear();
     createAdminRpc.mockClear();
+    resolveOrgId.mockClear();
   });
 
   it('creates a scoped invite token, sends email, and logs the admin action', async () => {
@@ -302,7 +342,7 @@ describe('admin invite edge function', () => {
     expect(adminActionRows).toHaveLength(0);
   }, 20_000);
 
-  it('deletes the invite token when email delivery fails', async () => {
+  it('revokes the invite token when email delivery fails', async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
     const handler = await loadHandler();
 
@@ -317,7 +357,8 @@ describe('admin invite edge function', () => {
     expect(response.status).toBe(502);
     await expect(response.json()).resolves.toMatchObject({ error: 'email_delivery_failed' });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(inviteTokens).toHaveLength(0);
+    expect(inviteTokens).toHaveLength(1);
+    expect(inviteTokens[0]?.revoked_at).toEqual(expect.any(String));
     expect(adminActionRows).toHaveLength(1);
     expect(adminActionRows[0]?.action_details).toMatchObject({
       email: 'mailer-failure@example.com',
@@ -328,7 +369,7 @@ describe('admin invite edge function', () => {
   }, 20_000);
 
   it('surfaces rollback failure when email delivery fails and token cleanup cannot complete', async () => {
-    rollbackDeleteError = { message: 'delete denied' };
+    rollbackUpdateError = { message: 'delete denied' };
     fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
     const handler = await loadHandler();
 
@@ -365,6 +406,7 @@ describe('admin invite edge function', () => {
       created_by: 'admin-1',
       created_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
       role: 'admin',
+      revoked_at: null,
     };
     inviteTokens.push(expiredToken);
 
@@ -404,6 +446,7 @@ describe('admin invite edge function', () => {
       created_by: 'admin-1',
       created_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
       role: 'admin',
+      revoked_at: null,
     });
 
     const handler = await loadHandler();
@@ -435,6 +478,7 @@ describe('admin invite edge function', () => {
         created_by: 'admin-1',
         created_at: new Date(now - index * 60 * 1000).toISOString(),
         role: 'admin',
+        revoked_at: null,
       });
     }
 
@@ -533,6 +577,147 @@ describe('admin invite edge function', () => {
       role: 'bt',
       email_delivery_status: 'sent',
     });
+  }, 20_000);
+
+  it('issues targeted BT invites against the canonical organization scope', async () => {
+    therapists.push({
+      id: '11111111-1111-4111-8111-111111111111',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'bt.staff@example.com',
+          role: 'bt',
+          targetTherapistId: '11111111-1111-4111-8111-111111111111',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(resolveOrgId).toHaveBeenCalledWith(expect.anything());
+    expect(createAdminRpc).toHaveBeenCalledWith(
+      'create_admin_invite_token_rate_limited',
+      expect.objectContaining({ p_target_therapist_id: '11111111-1111-4111-8111-111111111111' }),
+    );
+    expect(adminActionRows[0]?.action_details).toMatchObject({
+      target_therapist_id: '11111111-1111-4111-8111-111111111111',
+    });
+  }, 20_000);
+
+  it('rejects targeted invites when the therapist belongs to another organization', async () => {
+    therapists.push({
+      id: '22222222-2222-4222-8222-222222222222',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-999',
+      status: 'active',
+      deleted_at: null,
+    });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'bt.staff@example.com',
+          role: 'bt',
+          targetTherapistId: '22222222-2222-4222-8222-222222222222',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(createAdminRpc).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it('rejects targeted invites when the therapist email does not match', async () => {
+    therapists.push({
+      id: '33333333-3333-4333-8333-333333333333',
+      email: 'other.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'bt.staff@example.com',
+          role: 'bt',
+          targetTherapistId: '33333333-3333-4333-8333-333333333333',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(createAdminRpc).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it('rejects targeted invites when the therapist is inactive', async () => {
+    therapists.push({
+      id: '44444444-4444-4444-8444-444444444444',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'inactive',
+      deleted_at: null,
+    });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'bt.staff@example.com',
+          role: 'bt',
+          targetTherapistId: '44444444-4444-4444-8444-444444444444',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(createAdminRpc).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it('rejects targeted invites when the therapist is soft deleted', async () => {
+    therapists.push({
+      id: '55555555-5555-4555-8555-555555555555',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: new Date().toISOString(),
+    });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'bt.staff@example.com',
+          role: 'bt',
+          targetTherapistId: '55555555-5555-4555-8555-555555555555',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(createAdminRpc).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   }, 20_000);
 
   it('fails closed for BCBA callers before invite side effects begin', async () => {

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -615,6 +615,88 @@ describe('admin invite edge function', () => {
     });
   }, 20_000);
 
+  it('rejects a targeted invite when a generic active invite already exists for the same org and email', async () => {
+    inviteTokens.push({
+      id: 'invite-generic-active',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      token_hash: 'generic-active-hash',
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      created_by: 'admin-1',
+      created_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      role: 'bt',
+      revoked_at: null,
+    });
+    therapists.push({
+      id: '77777777-7777-4777-8777-777777777777',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      status: 'active',
+      deleted_at: null,
+    });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'bt.staff@example.com',
+          role: 'bt',
+          targetTherapistId: '77777777-7777-4777-8777-777777777777',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: 'active_invite_exists' });
+    expect(therapistLookupSpy).toHaveBeenCalledTimes(1);
+    expect(createAdminRpc).toHaveBeenCalledWith(
+      'create_admin_invite_token_rate_limited',
+      expect.objectContaining({ p_target_therapist_id: '77777777-7777-4777-8777-777777777777' }),
+    );
+    expect(inviteTokens).toHaveLength(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adminActionRows).toHaveLength(0);
+  }, 20_000);
+
+  it('rejects a generic invite when a targeted active invite already exists for the same org and email', async () => {
+    inviteTokens.push({
+      id: 'invite-targeted-active',
+      email: 'bt.staff@example.com',
+      organization_id: 'org-123',
+      token_hash: 'targeted-active-hash',
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      created_by: 'admin-1',
+      created_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      role: 'bt',
+      revoked_at: null,
+    });
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        body: JSON.stringify({
+          email: 'bt.staff@example.com',
+          role: 'bt',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: 'active_invite_exists' });
+    expect(createAdminRpc).toHaveBeenCalledWith(
+      'create_admin_invite_token_rate_limited',
+      expect.objectContaining({ p_target_therapist_id: null }),
+    );
+    expect(therapistLookupSpy).not.toHaveBeenCalled();
+    expect(inviteTokens).toHaveLength(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adminActionRows).toHaveLength(0);
+  }, 20_000);
+
   it('rejects targeted invites when the requested role is not bt', async () => {
     therapists.push({
       id: '66666666-6666-4666-8666-666666666666',

--- a/tests/admins/therapist_invite_fk_lifecycle_migration.spec.ts
+++ b/tests/admins/therapist_invite_fk_lifecycle_migration.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const migrationPath = join(
+  process.cwd(),
+  'supabase/migrations/20260730183000_preserve_admin_invite_audit_fks.sql',
+);
+
+const migrationSql = readFileSync(migrationPath, 'utf-8').replace(/\r\n/g, '\n');
+
+describe('admin invite audit FK lifecycle migration', () => {
+  it('documents the forward-fix intent and rollback scope', () => {
+    expect(migrationSql).toMatch(/^-- @migration-intent:.*preserve admin invite audit rows/i);
+    expect(migrationSql).toMatch(/^-- @migration-dependencies: 20260730170000_therapist_invite_target_lifecycle\.sql/im);
+    expect(migrationSql).toMatch(
+      /^-- @migration-rollback:.*restore the prior admin_invite_tokens created_by and accepted_by_user_id foreign keys/im,
+    );
+  });
+
+  it('makes created_by nullable before recreating its FK as on delete set null', () => {
+    expect(migrationSql).toMatch(/alter table public\.admin_invite_tokens\s+alter column created_by drop not null;/i);
+    expect(migrationSql).toMatch(/drop constraint if exists admin_invite_tokens_created_by_fkey/i);
+    expect(migrationSql).toMatch(
+      /add constraint admin_invite_tokens_created_by_fkey[\s\S]+foreign key \(created_by\) references auth\.users\(id\) on delete set null/i,
+    );
+  });
+
+  it('recreates accepted_by_user_id with on delete set null using the canonical constraint name', () => {
+    expect(migrationSql).toMatch(/drop constraint if exists admin_invite_tokens_accepted_by_user_id_fkey/i);
+    expect(migrationSql).toMatch(
+      /add constraint admin_invite_tokens_accepted_by_user_id_fkey[\s\S]+foreign key \(accepted_by_user_id\) references auth\.users\(id\) on delete set null/i,
+    );
+  });
+
+  it('keeps the changes transactional and append-only for migration history', () => {
+    expect(migrationSql).toMatch(/begin;/i);
+    expect(migrationSql).toMatch(/commit;/i);
+    expect(migrationSql).not.toMatch(/drop column/i);
+    expect(migrationSql).not.toMatch(/delete from public\.admin_invite_tokens/i);
+  });
+});

--- a/tests/admins/therapist_invite_target_migration.spec.ts
+++ b/tests/admins/therapist_invite_target_migration.spec.ts
@@ -13,6 +13,14 @@ const functionSql = migrationSql.match(
   /create or replace function public\.create_admin_invite_token_rate_limited[\s\S]+?\n\$\$;/i,
 )?.[0] ?? '';
 
+const activeDuplicateLookupSql = functionSql.match(
+  /select t\.id, t\.expires_at[\s\S]+?limit 1;/i,
+)?.[0] ?? '';
+
+const expiredInviteCleanupSql = functionSql.match(
+  /delete from public\.admin_invite_tokens t[\s\S]+?and t\.expires_at <= v_now;/i,
+)?.[0] ?? '';
+
 describe('therapist invite target lifecycle migration', () => {
   it('adds invite target and lifecycle columns to admin_invite_tokens', () => {
     expect(migrationSql).toMatch(/add column if not exists target_therapist_id uuid/i);
@@ -32,7 +40,7 @@ describe('therapist invite target lifecycle migration', () => {
     expect(functionSql).toMatch(/where t\.id = p_target_therapist_id/i);
     expect(functionSql).toMatch(/t\.organization_id = p_organization_id/i);
     expect(functionSql).toMatch(/t\.deleted_at is null/i);
-    expect(functionSql).toMatch(/lower\(coalesce\(t\.status, 'active'\)\) = 'active'/i);
+    expect(functionSql).toMatch(/lower\(trim\(coalesce\(t\.status, 'active'\)\)\) = 'active'/i);
     expect(functionSql).toMatch(/lower\(trim\(t\.email\)\) = v_normalized_email/i);
   });
 
@@ -46,6 +54,25 @@ describe('therapist invite target lifecycle migration', () => {
     expect(functionSql).toMatch(/and t\.accepted_at is null/i);
     expect(functionSql).toMatch(/and t\.revoked_at is null/i);
     expect(functionSql).toMatch(/and t\.expires_at > v_now/i);
+  });
+
+  it('blocks targeted invites when a generic active invite already exists for the same org and email', () => {
+    expect(activeDuplicateLookupSql).toMatch(/where t\.email = v_normalized_email/i);
+    expect(activeDuplicateLookupSql).toMatch(/and t\.organization_id = p_organization_id/i);
+    expect(activeDuplicateLookupSql).not.toMatch(/t\.target_therapist_id/i);
+  });
+
+  it('blocks generic invites when a targeted active invite already exists for the same org and email', () => {
+    expect(functionSql).toMatch(/return query select v_existing_id, v_existing_expires_at, 'active_invite_exists'::text;/i);
+    expect(activeDuplicateLookupSql).not.toMatch(/p_target_therapist_id is null/i);
+    expect(activeDuplicateLookupSql).not.toMatch(/p_target_therapist_id/i);
+  });
+
+  it('prunes expired invites by org and email without preserving generic or targeted coexistence semantics', () => {
+    expect(expiredInviteCleanupSql).toMatch(/where t\.email = v_normalized_email/i);
+    expect(expiredInviteCleanupSql).toMatch(/and t\.organization_id = p_organization_id/i);
+    expect(expiredInviteCleanupSql).not.toMatch(/t\.target_therapist_id/i);
+    expect(expiredInviteCleanupSql).not.toMatch(/p_target_therapist_id/i);
   });
 
   it('keeps the function restricted to service_role execution', () => {

--- a/tests/admins/therapist_invite_target_migration.spec.ts
+++ b/tests/admins/therapist_invite_target_migration.spec.ts
@@ -13,6 +13,14 @@ const functionSql = migrationSql.match(
   /create or replace function public\.create_admin_invite_token_rate_limited[\s\S]+?\n\$\$;/i,
 )?.[0] ?? '';
 
+const createAdminInviteFunctions = Array.from(
+  migrationSql.matchAll(/create or replace function public\.create_admin_invite_token_rate_limited\([\s\S]+?\n\$\$;/gi),
+).map((match) => match[0]);
+
+const compatibilityWrapperSql = createAdminInviteFunctions.find(
+  (sql) => !/p_target_therapist_id uuid/i.test(sql),
+) ?? '';
+
 const activeDuplicateLookupSql = functionSql.match(
   /select t\.id, t\.expires_at[\s\S]+?limit 1;/i,
 )?.[0] ?? '';
@@ -34,6 +42,13 @@ describe('therapist invite target lifecycle migration', () => {
     expect(functionSql).toMatch(/p_target_therapist_id uuid/i);
     expect(functionSql).not.toMatch(/auth\.uid\(\)/i);
     expect(functionSql).toMatch(/service-role-only/i);
+  });
+
+  it('preserves the six-argument service-role-only signature as a null-target wrapper', () => {
+    expect(compatibilityWrapperSql).toMatch(/returns table\(id uuid, expires_at timestamptz, status text\)/i);
+    expect(compatibilityWrapperSql).toMatch(/select\s+\*\s+from public\.create_admin_invite_token_rate_limited\([\s\S]*p_role,[\s\S]*null\s*\)/i);
+    expect(migrationSql).toMatch(/revoke all on function public\.create_admin_invite_token_rate_limited\(text, text, uuid, timestamptz, uuid, public\.role_type\) from public, anon, authenticated;/i);
+    expect(migrationSql).toMatch(/grant execute on function public\.create_admin_invite_token_rate_limited\(text, text, uuid, timestamptz, uuid, public\.role_type\) to service_role;/i);
   });
 
   it('validates active target therapists against org, status, deletion, and normalized email', () => {

--- a/tests/admins/therapist_invite_target_migration.spec.ts
+++ b/tests/admins/therapist_invite_target_migration.spec.ts
@@ -36,6 +36,12 @@ describe('therapist invite target lifecycle migration', () => {
     expect(functionSql).toMatch(/lower\(trim\(t\.email\)\) = v_normalized_email/i);
   });
 
+  it('requires therapist-targeted invites to use the bt role', () => {
+    expect(functionSql).toMatch(/p_target_therapist_id is not null/i);
+    expect(functionSql).toMatch(/p_role is distinct from 'bt'::public\.role_type/i);
+    expect(functionSql).toMatch(/Target therapist invites must use the bt role/i);
+  });
+
   it('treats only unaccepted, unrevoked, unexpired invites as active duplicates', () => {
     expect(functionSql).toMatch(/and t\.accepted_at is null/i);
     expect(functionSql).toMatch(/and t\.revoked_at is null/i);

--- a/tests/admins/therapist_invite_target_migration.spec.ts
+++ b/tests/admins/therapist_invite_target_migration.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const migrationPath = join(
+  process.cwd(),
+  'supabase/migrations/20260730170000_therapist_invite_target_lifecycle.sql',
+);
+
+const migrationSql = readFileSync(migrationPath, 'utf-8').replace(/\r\n/g, '\n');
+
+const functionSql = migrationSql.match(
+  /create or replace function public\.create_admin_invite_token_rate_limited[\s\S]+?\n\$\$;/i,
+)?.[0] ?? '';
+
+describe('therapist invite target lifecycle migration', () => {
+  it('adds invite target and lifecycle columns to admin_invite_tokens', () => {
+    expect(migrationSql).toMatch(/add column if not exists target_therapist_id uuid/i);
+    expect(migrationSql).toMatch(/references public\.therapists\(id\)/i);
+    expect(migrationSql).toMatch(/accepted_at timestamptz/i);
+    expect(migrationSql).toMatch(/accepted_by_user_id uuid/i);
+    expect(migrationSql).toMatch(/revoked_at timestamptz/i);
+  });
+
+  it('extends the service-only RPC to a seven-argument therapist-target-aware signature', () => {
+    expect(functionSql).toMatch(/p_target_therapist_id uuid/i);
+    expect(functionSql).not.toMatch(/auth\.uid\(\)/i);
+    expect(functionSql).toMatch(/service-role-only/i);
+  });
+
+  it('validates active target therapists against org, status, deletion, and normalized email', () => {
+    expect(functionSql).toMatch(/where t\.id = p_target_therapist_id/i);
+    expect(functionSql).toMatch(/t\.organization_id = p_organization_id/i);
+    expect(functionSql).toMatch(/t\.deleted_at is null/i);
+    expect(functionSql).toMatch(/lower\(coalesce\(t\.status, 'active'\)\) = 'active'/i);
+    expect(functionSql).toMatch(/lower\(trim\(t\.email\)\) = v_normalized_email/i);
+  });
+
+  it('treats only unaccepted, unrevoked, unexpired invites as active duplicates', () => {
+    expect(functionSql).toMatch(/and t\.accepted_at is null/i);
+    expect(functionSql).toMatch(/and t\.revoked_at is null/i);
+    expect(functionSql).toMatch(/and t\.expires_at > v_now/i);
+  });
+
+  it('keeps the function restricted to service_role execution', () => {
+    expect(migrationSql).toMatch(/grant execute[\s\S]+to service_role/i);
+  });
+});


### PR DESCRIPTION
## Summary
- issue therapist-bound BT invites automatically after therapist onboarding and support exact-target retry
- persist invite target/accepted/revoked lifecycle and create the Auth/profile/role/therapist link on acceptance
- enforce canonical organization scope, service-role-only RPC grants, one active invite per org/email, and backward-compatible rollout ordering

## Verification
- focused invite/acceptance/migration/UI suite: 5 files, 60 tests passed after syncing current main
- `npm run ci:check-focused`: passed (DB-backed checks skipped without `SUPABASE_DB_URL`)
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run validate:tenant`: passed
- `npm run build`: passed
- `npm run test:routes:tier0`: 7 specs / 220 tests passed
- `npm run test:ci`: blocked by local Node heap OOM during coverage
- `npm run verify:local`: blocked by the same inherited coverage OOM
- `npm run ci:playwright`: blocked by missing protected Playwright credentials

## Risk / rollout
Critical auth/Supabase change. Independent code, security, and Supabase reviews approved the final implementation. Human review is required before merge. No production migration/function deployment or live-account mutation was performed.

Detailed handoff: `docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md`

Linear: WIN-265