### PR TITLE
WIN-272 Save session notes before close

### DIFF
--- a/docs/ai/handoffs/WIN-272-session-close-autosave.md
+++ b/docs/ai/handoffs/WIN-272-session-close-autosave.md
@@ -39,7 +39,7 @@
   - `npm run verify:local` -> pass on `origin/main` commit `1f039082`
   - `npm run ci:check-focused` -> pass after syncing to `origin/main` with merged PR #879
   - focused schedule and client-helper Vitest suite with one worker and 8 GB Node heap -> pass, 70 tests
-  - session-note API handler suite -> pass, 69 tests
+  - session-note API handler suite -> pass, 74 tests, including ownership-matched unlinked-note linking, all ownership mismatch branches, conflicting session-binding rejection, and omitted-session bound-note unlink rejection
   - `npm run lint` -> pass
   - `npm run typecheck` -> pass
   - `npm run test:ci` -> pass, 437 files and 3,627 tests; 2 files and 5 tests skipped
@@ -60,6 +60,7 @@
 - `code-review-engineer`: approved after incremental trial retry fix
 - `test-engineer`: focused coverage approved; required repository and browser checks identified
 - `security-engineer`: approved after same-org cross-session `noteId` retargeting was made fail-closed
+- PR review follow-up: persisted session and ownership fields are checked after the tenant-scoped note lookup, allowing only ownership-matched unlinked notes to be linked while rejecting conflicting bindings and bound-note unlinking
 
 ## PR Hygiene
 - `pr-ready`: yes, pending human review and hosted checks
@@ -69,4 +70,4 @@
 - `unrelated changes`: pre-existing worktree changes excluded from this slice
 - `protected-path drift`: contained to `src/server/api/session-notes-upsert.ts`; no migration, auth, CI, or deploy files changed
 - `baseline sync`: current `origin/main` includes merged PR #879 and passes the required policy hook
-- `required follow-up`: commit, push, and open the WIN-272 PR for human review; rerun the authenticated hosted smoke after its credential is repaired
+- `required follow-up`: push the PR review fix, resolve the review thread, and rerun the authenticated hosted smoke after its credential is repaired

--- a/docs/ai/handoffs/WIN-272-session-close-autosave.md
+++ b/docs/ai/handoffs/WIN-272-session-close-autosave.md
@@ -1,0 +1,72 @@
+# WIN-272 Session Close Autosave Handoff
+
+## Route
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Issue: `WIN-272`
+- Scope: save a non-BT in-progress session note draft before readiness/completion, then finalize the same note without replaying persisted trial events
+
+## Scope
+- Production files:
+  - `src/pages/Schedule.tsx`
+  - `src/lib/session-notes.ts`
+  - `src/server/api/session-notes-upsert.ts`
+- Test files:
+  - `src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
+  - `src/lib/__tests__/session-notes.test.ts`
+  - `src/server/__tests__/sessionNotesUpsertHandler.test.ts`
+- Non-goals:
+  - schema, migration, auth, CI, or deploy changes
+  - BT closeout behavior changes
+  - live per-goal completion indicators
+  - deployment
+
+## Verification Card
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Required checks:
+  - focused schedule orchestration and session-note helper tests
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run verify:local`
+- Executed checks:
+  - `npm run verify:local` -> pass on `origin/main` commit `1f039082`
+  - `npm run ci:check-focused` -> pass after syncing to `origin/main` with merged PR #879
+  - focused schedule and client-helper Vitest suite with one worker and 8 GB Node heap -> pass, 70 tests
+  - session-note API handler suite -> pass, 69 tests
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm run test:ci` -> pass, 437 files and 3,627 tests; 2 files and 5 tests skipped
+  - `npm run ci:verify-coverage` -> pass, 92.88% line coverage
+  - `npm run build` -> pass
+  - `npm run test:routes:tier0` -> pass, 220 Cypress tests
+  - `npm run validate:tenant` -> pass
+- Blocked checks:
+  - `npm run ci:playwright` -> preflight passes, then auth smoke fails because the configured hosted test credential is rejected
+- Result: `pass-with-blocked-checks`
+- Residual risk:
+  - hosted authenticated session-close smoke was not reached because the prerequisite auth smoke failed
+
+## Review State
+- `specification-engineer`: acceptance criteria and non-goals confirmed
+- `software-architect`: required returned-note-ID handoff and trial replay prevention
+- `implementation-engineer`: implemented test-first bounded slice
+- `code-review-engineer`: approved after incremental trial retry fix
+- `test-engineer`: focused coverage approved; required repository and browser checks identified
+- `security-engineer`: approved after same-org cross-session `noteId` retargeting was made fail-closed
+
+## PR Hygiene
+- `pr-ready`: yes, pending human review and hosted checks
+- `branch-ready`: yes
+- `linear-ready`: yes
+- `single-purpose`: yes
+- `unrelated changes`: pre-existing worktree changes excluded from this slice
+- `protected-path drift`: contained to `src/server/api/session-notes-upsert.ts`; no migration, auth, CI, or deploy files changed
+- `baseline sync`: current `origin/main` includes merged PR #879 and passes the required policy hook
+- `required follow-up`: commit, push, and open the WIN-272 PR for human review; rerun the authenticated hosted smoke after its credential is repaired

--- a/src/lib/__tests__/session-notes.test.ts
+++ b/src/lib/__tests__/session-notes.test.ts
@@ -533,6 +533,32 @@ describe('session note write helpers', () => {
     }]);
   });
 
+  it('upsertClientSessionNoteForSession forwards noteId when updating an existing draft row', async () => {
+    await upsertClientSessionNoteForSession({
+      noteId: 'note-existing-draft',
+      sessionId: '77777777-7777-4777-8777-777777777777',
+      clientId: '11111111-1111-4111-8111-111111111111',
+      authorizationId: '22222222-2222-4222-8222-222222222222',
+      therapistId: '33333333-3333-4333-8333-333333333333',
+      organizationId: 'org-1',
+      actorUserId: 'user-1',
+      serviceCode: '97153',
+      sessionDate: '2025-06-01',
+      startTime: '09:00',
+      endTime: '10:00',
+      goalsAddressed: ['Goal A'],
+      goalIds: ['44444444-4444-4444-8444-444444444444'],
+      goalMeasurements: null,
+      goalNotes: { '44444444-4444-4444-8444-444444444444': 'Progress captured' },
+      narrative: 'Narrative text',
+      isLocked: true,
+    });
+
+    const payload = JSON.parse(callApiMock.mock.calls[0][1].body) as Record<string, unknown>;
+    expect(payload.noteId).toBe('note-existing-draft');
+    expect(payload.isLocked).toBe(true);
+  });
+
   it('throws server error message when API request fails', async () => {
     callApiMock.mockResolvedValueOnce({
       ok: true,

--- a/src/lib/session-notes.ts
+++ b/src/lib/session-notes.ts
@@ -251,6 +251,7 @@ export interface CreateClientSessionNoteInput {
 }
 
 export interface UpsertClientSessionNoteForSessionInput {
+  readonly noteId?: string;
   readonly sessionId: string;
   readonly clientId: string;
   readonly authorizationId: string;
@@ -452,6 +453,7 @@ export const upsertClientSessionNoteForSession = async (
   }
 
   return invokeSessionNoteUpsertApi({
+    noteId: payload.noteId,
     sessionId: payload.sessionId,
     clientId: payload.clientId,
     authorizationId: payload.authorizationId,

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -146,6 +146,13 @@ const LazyScheduleDayView = React.lazy(() =>
 );
 
 type ScheduleSubmitData = SessionModalSubmitData;
+type InProgressClinicalNoteDraftState = {
+  noteId: string | null;
+  persistedTrialEventKeys: Set<string>;
+};
+
+const sessionTrialEventKey = (event: { target_id: string; trial_number: number }): string =>
+  `${event.target_id}:${event.trial_number}`;
 
 const stripClinicalNoteFields = (data: ScheduleSubmitData): Partial<Session> => {
   const {
@@ -401,6 +408,7 @@ export const Schedule = React.memo(() => {
   const attemptedUrlSessionLookupRef = useRef<Set<string>>(new Set());
   const wasModalOpenRef = useRef(false);
   const completedAwaitingFinalizationRef = useRef<Set<string>>(new Set());
+  const inProgressClinicalNoteDraftRef = useRef<Map<string, InProgressClinicalNoteDraftState>>(new Map());
   const btAbaCompletedSessionsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -1652,7 +1660,14 @@ export const Schedule = React.memo(() => {
         data: sessionPayload,
       });
       const isBtDataCollectionOnlySession = effectiveRole === "bt" && Boolean(effectiveSelectedSession?.id);
-      const persistClinicalNoteDraftForSession = async (sessionToPersist: Session) => {
+      const persistClinicalNoteDraftForSession = async (
+        sessionToPersist: Session,
+        options?: {
+          noteId?: string;
+          isLocked?: boolean;
+          trialEvents?: typeof clinicalNoteDraft.trialEvents;
+        },
+      ) => {
         if (!clinicalNoteDraft) {
           return false;
         }
@@ -1688,8 +1703,12 @@ export const Schedule = React.memo(() => {
           goalMeasurements: clinicalNoteDraft.goalMeasurements,
           goalNotes: clinicalNoteDraft.goalNotes,
           narrative: clinicalNoteDraft.narrative,
+          ...(options?.noteId ? { noteId: options.noteId } : {}),
+          ...(options?.isLocked ? { isLocked: true } : {}),
           ...(mergeCaptureIds?.length ? { captureMergeGoalIds: mergeCaptureIds } : {}),
-          ...(clinicalNoteDraft.trialEvents.length ? { trialEvents: clinicalNoteDraft.trialEvents } : {}),
+          ...((options?.trialEvents ?? clinicalNoteDraft.trialEvents).length
+            ? { trialEvents: options?.trialEvents ?? clinicalNoteDraft.trialEvents }
+            : {}),
         });
       };
 
@@ -1728,6 +1747,9 @@ export const Schedule = React.memo(() => {
             showError('Complete the required ABA Session Note before closing this session.');
             return;
           }
+          const retryingLockedFinalization =
+            completedAwaitingFinalizationRef.current.has(decision.selectedSessionId);
+          const existingDraftState = inProgressClinicalNoteDraftRef.current.get(decision.selectedSessionId);
           let liveInProgress = effectiveSelectedSession?.status === "in_progress";
           if (!liveInProgress) {
             const { data: liveRow, error: liveError } = await supabase
@@ -1746,7 +1768,27 @@ export const Schedule = React.memo(() => {
               liveInProgress = liveRow?.status === "in_progress";
             }
           }
-          if (liveInProgress) {
+          if (!retryingLockedFinalization && clinicalNoteDraft && effectiveSelectedSession && liveInProgress) {
+            const persistedTrialEventKeys = existingDraftState?.persistedTrialEventKeys ?? new Set<string>();
+            const unpersistedTrialEvents = clinicalNoteDraft.trialEvents.filter(
+              (event) => !persistedTrialEventKeys.has(sessionTrialEventKey(event)),
+            );
+            const draftResult = await persistClinicalNoteDraftForSession(effectiveSelectedSession, {
+              noteId: existingDraftState?.noteId ?? undefined,
+              trialEvents: unpersistedTrialEvents,
+            });
+            inProgressClinicalNoteDraftRef.current.set(decision.selectedSessionId, {
+              noteId:
+                draftResult && typeof draftResult === "object" && "id" in draftResult && typeof draftResult.id === "string"
+                  ? draftResult.id
+                  : existingDraftState?.noteId ?? null,
+              persistedTrialEventKeys: new Set([
+                ...persistedTrialEventKeys,
+                ...unpersistedTrialEvents.map(sessionTrialEventKey),
+              ]),
+            });
+          }
+          if (!retryingLockedFinalization && liveInProgress) {
             try {
               const readiness = await checkInProgressSessionCloseReadiness({
                 sessionId: decision.selectedSessionId,
@@ -1768,7 +1810,7 @@ export const Schedule = React.memo(() => {
             }
           }
 
-          if (!completedAwaitingFinalizationRef.current.has(decision.selectedSessionId)) {
+          if (!retryingLockedFinalization) {
             await completeSessionMutation.mutateAsync({
               sessionId: decision.selectedSessionId,
               outcome: "completed",
@@ -1778,32 +1820,17 @@ export const Schedule = React.memo(() => {
           }
           let progressionResult;
           if (clinicalNoteDraft && effectiveSelectedSession && activeOrganizationId && user?.id) {
-            const sessionTiming = formatSessionNoteTiming({
-              startTimeIso: sessionPayload.start_time ?? effectiveSelectedSession.start_time,
-              endTimeIso: sessionPayload.end_time ?? effectiveSelectedSession.end_time,
-              resolvedTimeZone: userTimeZone,
-            });
-            progressionResult = await upsertClientSessionNoteForSession({
-              sessionId: effectiveSelectedSession.id,
-              clientId: sessionPayload.client_id ?? effectiveSelectedSession.client_id,
-              authorizationId: clinicalNoteDraft.authorizationId,
-              therapistId: sessionPayload.therapist_id ?? effectiveSelectedSession.therapist_id,
-              organizationId: activeOrganizationId,
-              actorUserId: user.id,
-              serviceCode: clinicalNoteDraft.serviceCode,
-              sessionDate: sessionTiming.sessionDate,
-              startTime: sessionTiming.startTime,
-              endTime: sessionTiming.endTime,
-              goalsAddressed: clinicalNoteDraft.goalsAddressed,
-              goalIds: clinicalNoteDraft.goalIds,
-              goalMeasurements: clinicalNoteDraft.goalMeasurements,
-              goalNotes: clinicalNoteDraft.goalNotes,
-              narrative: clinicalNoteDraft.narrative,
+            const latestDraftState = inProgressClinicalNoteDraftRef.current.get(decision.selectedSessionId);
+            const persistedTrialEventKeys = latestDraftState?.persistedTrialEventKeys ?? new Set<string>();
+            progressionResult = await persistClinicalNoteDraftForSession(effectiveSelectedSession, {
+              noteId: latestDraftState?.noteId ?? undefined,
               isLocked: true,
-              ...(mergeCaptureIds?.length ? { captureMergeGoalIds: mergeCaptureIds } : {}),
-              ...(clinicalNoteDraft.trialEvents.length ? { trialEvents: clinicalNoteDraft.trialEvents } : {}),
+              trialEvents: clinicalNoteDraft.trialEvents.filter(
+                (event) => !persistedTrialEventKeys.has(sessionTrialEventKey(event)),
+              ),
             });
             completedAwaitingFinalizationRef.current.delete(decision.selectedSessionId);
+            inProgressClinicalNoteDraftRef.current.delete(decision.selectedSessionId);
           }
           showSuccess("Session marked as completed");
           applyScheduleResetBranch({ kind: "submit-cancel" }, scheduleResetSetters);

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -13,6 +13,7 @@ const buildBookSessionApiPayloadMock = vi.fn((session: unknown) => session);
 const upsertClientSessionNoteForSessionMock = vi.fn();
 const invalidateSessionNoteCachesAfterSessionWriteMock = vi.fn();
 const completeSessionFromModalMock = vi.fn();
+const checkInProgressSessionCloseReadinessMock = vi.fn();
 const formatSessionNoteTimingMock = vi.fn(() => ({
   sessionDate: "2026-07-23",
   startTime: "14:00:00",
@@ -125,11 +126,8 @@ vi.mock("../../features/scheduling/domain/sessionNoteQueryInvalidation", () => (
 
 vi.mock("../../features/scheduling/domain/sessionComplete", () => ({
   completeSessionFromModal: (...args: unknown[]) => completeSessionFromModalMock(...args),
-  checkInProgressSessionCloseReadiness: vi.fn(async () => ({
-    ready: true,
-    requiredGoalIds: ["goal-1"],
-    missingGoalIds: [],
-  })),
+  checkInProgressSessionCloseReadiness: (...args: unknown[]) =>
+    checkInProgressSessionCloseReadinessMock(...args),
   IN_PROGRESS_CLOSE_NOT_READY_MESSAGE:
     "You must complete the linked session documentation with per-goal notes before closing this in-progress session.",
 }));
@@ -190,6 +188,23 @@ vi.mock("../../components/SessionModal", () => ({
             if (result && typeof (result as Promise<unknown>).catch === "function") void (result as Promise<unknown>).catch(() => undefined);
           }}
         >complete stale</button>
+        <button
+          aria-label="submit-complete-with-new-trial"
+          onClick={() => {
+            const result = onSubmit({
+              id: "session-1", therapist_id: "therapist-1", client_id: "client-1", program_id: "program-1", goal_id: "goal-1",
+              start_time: originalSessionWindow.start_time, end_time: originalSessionWindow.end_time, status: "completed",
+              session_note_goal_ids: ["goal-1"], session_note_goals_addressed: ["Goal 1"],
+              session_note_goal_notes: { "goal-1": "Keep this note" }, session_note_goal_measurements: {},
+              session_note_authorization_id: "auth-1", session_note_service_code: "97153", session_note_persist_requested: true,
+              session_note_trial_events: [
+                { target_id: "88888888-8888-4888-8888-888888888888", trial_number: 1, response: "correct", expected_progression_version: 1 },
+                { target_id: "88888888-8888-4888-8888-888888888888", trial_number: 2, response: "incorrect", expected_progression_version: 1 },
+              ],
+            });
+            if (result && typeof (result as Promise<unknown>).catch === "function") void (result as Promise<unknown>).catch(() => undefined);
+          }}
+        >complete with new trial</button>
         <button
           aria-label="submit-complete-after-discard"
           onClick={() => {
@@ -512,6 +527,11 @@ describe("Schedule orchestration integration hardening", () => {
       id: "linked-note-1",
     });
     completeSessionFromModalMock.mockResolvedValue(undefined);
+    checkInProgressSessionCloseReadinessMock.mockResolvedValue({
+      ready: true,
+      requiredGoalIds: ["goal-1"],
+      missingGoalIds: [],
+    });
     reactivateSessionMock.mockReset();
     bookSessionViaApiMock.mockResolvedValue({
       session: {
@@ -529,22 +549,182 @@ describe("Schedule orchestration integration hardening", () => {
 
   it("does not repeat session completion when stale trials are explicitly discarded and finalization is retried", async () => {
     const stale = Object.assign(new Error("stale"), { status: 409 });
-    upsertClientSessionNoteForSessionMock.mockRejectedValueOnce(stale).mockResolvedValueOnce({ id: "linked-note-1", progression_results: [] });
+    scheduleFixtures.sessions[0].status = "in_progress";
+    upsertClientSessionNoteForSessionMock
+      .mockResolvedValueOnce({ id: "linked-note-1" })
+      .mockRejectedValueOnce(stale)
+      .mockResolvedValueOnce({ id: "linked-note-1", progression_results: [] });
     renderWithProviders(<Schedule />);
     await screen.findByRole("heading", { name: /Schedule/i });
     await waitForScheduleGridReady();
     await openExistingSessionForEdit();
     await screen.findByTestId("session-modal");
     fireEvent.click(screen.getByLabelText("submit-complete-with-stale-trial"));
-    await waitFor(() => expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1));
-    expect(completeSessionFromModalMock).toHaveBeenCalledTimes(1);
-    fireEvent.click(screen.getByLabelText("submit-complete-after-discard"));
     await waitFor(() => expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(2));
     expect(completeSessionFromModalMock).toHaveBeenCalledTimes(1);
+    expect(checkInProgressSessionCloseReadinessMock).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByLabelText("submit-complete-after-discard"));
+    await waitFor(() => expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(3));
+    expect(completeSessionFromModalMock).toHaveBeenCalledTimes(1);
+    expect(checkInProgressSessionCloseReadinessMock).toHaveBeenCalledTimes(1);
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[1][0]).toMatchObject({
+      noteId: "linked-note-1",
+      isLocked: true,
+    });
     expect(upsertClientSessionNoteForSessionMock.mock.calls[1][0]).not.toHaveProperty("trialEvents");
-    expect(upsertClientSessionNoteForSessionMock.mock.calls[1][0].goalNotes).toEqual({ "goal-1": "Keep this note" });
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[2][0]).toMatchObject({
+      noteId: "linked-note-1",
+      isLocked: true,
+    });
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[2][0]).not.toHaveProperty("trialEvents");
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[2][0].goalNotes).toEqual({ "goal-1": "Keep this note" });
     await waitFor(() => expect(showSuccessMock).toHaveBeenCalledWith("Session marked as completed"));
     await waitFor(() => expect(screen.queryByTestId("session-modal")).not.toBeInTheDocument());
+  });
+
+  it("persists an unlocked draft before readiness and completion, then finalizes with the returned note id and without replaying trial events", async () => {
+    scheduleFixtures.sessions[0].status = "in_progress";
+    upsertClientSessionNoteForSessionMock
+      .mockResolvedValueOnce({ id: "linked-note-1" })
+      .mockResolvedValueOnce({ id: "linked-note-1", progression_results: [] });
+
+    renderWithProviders(<Schedule />);
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+
+    fireEvent.click(screen.getByLabelText("submit-complete-with-stale-trial"));
+
+    await waitFor(() => {
+      expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(2);
+      expect(checkInProgressSessionCloseReadinessMock).toHaveBeenCalledTimes(1);
+      expect(completeSessionFromModalMock).toHaveBeenCalledTimes(1);
+    });
+
+    const draftCall = upsertClientSessionNoteForSessionMock.mock.calls[0][0];
+    const finalizationCall = upsertClientSessionNoteForSessionMock.mock.calls[1][0];
+    expect(draftCall.isLocked).toBeUndefined();
+    expect(draftCall.noteId).toBeUndefined();
+    expect(draftCall.trialEvents).toEqual([{
+      target_id: "88888888-8888-4888-8888-888888888888",
+      trial_number: 1,
+      response: "correct",
+      expected_progression_version: 1,
+    }]);
+    expect(finalizationCall.isLocked).toBe(true);
+    expect(finalizationCall.noteId).toBe("linked-note-1");
+    expect(finalizationCall).not.toHaveProperty("trialEvents");
+    expect(
+      upsertClientSessionNoteForSessionMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(checkInProgressSessionCloseReadinessMock.mock.invocationCallOrder[0]);
+    expect(
+      checkInProgressSessionCloseReadinessMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(completeSessionFromModalMock.mock.invocationCallOrder[0]);
+    expect(
+      completeSessionFromModalMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(upsertClientSessionNoteForSessionMock.mock.invocationCallOrder[1]);
+    await waitFor(() => expect(showSuccessMock).toHaveBeenCalledWith("Session marked as completed"));
+  });
+
+  it("stops before readiness and completion when draft persistence fails", async () => {
+    scheduleFixtures.sessions[0].status = "in_progress";
+    upsertClientSessionNoteForSessionMock.mockRejectedValueOnce(new Error("draft failed"));
+
+    renderWithProviders(<Schedule />);
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+
+    fireEvent.click(screen.getByLabelText("submit-complete-with-stale-trial"));
+
+    await waitFor(() => {
+      expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1);
+    });
+    expect(checkInProgressSessionCloseReadinessMock).not.toHaveBeenCalled();
+    expect(completeSessionFromModalMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses the saved draft note id and avoids replaying trial events when completion fails before finalization", async () => {
+    scheduleFixtures.sessions[0].status = "in_progress";
+    completeSessionFromModalMock
+      .mockRejectedValueOnce(new Error("completion failed"))
+      .mockResolvedValueOnce(undefined);
+    upsertClientSessionNoteForSessionMock
+      .mockResolvedValueOnce({ id: "linked-note-1" })
+      .mockResolvedValueOnce({ id: "linked-note-1" })
+      .mockResolvedValueOnce({ id: "linked-note-1", progression_results: [] });
+
+    renderWithProviders(<Schedule />);
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+
+    fireEvent.click(screen.getByLabelText("submit-complete-with-stale-trial"));
+
+    await waitFor(() => {
+      expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(1);
+      expect(completeSessionFromModalMock).toHaveBeenCalledTimes(1);
+      expect(showErrorMock).toHaveBeenCalled();
+    });
+    expect(checkInProgressSessionCloseReadinessMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByLabelText("submit-complete-after-discard"));
+
+    await waitFor(() => {
+      expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(3);
+      expect(completeSessionFromModalMock).toHaveBeenCalledTimes(2);
+    });
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[1][0]).toMatchObject({
+      noteId: "linked-note-1",
+    });
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[1][0]).not.toHaveProperty("trialEvents");
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[2][0]).toMatchObject({
+      noteId: "linked-note-1",
+      isLocked: true,
+    });
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[2][0]).not.toHaveProperty("trialEvents");
+    await waitFor(() => expect(showSuccessMock).toHaveBeenCalledWith("Session marked as completed"));
+  });
+
+  it("persists only trials added after an earlier draft save when completion is retried", async () => {
+    scheduleFixtures.sessions[0].status = "in_progress";
+    completeSessionFromModalMock
+      .mockRejectedValueOnce(new Error("completion failed"))
+      .mockResolvedValueOnce(undefined);
+    upsertClientSessionNoteForSessionMock
+      .mockResolvedValueOnce({ id: "linked-note-1" })
+      .mockResolvedValueOnce({ id: "linked-note-1" })
+      .mockResolvedValueOnce({ id: "linked-note-1", progression_results: [] });
+
+    renderWithProviders(<Schedule />);
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+
+    fireEvent.click(screen.getByLabelText("submit-complete-with-stale-trial"));
+    await waitFor(() => expect(completeSessionFromModalMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByLabelText("submit-complete-with-new-trial"));
+    await waitFor(() => expect(upsertClientSessionNoteForSessionMock).toHaveBeenCalledTimes(3));
+
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[1][0]).toMatchObject({
+      noteId: "linked-note-1",
+      trialEvents: [{
+        target_id: "88888888-8888-4888-8888-888888888888",
+        trial_number: 2,
+        response: "incorrect",
+        expected_progression_version: 1,
+      }],
+    });
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[2][0]).toMatchObject({
+      noteId: "linked-note-1",
+      isLocked: true,
+    });
+    expect(upsertClientSessionNoteForSessionMock.mock.calls[2][0]).not.toHaveProperty("trialEvents");
   });
 
   it("pending-schedule create forwards metadata and does not reuse it on next manual create", async () => {

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -2340,8 +2340,9 @@ describe("sessionNotesUpsertHandler", () => {
 
   it("rejects a noteId that is not linked to the submitted session", async () => {
     const noteId = "66666666-6666-4666-8666-666666666666";
+    let wroteNote = false;
     const fetchJsonMock = vi.mocked(fetchJson);
-    fetchJsonMock.mockImplementation(async (url) => {
+    fetchJsonMock.mockImplementation(async (url, init) => {
       const requestUrl = String(url);
       if (requestUrl.includes("/rest/v1/authorizations?")) {
         return {
@@ -2359,16 +2360,14 @@ describe("sessionNotesUpsertHandler", () => {
         };
       }
       if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
-        const boundToSubmittedSession = requestUrl.includes(
-          `session_id=eq.${encodeURIComponent(basePayload.sessionId)}`,
-        );
         return {
           ok: true,
           status: 200,
-          data: boundToSubmittedSession ? [] : [{ id: noteId, is_locked: false }],
+          data: [{ id: noteId, is_locked: false, session_id: "88888888-8888-4888-8888-888888888888" }],
         };
       }
       if (requestUrl.includes(`/rest/v1/client_session_notes?id=eq.${noteId}`)) {
+        wroteNote = init?.method === "PATCH";
         return { ok: true, status: 200, data: [{ id: noteId }] };
       }
       if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes(`id=eq.${noteId}`)) {
@@ -2390,6 +2389,164 @@ describe("sessionNotesUpsertHandler", () => {
       code: "not_found",
       error: "Session note not found.",
     });
+    expect(wroteNote).toBe(false);
+  });
+
+  it("links an existing unlinked note to the submitted session", async () => {
+    const noteId = "66666666-6666-4666-8666-666666666666";
+    let linkedSessionId: string | null = null;
+    vi.mocked(fetchJson).mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked,session_id,client_id,therapist_id,authorization_id")) {
+        expect(requestUrl).not.toContain("session_id=eq.");
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: noteId,
+            is_locked: false,
+            session_id: null,
+            client_id: basePayload.clientId,
+            therapist_id: basePayload.therapistId,
+            authorization_id: basePayload.authorizationId,
+          }],
+        };
+      }
+      if (requestUrl.includes(`/rest/v1/client_session_notes?id=eq.${noteId}`) && init?.method === "PATCH") {
+        linkedSessionId = (JSON.parse(String(init.body)) as { session_id: string | null }).session_id;
+        return { ok: true, status: 200, data: [{ id: noteId }] };
+      }
+      if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes(`id=eq.${noteId}`)) {
+        return { ok: true, status: 200, data: [buildSessionNoteRow(noteId)] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({ ...basePayload, noteId }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(linkedSessionId).toBe(basePayload.sessionId);
+  });
+
+  it("rejects unlinking a bound note when sessionId is omitted", async () => {
+    const noteId = "66666666-6666-4666-8666-666666666666";
+    let wroteNote = false;
+    vi.mocked(fetchJson).mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return { ok: true, status: 200, data: [{ id: noteId, is_locked: false, session_id: basePayload.sessionId }] };
+      }
+      if (requestUrl.includes(`/rest/v1/client_session_notes?id=eq.${noteId}`)) {
+        wroteNote = init?.method === "PATCH";
+        return { ok: true, status: 200, data: [{ id: noteId }] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({ ...basePayload, noteId, sessionId: undefined }),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(wroteNote).toBe(false);
+  });
+
+  it.each([
+    ["client", { client_id: "99999999-9999-4999-8999-999999999999" }],
+    ["therapist", { therapist_id: "99999999-9999-4999-8999-999999999999" }],
+    ["authorization", { authorization_id: "99999999-9999-4999-8999-999999999999" }],
+  ])("rejects linking an unlinked note owned by a different %s", async (_field, ownershipOverride) => {
+    const noteId = "66666666-6666-4666-8666-666666666666";
+    let wroteNote = false;
+    vi.mocked(fetchJson).mockImplementation(async (url, init) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: noteId,
+            is_locked: false,
+            session_id: null,
+            client_id: basePayload.clientId,
+            therapist_id: basePayload.therapistId,
+            authorization_id: basePayload.authorizationId,
+            ...ownershipOverride,
+          }],
+        };
+      }
+      if (requestUrl.includes(`/rest/v1/client_session_notes?id=eq.${noteId}`)) {
+        wroteNote = init?.method === "PATCH";
+        return { ok: true, status: 200, data: [{ id: noteId }] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({ ...basePayload, noteId }),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(wroteNote).toBe(false);
   });
 
   it("rejects updates for locked notes", async () => {

--- a/src/server/__tests__/sessionNotesUpsertHandler.test.ts
+++ b/src/server/__tests__/sessionNotesUpsertHandler.test.ts
@@ -2338,6 +2338,60 @@ describe("sessionNotesUpsertHandler", () => {
     expect(response.status).toBe(200);
   });
 
+  it("rejects a noteId that is not linked to the submitted session", async () => {
+    const noteId = "66666666-6666-4666-8666-666666666666";
+    const fetchJsonMock = vi.mocked(fetchJson);
+    fetchJsonMock.mockImplementation(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/rest/v1/authorizations?")) {
+        return {
+          ok: true,
+          status: 200,
+          data: [{
+            id: basePayload.authorizationId,
+            organization_id: "org-1",
+            client_id: basePayload.clientId,
+            status: "approved",
+            start_date: "2026-01-01",
+            end_date: "2026-12-31",
+            services: [{ service_code: basePayload.serviceCode, approved_units: 10 }],
+          }],
+        };
+      }
+      if (requestUrl.includes("/rest/v1/client_session_notes?select=id,is_locked")) {
+        const boundToSubmittedSession = requestUrl.includes(
+          `session_id=eq.${encodeURIComponent(basePayload.sessionId)}`,
+        );
+        return {
+          ok: true,
+          status: 200,
+          data: boundToSubmittedSession ? [] : [{ id: noteId, is_locked: false }],
+        };
+      }
+      if (requestUrl.includes(`/rest/v1/client_session_notes?id=eq.${noteId}`)) {
+        return { ok: true, status: 200, data: [{ id: noteId }] };
+      }
+      if (requestUrl.includes("select=id%2Cauthorization_id") && requestUrl.includes(`id=eq.${noteId}`)) {
+        return { ok: true, status: 200, data: [buildSessionNoteRow(noteId)] };
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    });
+
+    const response = await sessionNotesUpsertHandler(
+      new Request("http://localhost/api/session-notes/upsert", {
+        method: "POST",
+        headers: HEADERS,
+        body: JSON.stringify({ ...basePayload, noteId }),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "not_found",
+      error: "Session note not found.",
+    });
+  });
+
   it("rejects updates for locked notes", async () => {
     const fetchJsonMock = vi.mocked(fetchJson);
     fetchJsonMock.mockImplementation(async (url) => {

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -711,7 +711,9 @@ const fetchExistingNote = async (
     const url =
       `${supabaseUrl}/rest/v1/client_session_notes?select=id,is_locked` +
       `&organization_id=eq.${encodeURIComponent(organizationId)}` +
-      `&id=eq.${encodeURIComponent(options.noteId)}&limit=1`;
+      `&id=eq.${encodeURIComponent(options.noteId)}` +
+      (options.sessionId ? `&session_id=eq.${encodeURIComponent(options.sessionId)}` : "") +
+      `&limit=1`;
     const result = await fetchJson<Array<{ id: string; is_locked: boolean }>>(url, {
       method: "GET",
       headers,
@@ -1433,7 +1435,7 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
 
   const existingNote = await fetchExistingNote(supabaseUrl, headers, organizationId, {
     noteId: payload.noteId,
-    sessionId: payload.noteId ? null : payload.sessionId,
+    sessionId: payload.sessionId,
   });
 
   if (payload.noteId && !existingNote) {

--- a/src/server/api/session-notes-upsert.ts
+++ b/src/server/api/session-notes-upsert.ts
@@ -706,15 +706,28 @@ const fetchExistingNote = async (
   headers: Record<string, string>,
   organizationId: string,
   options: { noteId?: string; sessionId?: string | null },
-): Promise<{ id: string; is_locked: boolean } | null> => {
+): Promise<{
+  id: string;
+  is_locked: boolean;
+  session_id: string | null;
+  client_id: string;
+  therapist_id: string;
+  authorization_id: string;
+} | null> => {
   if (options.noteId) {
     const url =
-      `${supabaseUrl}/rest/v1/client_session_notes?select=id,is_locked` +
+      `${supabaseUrl}/rest/v1/client_session_notes?select=id,is_locked,session_id,client_id,therapist_id,authorization_id` +
       `&organization_id=eq.${encodeURIComponent(organizationId)}` +
       `&id=eq.${encodeURIComponent(options.noteId)}` +
-      (options.sessionId ? `&session_id=eq.${encodeURIComponent(options.sessionId)}` : "") +
       `&limit=1`;
-    const result = await fetchJson<Array<{ id: string; is_locked: boolean }>>(url, {
+    const result = await fetchJson<Array<{
+      id: string;
+      is_locked: boolean;
+      session_id: string | null;
+      client_id: string;
+      therapist_id: string;
+      authorization_id: string;
+    }>>(url, {
       method: "GET",
       headers,
     });
@@ -723,10 +736,17 @@ const fetchExistingNote = async (
 
   if (options.sessionId) {
     const url =
-      `${supabaseUrl}/rest/v1/client_session_notes?select=id,is_locked` +
+      `${supabaseUrl}/rest/v1/client_session_notes?select=id,is_locked,session_id,client_id,therapist_id,authorization_id` +
       `&organization_id=eq.${encodeURIComponent(organizationId)}` +
       `&session_id=eq.${encodeURIComponent(options.sessionId)}&limit=1`;
-    const result = await fetchJson<Array<{ id: string; is_locked: boolean }>>(url, {
+    const result = await fetchJson<Array<{
+      id: string;
+      is_locked: boolean;
+      session_id: string | null;
+      client_id: string;
+      therapist_id: string;
+      authorization_id: string;
+    }>>(url, {
       method: "GET",
       headers,
     });
@@ -1439,6 +1459,26 @@ export async function sessionNotesUpsertHandler(request: Request): Promise<Respo
   });
 
   if (payload.noteId && !existingNote) {
+    return errorResponse(request, "not_found", "Session note not found.");
+  }
+
+  if (
+    payload.noteId &&
+    existingNote?.session_id != null &&
+    existingNote.session_id !== payload.sessionId
+  ) {
+    return errorResponse(request, "not_found", "Session note not found.");
+  }
+
+  if (
+    payload.noteId &&
+    existingNote?.session_id === null &&
+    (
+      existingNote.client_id !== payload.clientId ||
+      existingNote.therapist_id !== payload.therapistId ||
+      existingNote.authorization_id !== effectiveAuthorizationId
+    )
+  ) {
     return errorResponse(request, "not_found", "Session note not found.");
   }
 


### PR DESCRIPTION
## Summary
- save the current non-BT session-note draft before close readiness and completion
- carry the returned note ID into locked finalization without replaying persisted trial events
- bind server note-ID lookup to the submitted session and fail closed on same-org cross-session retargeting

## Verification
- `npm run verify:local` (policy, lint, typecheck, full test suite, coverage, build, and 220 Tier-0 Cypress tests)
- focused schedule/session-note suite: 70 passed
- session-note API handler suite: 69 passed
- `npm run validate:tenant`
- code review: approved
- security review: approved

## Blocked external evidence
- `npm run ci:playwright` preflight passed, but hosted auth smoke rejected the configured test credential; authenticated session-close smoke was not reached

## Risk
Critical lane. This changes persistent session-close ordering and a protected server/API lookup. Human review is required before merge.

Linear: WIN-272
