### PR TITLE
WIN-203: Restrict BT schedules to assigned clients

### DIFF
--- a/supabase/migrations/20260810171520_restrict_bt_schedule_to_assigned_clients.sql
+++ b/supabase/migrations/20260810171520_restrict_bt_schedule_to_assigned_clients.sql
@@ -1,0 +1,367 @@
+-- @migration-intent: Restrict BT and legacy therapist schedule reads to active client assignments without changing schedule write authority.
+-- @migration-dependencies: app.current_user_has_exact_role_for_org, app.current_user_organization_id, app.current_therapist_id, client_therapist_links.
+-- @migration-rollback: Restore org_read_sessions from 20260701150000_employee_role_capability_matrix.sql, get_sessions_optimized from 20260204201000_update_schedule_rpcs.sql, and get_dropdown_data/get_schedule_data_batch from 20260408142721_schedule_rpc_include_availability_hours.sql; then DROP FUNCTION app.current_user_can_read_schedule_client(uuid, uuid); DROP FUNCTION app.current_user_has_active_schedule_client(uuid, uuid); DROP FUNCTION app.current_user_can_read_full_schedule(uuid).
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_read_full_schedule(target_organization_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT app.current_user_has_exact_role_for_org(
+    target_organization_id,
+    ARRAY['admin', 'admin_schedule', 'midtier', 'bcba']::text[]
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_has_active_schedule_client(
+  target_organization_id uuid,
+  target_client_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+DECLARE
+  caller_id uuid := auth.uid();
+  caller_therapist_id uuid;
+BEGIN
+  IF caller_id IS NULL OR target_organization_id IS NULL OR target_client_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF target_organization_id IS DISTINCT FROM app.current_user_organization_id() THEN
+    RETURN false;
+  END IF;
+
+  caller_therapist_id := app.current_therapist_id();
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.clients c
+    WHERE c.id = target_client_id
+      AND c.organization_id = target_organization_id
+      AND c.deleted_at IS NULL
+      AND (
+        c.therapist_id IS NOT DISTINCT FROM caller_id
+        OR c.therapist_id IS NOT DISTINCT FROM caller_therapist_id
+        OR EXISTS (
+          SELECT 1
+          FROM public.client_therapist_links ctl
+          WHERE ctl.client_id = target_client_id
+            AND ctl.organization_id = target_organization_id
+            AND ctl.therapist_id = caller_therapist_id
+        )
+      )
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_read_schedule_client(
+  target_organization_id uuid,
+  target_client_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT
+    app.current_user_can_read_full_schedule(target_organization_id)
+    OR (
+      app.current_user_has_exact_role_for_org(
+        target_organization_id,
+        ARRAY['bt', 'therapist']::text[]
+      )
+      AND app.current_user_has_active_schedule_client(target_organization_id, target_client_id)
+    );
+$$;
+
+REVOKE EXECUTE ON FUNCTION app.current_user_can_read_full_schedule(uuid) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION app.current_user_has_active_schedule_client(uuid, uuid) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION app.current_user_can_read_schedule_client(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION app.current_user_can_read_full_schedule(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_has_active_schedule_client(uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION app.current_user_can_read_schedule_client(uuid, uuid) TO authenticated, service_role;
+
+DROP POLICY IF EXISTS org_read_sessions ON public.sessions;
+CREATE POLICY org_read_sessions
+ON public.sessions
+FOR SELECT
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_read_schedule_client(organization_id, client_id)
+);
+
+CREATE OR REPLACE FUNCTION public.get_dropdown_data()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_org uuid := app.current_user_organization_id();
+  v_therapists jsonb := '[]'::jsonb;
+  v_clients jsonb := '[]'::jsonb;
+  v_locations jsonb := '[]'::jsonb;
+  v_has_org_col boolean;
+BEGIN
+  IF v_org IS NULL THEN
+    RETURN jsonb_build_object(
+      'therapists', v_therapists,
+      'clients', v_clients,
+      'locations', v_locations
+    );
+  END IF;
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', t.id,
+      'full_name', t.full_name,
+      'availability_hours', t.availability_hours
+    )
+    ORDER BY t.full_name
+  )
+  INTO v_therapists
+  FROM public.therapists t
+  WHERE t.status = 'active'
+    AND t.organization_id = v_org
+    AND (
+      app.current_user_can_read_full_schedule(v_org)
+      OR t.id = app.current_therapist_id()
+    );
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', c.id,
+      'full_name', c.full_name,
+      'availability_hours', c.availability_hours
+    )
+    ORDER BY c.full_name
+  )
+  INTO v_clients
+  FROM public.clients c
+  WHERE c.organization_id = v_org
+    AND c.deleted_at IS NULL
+    AND app.current_user_can_read_schedule_client(v_org, c.id);
+
+  IF app.current_user_can_read_full_schedule(v_org) THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'locations'
+        AND column_name = 'organization_id'
+    ) INTO v_has_org_col;
+
+    IF v_has_org_col THEN
+      EXECUTE format($sql$
+        SELECT jsonb_agg(jsonb_build_object('id', id, 'name', name) ORDER BY name)
+        FROM public.locations
+        WHERE is_active = true AND organization_id = $1
+      $sql$)
+      INTO v_locations
+      USING v_org;
+    ELSE
+      SELECT jsonb_agg(jsonb_build_object('id', l.id, 'name', l.name) ORDER BY l.name)
+      INTO v_locations
+      FROM public.locations l
+      WHERE l.is_active = true;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'therapists', COALESCE(v_therapists, '[]'::jsonb),
+    'clients', COALESCE(v_clients, '[]'::jsonb),
+    'locations', COALESCE(v_locations, '[]'::jsonb)
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_sessions_optimized(
+  p_start_date timestamptz,
+  p_end_date timestamptz,
+  p_therapist_id uuid DEFAULT NULL,
+  p_client_id uuid DEFAULT NULL
+)
+RETURNS TABLE (session_data jsonb)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_org uuid := app.current_user_organization_id();
+BEGIN
+  IF v_org IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Organization context is required';
+  END IF;
+
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'id', s.id,
+    'start_time', s.start_time,
+    'end_time', s.end_time,
+    'status', s.status,
+    'notes', s.notes,
+    'created_at', s.created_at,
+    'created_by', s.created_by,
+    'updated_at', s.updated_at,
+    'updated_by', s.updated_by,
+    'therapist_id', s.therapist_id,
+    'client_id', s.client_id,
+    'program_id', s.program_id,
+    'goal_id', s.goal_id,
+    'started_at', s.started_at,
+    'duration_minutes', s.duration_minutes,
+    'location_type', s.location_type,
+    'session_type', s.session_type,
+    'rate_per_hour', s.rate_per_hour,
+    'total_cost', s.total_cost,
+    'therapist', jsonb_build_object(
+      'id', t.id,
+      'full_name', t.full_name,
+      'email', t.email,
+      'service_type', t.service_type
+    ),
+    'client', jsonb_build_object(
+      'id', c.id,
+      'full_name', c.full_name,
+      'email', c.email,
+      'service_preference', c.service_preference
+    )
+  ) AS session_data
+  FROM public.sessions s
+  JOIN public.therapists t
+    ON s.therapist_id = t.id
+   AND t.organization_id = v_org
+  JOIN public.clients c
+    ON s.client_id = c.id
+   AND c.organization_id = v_org
+  WHERE s.organization_id = v_org
+    AND s.start_time >= p_start_date
+    AND s.start_time <= p_end_date
+    AND (p_therapist_id IS NULL OR s.therapist_id = p_therapist_id)
+    AND (p_client_id IS NULL OR s.client_id = p_client_id)
+    AND app.current_user_can_read_schedule_client(v_org, s.client_id)
+  ORDER BY s.start_time;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_schedule_data_batch(
+  p_start_date timestamptz,
+  p_end_date timestamptz
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_org uuid := app.current_user_organization_id();
+  v_sessions jsonb := '[]'::jsonb;
+  v_therapists jsonb := '[]'::jsonb;
+  v_clients jsonb := '[]'::jsonb;
+BEGIN
+  IF v_org IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Organization context is required';
+  END IF;
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', s.id,
+      'start_time', s.start_time,
+      'end_time', s.end_time,
+      'status', s.status,
+      'notes', s.notes,
+      'created_at', s.created_at,
+      'created_by', s.created_by,
+      'updated_at', s.updated_at,
+      'updated_by', s.updated_by,
+      'therapist_id', s.therapist_id,
+      'client_id', s.client_id,
+      'program_id', s.program_id,
+      'goal_id', s.goal_id,
+      'started_at', s.started_at,
+      'duration_minutes', s.duration_minutes,
+      'location_type', s.location_type,
+      'session_type', s.session_type,
+      'rate_per_hour', s.rate_per_hour,
+      'total_cost', s.total_cost,
+      'therapist', jsonb_build_object('id', t.id, 'full_name', t.full_name),
+      'client', jsonb_build_object('id', c.id, 'full_name', c.full_name)
+    )
+    ORDER BY s.start_time
+  )
+  INTO v_sessions
+  FROM public.sessions s
+  JOIN public.therapists t
+    ON s.therapist_id = t.id
+   AND t.organization_id = v_org
+  JOIN public.clients c
+    ON s.client_id = c.id
+   AND c.organization_id = v_org
+  WHERE s.organization_id = v_org
+    AND s.start_time >= p_start_date
+    AND s.start_time <= p_end_date
+    AND app.current_user_can_read_schedule_client(v_org, s.client_id);
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', t.id,
+      'full_name', t.full_name,
+      'email', t.email,
+      'service_type', t.service_type,
+      'availability_hours', t.availability_hours
+    )
+    ORDER BY t.full_name
+  )
+  INTO v_therapists
+  FROM public.therapists t
+  WHERE t.status = 'active'
+    AND t.organization_id = v_org
+    AND (
+      app.current_user_can_read_full_schedule(v_org)
+      OR t.id = app.current_therapist_id()
+    );
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', c.id,
+      'full_name', c.full_name,
+      'email', c.email,
+      'service_preference', c.service_preference,
+      'availability_hours', c.availability_hours
+    )
+    ORDER BY c.full_name
+  )
+  INTO v_clients
+  FROM public.clients c
+  WHERE c.organization_id = v_org
+    AND c.deleted_at IS NULL
+    AND app.current_user_can_read_schedule_client(v_org, c.id);
+
+  RETURN jsonb_build_object(
+    'sessions', COALESCE(v_sessions, '[]'::jsonb),
+    'therapists', COALESCE(v_therapists, '[]'::jsonb),
+    'clients', COALESCE(v_clients, '[]'::jsonb)
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_dropdown_data() FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_sessions_optimized(timestamptz, timestamptz, uuid, uuid) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_schedule_data_batch(timestamptz, timestamptz) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_dropdown_data() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_sessions_optimized(timestamptz, timestamptz, uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_schedule_data_batch(timestamptz, timestamptz) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/tests/bt-schedule-client-scope-migration.test.ts
+++ b/tests/bt-schedule-client-scope-migration.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  "supabase",
+  "migrations",
+  "20260810171520_restrict_bt_schedule_to_assigned_clients.sql",
+);
+const SMOKE_PATH = path.join(
+  process.cwd(),
+  "tests",
+  "sql",
+  "employee_role_capability_smoke.sql",
+);
+
+const sql = readFileSync(MIGRATION_PATH, "utf8");
+const smokeSql = readFileSync(SMOKE_PATH, "utf8");
+
+const extractFunction = (name: string): string => {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `create or replace function ${escapedName}\\([\\s\\S]*?\\n\\$\\$;`,
+    "i",
+  );
+  const match = sql.match(pattern);
+  expect(match, `${name} function should exist`).not.toBeNull();
+  return match?.[0] ?? "";
+};
+
+describe("BT schedule assigned-client scope migration", () => {
+  it("separates org-wide reads from the existing schedule write helper", () => {
+    const helper = extractFunction("app.current_user_can_read_full_schedule");
+
+    expect(helper).toContain(
+      "ARRAY['admin', 'admin_schedule', 'midtier', 'bcba']::text[]",
+    );
+    expect(helper).not.toContain("'therapist'");
+    expect(helper).not.toContain("'bt'");
+    expect(sql).not.toContain(
+      "CREATE OR REPLACE FUNCTION app.current_user_can_manage_schedule",
+    );
+  });
+
+  it("uses active assignments rather than historical sessions", () => {
+    const assignmentHelper = extractFunction(
+      "app.current_user_has_active_schedule_client",
+    );
+    const readHelper = extractFunction(
+      "app.current_user_can_read_schedule_client",
+    );
+
+    expect(assignmentHelper).toContain("FROM public.client_therapist_links ctl");
+    expect(assignmentHelper).toContain("ctl.client_id = target_client_id");
+    expect(assignmentHelper).toContain("ctl.therapist_id = caller_therapist_id");
+    expect(assignmentHelper).not.toContain("FROM public.sessions");
+    expect(readHelper).toContain(
+      "app.current_user_can_read_full_schedule(target_organization_id)",
+    );
+    expect(readHelper).toContain("ARRAY['bt', 'therapist']::text[]");
+    expect(readHelper).toContain(
+      "app.current_user_has_active_schedule_client(target_organization_id, target_client_id)",
+    );
+  });
+
+  it("uses the shared predicate for direct session reads", () => {
+    expect(sql).toContain("CREATE POLICY org_read_sessions");
+    expect(sql).toContain(
+      "app.current_user_can_read_schedule_client(organization_id, client_id)",
+    );
+  });
+
+  it.each([
+    ["public.get_dropdown_data", "c.id"],
+    ["public.get_sessions_optimized", "s.client_id"],
+    ["public.get_schedule_data_batch", "s.client_id"],
+  ])("scopes %s through assigned-client authority", (name, clientExpression) => {
+    const functionSql = extractFunction(name);
+
+    expect(functionSql).toContain(
+      `app.current_user_can_read_schedule_client(v_org, ${clientExpression})`,
+    );
+  });
+
+  it("withholds location directory data from scoped BT and therapist users", () => {
+    const dropdownSql = extractFunction("public.get_dropdown_data");
+
+    expect(dropdownSql).toContain(
+      "IF app.current_user_can_read_full_schedule(v_org) THEN",
+    );
+    expect(dropdownSql).toContain("IF v_org IS NULL THEN");
+    expect(dropdownSql).toContain("'locations', v_locations");
+  });
+
+  it("preserves the established scheduling RPC payload fields", () => {
+    const dropdownSql = extractFunction("public.get_dropdown_data");
+    const optimizedSql = extractFunction("public.get_sessions_optimized");
+    const batchSql = extractFunction("public.get_schedule_data_batch");
+
+    expect(dropdownSql).toContain("'availability_hours', t.availability_hours");
+    expect(dropdownSql).toContain("'availability_hours', c.availability_hours");
+
+    for (const field of ["program_id", "goal_id", "started_at"]) {
+      expect(optimizedSql).toContain(`'${field}', s.${field}`);
+      expect(batchSql).toContain(`'${field}', s.${field}`);
+    }
+
+    expect(batchSql).toContain("'availability_hours', t.availability_hours");
+    expect(batchSql).toContain("'availability_hours', c.availability_hours");
+  });
+
+  it("hardens helper and RPC execution grants", () => {
+    expect(sql).toContain(
+      "REVOKE EXECUTE ON FUNCTION app.current_user_can_read_full_schedule(uuid) FROM PUBLIC, anon;",
+    );
+    expect(sql).toContain(
+      "REVOKE EXECUTE ON FUNCTION app.current_user_has_active_schedule_client(uuid, uuid) FROM PUBLIC, anon;",
+    );
+    expect(sql).toContain(
+      "REVOKE EXECUTE ON FUNCTION app.current_user_can_read_schedule_client(uuid, uuid) FROM PUBLIC, anon;",
+    );
+    expect(sql).toContain(
+      "REVOKE EXECUTE ON FUNCTION public.get_dropdown_data() FROM PUBLIC, anon;",
+    );
+    expect(sql).toContain(
+      "GRANT EXECUTE ON FUNCTION public.get_dropdown_data() TO authenticated;",
+    );
+  });
+
+  it("documents complete rollback of the new definer helpers", () => {
+    expect(sql).toContain(
+      "DROP FUNCTION app.current_user_can_read_schedule_client(uuid, uuid)",
+    );
+    expect(sql).toContain(
+      "DROP FUNCTION app.current_user_has_active_schedule_client(uuid, uuid)",
+    );
+    expect(sql).toContain(
+      "DROP FUNCTION app.current_user_can_read_full_schedule(uuid)",
+    );
+  });
+
+  it("extends the hosted smoke with positive and negative runtime probes", () => {
+    expect(smokeSql).toContain("bt_schedule_assigned_client_allowed");
+    expect(smokeSql).toContain("bt_schedule_unassigned_client_denied");
+    expect(smokeSql).toContain("bt_schedule_cross_org_client_denied");
+    expect(smokeSql).toContain("bt_schedule_historical_only_client_denied");
+    expect(smokeSql).toContain("bt_schedule_rpc_client_scope");
+    expect(smokeSql).toContain("therapist_schedule_rpc_client_scope");
+  });
+});

--- a/tests/sql/employee_role_capability_smoke.sql
+++ b/tests/sql/employee_role_capability_smoke.sql
@@ -44,7 +44,8 @@ begin
     '00000000-0000-4000-8000-000000000502',
     '00000000-0000-4000-8000-000000000503',
     '00000000-0000-4000-8000-000000000504',
-    '00000000-0000-4000-8000-000000000505'
+    '00000000-0000-4000-8000-000000000505',
+    '00000000-0000-4000-8000-000000000506'
   );
 
   delete from public.authorization_services
@@ -79,7 +80,8 @@ begin
   delete from public.client_therapist_links
   where id in (
     '00000000-0000-4000-8000-000000000901',
-    '00000000-0000-4000-8000-000000000902'
+    '00000000-0000-4000-8000-000000000902',
+    '00000000-0000-4000-8000-000000000903'
   );
 
   delete from public.clients
@@ -89,12 +91,14 @@ begin
     '00000000-0000-4000-8000-000000000103',
     '00000000-0000-4000-8000-000000000104',
     '00000000-0000-4000-8000-000000000105',
-    '00000000-0000-4000-8000-000000000106'
+    '00000000-0000-4000-8000-000000000106',
+    '00000000-0000-4000-8000-000000000107'
   );
 
   delete from public.therapists
   where id in (
     '00000000-0000-4000-8000-000000000013',
+    '00000000-0000-4000-8000-000000000015',
     '00000000-0000-4000-8000-000000000021',
     '00000000-0000-4000-8000-000000000023'
   );
@@ -207,16 +211,20 @@ begin
   insert into public.therapists (id, email, full_name, first_name, last_name, status, organization_id)
   values
     ('00000000-0000-4000-8000-000000000013', 'codex-smoke-bt@example.invalid', 'Codex BT Staff', 'Codex', 'BT', 'active', '00000000-0000-4000-8000-000000000001'),
+    ('00000000-0000-4000-8000-000000000015', 'codex-smoke-therapist@example.invalid', 'Codex Therapist Staff', 'Codex', 'Therapist', 'active', '00000000-0000-4000-8000-000000000001'),
     ('00000000-0000-4000-8000-000000000021', 'codex-smoke-provider@example.invalid', 'Codex Provider', 'Codex', 'Provider', 'active', '00000000-0000-4000-8000-000000000001');
 
   insert into public.clients (id, full_name, status, organization_id, therapist_id, created_by, updated_by)
   values
     ('00000000-0000-4000-8000-000000000101', 'Codex Assigned Client', 'active', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011'),
     ('00000000-0000-4000-8000-000000000102', 'Codex Unassigned Client', 'active', '00000000-0000-4000-8000-000000000001', null, '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011'),
-    ('00000000-0000-4000-8000-000000000103', 'Codex Cross Org Client', 'active', '00000000-0000-4000-8000-000000000002', null, null, null);
+    ('00000000-0000-4000-8000-000000000103', 'Codex Cross Org Client', 'active', '00000000-0000-4000-8000-000000000002', null, null, null),
+    ('00000000-0000-4000-8000-000000000107', 'Codex Historical Only Client', 'active', '00000000-0000-4000-8000-000000000001', null, '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011');
 
   insert into public.client_therapist_links (id, client_id, therapist_id, organization_id, created_by)
-  values ('00000000-0000-4000-8000-000000000901', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011');
+  values
+    ('00000000-0000-4000-8000-000000000901', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011'),
+    ('00000000-0000-4000-8000-000000000903', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000015', '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011');
 
   insert into public.programs (id, organization_id, client_id, name, status, created_by, updated_by)
   values
@@ -238,7 +246,8 @@ begin
   insert into public.sessions (id, client_id, therapist_id, start_time, end_time, status, has_transcription_consent, organization_id, created_by, updated_by, session_date, program_id, goal_id)
   values
     ('00000000-0000-4000-8000-000000000501', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000013', now() + interval '7 days', now() + interval '7 days 1 hour', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 7, '00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000301'),
-    ('00000000-0000-4000-8000-000000000502', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000021', now() + interval '8 days', now() + interval '8 days 1 hour', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 8, '00000000-0000-4000-8000-000000000202', '00000000-0000-4000-8000-000000000302');
+    ('00000000-0000-4000-8000-000000000502', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000021', now() + interval '8 days', now() + interval '8 days 1 hour', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 8, '00000000-0000-4000-8000-000000000202', '00000000-0000-4000-8000-000000000302'),
+    ('00000000-0000-4000-8000-000000000506', '00000000-0000-4000-8000-000000000107', '00000000-0000-4000-8000-000000000013', now() + interval '12 days', now() + interval '12 days 1 hour', 'completed', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 12, null, null);
 
   insert into public.authorizations (id, authorization_number, client_id, provider_id, diagnosis_code, start_date, end_date, status, organization_id, created_by)
   values
@@ -407,6 +416,9 @@ declare
   assigned_note_count int;
   unassigned_note_count int;
   cross_org_note_count int;
+  optimized_count int;
+  batch_data jsonb;
+  dropdown_data jsonb;
 begin
   insert into role_smoke_results
   values (
@@ -457,6 +469,31 @@ begin
   exception when others then
     insert into role_smoke_results values ('therapist_program_note_write_denied', sqlstate = '42501', sqlstate || ': ' || sqlerrm, current_user);
   end;
+
+  select count(*)
+  into optimized_count
+  from public.get_sessions_optimized(now(), now() + interval '30 days');
+  batch_data := public.get_schedule_data_batch(now(), now() + interval '30 days');
+  dropdown_data := public.get_dropdown_data();
+
+  insert into role_smoke_results
+  values (
+    'therapist_schedule_rpc_client_scope',
+    app.current_user_has_active_schedule_client('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101')
+      and not app.current_user_has_active_schedule_client('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000102')
+      and optimized_count = 1
+      and jsonb_array_length(batch_data->'sessions') = 1
+      and jsonb_array_length(batch_data->'clients') = 1
+      and batch_data->'clients'->0->>'id' = '00000000-0000-4000-8000-000000000101'
+      and jsonb_array_length(dropdown_data->'clients') = 1
+      and dropdown_data->'clients'->0->>'id' = '00000000-0000-4000-8000-000000000101'
+      and jsonb_array_length(dropdown_data->'locations') = 0,
+    'optimized=' || optimized_count
+      || ', batch_sessions=' || jsonb_array_length(batch_data->'sessions')
+      || ', batch_clients=' || jsonb_array_length(batch_data->'clients')
+      || ', dropdown_clients=' || jsonb_array_length(dropdown_data->'clients'),
+    current_user
+  );
 end
 $therapist$;
 
@@ -466,6 +503,10 @@ declare
   assigned_count int;
   unassigned_count int;
   cross_org_count int;
+  historical_count int;
+  optimized_count int;
+  batch_data jsonb;
+  dropdown_data jsonb;
 begin
   insert into role_smoke_results
   values (
@@ -484,6 +525,73 @@ begin
   select count(*) into cross_org_count from public.clients where id = '00000000-0000-4000-8000-000000000103';
   insert into role_smoke_results
   values ('bt_assigned_client_read_only', assigned_count = 1 and unassigned_count = 0 and cross_org_count = 0, 'assigned=' || assigned_count || ', unassigned=' || unassigned_count || ', cross_org=' || cross_org_count, current_user);
+
+  insert into role_smoke_results
+  values (
+    'bt_schedule_assigned_client_allowed',
+    app.current_user_has_active_schedule_client('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101'),
+    'active assignment helper accepted assigned client',
+    current_user
+  );
+  insert into role_smoke_results
+  values (
+    'bt_schedule_unassigned_client_denied',
+    not app.current_user_has_active_schedule_client('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000102'),
+    'active assignment helper rejected unassigned client',
+    current_user
+  );
+  insert into role_smoke_results
+  values (
+    'bt_schedule_cross_org_client_denied',
+    not app.current_user_has_active_schedule_client('00000000-0000-4000-8000-000000000002', '00000000-0000-4000-8000-000000000103'),
+    'active assignment helper rejected cross-org client',
+    current_user
+  );
+  insert into role_smoke_results
+  values (
+    'bt_schedule_historical_only_client_denied',
+    not app.current_user_has_active_schedule_client('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000107'),
+    'historical session did not create an active assignment',
+    current_user
+  );
+
+  select count(*) into assigned_count from public.sessions where client_id = '00000000-0000-4000-8000-000000000101';
+  select count(*) into unassigned_count from public.sessions where client_id = '00000000-0000-4000-8000-000000000102';
+  select count(*) into historical_count from public.sessions where client_id = '00000000-0000-4000-8000-000000000107';
+  select count(*)
+  into optimized_count
+  from public.get_sessions_optimized(now(), now() + interval '30 days');
+  batch_data := public.get_schedule_data_batch(now(), now() + interval '30 days');
+  dropdown_data := public.get_dropdown_data();
+
+  insert into role_smoke_results
+  values (
+    'bt_schedule_rpc_client_scope',
+    assigned_count = 1
+      and unassigned_count = 0
+      and historical_count = 0
+      and optimized_count = 1
+      and jsonb_array_length(batch_data->'sessions') = 1
+      and jsonb_array_length(batch_data->'clients') = 1
+      and batch_data->'clients'->0->>'id' = '00000000-0000-4000-8000-000000000101'
+      and batch_data->'clients'->0 ? 'availability_hours'
+      and batch_data->'sessions'->0 ? 'program_id'
+      and batch_data->'sessions'->0 ? 'goal_id'
+      and batch_data->'sessions'->0 ? 'started_at'
+      and jsonb_array_length(dropdown_data->'clients') = 1
+      and dropdown_data->'clients'->0->>'id' = '00000000-0000-4000-8000-000000000101'
+      and dropdown_data->'clients'->0 ? 'availability_hours'
+      and jsonb_array_length(dropdown_data->'locations') = 0,
+    'direct_assigned=' || assigned_count
+      || ', direct_unassigned=' || unassigned_count
+      || ', direct_historical=' || historical_count
+      || ', optimized=' || optimized_count
+      || ', batch_sessions=' || jsonb_array_length(batch_data->'sessions')
+      || ', batch_clients=' || jsonb_array_length(batch_data->'clients')
+      || ', dropdown_clients=' || jsonb_array_length(dropdown_data->'clients')
+      || ', dropdown_locations=' || jsonb_array_length(dropdown_data->'locations'),
+    current_user
+  );
 
   select count(*) into assigned_count from public.program_notes where program_id = '00000000-0000-4000-8000-000000000201';
   select count(*) into unassigned_count from public.program_notes where program_id = '00000000-0000-4000-8000-000000000202';
@@ -639,7 +747,8 @@ begin
     '00000000-0000-4000-8000-000000000502',
     '00000000-0000-4000-8000-000000000503',
     '00000000-0000-4000-8000-000000000504',
-    '00000000-0000-4000-8000-000000000505'
+    '00000000-0000-4000-8000-000000000505',
+    '00000000-0000-4000-8000-000000000506'
   );
 
   delete from public.authorization_services
@@ -673,7 +782,8 @@ begin
   delete from public.client_therapist_links
   where id in (
     '00000000-0000-4000-8000-000000000901',
-    '00000000-0000-4000-8000-000000000902'
+    '00000000-0000-4000-8000-000000000902',
+    '00000000-0000-4000-8000-000000000903'
   );
 
   delete from public.clients
@@ -683,12 +793,14 @@ begin
     '00000000-0000-4000-8000-000000000103',
     '00000000-0000-4000-8000-000000000104',
     '00000000-0000-4000-8000-000000000105',
-    '00000000-0000-4000-8000-000000000106'
+    '00000000-0000-4000-8000-000000000106',
+    '00000000-0000-4000-8000-000000000107'
   );
 
   delete from public.therapists
   where id in (
     '00000000-0000-4000-8000-000000000013',
+    '00000000-0000-4000-8000-000000000015',
     '00000000-0000-4000-8000-000000000021',
     '00000000-0000-4000-8000-000000000023'
   );
@@ -735,12 +847,12 @@ from (
   union all select id from auth.users where id in ('00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000014', '00000000-0000-4000-8000-000000000015')
   union all select id from public.profiles where id in ('00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000014', '00000000-0000-4000-8000-000000000015')
   union all select id from public.user_roles where user_id in ('00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000014', '00000000-0000-4000-8000-000000000015')
-  union all select id from public.clients where id in ('00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000103', '00000000-0000-4000-8000-000000000104', '00000000-0000-4000-8000-000000000105', '00000000-0000-4000-8000-000000000106')
-  union all select id from public.therapists where id in ('00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000021', '00000000-0000-4000-8000-000000000023')
+  union all select id from public.clients where id in ('00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000103', '00000000-0000-4000-8000-000000000104', '00000000-0000-4000-8000-000000000105', '00000000-0000-4000-8000-000000000106', '00000000-0000-4000-8000-000000000107')
+  union all select id from public.therapists where id in ('00000000-0000-4000-8000-000000000013', '00000000-0000-4000-8000-000000000015', '00000000-0000-4000-8000-000000000021', '00000000-0000-4000-8000-000000000023')
   union all select id from public.programs where id in ('00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000202', '00000000-0000-4000-8000-000000000203', '00000000-0000-4000-8000-000000000204', '00000000-0000-4000-8000-000000000205')
   union all select id from public.program_notes where id in ('00000000-0000-4000-8000-000000000801', '00000000-0000-4000-8000-000000000802', '00000000-0000-4000-8000-000000000803', '00000000-0000-4000-8000-000000000804')
   union all select id from public.goals where id in ('00000000-0000-4000-8000-000000000301', '00000000-0000-4000-8000-000000000302', '00000000-0000-4000-8000-000000000303', '00000000-0000-4000-8000-000000000304')
-  union all select id from public.sessions where id in ('00000000-0000-4000-8000-000000000501', '00000000-0000-4000-8000-000000000502', '00000000-0000-4000-8000-000000000503', '00000000-0000-4000-8000-000000000504', '00000000-0000-4000-8000-000000000505')
+  union all select id from public.sessions where id in ('00000000-0000-4000-8000-000000000501', '00000000-0000-4000-8000-000000000502', '00000000-0000-4000-8000-000000000503', '00000000-0000-4000-8000-000000000504', '00000000-0000-4000-8000-000000000505', '00000000-0000-4000-8000-000000000506')
   union all select id from public.authorizations where id in ('00000000-0000-4000-8000-000000000401', '00000000-0000-4000-8000-000000000402', '00000000-0000-4000-8000-000000000403', '00000000-0000-4000-8000-000000000404', '00000000-0000-4000-8000-000000000405', '00000000-0000-4000-8000-000000000406')
   union all select id from public.goal_data_points where id in ('00000000-0000-4000-8000-000000000601', '00000000-0000-4000-8000-000000000602')
 ) residue;


### PR DESCRIPTION
## Summary
- separate full-schedule read authority from the existing schedule write helper
- restrict BT and legacy therapist schedule reads to active client assignments across direct session RLS and all three scheduling RPCs
- preserve existing RPC payload fields and no-org dropdown behavior while withholding broad staff/location directories from scoped users
- extend the hosted synthetic role smoke for assigned, unassigned, cross-org, historical-only, BT, and therapist cases

## Verification
- `npx vitest run tests/bt-schedule-client-scope-migration.test.ts tests/employee-role-capability-matrix-migration.test.ts tests/integration/user-therapist-links-cleanup-migration.contract.test.ts tests/integration/rpc.scheduling.security-migration.test.ts` (39 passed)
- `NODE_OPTIONS=--max-old-space-size=8192 npm run test:ci` (480 files, 4146 tests passed; 5 credential-gated tests skipped)
- `npm run ci:check-focused` (passed; DB-backed checks skipped without DB URL)
- `npm run validate:tenant` (passed)
- `npm run lint` (passed)
- `npm run typecheck` (passed)
- `npm run build` (passed)
- `npm run ci:verify-coverage` (passed, 92.92% lines)
- `npm run test:routes:tier0` (220 passed)

## Critical-lane gate
This migration changes RLS and SECURITY DEFINER scheduling RPCs. It requires human review before merge. The execution-level SQL smoke and Steve Job hosted verification remain post-review/post-migration checks.