### PR TITLE
[WIN-260] Allow schedule creation within occupied blocks

### DIFF
--- a/docs/ai/handoffs/WIN-260-schedule-interaction-polish.md
+++ b/docs/ai/handoffs/WIN-260-schedule-interaction-polish.md
@@ -1,5 +1,7 @@
 # WIN-260 Schedule Interaction Polish Handoff
 
+> Current status (2026-08-07): `WIN-260` is reopened. The occupied-block creation follow-up at the end of this document supersedes the original occupied-time manage-only rule. Current PR readiness is `no`; earlier readiness sections are historical records for the merged original scope.
+
 - classification: low-risk autonomous
 - lane: standard
 - issue: WIN-260
@@ -48,7 +50,7 @@
 - residual risk: hosted credential-backed browser coverage remains for CI; the changed interaction paths have focused unit, integration, and synthetic real-browser coverage
 - pr handoff: ready for commit, push, and live PR inspection
 
-## PR Hygiene
+## Historical PR Hygiene For Original PR #871
 
 - pr-ready: yes
 - lane: standard
@@ -63,7 +65,7 @@
 - pr handoff: ready
 - reviewer: completed
 - required follow-up: push branch, open PR, move WIN-260 to In Review, and inspect live checks and review threads
-- handoff summary: WIN-260 makes occupied schedule time manage-only and empty time create-only, adds compact overlap handling, and simplifies the session modal without changing role policy. Focused tests, policy, lint, typecheck, build, route tests, and a synthetic real-browser proof passed; credentialed Playwright and the unrelated full-suite baseline failures remain explicitly blocked.
+- handoff summary: The original PR #871 made occupied schedule time manage-only and empty time create-only, added compact overlap handling, and simplified the session modal without changing role policy. That historical interaction rule is superseded by the 2026-08-07 follow-up below.
 
 ## Browser Evidence
 
@@ -104,3 +106,78 @@
 - reviewer: completed; the initial unbounded-query finding was corrected and the final diff was approved
 - residual risk: the hosted smoke remains the decisive proof that current fixture data includes a date-covered authorization service in the candidate booking window
 - pr handoff: ready for commit and push; completion remains blocked until PR #871 live CI passes
+
+## 2026-08-07 Occupied-Block Creation Follow-up
+
+### Routing
+
+- classification: `low-risk autonomous`
+- lane: `standard`
+- why: non-trivial schedule page interaction change outside protected paths
+- triggering paths: `src/pages/**` and focused page tests
+
+### Scope
+
+- task intent: allow schedule-authoring admin roles to create another appointment within an occupied ordinary block or overlap cluster
+- roles enabled: `admin_schedule`, `admin`, `bcba`, and `super_admin`
+- roles unchanged: `therapist` and `bt` cannot create within occupied blocks
+- files touched:
+  - `src/pages/Schedule.tsx`
+  - `src/pages/ScheduleCalendarViewShared.tsx`
+  - `src/pages/ScheduleDayView.tsx`
+  - `src/pages/ScheduleWeekView.tsx`
+  - focused schedule day, week, and orchestration tests
+- non-goals: auth policy, scheduling persistence, conflict handling, API/server, Supabase, CI, and deploy behavior
+- single-purpose diff: yes
+
+### Required Agents
+
+- required sequence: `specification-engineer` -> `implementation-engineer` -> `code-review-engineer` -> `test-engineer`
+- agents used: specification, implementation, review, and test roles completed during the bounded implementation; code-review-engineer completed a final exact-diff pass after the touch-accessibility fixes
+- reviewer: completed; no remaining code findings or protected-path drift, and the requested handoff accuracy correction is incorporated here
+
+### Verification Card
+
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - targeted schedule tests
+  - `npm run test:ci`
+  - `npm run build`
+  - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4173 --route=/schedule`
+- executed checks:
+  - `npm run ci:check-focused`: pass
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npx vitest run src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx`: pass, 38/38
+  - `npx vitest run src/pages/__tests__/Schedule.orchestration.integration.test.tsx -t "gates occupied-block create actions"`: pass, 6/6
+  - `NODE_OPTIONS=--max-old-space-size=8192 npx vitest run src/pages/__tests__/Schedule.orchestration.integration.test.tsx`: pass, 63/63
+  - `npm run build`: pass
+  - `npm run test:ci`: fail after 4,112 passing tests on two Agent Work Ledger hash-attestation tests unrelated to this diff
+  - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4173 --route=/schedule`: fail on the unauthenticated login shell
+- blocked checks:
+  - `npm run test:ci`: `origin/main` contains a canonical-hash mismatch for `docs/ai/handoffs/agent-work-ledger-foundation.md` in `tests/agentWorkLedgerHostedShadowProof.test.ts` and `tests/agentWorkLedgerRetentionPolicyEncodingMigration.test.ts`
+  - responsive desktop: console error because the plain Vite preview serves SPA HTML for `/api/runtime-config`
+  - responsive mobile: the same console error plus a 35x24 login-shell touch target
+  - authenticated schedule observation: the observer intentionally forbids session/storage reuse and external requests, so it cannot render the signed-in schedule grid
+- evidence:
+  - `artifacts/responsive-ui-observer/route-b8269c2977ef848259bf5694da1ebe4e7a041d55cb00a9e9fd3689b0c23f675f.desktop.1440x900.json`
+  - `artifacts/responsive-ui-observer/route-b8269c2977ef848259bf5694da1ebe4e7a041d55cb00a9e9fd3689b0c23f675f.mobile.390x844.json`
+- result: `fail`
+- residual risk: deterministic responsive proof of the authenticated schedule grid is unavailable, while targeted role and interaction regressions are green
+
+### PR Hygiene
+
+- branch-ready: yes
+- linear-ready: yes, `WIN-260` reopened with the superseding behavior and current blockers
+- protected-path drift: none
+- unrelated changes: none
+- generated artifact drift: none; responsive observer artifacts remain untracked evidence
+- verification summary: present
+- pr-ready: no
+- required follow-up: obtain a passing responsive card and resolve or update the upstream Agent Work Ledger attestation before claiming review-ready closure
+
+### Handoff Summary
+
+The schedule day/week overlays now expose a separate create action within occupied ordinary blocks and overlap clusters for schedule-authoring admin roles while preserving edit, popover, drag, long-press, and empty-slot behavior. Focused role and interaction tests, policy checks, lint, typecheck, and build pass. Full-suite and responsive hard gates remain accurately blocked by failures outside the changed schedule surface.

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -2816,6 +2816,7 @@ export const Schedule = React.memo(() => {
               onEditSession={handleEditSession}
               onRescheduleSession={handleRescheduleSession}
               allowCreateInEmptySlot={!therapistScopedView}
+              allowCreateInOccupiedSlot={useImprovedAppointmentLayout}
               allowDragAndDrop={!therapistScopedView}
             />
           ) : (
@@ -2829,6 +2830,7 @@ export const Schedule = React.memo(() => {
               onEditSession={handleEditSession}
               onRescheduleSession={handleRescheduleSession}
               allowCreateInEmptySlot={!therapistScopedView}
+              allowCreateInOccupiedSlot={useImprovedAppointmentLayout}
               allowDragAndDrop={!therapistScopedView}
             />
           )}

--- a/src/pages/ScheduleCalendarViewShared.tsx
+++ b/src/pages/ScheduleCalendarViewShared.tsx
@@ -160,6 +160,23 @@ function getOverlayCardHeight(spanRows: number): number {
   return Math.max(unclampedHeight, MIN_OVERLAY_HEIGHT_PX);
 }
 
+function getOverlayCreatePosition(day: Date, topRows: number): ScheduleSlotPosition {
+  const slotStart = new Date(day);
+  slotStart.setHours(VISIBLE_GRID_START_HOUR, 0, 0, 0);
+  const createStart = addMinutes(slotStart, topRows * SLOT_DURATION_MINUTES);
+  return {
+    date: createStart,
+    time: format(createStart, 'HH:mm'),
+  };
+}
+
+function getCreateSessionLabel(position: ScheduleSlotPosition): string {
+  return `Add session within occupied block on ${format(position.date, 'EEEE, MMMM d, yyyy')} at ${format(
+    position.date,
+    'h:mm a',
+  )}`;
+}
+
 /**
  * True when a precise pointing device (mouse, trackpad, stylus) is available.
  * Use HTML5 drag/drop in that case — even on hybrid touch laptops where `(pointer: coarse)` can still match.
@@ -744,6 +761,36 @@ function OverlaySessionCard({
   );
 }
 
+function OccupiedBlockCreateButton({
+  createPosition,
+  onCreateSession,
+  touchOnly = false,
+}: {
+  createPosition: ScheduleSlotPosition;
+  onCreateSession: ScheduleTimeSlotHandler;
+  touchOnly?: boolean;
+}) {
+  const label = getCreateSessionLabel(createPosition);
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className={`absolute right-1 top-1 z-30 inline-flex items-center justify-center rounded-full bg-white/95 text-blue-700 shadow-sm ring-1 ring-slate-300 transition-opacity hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:bg-slate-950/95 dark:text-blue-200 dark:ring-slate-600 ${
+        touchOnly ? 'h-8 w-8' : 'h-6 w-6'
+      }`}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onCreateSession(createPosition);
+      }}
+    >
+      <Plus className="h-3.5 w-3.5" />
+    </button>
+  );
+}
+
 function InvalidSessionFallback({ session, top }: { session: Session; top: number }) {
   return (
     <div
@@ -762,19 +809,26 @@ function InvalidSessionFallback({ session, top }: { session: Session; top: numbe
 
 function ScheduleOverlayItem({
   item,
+  day,
+  onCreateSession,
   onEditSession,
+  allowCreateInOccupiedSlot = false,
   allowDragAndDrop = false,
   activeDragSessionId = null,
   onStartSessionDrag,
   onEndSessionDrag,
 }: {
   item: ScheduleLayoutItem;
+  day: Date;
+  onCreateSession: ScheduleTimeSlotHandler;
   onEditSession: ScheduleEditSessionHandler;
+  allowCreateInOccupiedSlot?: boolean;
   allowDragAndDrop?: boolean;
   activeDragSessionId?: string | null;
   onStartSessionDrag?: (session: Session, source: ScheduleSlotPosition) => void;
   onEndSessionDrag?: () => void;
 }) {
+  const hasFinePointer = useHasFinePointer();
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
@@ -829,12 +883,16 @@ function ScheduleOverlayItem({
     left: OVERLAY_HORIZONTAL_INSET_PX,
     right: OVERLAY_HORIZONTAL_INSET_PX,
   };
+  const createPosition = useMemo(() => getOverlayCreatePosition(day, item.topRows), [day, item.topRows]);
+  const occupiedCreateVisibilityClasses = hasFinePointer
+    ? 'pointer-events-none opacity-0 transition-opacity group-hover/overlay:pointer-events-auto group-hover/overlay:opacity-100 group-focus-within/overlay:pointer-events-auto group-focus-within/overlay:opacity-100'
+    : 'pointer-events-auto opacity-100';
 
   if (item.kind === 'appointment') {
     const compact = item.spanRows <= 1;
     return (
       <div
-        className={`absolute ${activeDragSessionId !== null ? 'pointer-events-none' : 'pointer-events-auto'} ${
+        className={`group/overlay absolute ${activeDragSessionId !== null ? 'pointer-events-none' : 'pointer-events-auto'} ${
           compact ? 'overflow-hidden' : ''
         }`}
         data-layout-kind="appointment"
@@ -852,6 +910,15 @@ function ScheduleOverlayItem({
           className="h-full shadow-sm"
           compact={compact}
         />
+        {allowCreateInOccupiedSlot ? (
+          <div className={occupiedCreateVisibilityClasses}>
+            <OccupiedBlockCreateButton
+              createPosition={createPosition}
+              onCreateSession={onCreateSession}
+              touchOnly={!hasFinePointer}
+            />
+          </div>
+        ) : null}
       </div>
     );
   }
@@ -861,7 +928,7 @@ function ScheduleOverlayItem({
 
   return (
     <div
-      className={`absolute z-20 ${activeDragSessionId !== null ? 'pointer-events-none' : 'pointer-events-auto'}`}
+      className={`group/overlay absolute z-20 ${activeDragSessionId !== null ? 'pointer-events-none' : 'pointer-events-auto'}`}
       data-layout-kind="cluster"
       style={style}
     >
@@ -886,6 +953,16 @@ function ScheduleOverlayItem({
         </div>
         <div className="truncate text-[11px]">{clusterLabel.replace(/^\d+ appointments, /i, '')}</div>
       </button>
+
+      {allowCreateInOccupiedSlot ? (
+        <div className={occupiedCreateVisibilityClasses}>
+          <OccupiedBlockCreateButton
+            createPosition={createPosition}
+            onCreateSession={onCreateSession}
+            touchOnly={!hasFinePointer}
+          />
+        </div>
+      ) : null}
 
       {open ? (
         <div
@@ -922,7 +999,9 @@ function ScheduleOverlayItem({
 function ScheduleOverlayColumn({
   day,
   scheduleSessions,
+  onCreateSession,
   onEditSession,
+  allowCreateInOccupiedSlot = false,
   allowDragAndDrop = false,
   activeDragSessionId = null,
   onStartSessionDrag,
@@ -931,7 +1010,9 @@ function ScheduleOverlayColumn({
 }: {
   day: Date;
   scheduleSessions: readonly Session[];
+  onCreateSession: ScheduleTimeSlotHandler;
   onEditSession: ScheduleEditSessionHandler;
+  allowCreateInOccupiedSlot?: boolean;
   allowDragAndDrop?: boolean;
   activeDragSessionId?: string | null;
   onStartSessionDrag?: (session: Session, source: ScheduleSlotPosition) => void;
@@ -949,7 +1030,10 @@ function ScheduleOverlayColumn({
         <ScheduleOverlayItem
           key={item.kind === 'appointment' ? item.session.id : item.sessions.map((session) => session.id).join('|')}
           item={item}
+          day={day}
+          onCreateSession={onCreateSession}
           onEditSession={onEditSession}
+          allowCreateInOccupiedSlot={allowCreateInOccupiedSlot}
           allowDragAndDrop={allowDragAndDrop}
           activeDragSessionId={activeDragSessionId}
           onStartSessionDrag={onStartSessionDrag}
@@ -974,6 +1058,7 @@ export const DayColumn = React.memo(
     onCreateSession,
     onEditSession,
     allowCreateInEmptySlot = true,
+    allowCreateInOccupiedSlot = false,
     allowDragAndDrop = false,
     activeDragSessionId = null,
     activeDropSlotKey = null,
@@ -995,6 +1080,7 @@ export const DayColumn = React.memo(
     onCreateSession: ScheduleTimeSlotHandler;
     onEditSession: ScheduleEditSessionHandler;
     allowCreateInEmptySlot?: boolean;
+    allowCreateInOccupiedSlot?: boolean;
     allowDragAndDrop?: boolean;
     activeDragSessionId?: string | null;
     activeDropSlotKey?: string | null;
@@ -1046,7 +1132,9 @@ export const DayColumn = React.memo(
           <ScheduleOverlayColumn
             day={day}
             scheduleSessions={scheduleSessions}
+            onCreateSession={onCreateSession}
             onEditSession={onEditSession}
+            allowCreateInOccupiedSlot={allowCreateInOccupiedSlot}
             allowDragAndDrop={allowDragAndDrop}
             activeDragSessionId={activeDragSessionId}
             onStartSessionDrag={onStartSessionDrag}

--- a/src/pages/ScheduleDayView.tsx
+++ b/src/pages/ScheduleDayView.tsx
@@ -20,6 +20,7 @@ interface ScheduleDayViewProps {
   onEditSession: ScheduleEditSessionHandler;
   onRescheduleSession?: (session: Session, target: ScheduleSlotPosition) => void;
   allowCreateInEmptySlot?: boolean;
+  allowCreateInOccupiedSlot?: boolean;
   allowDragAndDrop?: boolean;
 }
 
@@ -33,6 +34,7 @@ const ScheduleDayViewComponent: React.FC<ScheduleDayViewProps> = ({
   onEditSession,
   onRescheduleSession,
   allowCreateInEmptySlot = true,
+  allowCreateInOccupiedSlot = false,
   allowDragAndDrop = false,
 }) => {
   const [draggedSession, setDraggedSession] = useState<Session | null>(null);
@@ -153,6 +155,7 @@ const ScheduleDayViewComponent: React.FC<ScheduleDayViewProps> = ({
           onCreateSession={onCreateSession}
           onEditSession={onEditSession}
           allowCreateInEmptySlot={allowCreateInEmptySlot}
+          allowCreateInOccupiedSlot={allowCreateInOccupiedSlot}
           allowDragAndDrop={allowDragAndDrop}
           activeDragSessionId={draggedSession?.id ?? null}
           activeDropSlotKey={dropSlotKey}

--- a/src/pages/ScheduleWeekView.tsx
+++ b/src/pages/ScheduleWeekView.tsx
@@ -20,6 +20,7 @@ interface ScheduleWeekViewProps {
   onEditSession: ScheduleEditSessionHandler;
   onRescheduleSession?: (session: Session, target: ScheduleSlotPosition) => void;
   allowCreateInEmptySlot?: boolean;
+  allowCreateInOccupiedSlot?: boolean;
   allowDragAndDrop?: boolean;
 }
 
@@ -33,6 +34,7 @@ const ScheduleWeekViewComponent: React.FC<ScheduleWeekViewProps> = ({
   onEditSession,
   onRescheduleSession,
   allowCreateInEmptySlot = true,
+  allowCreateInOccupiedSlot = false,
   allowDragAndDrop = false,
 }) => {
   const [draggedSession, setDraggedSession] = useState<Session | null>(null);
@@ -161,6 +163,7 @@ const ScheduleWeekViewComponent: React.FC<ScheduleWeekViewProps> = ({
             onCreateSession={onCreateSession}
             onEditSession={onEditSession}
             allowCreateInEmptySlot={allowCreateInEmptySlot}
+            allowCreateInOccupiedSlot={allowCreateInOccupiedSlot}
             allowDragAndDrop={allowDragAndDrop}
             activeDragSessionId={draggedSession?.id ?? null}
             activeDropSlotKey={dropSlotKey}

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -855,6 +855,37 @@ describe("Schedule orchestration integration hardening", () => {
   });
 
   it.each([
+    ["admin schedule", "admin_schedule", true],
+    ["admin", "admin", true],
+    ["bcba", "bcba", true],
+    ["super admin", "super_admin", true],
+    ["therapist", "therapist", false],
+    ["BT", "bt", false],
+  ] as const)("gates occupied-block create actions for %s", async (_label, role, expectedVisible) => {
+    renderWithProviders(<Schedule />, {
+      auth: { role, organizationId: "org-1" },
+    });
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+
+    const occupiedCreateButton = screen.queryByRole("button", {
+      name: /add session within occupied block/i,
+    });
+
+    if (!expectedVisible) {
+      expect(occupiedCreateButton).toBeNull();
+      return;
+    }
+
+    expect(occupiedCreateButton).toBeTruthy();
+    fireEvent.click(occupiedCreateButton!);
+    await screen.findByTestId("session-modal");
+
+    expect(screen.getByTestId("modal-mode")).toHaveTextContent("create");
+    expect(screen.getByTestId("can-create-schedules")).toHaveTextContent("true");
+  });
+
+  it.each([
     ["admin", "admin", "true"],
     ["admin schedule", "admin_schedule", "true"],
     ["bcba", "bcba", "true"],

--- a/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
@@ -361,7 +361,7 @@ describe("ScheduleDayView drag and drop", () => {
       expect(onEditSession).not.toHaveBeenCalled();
     });
 
-    it("exposes create semantics only on truly empty slots and keeps occupied clicks in edit mode", () => {
+    it("lets occupied appointment blocks expose a separate create action without breaking edit mode", () => {
       const selectedDate = new Date(2025, 6, 7);
       const session = buildSession(new Date(2025, 6, 7, 9, 0), {
         id: "occupied-contract",
@@ -379,17 +379,22 @@ describe("ScheduleDayView drag and drop", () => {
           useImprovedAppointmentLayout
           onCreateSession={onCreateSession}
           onEditSession={onEditSession}
+          allowCreateInOccupiedSlot
         />,
       );
 
-      expect(screen.queryByRole("button", { name: /add session.*9:15 am/i })).toBeNull();
+      const occupiedCreateButton = screen.getByRole("button", {
+        name: /add session within occupied block on monday, july 7, 2025 at 9:00 am/i,
+      });
       const emptySlot = screen.getByRole("button", { name: /add session.*10:00 am/i });
       expect(within(emptySlot).getByText("+ Add session")).toBeTruthy();
       fireEvent.click(container.querySelector('[data-session-id="occupied-contract"]')!);
       expect(onEditSession).toHaveBeenCalledWith(expect.objectContaining({ id: "occupied-contract" }));
       expect(onCreateSession).not.toHaveBeenCalled();
+      fireEvent.click(occupiedCreateButton);
+      expect(onCreateSession).toHaveBeenCalledWith(expect.objectContaining({ time: "09:00", date: expect.any(Date) }));
       fireEvent.click(emptySlot);
-      expect(onCreateSession).toHaveBeenCalledWith(expect.objectContaining({ time: "10:00" }));
+      expect(onCreateSession).toHaveBeenLastCalledWith(expect.objectContaining({ time: "10:00" }));
     });
 
     it("keeps a 15-minute appointment inside its visual duration", () => {
@@ -711,6 +716,44 @@ describe("ScheduleDayView drag and drop", () => {
       vi.clearAllTimers();
       vi.useRealTimers();
       vi.restoreAllMocks();
+    });
+
+    it("keeps occupied-block creation visible and separate from edit on touch-only devices", () => {
+      const selectedDate = new Date(2025, 6, 7);
+      const session = buildSession(new Date(2025, 6, 7, 9, 0), {
+        id: "occupied-touch-contract",
+        start_time: "2025-07-07T09:00:00",
+        end_time: "2025-07-07T10:00:00",
+      });
+      const onCreateSession = vi.fn();
+      const onEditSession = vi.fn();
+
+      render(
+        <ScheduleDayView
+          selectedDate={selectedDate}
+          timeSlots={["09:00", "09:15", "09:30", "09:45", "10:00"]}
+          sessionSlotIndex={new Map()}
+          scheduleSessions={[session]}
+          useImprovedAppointmentLayout
+          onCreateSession={onCreateSession}
+          onEditSession={onEditSession}
+          onRescheduleSession={vi.fn()}
+          allowDragAndDrop
+          allowCreateInOccupiedSlot
+        />,
+      );
+
+      const occupiedCreateButton = screen.getByRole("button", {
+        name: /add session within occupied block on monday, july 7, 2025 at 9:00 am/i,
+      });
+      expect(occupiedCreateButton).toBeVisible();
+      expect(occupiedCreateButton.parentElement).not.toHaveClass("opacity-0");
+      expect(occupiedCreateButton.parentElement).not.toHaveClass("pointer-events-none");
+
+      fireEvent.click(occupiedCreateButton);
+
+      expect(onCreateSession).toHaveBeenCalledWith(expect.objectContaining({ time: "09:00", date: expect.any(Date) }));
+      expect(onEditSession).not.toHaveBeenCalled();
     });
 
     it("short tap still opens edit via onEditSession", () => {

--- a/src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
@@ -458,36 +458,54 @@ describe("ScheduleWeekView drag and drop", () => {
       expect(secondDaySlot?.querySelector('[data-session-id="week-fractional"]')).toBeNull();
     });
 
-    it("exposes create semantics only on truly empty week slots and keeps occupied clicks in edit mode", () => {
+    it("keeps occupied clicks in edit mode while exposing a separate create action for overlap clusters", () => {
       const sourceDay = new Date(2025, 6, 7);
       const targetDay = new Date(2025, 6, 8);
-      const session = buildSession(new Date(2025, 6, 7, 9, 0, 0, 0), {
-        id: "week-occupied-contract",
+      const alpha = buildSession(new Date(2025, 6, 7, 9, 0, 0, 0), {
+        id: "week-occupied-alpha",
         start_time: "2025-07-07T09:00:00",
-        end_time: "2025-07-07T10:00:00",
+        end_time: "2025-07-07T09:30:00",
+        client: { id: "client-alpha", full_name: "Alpha Client" },
+      });
+      const beta = buildSession(new Date(2025, 6, 7, 9, 0, 0, 0), {
+        id: "week-occupied-beta",
+        start_time: "2025-07-07T09:00:00",
+        end_time: "2025-07-07T09:45:00",
+        client: { id: "client-beta", full_name: "Beta Client" },
       });
       const onCreateSession = vi.fn();
       const onEditSession = vi.fn();
-      const { container } = render(
+      render(
         <ScheduleWeekView
           weekDays={[sourceDay, targetDay]}
           timeSlots={["09:00", "09:15", "09:30", "09:45", "10:00"]}
           sessionSlotIndex={new Map()}
-          scheduleSessions={[session]}
+          scheduleSessions={[alpha, beta]}
           useImprovedAppointmentLayout
           onCreateSession={onCreateSession}
           onEditSession={onEditSession}
+          allowCreateInOccupiedSlot
         />,
       );
 
-      expect(screen.queryByRole("button", { name: /add session on monday, july 7, 2025 at 9:15 am/i })).toBeNull();
+      const clusterTrigger = screen.getByRole("button", { name: /2 appointments/i });
+      fireEvent.click(clusterTrigger);
+      expect(onCreateSession).not.toHaveBeenCalled();
+      expect(onEditSession).not.toHaveBeenCalled();
+
+      const occupiedCreateButton = screen.getByRole("button", {
+        name: /add session within occupied block on monday, july 7, 2025 at 9:00 am/i,
+      });
       const emptySlot = screen.getByRole("button", { name: /add session on tuesday, july 8, 2025 at 10:00 am/i });
       expect(within(emptySlot).getByText("+ Add session")).toBeTruthy();
-      fireEvent.click(container.querySelector('[data-session-id="week-occupied-contract"]')!);
-      expect(onEditSession).toHaveBeenCalledWith(expect.objectContaining({ id: "week-occupied-contract" }));
-      expect(onCreateSession).not.toHaveBeenCalled();
-      fireEvent.click(emptySlot);
+      fireEvent.click(screen.getByRole("button", { name: /alpha client/i }));
+      expect(onEditSession).toHaveBeenCalledWith(expect.objectContaining({ id: "week-occupied-alpha" }));
+      fireEvent.click(occupiedCreateButton);
       expect(onCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ time: "09:00", date: expect.any(Date) }),
+      );
+      fireEvent.click(emptySlot);
+      expect(onCreateSession).toHaveBeenLastCalledWith(
         expect.objectContaining({ time: "10:00", date: expect.any(Date) }),
       );
     });
@@ -736,6 +754,45 @@ describe("ScheduleWeekView drag and drop", () => {
     beforeEach(() => {
       installMatchMedia(false);
       installPointerEvent();
+    });
+
+    it("keeps overlap-cluster creation visible and separate from the popover on touch-only devices", () => {
+      const sourceDay = new Date(2025, 6, 7);
+      const alpha = buildSession(new Date(2025, 6, 7, 9, 0), {
+        id: "week-touch-alpha",
+        start_time: "2025-07-07T09:00:00",
+        end_time: "2025-07-07T09:30:00",
+      });
+      const beta = buildSession(new Date(2025, 6, 7, 9, 0), {
+        id: "week-touch-beta",
+        start_time: "2025-07-07T09:00:00",
+        end_time: "2025-07-07T09:45:00",
+      });
+      const onCreateSession = vi.fn();
+
+      render(
+        <ScheduleWeekView
+          weekDays={[sourceDay]}
+          timeSlots={["09:00", "09:15", "09:30", "09:45"]}
+          sessionSlotIndex={new Map()}
+          scheduleSessions={[alpha, beta]}
+          useImprovedAppointmentLayout
+          onCreateSession={onCreateSession}
+          onEditSession={vi.fn()}
+          allowCreateInOccupiedSlot
+        />,
+      );
+
+      const occupiedCreateButton = screen.getByRole("button", {
+        name: /add session within occupied block on monday, july 7, 2025 at 9:00 am/i,
+      });
+      expect(occupiedCreateButton.parentElement).not.toHaveClass("opacity-0");
+      expect(occupiedCreateButton.parentElement).not.toHaveClass("pointer-events-none");
+
+      fireEvent.click(occupiedCreateButton);
+
+      expect(onCreateSession).toHaveBeenCalledWith(expect.objectContaining({ time: "09:00", date: expect.any(Date) }));
+      expect(screen.queryByRole("dialog", { name: /2 overlapping appointments/i })).toBeNull();
     });
 
     it("long-presses a cluster row for 480ms and reschedules it by slot tap in week view", async () => {


### PR DESCRIPTION
## Summary

- add a separate create-session action to occupied appointment blocks and overlap clusters in day/week schedule views
- enable the action for `admin_schedule`, `admin`, `bcba`, and `super_admin` while preserving therapist/BT restrictions
- keep edit, cluster popover, fine-pointer drag, touch long-press, and empty-slot interactions intact
- make the create action persistently reachable on touch-only devices

Linear: [WIN-260](https://linear.app/winningedgeai/issue/WIN-260/polish-schedule-appointment-and-create-session-interactions)

## Verification

Passed:
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- day/week schedule tests: 38/38
- occupied-block role gate: 6/6
- full schedule orchestration integration: 63/63 with `NODE_OPTIONS=--max-old-space-size=8192`
- `npm run build`
- independent exact-diff code review after touch-accessibility fixes

Blocked:
- `npm run test:ci`: 4,112 tests pass, then two unrelated `origin/main` Agent Work Ledger canonical-hash attestation tests fail for `docs/ai/handoffs/agent-work-ledger-foundation.md`
- responsive observer for `/schedule`: the mandated empty browser context redirects to the login shell; desktop reports a runtime-config console error, and mobile reports the same plus a 35x24 login-shell touch target. The observer forbids session/storage reuse and external requests, so it cannot render the authenticated schedule grid.

## Risk

No auth, server/API, Supabase, persistence, CI, or deploy paths changed. This PR remains draft until the full-suite baseline and responsive observer hard gates are resolved or explicitly superseded by repository policy.