### PR TITLE
fix(ci): install Chromium in Supabase validation

### DIFF
--- a/.github/workflows/supabase-validate.yml
+++ b/.github/workflows/supabase-validate.yml
@@ -74,6 +74,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Install Playwright browser for runtime contracts
+        run: ./node_modules/.bin/playwright install chromium
       - name: Run unit tests
         env:
           NODE_OPTIONS: --max-old-space-size=6144

--- a/docs/ai/handoffs/WIN-275-supabase-validate-playwright.md
+++ b/docs/ai/handoffs/WIN-275-supabase-validate-playwright.md
@@ -1,0 +1,24 @@
+# WIN-275 Supabase Validate Chromium Repair
+
+## Scope
+
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Branch: `codex/win-275-supabase-validate-playwright`
+- Base: `79301e387d9989400b4999cbc4902c5b6466eaaa`
+- Implementation files: `.github/workflows/supabase-validate.yml` and `tests/integration/live-rls-fixture-schema.contract.test.ts`
+- Non-goals: migrations, Supabase configuration, secrets, application behavior, deployments, and hosted actions
+
+The repair installs the lockfile-pinned Playwright Chromium binary after `npm ci` and before the Supabase Validate application tests. The structural contract parses the workflow and requires `npm ci` -> `playwright install [options] chromium` -> first `npm test` ordering while rejecting `install-deps` and npm package-install false positives.
+
+## Verification Card
+
+- Required checks: direct YAML validation, focused contract and observer tests, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, and `npm run verify:local`
+- TDD: initial RED `1 failed / 16 passed`; structural removal RED `1 failed / 16 passed`; final focused contract GREEN `21/21`; contract plus observer GREEN `27/27`
+- Resource diagnosis: the default approximately 4 GB heap exhausted; one 6 GB run hit unrelated full-suite contention; a clean 6 GB `npm run test:ci` passed `479` files and `4105` tests, with `2` files and `5` tests skipped
+- Specialist review: implementation, architecture, test, DevOps, and security reviews found no implementation or privilege regression; two code-review test-predicate findings were fixed
+- Result: `pass-with-blocked-checks`; the final clean `verify:local` passed after preserving the hash-bound canonical ledger handoff
+- Blocked hosted proof: the pull-request checks and post-merge Supabase Validate main-push run have not run yet
+- Residual risk: the existing Supabase CI project-identity guard remains separate security hardening debt; this slice does not widen secrets, triggers, permissions, or mutation scope
+
+The canonical `docs/ai/handoffs/agent-work-ledger-foundation.md` remains unchanged because existing shadow and retention attestations bind its exact hash.

--- a/tests/integration/live-rls-fixture-schema.contract.test.ts
+++ b/tests/integration/live-rls-fixture-schema.contract.test.ts
@@ -1,9 +1,24 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+type WorkflowStep = {
+  name?: string;
+  run?: string;
+};
+
+type Workflow = {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+};
 
 const readRepoFile = (path: string) =>
   readFileSync(resolve(process.cwd(), path), "utf8").replace(/\r\n/g, "\n");
+
+const installsChromiumBrowser = (command: string | undefined) =>
+  /(?:^|[\\/\s])playwright(?:\.cmd)?\s+install(?:\s+--\S+)*\s+chromium(?:\s|$)/.test(
+    command ?? "",
+  );
 
 const therapistInsertBodies = (source: string) =>
   Array.from(
@@ -22,6 +37,37 @@ const assignTherapistRoleBodies = (source: string) =>
   );
 
 describe("live RLS fixture schema contract", () => {
+  it.each([
+    ["./node_modules/.bin/playwright install chromium", true],
+    ["npx playwright install --with-deps chromium", true],
+    ["npx playwright install-deps chromium", false],
+    ["npm install playwright chromium", false],
+  ])("classifies Chromium browser installation commands: %s", (command, expected) => {
+    expect(installsChromiumBrowser(command)).toBe(expected);
+  });
+
+  it("installs Chromium before browser-backed application tests", () => {
+    const workflow = parse(
+      readRepoFile(".github/workflows/supabase-validate.yml"),
+    ) as Workflow;
+    const steps = workflow.jobs?.["test-main"]?.steps;
+
+    expect(steps).toBeDefined();
+    const installDependenciesIndex = steps!.findIndex(
+      (step) => step.run?.trim() === "npm ci",
+    );
+    const installChromiumIndex = steps!.findIndex(
+      (step) => installsChromiumBrowser(step.run),
+    );
+    const runUnitTestsIndex = steps!.findIndex(
+      (step) => /\bnpm (?:run )?test\b/.test(step.run ?? ""),
+    );
+
+    expect(installDependenciesIndex).toBeGreaterThan(-1);
+    expect(installChromiumIndex).toBeGreaterThan(installDependenciesIndex);
+    expect(runUnitTestsIndex).toBeGreaterThan(installChromiumIndex);
+  });
+
   it("runs hosted database validation when live RLS fixtures merge to main", () => {
     const workflow = readRepoFile(".github/workflows/supabase-validate.yml");
     const pullRequestSection = workflow.match(


### PR DESCRIPTION
## Summary
- install the lockfile-pinned Playwright Chromium binary in Supabase Validate after `npm ci` and before application tests
- add a parsed-workflow ordering contract that rejects `install-deps` and package-install false positives
- record the critical-lane verification card in a standalone WIN-275 handoff without changing hash-bound ledger evidence

## Routing and safety
- Linear: WIN-275
- classification: high-risk human-reviewed
- lane: critical
- no migration, Supabase config, secret, permission, trigger, test-selection, deployment, or application-runtime changes
- final code, security, architecture, test, implementation, and DevOps reviews found no remaining diff blocker

## Verification
- TDD RED: missing workflow step failed `1/17`; structural-removal RED failed `1/17`
- focused contract: `21/21`
- contract + responsive observer: `27/27`
- hash-bound ledger/retention plus workflow contracts: `64/64`
- direct YAML parse and `git diff --check`: passed
- `npm run ci:check-focused`: passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `NODE_OPTIONS=--max-old-space-size=6144 npm run test:ci`: passed, 479 files / 4105 tests; 2 files / 5 tests skipped
- `npm run build`: passed
- `NODE_OPTIONS=--max-old-space-size=6144 npm run verify:local`: passed, including Tier-0 220/220
- normal pre-commit hook: passed; no bypass

## Failed attempts retained
- default approximately 4 GB `test:ci` exhausted the V8 heap and was not counted as passing
- first 6 GB retry hit unrelated full-suite contention; the isolated failing file passed 116/116 and clean bounded retries passed
- an attempted canonical ledger-handoff update correctly failed hash-bound attestation tests; it was reverted and replaced with a standalone handoff

## Remaining proof
- required PR checks must pass at exact head
- after owner review and merge, Supabase Validate must pass on trusted `main`; the repaired `test-main` job intentionally runs only on main pushes