### PR TITLE
WIN-265 Document SMTP rollout continuation

### DIFF
--- a/docs/ADMIN_INVITE_CONFIGURATION.md
+++ b/docs/ADMIN_INVITE_CONFIGURATION.md
@@ -36,6 +36,26 @@ The Netlify Function runtime also requires these values, scoped to Functions and
 | `ADMIN_INVITE_SMTP_PASSWORD` | SMTP account password or provider-generated credential. |
 | `ADMIN_INVITE_SMTP_FROM` | Verified sender mailbox or formatted sender identity. |
 
+## Production continuation checklist
+
+The delivery adapter and Supabase invite function are deployed, but production email delivery remains fail-closed until the protected SMTP configuration is supplied. To resume the WIN-265 rollout:
+
+1. In Netlify, add all six `ADMIN_INVITE_SMTP_*` variables from the table above as protected production values. Do not put their values in this repository, a pull request, Linear, chat, screenshots, or command output.
+2. For Gmail SMTP, use `smtp.gmail.com`, port `587`, and `ADMIN_INVITE_SMTP_SECURE=false`. Use the full sender mailbox as the username and a Google-generated app password as the SMTP password. Do not reuse an application login password or a Supabase Auth password.
+3. Confirm `ADMIN_INVITE_SMTP_FROM` is a sender identity the SMTP account is permitted to use.
+4. Provide an inbox-controlled, non-customer test address for the synthetic invite. Do not use PHI or a real client/staff onboarding record.
+5. Tell the operator or Codex only that **SMTP variables are set** and provide the test address. Never copy the credential values back out of Netlify.
+
+After that confirmation, the remaining rollout work is to generate and configure one shared `ADMIN_INVITE_DELIVERY_SECRET` in Netlify and Supabase, confirm the production adapter and portal URLs, redeploy only if the configuration change requires it, and run the synthetic checks below:
+
+- send an invite and confirm delivery without exposing the invite URL or token in logs;
+- accept the invite with a user-chosen password;
+- verify the expected Auth user, profile, organization role, and therapist link;
+- deliberately exercise a delivery failure with synthetic data and confirm the newly created invite token is rolled back;
+- record only redacted pass/fail evidence.
+
+Do not use the affected user's account password as an SMTP credential. Account-password creation and email transport authentication are separate concerns.
+
 ## Token Storage
 - **Table:** `admin_invite_tokens`
 - **Columns referenced:** `id`, `email`, `organization_id`, `token_hash`, `role`, `expires_at`, `created_by`.

--- a/docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md
+++ b/docs/ai/handoffs/WIN-265-therapist-onboarding-invite.md
@@ -160,7 +160,7 @@
 - result: pass-with-blocked-checks; review-ready, not merge-ready
 - residual risk: a captured valid delivery request can resend the identical invite within the five-minute signature window; it cannot mint, mutate, or retarget an invite. Production SMTP/shared-secret configuration, hosted log-redaction checks, end-to-end delivery, and critical-lane human review remain mandatory.
 
-### Current Adapter PR Hygiene
+### Adapter PR hygiene at review handoff
 
 - branch: `codex/win-265-invite-email-adapter`
 - linked issue: WIN-265
@@ -171,4 +171,13 @@
 - reviewer status: code, security, Supabase, Netlify, and test-engineer rereviews approved
 - pull request: #884
 - pr-ready: yes for human review
-- merge-ready: no; critical-lane human review, live CI, protected configuration, and hosted end-to-end proof remain
+- merge-ready at that handoff: no; critical-lane human review, live CI, protected configuration, and hosted end-to-end proof remained
+
+### Production continuation status (July 31, 2026)
+
+- PR #884 merged and the production Netlify adapter is reachable at `https://app.allincompassing.ai/.netlify/functions/admin-invite-email`; an unsigned request is rejected with `401 invalid_signature`.
+- Supabase project `wnnjeqheqxxyrgsjmygy` has `admin-invite` version 18 active with JWT verification, signed delivery, and delivery-failure rollback behavior.
+- Remaining external prerequisite: an operator must configure the protected Netlify `ADMIN_INVITE_SMTP_HOST`, `ADMIN_INVITE_SMTP_PORT`, `ADMIN_INVITE_SMTP_SECURE`, `ADMIN_INVITE_SMTP_USERNAME`, `ADMIN_INVITE_SMTP_PASSWORD`, and `ADMIN_INVITE_SMTP_FROM` values and provide an inbox-controlled synthetic test address.
+- Resume signal: state **SMTP variables are set** and provide only the test address; do not disclose SMTP credentials.
+- Once resumed: configure the shared delivery secret on both platforms, confirm the production adapter/portal URLs, redeploy if required, and verify synthetic delivery, acceptance, Auth/profile/org-role/therapist linking, and delivery-failure rollback.
+- Detailed operator instructions: `docs/ADMIN_INVITE_CONFIGURATION.md` under **Production continuation checklist**.


### PR DESCRIPTION
## Summary
- add the production SMTP continuation checklist for WIN-265
- distinguish SMTP app credentials from user/Supabase Auth passwords
- record the exact resume signal and synthetic delivery, acceptance, linkage, and rollback checks
- refresh the handoff with PR #884 and current hosted deployment state

## Routing
- classification: low-risk autonomous
- lane: fast
- triggering paths: docs/** only
- reviewer required: no
- verify-change required: no

## Verification
- `git diff --check`
- manually verified documented variable names against the Netlify and Supabase function sources
- confirmed no supplied account password or email address was added to the documentation

Linear: WIN-265