### PR TITLE
WIN-265 Land request-aware admin-invite CORS on main

### DIFF
--- a/docs/ai/handoffs/WIN-265-admin-invite-cors.md
+++ b/docs/ai/handoffs/WIN-265-admin-invite-cors.md
@@ -1,0 +1,93 @@
+# WIN-265 Admin Invite CORS Handoff
+
+- classification: high-risk human-reviewed
+- lane: critical
+- issue: WIN-265
+- scope: fix the admin-invite request-scoped CORS behavior so production admin invite submission can complete without a static-response CORS failure, while preserving the invite flow and existing authorization boundaries
+- allowed files:
+  - `supabase/functions/admin-invite/index.ts`
+  - `tests/admins/invite_flow.spec.ts`
+  - `docs/ai/handoffs/WIN-265-admin-invite-cors.md`
+- non-goals: production mail configuration changes, new invite UX, broader auth/routing refactors, unrelated Supabase or Netlify work, and any secret-value disclosure
+- required agents: `specification-engineer`, `software-architect`, `implementation-engineer`, `code-review-engineer`, `test-engineer`, `security-engineer`
+
+## Triggering Evidence
+
+- production admin invite submit reproduced `FunctionsFetchError`
+- no invite row was created after the failed submit
+- hosted secret names showed `ADMIN_INVITE_EMAIL_URL` and `ADMIN_PORTAL_URL` absent
+- code root cause is a static response CORS path in the admin-invite function
+- the follow-up fix is request-scoped CORS for admin-invite plus TDD coverage in `tests/admins/invite_flow.spec.ts`
+- a separate Netlify secret incident is involved and remains critical, but values are intentionally omitted here
+
+## Current Decision
+
+- keep the fix tightly scoped to the admin-invite request path
+- do not broaden into general CORS middleware, mail provider migration, or environment rewiring
+- stop if the fix requires touching shared runtime config, deploy config, or any secret-bearing surface
+
+## Verification Card
+
+- lane: critical
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run verify:local`
+- executed checks:
+  - targeted `tests/admins/invite_flow.spec.ts`: pass, 27/27
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+  - `npm run validate:tenant`: pass
+  - `git diff --check`: pass
+  - stacked-branch targeted `tests/admins/invite_flow.spec.ts`: pass, 27/27
+  - base policy PR `#879`: all live required checks pass, including policy, unit tests, build, Tier-0, auth browser smoke, tenant safety, and the final CI gate
+  - code-review-engineer: approve, no required fixes
+  - security-engineer: approve, no authz, tenant, or business-logic drift
+- blocked checks:
+  - the earlier `npm run verify:local` policy blocker is resolved on the stacked base by PR `#879`; the complete composite command has not yet been rerun on this stacked branch
+  - `npm run ci:playwright`: blocked in preflight because the required Playwright admin or super-admin test credentials are unavailable
+  - `npm run ci:verify-coverage`: blocked because the composite run stopped before producing `coverage/coverage-summary.json`; no coverage-threshold regression was reported
+  - `npm run test:ci`: inconclusive after two runs emitted only passing assertions, including the WIN-265 invite coverage, but exited without a final Vitest summary or recoverable exit code
+  - `npm run test:routes:tier0`: bounded timeout after the preview server and Cypress launched but before a spec result was emitted
+  - production invite issuance: Supabase Edge secrets `ADMIN_INVITE_EMAIL_URL` and `ADMIN_PORTAL_URL` are absent
+  - production deployment: paused pending human review and the separate Netlify secret incident
+- result: implementation complete and ready for a stacked human-review PR; production rollout still requires both critical PRs to merge
+
+## Residual Risk
+
+- production invite submission will continue to hide handler errors until the request-scoped CORS fix is merged and deployed
+- invite creation remains blocked if the missing production mail config is not corrected separately
+- the separate Netlify secret incident requires rotation and scope remediation outside this branch; no values are recorded here
+- any broader CORS or runtime-config change would increase blast radius and should be re-routed before implementation
+
+## PR And Review Requirements
+
+- PR required before merge
+- human review required because this is critical-lane work
+- reviewer approval required before closure
+- tester verification required before closure
+- do not merge until the branch carries the bounded request-scoped CORS fix and the invite-flow regression coverage
+- keep the change reviewable and isolated from the separate secret incident
+
+## PR Hygiene Verdict
+
+- pr-ready: yes, as a stacked PR based on `codex/win-270-api-exception-renewal`
+- lane: critical
+- branch-ready: yes, `codex/win-265-admin-invite-cors-stacked`
+- linear-ready: yes, `WIN-265`
+- single-purpose: yes
+- unrelated changes: none
+- generated artifact drift: none
+- protected-path drift: none; the Supabase function path is correctly routed as critical
+- change summary: present
+- verification summary: present, including blocked and inconclusive checks
+- reviewer: completed and approved
+- security review: completed and approved
+- required follow-up: open the stacked PR against policy PR `#879`, obtain human review for both critical changes, merge `#879` first, retarget this PR to `main`, rerun live checks, resolve the separate production configuration and secret-remediation blockers, then deploy and re-run the invite lifecycle

--- a/supabase/functions/admin-invite/index.ts
+++ b/supabase/functions/admin-invite/index.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import {
   createProtectedRoute,
-  corsHeaders,
+  corsHeadersForRequest,
   logApiAccess,
   RouteOptions,
   type UserContext,
@@ -43,10 +43,15 @@ type InsertInviteResult = {
   error: { message?: string } | null;
 };
 
-const jsonResponse = (status: number, body: Record<string, unknown>, headers: Record<string, string> = {}) =>
+const jsonResponse = (
+  req: Request,
+  status: number,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) =>
   new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeaders, ...headers, "Content-Type": "application/json" },
+    headers: { ...corsHeadersForRequest(req), ...headers, "Content-Type": "application/json" },
   });
 
 const normalizeEmail = (email: string) => email.trim().toLowerCase();
@@ -137,7 +142,7 @@ async function sendInviteEmail(
 
 async function handleInvite(req: Request, userContext: UserContext) {
   if (req.method !== "POST") {
-    return jsonResponse(405, { error: "method_not_allowed" });
+    return jsonResponse(req, 405, { error: "method_not_allowed" });
   }
 
   try {
@@ -148,7 +153,7 @@ async function handleInvite(req: Request, userContext: UserContext) {
 
     const payloadResult = InviteRequestSchema.safeParse(await req.json());
     if (!payloadResult.success) {
-      return jsonResponse(400, {
+      return jsonResponse(req, 400, {
         error: "invalid_payload",
         details: payloadResult.error.flatten(),
       });
@@ -164,13 +169,13 @@ async function handleInvite(req: Request, userContext: UserContext) {
 
     if (!callerIsAdmin && !callerIsSuperAdmin && !isTargetedBtInvite) {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
-      return jsonResponse(403, { error: "insufficient_role" });
+      return jsonResponse(req, 403, { error: "insufficient_role" });
     }
 
     const { data: authResult, error: authError } = await adminClient.auth.getUser();
     if (authError || !authResult?.user) {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 401);
-      return jsonResponse(401, { error: "unauthorized" });
+      return jsonResponse(req, 401, { error: "unauthorized" });
     }
 
     const callerOrganizationId = await resolveOrgId(adminClient);
@@ -179,22 +184,22 @@ async function handleInvite(req: Request, userContext: UserContext) {
 
     if (!targetOrganizationId) {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
-      return jsonResponse(403, { error: "organization_context_required" });
+      return jsonResponse(req, 403, { error: "organization_context_required" });
     }
 
     if (!callerIsSuperAdmin && targetOrganizationId !== callerOrganizationId) {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
-      return jsonResponse(403, { error: "cross_org_invite_forbidden" });
+      return jsonResponse(req, 403, { error: "cross_org_invite_forbidden" });
     }
 
     if ((desiredRole === "super_admin" || desiredRole === "bcba") && !callerIsSuperAdmin) {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
-      return jsonResponse(403, { error: "insufficient_role_for_target" });
+      return jsonResponse(req, 403, { error: "insufficient_role_for_target" });
     }
 
     if (payload.targetTherapistId && desiredRole !== "bt") {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
-      return jsonResponse(403, { error: "target_therapist_role_forbidden" });
+      return jsonResponse(req, 403, { error: "target_therapist_role_forbidden" });
     }
 
     if (payload.targetTherapistId) {
@@ -207,12 +212,12 @@ async function handleInvite(req: Request, userContext: UserContext) {
       if (targetTherapistError) {
         console.error("Failed to validate invite target therapist", { code: "target_therapist_lookup_failed" });
         logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-        return jsonResponse(500, { error: "invite_target_validation_failed" });
+        return jsonResponse(req, 500, { error: "invite_target_validation_failed" });
       }
 
       if (!targetTherapist) {
         logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
-        return jsonResponse(409, { error: "target_therapist_not_available" });
+        return jsonResponse(req, 409, { error: "target_therapist_not_available" });
       }
 
       const therapistRecord = targetTherapist as {
@@ -224,22 +229,22 @@ async function handleInvite(req: Request, userContext: UserContext) {
 
       if (therapistRecord.organization_id !== targetOrganizationId) {
         logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 403);
-        return jsonResponse(403, { error: "target_therapist_org_mismatch" });
+        return jsonResponse(req, 403, { error: "target_therapist_org_mismatch" });
       }
 
       if (normalizeEmail(therapistRecord.email ?? "") !== normalizedEmail) {
         logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
-        return jsonResponse(409, { error: "target_therapist_email_mismatch" });
+        return jsonResponse(req, 409, { error: "target_therapist_email_mismatch" });
       }
 
       if (!isActiveTherapistStatus(therapistRecord.status)) {
         logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
-        return jsonResponse(409, { error: "target_therapist_inactive" });
+        return jsonResponse(req, 409, { error: "target_therapist_inactive" });
       }
 
       if (therapistRecord.deleted_at) {
         logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
-        return jsonResponse(409, { error: "target_therapist_deleted" });
+        return jsonResponse(req, 409, { error: "target_therapist_deleted" });
       }
     }
 
@@ -247,13 +252,13 @@ async function handleInvite(req: Request, userContext: UserContext) {
     if (!emailServiceUrl) {
       console.error("ADMIN_INVITE_EMAIL_URL is not configured", { code: 'invite_email_url_missing' });
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-      return jsonResponse(500, { error: "email_service_unconfigured" });
+      return jsonResponse(req, 500, { error: "email_service_unconfigured" });
     }
 
     if (!portalBaseUrl) {
       console.error("ADMIN_PORTAL_URL is not configured", { code: 'portal_url_missing' });
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-      return jsonResponse(500, { error: "portal_url_unconfigured" });
+      return jsonResponse(req, 500, { error: "portal_url_unconfigured" });
     }
 
     const now = new Date();
@@ -275,18 +280,19 @@ async function handleInvite(req: Request, userContext: UserContext) {
     if (insertedInvite.error || !insertedInvite.data?.[0]) {
       console.error("Failed to insert invite token", { code: 'invite_insert_failed' });
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-      return jsonResponse(500, { error: "invite_creation_failed" });
+      return jsonResponse(req, 500, { error: "invite_creation_failed" });
     }
 
     const inviteResult = insertedInvite.data[0];
     if (inviteResult.status === "active_invite_exists") {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 409);
-      return jsonResponse(409, { error: "active_invite_exists" });
+      return jsonResponse(req, 409, { error: "active_invite_exists" });
     }
 
     if (inviteResult.status === "rate_limited") {
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 429);
       return jsonResponse(
+        req,
         429,
         {
           error: "invite_rate_limit_exceeded",
@@ -299,7 +305,7 @@ async function handleInvite(req: Request, userContext: UserContext) {
     if (inviteResult.status !== "created" || !inviteResult.id || !inviteResult.expires_at) {
       console.error("Unexpected invite RPC result", { code: 'invite_rpc_unexpected_status' });
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-      return jsonResponse(500, { error: "invite_creation_failed" });
+      return jsonResponse(req, 500, { error: "invite_creation_failed" });
     }
 
     const inviteUrl = buildInviteUrl(portalBaseUrl, rawToken);
@@ -337,21 +343,21 @@ async function handleInvite(req: Request, userContext: UserContext) {
       const rollbackResult = await rollbackInviteToken(inviteResult.id, targetOrganizationId);
       if (rollbackResult.error) {
         logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-        return jsonResponse(500, { error: "invite_rollback_failed" });
+        return jsonResponse(req, 500, { error: "invite_rollback_failed" });
       }
       logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 502);
-      return jsonResponse(502, { error: "email_delivery_failed" });
+      return jsonResponse(req, 502, { error: "email_delivery_failed" });
     }
 
     logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 201);
-    return jsonResponse(201, {
+    return jsonResponse(req, 201, {
       inviteId: inviteResult.id,
       expiresAt: inviteResult.expires_at,
     });
   } catch (error) {
     console.error("Unexpected admin invite error", { code: 'unexpected_invite_error' });
     logApiAccess("POST", ADMIN_INVITE_PATH, userContext, 500);
-    return jsonResponse(500, { error: "internal_server_error" });
+    return jsonResponse(req, 500, { error: "internal_server_error" });
   }
 }
 

--- a/tests/admins/invite_flow.spec.ts
+++ b/tests/admins/invite_flow.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { stubDenoEnv } from '../utils/stubDeno';
+import { corsHeadersForRequest as realCorsHeadersForRequest } from '../../supabase/functions/_shared/cors.ts';
 
 type TestRole = 'client' | 'bt' | 'therapist' | 'admin_schedule' | 'admin' | 'bcba' | 'super_admin';
 
@@ -214,6 +215,7 @@ createRequestClient.mockImplementation(() => createMockClient());
 
 vi.mock('../../supabase/functions/_shared/auth-middleware.ts', () => ({
   corsHeaders,
+  corsHeadersForRequest: realCorsHeadersForRequest,
   RouteOptions: {
     admin: { requireAuth: true, allowedRoles: [...wrapperAllowedRolesByName.admin] },
     staffAdmin: { requireAuth: true, allowedRoles: [...wrapperAllowedRolesByName.staffAdmin] },
@@ -331,6 +333,37 @@ describe('admin invite edge function', () => {
     expect(getUserRoles).toHaveBeenCalledTimes(1);
   }, 20_000);
 
+  it('uses request-aware CORS headers for handler-generated responses', async () => {
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'GET',
+        headers: { Origin: 'https://app.allincompassing.ai' },
+      }),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.allincompassing.ai');
+    expect(response.headers.get('Vary')).toBe('Origin');
+  });
+
+  it('does not reflect an untrusted origin in handler-generated responses', async () => {
+    const handler = await loadHandler();
+
+    const response = await handler(
+      new Request('https://edge.example.com/admin/invite', {
+        method: 'GET',
+        headers: { Origin: 'https://attacker.example.com' },
+      }),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.allincompassing.ai');
+    expect(response.headers.get('Access-Control-Allow-Origin')).not.toBe('https://attacker.example.com');
+    expect(response.headers.get('Vary')).toBe('Origin');
+  });
+
   it('does not persist an invite token when the email service URL is missing', async () => {
     envValues.set('ADMIN_INVITE_EMAIL_URL', '');
     const handler = await loadHandler();
@@ -338,13 +371,19 @@ describe('admin invite edge function', () => {
     const response = await handler(
       new Request('https://edge.example.com/admin/invite', {
         method: 'POST',
-        headers: { 'content-type': 'application/json', Authorization: 'Bearer valid' },
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer valid',
+          Origin: 'https://app.allincompassing.ai',
+        },
         body: JSON.stringify({ email: 'missing-mailer@example.com', reason: 'Coverage for missing mailer.' }),
       }),
     );
 
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toMatchObject({ error: 'email_service_unconfigured' });
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.allincompassing.ai');
+    expect(response.headers.get('Vary')).toBe('Origin');
     expect(createAdminRpc).not.toHaveBeenCalled();
     expect(inviteTokens).toHaveLength(0);
     expect(fetchMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- lands the exact three-file CORS patch already reviewed and merged in #880
- corrects the stacked-PR merge target: #880 merged into the WIN-270 branch after #879 reached main, so the patch never landed on main
- no authz, tenant, invite lifecycle, RPC, schema, or mail-provider behavior changes

## Verification
- npm run lint
- npm run typecheck
- npm run build
- npm run validate:tenant
- npm test -- tests/admins/invite_flow.spec.ts (27/27)
- git diff --check origin/main...HEAD

## Review
Critical-lane protected function change. This is byte-for-byte the reviewed #880 content, cherry-picked onto current main with provenance.