### PR TITLE
WIN-34 Restore client archive RPC

### DIFF
--- a/docs/ai/WIN-34-client-archive-rpc-handoff.md
+++ b/docs/ai/WIN-34-client-archive-rpc-handoff.md
@@ -1,0 +1,55 @@
+# WIN-34 Client Archive RPC Handoff
+
+## Routing
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- why: The fix restores a PostgREST RPC through a database migration and changes function grant exposure.
+- triggering paths: `supabase/migrations/**`, RPC exposure, grants, tenant-scoped client writes
+
+## Scope
+
+- task intent: Restore the existing client archive action without duplicating or weakening the authoritative tenant and role checks in `app.set_client_archive_state`.
+- files touched: `supabase/migrations/20260810172500_restore_client_archive_public_rpc.sql`, `tests/clients/client-archive-public-wrapper-migration.contract.test.ts`, `docs/ai/WIN-34-client-archive-rpc-handoff.md`
+- single-purpose diff: yes
+- non-goals: No frontend changes, therapist archive changes, authorization-policy rewrites, or hosted migration application.
+
+## Required Agents
+
+- required sequence: specification-engineer, software-architect, implementation-engineer, code-review-engineer, test-engineer, security-engineer
+- agents used: specification-engineer, software-architect, implementation-engineer, code-review-engineer, test-engineer, security-engineer, supabase-reviewer
+- reviewer: completed; final security review reported no findings
+
+## Verification Card
+
+- required checks: `npx vitest run tests/clients/client-archive-public-wrapper-migration.contract.test.ts`, `npm run ci:check:migrations`, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run validate:tenant`, `npm run build`, local migration/runtime smoke
+- executed checks:
+  - `npx vitest run tests/clients/client-archive-public-wrapper-migration.contract.test.ts`: pass, 1 test
+  - `npm run ci:check:migrations`: pass
+  - `npm run ci:check-focused`: pass; database-backed grant and preview-drift checks skipped because no database URL is configured
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run build`: pass
+  - `$env:NODE_OPTIONS='--max-old-space-size=8192'; npm run test:ci`: blocked after a 183-second timeout while unrelated AI-documentation tests attempted unavailable network calls
+- blocked checks:
+  - `npm run test:ci`: bounded run timed out; an earlier run also failed during coverage aggregation because a generated `coverage/.tmp/coverage-47.json` file was missing
+  - `npm run verify:local`: cannot complete while its required `test:ci` phase is blocked
+  - local migration/runtime smoke: Docker Desktop Linux engine is unavailable, so the migration could not be replayed against local Postgres/PostgREST
+- result: pass-with-blocked-checks
+- residual risk: SQL behavior has not been exercised against a running Postgres/PostgREST instance. Production remains unchanged until a human-reviewed migration is applied, after which authorized, anonymous, and cross-organization behavior must be verified.
+
+## PR Hygiene
+
+- branch-ready: yes, `codex/win-34-client-archive-rpc`
+- linear-ready: yes, `WIN-34`
+- protected-path drift: none beyond the declared migration
+- unrelated changes: none in the isolated worktree
+- generated artifact drift: none
+- verification summary: present
+- pr-ready: yes, with blocked checks disclosed
+- required follow-up: Human review, CI, migration deployment through the normal protected workflow, and hosted archive smoke verification.
+
+## Handoff Summary
+
+The client page calls `public.set_client_archive_state`, but hosted PostgREST only has the tenant-authorized implementation in the unexposed `app` schema. This change adds a restricted public wrapper that delegates to that authority with an empty search path and grants execution only to authenticated users. Targeted, policy, tenant, lint, typecheck, and build checks pass; full CI and runtime database proof remain blocked locally and must be completed by CI and the reviewed deployment workflow.

--- a/supabase/migrations/20260810172500_restore_client_archive_public_rpc.sql
+++ b/supabase/migrations/20260810172500_restore_client_archive_public_rpc.sql
@@ -1,0 +1,41 @@
+-- @migration-intent: Restore the PostgREST client archive RPC without duplicating tenant authorization logic.
+-- @migration-dependencies: 20251101100000_soft_delete_archival
+-- @migration-rollback: Drop public.set_client_archive_state(uuid, boolean); the app-schema authority remains unchanged.
+
+begin;
+
+create or replace function public.set_client_archive_state(
+  p_client_id uuid,
+  p_restore boolean default false
+)
+returns public.clients
+language sql
+security definer
+set search_path = ''
+as $function$
+  select app.set_client_archive_state(p_client_id, p_restore);
+$function$;
+
+revoke execute on function public.set_client_archive_state(uuid, boolean) from public, anon;
+grant execute on function public.set_client_archive_state(uuid, boolean) to authenticated;
+
+do $$
+declare
+  target_function regprocedure :=
+    'public.set_client_archive_state(uuid,boolean)'::regprocedure;
+begin
+  if has_function_privilege('public', target_function::oid, 'EXECUTE')
+     or has_function_privilege('anon', target_function::oid, 'EXECUTE') then
+    raise exception 'Client archive RPC exposure failed: % is executable by an unauthenticated role',
+      target_function;
+  end if;
+
+  if not has_function_privilege('authenticated', target_function::oid, 'EXECUTE') then
+    raise exception 'Client archive RPC exposure failed: % is unavailable to authenticated callers',
+      target_function;
+  end if;
+end $$;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/clients/client-archive-public-wrapper-migration.contract.test.ts
+++ b/tests/clients/client-archive-public-wrapper-migration.contract.test.ts
@@ -1,0 +1,50 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const migrationsDirectory = path.join(process.cwd(), "supabase", "migrations");
+const migrationNames = readdirSync(migrationsDirectory).filter((name) =>
+  name.endsWith("_restore_client_archive_public_rpc.sql"),
+);
+
+describe("client archive public RPC migration", () => {
+  it("adds one restricted public wrapper around the existing tenant-authorized function", () => {
+    expect(migrationNames).toHaveLength(1);
+
+    const migrationSql = readFileSync(
+      path.join(migrationsDirectory, migrationNames[0]),
+      "utf8",
+    );
+
+    expect(migrationSql).toMatch(
+      /create or replace function public\.set_client_archive_state\(\s*p_client_id uuid,\s*p_restore boolean default false\s*\)/i,
+    );
+    expect(migrationSql).toMatch(/returns public\.clients/i);
+    expect(migrationSql).toMatch(/language sql[\s\S]*security definer[\s\S]*set search_path = ''/i);
+    expect(migrationSql).toContain(
+      "select app.set_client_archive_state(p_client_id, p_restore);",
+    );
+    expect(migrationSql).toMatch(
+      /revoke execute on function public\.set_client_archive_state\(uuid, boolean\) from public, anon;/i,
+    );
+    expect(migrationSql).toMatch(
+      /grant execute on function public\.set_client_archive_state\(uuid, boolean\) to authenticated;/i,
+    );
+    expect(migrationSql).not.toMatch(
+      /grant execute on function public\.set_client_archive_state\(uuid, boolean\)[^;]*service_role/i,
+    );
+    expect(migrationSql).toContain("'public.set_client_archive_state(uuid,boolean)'::regprocedure");
+    expect(migrationSql).toContain(
+      "has_function_privilege('anon', target_function::oid, 'EXECUTE')",
+    );
+    expect(migrationSql).toContain(
+      "has_function_privilege('public', target_function::oid, 'EXECUTE')",
+    );
+    expect(migrationSql).toContain(
+      "has_function_privilege('authenticated', target_function::oid, 'EXECUTE')",
+    );
+    expect(migrationSql).toContain("notify pgrst, 'reload schema';");
+    expect(migrationSql).not.toContain("set_therapist_archive_state");
+  });
+});


### PR DESCRIPTION
## Summary
- restore the PostgREST-visible `public.set_client_archive_state(uuid, boolean)` RPC
- delegate to the existing tenant-authorized `app.set_client_archive_state` implementation
- restrict execution to authenticated users and add a migration contract test
- add the critical-lane verification handoff

## Root cause
The Clients page calls the public RPC, but the hosted database only exposes the implementation in the non-Data-API `app` schema, causing PostgREST `PGRST202`.

## Verification
- `npx vitest run tests/clients/client-archive-public-wrapper-migration.contract.test.ts`
- `npm run ci:check:migrations`
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:tenant`
- `npm run build`

## Blocked locally
- `npm run test:ci` timed out after 183 seconds in unrelated AI-documentation network tests; an earlier attempt failed during coverage temp-file aggregation.
- Local Postgres/PostgREST smoke could not run because Docker Desktop's Linux engine was unavailable.
- No hosted migration was applied. Production remains unchanged until reviewed deployment.

## Risk
This is a critical-lane migration affecting RPC exposure. Human review and post-deployment smoke verification are required.

Linear: WIN-34