### PR TITLE
WIN-203: Enforce assigned-client scope on direct session reads

### DIFF
--- a/supabase/migrations/20260810190000_enforce_sessions_schedule_read_scope.sql
+++ b/supabase/migrations/20260810190000_enforce_sessions_schedule_read_scope.sql
@@ -1,0 +1,18 @@
+-- @migration-intent: Ensure permissive sessions write policies cannot widen authenticated schedule reads beyond the shared client-scope predicate. PostgreSQL UPDATE/DELETE visibility follows this same assigned-client boundary; INSERT authority is unchanged.
+-- @migration-dependencies: 20260810171520_restrict_bt_schedule_to_assigned_clients.sql.
+-- @migration-rollback: DROP POLICY IF EXISTS sessions_schedule_read_scope ON public.sessions;
+
+BEGIN;
+
+DROP POLICY IF EXISTS sessions_schedule_read_scope ON public.sessions;
+CREATE POLICY sessions_schedule_read_scope
+ON public.sessions
+AS RESTRICTIVE
+FOR SELECT
+TO authenticated
+USING (
+  organization_id = app.current_user_organization_id()
+  AND app.current_user_can_read_schedule_client(organization_id, client_id)
+);
+
+COMMIT;

--- a/tests/sessions-schedule-read-restrictive-policy-migration.test.ts
+++ b/tests/sessions-schedule-read-restrictive-policy-migration.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const migrationPath = path.join(
+  process.cwd(),
+  "supabase",
+  "migrations",
+  "20260810190000_enforce_sessions_schedule_read_scope.sql",
+);
+const smokePath = path.join(
+  process.cwd(),
+  "tests",
+  "sql",
+  "employee_role_capability_smoke.sql",
+);
+
+describe("sessions schedule read restrictive policy migration", () => {
+  const sql = readFileSync(migrationPath, "utf8");
+  const smokeSql = readFileSync(smokePath, "utf8");
+
+  it("adds a restrictive SELECT policy using the shared schedule predicate", () => {
+    expect(sql).toContain("CREATE POLICY sessions_schedule_read_scope");
+    expect(sql).toContain("AS RESTRICTIVE");
+    expect(sql).toContain("FOR SELECT");
+    expect(sql).toContain("TO authenticated");
+    expect(sql).toContain(
+      "app.current_user_can_read_schedule_client(organization_id, client_id)",
+    );
+  });
+
+  it("does not rewrite schedule write grants, helpers, or public RPCs", () => {
+    expect(sql).not.toContain("CREATE POLICY org_write_sessions");
+    expect(sql).not.toContain("current_user_can_manage_schedule");
+    expect(sql).not.toContain("CREATE OR REPLACE FUNCTION");
+  });
+
+  it("runtime-smokes assigned and unassigned therapist mutation visibility", () => {
+    expect(smokeSql).toContain("therapist_assigned_session_update_allowed");
+    expect(smokeSql).toContain("therapist_unassigned_session_update_denied");
+  });
+
+  it("documents a bounded rollback", () => {
+    expect(sql).toContain(
+      "DROP POLICY IF EXISTS sessions_schedule_read_scope ON public.sessions",
+    );
+  });
+});

--- a/tests/sql/employee_role_capability_smoke.sql
+++ b/tests/sql/employee_role_capability_smoke.sql
@@ -417,6 +417,7 @@ declare
   unassigned_note_count int;
   cross_org_note_count int;
   optimized_count int;
+  affected_rows int;
   batch_data jsonb;
   dropdown_data jsonb;
 begin
@@ -492,6 +493,30 @@ begin
       || ', batch_sessions=' || jsonb_array_length(batch_data->'sessions')
       || ', batch_clients=' || jsonb_array_length(batch_data->'clients')
       || ', dropdown_clients=' || jsonb_array_length(dropdown_data->'clients'),
+    current_user
+  );
+
+  update public.sessions
+  set notes = notes
+  where id = '00000000-0000-4000-8000-000000000501';
+  get diagnostics affected_rows = row_count;
+  insert into role_smoke_results
+  values (
+    'therapist_assigned_session_update_allowed',
+    affected_rows = 1,
+    'updated_rows=' || affected_rows,
+    current_user
+  );
+
+  update public.sessions
+  set notes = notes
+  where id = '00000000-0000-4000-8000-000000000502';
+  get diagnostics affected_rows = row_count;
+  insert into role_smoke_results
+  values (
+    'therapist_unassigned_session_update_denied',
+    affected_rows = 0,
+    'updated_rows=' || affected_rows,
     current_user
   );
 end


### PR DESCRIPTION
## Summary
- add a restrictive authenticated SELECT policy so the permissive `org_write_sessions` ALL policy cannot widen direct session reads
- align therapist UPDATE/DELETE visibility with assigned-client visibility while leaving INSERT authority and write helpers unchanged
- extend the hosted synthetic smoke to prove assigned updates succeed and unassigned updates are denied

## Root cause
After PR #917 deployed, schedule RPCs correctly returned only Steve Job's three assigned clients, but direct `sessions` reads still returned 12 clients. PostgreSQL OR-combined `org_read_sessions` with the existing permissive `org_write_sessions` ALL policy for legacy therapist users.

## Verification
- 39 focused migration/security tests passed
- `npm run ci:check-focused` passed
- `npm run validate:tenant` passed
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run build` passed
- code and Supabase reviews report no actionable findings

## Critical-lane gate
This is an RLS migration and requires human review before merge. After merge, apply the migration to hosted Supabase and rerun Steve's direct-table plus RPC scope verification.