### PR TITLE
fix(ci): use provisioned lifecycle fallback

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -258,7 +258,7 @@ Fail-fast contract:
 
 - Run `npm run playwright:preflight` first.
 - Preflight now hard-fails when session-flow requirements are missing/placeholder:
-  - credential pair: `PW_SCHEDULE_EMAIL/PW_SCHEDULE_PASSWORD` **or** `PW_ADMIN_EMAIL/PW_ADMIN_PASSWORD`
+  - credential pair: `PW_SUPERADMIN_EMAIL/PW_SUPERADMIN_PASSWORD`, `PW_SCHEDULE_EMAIL/PW_SCHEDULE_PASSWORD`, **or** `PW_ADMIN_EMAIL/PW_ADMIN_PASSWORD`
   - `VITE_SUPABASE_URL`
   - `VITE_SUPABASE_ANON_KEY` (or `SUPABASE_ANON_KEY`)
   - `SUPABASE_SERVICE_ROLE_KEY`

--- a/docs/ai/playwright-readiness-and-optional-smoke.md
+++ b/docs/ai/playwright-readiness-and-optional-smoke.md
@@ -43,7 +43,7 @@ The readiness report treats these as required for the critical browser environme
 - `PW_ASSESSMENT_CLIENT_ID` / `PW_ASSESSMENT_SAMPLE_FILE`
 - Supabase runtime URL, anon/publishable key, and service-role key
 
-The dynamic `PW_SUPERADMIN_*` lifecycle account remains owned by `scripts/provision-ci-smoke-admin.ts`; readiness only reports whether a super-admin pair is already configured.
+The dynamic `PW_SUPERADMIN_*` lifecycle account remains owned by `scripts/provision-ci-smoke-admin.ts`. Shared blocked-close and measurement flows retain schedule/admin precedence; no-show and complete lifecycle flows attempt the provisioned superadmin before the schedule fallback when the durable admin pair cannot authenticate. Readiness only reports whether a super-admin pair is already configured.
 
 Dedicated `PW_CLINICAL_QA_*` credentials are optional in the readiness report but preferred for recurring staff upload/output parity. If they are absent, the report makes that visible without blocking normal CI. Browser artifact capture for clinical QA also requires `PW_CLINICAL_QA_TARGET_MARKER` with one of `redacted`, `synthetic`, `smoke`, or `test`.
 

--- a/scripts/ci/select-browser-checks.mjs
+++ b/scripts/ci/select-browser-checks.mjs
@@ -165,6 +165,7 @@ const classifyFile = (file) => {
     /^cypress\/e2e\/routes_auth\.cy\.ts$/,
     /^scripts\/playwright-/,
     /^scripts\/lib\/playwright-inprogress-session-setup\.ts$/,
+    /^scripts\/lib\/playwright-nonai-sessions-contract\.ts$/,
     /^scripts\/lib\/playwright-smoke\.ts$/,
     /^supabase\/functions\/(sessions-|session-|auth-|programs|goals|program-notes)/,
   ])) {

--- a/scripts/lib/playwright-nonai-sessions-contract.ts
+++ b/scripts/lib/playwright-nonai-sessions-contract.ts
@@ -49,6 +49,8 @@ const buildFailureMessage = (flowLabel: string, issues: EnvIssue[], extraGuidanc
 };
 
 export const resolveNonAiSessionCredentialCandidates = (): CredentialCandidate[] => {
+  const superadminEmail = normalizeEnvValue(process.env.PW_SUPERADMIN_EMAIL);
+  const superadminPassword = normalizeEnvValue(process.env.PW_SUPERADMIN_PASSWORD);
   const scheduleEmail = normalizeEnvValue(process.env.PW_SCHEDULE_EMAIL);
   const schedulePassword = normalizeEnvValue(process.env.PW_SCHEDULE_PASSWORD);
   const adminEmail = normalizeEnvValue(process.env.PW_ADMIN_EMAIL ?? process.env.PLAYWRIGHT_ADMIN_EMAIL);
@@ -67,6 +69,13 @@ export const resolveNonAiSessionCredentialCandidates = (): CredentialCandidate[]
       email: adminEmail,
       password: adminPassword,
       label: "PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD",
+    });
+  }
+  if (superadminEmail && superadminPassword) {
+    candidates.push({
+      email: superadminEmail,
+      password: superadminPassword,
+      label: "PW_SUPERADMIN_EMAIL + PW_SUPERADMIN_PASSWORD",
     });
   }
   return candidates;
@@ -92,9 +101,16 @@ export const assertNonAiSessionsEnvContract = (flowLabel: string): CredentialCan
   const serviceRole = normalizeEnvValue(process.env.SUPABASE_SERVICE_ROLE_KEY);
   collectIssue(issues, "SUPABASE_SERVICE_ROLE_KEY", serviceRole);
 
+  const superadminEmail = normalizeEnvValue(process.env.PW_SUPERADMIN_EMAIL);
+  const superadminPassword = normalizeEnvValue(process.env.PW_SUPERADMIN_PASSWORD);
+  if (superadminEmail || superadminPassword) {
+    collectIssue(issues, "PW_SUPERADMIN_EMAIL", superadminEmail);
+    collectIssue(issues, "PW_SUPERADMIN_PASSWORD", superadminPassword);
+  }
+
   const candidates = resolveNonAiSessionCredentialCandidates();
   if (candidates.length === 0) {
-    issues.push({ key: "PW_SCHEDULE_* or PW_ADMIN_* credential pair", reason: "missing" });
+    issues.push({ key: "PW_SUPERADMIN_*, PW_SCHEDULE_*, or PW_ADMIN_* credential pair", reason: "missing" });
   }
 
   if (issues.length > 0) {
@@ -102,7 +118,7 @@ export const assertNonAiSessionsEnvContract = (flowLabel: string): CredentialCan
       buildFailureMessage(
         flowLabel,
         issues,
-        "Set either PW_SCHEDULE_EMAIL/PW_SCHEDULE_PASSWORD or PW_ADMIN_EMAIL/PW_ADMIN_PASSWORD.",
+        "Set PW_SUPERADMIN_EMAIL/PW_SUPERADMIN_PASSWORD, PW_SCHEDULE_EMAIL/PW_SCHEDULE_PASSWORD, or PW_ADMIN_EMAIL/PW_ADMIN_PASSWORD.",
       ),
     );
   }

--- a/scripts/playwright-session-lifecycle.ts
+++ b/scripts/playwright-session-lifecycle.ts
@@ -1835,6 +1835,19 @@ async function markTerminalViaScheduleModal(
   await editDialog.waitFor({ state: "hidden", timeout: 90_000 }).catch(() => undefined);
 }
 
+export const resolveLifecycleCredentialCandidates = (
+  flowLabel = "Session lifecycle Playwright regression",
+) =>
+  assertNonAiSessionsEnvContract(flowLabel)
+    .sort((left, right) => {
+      const priority = (label: string): number => {
+        if (label.startsWith("PW_ADMIN_")) return 0;
+        if (label.startsWith("PW_SUPERADMIN_")) return 1;
+        return 2;
+      };
+      return priority(left.label) - priority(right.label);
+    });
+
 export async function run() {
   loadPlaywrightEnv();
   const base = getEnv("PW_BASE_URL", "https://app.allincompassing.ai");
@@ -1845,16 +1858,9 @@ export async function run() {
     throw new Error("PW_LIFECYCLE_TERMINAL_STATUS must be either 'no-show' or 'completed'.");
   }
   const terminalStatus = terminalStatusRaw as TerminalStatus;
-  const credentialCandidates = assertNonAiSessionsEnvContract(
+  const credentialCandidates = resolveLifecycleCredentialCandidates(
     `Session lifecycle (${terminalStatus}) Playwright regression`,
-  ).sort((left, right) => {
-    const leftIsAdmin = left.label.startsWith("PW_ADMIN_");
-    const rightIsAdmin = right.label.startsWith("PW_ADMIN_");
-    if (leftIsAdmin === rightIsAdmin) {
-      return 0;
-    }
-    return leftIsAdmin ? -1 : 1;
-  });
+  );
   console.log(
     JSON.stringify({
       ok: true,

--- a/tests/scripts/playwright-nonai-sessions-contract.test.ts
+++ b/tests/scripts/playwright-nonai-sessions-contract.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  assertNonAiSessionsEnvContract,
+  resolveNonAiSessionCredentialCandidates,
+} from '../../scripts/lib/playwright-nonai-sessions-contract';
+import { resolveLifecycleCredentialCandidates } from '../../scripts/playwright-session-lifecycle';
+
+const CONTRACT_ENV_KEYS = [
+  'PW_BASE_URL',
+  'PW_SUPERADMIN_EMAIL',
+  'PW_SUPERADMIN_PASSWORD',
+  'PW_SCHEDULE_EMAIL',
+  'PW_SCHEDULE_PASSWORD',
+  'PW_ADMIN_EMAIL',
+  'PW_ADMIN_PASSWORD',
+  'PLAYWRIGHT_ADMIN_EMAIL',
+  'PLAYWRIGHT_ADMIN_PASSWORD',
+  'VITE_SUPABASE_URL',
+  'VITE_SUPABASE_ANON_KEY',
+  'SUPABASE_ANON_KEY',
+  'SUPABASE_SERVICE_ROLE_KEY',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+beforeEach(() => {
+  for (const key of CONTRACT_ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of CONTRACT_ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  originalEnv.clear();
+});
+
+describe('non-AI sessions Playwright credential contract', () => {
+  it('keeps schedule and admin ahead of the provisioned superadmin fallback', () => {
+    process.env.PW_SUPERADMIN_EMAIL = 'provisioned@example.test';
+    process.env.PW_SUPERADMIN_PASSWORD = 'super-secret';
+    process.env.PW_SCHEDULE_EMAIL = 'schedule@example.test';
+    process.env.PW_SCHEDULE_PASSWORD = 'schedule-secret';
+    process.env.PW_ADMIN_EMAIL = 'admin@example.test';
+    process.env.PW_ADMIN_PASSWORD = 'admin-secret';
+
+    expect(resolveNonAiSessionCredentialCandidates()).toEqual([
+      {
+        email: 'schedule@example.test',
+        password: 'schedule-secret',
+        label: 'PW_SCHEDULE_EMAIL + PW_SCHEDULE_PASSWORD',
+      },
+      {
+        email: 'admin@example.test',
+        password: 'admin-secret',
+        label: 'PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD',
+      },
+      {
+        email: 'provisioned@example.test',
+        password: 'super-secret',
+        label: 'PW_SUPERADMIN_EMAIL + PW_SUPERADMIN_PASSWORD',
+      },
+    ]);
+  });
+
+  it('names every accepted credential family when none is configured', () => {
+    process.env.PW_BASE_URL = 'https://preview.example.test';
+    process.env.VITE_SUPABASE_URL = 'https://supabase.example.test';
+    process.env.VITE_SUPABASE_ANON_KEY = 'synthetic-anon-key';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'synthetic-service-role';
+
+    expect(() => assertNonAiSessionsEnvContract('Synthetic browser flow'))
+      .toThrow(/PW_SUPERADMIN_EMAIL\/PW_SUPERADMIN_PASSWORD/);
+  });
+
+  it('fails closed on a partial provisioned superadmin pair instead of using a fallback', () => {
+    process.env.PW_BASE_URL = 'https://preview.example.test';
+    process.env.VITE_SUPABASE_URL = 'https://supabase.example.test';
+    process.env.VITE_SUPABASE_ANON_KEY = 'synthetic-anon-key';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'synthetic-service-role';
+    process.env.PW_SUPERADMIN_EMAIL = 'provisioned@example.test';
+    process.env.PW_SCHEDULE_EMAIL = 'schedule@example.test';
+    process.env.PW_SCHEDULE_PASSWORD = 'schedule-secret';
+
+    expect(() => assertNonAiSessionsEnvContract('Synthetic browser flow'))
+      .toThrow(/PW_SUPERADMIN_PASSWORD is missing/);
+  });
+
+  it('uses the canonical resolver order for lifecycle credential attempts', () => {
+    process.env.PW_BASE_URL = 'https://preview.example.test';
+    process.env.VITE_SUPABASE_URL = 'https://supabase.example.test';
+    process.env.VITE_SUPABASE_ANON_KEY = 'synthetic-anon-key';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'synthetic-service-role';
+    process.env.PW_SUPERADMIN_EMAIL = 'provisioned@example.test';
+    process.env.PW_SUPERADMIN_PASSWORD = 'super-secret';
+    process.env.PW_SCHEDULE_EMAIL = 'schedule@example.test';
+    process.env.PW_SCHEDULE_PASSWORD = 'schedule-secret';
+    process.env.PW_ADMIN_EMAIL = 'admin@example.test';
+    process.env.PW_ADMIN_PASSWORD = 'admin-secret';
+
+    expect(resolveLifecycleCredentialCandidates().map(({ label }) => label)).toEqual([
+      'PW_ADMIN_EMAIL + PW_ADMIN_PASSWORD',
+      'PW_SUPERADMIN_EMAIL + PW_SUPERADMIN_PASSWORD',
+      'PW_SCHEDULE_EMAIL + PW_SCHEDULE_PASSWORD',
+    ]);
+  });
+});

--- a/tests/scripts/select-browser-checks.test.ts
+++ b/tests/scripts/select-browser-checks.test.ts
@@ -85,6 +85,22 @@ describe('select-browser-checks', () => {
     expect(selection.iehpAssessmentImportSmokeRequired).toBe(true);
   });
 
+  it('requires hosted auth smoke when the non-AI session credential contract changes', () => {
+    const selection = runSelector(
+      '--changed-file',
+      'scripts/lib/playwright-nonai-sessions-contract.ts',
+    );
+
+    expect(selection.authSmokeRequired).toBe(true);
+    expect(selection.tier0Specs).toEqual([
+      'cypress/e2e/routes_auth.cy.ts',
+      'cypress/e2e/routes_schedule.cy.ts',
+    ]);
+    expect(selection.reasons).toEqual([
+      'scripts/lib/playwright-nonai-sessions-contract.ts: auth/session browser flow',
+    ]);
+  });
+
   it('requires IEHP assessment import smoke for API and provisioning surfaces', () => {
     for (const file of [
       'netlify/functions/assessment-documents.ts',


### PR DESCRIPTION
## Summary
- add the dynamically provisioned `PW_SUPERADMIN_*` pair as a fail-closed lifecycle fallback
- preserve schedule/admin precedence for shared least-privilege session smokes
- force hosted auth smoke whenever the shared credential contract changes

## Evidence
- TDD RED: 2/2 credential-contract assertions failed before implementation; selector RED: 1/18 failed
- focused GREEN: 36/36
- `npm run verify:local`: passed on the exact stacked tree in 329.8s
- code, test, security, and specification reviews: PASS

## Scope
Stacked on PR #907 to use its pending canonical attestation refresh. No production auth, schema, secret, deployment, or tenant-policy change. WIN-275.