### PR TITLE
fix: disambiguate admin therapist link upsert

### DIFF
--- a/docs/ai/handoffs/WIN-274-bcba-staff-links.md
+++ b/docs/ai/handoffs/WIN-274-bcba-staff-links.md
@@ -46,3 +46,27 @@
 
 - Linear: [WIN-274](https://linear.app/winningedgeai/issue/WIN-274/link-bcba-staff-roles-to-therapist-records-safely)
 - Branch: `codex/win-274-bcba-staff-links`
+
+## Production Link-Mutation Follow-up
+
+- Production `set_admin_therapist_link` returned HTTP 400 after the original merge.
+- Live Postgres logs and the deployed function definition confirmed `column reference "user_id" is ambiguous` at the insert conflict target.
+- Cause: the RPC returns output columns named `user_id` and `therapist_id`, which collide with `on conflict (user_id, therapist_id)` inside PL/pgSQL.
+- Forward repair: redefine only `set_admin_therapist_link` and target the confirmed `user_therapist_links_user_id_therapist_id_key` constraint explicitly.
+- Migration application fails closed unless that named unique constraint covers exactly `(user_id, therapist_id)` in order.
+- Caller authentication, role allowlists, tenant checks, function signature, return shape, and execute grants remain unchanged.
+- Follow-up branch: `codex/win-274-link-rpc-followup`.
+- Local proof: focused contracts `5/5`, full suite `3999/3999`, policy checks, tenant safety, lint, typecheck, and production build pass.
+- Hosted read-only proof: the migration's exact constraint-shape guard evaluates true against the production schema.
+- Remaining closure proof: preview migration replay, human review, merge, production migration confirmation, and a successful hosted link mutation.
+
+### Verification Card
+
+- Classification: high-risk human-reviewed
+- Lane: critical
+- Change type: database migration, tenant-scoped security-definer RPC
+- Required checks: `npm run ci:check-focused`, `npm run test:ci`, `npm run validate:tenant`, `npm run build`, focused migration contracts, hosted schema-shape preflight, `npm run verify:local`
+- Executed checks: policy pass; full suite pass (`472` files, `3999` tests); tenant validation pass; build pass; focused contracts pass (`5/5`); hosted schema-shape preflight pass; aggregate `verify:local` pass, including `220/220` Tier-0 route checks
+- Blocked checks: local migration runtime replay unavailable because the local Supabase database container is not running; use the PR preview branch for runtime proof
+- Result: pass-with-blocked-checks pending preview runtime replay
+- Residual risk: the SQL has not yet executed on an isolated Supabase preview branch, and critical-lane human review remains mandatory before merge

--- a/docs/ai/handoffs/WIN-274-bcba-staff-links.md
+++ b/docs/ai/handoffs/WIN-274-bcba-staff-links.md
@@ -58,7 +58,8 @@
 - Follow-up branch: `codex/win-274-link-rpc-followup`.
 - Local proof: focused contracts `5/5`, full suite `3999/3999`, policy checks, tenant safety, lint, typecheck, and production build pass.
 - Hosted read-only proof: the migration's exact constraint-shape guard evaluates true against the production schema.
-- Remaining closure proof: preview migration replay, human review, merge, production migration confirmation, and a successful hosted link mutation.
+- Preview runtime proof: migration `20260805160000` applied; the function uses the named constraint; grants remain denied to `anon` and allowed to `authenticated`/`service_role`; two transactional calls returned one row each and left exactly one link row; rollback restored the seeded fixture and removed the temp proof table.
+- Remaining closure proof: human review, merge, production migration confirmation, and a successful hosted link mutation.
 
 ### Verification Card
 
@@ -67,6 +68,6 @@
 - Change type: database migration, tenant-scoped security-definer RPC
 - Required checks: `npm run ci:check-focused`, `npm run test:ci`, `npm run validate:tenant`, `npm run build`, focused migration contracts, hosted schema-shape preflight, `npm run verify:local`
 - Executed checks: policy pass; full suite pass (`472` files, `3999` tests); tenant validation pass; build pass; focused contracts pass (`5/5`); hosted schema-shape preflight pass; aggregate `verify:local` pass, including `220/220` Tier-0 route checks
-- Blocked checks: local migration runtime replay unavailable because the local Supabase database container is not running; use the PR preview branch for runtime proof
-- Result: pass-with-blocked-checks pending preview runtime replay
-- Residual risk: the SQL has not yet executed on an isolated Supabase preview branch, and critical-lane human review remains mandatory before merge
+- Blocked checks: none; local migration runtime was unavailable, so the equivalent isolated replay and rollback-safe mutation proof ran on the PR Supabase preview branch
+- Result: pass
+- Residual risk: critical-lane human review remains mandatory before merge, followed by production migration and hosted UI mutation confirmation

--- a/supabase/migrations/20260805160000_disambiguate_admin_therapist_link_conflict.sql
+++ b/supabase/migrations/20260805160000_disambiguate_admin_therapist_link_conflict.sql
@@ -1,0 +1,141 @@
+-- @migration-intent: Disambiguate the admin therapist-link upsert conflict target without changing caller or tenant authorization.
+-- @migration-dependencies: public.user_therapist_links_user_id_therapist_id_key, 20260804103000_expand_staff_therapist_link_targets.sql
+-- @migration-rollback: Restore the prior authorization body only if required, while retaining ON CONFLICT ON CONSTRAINT user_therapist_links_user_id_therapist_id_key; do not restore the ambiguous column-list target.
+
+begin;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_catalog.pg_constraint c
+    where c.conrelid = 'public.user_therapist_links'::regclass
+      and c.conname = 'user_therapist_links_user_id_therapist_id_key'
+      and c.contype = 'u'
+      and c.conkey = array[
+        (
+          select a.attnum
+          from pg_catalog.pg_attribute a
+          where a.attrelid = c.conrelid
+            and a.attname = 'user_id'
+            and not a.attisdropped
+        ),
+        (
+          select a.attnum
+          from pg_catalog.pg_attribute a
+          where a.attrelid = c.conrelid
+            and a.attname = 'therapist_id'
+            and not a.attisdropped
+        )
+      ]::smallint[]
+  ) then
+    raise exception using
+      errcode = '55000',
+      message = 'Expected user/therapist link unique constraint is unavailable';
+  end if;
+end;
+$$;
+
+create or replace function public.set_admin_therapist_link(
+  target_user_id uuid,
+  target_therapist_id uuid,
+  p_organization_id uuid
+)
+returns table (
+  user_id uuid,
+  therapist_id uuid,
+  therapist_name text
+)
+language plpgsql
+security definer
+set search_path = public, auth, app
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_target_org uuid;
+  v_therapist_org uuid;
+  v_is_super_admin boolean;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+
+  if target_user_id is null or target_therapist_id is null or p_organization_id is null then
+    raise exception using errcode = '22023', message = 'Target user, therapist, and organization are required';
+  end if;
+
+  v_is_super_admin := app.current_user_is_super_admin();
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+
+  if not v_is_super_admin then
+    if v_actor_org is null or v_actor_org <> p_organization_id then
+      raise exception using errcode = '42501', message = 'Caller organization mismatch';
+    end if;
+
+    if not exists (
+      select 1
+      from public.user_roles ur
+      join public.roles r on r.id = ur.role_id
+      where ur.user_id = v_actor
+        and coalesce(ur.is_active, true) = true
+        and (ur.expires_at is null or ur.expires_at > now())
+        and r.name in ('admin', 'org_admin', 'super_admin', 'org_super_admin')
+    ) then
+      raise exception using errcode = '42501', message = 'Only administrators can manage therapist links for this organization';
+    end if;
+  end if;
+
+  v_target_org := app.resolve_user_organization_id(target_user_id);
+  if v_target_org is null or v_target_org <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Target user organization mismatch';
+  end if;
+
+  if not exists (
+    select 1
+    from public.user_roles ur
+    join public.roles r on r.id = ur.role_id
+    where ur.user_id = target_user_id
+      and coalesce(ur.is_active, true) = true
+      and (ur.expires_at is null or ur.expires_at > now())
+      and (
+        r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')
+        or (
+          v_is_super_admin
+          and r.name in ('bt', 'therapist', 'midtier', 'admin_schedule', 'bcba')
+        )
+      )
+  ) then
+    raise exception using errcode = '42501', message = 'Target user does not hold a linkable role for this caller';
+  end if;
+
+  select t.organization_id
+  into v_therapist_org
+  from public.therapists t
+  where t.id = target_therapist_id
+    and lower(coalesce(t.status, 'active')) = 'active'
+    and t.deleted_at is null;
+
+  if v_therapist_org is null then
+    raise exception using errcode = '22023', message = 'Therapist not found or inactive';
+  end if;
+
+  if v_therapist_org <> p_organization_id then
+    raise exception using errcode = '42501', message = 'Therapist organization mismatch';
+  end if;
+
+  insert into public.user_therapist_links (user_id, therapist_id)
+  values (target_user_id, target_therapist_id)
+  on conflict on constraint user_therapist_links_user_id_therapist_id_key do nothing;
+
+  return query
+  select target_user_id, t.id, t.full_name
+  from public.therapists t
+  where t.id = target_therapist_id;
+end;
+$$;
+
+revoke execute on function public.set_admin_therapist_link(uuid, uuid, uuid) from public, anon;
+grant execute on function public.set_admin_therapist_link(uuid, uuid, uuid) to authenticated, service_role;
+
+commit;

--- a/tests/edge/adminTherapistLinkConflictTarget.contract.test.ts
+++ b/tests/edge/adminTherapistLinkConflictTarget.contract.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260805160000_disambiguate_admin_therapist_link_conflict.sql',
+);
+
+const readMigration = () => fs.readFileSync(MIGRATION_PATH, 'utf8').replace(/\r\n/g, '\n');
+
+describe('admin therapist link conflict target repair', () => {
+  it('uses the named user/therapist unique constraint instead of ambiguous output column names', () => {
+    const sql = readMigration();
+
+    expect(sql).toContain('create or replace function public.set_admin_therapist_link(');
+    expect(sql).toContain(
+      'on conflict on constraint user_therapist_links_user_id_therapist_id_key do nothing',
+    );
+    expect(sql).not.toContain('on conflict (user_id, therapist_id) do nothing');
+    expect(sql).toContain('from pg_catalog.pg_constraint c');
+    expect(sql).toContain("c.conname = 'user_therapist_links_user_id_therapist_id_key'");
+    expect(sql).toContain("c.contype = 'u'");
+    expect(sql).toContain('c.conkey = array[');
+    expect(sql).toContain('from pg_catalog.pg_attribute a');
+    expect(sql).toContain("a.attname = 'user_id'");
+    expect(sql).toContain("a.attname = 'therapist_id'");
+    expect(sql).toContain(']::smallint[]');
+    expect(sql).not.toContain(
+      'Re-apply supabase/migrations/20260804103000_expand_staff_therapist_link_targets.sql',
+    );
+    expect(sql).toContain(
+      'while retaining ON CONFLICT ON CONSTRAINT user_therapist_links_user_id_therapist_id_key',
+    );
+  });
+
+  it('preserves the protected caller, target-role, tenant, and execute-grant boundaries', () => {
+    const sql = readMigration();
+
+    expect(sql).toContain('v_is_super_admin := app.current_user_is_super_admin()');
+    expect(sql).toContain("r.name in ('admin', 'super_admin', 'org_admin', 'org_super_admin')");
+    expect(sql).toContain("r.name in ('bt', 'therapist', 'midtier', 'admin_schedule', 'bcba')");
+    expect(sql).toContain('v_target_org is null or v_target_org <> p_organization_id');
+    expect(sql).toContain('v_therapist_org <> p_organization_id');
+    expect(sql).toContain(
+      'revoke execute on function public.set_admin_therapist_link(uuid, uuid, uuid) from public, anon;',
+    );
+    expect(sql).toContain(
+      'grant execute on function public.set_admin_therapist_link(uuid, uuid, uuid) to authenticated, service_role;',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- fix the production `set_admin_therapist_link` HTTP 400 caused by PL/pgSQL output-column ambiguity in `ON CONFLICT (user_id, therapist_id)`
- target the existing named unique constraint explicitly and fail closed unless it covers exactly `(user_id, therapist_id)`
- preserve the existing authentication, role, tenant, return-shape, and execute-grant boundaries
- add a focused migration contract and record the WIN-274 follow-up evidence

## Route
- issue: WIN-274
- classification: high-risk human-reviewed
- lane: critical
- protected path: `supabase/migrations/**`
- human review required before merge

## Verification
- `npm run verify:local` (pass: 3999 tests, coverage, build, 220 Tier-0 routes)
- `npm run validate:tenant` (pass)
- focused admin therapist-link contracts (5/5)
- hosted read-only production constraint-shape preflight (pass)
- code-review-engineer, security-engineer, and supabase-reviewer: APPROVE
- all PR checks green, including Supabase Preview, tenant safety, migration lint, unit coverage, build, auth browser, Tier-0 browser, Netlify, and `ci-gate`

## Supabase preview proof
- migration `20260805160000` applied on preview project `ewpynzdfcrcwterzlxqc`
- deployed RPC uses the named constraint
- `anon` execute remains denied; `authenticated` and `service_role` remain allowed
- first and duplicate transactional calls each returned one row and left exactly one link row
- rollback restored the seeded fixture and removed the temporary proof table

## Remaining proof
- critical-lane human review
- after reviewed merge: production migration confirmation and hosted UI mutation

## Risk
The migration redefines a tenant-scoped security-definer RPC. It does not widen callers or grants. Preview runtime proof is complete; human review remains mandatory before merge.