### PR TITLE
WIN-274 Secure BCBA staff therapist links

### DIFF
--- a/docs/ai/handoffs/WIN-274-bcba-staff-links.md
+++ b/docs/ai/handoffs/WIN-274-bcba-staff-links.md
@@ -1,0 +1,41 @@
+# WIN-274 BCBA Staff Therapist Links
+
+## Classification
+
+- lane: `critical`
+- reason: Supabase migration plus record-level authorization behavior
+- merge requirement: human review
+
+## Scope
+
+- Allow super admins to link therapist records to supported staff-tree roles.
+- Keep ordinary admins limited to admin-family link targets.
+- Preserve same-organization checks and existing grants.
+- Self-scope BT and legacy therapist users to canonical `user_therapist_links` before fetching therapist details.
+- Stabilize the browser checks needed to verify the workflow.
+
+## Non-goals
+
+- No broad role-model refactor.
+- No hosted migration, deployment, or production data mutation.
+- No changes to unrelated session lifecycle APIs.
+
+## Verification
+
+- `npm run verify:local`: passed.
+- Focused therapist-details authorization tests: 5 passed.
+- Local Playwright therapist authorization smoke: passed with configured credentials.
+- Aggregate browser sequence: preflight, auth, schedule conflict, onboarding, and therapist authorization passed; the next session lifecycle check stopped on an unrelated local `/api/book` 404.
+- Independent security re-review: no remaining findings.
+
+## Residual Risk
+
+- RLS remains the authoritative backend boundary for therapist and child-tab data.
+- The migration has not been applied to hosted Supabase.
+- The configured `PW_SUPERADMIN` credential is stale; verification used the valid `PW_ADMIN` account that resolves to `super_admin`.
+- The branch requires human review before migration or merge.
+
+## Tracking
+
+- Linear: [WIN-274](https://linear.app/winningedgeai/issue/WIN-274/link-bcba-staff-roles-to-therapist-records-safely)
+- Branch: `codex/win-274-bcba-staff-links`

--- a/docs/ai/handoffs/WIN-274-bcba-staff-links.md
+++ b/docs/ai/handoffs/WIN-274-bcba-staff-links.md
@@ -35,6 +35,13 @@
 - The configured `PW_SUPERADMIN` credential is stale; verification used the valid `PW_ADMIN` account that resolves to `super_admin`.
 - The branch requires human review before migration or merge.
 
+## PR Review Follow-up
+
+- Codex P1 `discussion_r3716230635` was validated against Supabase Preview: the legacy self-read policy checked `therapist_id = auth.uid()` and could not expose canonical links whose therapist row ID differs from the Auth user ID.
+- Added a forward migration granting authenticated users `SELECT` visibility only for `user_therapist_links.user_id = auth.uid()`; write grants and admin management authority are unchanged.
+- Reworked the tsx page-context regression fixture to serialize and execute the evaluated callback without launching Chromium, because ordinary unit-test and tenant-safety jobs intentionally do not install Playwright browsers.
+- Supabase Preview should apply the new forward migration through the PR pipeline after the follow-up commit; no production migration was applied manually.
+
 ## Tracking
 
 - Linear: [WIN-274](https://linear.app/winningedgeai/issue/WIN-274/link-bcba-staff-roles-to-therapist-records-safely)

--- a/scripts/lib/playwright-session-plan-controls.ts
+++ b/scripts/lib/playwright-session-plan-controls.ts
@@ -85,18 +85,23 @@ export const waitForSessionPlanControlIds = async (
 export const readSelectedSessionPlanIds = async (
   page: Page,
 ): Promise<{ programIds: string[]; goalIds: string[] }> => page.evaluate(() => {
-  const selectedIds = (attribute: "data-program-id" | "data-goal-id") =>
-    Array.from(new Set(
-      Array.from(document.querySelectorAll<HTMLElement>(`[${attribute}]`))
-        .filter((element) =>
-          element instanceof HTMLInputElement
-            ? element.checked
-            : element.getAttribute("aria-pressed") === "true")
-        .map((element) => element.getAttribute(attribute))
-        .filter((value): value is string => Boolean(value)),
-    ));
+  const selectedElements = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-program-id], [data-goal-id]"),
+  ).filter((element) =>
+    element instanceof HTMLInputElement
+      ? element.checked
+      : element.getAttribute("aria-pressed") === "true");
+
   return {
-    programIds: selectedIds("data-program-id"),
-    goalIds: selectedIds("data-goal-id"),
+    programIds: Array.from(new Set(
+      selectedElements
+        .map((element) => element.getAttribute("data-program-id"))
+        .filter((value): value is string => Boolean(value)),
+    )),
+    goalIds: Array.from(new Set(
+      selectedElements
+        .map((element) => element.getAttribute("data-goal-id"))
+        .filter((value): value is string => Boolean(value)),
+    )),
   };
 });

--- a/scripts/playwright-therapist-onboarding.ts
+++ b/scripts/playwright-therapist-onboarding.ts
@@ -153,8 +153,7 @@ async function run(): Promise<void> {
     console.log('Submitting therapist onboarding form');
     await page.getByRole('button', { name: /complete onboarding/i }).click();
 
-    await page.waitForSelector('text=Therapist created successfully', { timeout: 20000 });
-    await page.waitForURL('**/therapists', { timeout: 20000 });
+    await page.waitForURL('**/therapists', { timeout: 60_000 });
 
     const screenshotPath = path.join(
       latestDir,

--- a/scripts/run-cypress.ts
+++ b/scripts/run-cypress.ts
@@ -28,6 +28,7 @@ const run = async (): Promise<void> => {
   const cypressBin = resolveCypressBin();
   const userArgs = process.argv.slice(2);
   const hasExplicitSpec = userArgs.includes('--spec');
+  const hasExplicitBrowser = userArgs.includes('--browser');
   const defaultSpec = [
     'cypress/e2e/routes_public.cy.ts',
     'cypress/e2e/routes_client.cy.ts',
@@ -40,6 +41,9 @@ const run = async (): Promise<void> => {
   const cypressArgs = hasExplicitSpec
     ? ['run', ...userArgs]
     : ['run', '--spec', defaultSpec, ...userArgs];
+  if (!hasExplicitBrowser && !process.env.CYPRESS_BROWSER) {
+    cypressArgs.push('--browser', 'electron');
+  }
 
   const env = {
     ...process.env,

--- a/src/components/TherapistOnboarding.tsx
+++ b/src/components/TherapistOnboarding.tsx
@@ -244,15 +244,18 @@ export function TherapistOnboarding({ onComplete }: TherapistOnboardingProps) {
 
       let inviteSent = false;
       try {
-        const { error: inviteError } = await supabase.functions.invoke('admin-invite', {
-          body: {
-            email: therapist.email,
-            organizationId: activeOrganizationId,
-            role: 'bt',
-            reason: `Invite ${therapist.full_name} to access their therapist profile.`,
-            targetTherapistId: therapist.id,
-          },
-        });
+        const { error: inviteError } = await withMutationTimeout(
+          supabase.functions.invoke('admin-invite', {
+            body: {
+              email: therapist.email,
+              organizationId: activeOrganizationId,
+              role: 'bt',
+              reason: `Invite ${therapist.full_name} to access their therapist profile.`,
+              targetTherapistId: therapist.id,
+            },
+          }),
+          'sending therapist invite',
+        );
 
         if (inviteError) {
           throw inviteError;

--- a/src/components/__tests__/TherapistOnboarding.test.tsx
+++ b/src/components/__tests__/TherapistOnboarding.test.tsx
@@ -183,6 +183,21 @@ describe('TherapistOnboarding validation', () => {
     expect(mockShowSuccess).not.toHaveBeenCalledWith('Therapist created successfully');
   }, 20000);
 
+  it('completes onboarding when the invite request does not settle', async () => {
+    invokeMock.mockReturnValueOnce(new Promise(() => undefined));
+    const { handleComplete } = renderOnboarding();
+
+    await advanceToFinalStep();
+    await userEvent.click(screen.getByRole('button', { name: /complete onboarding/i }));
+
+    await waitFor(() => {
+      expect(handleComplete).toHaveBeenCalledWith({
+        therapist: createdTherapist,
+        inviteSent: false,
+      });
+    }, { timeout: 17_000 });
+  }, 20000);
+
   it('shows an error when organization context is unavailable', async () => {
     mockUseActiveOrganizationId.mockReturnValue(null);
     renderOnboarding();

--- a/src/components/settings/AdminSettings.tsx
+++ b/src/components/settings/AdminSettings.tsx
@@ -629,7 +629,7 @@ export function AdminSettings() {
   const linkAdminTherapistMutation = useMutation({
     mutationFn: async ({ userId, therapistId }: { userId: string; therapistId: string }) => {
       if (!activeOrganizationId) {
-        throw new Error('Select an organization before linking admins to therapists.');
+        throw new Error('Select an organization before linking staff members to therapists.');
       }
 
       const { error } = await supabase.rpc('set_admin_therapist_link', {
@@ -645,7 +645,7 @@ export function AdminSettings() {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['admin-therapist-links', activeOrganizationId ?? 'ALL'] });
       setSelectedTherapistByAdmin((previous) => ({ ...previous, [variables.userId]: '' }));
-      showSuccess('Admin linked to therapist');
+      showSuccess('Staff member linked to therapist');
     },
     onError: (error) => {
       showError(error);
@@ -655,7 +655,7 @@ export function AdminSettings() {
   const unlinkAdminTherapistMutation = useMutation({
     mutationFn: async ({ userId, therapistId }: { userId: string; therapistId: string }) => {
       if (!activeOrganizationId) {
-        throw new Error('Select an organization before unlinking admins from therapists.');
+        throw new Error('Select an organization before unlinking staff members from therapists.');
       }
 
       const { error } = await supabase.rpc('delete_admin_therapist_link', {
@@ -670,7 +670,7 @@ export function AdminSettings() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin-therapist-links', activeOrganizationId ?? 'ALL'] });
-      showSuccess('Admin unlinked from therapist');
+      showSuccess('Staff member unlinked from therapist');
     },
     onError: (error) => {
       showError(error);
@@ -771,7 +771,7 @@ export function AdminSettings() {
   };
 
   const handleUnlinkAdminTherapist = async (userId: string, therapistId: string, therapistName: string) => {
-    const shouldUnlink = window.confirm(`Unlink this admin from ${therapistName}?`);
+    const shouldUnlink = window.confirm(`Unlink this staff member from ${therapistName}?`);
     if (!shouldUnlink) {
       return;
     }
@@ -947,6 +947,7 @@ export function AdminSettings() {
                     <th scope="col" className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Organization</th>
                     <th scope="col" className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Role</th>
                     <th scope="col" className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Status</th>
+                    <th scope="col" className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Therapist Links</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
@@ -996,6 +997,71 @@ export function AdminSettings() {
                           }`}>
                             {employee.is_active === false ? 'Inactive' : 'Active'}
                           </span>
+                        </td>
+                        <td className="px-3 py-3 align-top">
+                          {!activeOrganizationId ? (
+                            <span className="text-xs text-amber-600 dark:text-amber-300">
+                              Select an organization to manage therapist links.
+                            </span>
+                          ) : isTherapistOptionsLoading || isAdminTherapistLinksLoading ? (
+                            <span className="text-xs text-gray-500 dark:text-gray-400">Loading therapist links…</span>
+                          ) : (
+                            <div className="space-y-2">
+                              <div className="flex flex-wrap gap-2">
+                                {(adminTherapistLinksByUser.get(employee.id) ?? []).length === 0 ? (
+                                  <span className="text-xs text-gray-500 dark:text-gray-400">No therapists linked</span>
+                                ) : (
+                                  (adminTherapistLinksByUser.get(employee.id) ?? []).map((link) => {
+                                    const therapistName = link.therapist_name ?? link.therapist_id;
+                                    return (
+                                      <span
+                                        key={`${employee.id}-${link.therapist_id}`}
+                                        className="inline-flex items-center gap-2 rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700 dark:bg-blue-900/20 dark:text-blue-200"
+                                      >
+                                        {therapistName}
+                                        <button
+                                          type="button"
+                                          className="text-blue-500 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50"
+                                          disabled={unlinkAdminTherapistMutation.isPending}
+                                          onClick={() => handleUnlinkAdminTherapist(employee.id, link.therapist_id, therapistName)}
+                                          aria-label={`Unlink ${therapistName} from ${employee.email}`}
+                                        >
+                                          ×
+                                        </button>
+                                      </span>
+                                    );
+                                  })
+                                )}
+                              </div>
+                              <div className="flex gap-2">
+                                <select
+                                  className="min-w-0 flex-1 rounded-md border border-gray-300 px-2 py-1 text-xs dark:border-gray-600 dark:bg-dark dark:text-gray-200"
+                                  value={selectedTherapistByAdmin[employee.id] ?? ''}
+                                  onChange={(event) => updateSelectedAdminTherapist(employee.id, event.target.value)}
+                                  aria-label={`Select therapist for ${employee.email}`}
+                                >
+                                  <option value="">Select therapist</option>
+                                  {therapistOptions.map((therapist) => (
+                                    <option key={therapist.id} value={therapist.id}>
+                                      {therapist.full_name ?? therapist.email ?? therapist.id}
+                                    </option>
+                                  ))}
+                                </select>
+                                <button
+                                  type="button"
+                                  className="rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                                  disabled={
+                                    linkAdminTherapistMutation.isPending ||
+                                    !selectedTherapistByAdmin[employee.id] ||
+                                    therapistOptions.length === 0
+                                  }
+                                  onClick={() => handleLinkAdminTherapist(employee.id)}
+                                >
+                                  Link
+                                </button>
+                              </div>
+                            </div>
+                          )}
                         </td>
                       </tr>
                     );

--- a/src/components/settings/__tests__/AdminSettings.test.tsx
+++ b/src/components/settings/__tests__/AdminSettings.test.tsx
@@ -612,7 +612,7 @@ describe('Admin therapist links', () => {
         }
       );
     });
-    expect(showSuccess).toHaveBeenCalledWith('Admin linked to therapist');
+    expect(showSuccess).toHaveBeenCalledWith('Staff member linked to therapist');
   });
 
   it('unlinks an existing admin therapist relationship through the scoped RPC', async () => {
@@ -657,8 +657,8 @@ describe('Admin therapist links', () => {
         }
       );
     });
-    expect(confirmSpy).toHaveBeenCalledWith(`Unlink this admin from ${mockTherapist.full_name}?`);
-    expect(showSuccess).toHaveBeenCalledWith('Admin unlinked from therapist');
+    expect(confirmSpy).toHaveBeenCalledWith(`Unlink this staff member from ${mockTherapist.full_name}?`);
+    expect(showSuccess).toHaveBeenCalledWith('Staff member unlinked from therapist');
   });
 
   it('surfaces scoped RPC denial without falling back to direct table writes', async () => {
@@ -878,6 +878,65 @@ describe('AdminSettings super admin access', () => {
     expect(showSuccess).toHaveBeenCalledWith('Employee role updated successfully');
   });
 
+  it('allows super admins to link an employee-role BCBA or midtier user to a therapist from the employee table', async () => {
+    rpcMock.mockImplementation(async (functionName: string, params?: Record<string, unknown>) => {
+      if (functionName === 'get_admin_users_paged') {
+        return { data: [mockAdminUser], error: null };
+      }
+      if (functionName === 'get_employee_users_paged') {
+        return {
+          data: [{ ...mockEmployeeUser, role: 'bcba', email: 'bcba.employee@example.com' }],
+          error: null,
+        };
+      }
+      if (functionName === 'get_admin_linkable_therapists') {
+        return { data: [mockTherapist], error: null };
+      }
+      if (functionName === 'get_admin_therapist_links') {
+        return { data: [], error: null };
+      }
+      if (functionName === 'guardian_link_queue_admin_view') {
+        return { data: [], error: null };
+      }
+      if (functionName === 'set_admin_therapist_link') {
+        return {
+          data: [{
+            user_id: mockEmployeeUser.id,
+            therapist_id: mockTherapist.id,
+            therapist_name: mockTherapist.full_name,
+          }],
+          error: null,
+        };
+      }
+
+      if (defaultRpcImplementation) {
+        return defaultRpcImplementation(functionName, params as never);
+      }
+      return fallbackRpc(functionName, params);
+    });
+
+    renderWithProviders(<AdminSettings />);
+
+    await screen.findByRole('option', { name: 'Acme Behavioral' });
+    const filterSelect = await screen.findByDisplayValue('All organizations');
+    await userEvent.selectOptions(filterSelect, 'org-1');
+
+    const therapistSelect = await screen.findByLabelText('Select therapist for bcba.employee@example.com');
+    await userEvent.selectOptions(therapistSelect, mockTherapist.id);
+    const employeeRow = therapistSelect.closest('tr');
+    expect(employeeRow).not.toBeNull();
+    await userEvent.click(within(employeeRow as HTMLTableRowElement).getByRole('button', { name: 'Link' }));
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('set_admin_therapist_link', {
+        target_user_id: mockEmployeeUser.id,
+        target_therapist_id: mockTherapist.id,
+        p_organization_id: 'org-1',
+      });
+    });
+    expect(showSuccess).toHaveBeenCalledWith('Staff member linked to therapist');
+  });
+
   it('shows row-level saving feedback while an employee role update is pending', async () => {
     callEdgeSpy?.mockReturnValue(new Promise<Response>(() => {}));
     renderWithProviders(<AdminSettings />);
@@ -905,7 +964,8 @@ describe('AdminSettings super admin access', () => {
     renderWithProviders(<AdminSettings />);
 
     const filterSelect = await screen.findByDisplayValue('All organizations');
-    await screen.findByText('Select an organization to manage therapist links.');
+    const placeholders = await screen.findAllByText('Select an organization to manage therapist links.');
+    expect(placeholders.length).toBeGreaterThan(0);
 
     expect(rpcMock.mock.calls.some(([fnName]) => fnName === 'get_admin_linkable_therapists')).toBe(false);
     expect(rpcMock.mock.calls.some(([fnName]) => fnName === 'get_admin_therapist_links')).toBe(false);

--- a/src/pages/TherapistDetails.tsx
+++ b/src/pages/TherapistDetails.tsx
@@ -15,7 +15,34 @@ export function TherapistDetails() {
   const { therapistId } = useParams<{ therapistId: string }>();
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<TabType>('profile');
-  const { profile, effectiveRole } = useAuth();
+  const { user, profile, effectiveRole } = useAuth();
+  const isSelfScopedRole = effectiveRole === 'bt' || effectiveRole === 'therapist';
+  const directlyOwnedTherapistIds = new Set(
+    [user?.id, profile?.id].filter((id): id is string => Boolean(id)),
+  );
+  const directlyOwnsTarget = Boolean(therapistId && directlyOwnedTherapistIds.has(therapistId));
+
+  const { data: linkedTherapistIds = [], isLoading: isAuthorizationLoading } = useQuery({
+    queryKey: ['therapist-record-access', user?.id],
+    queryFn: async () => {
+      if (!user?.id) return [];
+
+      const { data, error } = await supabase
+        .from('user_therapist_links')
+        .select('therapist_id')
+        .eq('user_id', user.id);
+
+      if (error) throw error;
+      return (data ?? [])
+        .map((row) => row.therapist_id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    },
+    enabled: isSelfScopedRole && Boolean(user?.id) && !directlyOwnsTarget,
+  });
+
+  const canViewTarget = !isSelfScopedRole
+    || directlyOwnsTarget
+    || Boolean(therapistId && linkedTherapistIds.includes(therapistId));
 
   const { data: therapist, isLoading } = useQuery({
     queryKey: ['therapist', therapistId],
@@ -31,7 +58,7 @@ export function TherapistDetails() {
       if (error) throw error;
       return data;
     },
-    enabled: !!therapistId,
+    enabled: Boolean(therapistId) && canViewTarget && !isAuthorizationLoading,
   });
 
   const tabs = [
@@ -41,10 +68,27 @@ export function TherapistDetails() {
     { id: 'clients' as TabType, name: 'Assigned Clients', icon: FileText },
   ];
 
-  if (isLoading) {
+  if (isAuthorizationLoading || isLoading) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (!canViewTarget) {
+    return (
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900/40 rounded-lg shadow p-8 text-red-700 dark:text-red-200">
+        <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+          You can only view your own therapist profile
+        </h2>
+        <button
+          onClick={() => navigate('/therapists')}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+        >
+          Back to Therapist List
+        </button>
       </div>
     );
   }
@@ -62,23 +106,6 @@ export function TherapistDetails() {
           className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
         >
           Return to Therapists
-        </button>
-      </div>
-    );
-  }
-
-  if (effectiveRole === 'therapist' && profile?.id !== therapist.id) {
-    return (
-      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900/40 rounded-lg shadow p-8 text-red-700 dark:text-red-200">
-        <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
-          You can only view your own therapist profile
-        </h2>
-        <button
-          onClick={() => navigate('/therapists')}
-          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-        >
-          Back to Therapist List
         </button>
       </div>
     );

--- a/src/pages/__tests__/TherapistDetails.test.tsx
+++ b/src/pages/__tests__/TherapistDetails.test.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TherapistDetails } from '../TherapistDetails';
+
+const mockUseAuth = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('../../lib/authContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+vi.mock('../../components/TherapistDetails/ProfileTab', () => ({
+  ProfileTab: () => <div>Profile content</div>,
+}));
+
+vi.mock('../../components/TherapistDetails/CertificationsTab', () => ({
+  CertificationsTab: () => <div>Certifications content</div>,
+}));
+
+vi.mock('../../components/TherapistDetails/ScheduleTab', () => ({
+  ScheduleTab: () => <div>Schedule content</div>,
+}));
+
+vi.mock('../../components/TherapistDetails/ClientsTab', () => ({
+  ClientsTab: () => <div>Clients content</div>,
+}));
+
+const renderDetails = (therapistId: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/therapists/${therapistId}`]}>
+        <Routes>
+          <Route path="/therapists/:therapistId" element={<TherapistDetails />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+describe('TherapistDetails record authorization', () => {
+  const therapistRecord = {
+    id: 'own-therapist-id',
+    full_name: 'Own Therapist',
+    weekly_hours_min: 10,
+    weekly_hours_max: 20,
+    service_type: ['In-home'],
+  };
+
+  beforeEach(() => {
+    mockFrom.mockReset();
+    mockUseAuth.mockReturnValue({
+      effectiveRole: 'bt',
+      profile: { id: 'auth-user-id', role: 'bt' },
+      user: {
+        id: 'auth-user-id',
+        user_metadata: { therapist_id: 'own-therapist-id' },
+      },
+    });
+  });
+
+  it('blocks a BT from fetching a foreign therapist record', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'user_therapist_links') {
+        return {
+          select: () => ({
+            eq: async () => ({ data: [], error: null }),
+          }),
+        };
+      }
+
+      throw new Error('A foreign therapist query must not be issued');
+    });
+
+    renderDetails('foreign-therapist-id');
+
+    expect(await screen.findByText(/only view your own therapist profile/i)).toBeInTheDocument();
+    await waitFor(() => expect(mockFrom).toHaveBeenCalledWith('user_therapist_links'));
+    expect(mockFrom).not.toHaveBeenCalledWith('therapists');
+  });
+
+  it('does not trust therapist ownership from mutable auth metadata', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'user_therapist_links') {
+        return {
+          select: () => ({
+            eq: async () => ({ data: [], error: null }),
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    renderDetails('own-therapist-id');
+
+    expect(await screen.findByText(/only view your own therapist profile/i)).toBeInTheDocument();
+    expect(mockFrom).toHaveBeenCalledWith('user_therapist_links');
+    expect(mockFrom).not.toHaveBeenCalledWith('therapists');
+  });
+
+  it('allows a BT to fetch a therapist record through the canonical user link', async () => {
+    const linkedTherapist = { ...therapistRecord, id: 'linked-therapist-id' };
+    mockUseAuth.mockReturnValue({
+      effectiveRole: 'bt',
+      profile: { id: 'auth-user-id', role: 'bt' },
+      user: { id: 'auth-user-id', user_metadata: {} },
+    });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'user_therapist_links') {
+        return {
+          select: () => ({
+            eq: async () => ({
+              data: [{ therapist_id: 'linked-therapist-id' }],
+              error: null,
+            }),
+          }),
+        };
+      }
+      if (table === 'therapists') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: linkedTherapist, error: null }),
+            }),
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    renderDetails('linked-therapist-id');
+
+    expect(await screen.findByText('Therapist Records: Own Therapist')).toBeInTheDocument();
+    expect(mockFrom).toHaveBeenCalledWith('user_therapist_links');
+    expect(mockFrom).toHaveBeenCalledWith('therapists');
+  });
+
+  it('fails closed when the canonical therapist link lookup fails', async () => {
+    mockUseAuth.mockReturnValue({
+      effectiveRole: 'bt',
+      profile: { id: 'auth-user-id', role: 'bt' },
+      user: { id: 'auth-user-id', user_metadata: {} },
+    });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'user_therapist_links') {
+        return {
+          select: () => ({
+            eq: async () => ({ data: null, error: new Error('link lookup failed') }),
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    renderDetails('foreign-therapist-id');
+
+    expect(await screen.findByText(/only view your own therapist profile/i)).toBeInTheDocument();
+    expect(mockFrom).not.toHaveBeenCalledWith('therapists');
+  });
+
+  it('preserves therapist record access for an admin role', async () => {
+    mockUseAuth.mockReturnValue({
+      effectiveRole: 'admin',
+      profile: { id: 'admin-user-id', role: 'admin' },
+      user: { id: 'admin-user-id', user_metadata: {} },
+    });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'therapists') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: therapistRecord, error: null }),
+            }),
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    renderDetails('foreign-therapist-id');
+
+    expect(await screen.findByText('Therapist Records: Own Therapist')).toBeInTheDocument();
+    expect(mockFrom).not.toHaveBeenCalledWith('user_therapist_links');
+    expect(mockFrom).toHaveBeenCalledWith('therapists');
+  });
+});

--- a/supabase/migrations/20260804103000_expand_staff_therapist_link_targets.sql
+++ b/supabase/migrations/20260804103000_expand_staff_therapist_link_targets.sql
@@ -1,0 +1,340 @@
+-- @migration-intent: Expand therapist-link RPC targets from admin-only users to canonical employee-role users without widening caller authority.
+-- @migration-dependencies: public.user_therapist_links, public.therapists, public.profiles, public.user_roles, public.roles, app.resolve_user_organization_id
+-- @migration-rollback: Re-apply supabase/migrations/20260506190000_fix_admin_therapist_link_active_filter.sql if rollback is required.
+
+begin;
+
+create or replace function public.get_admin_linkable_therapists(
+  p_organization_id uuid
+)
+returns table (
+  id uuid,
+  full_name text,
+  email text
+)
+language plpgsql
+security definer
+stable
+set search_path = public, auth, app
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_is_super_admin boolean;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  if p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Organization context required';
+  end if;
+
+  v_is_super_admin := app.current_user_is_super_admin();
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+
+  if not v_is_super_admin then
+    if v_actor_org is null or v_actor_org <> p_organization_id then
+      raise exception using errcode = '42501', message = 'Caller organization mismatch';
+    end if;
+
+    if not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_actor
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+        and r.name in ('admin', 'org_admin', 'super_admin', 'org_super_admin')
+    ) then
+      raise exception using errcode = '42501', message = 'Only administrators can view linkable therapists';
+    end if;
+  end if;
+
+  return query
+  select t.id, t.full_name, t.email
+  from public.therapists t
+  where t.organization_id = p_organization_id
+    and lower(coalesce(t.status, 'active')) = 'active'
+    and t.deleted_at is null
+  order by t.full_name nulls last, t.email nulls last, t.id;
+end;
+$$;
+
+create or replace function public.get_admin_therapist_links(
+  p_organization_id uuid
+)
+returns table (
+  user_id uuid,
+  therapist_id uuid,
+  therapist_name text
+)
+language plpgsql
+security definer
+stable
+set search_path = public, auth, app
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_is_super_admin boolean;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  if p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Organization context required';
+  end if;
+
+  v_is_super_admin := app.current_user_is_super_admin();
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+
+  if not v_is_super_admin then
+    if v_actor_org is null or v_actor_org <> p_organization_id then
+      raise exception using errcode = '42501', message = 'Caller organization mismatch';
+    end if;
+
+    if not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_actor
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+        and r.name in ('admin', 'org_admin', 'super_admin', 'org_super_admin')
+    ) then
+      raise exception using errcode = '42501', message = 'Only administrators can view therapist links for this organization';
+    end if;
+  end if;
+
+  return query
+  select
+    utl.user_id,
+    utl.therapist_id,
+    t.full_name as therapist_name
+  from public.user_therapist_links utl
+  join public.therapists t
+    on t.id = utl.therapist_id
+   and t.organization_id = p_organization_id
+   and lower(coalesce(t.status, 'active')) = 'active'
+   and t.deleted_at is null
+  join public.profiles p
+    on p.id = utl.user_id
+   and p.organization_id = p_organization_id
+  where exists (
+    select 1
+    from public.user_roles ur
+    join public.roles r on r.id = ur.role_id
+    where ur.user_id = utl.user_id
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+      and (
+        r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')
+        or (
+          v_is_super_admin
+          and r.name in ('bt', 'therapist', 'midtier', 'admin_schedule', 'bcba')
+        )
+      )
+  )
+  order by t.full_name nulls last, utl.created_at;
+end;
+$$;
+
+create or replace function public.set_admin_therapist_link(
+  target_user_id uuid,
+  target_therapist_id uuid,
+  p_organization_id uuid
+)
+returns table (
+  user_id uuid,
+  therapist_id uuid,
+  therapist_name text
+)
+language plpgsql
+security definer
+set search_path = public, auth, app
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_target_org uuid;
+  v_therapist_org uuid;
+  v_is_super_admin boolean;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  if target_user_id is null or target_therapist_id is null or p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Target user, therapist, and organization are required';
+  end if;
+
+  v_is_super_admin := app.current_user_is_super_admin();
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+
+  if not v_is_super_admin then
+    if v_actor_org is null or v_actor_org <> p_organization_id then
+      raise exception using errcode = '42501', message = 'Caller organization mismatch';
+    end if;
+
+    if not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_actor
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+        and r.name in ('admin', 'org_admin', 'super_admin', 'org_super_admin')
+    ) then
+      raise exception using errcode = '42501', message = 'Only administrators can manage therapist links for this organization';
+    end if;
+  end if;
+
+  v_target_org := app.resolve_user_organization_id(target_user_id);
+  if v_target_org is null or v_target_org <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Target user organization mismatch';
+  end if;
+
+  if not exists (
+    select 1
+    from public.user_roles ur
+    join public.roles r on r.id = ur.role_id
+    where ur.user_id = target_user_id
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+      and (
+        r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')
+        or (
+          v_is_super_admin
+          and r.name in ('bt', 'therapist', 'midtier', 'admin_schedule', 'bcba')
+        )
+      )
+  ) then
+    raise exception using errcode = '42501', message = 'Target user does not hold a linkable role for this caller';
+  end if;
+
+  select t.organization_id
+  into v_therapist_org
+  from public.therapists t
+  where t.id = target_therapist_id
+    and lower(coalesce(t.status, 'active')) = 'active'
+    and t.deleted_at is null;
+
+  if v_therapist_org is null then
+    raise exception using errcode = '22023', message = 'Therapist not found or inactive';
+  end if;
+
+  if v_therapist_org <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Therapist organization mismatch';
+  end if;
+
+  insert into public.user_therapist_links (user_id, therapist_id)
+  values (target_user_id, target_therapist_id)
+  on conflict (user_id, therapist_id) do nothing;
+
+  return query
+  select target_user_id, t.id, t.full_name
+  from public.therapists t
+  where t.id = target_therapist_id;
+end;
+$$;
+
+create or replace function public.delete_admin_therapist_link(
+  target_user_id uuid,
+  target_therapist_id uuid,
+  p_organization_id uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, auth, app
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_target_org uuid;
+  v_therapist_org uuid;
+  v_is_super_admin boolean;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  if target_user_id is null or target_therapist_id is null or p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Target user, therapist, and organization are required';
+  end if;
+
+  v_is_super_admin := app.current_user_is_super_admin();
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+
+  if not v_is_super_admin then
+    if v_actor_org is null or v_actor_org <> p_organization_id then
+      raise exception using errcode = '42501', message = 'Caller organization mismatch';
+    end if;
+
+    if not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_actor
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+        and r.name in ('admin', 'org_admin', 'super_admin', 'org_super_admin')
+    ) then
+      raise exception using errcode = '42501', message = 'Only administrators can manage therapist links for this organization';
+    end if;
+  end if;
+
+  v_target_org := app.resolve_user_organization_id(target_user_id);
+  if v_target_org is null or v_target_org <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Target user organization mismatch';
+  end if;
+
+  if not exists (
+    select 1
+    from public.user_roles ur
+    join public.roles r on r.id = ur.role_id
+    where ur.user_id = target_user_id
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+      and (
+        r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')
+        or (
+          v_is_super_admin
+          and r.name in ('bt', 'therapist', 'midtier', 'admin_schedule', 'bcba')
+        )
+      )
+  ) then
+    raise exception using errcode = '42501', message = 'Target user does not hold a linkable role for this caller';
+  end if;
+
+  select t.organization_id
+  into v_therapist_org
+  from public.therapists t
+  where t.id = target_therapist_id
+    and t.deleted_at is null;
+
+  if v_therapist_org is null or v_therapist_org <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Therapist organization mismatch';
+  end if;
+
+  delete from public.user_therapist_links
+  where user_id = target_user_id
+    and therapist_id = target_therapist_id;
+
+  return true;
+end;
+$$;
+
+revoke execute on function public.get_admin_linkable_therapists(uuid) from public, anon;
+revoke execute on function public.get_admin_therapist_links(uuid) from public, anon;
+revoke execute on function public.set_admin_therapist_link(uuid, uuid, uuid) from public, anon;
+revoke execute on function public.delete_admin_therapist_link(uuid, uuid, uuid) from public, anon;
+
+grant execute on function public.get_admin_linkable_therapists(uuid) to authenticated, service_role;
+grant execute on function public.get_admin_therapist_links(uuid) to authenticated, service_role;
+grant execute on function public.set_admin_therapist_link(uuid, uuid, uuid) to authenticated, service_role;
+grant execute on function public.delete_admin_therapist_link(uuid, uuid, uuid) to authenticated, service_role;
+
+commit;

--- a/supabase/migrations/20260804211800_allow_user_therapist_link_self_read.sql
+++ b/supabase/migrations/20260804211800_allow_user_therapist_link_self_read.sql
@@ -1,0 +1,16 @@
+-- @migration-intent: Allow authenticated staff to read only their own canonical user-to-therapist links for record-level self-authorization.
+-- @migration-dependencies: public.user_therapist_links, auth.uid
+-- @migration-rollback: Drop policy public.user_therapist_links_self_select from public.user_therapist_links.
+
+begin;
+
+drop policy if exists user_therapist_links_self_select
+  on public.user_therapist_links;
+
+create policy user_therapist_links_self_select
+  on public.user_therapist_links
+  for select
+  to authenticated
+  using (user_id = (select auth.uid()));
+
+commit;

--- a/tests/edge/adminTherapistLinkEmployeeTargets.contract.test.ts
+++ b/tests/edge/adminTherapistLinkEmployeeTargets.contract.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260804103000_expand_staff_therapist_link_targets.sql',
+);
+
+const readMigration = () => fs.readFileSync(MIGRATION_PATH, 'utf8').replace(/\r\n/g, '\n');
+
+const extractFunction = (sql: string, functionName: string) => {
+  const start = sql.indexOf(`create or replace function public.${functionName}(`);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const nextFunction = sql.indexOf('create or replace function public.', start + 1);
+  return sql.slice(start, nextFunction === -1 ? sql.length : nextFunction);
+};
+
+describe('admin therapist link employee-target repair', () => {
+  it('keeps non-super-admin callers on admin targets while allowing super admins to manage the broader employee role tree', () => {
+    const sql = readMigration();
+    const listFn = extractFunction(sql, 'get_admin_therapist_links');
+    const setFn = extractFunction(sql, 'set_admin_therapist_link');
+    const deleteFn = extractFunction(sql, 'delete_admin_therapist_link');
+
+    expect(sql.match(/r\.name in \('admin', 'org_admin', 'super_admin', 'org_super_admin'\)/g)?.length ?? 0).toBeGreaterThanOrEqual(4);
+
+    for (const fn of [listFn, setFn, deleteFn]) {
+      expect(fn).toContain("r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')");
+      expect(fn).toContain("v_is_super_admin");
+      expect(fn).toContain("and r.name in ('bt', 'therapist', 'midtier', 'admin_schedule', 'bcba')");
+    }
+
+    expect(setFn).toContain("raise exception using errcode = '42501', message = 'Target user does not hold a linkable role for this caller'");
+    expect(deleteFn).toContain("raise exception using errcode = '42501', message = 'Target user does not hold a linkable role for this caller'");
+  });
+
+  it('keeps execute grants scoped to authenticated and service_role only', () => {
+    const sql = readMigration();
+
+    expect(sql).toContain('revoke execute on function public.get_admin_linkable_therapists(uuid) from public, anon;');
+    expect(sql).toContain('revoke execute on function public.get_admin_therapist_links(uuid) from public, anon;');
+    expect(sql).toContain('revoke execute on function public.set_admin_therapist_link(uuid, uuid, uuid) from public, anon;');
+    expect(sql).toContain('revoke execute on function public.delete_admin_therapist_link(uuid, uuid, uuid) from public, anon;');
+
+    expect(sql).toContain('grant execute on function public.get_admin_linkable_therapists(uuid) to authenticated, service_role;');
+    expect(sql).toContain('grant execute on function public.get_admin_therapist_links(uuid) to authenticated, service_role;');
+    expect(sql).toContain('grant execute on function public.set_admin_therapist_link(uuid, uuid, uuid) to authenticated, service_role;');
+    expect(sql).toContain('grant execute on function public.delete_admin_therapist_link(uuid, uuid, uuid) to authenticated, service_role;');
+  });
+
+  it('keeps same-org therapist checks and active therapist filtering in the write paths', () => {
+    const sql = readMigration();
+    const setFn = extractFunction(sql, 'set_admin_therapist_link');
+    const deleteFn = extractFunction(sql, 'delete_admin_therapist_link');
+
+    expect(setFn).toContain("v_target_org is null or v_target_org <> p_organization_id");
+    expect(setFn).toContain("lower(coalesce(t.status, 'active')) = 'active'");
+    expect(setFn).toContain('t.deleted_at is null');
+    expect(setFn).toContain('insert into public.user_therapist_links (user_id, therapist_id)');
+
+    expect(deleteFn).toContain("v_target_org is null or v_target_org <> p_organization_id");
+    expect(deleteFn).toContain('delete from public.user_therapist_links');
+    expect(deleteFn).toContain("where user_id = target_user_id\n    and therapist_id = target_therapist_id");
+  });
+});

--- a/tests/edge/userTherapistLinksSelfRead.contract.test.ts
+++ b/tests/edge/userTherapistLinksSelfRead.contract.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("user_therapist_links self-read policy", () => {
+  it("lets authenticated users select only their own canonical therapist links", () => {
+    const migrationDir = resolve("supabase/migrations");
+    const source = readdirSync(migrationDir)
+      .filter((name) => name.endsWith(".sql"))
+      .map((name) => readFileSync(resolve(migrationDir, name), "utf8"))
+      .find((sql) => sql.includes("user_therapist_links_self_select"));
+
+    expect(source, "missing forward migration for canonical self-link reads").toBeDefined();
+    expect(source).toMatch(
+      /create\s+policy\s+user_therapist_links_self_select[\s\S]*?on\s+public\.user_therapist_links[\s\S]*?for\s+select[\s\S]*?to\s+authenticated/i,
+    );
+    expect(source).toMatch(/using\s*\(\s*user_id\s*=\s*\(\s*select\s+auth\.uid\(\)\s*\)\s*\)/i);
+    expect(source).not.toMatch(/grant\s+(?:insert|update|delete|all)[^;]*user_therapist_links/i);
+  });
+});

--- a/tests/scripts/fixtures/read-selected-session-plan-ids.ts
+++ b/tests/scripts/fixtures/read-selected-session-plan-ids.ts
@@ -1,0 +1,19 @@
+import { chromium } from "playwright";
+
+import { readSelectedSessionPlanIds } from "../../../scripts/lib/playwright-session-plan-controls";
+
+const browser = await chromium.launch({ headless: true });
+
+try {
+  const page = await browser.newPage();
+  await page.setContent(`
+    <input type="checkbox" data-program-id="program-selected" checked>
+    <input type="checkbox" data-program-id="program-unselected">
+    <button data-goal-id="goal-selected" aria-pressed="true"></button>
+    <button data-goal-id="goal-unselected" aria-pressed="false"></button>
+  `);
+
+  console.log(JSON.stringify(await readSelectedSessionPlanIds(page)));
+} finally {
+  await browser.close();
+}

--- a/tests/scripts/fixtures/read-selected-session-plan-ids.ts
+++ b/tests/scripts/fixtures/read-selected-session-plan-ids.ts
@@ -1,19 +1,41 @@
-import { chromium } from "playwright";
+import type { Page } from "playwright";
 
 import { readSelectedSessionPlanIds } from "../../../scripts/lib/playwright-session-plan-controls";
 
-const browser = await chromium.launch({ headless: true });
+class FixtureElement {
+  constructor(private readonly attributes: Record<string, string>) {}
 
-try {
-  const page = await browser.newPage();
-  await page.setContent(`
-    <input type="checkbox" data-program-id="program-selected" checked>
-    <input type="checkbox" data-program-id="program-unselected">
-    <button data-goal-id="goal-selected" aria-pressed="true"></button>
-    <button data-goal-id="goal-unselected" aria-pressed="false"></button>
-  `);
-
-  console.log(JSON.stringify(await readSelectedSessionPlanIds(page)));
-} finally {
-  await browser.close();
+  getAttribute(name: string): string | null {
+    return this.attributes[name] ?? null;
+  }
 }
+
+class FixtureInputElement extends FixtureElement {
+  constructor(attributes: Record<string, string>, readonly checked: boolean) {
+    super(attributes);
+  }
+}
+
+const elements = [
+  new FixtureInputElement({ "data-program-id": "program-selected" }, true),
+  new FixtureInputElement({ "data-program-id": "program-unselected" }, false),
+  new FixtureElement({ "data-goal-id": "goal-selected", "aria-pressed": "true" }),
+  new FixtureElement({ "data-goal-id": "goal-unselected", "aria-pressed": "false" }),
+];
+
+const page = {
+  evaluate: async <T>(callback: () => T): Promise<T> => {
+    const runInPageContext = Function(
+      "document",
+      "HTMLInputElement",
+      `return (${callback.toString()})()`,
+    ) as (documentValue: unknown, inputType: unknown) => T;
+
+    return runInPageContext(
+      { querySelectorAll: () => elements },
+      FixtureInputElement,
+    );
+  },
+} as unknown as Page;
+
+console.log(JSON.stringify(await readSelectedSessionPlanIds(page)));

--- a/tests/scripts/playwright-session-plan-controls.test.ts
+++ b/tests/scripts/playwright-session-plan-controls.test.ts
@@ -1,0 +1,23 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("readSelectedSessionPlanIds", () => {
+  it("reads selected ids when executed through the Playwright tsx runtime", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        resolve("node_modules/tsx/dist/cli.mjs"),
+        resolve("tests/scripts/fixtures/read-selected-session-plan-ids.ts"),
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      programIds: ["program-selected"],
+      goalIds: ["goal-selected"],
+    });
+  });
+});

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -233,5 +233,6 @@ describe('select-browser-checks', () => {
     const runCypressSource = readFileSync('scripts/run-cypress.ts', 'utf8');
 
     expect(runCypressSource).toContain("'cypress/e2e/preauth_workflow.cy.ts'");
+    expect(runCypressSource).toContain("cypressArgs.push('--browser', 'electron')");
   });
 });


### PR DESCRIPTION
## Summary
- expand super-admin therapist link targets to supported clinical, scheduling, and admin staff roles while preserving same-org and ordinary-admin restrictions
- add therapist-link controls to employee role management
- self-scope BT and legacy therapist detail access through canonical user-to-therapist links before protected records are fetched
- harden onboarding and browser harness behavior needed for decisive end-to-end verification

## Verification
- `npm run verify:local`
- post-rebase: `npm run ci:check-focused`, `npm run typecheck`, 53 focused tests, and `npm run build`
- Playwright therapist authorization smoke passed with configured credentials
- aggregate browser sequence passed auth, schedule conflict, onboarding, and therapist authorization; later stopped on unrelated local `/api/book` 404
- independent security re-review: no remaining findings

## Risk
Critical lane. Includes a Supabase migration and record-level authorization behavior. Human review is required. No hosted migration or deployment was performed.

Linear: [WIN-274](https://linear.app/winningedgeai/issue/WIN-274/link-bcba-staff-roles-to-therapist-records-safely)