### PR TITLE
fix(ci): require auth smoke for session setup helper

### DIFF
--- a/docs/ai/handoffs/WIN-273-bcba-booking-target.md
+++ b/docs/ai/handoffs/WIN-273-bcba-booking-target.md
@@ -64,3 +64,12 @@
 - `unrelated changes`: none
 - `generated artifact drift`: none
 - `protected-path drift`: no production, schema, workflow, or deploy paths changed
+
+## Trusted-Main Browser Selector Follow-Up
+- Current-main CI run `30926840449` attempt 2 concluded `success`, but its `auth-browser-smoke` job took the explicit no-op path because `scripts/lib/playwright-inprogress-session-setup.ts` was not classified as an auth/session browser surface. That run is not counted as the required hosted browser proof.
+- Follow-up scope is limited to `scripts/ci/select-browser-checks.mjs` and its focused regression in `tests/scripts/select-browser-checks.test.ts`; production booking, auth policy, RLS, schema, migrations, secrets, and runtime configuration remain unchanged.
+- TDD evidence: focused selector test RED at `1 failed, 16 passed`, then GREEN at `17/17` after adding the exact helper path to the existing auth/session matcher.
+- Verification: `npm run ci:check-focused`, `npm run lint`, and `npm run typecheck` passed; `NODE_OPTIONS=--max-old-space-size=8192 npm run verify:local` passed in 285.5 seconds, including full tests and coverage, build, and Tier-0 routes `220/220`.
+- Local skips: branch protection, live privileged-function grants, Supabase preview drift, and function-auth parity require CI or hosted credentials and were reported as skipped rather than passed.
+- Review: fresh code, security, and DevOps reviews found no blocking issue. The selector now requires auth/schedule Tier-0, hosted readiness, and hosted auth smoke for the exact helper path.
+- Remaining gate: human review and a trusted post-merge main run where `auth-browser-smoke` actually executes Playwright and `ci-gate` succeeds.

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -164,6 +164,7 @@ const classifyFile = (file) => {
   if (matchAny(file, [
     /^cypress\/e2e\/routes_auth\.cy\.ts$/,
     /^scripts\/playwright-/,
+    /^scripts\/lib\/playwright-inprogress-session-setup\.ts$/,
     /^scripts\/lib\/playwright-smoke\.ts$/,
     /^supabase\/functions\/(sessions-|session-|auth-|programs|goals|program-notes)/,
   ])) {

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -215,6 +215,20 @@ describe('select-browser-checks', () => {
     ]);
   });
 
+  it('requires hosted auth smoke when the in-progress session setup helper changes', () => {
+    const selection = runSelector('--changed-file', 'scripts/lib/playwright-inprogress-session-setup.ts');
+
+    expect(selection.tier0Required).toBe(true);
+    expect(selection.authSmokeRequired).toBe(true);
+    expect(selection.tier0Specs).toEqual([
+      'cypress/e2e/routes_auth.cy.ts',
+      'cypress/e2e/routes_schedule.cy.ts',
+    ]);
+    expect(selection.reasons).toEqual([
+      'scripts/lib/playwright-inprogress-session-setup.ts: auth/session browser flow',
+    ]);
+  });
+
   it('keeps the PreAuth spec in the default local tier-0 Cypress run', () => {
     const runCypressSource = readFileSync('scripts/run-cypress.ts', 'utf8');
 


### PR DESCRIPTION
## Summary
- classify `scripts/lib/playwright-inprogress-session-setup.ts` as an auth/session browser surface
- require auth/schedule Tier-0, hosted Playwright readiness, and hosted auth smoke for that helper
- record the trusted-main selector gap and verification evidence under WIN-273

## Safety
- no production booking, auth policy, schema, RLS, migration, secret, runtime, Supabase, or Netlify change
- critical lane; human review required

## Verification
- TDD RED: 1 failed, 16 passed
- focused GREEN: 17/17
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 npm run verify:local` (285.5s; Tier-0 220/220)
- local hosted/CI-only skips are recorded in the handoff

## Tracking
- WIN-273