### PR TITLE
Add authorized appointment deletion to Schedule

### DIFF
--- a/docs/ai/handoffs/schedule-delete-appointment.md
+++ b/docs/ai/handoffs/schedule-delete-appointment.md
@@ -1,0 +1,110 @@
+# Schedule Appointment Deletion
+
+## Routing
+
+- classification: high-risk human-reviewed
+- lane: critical
+- triggering protected path: `supabase/functions/sessions-cancel/index.ts`
+- reason: the requested role contract required a narrowly scoped authorization change in the existing cancellation Edge Function
+
+## Scope
+
+- Show a delete action only when an authorized user opens an existing appointment on `/schedule`.
+- Reuse the existing `cancelSessions` adapter with exactly one selected appointment id.
+- Confirm client, therapist, date, and time before submission.
+- Keep the destructive action disabled while deletion is pending and prevent double submit.
+- On success, close the appointment UI and refresh schedule queries without a full-page reload.
+- On failure, keep the confirmation open and show a clear error.
+- Cover authorized and unauthorized visibility, confirmation content, successful deletion, failure/loading behavior, overlap selection, and the protected authz edge case for `admin_schedule`.
+- Observe `/schedule` locally at desktop `1440x900` and mobile `390x844`.
+
+## Non-goals
+
+- Physical row deletion, bulk deletion, recurring-series deletion, or cancellation-policy redesign.
+- New roles or broad schedule-management capability expansion.
+- Migrations, RLS/grant changes, new server endpoints, or unrelated overlap/reschedule refactors.
+- Broadening `admin_schedule` beyond one exact `session_ids` cancellation request.
+
+## Files touched
+
+- `src/pages/Schedule.tsx`
+- `src/components/SessionModal.tsx`
+- `src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
+- `src/components/__tests__/SessionModal.test.tsx`
+- `supabase/functions/sessions-cancel/index.ts`
+- `tests/edge/sessions-cancel.org-scope.test.ts`
+
+## Implementation summary
+
+- Added a delete control to the existing appointment modal for `admin_schedule`, `admin`, `bcba`, and `super_admin` schedule managers.
+- Added a confirmation dialog with immutable appointment details from the selected session record, plus pending/error handling and double-submit protection.
+- Reused the existing cancellation API with `sessionIds: [selectedSession.id]`, then closed the modal and invalidated/refetched schedule queries on success.
+- Kept overlap deletion exact by reusing the selected session from the overlap chooser.
+- Narrowed the protected function so `admin_schedule` is allowed only for one explicit session-id cancellation request and is fail-closed for hold/date/therapist/bulk request shapes.
+
+## Tracking
+
+- Linear issue creation attempted on August 7, 2026.
+- Blocked by the workspace free issue limit; no exact issue key was available for this slice.
+- This remains a PR-readiness blocker under the critical-lane contract.
+
+## Verification card
+
+- classification: high-risk human-reviewed
+- lane: critical
+- change type:
+  - UI/component/page
+  - server/API/edge integration
+  - database/RLS/migrations/tenant isolation
+- required checks:
+  - `npm run ci:check-focused`
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:ci`
+  - `npm run validate:tenant`
+  - `npm run build`
+  - `npm run test:routes:tier0`
+  - `npm run ci:playwright`
+  - `npm run verify:local`
+  - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:<port> --route=/schedule`
+- executed checks:
+  - `npx vitest src/components/__tests__/SessionModal.test.tsx -t "appointment deletion|deletion error|confirms appointment deletion|persisted appointment" --maxWorkers=2 --minWorkers=1` -> pass
+  - `npx vitest src/pages/__tests__/Schedule.orchestration.integration.test.tsx --maxWorkers=1 --minWorkers=1 -t "appointment deletion|deletes the selected appointment|overlapping block"` -> pass
+  - `npx vitest tests/edge/sessions-cancel.org-scope.test.ts` -> pass
+  - `npm run ci:check-focused` -> pass
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm run validate:tenant` -> pass
+  - `npm run build` -> pass
+  - `npm run test:routes:tier0` -> pass
+- blocked checks:
+  - `npm run ci:playwright` -> fail: hosted auth smoke stopped on `Invalid email or password`
+  - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4174 --route=/schedule` -> fail: desktop `console-error`; mobile `console-error`, `undersized-mobile-touch-target`
+  - `npm run test:ci` -> fail: repository-level `tests/responsiveUiObserverRuntime.test.ts` failure followed by coverage temp-file `ENOENT`
+  - `npm run verify:local` -> fail: inherits the current `test:ci` and route-preview instability in this environment
+- reviewer:
+  - specification review completed
+  - software-architect review completed
+  - implementation review completed
+  - security review completed after protected-path narrowing
+  - code review requested changes, then re-review identified only handoff and verification blockers
+- result: pass-with-blocked-checks
+- residual risk:
+  - the slice itself is locally covered and protected-path authorization is narrowed, but merge readiness is blocked by missing Linear linkage and unresolved repo-level/browser verification failures
+
+## PR hygiene status
+
+- branch-ready: yes (`codex/schedule-delete-appointment`)
+- single-purpose: yes
+- protected-path drift: contained to the scoped `sessions-cancel` authorization check
+- generated artifact drift: none observed
+- pr-ready: no
+- blockers:
+  - missing Linear issue linkage for critical work
+  - responsive observer failure on `/schedule`
+  - `ci:playwright` auth failure
+  - `test:ci` / `verify:local` red in the current repository state
+
+## Next action
+
+- Push the scoped branch and open a human-review PR with the above blockers called out explicitly.

--- a/docs/ai/handoffs/schedule-delete-appointment.md
+++ b/docs/ai/handoffs/schedule-delete-appointment.md
@@ -87,6 +87,9 @@
   - GitHub Actions run `31215201119`, `unit-tests` -> fail; the blank persisted plan-target row assertion ran before that row's asynchronous form hydration completed
   - `npx vitest run src/components/__tests__/SessionModal.test.tsx -t "keeps a blank persisted plan-target evidence row visible and bindable when legacy target strings are missing" --maxWorkers=1 --minWorkers=1` -> pass, 8/8 pre-fix isolation runs and one post-fix run; the assertion now awaits the intended persisted row
   - `npx vitest run src/components/__tests__/SessionModal.test.tsx --maxWorkers=1 --minWorkers=1` after the synchronization fix -> pass, 165 tests
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm run build` -> pass
   - GitHub Actions run `31215201119`, `tenant-safety` -> infrastructure failure during `npm ci`; Cypress 13.17.0 could not be downloaded, while the separate same-head tenant-safety workflow passed
   - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4174 --route=/schedule` -> fail with sanitized artifacts; desktop reported `console-error`, mobile reported `console-error` and `undersized-mobile-touch-target`
 - Blocked checks:

--- a/docs/ai/handoffs/schedule-delete-appointment.md
+++ b/docs/ai/handoffs/schedule-delete-appointment.md
@@ -4,107 +4,128 @@
 
 - classification: high-risk human-reviewed
 - lane: critical
+- routing date: 2026-08-07
 - triggering protected path: `supabase/functions/sessions-cancel/index.ts`
-- reason: the requested role contract required a narrowly scoped authorization change in the existing cancellation Edge Function
+- reason: the requested role minimum included `admin_schedule`, which required a narrowly scoped authorization change in the existing cancellation Edge Function
 
 ## Scope
 
 - Show a delete action only when an authorized user opens an existing appointment on `/schedule`.
-- Reuse the existing `cancelSessions` adapter with exactly one selected appointment id.
-- Confirm client, therapist, date, and time before submission.
-- Keep the destructive action disabled while deletion is pending and prevent double submit.
-- On success, close the appointment UI and refresh schedule queries without a full-page reload.
-- On failure, keep the confirmation open and show a clear error.
-- Cover authorized and unauthorized visibility, confirmation content, successful deletion, failure/loading behavior, overlap selection, and the protected authz edge case for `admin_schedule`.
-- Observe `/schedule` locally at desktop `1440x900` and mobile `390x844`.
+- Reuse the existing `sessions-cancel` boundary with exactly one selected `session_id`.
+- Require confirmation with client, therapist, date, and time.
+- Keep the destructive action disabled while pending and prevent double-submit.
+- Close the appointment UI on success and refresh the schedule with query invalidation/refetch only.
+- Keep the confirmation open and show a clear inline error if deletion fails.
+- Preserve exact-session behavior for appointments selected from overlap blocks.
 
 ## Non-goals
 
-- Physical row deletion, bulk deletion, recurring-series deletion, or cancellation-policy redesign.
-- New roles or broad schedule-management capability expansion.
-- Migrations, RLS/grant changes, new server endpoints, or unrelated overlap/reschedule refactors.
+- Physical row deletion, recurring-series deletion, or bulk cancellation UX.
+- New roles, migrations, RLS or grant changes, CI workflow changes, or deployment changes.
+- Broad schedule authorization redesign outside the existing scheduling capability and `sessions-cancel` boundary.
 - Broadening `admin_schedule` beyond one exact `session_ids` cancellation request.
 
 ## Files touched
 
-- `src/pages/Schedule.tsx`
 - `src/components/SessionModal.tsx`
-- `src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
 - `src/components/__tests__/SessionModal.test.tsx`
+- `src/pages/Schedule.tsx`
+- `src/pages/__tests__/Schedule.orchestration.integration.test.tsx`
 - `supabase/functions/sessions-cancel/index.ts`
 - `tests/edge/sessions-cancel.org-scope.test.ts`
 
 ## Implementation summary
 
-- Added a delete control to the existing appointment modal for `admin_schedule`, `admin`, `bcba`, and `super_admin` schedule managers.
-- Added a confirmation dialog with immutable appointment details from the selected session record, plus pending/error handling and double-submit protection.
-- Reused the existing cancellation API with `sessionIds: [selectedSession.id]`, then closed the modal and invalidated/refetched schedule queries on success.
-- Kept overlap deletion exact by reusing the selected session from the overlap chooser.
-- Narrowed the protected function so `admin_schedule` is allowed only for one explicit session-id cancellation request and is fail-closed for hold/date/therapist/bulk request shapes.
+- `SessionModal` now renders a delete action only for authorized existing `scheduled` or `in_progress` appointments, opens a confirmation dialog, shows immutable persisted appointment details, blocks repeat submission, and keeps failures in-context with a clear message.
+- `Schedule` now exposes deletion only to `admin_schedule`, `admin`, `bcba`, and `super_admin` users that already satisfy the existing schedule-management capability gate, then calls `cancelSessions({ sessionIds: [selectedSession.id], cancellationAttribution: "staff" })`.
+- The schedule delete success path closes the modal, shows success feedback, and invalidates/refetches schedule queries without a full reload.
+- Overlap deletion stays exact because the modal continues to operate on the selected overlap session record only.
+- `sessions-cancel` now resolves exact in-org `admin_schedule` callers distinctly and fail-closes them unless the request is exactly one explicit session id with no hold key, date range, or therapist scope.
 
-## Tracking
+## Targeted test coverage added
 
-- Linear issue creation attempted on August 7, 2026.
-- Blocked by the workspace free issue limit; no exact issue key was available for this slice.
-- This remains a PR-readiness blocker under the critical-lane contract.
+- SessionModal visibility, confirmation details, immutable persisted-summary behavior, pending/double-submit protection, and failure messaging.
+- Schedule orchestration visibility matrix for authorized and unauthorized roles.
+- Successful single-appointment deletion flow with modal close and query refresh.
+- Overlap selection flow proving only the chosen appointment id is cancelled.
+- Edge-function org-scope coverage for exact `admin_schedule` role resolution, Mid Tier denial, and exact-session-only request-shape enforcement.
 
-## Verification card
+## Verification
 
-- classification: high-risk human-reviewed
-- lane: critical
-- change type:
-  - UI/component/page
-  - server/API/edge integration
-  - database/RLS/migrations/tenant isolation
-- required checks:
+### Verification card
+
+- Classification: high-risk human-reviewed
+- Lane: critical
+- Change type: UI/component/page; server/API/edge integration; tenant-scoped authorization
+- Required checks:
   - `npm run ci:check-focused`
   - `npm run lint`
   - `npm run typecheck`
   - `npm run test:ci`
+  - `npm run ci:verify-coverage`
   - `npm run validate:tenant`
   - `npm run build`
   - `npm run test:routes:tier0`
   - `npm run ci:playwright`
   - `npm run verify:local`
-  - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:<port> --route=/schedule`
-- executed checks:
-  - `npx vitest src/components/__tests__/SessionModal.test.tsx -t "appointment deletion|deletion error|confirms appointment deletion|persisted appointment" --maxWorkers=2 --minWorkers=1` -> pass
-  - `npx vitest src/pages/__tests__/Schedule.orchestration.integration.test.tsx --maxWorkers=1 --minWorkers=1 -t "appointment deletion|deletes the selected appointment|overlapping block"` -> pass
-  - `npx vitest tests/edge/sessions-cancel.org-scope.test.ts` -> pass
-  - `npm run ci:check-focused` -> pass
+  - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4174 --route=/schedule`
+- Executed checks:
+  - `npx vitest run src/components/__tests__/SessionModal.test.tsx -t "appointment deletion|deletion error|persisted appointment" --maxWorkers=2 --minWorkers=1` -> pass, 5 tests
+  - `npx vitest run src/pages/__tests__/Schedule.orchestration.integration.test.tsx -t "wires appointment deletion authority|deletes the selected appointment|deletes only the appointment" --maxWorkers=1 --minWorkers=1` -> pass, 9 tests
+  - `npx vitest run tests/edge/sessions-cancel.org-scope.test.ts --maxWorkers=2 --minWorkers=1` -> pass, 16 tests
+  - `npm run ci:check-focused` -> pass; database-backed grant/drift checks skipped because no database URL was configured
   - `npm run lint` -> pass
   - `npm run typecheck` -> pass
   - `npm run validate:tenant` -> pass
   - `npm run build` -> pass
-  - `npm run test:routes:tier0` -> pass
-- blocked checks:
-  - `npm run ci:playwright` -> fail: hosted auth smoke stopped on `Invalid email or password`
-  - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4174 --route=/schedule` -> fail: desktop `console-error`; mobile `console-error`, `undersized-mobile-touch-target`
-  - `npm run test:ci` -> fail: repository-level `tests/responsiveUiObserverRuntime.test.ts` failure followed by coverage temp-file `ENOENT`
-  - `npm run verify:local` -> fail: inherits the current `test:ci` and route-preview instability in this environment
-- reviewer:
-  - specification review completed
-  - software-architect review completed
-  - implementation review completed
-  - security review completed after protected-path narrowing
-  - code review requested changes, then re-review identified only handoff and verification blockers
-- result: pass-with-blocked-checks
-- residual risk:
-  - the slice itself is locally covered and protected-path authorization is narrowed, but merge readiness is blocked by missing Linear linkage and unresolved repo-level/browser verification failures
+  - `npm run test:ci` with an 8 GB Node heap -> fail; 4,133 tests passed, five skipped, and one unrelated deploy-script test timed out; that isolated test passed 2/2 immediately on rerun
+  - `npm run verify:local` with an 8 GB Node heap -> fail during coverage collation with missing `coverage/.tmp/coverage-68.json` after the test execution phase
+  - `npm run test:routes:tier0` -> fail; an initial run overlapped a production build and recorded five transient preview 404s, while the isolated rerun did not complete cleanly within the local wrapper run
+  - `npm run ci:playwright` -> fail during `playwright:auth`; configured hosted smoke credentials returned `Invalid email or password`
+  - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4174 --route=/schedule` -> fail with sanitized artifacts; desktop reported `console-error`, mobile reported `console-error` and `undersized-mobile-touch-target`
+- Blocked checks:
+  - `npm run ci:verify-coverage` -> blocked because both coverage-producing runs failed before a trustworthy summary could be finalized
+  - hosted browser continuation after `playwright:auth` -> blocked by rejected configured credentials
+- Result: fail
+- Residual risk: targeted behavior, static checks, build, and tenant validation are green, but the required aggregate, responsive, route, and hosted-browser gates are not merge-clean.
+
+Responsive evidence:
+
+- `artifacts/responsive-ui-observer/route-b8269c2977ef848259bf5694da1ebe4e7a041d55cb00a9e9fd3689b0c23f675f.desktop.1440x900.json`
+- `artifacts/responsive-ui-observer/route-b8269c2977ef848259bf5694da1ebe4e7a041d55cb00a9e9fd3689b0c23f675f.mobile.390x844.json`
+
+## Specialist review status
+
+- specification-engineer: completed before implementation
+- software-architect: completed before protected-path expansion
+- implementation-engineer: completed
+- code-review-engineer: core diff re-reviewed; no remaining code defects, but handoff and verification blockers remain
+- security-engineer: approved diff after protected-path narrowing; verification blockers remain
+- test-engineer: initial verification plan completed before implementation
+
+## Tracking
+
+- branch: `codex/schedule-delete-appointment`
+- Linear issue creation attempted on 2026-08-07 and failed because the workspace exceeded the free issue limit.
+- No exact replacement issue was available without repurposing materially different work.
 
 ## PR hygiene status
 
-- branch-ready: yes (`codex/schedule-delete-appointment`)
-- single-purpose: yes
-- protected-path drift: contained to the scoped `sessions-cancel` authorization check
-- generated artifact drift: none observed
-- pr-ready: no
-- blockers:
-  - missing Linear issue linkage for critical work
-  - responsive observer failure on `/schedule`
-  - `ci:playwright` auth failure
-  - `test:ci` / `verify:local` red in the current repository state
+- `pr-ready`: no
+- `lane`: critical
+- `branch-ready`: yes
+- `linear-ready`: no; issue creation is blocked by the workspace free-tier issue limit
+- `single-purpose`: yes
+- `unrelated changes`: none
+- `generated artifact drift`: none; responsive artifacts are untracked verification output
+- `protected-path drift`: none beyond the routed `supabase/functions/sessions-cancel/index.ts` authorization slice
+- `change summary`: present
+- `verification summary`: present and failing
+- `pr handoff`: branch pushed; PR may be opened for human review but is not merge-ready
+- `reviewer`: completed; code and security reviews found no remaining application defect, with verification blockers retained
+- `required follow-up`: restore Linear capacity/linkage, repair hosted smoke credentials, and obtain passing responsive, tier-0, full-coverage, and aggregate verification before merge
 
-## Next action
+## Residual risk
 
-- Push the scoped branch and open a human-review PR with the above blockers called out explicitly.
+- Code-path risk is low and contained to the requested exact-appointment cancellation slice.
+- Merge readiness is blocked by repository verification failures outside this diff, failing responsive observer evidence on `/schedule`, and missing Linear linkage for critical-lane PR hygiene.

--- a/docs/ai/handoffs/schedule-delete-appointment.md
+++ b/docs/ai/handoffs/schedule-delete-appointment.md
@@ -82,12 +82,14 @@
   - `npm run verify:local` with an 8 GB Node heap -> fail during coverage collation with missing `coverage/.tmp/coverage-68.json` after the test execution phase
   - `npm run test:routes:tier0` -> fail; an initial run overlapped a production build and recorded five transient preview 404s, while the isolated rerun did not complete cleanly within the local wrapper run
   - `npm run ci:playwright` -> fail during `playwright:auth`; configured hosted smoke credentials returned `Invalid email or password`
+  - `npm run playwright:auth` after synchronizing the approved `.env*` super-admin smoke password with the hosted Supabase auth user -> pass
+  - `TZ=UTC npx vitest run src/components/__tests__/SessionModal.test.tsx -t "confirms appointment deletion|keeps deletion confirmation"` -> pass, 2 tests; the CI-only hard-coded timezone assertions were replaced with environment-derived date-fns formatting
   - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4174 --route=/schedule` -> fail with sanitized artifacts; desktop reported `console-error`, mobile reported `console-error` and `undersized-mobile-touch-target`
 - Blocked checks:
   - `npm run ci:verify-coverage` -> blocked because both coverage-producing runs failed before a trustworthy summary could be finalized
-  - hosted browser continuation after `playwright:auth` -> blocked by rejected configured credentials
+  - responsive observer feature-state proof -> blocked because the mandatory observer is intentionally unauthenticated and aborts the external Supabase requests required to leave the login/loading shell
 - Result: fail
-- Residual risk: targeted behavior, static checks, build, and tenant validation are green, but the required aggregate, responsive, route, and hosted-browser gates are not merge-clean.
+- Residual risk: targeted behavior, static checks, build, tenant validation, and hosted auth smoke are green, but the required aggregate, responsive, route, and CI gates are not yet merge-clean.
 
 Responsive evidence:
 
@@ -123,9 +125,9 @@ Responsive evidence:
 - `verification summary`: present and failing
 - `pr handoff`: branch pushed; PR may be opened for human review but is not merge-ready
 - `reviewer`: completed; code and security reviews found no remaining application defect, with verification blockers retained
-- `required follow-up`: restore Linear capacity/linkage, repair hosted smoke credentials, and obtain passing responsive, tier-0, full-coverage, and aggregate verification before merge
+- `required follow-up`: restore Linear capacity/linkage and obtain passing responsive, tier-0, full-coverage, and aggregate verification before merge
 
 ## Residual risk
 
 - Code-path risk is low and contained to the requested exact-appointment cancellation slice.
-- Merge readiness is blocked by repository verification failures outside this diff, failing responsive observer evidence on `/schedule`, and missing Linear linkage for critical-lane PR hygiene.
+- Merge readiness is blocked by the CI rerun needed for the timezone-deterministic test fix, repository verification failures outside this diff, failing unauthenticated responsive observer evidence on `/schedule`, and missing Linear linkage for critical-lane PR hygiene.

--- a/docs/ai/handoffs/schedule-delete-appointment.md
+++ b/docs/ai/handoffs/schedule-delete-appointment.md
@@ -84,12 +84,16 @@
   - `npm run ci:playwright` -> fail during `playwright:auth`; configured hosted smoke credentials returned `Invalid email or password`
   - `npm run playwright:auth` after synchronizing the approved `.env*` super-admin smoke password with the hosted Supabase auth user -> pass
   - `TZ=UTC npx vitest run src/components/__tests__/SessionModal.test.tsx -t "confirms appointment deletion|keeps deletion confirmation"` -> pass, 2 tests; the CI-only hard-coded timezone assertions were replaced with environment-derived date-fns formatting
+  - GitHub Actions run `31215201119`, `unit-tests` -> fail; the blank persisted plan-target row assertion ran before that row's asynchronous form hydration completed
+  - `npx vitest run src/components/__tests__/SessionModal.test.tsx -t "keeps a blank persisted plan-target evidence row visible and bindable when legacy target strings are missing" --maxWorkers=1 --minWorkers=1` -> pass, 8/8 pre-fix isolation runs and one post-fix run; the assertion now awaits the intended persisted row
+  - `npx vitest run src/components/__tests__/SessionModal.test.tsx --maxWorkers=1 --minWorkers=1` after the synchronization fix -> pass, 165 tests
+  - GitHub Actions run `31215201119`, `tenant-safety` -> infrastructure failure during `npm ci`; Cypress 13.17.0 could not be downloaded, while the separate same-head tenant-safety workflow passed
   - `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4174 --route=/schedule` -> fail with sanitized artifacts; desktop reported `console-error`, mobile reported `console-error` and `undersized-mobile-touch-target`
 - Blocked checks:
   - `npm run ci:verify-coverage` -> blocked because both coverage-producing runs failed before a trustworthy summary could be finalized
   - responsive observer feature-state proof -> blocked because the mandatory observer is intentionally unauthenticated and aborts the external Supabase requests required to leave the login/loading shell
 - Result: fail
-- Residual risk: targeted behavior, static checks, build, tenant validation, and hosted auth smoke are green, but the required aggregate, responsive, route, and CI gates are not yet merge-clean.
+- Residual risk: targeted behavior, static checks, build, tenant validation, hosted auth smoke, and the locally reproduced CI unit suite are green, but a fresh GitHub Actions head and the required responsive, route, and aggregate gates must still complete.
 
 Responsive evidence:
 

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -38,6 +38,7 @@ import {
 } from '../lib/bt-aba-session-note';
 import { checkSchedulingConflicts, suggestAlternativeTimes, type Conflict, type AlternativeTime } from '../lib/conflicts';
 import { logger } from '../lib/logger/logger';
+import { toError } from '../lib/logger/normalizeError';
 import { AlternativeTimes } from './AlternativeTimes';
 import { supabase } from '../lib/supabase';
 import { fetchLinkedClientSessionNoteForSession } from '../lib/session-note-linked-fetch';
@@ -713,6 +714,7 @@ interface SessionModalProps {
   onClose: () => void;
   onSubmit: (data: SessionModalSubmitData) => Promise<void | SessionNoteUpsertResult>;
   onReactivate?: (input: { session: Session; start_time: string; end_time: string }) => Promise<void>;
+  onDeleteAppointment?: (input: { session: Session }) => Promise<void>;
   session?: Session;
   selectedDate?: Date;
   selectedTime?: string;
@@ -730,7 +732,9 @@ interface SessionModalProps {
   dataCollectionOnly?: boolean;
   allowStartSession?: boolean;
   canCreateSchedules?: boolean;
+  canDeleteAppointments?: boolean;
   isReactivating?: boolean;
+  isDeletingAppointment?: boolean;
   hideGoalCaptureFields?: boolean;
   onBtAbaSessionFinalized?: (result: BtAbaFinalizeResult & { sessionId: string }) => void | Promise<void>;
 }
@@ -740,6 +744,7 @@ export function SessionModal({
   onClose,
   onSubmit,
   onReactivate,
+  onDeleteAppointment,
   session,
   selectedDate,
   selectedTime,
@@ -757,7 +762,9 @@ export function SessionModal({
   dataCollectionOnly = false,
   allowStartSession = false,
   canCreateSchedules = true,
+  canDeleteAppointments = false,
   isReactivating = false,
+  isDeletingAppointment = false,
   hideGoalCaptureFields = false,
   onBtAbaSessionFinalized,
 }: SessionModalProps) {
@@ -813,6 +820,9 @@ export function SessionModal({
   const queryClient = useQueryClient();
   const [isEntered, setIsEntered] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
+  const [isDeleteSubmitting, setIsDeleteSubmitting] = useState(false);
+  const [isDeleteConfirmationOpen, setIsDeleteConfirmationOpen] = useState(false);
+  const [deleteAppointmentError, setDeleteAppointmentError] = useState<string | null>(null);
   const isDataCollectionOnly = Boolean(dataCollectionOnly && session?.id);
   const canUseStartSessionAction = !isDataCollectionOnly || allowStartSession;
   const canReactivateSession = Boolean(
@@ -820,6 +830,12 @@ export function SessionModal({
     session.status === 'cancelled' &&
     canCreateSchedules &&
     onReactivate,
+  );
+  const canDeleteAppointment = Boolean(
+    session?.id &&
+    (session.status === 'scheduled' || session.status === 'in_progress') &&
+    canDeleteAppointments &&
+    onDeleteAppointment,
   );
   const isBtClinicalCaptureSession = Boolean(
     isDataCollectionOnly && (session?.status === 'scheduled' || session?.status === 'in_progress'),
@@ -851,6 +867,17 @@ export function SessionModal({
     btAbaTransitionRef.current = 'idle';
     closeoutCaptureRef.current = null;
   }, [session?.id]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsDeleteSubmitting(false);
+      setIsDeleteConfirmationOpen(false);
+      setDeleteAppointmentError(null);
+      return;
+    }
+    setIsDeleteSubmitting(false);
+    setDeleteAppointmentError(null);
+  }, [isOpen, session?.id]);
 
   const resolvedTimeZone = useMemo(() => resolveSchedulingTimeZone(timeZone), [timeZone]);
 
@@ -3067,7 +3094,54 @@ export function SessionModal({
   ].join(' ');
   const isCloseInteractionDisabled = isSubmitting || btAbaBusy || btAbaFinalized || isClosing;
   const isReactivateDisabled =
-    isCloseInteractionDisabled || isDependentDataLoading || isLoadingAlternatives || isReactivating;
+    isCloseInteractionDisabled ||
+    isDependentDataLoading ||
+    isLoadingAlternatives ||
+    isReactivating ||
+    isDeletingAppointment ||
+    isDeleteSubmitting;
+  const isDeleteAppointmentBusy = isDeletingAppointment || isDeleteSubmitting;
+  const isDeleteAppointmentDisabled =
+    isCloseInteractionDisabled ||
+    isDependentDataLoading ||
+    isLoadingAlternatives ||
+    isReactivating ||
+    isDeleteAppointmentBusy;
+
+  const deleteAppointmentSummary = useMemo(() => {
+    const currentClientId = session?.client_id;
+    const currentTherapistId = session?.therapist_id;
+    const currentStartTime = session?.start_time || '';
+    const currentEndTime = session?.end_time || '';
+    const clientLabel =
+      clients.find((client) => client.id === currentClientId)?.full_name ??
+      session?.client?.full_name ??
+      'Unknown client';
+    const therapistLabel =
+      therapists.find((therapist) => therapist.id === currentTherapistId)?.full_name ??
+      session?.therapist?.full_name ??
+      'Unknown therapist';
+
+    const parsedStart = parseISO(currentStartTime);
+    const parsedEnd = parseISO(currentEndTime);
+    const appointmentDate = Number.isNaN(parsedStart.getTime())
+      ? currentStartTime
+      : format(parsedStart, 'PPP');
+    const startLabel = Number.isNaN(parsedStart.getTime())
+      ? currentStartTime
+      : format(parsedStart, 'p');
+    const endLabel = Number.isNaN(parsedEnd.getTime())
+      ? currentEndTime
+      : format(parsedEnd, 'p');
+
+    return {
+      clientLabel,
+      therapistLabel,
+      appointmentDate,
+      startLabel,
+      endLabel,
+    };
+  }, [clients, session?.client?.full_name, session?.client_id, session?.end_time, session?.start_time, session?.therapist?.full_name, session?.therapist_id, therapists]);
 
   const handleReactivateSession = useCallback(async () => {
     if (!session || !onReactivate) {
@@ -3095,6 +3169,31 @@ export function SessionModal({
       end_time: timeZone ? toUtcSessionIsoString(currentEndTime, resolvedTimeZone) : currentEndTime,
     });
   }, [getValues, onReactivate, resolvedTimeZone, session, timeZone]);
+
+  const handleDeleteAppointment = useCallback(async () => {
+    if (!session || !onDeleteAppointment) {
+      return;
+    }
+    setDeleteAppointmentError(null);
+    setIsDeleteConfirmationOpen(true);
+  }, [onDeleteAppointment, session]);
+
+  const handleConfirmDeleteAppointment = useCallback(async () => {
+    if (!session || !onDeleteAppointment || isDeleteAppointmentDisabled) {
+      return;
+    }
+
+    try {
+      setIsDeleteSubmitting(true);
+      await onDeleteAppointment({ session });
+      setIsDeleteConfirmationOpen(false);
+      setDeleteAppointmentError(null);
+    } catch (error) {
+      setDeleteAppointmentError(`Unable to delete appointment. ${toError(error, 'Appointment deletion failed').message}`);
+    } finally {
+      setIsDeleteSubmitting(false);
+    }
+  }, [isDeleteAppointmentDisabled, onDeleteAppointment, session]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -5355,6 +5454,16 @@ export function SessionModal({
                   {isReactivating ? 'Reactivating...' : 'Reactivate appointment'}
                 </button>
               ) : null}
+              {canDeleteAppointment ? (
+                <button
+                  type="button"
+                  onClick={() => void handleDeleteAppointment()}
+                  disabled={isDeleteAppointmentDisabled}
+                  className="min-h-11 shrink-0 rounded-full px-3 text-sm font-semibold text-rose-700 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:text-rose-300 dark:hover:bg-rose-950/40 sm:min-h-11 sm:w-auto sm:rounded-md sm:border sm:border-rose-200 sm:bg-rose-50/90 sm:px-4 sm:font-medium sm:text-rose-800 sm:shadow-sm sm:hover:bg-rose-100"
+                >
+                  {isDeletingAppointment ? 'Deleting...' : 'Delete appointment'}
+                </button>
+              ) : null}
             </div>
             <div className="flex justify-center sm:justify-end">
               <button
@@ -5380,6 +5489,83 @@ export function SessionModal({
             </div>
           </div>
         </div>
+        ) : null}
+        {isDeleteConfirmationOpen && canDeleteAppointment ? (
+          <div className="absolute inset-0 z-20 flex items-center justify-center bg-gray-950/45 px-4 backdrop-blur-[1px]">
+            <div
+              role="alertdialog"
+              aria-modal="true"
+              aria-labelledby="delete-appointment-title"
+              aria-describedby="delete-appointment-description"
+              className="w-full max-w-md rounded-2xl border border-rose-200 bg-white p-5 shadow-2xl dark:border-rose-900/60 dark:bg-dark-lighter"
+            >
+              <div className="flex items-start gap-3">
+                <div className="rounded-full bg-rose-100 p-2 text-rose-700 dark:bg-rose-950/40 dark:text-rose-300">
+                  <Trash2 className="h-5 w-5" aria-hidden="true" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h2 id="delete-appointment-title" className="text-lg font-semibold text-gray-900 dark:text-white">
+                    Delete appointment
+                  </h2>
+                  <p id="delete-appointment-description" className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                    This deletes only the selected appointment.
+                  </p>
+                </div>
+              </div>
+              <dl className="mt-4 space-y-2 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm dark:border-gray-700 dark:bg-dark">
+                <div className="flex justify-between gap-4">
+                  <dt className="font-medium text-gray-600 dark:text-gray-300">Client</dt>
+                  <dd className="text-right text-gray-900 dark:text-white">{deleteAppointmentSummary.clientLabel}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="font-medium text-gray-600 dark:text-gray-300">Therapist</dt>
+                  <dd className="text-right text-gray-900 dark:text-white">{deleteAppointmentSummary.therapistLabel}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="font-medium text-gray-600 dark:text-gray-300">Date</dt>
+                  <dd className="text-right text-gray-900 dark:text-white">{deleteAppointmentSummary.appointmentDate}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="font-medium text-gray-600 dark:text-gray-300">Time</dt>
+                  <dd className="text-right text-gray-900 dark:text-white">
+                    {deleteAppointmentSummary.startLabel} - {deleteAppointmentSummary.endLabel}
+                  </dd>
+                </div>
+              </dl>
+              {deleteAppointmentError ? (
+                <div
+                  role="alert"
+                  className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-800 dark:border-rose-900/60 dark:bg-rose-950/30 dark:text-rose-200"
+                >
+                  {deleteAppointmentError}
+                </div>
+              ) : null}
+              <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (isDeleteAppointmentBusy) {
+                      return;
+                    }
+                    setDeleteAppointmentError(null);
+                    setIsDeleteConfirmationOpen(false);
+                  }}
+                  disabled={isDeleteAppointmentBusy}
+                  className="min-h-11 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+                >
+                  Keep appointment
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleConfirmDeleteAppointment()}
+                  disabled={isDeleteAppointmentBusy}
+                  className="min-h-11 rounded-md border border-transparent bg-rose-600 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-700 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isDeleteAppointmentBusy ? 'Deleting...' : 'Confirm delete appointment'}
+                </button>
+              </div>
+            </div>
+          </div>
         ) : null}
       </div>
     </div>

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -8191,4 +8191,119 @@ describe('SessionModal', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(toastMocks.showError).toHaveBeenCalledWith('RPC failure');
   });
+
+  it('hides appointment deletion when no authorized delete handler is provided', () => {
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        session={validScheduledSession}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /delete appointment/i })).not.toBeInTheDocument();
+  });
+
+  it('confirms appointment deletion with client, therapist, date, and time details', async () => {
+    const onDeleteAppointment = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        session={validScheduledSession}
+        canDeleteAppointments
+        onDeleteAppointment={onDeleteAppointment}
+      />,
+    );
+
+    const deleteButton = screen.getByRole('button', { name: /delete appointment/i });
+    await waitFor(() => expect(deleteButton).not.toBeDisabled());
+    await userEvent.click(deleteButton);
+
+    const confirmation = await screen.findByRole('alertdialog', { name: /delete appointment/i });
+    expect(confirmation).toHaveTextContent('Test Client 1');
+    expect(confirmation).toHaveTextContent('Test Therapist 1');
+    expect(confirmation).toHaveTextContent('March 1st, 2026');
+    expect(confirmation).toHaveTextContent('2:00 AM');
+    expect(confirmation).toHaveTextContent('3:00 AM');
+    expect(onDeleteAppointment).not.toHaveBeenCalled();
+  });
+
+  it('keeps deletion confirmation bound to the persisted appointment when edits are unsaved', async () => {
+    const onDeleteAppointment = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        session={validScheduledSession}
+        canDeleteAppointments
+        onDeleteAppointment={onDeleteAppointment}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Start Time/i), { target: { value: '2026-03-01T09:30' } });
+    fireEvent.change(screen.getByLabelText(/End Time/i), { target: { value: '2026-03-01T10:30' } });
+
+    const deleteButton = screen.getByRole('button', { name: /delete appointment/i });
+    await waitFor(() => expect(deleteButton).not.toBeDisabled());
+    await userEvent.click(deleteButton);
+
+    const confirmation = await screen.findByRole('alertdialog', { name: /delete appointment/i });
+    expect(confirmation).toHaveTextContent('March 1st, 2026');
+    expect(confirmation).toHaveTextContent('2:00 AM');
+    expect(confirmation).toHaveTextContent('3:00 AM');
+    expect(confirmation).not.toHaveTextContent('9:30 AM');
+    expect(confirmation).not.toHaveTextContent('10:30 AM');
+  });
+
+  it('disables repeated appointment deletion while the request is pending', async () => {
+    let resolveDelete: (() => void) | null = null;
+    const onDeleteAppointment = vi.fn(() => new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    }));
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        session={validScheduledSession}
+        canDeleteAppointments
+        onDeleteAppointment={onDeleteAppointment}
+      />,
+    );
+
+    const deleteButton = screen.getByRole('button', { name: /delete appointment/i });
+    await waitFor(() => expect(deleteButton).not.toBeDisabled());
+    await userEvent.click(deleteButton);
+    const confirmButton = await screen.findByRole('button', { name: /confirm delete appointment/i });
+    await userEvent.click(confirmButton);
+
+    expect(confirmButton).toBeDisabled();
+    expect(confirmButton).toHaveTextContent('Deleting...');
+    fireEvent.click(confirmButton);
+    expect(onDeleteAppointment).toHaveBeenCalledTimes(1);
+
+    resolveDelete?.();
+    await waitFor(() => expect(onDeleteAppointment).toHaveBeenCalledTimes(1));
+  });
+
+  it('keeps the confirmation open and shows a clear deletion error', async () => {
+    const onDeleteAppointment = vi.fn().mockRejectedValue(new Error('Cancellation service unavailable'));
+
+    renderWithProviders(
+      <SessionModal
+        {...defaultProps}
+        session={validScheduledSession}
+        canDeleteAppointments
+        onDeleteAppointment={onDeleteAppointment}
+      />,
+    );
+
+    const deleteButton = screen.getByRole('button', { name: /delete appointment/i });
+    await waitFor(() => expect(deleteButton).not.toBeDisabled());
+    await userEvent.click(deleteButton);
+    await userEvent.click(await screen.findByRole('button', { name: /confirm delete appointment/i }));
+
+    const confirmation = await screen.findByRole('alertdialog', { name: /delete appointment/i });
+    expect(confirmation).toHaveTextContent('Unable to delete appointment. Cancellation service unavailable');
+    expect(screen.getByRole('button', { name: /confirm delete appointment/i })).not.toBeDisabled();
+  });
 });

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, screen, userEvent, waitFor } from '../../test/utils';
 import { act, fireEvent } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
 import {
   buildCloseoutDataPoints,
   SessionModal,
@@ -8205,6 +8206,8 @@ describe('SessionModal', () => {
 
   it('confirms appointment deletion with client, therapist, date, and time details', async () => {
     const onDeleteAppointment = vi.fn().mockResolvedValue(undefined);
+    const expectedStartTime = format(parseISO(validScheduledSession.start_time), 'p');
+    const expectedEndTime = format(parseISO(validScheduledSession.end_time), 'p');
 
     renderWithProviders(
       <SessionModal
@@ -8223,13 +8226,15 @@ describe('SessionModal', () => {
     expect(confirmation).toHaveTextContent('Test Client 1');
     expect(confirmation).toHaveTextContent('Test Therapist 1');
     expect(confirmation).toHaveTextContent('March 1st, 2026');
-    expect(confirmation).toHaveTextContent('2:00 AM');
-    expect(confirmation).toHaveTextContent('3:00 AM');
+    expect(confirmation).toHaveTextContent(expectedStartTime);
+    expect(confirmation).toHaveTextContent(expectedEndTime);
     expect(onDeleteAppointment).not.toHaveBeenCalled();
   });
 
   it('keeps deletion confirmation bound to the persisted appointment when edits are unsaved', async () => {
     const onDeleteAppointment = vi.fn().mockResolvedValue(undefined);
+    const expectedStartTime = format(parseISO(validScheduledSession.start_time), 'p');
+    const expectedEndTime = format(parseISO(validScheduledSession.end_time), 'p');
 
     renderWithProviders(
       <SessionModal
@@ -8249,8 +8254,8 @@ describe('SessionModal', () => {
 
     const confirmation = await screen.findByRole('alertdialog', { name: /delete appointment/i });
     expect(confirmation).toHaveTextContent('March 1st, 2026');
-    expect(confirmation).toHaveTextContent('2:00 AM');
-    expect(confirmation).toHaveTextContent('3:00 AM');
+    expect(confirmation).toHaveTextContent(expectedStartTime);
+    expect(confirmation).toHaveTextContent(expectedEndTime);
     expect(confirmation).not.toHaveTextContent('9:30 AM');
     expect(confirmation).not.toHaveTextContent('10:30 AM');
   });

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -7467,7 +7467,7 @@ describe('SessionModal', () => {
     expect(planTargetButton).toHaveTextContent(planTarget);
     expect(screen.queryByRole('button', { name: /Plan target selected/i })).not.toBeInTheDocument();
     expect(screen.getAllByText(planTarget)).toHaveLength(1);
-    expect(screen.getByText('No target selected')).toBeInTheDocument();
+    expect(await screen.findByText('No target selected')).toBeInTheDocument();
     expect(screen.getByText(/\+4 · −1/)).toBeInTheDocument();
     expect(screen.getByLabelText(/Prompts & reactions for target 1/i)).toHaveValue('Persisted blank target row note');
     expect(screen.getByRole('button', { name: /Increase correct trials for target 1/i })).toBeInTheDocument();

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -778,6 +778,12 @@ export const Schedule = React.memo(() => {
     effectiveRole === "admin" ||
     effectiveRole === "bcba" ||
     effectiveRole === "super_admin";
+  const canDeleteAppointments = hasCapability("manageStaff") && (
+    effectiveRole === "admin_schedule" ||
+    effectiveRole === "admin" ||
+    effectiveRole === "bcba" ||
+    effectiveRole === "super_admin"
+  );
 
   const showOrgDirectoryEmpty =
     displayData.therapists.length === 0 && displayData.clients.length === 0;
@@ -1282,6 +1288,15 @@ export const Schedule = React.memo(() => {
     },
   });
 
+  const deleteAppointmentMutation = useMutation({
+    mutationFn: async ({ sessionId }: { sessionId: string }) => {
+      return cancelSessions({
+        sessionIds: [sessionId],
+        cancellationAttribution: "staff",
+      });
+    },
+  });
+
   const rescheduleSessionMutation = useMutation({
     mutationFn: async ({
       session,
@@ -1626,22 +1641,41 @@ export const Schedule = React.memo(() => {
     });
   }, [reactivateSessionMutation]);
 
-  const _handleDeleteSession = useCallback(
-    async (sessionId: string) => {
-      if (window.confirm("Are you sure you want to cancel this session?")) {
-        const result = await cancelSessionMutation.mutateAsync({
-          sessionId,
-        });
+  const handleDeleteAppointment = useCallback(async (
+    { session: targetSession }: { session: Session },
+  ) => {
+    const result = await deleteAppointmentMutation.mutateAsync({
+      sessionId: targetSession.id,
+    });
 
-        showSuccess(
-          result.cancelledCount > 0
-            ? "Session cancelled successfully"
-            : "Session was already cancelled",
-        );
-      }
-    },
-    [cancelSessionMutation],
-  );
+    if (result.cancelledCount === 0 && result.alreadyCancelledCount === 0) {
+      throw new Error("Appointment is no longer cancellable.");
+    }
+
+    handleCloseSessionModal();
+    showSuccess(
+      result.cancelledCount > 0
+        ? "Appointment deleted"
+        : "Appointment was already deleted",
+    );
+
+    try {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["sessions"] }),
+        queryClient.invalidateQueries({ queryKey: ["sessions-batch"] }),
+        queryClient.refetchQueries({ queryKey: ["sessions"], type: "active" }),
+        queryClient.refetchQueries({ queryKey: ["sessions-batch"], type: "active" }),
+      ]);
+    } catch (error) {
+      logger.warn("Appointment deleted but schedule refresh failed", {
+        metadata: {
+          sessionId: targetSession.id,
+          reason: toError(error, "Schedule refresh failed").message,
+        },
+      });
+      showError("Appointment deleted, but the schedule refresh failed. Refresh the page to see the latest schedule.");
+    }
+  }, [deleteAppointmentMutation, handleCloseSessionModal, queryClient]);
 
   const handleSubmit = useCallback(
     async (data: ScheduleSubmitData) => {
@@ -2081,8 +2115,11 @@ export const Schedule = React.memo(() => {
           !selectedSession.started_at
         }
         canCreateSchedules={!therapistScopedView}
+        canDeleteAppointments={canDeleteAppointments}
         onReactivate={!therapistScopedView ? handleReactivateSession : undefined}
+        onDeleteAppointment={canDeleteAppointments ? handleDeleteAppointment : undefined}
         isReactivating={reactivateSessionMutation.isPending}
+        isDeletingAppointment={deleteAppointmentMutation.isPending}
         hideGoalCaptureFields={effectiveRole === "admin" || effectiveRole === "admin_schedule"}
         defaultTherapistId={selectedTherapist}
         defaultClientId={selectedClient}

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, within } from "@testing-library/react";
 import { QueryClient } from "@tanstack/react-query";
 import { useLocation } from "react-router-dom";
 import { renderWithProviders, screen, waitFor } from "../../test/utils";
@@ -142,6 +142,7 @@ vi.mock("../../components/SessionModal", () => ({
     onClose,
     onSubmit,
     onReactivate,
+    onDeleteAppointment,
     session,
     retryHint,
     dataCollectionOnly,
@@ -155,6 +156,7 @@ vi.mock("../../components/SessionModal", () => ({
     onClose: () => void;
     onSubmit: (data: Record<string, unknown>) => unknown;
     onReactivate?: (input: { session: { id: string }; start_time: string; end_time: string }) => unknown;
+    onDeleteAppointment?: (input: { session: { id: string } }) => unknown;
     session?: { id: string };
     retryHint?: string | null;
     dataCollectionOnly?: boolean;
@@ -167,13 +169,29 @@ vi.mock("../../components/SessionModal", () => ({
     isOpen ? (
       <div data-testid="session-modal">
         <div data-testid="modal-mode">{session ? "edit" : "create"}</div>
+        <div data-testid="selected-session-id">{session?.id ?? ""}</div>
         <div data-testid="retry-hint">{retryHint ?? ""}</div>
         <div data-testid="data-collection-only">{dataCollectionOnly ? "true" : "false"}</div>
         <div data-testid="allow-start-session">{allowStartSession ? "true" : "false"}</div>
         <div data-testid="can-create-schedules">{canCreateSchedules ? "true" : "false"}</div>
         <div data-testid="reactivate-available">{session && onReactivate ? "true" : "false"}</div>
         <div data-testid="reactivating">{isReactivating ? "true" : "false"}</div>
+        <div data-testid="delete-available">{session && onDeleteAppointment ? "true" : "false"}</div>
         <div data-testid="hide-goal-capture-fields">{hideGoalCaptureFields ? "true" : "false"}</div>
+        <button
+          aria-label="delete-appointment"
+          disabled={!session || !onDeleteAppointment}
+          onClick={() => {
+            const result = session && onDeleteAppointment
+              ? onDeleteAppointment({ session: { id: session.id } })
+              : undefined;
+            if (result && typeof (result as Promise<unknown>).catch === "function") {
+              void (result as Promise<unknown>).catch(() => undefined);
+            }
+          }}
+        >
+          delete-appointment
+        </button>
         <button
           aria-label="submit-complete-with-stale-trial"
           onClick={() => {
@@ -490,6 +508,7 @@ describe("Schedule orchestration integration hardening", () => {
   };
 
   const resetScheduleFixture = () => {
+    scheduleFixtures.sessions.splice(1);
     Object.assign(scheduleFixtures.sessions[0], originalSessionFixture);
   };
 
@@ -852,6 +871,90 @@ describe("Schedule orchestration integration hardening", () => {
     await screen.findByTestId("session-modal");
 
     expect(screen.getByTestId("can-create-schedules")).toHaveTextContent(expectedCanCreate);
+  });
+
+  it.each([
+    ["admin schedule", "admin_schedule", "true"],
+    ["admin", "admin", "true"],
+    ["bcba", "bcba", "true"],
+    ["super admin", "super_admin", "true"],
+    ["midtier", "midtier", "false"],
+    ["bt", "bt", "false"],
+    ["therapist", "therapist", "false"],
+  ] as const)("wires appointment deletion authority for %s", async (_label, role, expectedCanDelete) => {
+    renderWithProviders(<Schedule />, {
+      auth: { role, organizationId: "org-1" },
+    });
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+
+    expect(screen.getByTestId("delete-available")).toHaveTextContent(expectedCanDelete);
+  });
+
+  it("deletes the selected appointment, closes the modal, and refreshes schedule queries", async () => {
+    const invalidateQueriesSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+
+    renderWithProviders(<Schedule />, {
+      auth: { role: "admin_schedule", organizationId: "org-1" },
+    });
+    await screen.findByRole("heading", { name: /Schedule/i });
+    await waitForScheduleGridReady();
+    await openExistingSessionForEdit();
+    await screen.findByTestId("session-modal");
+
+    fireEvent.click(screen.getByLabelText("delete-appointment"));
+
+    await waitFor(() => {
+      expect(cancelSessionsMock).toHaveBeenCalledWith({
+        sessionIds: ["session-1"],
+        cancellationAttribution: "staff",
+      });
+    });
+    await waitFor(() => expect(screen.queryByTestId("session-modal")).not.toBeInTheDocument());
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["sessions"] });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["sessions-batch"] });
+    invalidateQueriesSpy.mockRestore();
+  });
+
+  it("deletes only the appointment selected from an overlapping block", async () => {
+    const overlapWindowStart = new Date(2025, 6, 7, 10, 0, 0, 0);
+    const overlapWindowEnd = new Date(2025, 6, 7, 10, 30, 0, 0);
+    const overlapSession = {
+      ...originalSessionFixture,
+      id: "session-overlap",
+      start_time: overlapWindowStart.toISOString(),
+      end_time: overlapWindowEnd.toISOString(),
+      client: { id: "client-1", full_name: "Overlap Client" },
+    };
+    Object.assign(scheduleFixtures.sessions[0], {
+      ...originalSessionFixture,
+      start_time: overlapWindowStart.toISOString(),
+      end_time: overlapWindowEnd.toISOString(),
+    });
+    scheduleFixtures.sessions.push(overlapSession);
+
+    renderWithProviders(<Schedule />, {
+      auth: { role: "bcba", organizationId: "org-1" },
+    });
+    await screen.findByRole("heading", { name: /Schedule/i });
+
+    const overlapTrigger = await screen.findByRole("button", { name: /2 appointments/i });
+    fireEvent.click(overlapTrigger);
+    const overlapDialog = screen.getByRole("dialog", { name: /2 overlapping appointments/i });
+    fireEvent.click(within(overlapDialog).getByRole("button", { name: /Overlap Client/i }));
+
+    expect(await screen.findByTestId("selected-session-id")).toHaveTextContent("session-overlap");
+    fireEvent.click(screen.getByLabelText("delete-appointment"));
+
+    await waitFor(() => {
+      expect(cancelSessionsMock).toHaveBeenCalledWith({
+        sessionIds: ["session-overlap"],
+        cancellationAttribution: "staff",
+      });
+    });
+    expect(cancelSessionsMock).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -919,8 +919,8 @@ describe("Schedule orchestration integration hardening", () => {
   });
 
   it("deletes only the appointment selected from an overlapping block", async () => {
-    const overlapWindowStart = new Date(2025, 6, 7, 10, 0, 0, 0);
-    const overlapWindowEnd = new Date(2025, 6, 7, 10, 30, 0, 0);
+    const overlapWindowStart = new Date(2025, 6, 2, 10, 0, 0, 0);
+    const overlapWindowEnd = new Date(2025, 6, 2, 10, 30, 0, 0);
     const overlapSession = {
       ...originalSessionFixture,
       id: "session-overlap",

--- a/supabase/functions/sessions-cancel/index.ts
+++ b/supabase/functions/sessions-cancel/index.ts
@@ -205,7 +205,7 @@ function parseCancelPayload(input: unknown): {
   return { holdKey, sessionIds, dateRange, therapistId, reason, cancellationAttribution };
 }
 
-type CancellationRole = "super_admin" | "admin" | "therapist" | null;
+type CancellationRole = "super_admin" | "admin" | "admin_schedule" | "therapist" | null;
 
 async function resolveCancellationRole(
   db: SupabaseClient,
@@ -218,6 +218,9 @@ async function resolveCancellationRole(
   if (await assertUserHasOrgRole(db, orgId, "admin")) {
     return "admin";
   }
+  if (await assertUserHasOrgRole(db, orgId, "admin_schedule")) {
+    return "admin_schedule";
+  }
   if (await assertUserHasOrgRole(db, orgId, "bcba")) {
     return "admin";
   }
@@ -225,6 +228,20 @@ async function resolveCancellationRole(
     return "therapist";
   }
   return null;
+}
+
+function isAdminScheduleExactSessionCancellationRequest(payload: {
+  holdKey: string | null;
+  sessionIds: string[];
+  dateRange: { start: string; end: string } | null;
+  therapistId: string | null;
+}): boolean {
+  return (
+    payload.holdKey === null &&
+    payload.sessionIds.length === 1 &&
+    payload.dateRange === null &&
+    payload.therapistId === null
+  );
 }
 
 async function currentUserIsSuperAdmin(db: SupabaseClient): Promise<boolean> {
@@ -697,6 +714,18 @@ Deno.serve(async (req) => {
       });
       throw new ForbiddenError("Forbidden");
     }
+    if (role === "admin_schedule" && !isAdminScheduleExactSessionCancellationRequest(payload)) {
+      const denialLogger = scopedLogger ?? userLogger;
+      denialLogger.warn("authorization.denied", {
+        reason: "admin-schedule-exact-session-only",
+      });
+      increment("tenant_denial_total", {
+        function: "sessions-cancel",
+        orgId,
+        reason: "admin-schedule-exact-session-only",
+      });
+      throw new ForbiddenError("Forbidden");
+    }
 
     const storageIdempotencyKey = normalizedKey
       ? buildScopedIdempotencyKey(normalizedKey, { organizationId: orgId, userId: user.id })
@@ -817,6 +846,7 @@ export const __TESTING__ = {
   parseCancelPayload,
   buildDateRange,
   resolveCancellationRole,
+  isAdminScheduleExactSessionCancellationRequest,
   resolveOrgForCancellationRequest,
   resolveOrgFromSessionIds,
   resolveOrgFromHoldKey,

--- a/tests/edge/sessions-cancel.org-scope.test.ts
+++ b/tests/edge/sessions-cancel.org-scope.test.ts
@@ -452,7 +452,7 @@ describe("sessions-cancel org scoping", () => {
     ).resolves.toBeNull();
   });
 
-  it("treats exact in-org bcba as admin-scoped without granting admin_schedule or midtier", async () => {
+  it("treats exact in-org bcba as admin-scoped without granting midtier", async () => {
     const assertUserHasOrgRoleSpy = vi
       .spyOn(orgHelpers, "assertUserHasOrgRole")
       .mockImplementation(async (_db, _orgId, role) => role === "bcba");
@@ -467,9 +467,77 @@ describe("sessions-cancel org scoping", () => {
 
     expect(assertUserHasOrgRoleSpy).toHaveBeenNthCalledWith(1, mockDb, "org-1", "super_admin");
     expect(assertUserHasOrgRoleSpy).toHaveBeenNthCalledWith(2, mockDb, "org-1", "admin");
-    expect(assertUserHasOrgRoleSpy).toHaveBeenNthCalledWith(3, mockDb, "org-1", "bcba");
-    expect(assertUserHasOrgRoleSpy).not.toHaveBeenCalledWith(mockDb, "org-1", "admin_schedule");
+    expect(assertUserHasOrgRoleSpy).toHaveBeenNthCalledWith(3, mockDb, "org-1", "admin_schedule");
+    expect(assertUserHasOrgRoleSpy).toHaveBeenNthCalledWith(4, mockDb, "org-1", "bcba");
     expect(assertUserHasOrgRoleSpy).not.toHaveBeenCalledWith(mockDb, "org-1", "midtier");
+  });
+
+  it("treats exact in-org admin_schedule as admin-scoped", async () => {
+    const assertUserHasOrgRoleSpy = vi
+      .spyOn(orgHelpers, "assertUserHasOrgRole")
+      .mockImplementation(async (_db, _orgId, role) => role === "admin_schedule");
+
+    const mockDb: any = {
+      rpc: vi.fn(),
+    };
+
+    await expect(
+      __TESTING__.resolveCancellationRole(mockDb, "org-1", "scheduler-user"),
+    ).resolves.toBe("admin_schedule");
+
+    expect(assertUserHasOrgRoleSpy).toHaveBeenCalledWith(
+      mockDb,
+      "org-1",
+      "admin_schedule",
+    );
+    expect(assertUserHasOrgRoleSpy).not.toHaveBeenCalledWith(mockDb, "org-1", "midtier");
+  });
+
+  it("does not grant cancellation authority to an exact in-org midtier role", async () => {
+    vi.spyOn(orgHelpers, "assertUserHasOrgRole")
+      .mockImplementation(async (_db, _orgId, role) => role === "midtier");
+
+    const mockDb: any = {
+      rpc: vi.fn(),
+    };
+
+    await expect(
+      __TESTING__.resolveCancellationRole(mockDb, "org-1", "midtier-user"),
+    ).resolves.toBeNull();
+  });
+
+  it("limits admin_schedule requests to one explicit session id", () => {
+    expect(__TESTING__.isAdminScheduleExactSessionCancellationRequest({
+      holdKey: null,
+      sessionIds: ["session-1"],
+      dateRange: null,
+      therapistId: null,
+    })).toBe(true);
+
+    expect(__TESTING__.isAdminScheduleExactSessionCancellationRequest({
+      holdKey: "hold-1",
+      sessionIds: [],
+      dateRange: null,
+      therapistId: null,
+    })).toBe(false);
+    expect(__TESTING__.isAdminScheduleExactSessionCancellationRequest({
+      holdKey: null,
+      sessionIds: ["session-1", "session-2"],
+      dateRange: null,
+      therapistId: null,
+    })).toBe(false);
+    expect(__TESTING__.isAdminScheduleExactSessionCancellationRequest({
+      holdKey: null,
+      sessionIds: ["session-1"],
+      dateRange: { start: "2026-03-01T00:00:00.000Z", end: "2026-03-02T00:00:00.000Z" },
+      therapistId: null,
+    })).toBe(false);
+    expect(__TESTING__.isAdminScheduleExactSessionCancellationRequest({
+      holdKey: null,
+      sessionIds: ["session-1"],
+      dateRange: null,
+      therapistId: "therapist-1",
+    })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- add an authorized Delete appointment action for existing scheduled/in-progress appointments
- confirm the exact client, therapist, date, and time before cancellation
- reuse sessions-cancel with one selected session id, including overlap-block selections
- add admin_schedule exact-session authority without widening date, therapist, hold, multi-session, RLS, grant, or migration surfaces

## Routing and risk
- classification: high-risk human-reviewed
- lane: critical
- protected path: supabase/functions/sessions-cancel/index.ts
- human review required; do not merge while the blockers below remain

## Verification
Passed:
- targeted SessionModal deletion tests: 4 (including UTC timezone verification)
- targeted Schedule authorization/success/overlap tests: 9
- sessions-cancel org-scope tests: 16
- playwright:auth against the hosted app after synchronizing the approved Supabase smoke credential
- ci:check-focused
- lint
- typecheck
- validate:tenant
- build
- independent security review approved; final code/test review is recorded in the handoff

Not merge-clean:
- fresh required CI is running for head 6093525e
- verify:local previously failed during coverage collation with a temporary worker-file ENOENT
- test:routes:tier0 previously hit a preview/build race and did not produce clean isolated evidence
- responsive /schedule observer remains fail-closed on its unauthenticated login/loading shell: desktop console-error; mobile console-error and an undersized shell touch target
- Linear issue creation is blocked until obsolete duplicate issues are removed; deletion requires an authenticated Linear UI session

See docs/ai/handoffs/schedule-delete-appointment.md for the verification card and PR-hygiene verdict.