### PR TITLE
WIN-273: Preserve org-wide admin booking scope

### DIFF
--- a/docs/ai/handoffs/WIN-273-bcba-booking-target.md
+++ b/docs/ai/handoffs/WIN-273-bcba-booking-target.md
@@ -17,6 +17,12 @@
 - The shared measurement helper restricted only by organization, selected an unrelated therapist-client pair, and exhausted repeated HTTP 409 responses.
 - The helper now validates the token, uses authenticated org-bound authority RPCs plus `user_therapist_links`, and intersects linked therapists with the active organization.
 
+## Post-Merge Review Follow-Up
+- PR `#889` merged the actor-scoped booking fix.
+- Codex review found that the helper still narrowed verified `admin`, `admin_schedule`, and `super_admin` actors when optional therapist links existed.
+- The follow-up makes verified organization-wide scheduling authority take precedence over link-based narrowing while keeping linkless clinical actors fail-closed.
+- Scope remains limited to the session-proof fixture helper and its focused regression coverage.
+
 ## Verification Card
 - Classification: `high-risk human-reviewed`
 - Lane: `critical`
@@ -31,11 +37,11 @@
   - `npm run test:routes:tier0`
   - trusted `auth-browser-smoke` / BCBA acceptance proof
 - Executed checks:
-  - focused Vitest -> pass, 13 tests
+  - focused Vitest -> pass, 14 tests
   - `npm run ci:check-focused` -> pass
   - `npm run lint` -> pass
   - `npm run typecheck` -> pass
-  - `NODE_OPTIONS=--max-old-space-size=8192 npm run test:ci` -> pass, 466 files and 3,967 tests; 2 files and 5 tests skipped
+  - `NODE_OPTIONS=--max-old-space-size=8192 npm run test:ci` -> pass, 466 files and 3,968 tests; 2 files and 5 tests skipped
   - `npm run ci:verify-coverage` -> pass, 92.92% line coverage
   - `npm run build` -> pass
   - `npm run test:routes:tier0` -> pass, 220 tests

--- a/scripts/lib/playwright-inprogress-session-setup.ts
+++ b/scripts/lib/playwright-inprogress-session-setup.ts
@@ -419,8 +419,12 @@ export const restrictTherapistIdsToActorLinks = (
   linkedTherapistIds: readonly string[],
   canUseOrganizationTherapists = false,
 ): Set<string> => {
+  if (canUseOrganizationTherapists) {
+    return organizationTherapistIds;
+  }
+
   if (linkedTherapistIds.length === 0) {
-    return canUseOrganizationTherapists ? organizationTherapistIds : new Set<string>();
+    return new Set<string>();
   }
   const linkedIds = new Set(linkedTherapistIds);
   return new Set([...organizationTherapistIds].filter((therapistId) => linkedIds.has(therapistId)));

--- a/src/scripts/__tests__/playwrightInprogressSessionSetup.test.ts
+++ b/src/scripts/__tests__/playwrightInprogressSessionSetup.test.ts
@@ -39,6 +39,14 @@ describe("playwright in-progress session setup", () => {
     )).toEqual(new Set(["org-a", "org-b"]));
   });
 
+  it("keeps the organization pool when an org-wide scheduling actor also has therapist links", () => {
+    expect(restrictTherapistIdsToActorLinks(
+      new Set(["org-linked", "org-unlinked"]),
+      ["org-linked"],
+      true,
+    )).toEqual(new Set(["org-linked", "org-unlinked"]));
+  });
+
   it("rejects a non-super-admin whose authoritative profile is outside the active organization", () => {
     expect(() => resolveEligibleTherapistIdsForActor({
       organizationTherapistIds: new Set(["org-a"]),


### PR DESCRIPTION
## Summary
- honor verified organization-wide scheduling authority before therapist-link narrowing
- keep clinical actors fail-closed and restricted to actor-linked therapists
- add the admin-with-links regression identified by Codex review on #889

## Routing
- issue: WIN-273
- classification: high-risk human-reviewed
- lane: critical
- human review required

## Verification
- focused Vitest: 14 passed
- ci:check-focused: passed
- lint: passed
- typecheck: passed
- test:ci: 466 files / 3,968 tests passed; 2 files / 5 tests skipped
- ci:verify-coverage: 92.92% lines, passed
- build: passed
- test:routes:tier0: 220 passed
- independent code, test, and security review: no behavioral findings

## Blocked
- trusted auth-browser-smoke / hosted BCBA acceptance proof requires protected CI credentials and hosted systems