### PR TITLE
WIN-110 Keep mobile session actions inside viewport

### DIFF
--- a/docs/ai/WIN-110-mobile-edit-session-forbidden-debug-handoff.md
+++ b/docs/ai/WIN-110-mobile-edit-session-forbidden-debug-handoff.md
@@ -18,6 +18,7 @@ Non-goals:
 1. The hosted mobile route and close-readiness flow are operational: authenticated booking, start, database status confirmation, modal open, close attempt, policy guidance, and recovery navigation passed.
 2. `SessionModal` is a `100dvh` flex column, but its long scrollable content child lacked `min-h-0`. On phone-height viewports, intrinsic content height could push the sticky Save progress / Close Session footer outside the usable viewport.
 3. The existing browser booking helper assumed desktop-visible program and goal controls. Mobile renders those controls inside closed `details` disclosures, so mobile proof could not create its temporary session until the helper revealed those disclosures.
+4. The blocked-close smoke mislabeled a Save progress submit as a terminal close. The deploy-preview RED run exposed this false-positive path; the harness now clicks the exact Close Session control and suppresses identifier-bearing dependency diagnostics.
 
 ## Fix Summary
 
@@ -27,6 +28,7 @@ Non-goals:
 - Added sanitized proof artifacts containing only method, pathname, status, timestamp, and tightly scoped action-control screenshots.
 - Removed raw identifiers and full-page screenshots from the modified scripts' failure artifacts.
 - Updated the session-plan browser helper to reveal containing mobile disclosures before selecting controls.
+- Corrected the blocked-close smoke to exercise the actual Close Session handler.
 
 ## Verification Card
 
@@ -56,7 +58,7 @@ Non-goals:
   - `npm run build` -> pass
   - `NODE_OPTIONS=--max-old-space-size=8192 npm run verify:local` -> pass, including `test:ci`, coverage, build, and 220 tier-0 route tests
   - responsive observer -> pass at desktop `1440x900` and mobile `390x844`
-  - hosted mobile blocked-close proof -> pass
+  - authenticated mobile blocked-close proof against Netlify deploy preview for PR #909 -> pass on the actual Close Session control
   - forced mobile proof failures -> pass; stderr and JSON remained generic and identifier-free
   - independent code, test, and security reviews -> approve with no required fixes
   - `npm run ci:playwright` -> blocked at the existing `playwright:session-no-show` target-selection failure after preflight, auth, schedule-conflict, therapist-onboarding, and therapist-authorization passed

--- a/docs/ai/WIN-110-mobile-edit-session-forbidden-debug-handoff.md
+++ b/docs/ai/WIN-110-mobile-edit-session-forbidden-debug-handoff.md
@@ -1,81 +1,73 @@
-# WIN-110 Mobile Edit Session Forbidden / Scheduling Issue Debug Handoff
+# WIN-110 Mobile Session Update And Close Handoff
 
 ## Scope
 
-- Debugged the mobile Edit Session regression after the WIN-109 multi-program / multi-goal work.
-- Kept scope contained to:
-  - `src/components/SessionModal.tsx`
-  - `src/pages/Schedule.tsx`
-  - focused regression tests for those surfaces
+- Keep the `SessionModal` action footer usable on phone-height viewports.
+- Add an opt-in iPhone 13 Playwright context and PHI-safe proof artifacts.
+- Make the existing Playwright booking helper reveal mobile program and goal disclosures.
+- Preserve session persistence, completion policy, authorization, and tenant behavior.
 
 Non-goals:
 
-- no auth/session library changes
-- no server/API handler changes
-- no Supabase/RLS/migration changes
-- no unrelated schedule cleanup
+- no server or API handler changes
+- no Supabase, RLS, schema, or migration changes
+- no auth, runtime configuration, CI, or deploy changes
 
 ## Findings
 
-1. Scheduled-session `Update Session` could carry linked session-note context into the Schedule submit path even when the user had not explicitly requested a capture save in the current modal interaction. That made the page eligible to call `upsertClientSessionNoteForSession(...)` before the ordinary session update.
-2. The SessionModal local fallback conflict check did not exclude the session currently being edited, so mobile could show a false `1 scheduling issue` prompt for the session itself.
+1. The hosted mobile route and close-readiness flow are operational: authenticated booking, start, database status confirmation, modal open, close attempt, policy guidance, and recovery navigation passed.
+2. `SessionModal` is a `100dvh` flex column, but its long scrollable content child lacked `min-h-0`. On phone-height viewports, intrinsic content height could push the sticky Save progress / Close Session footer outside the usable viewport.
+3. The existing browser booking helper assumed desktop-visible program and goal controls. Mobile renders those controls inside closed `details` disclosures, so mobile proof could not create its temporary session until the helper revealed those disclosures.
 
 ## Fix Summary
 
-- Added an explicit client-side `session_note_persist_requested` signal to the SessionModal submit payload.
-- Set that signal only when:
-  - the user explicitly saves partial capture, or
-  - capture fields/targets were dirtied in the current modal interaction, or
-  - the session is already in progress (`Save progress` semantics preserved)
-- Updated `Schedule.tsx` to ignore session-note draft persistence unless `session_note_persist_requested === true`.
-- Excluded the currently edited session id from SessionModal's raw-time self-conflict fallback.
+- Added `min-h-0` to the modal scroll region so content shrinks and scrolls inside the fixed-height dialog.
+- Added a focused component regression for the flex containment contract.
+- Added `PW_MOBILE_CONTEXT=true` for an iPhone 13 `390x844` browser context.
+- Added sanitized proof artifacts containing only method, pathname, status, timestamp, and tightly scoped action-control screenshots.
+- Removed raw identifiers and full-page screenshots from the modified scripts' failure artifacts.
+- Updated the session-plan browser helper to reveal containing mobile disclosures before selecting controls.
 
 ## Verification Card
 
-- classification: `low-risk autonomous`
-- lane: `standard`
+- classification: `high-risk human-reviewed`
+- lane: `critical`
 - change type:
   - `UI/component/page`
+  - `authenticated route browser regression harness`
 - required checks:
+  - `npm run ci:check-focused`
   - `npm run lint`
   - `npm run typecheck`
-  - `npm test -- --run src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
+  - `npm run test:ci`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
   - `npm run build`
   - `npm run verify:local`
+  - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:8888 --route=/schedule`
+  - `PW_MOBILE_CONTEXT=true npm run playwright:schedule-blocked-close`
 - executed checks:
+  - focused SessionModal RED -> failed before fix as expected
+  - focused SessionModal GREEN -> pass
+  - `npm test -- --run tests/scripts/playwright-mobile-proof.test.ts` -> pass
+  - `npm run ci:check-focused` -> pass
   - `npm run lint` -> pass
   - `npm run typecheck` -> pass
-  - `npm test -- --run src/components/__tests__/SessionModal.test.tsx src/pages/__tests__/Schedule.orchestration.integration.test.tsx` -> pass
   - `npm run build` -> pass
-  - `npm run verify:local` -> fail (unrelated broader repo test failure in `src/pages/__tests__/Schedule.sessionCloseReadiness.test.tsx`)
+  - `NODE_OPTIONS=--max-old-space-size=8192 npm run verify:local` -> pass, including `test:ci`, coverage, build, and 220 tier-0 route tests
+  - responsive observer -> pass at desktop `1440x900` and mobile `390x844`
+  - hosted mobile blocked-close proof -> pass
+  - forced mobile proof failures -> pass; stderr and JSON remained generic and identifier-free
+  - independent code, test, and security reviews -> approve with no required fixes
+  - `npm run ci:playwright` -> blocked at the existing `playwright:session-no-show` target-selection failure after preflight, auth, schedule-conflict, therapist-onboarding, and therapist-authorization passed
 - blocked checks:
-  - `none`
-- result: `pass-with-known-external-failure`
+  - full `npm run ci:playwright` -> stale lifecycle helper restricts the admin actor to one linked therapist and produces `candidatePairCount: 0`; this is outside the bounded mobile layout slice
+- result: `pass-with-blocked-checks`
 - residual risk:
-  - The bounded fix is covered locally, but full-repo `verify:local` still fails on an unrelated existing Schedule readiness test outside this slice.
+  - full authenticated Playwright completion remains blocked by the pre-existing no-show lifecycle target selector; the affected mobile close smoke itself passed.
 
-## PR Hygiene
+## Tracking
 
-- pr-ready: `yes`
-- lane: `standard`
-- branch-ready: `yes`
-- linear-ready: `yes` (`WIN-110`)
-- single-purpose: `yes`
-- unrelated changes:
-  - existing dirty files outside this task were left untouched:
-    - `.cursor/mcp.json`
-    - `AGENTS.md`
-- generated artifact drift: `none`
-- protected-path drift: `none`
-- change summary: `present`
-- verification summary: `present`
-- pr handoff: `ready`
-- reviewer:
-  - completed; one real gap around capture-target dirty tracking was found and fixed before closeout
-
-## Notes For Review
-
-- The intended behavior is now:
-  - scheduled `Update Session` updates session details without opportunistically re-saving unchanged linked session-note content
-  - in-progress `Save progress` continues to persist capture state
-  - editing a session no longer shows a self-conflict scheduling warning for the current session row
+- Linear: `WIN-110` reopened as High / In Progress because the workspace free issue limit blocked a new issue.
+- Branch: `codex/mobile-session-routes`
+- Human review is required before merge.

--- a/scripts/lib/playwright-mobile-proof.ts
+++ b/scripts/lib/playwright-mobile-proof.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs";
+import path from "node:path";
+import { devices, type BrowserContextOptions, type Locator } from "playwright";
+
+import { ensureArtifactsDir } from "./playwright-smoke";
+
+const MOBILE_CONTEXT_ENV_KEY = "PW_MOBILE_CONTEXT";
+const MOBILE_CONTEXT_TRUTHY = /^(1|true|yes)$/i;
+const SAFE_PROOF_PATHNAMES = new Set([
+  "/api/session-notes/upsert",
+  "/api/sessions-complete",
+]);
+
+const { defaultBrowserType: _defaultBrowserType, ...iPhone13 } = devices["iPhone 13"];
+const MOBILE_VIEWPORT = { width: 390, height: 844 } as const;
+
+export type SafeApiProofEntry = {
+  method: string;
+  pathname: string;
+  status: number;
+  timestamp: string;
+};
+
+export type SafeProofPayload = {
+  ok: boolean;
+  mode: "mobile" | "desktop";
+  script: string;
+  screenshotPath: string | null;
+  api: SafeApiProofEntry[];
+};
+
+export const shouldUseMobilePlaywrightContext = (
+  env: NodeJS.ProcessEnv = process.env,
+): boolean => MOBILE_CONTEXT_TRUTHY.test(env[MOBILE_CONTEXT_ENV_KEY] ?? "");
+
+export const getPlaywrightMobileContextOptions = (
+  env: NodeJS.ProcessEnv = process.env,
+): BrowserContextOptions =>
+  shouldUseMobilePlaywrightContext(env)
+    ? {
+        ...iPhone13,
+        screen: MOBILE_VIEWPORT,
+        viewport: MOBILE_VIEWPORT,
+      }
+    : {};
+
+export const buildSafeApiProofEntry = ({
+  method,
+  url,
+  status,
+  timestamp = new Date().toISOString(),
+}: {
+  method: string;
+  url: string;
+  status: number;
+  timestamp?: string;
+}): SafeApiProofEntry | null => {
+  const pathname = new URL(url, "http://localhost").pathname;
+  if (!SAFE_PROOF_PATHNAMES.has(pathname)) {
+    return null;
+  }
+  return {
+    method: method.toUpperCase(),
+    pathname,
+    status,
+    timestamp,
+  };
+};
+
+export const appendSafeApiProofEntry = (
+  entries: SafeApiProofEntry[],
+  input: {
+    method: string;
+    url: string;
+    status: number;
+    timestamp?: string;
+  },
+): void => {
+  const entry = buildSafeApiProofEntry(input);
+  if (entry) {
+    entries.push(entry);
+  }
+};
+
+export const captureSafeProofLocatorScreenshot = async (
+  prefix: string,
+  candidates: Array<{ name: string; locator: Locator }>,
+): Promise<string | null> => {
+  const latestDir = ensureArtifactsDir();
+  for (const candidate of candidates) {
+    const target = candidate.locator.first();
+    const visible = await target.isVisible().catch(() => false);
+    if (!visible) {
+      continue;
+    }
+    const screenshotPath = path.join(latestDir, `${prefix}-${candidate.name}-${Date.now()}.png`);
+    await target.screenshot({ path: screenshotPath }).catch(() => undefined);
+    if (fs.existsSync(screenshotPath)) {
+      return screenshotPath;
+    }
+  }
+  return null;
+};
+
+export const writeSafeProofArtifact = (
+  prefix: string,
+  payload: SafeProofPayload,
+): string => {
+  const latestDir = ensureArtifactsDir();
+  const artifactPath = path.join(latestDir, `${prefix}-${Date.now()}.json`);
+  fs.writeFileSync(artifactPath, JSON.stringify(payload, null, 2));
+  return artifactPath;
+};

--- a/scripts/lib/playwright-session-plan-controls.ts
+++ b/scripts/lib/playwright-session-plan-controls.ts
@@ -26,6 +26,19 @@ const selectPlanControl = async (
   selector: string,
   timeoutMs: number,
 ): Promise<boolean> => {
+  const rawSelector = selector.replace(/:visible$/, "");
+  const rawControls = page.locator(rawSelector);
+  if ((await rawControls.count()) > 0) {
+    await rawControls.evaluateAll((elements) => {
+      elements.forEach((element) => {
+        const disclosure = element.closest("details");
+        if (disclosure) {
+          disclosure.open = true;
+          disclosure.dispatchEvent(new Event("toggle"));
+        }
+      });
+    });
+  }
   const control = page.locator(selector).first();
   const visible = await control
     .waitFor({ state: "visible", timeout: timeoutMs })

--- a/scripts/playwright-schedule-blocked-close.ts
+++ b/scripts/playwright-schedule-blocked-close.ts
@@ -18,8 +18,15 @@ import { chromium, type BrowserContext, type Page } from "playwright";
 
 import { loadPlaywrightEnv } from "./lib/load-playwright-env";
 import {
+  appendSafeApiProofEntry,
+  captureSafeProofLocatorScreenshot,
+  getPlaywrightMobileContextOptions,
+  shouldUseMobilePlaywrightContext,
+  type SafeApiProofEntry,
+  writeSafeProofArtifact,
+} from "./lib/playwright-mobile-proof";
+import {
   assertRouteAccessible,
-  captureFailureScreenshot,
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
 import { assertNonAiSessionsEnvContract } from "./lib/playwright-nonai-sessions-contract";
@@ -252,18 +259,27 @@ async function run(): Promise<void> {
   );
 
   const browser = await chromium.launch({ headless });
+  const contextOptions = getPlaywrightMobileContextOptions();
+  const mobileMode = shouldUseMobilePlaywrightContext() ? "mobile" : "desktop";
   let context: BrowserContext | undefined;
   let page: Page | undefined;
   let authenticatedCredential: { email: string; password: string } | null = null;
   let capturedAccessToken: string | null = null;
+  const apiProof: SafeApiProofEntry[] = [];
   const bookedIds: Partial<LifecycleIds> = {};
+  let proofArtifactPath: string | null = null;
 
   try {
     for (const candidate of credentialCandidates) {
-      const attemptContext = await browser.newContext();
+      const attemptContext = await browser.newContext(contextOptions);
       const attemptPage = await attemptContext.newPage();
       let candidateToken: string | null = null;
       attemptPage.on("response", async (response) => {
+        appendSafeApiProofEntry(apiProof, {
+          method: response.request().method(),
+          url: response.url(),
+          status: response.status(),
+        });
         if (candidateToken || response.request().method().toUpperCase() !== "POST") {
           return;
         }
@@ -558,6 +574,18 @@ async function run(): Promise<void> {
 
       if (outcome.kind === "edge") {
         await edgeNotesGate.waitFor({ state: "visible", timeout: 5_000 });
+        const screenshotPath = await captureSafeProofLocatorScreenshot("playwright-schedule-blocked-close-proof", [
+          { name: "policy-toast", locator: edgeNotesGate },
+          { name: "modal-footer", locator: submitButton },
+        ]);
+        assert.ok(screenshotPath, "A cropped blocked-close proof screenshot is required.");
+        proofArtifactPath = writeSafeProofArtifact("playwright-schedule-blocked-close-proof", {
+          ok: true,
+          mode: mobileMode,
+          script: "playwright-schedule-blocked-close",
+          screenshotPath,
+          api: apiProof,
+        });
         return;
       }
 
@@ -581,6 +609,19 @@ async function run(): Promise<void> {
             "[blocked-close] Policy error toast may have dismissed; modal guidance + next-step button asserted.",
           );
         });
+      const screenshotPath = await captureSafeProofLocatorScreenshot("playwright-schedule-blocked-close-proof", [
+        { name: "retry-heading", locator: retryHeading },
+        { name: "open-client-details", locator: activePage.getByRole("button", { name: "Open Client Details" }) },
+        { name: "modal-footer", locator: submitButton },
+      ]);
+      assert.ok(screenshotPath, "A cropped blocked-close proof screenshot is required.");
+      proofArtifactPath = writeSafeProofArtifact("playwright-schedule-blocked-close-proof", {
+        ok: true,
+        mode: mobileMode,
+        script: "playwright-schedule-blocked-close",
+        screenshotPath,
+        api: apiProof,
+      });
     });
 
     await withStepTimeout("navigate-to-client-session-notes", async () => {
@@ -605,15 +646,24 @@ async function run(): Promise<void> {
       JSON.stringify({
         ok: true,
         message: "Blocked-close guidance regression passed",
-        sessionId: booked.sessionId,
-        clientId: booked.clientId,
+        proofArtifactPath,
       }),
     );
-  } catch (error) {
-    if (page) {
-      await captureFailureScreenshot(page, "playwright-schedule-blocked-close-failure");
-    }
-    throw error;
+  } catch {
+    const screenshotPath = page
+      ? await captureSafeProofLocatorScreenshot("playwright-schedule-blocked-close-failure", [
+          { name: "close-session-button", locator: page.getByRole("button", { name: /^Close Session$/i }) },
+          { name: "save-progress-button", locator: page.getByRole("button", { name: /^Save progress$/i }) },
+        ])
+      : null;
+    writeSafeProofArtifact("playwright-schedule-blocked-close-failure", {
+      ok: false,
+      mode: mobileMode,
+      script: "playwright-schedule-blocked-close",
+      screenshotPath,
+      api: apiProof,
+    });
+    throw new Error("Blocked-close regression failed; inspect the sanitized proof artifact.");
   } finally {
     if (bookedIds.sessionId && authenticatedCredential && page) {
       try {
@@ -622,10 +672,8 @@ async function run(): Promise<void> {
           (await getTokenFromBrowserStorage(page)) ??
           (await fetchAccessTokenForCredentials(authenticatedCredential.email, authenticatedCredential.password));
         await cancelSession(page, t, bookedIds.sessionId, bookedIds);
-      } catch (cleanupError) {
-        console.warn(
-          `[blocked-close] cleanup cancel failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
-        );
+      } catch {
+        console.warn("[blocked-close] cleanup cancel failed; no identifiers were logged.");
       }
     }
     if (context) {
@@ -648,8 +696,8 @@ const isMainModule = (): boolean => {
 };
 
 if (isMainModule()) {
-  run().catch((error) => {
-    console.error(error);
+  run().catch(() => {
+    console.error("Blocked-close regression failed; inspect the sanitized proof artifact.");
     process.exit(1);
   });
 }

--- a/scripts/playwright-schedule-blocked-close.ts
+++ b/scripts/playwright-schedule-blocked-close.ts
@@ -69,6 +69,19 @@ const withStepTimeout = async <T>(
   return result as T;
 };
 
+const withSuppressedDependencyDiagnostics = async <T>(operation: () => Promise<T>): Promise<T> => {
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  console.log = () => undefined;
+  console.warn = () => undefined;
+  try {
+    return await operation();
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+  }
+};
+
 /**
  * `checkInProgressSessionCloseReadiness` keys off `session_goals` rows; if start_session did not
  * insert any (environment variance), close would incorrectly succeed. Seed one row via service role.
@@ -341,13 +354,15 @@ async function run(): Promise<void> {
     let booked: LifecycleIds;
     try {
       booked = await withStepTimeout("book-session", () =>
-        bookSession(activePage, token, strictParityMode, bookOpts), BOOK_SESSION_STEP_TIMEOUT_MS);
+        withSuppressedDependencyDiagnostics(() => bookSession(activePage, token, strictParityMode, bookOpts)),
+      BOOK_SESSION_STEP_TIMEOUT_MS);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (strictParityMode && message.includes("Organization context required") && authenticatedCredential) {
         token = await fetchAccessTokenForCredentials(authenticatedCredential.email, authenticatedCredential.password);
         booked = await withStepTimeout("book-session retry", () =>
-          bookSession(activePage, token, strictParityMode, bookOpts), BOOK_SESSION_STEP_TIMEOUT_MS);
+          withSuppressedDependencyDiagnostics(() => bookSession(activePage, token, strictParityMode, bookOpts)),
+        BOOK_SESSION_STEP_TIMEOUT_MS);
       } else {
         throw error;
       }
@@ -500,10 +515,11 @@ async function run(): Promise<void> {
         );
       }
       await activePage.locator("#status-select").selectOption("completed");
+      const closeSessionButton = activePage.getByRole("button", { name: /^Close Session$/i });
+      await closeSessionButton.waitFor({ state: "visible", timeout: 90_000 });
       await activePage.waitForFunction(() => {
-        const el = document.querySelector<HTMLButtonElement>(
-          'button[type="submit"][form="session-form"]',
-        );
+        const el = Array.from(document.querySelectorAll<HTMLButtonElement>("button"))
+          .find((button) => button.textContent?.trim() === "Close Session");
         return Boolean(el && !el.disabled);
       }, { timeout: 90_000 });
       activePage.once("dialog", (dialog) => {
@@ -514,10 +530,7 @@ async function run(): Promise<void> {
       const edgeNotesGate = activePage.getByText(/Session notes with goal progress are required/i).first();
       const completedToast = activePage.getByText(/Session marked as completed/i).first();
 
-      const submitButton = activePage
-        .locator('form#session-form button[type="submit"], button[type="submit"][form="session-form"]')
-        .first();
-      await submitButton.click();
+      await closeSessionButton.click();
 
       // Poll: do not Promise.race locators that reject on timeout — a fast reject from one branch
       // can abort before the blocked-close panel (slower) becomes visible.
@@ -576,7 +589,7 @@ async function run(): Promise<void> {
         await edgeNotesGate.waitFor({ state: "visible", timeout: 5_000 });
         const screenshotPath = await captureSafeProofLocatorScreenshot("playwright-schedule-blocked-close-proof", [
           { name: "policy-toast", locator: edgeNotesGate },
-          { name: "modal-footer", locator: submitButton },
+          { name: "close-session-button", locator: closeSessionButton },
         ]);
         assert.ok(screenshotPath, "A cropped blocked-close proof screenshot is required.");
         proofArtifactPath = writeSafeProofArtifact("playwright-schedule-blocked-close-proof", {
@@ -612,7 +625,7 @@ async function run(): Promise<void> {
       const screenshotPath = await captureSafeProofLocatorScreenshot("playwright-schedule-blocked-close-proof", [
         { name: "retry-heading", locator: retryHeading },
         { name: "open-client-details", locator: activePage.getByRole("button", { name: "Open Client Details" }) },
-        { name: "modal-footer", locator: submitButton },
+        { name: "close-session-button", locator: closeSessionButton },
       ]);
       assert.ok(screenshotPath, "A cropped blocked-close proof screenshot is required.");
       proofArtifactPath = writeSafeProofArtifact("playwright-schedule-blocked-close-proof", {

--- a/scripts/playwright-session-capture-adhoc-upsert.ts
+++ b/scripts/playwright-session-capture-adhoc-upsert.ts
@@ -12,8 +12,15 @@ import { chromium, type BrowserContext, type Page } from "playwright";
 
 import { loadPlaywrightEnv } from "./lib/load-playwright-env";
 import {
+  appendSafeApiProofEntry,
+  captureSafeProofLocatorScreenshot,
+  getPlaywrightMobileContextOptions,
+  shouldUseMobilePlaywrightContext,
+  type SafeApiProofEntry,
+  writeSafeProofArtifact,
+} from "./lib/playwright-mobile-proof";
+import {
   assertRouteAccessible,
-  captureFailureScreenshot,
   loginAndAssertSession,
 } from "./lib/playwright-smoke";
 import { assertNonAiSessionsEnvContract } from "./lib/playwright-nonai-sessions-contract";
@@ -122,18 +129,27 @@ async function run(): Promise<void> {
   );
 
   const browser = await chromium.launch({ headless });
+  const contextOptions = getPlaywrightMobileContextOptions();
+  const mobileMode = shouldUseMobilePlaywrightContext() ? "mobile" : "desktop";
   let context: BrowserContext | undefined;
   let page: Page | undefined;
   let authenticatedCredential: { email: string; password: string } | null = null;
   let capturedAccessToken: string | null = null;
+  const apiProof: SafeApiProofEntry[] = [];
   const ids: Partial<LifecycleIds> = {};
+  let proofArtifactPath: string | null = null;
 
   try {
     for (const candidate of credentialCandidates) {
-      const attemptContext = await browser.newContext();
+      const attemptContext = await browser.newContext(contextOptions);
       const attemptPage = await attemptContext.newPage();
       let candidateToken: string | null = null;
       attemptPage.on("response", async (response) => {
+        appendSafeApiProofEntry(apiProof, {
+          method: response.request().method(),
+          url: response.url(),
+          status: response.status(),
+        });
         if (candidateToken || response.request().method().toUpperCase() !== "POST") {
           return;
         }
@@ -327,6 +343,18 @@ async function run(): Promise<void> {
           (body.goal_ids ?? []).some((id) => /^adhoc-skill-/i.test(id)),
           "response.goal_ids must include ad-hoc id",
         );
+        const screenshotPath = await captureSafeProofLocatorScreenshot("playwright-session-capture-adhoc-upsert-proof", [
+          { name: "save-progress-button", locator: editDialog.getByRole("button", { name: /^Save progress$/i }) },
+          { name: "capture-footer", locator: editDialog.locator('button[type="submit"][form="session-form"]') },
+        ]);
+        assert.ok(screenshotPath, "A cropped session-update proof screenshot is required.");
+        proofArtifactPath = writeSafeProofArtifact("playwright-session-capture-adhoc-upsert-proof", {
+          ok: true,
+          mode: mobileMode,
+          script: "playwright-session-capture-adhoc-upsert",
+          screenshotPath,
+          api: apiProof,
+        });
       } finally {
         activePage.off("request", requestListener);
         activePage.off("requestfailed", requestFailedListener);
@@ -341,21 +369,31 @@ async function run(): Promise<void> {
         ok: true,
         message: "Session capture ad-hoc upsert validated",
         marker,
-        ids,
+        proofArtifactPath,
       }),
     );
-  } catch (error) {
-    const shotPath = page ? await captureFailureScreenshot(page, "playwright-session-capture-adhoc-upsert") : "N/A";
+  } catch {
+    const screenshotPath = page
+      ? await captureSafeProofLocatorScreenshot("playwright-session-capture-adhoc-upsert-failure", [
+          { name: "save-progress-button", locator: page.getByRole("button", { name: /^Save progress$/i }) },
+          { name: "close-session-button", locator: page.getByRole("button", { name: /^Close Session$/i }) },
+        ])
+      : null;
+    const failureArtifactPath = writeSafeProofArtifact("playwright-session-capture-adhoc-upsert-failure", {
+      ok: false,
+      mode: mobileMode,
+      script: "playwright-session-capture-adhoc-upsert",
+      screenshotPath,
+      api: apiProof,
+    });
     console.error(
       JSON.stringify({
         ok: false,
         message: "Session capture ad-hoc upsert failed",
-        error: error instanceof Error ? error.message : String(error),
-        screenshot: shotPath,
-        ids,
+        proofArtifactPath: failureArtifactPath,
       }),
     );
-    throw error;
+    throw new Error("Session capture ad-hoc upsert failed; inspect the sanitized proof artifact.");
   } finally {
     if (context) {
       await context.close();
@@ -377,8 +415,8 @@ const isMainModule = (): boolean => {
 };
 
 if (isMainModule()) {
-  run().catch((error) => {
-    console.error(error);
+  run().catch(() => {
+    console.error("Session capture ad-hoc upsert failed; inspect the sanitized proof artifact.");
     process.exit(1);
   });
 }

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -3493,7 +3493,7 @@ export function SessionModal({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto px-4 py-3 pb-24 sm:p-4 sm:pb-5 max-sm:pb-[calc(5.5rem+env(safe-area-inset-bottom,0px))]">
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3 pb-24 sm:p-4 sm:pb-5 max-sm:pb-[calc(5.5rem+env(safe-area-inset-bottom,0px))]">
           <p id={dialogDescriptionId} className="sr-only">
             Use this form to create or update a therapy session.
           </p>

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -1300,6 +1300,15 @@ describe('SessionModal', () => {
     expect(screen.queryByRole('region', { name: /Scheduling Conflicts/i })).not.toBeInTheDocument();
   });
 
+  it('keeps the mobile action footer inside the viewport by allowing content to shrink', () => {
+    renderWithProviders(<SessionModal {...defaultProps} />);
+
+    const dialog = screen.getByRole('dialog');
+    const scrollRegion = dialog.querySelector('.flex-1.overflow-y-auto');
+
+    expect(scrollRegion).toHaveClass('min-h-0');
+  });
+
   it('shows validation errors for required fields', async () => {
     renderWithProviders(<SessionModal {...defaultProps} />);
     

--- a/tests/scripts/fixtures/select-mobile-session-plan-controls.ts
+++ b/tests/scripts/fixtures/select-mobile-session-plan-controls.ts
@@ -1,0 +1,31 @@
+import { chromium } from "playwright";
+
+import { selectSessionPlanControls } from "../../../scripts/lib/playwright-session-plan-controls";
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+
+try {
+  await page.setContent(`
+    <details id="program-disclosure">
+      <summary>Selected programs</summary>
+      <button data-program-id="program-mobile" aria-pressed="false"
+        onclick="this.setAttribute('aria-pressed', 'true')">Program</button>
+    </details>
+    <details id="goal-disclosure">
+      <summary>Additional goals</summary>
+      <button data-goal-id="goal-mobile" aria-pressed="false"
+        onclick="this.setAttribute('aria-pressed', 'true')">Goal</button>
+    </details>
+  `);
+
+  const selected = await selectSessionPlanControls(page, "program-mobile", "goal-mobile");
+  const disclosureState = await page.evaluate(() => ({
+    programDisclosureOpen: document.querySelector<HTMLDetailsElement>("#program-disclosure")?.open ?? false,
+    goalDisclosureOpen: document.querySelector<HTMLDetailsElement>("#goal-disclosure")?.open ?? false,
+  }));
+
+  console.log(JSON.stringify({ selected, ...disclosureState }));
+} finally {
+  await browser.close();
+}

--- a/tests/scripts/playwright-mobile-proof.test.ts
+++ b/tests/scripts/playwright-mobile-proof.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildSafeApiProofEntry,
+  getPlaywrightMobileContextOptions,
+  shouldUseMobilePlaywrightContext,
+} from "../../scripts/lib/playwright-mobile-proof";
+
+const originalMobileContext = process.env.PW_MOBILE_CONTEXT;
+
+describe("playwright mobile proof helpers", () => {
+  afterEach(() => {
+    if (originalMobileContext === undefined) {
+      delete process.env.PW_MOBILE_CONTEXT;
+      return;
+    }
+    process.env.PW_MOBILE_CONTEXT = originalMobileContext;
+  });
+
+  it("enables the iPhone 13 mobile context only when the env flag is truthy", () => {
+    delete process.env.PW_MOBILE_CONTEXT;
+    expect(shouldUseMobilePlaywrightContext()).toBe(false);
+
+    process.env.PW_MOBILE_CONTEXT = "true";
+    expect(shouldUseMobilePlaywrightContext()).toBe(true);
+
+    const options = getPlaywrightMobileContextOptions();
+    expect(options.viewport).toEqual({ width: 390, height: 844 });
+    expect(options.isMobile).toBe(true);
+    expect(options.hasTouch).toBe(true);
+    expect(options.userAgent).toContain("iPhone");
+  });
+
+  it("records only method, pathname, status, and timestamp for exact proof endpoints", () => {
+    expect(buildSafeApiProofEntry({
+      method: "post",
+      url: "https://app.example.com/api/session-notes/upsert?session_id=secret&client=phi",
+      status: 200,
+      timestamp: "2026-08-07T00:00:00.000Z",
+    })).toEqual({
+      method: "POST",
+      pathname: "/api/session-notes/upsert",
+      status: 200,
+      timestamp: "2026-08-07T00:00:00.000Z",
+    });
+
+    expect(buildSafeApiProofEntry({
+      method: "POST",
+      url: "https://app.example.com/api/sessions-complete?id=1234",
+      status: 409,
+      timestamp: "2026-08-07T00:01:00.000Z",
+    })).toEqual({
+      method: "POST",
+      pathname: "/api/sessions-complete",
+      status: 409,
+      timestamp: "2026-08-07T00:01:00.000Z",
+    });
+  });
+
+  it("rejects non-proof endpoints so no extra request data is serialized", () => {
+    expect(buildSafeApiProofEntry({
+      method: "POST",
+      url: "https://app.example.com/api/session-notes/upsert-extra?client=phi",
+      status: 200,
+      timestamp: "2026-08-07T00:00:00.000Z",
+    })).toBeNull();
+
+    expect(buildSafeApiProofEntry({
+      method: "GET",
+      url: "https://app.example.com/schedule?client=phi",
+      status: 200,
+      timestamp: "2026-08-07T00:00:00.000Z",
+    })).toBeNull();
+  });
+});

--- a/tests/scripts/playwright-session-plan-controls.test.ts
+++ b/tests/scripts/playwright-session-plan-controls.test.ts
@@ -20,4 +20,23 @@ describe("readSelectedSessionPlanIds", () => {
       goalIds: ["goal-selected"],
     });
   });
+
+  it("reveals mobile disclosures before selecting program and goal controls", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        resolve("node_modules/tsx/dist/cli.mjs"),
+        resolve("tests/scripts/fixtures/select-mobile-session-plan-controls.ts"),
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      selected: true,
+      programDisclosureOpen: true,
+      goalDisclosureOpen: true,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- keep the SessionModal scroll region shrinkable so Save progress and Close Session remain inside a phone-height viewport
- add an opt-in iPhone 13 Playwright context with identifier-free proof artifacts
- reveal mobile program and goal disclosures in the existing session booking helper

## Verification
- npm run verify:local (includes test:ci, coverage, build, and 220 tier-0 route tests)
- npm run lint
- npm run typecheck
- npm run build
- npm run ci:check-focused
- responsive /schedule observer at 1440x900 and 390x844
- authenticated hosted mobile blocked-close proof
- focused SessionModal RED/GREEN regression and mobile helper tests
- independent code, test, and security reviews: approved

## Known blocked check
Full npm run ci:playwright reaches the pre-existing playwright:session-no-show selector failure after earlier stages pass. The stale lifecycle helper returns candidatePairCount: 0 and is outside this bounded mobile layout slice.

## Risk
Critical lane because this exercises authenticated session lifecycle behavior. The production change is one CSS flex-containment class; no auth, API, server, Supabase, tenant, schema, migration, CI, or deploy path changed.

Linear: WIN-110