### PR TITLE
WIN-258: restore Admin Schedule cancellation and landing

### DIFF
--- a/docs/ai/WIN-258-schedule-cancellation-attribution-handoff.md
+++ b/docs/ai/WIN-258-schedule-cancellation-attribution-handoff.md
@@ -93,3 +93,65 @@
 ## Handoff Summary
 
 Schedule creators now choose Staff cancellation or Client cancellation, and the selected attribution is forwarded through the existing cancellation helper. BT and therapist-scoped users do not receive selectable cancellation actions, while already-cancelled records remain representable. The redundant upper Program and Primary Goal dropdowns are removed; the lower clickable program and goal controls remain interactive, distinguish query failures from empty data, retain focused retry actions, and expose stable selectors to the hosted lifecycle smoke. All slice-specific checks pass, with full local verification blocked only by five tests in unchanged current-main surfaces.
+
+## 2026-08-07 Admin Schedule Regression Follow-up
+
+### Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: the bounded fix changes route authorization and the protected `sessions-cancel` Supabase edge function
+- allowed scope: exact-role `admin_schedule` cancellation authorization, schedule-first root routing, Dashboard navigation/query suppression, focused tests, and this handoff
+- non-goals: no dashboard RPC grant expansion, no `midtier` policy change, no migration, no production deployment, and no unrelated schedule-modal data-access cleanup
+
+### Implementation
+
+- `admin_schedule` now resolves to the existing admin-scoped cancellation path only after an exact organization-role check.
+- `/` redirects `admin_schedule` to `/schedule`; Dashboard is removed from its Sidebar and dashboard-only supervision-count traffic is disabled.
+- Dashboard route authority is named separately from the broader legacy `staffDashboard` capability so unrelated messaging behavior is unchanged.
+- focused regressions cover the root redirect, Sidebar visibility/query gate, Dashboard query gate, and organization-scoped cancellation role resolution.
+
+### Required Agents
+
+- specification engineer: confirmed the bounded role behavior and non-goals
+- software architect: recommended schedule-first least privilege instead of widening the dashboard edge/RPC
+- implementation engineer: completed the initial bounded production edits
+- test engineer: selected focused and lane-required verification
+- security engineer: `approve` after the Sidebar supervision-query authorization fix
+- Supabase reviewer: tenant boundary approved; identified the pre-existing `midtier` UI/API cancellation mismatch as a separate policy decision
+- code review engineer: `approve` after route-authority naming cleanup
+
+### Verification Card
+
+- lane: `critical`
+- required checks: focused tests, policy, lint, typecheck, tenant safety, production build, Tier-0 routes, hosted Playwright, responsive observer, `test:ci`, and `verify:local`
+- `npm test -- --run src/pages/__tests__/AppNavigation.test.tsx src/components/__tests__/SidebarNavigation.test.tsx src/pages/__tests__/Dashboard.dashboardQueryGate.test.tsx tests/edge/sessions-cancel.org-scope.test.ts src/lib/__tests__/roles.test.ts`: pass, 87 tests
+- `npm run ci:check-focused`: pass; documented local database, auth-parity, and branch-protection checks skipped without their external configuration
+- `npm run lint`: pass
+- `npm run typecheck`: pass
+- `npm run validate:tenant`: pass
+- `npm run build`: pass
+- `PREVIEW_PORT=4180 npm run test:routes:tier0`: pass, 220 tests across 7 specs
+- `npm run ci:playwright`: blocked after preflight because the configured hosted super-admin credential was rejected; no authenticated hosted claim
+- responsive observer for `/` and `/schedule`: desktop pass; mobile fails on the shared unauthenticated login page's existing `undersized-mobile-touch-target` (28x19); the observer intentionally carries no auth state
+- `npm run test:ci`: fail outside the changed surface from an existing Agent Work Ledger handoff-hash mismatch and Node heap exhaustion near 4 GB
+- `npm run verify:local`: policy, lint, and typecheck pass, then the aggregate stops in `test:ci` on the same Node heap exhaustion
+- result: `pass-with-blocked-checks`; all focused and route/tenant/build gates pass, but hosted authenticated proof and the repository-wide coverage run remain blocked
+
+### PR Hygiene
+
+- branch: `codex/win-258-admin-schedule-regression`
+- issue: `WIN-258`
+- single-purpose diff: yes
+- protected-path drift: contained to the exact organization-scoped `sessions-cancel` role resolver
+- unrelated tracked changes: none
+- reviewer verdicts: code review `approve`; security review `approve`; Supabase tenant-boundary review `approve` with a separate pre-existing policy follow-up
+- verification evidence: complete with blocked checks identified above
+- pr-ready: yes; human review and live required checks remain mandatory before merge
+
+### Residual Risk And Follow-up
+
+- production behavior is unchanged until the human-reviewed PR is merged and the client plus `sessions-cancel` function are deployed
+- `midtier` currently sees cancellation UI but is denied by the edge resolver; changing that role contract requires a separate explicit policy decision
+- architecture review found schedule-modal program, goal, authorization, and billing-adjacent queries that may still execute for `admin_schedule`; audit and minimize those queries as a separate protected slice
+- the shared login mobile touch-target finding and repository-wide `test:ci` memory/hash failures remain outside this bounded regression fix

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { AuthProvider } from './lib/authContext';
 import { appQueryClient } from './lib/queryClient';
 import { useTheme } from './lib/theme';
 import { useAuth } from './lib/authContext';
-import { canAccessStaffDashboard } from './lib/dashboardAccess';
+import { canAccessDashboardRoute } from './lib/dashboardAccess';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { PrivateRoute } from './components/PrivateRoute';
 import { RoleGuard } from './components/RoleGuard';
@@ -105,7 +105,11 @@ const DashboardLanding: React.FC = () => {
     return <Navigate to="/family" replace />;
   }
 
-  if (canAccessStaffDashboard(effectiveRole)) {
+  if (effectiveRole === 'admin_schedule') {
+    return <Navigate to="/schedule" replace />;
+  }
+
+  if (canAccessDashboardRoute(effectiveRole)) {
     return <Dashboard />;
   }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
 } from '../lib/supervision-session-notes';
 import { useTheme } from '../lib/theme';
 import { preloadRouteModule } from '../lib/routeModulePrefetch';
+import { canAccessDashboardRoute } from '../lib/dashboardAccess';
 import type { AppRole } from '../lib/roles';
 // Theme is toggled directly via context; no hidden proxy button
 import { logger } from '../lib/logger/logger';
@@ -118,7 +119,7 @@ export function Sidebar() {
       icon: LayoutDashboard,
       label: 'Dashboard',
       path: '/',
-      roles: ['bt', 'admin_schedule', 'admin', 'bcba', 'super_admin'] as AppRole[],
+      roles: ['bt', 'admin', 'bcba', 'super_admin'] as AppRole[],
       requiresGuardian: false,
     },
     { 
@@ -227,9 +228,10 @@ export function Sidebar() {
 
   const canAccessChatAssistant = hasCapability('viewSchedule') || hasCapability('dataTaking');
   const canAccessMessages = hasCapability('viewMessages');
+  const canViewStaffDashboard = canAccessDashboardRoute(effectiveRole);
   const canViewSupervisionNotifications =
-    hasCapability('staffDashboard') || isBtCorrectionDashboardRole(profile?.role);
-  const supervisionRoleBucket = hasCapability('staffDashboard') ? 'staff' : isBtCorrectionDashboardRole(profile?.role) ? 'bt' : 'other';
+    canViewStaffDashboard || isBtCorrectionDashboardRole(profile?.role);
+  const supervisionRoleBucket = canViewStaffDashboard ? 'staff' : isBtCorrectionDashboardRole(profile?.role) ? 'bt' : 'other';
 
   const { data: unreadMessagesData } = useQuery({
     queryKey: [MESSAGES_QUERY_KEY, 'inbox', organizationId, profile?.id],

--- a/src/components/__tests__/SidebarNavigation.test.tsx
+++ b/src/components/__tests__/SidebarNavigation.test.tsx
@@ -158,6 +158,34 @@ describe("Sidebar navigation active styling", () => {
     expect(screen.getByRole("link", { name: /clients/i })).toBeInTheDocument();
   });
 
+  it("hides the dashboard link for admin_schedule while preserving schedule access", () => {
+    const hasRole = vi.fn((role: string) => role === "admin_schedule");
+
+    mockUseAuth.mockReturnValue({
+      signOut: vi.fn(),
+      hasRole,
+      user: {
+        email: "admin-schedule@example.com",
+        user_metadata: {},
+      },
+      profile: {
+        id: "admin-schedule-user-1",
+        role: "admin_schedule",
+      },
+      isGuardian: false,
+      hasAnyRole: vi.fn((roles: string[]) => roles.some(role => hasRole(role))),
+      effectiveRole: "admin_schedule",
+      hasCapability: vi.fn(capabilityForRole("admin_schedule")),
+      hasAnyCapability: vi.fn((capabilities: string[]) => capabilities.some(capabilityForRole("admin_schedule"))),
+    });
+
+    renderSidebar(["/schedule"]);
+
+    expect(screen.queryByRole("link", { name: /^dashboard$/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /schedule/i })).toBeInTheDocument();
+    expect(mockFetchPendingSupervisionSessionNoteCount).not.toHaveBeenCalled();
+  });
+
   it("shows schedule and client links for canonical BT users", () => {
     const hasRole = vi.fn((role: string) => role === "bt");
 

--- a/src/lib/dashboardAccess.ts
+++ b/src/lib/dashboardAccess.ts
@@ -1,17 +1,15 @@
 import type { UserProfile } from './authContext';
-import { roleHasCapability } from './roles';
 
-export const STAFF_DASHBOARD_ROLES: ReadonlyArray<UserProfile['role']> = [
-  'admin_schedule',
+export const DASHBOARD_ROUTE_ROLES: ReadonlyArray<UserProfile['role']> = [
   'admin',
   'bcba',
   'super_admin',
 ];
 
-export const canAccessStaffDashboard = (role: UserProfile['role'] | null | undefined): boolean => {
+export const canAccessDashboardRoute = (role: UserProfile['role'] | null | undefined): boolean => {
   if (!role) {
     return false;
   }
-  return roleHasCapability(role, 'staffDashboard');
+  return DASHBOARD_ROUTE_ROLES.includes(role);
 };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -26,7 +26,7 @@ import {
   type BtAbaSessionNoteResponses,
   validateBtAbaSessionNoteResponses,
 } from '../lib/bt-aba-session-note';
-import { canAccessStaffDashboard } from '../lib/dashboardAccess';
+import { canAccessDashboardRoute } from '../lib/dashboardAccess';
 import { showError, showSuccess } from '../lib/toast';
 import {
   type BtCorrectionTask,
@@ -2183,7 +2183,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
 const Dashboard = () => {
   const queryClient = useQueryClient();
   const { effectiveRole, session, loading: authLoading, user, profile } = useAuth();
-  const canViewStaffDashboard = canAccessStaffDashboard(effectiveRole);
+  const canViewStaffDashboard = canAccessDashboardRoute(effectiveRole);
   const canViewCorrectionOnlyDashboard = isBtCorrectionDashboardRole(effectiveRole, profile?.role);
   const hasAccessToken = Boolean(session?.access_token && session.access_token.trim().length > 0);
   const organizationId = useActiveOrganizationId();

--- a/src/pages/__tests__/AppNavigation.test.tsx
+++ b/src/pages/__tests__/AppNavigation.test.tsx
@@ -226,7 +226,17 @@ describe('App navigation landing', () => {
     expect(window.location.pathname).toBe('/');
   });
 
-  it.each(['admin_schedule', 'admin', 'bcba', 'super_admin'] as const)('keeps %s on the dashboard', async (role) => {
+  it('redirects admin_schedule users to schedule from dashboard landing', async () => {
+    authRole = 'admin_schedule';
+    window.history.pushState({}, '', '/');
+    renderApp();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/schedule');
+    });
+  });
+
+  it.each(['admin', 'bcba', 'super_admin'] as const)('keeps %s on the dashboard', async (role) => {
     authRole = role;
     window.history.pushState({}, '', '/');
     const view = renderApp();

--- a/supabase/functions/sessions-cancel/index.ts
+++ b/supabase/functions/sessions-cancel/index.ts
@@ -221,6 +221,9 @@ async function resolveCancellationRole(
   if (await assertUserHasOrgRole(db, orgId, "bcba")) {
     return "admin";
   }
+  if (await assertUserHasOrgRole(db, orgId, "admin_schedule")) {
+    return "admin";
+  }
   if (await assertUserHasOrgRole(db, orgId, "therapist", { targetTherapistId: userId })) {
     return "therapist";
   }

--- a/tests/edge/sessions-cancel.org-scope.test.ts
+++ b/tests/edge/sessions-cancel.org-scope.test.ts
@@ -452,6 +452,22 @@ describe("sessions-cancel org scoping", () => {
     ).resolves.toBeNull();
   });
 
+  it("treats exact in-org admin_schedule as admin-scoped", async () => {
+    const assertUserHasOrgRoleSpy = vi
+      .spyOn(orgHelpers, "assertUserHasOrgRole")
+      .mockImplementation(async (_db, _orgId, role) => role === "admin_schedule");
+
+    const mockDb: any = {
+      rpc: vi.fn(),
+    };
+
+    await expect(
+      __TESTING__.resolveCancellationRole(mockDb, "org-1", "admin-schedule-user"),
+    ).resolves.toBe("admin");
+
+    expect(assertUserHasOrgRoleSpy).toHaveBeenCalledWith(mockDb, "org-1", "admin_schedule");
+  });
+
   it("treats exact in-org bcba as admin-scoped without granting admin_schedule or midtier", async () => {
     const assertUserHasOrgRoleSpy = vi
       .spyOn(orgHelpers, "assertUserHasOrgRole")


### PR DESCRIPTION
## Summary
- allow exact in-org `admin_schedule` users to use the existing admin-scoped cancellation path
- redirect `admin_schedule` root navigation to `/schedule` and remove Dashboard/sidebar supervision-query access
- add focused route, Sidebar, query-gate, and edge authorization regressions

## Verification
- focused Vitest: 87 passed
- `npm run ci:check-focused`: passed
- `npm run lint`: passed
- `npm run typecheck`: passed
- `npm run validate:tenant`: passed
- `npm run build`: passed
- Tier-0 Cypress routes: 220 passed
- security review: approved
- code review: approved
- Supabase tenant review: approved

## Blocked checks
- `npm run ci:playwright`: hosted preflight passed, then the configured super-admin credential was rejected
- responsive observer: desktop passed; mobile reached the shared unauthenticated login page and found its existing 28x19 touch target
- `npm run test:ci` / `npm run verify:local`: repository-wide coverage run exhausted the Node heap; a standalone run also reported the existing Agent Work Ledger handoff-hash mismatch

## Risk
Critical protected-path change. Human review is required before merge. Production remains unchanged until the client and `sessions-cancel` function are deployed.

Linear: WIN-258