### PR TITLE
WIN-240: restore BT session closeout capture

### DIFF
--- a/docs/ai/handoffs/WIN-240-bt-session-closeout-recovery.md
+++ b/docs/ai/handoffs/WIN-240-bt-session-closeout-recovery.md
@@ -18,7 +18,8 @@
 
 ## Implementation
 
-- `Schedule` now opens the data-only closeout flow for normalized BT users without widening the start-session exception.
+- `Schedule` now opens the data-only closeout flow only when authoritative role assignments contain exact `bt` without excluded overlaps or exclusive legacy `therapist`; profile-only aliases fail closed.
+- Auth stub role assignments preserve exact role names so local and integration tests exercise the same authority boundary as production.
 - A new internal, service-role-only helper centralizes the closeout actor predicate for the billing resolver, draft, read, finalize, and supervision-request creator RPCs.
 - The helper accepts authoritative active `bt` or legacy `therapist` roles, then applies the existing same-org, active BT/RBT, direct-or-linked assignment, and elevated-role denial checks.
 - Resolver, draft, and finalize retain their existing trial-capture capability checks; read and supervision-request creation were not tightened.
@@ -27,6 +28,7 @@
 
 - Required checks: focused migration and Schedule regressions; policy; lint; typecheck; full test suite; tenant validation; build; local SQL reset/smoke; exact-head CI; human protected-path review.
 - Focused migration contracts: PASS, 3 files / 22 tests.
+- Focused frontend authority regressions: PASS, 2 files / 22 tests (3 Schedule closeout cases and 19 auth-context/stub cases).
 - `npm run ci:check-focused`: PASS; DB-backed grant/parity checks skipped because no database URL is configured.
 - `npm run lint`: PASS.
 - `npm run typecheck`: PASS.
@@ -36,10 +38,11 @@
 - `npm run validate:tenant`: PASS.
 - `npm run build`: PASS.
 - `npm run test:routes:tier0`: PASS, 7 specs / 220 tests.
+- `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4173 --route=/schedule`: FAIL on the unauthenticated route shell with existing `console-error` at both viewports and `undersized-mobile-touch-target` on mobile; sanitized evidence was generated, but it cannot exercise the authenticated BT closeout modal.
 - Default-heap `npm run test:ci`: failed at the local approximately 4 GB Node heap limit; the bounded 8 GB rerun passed.
 - `npx supabase db reset --local --yes`: BLOCKED because the Docker Desktop Linux engine is unavailable.
 - `tests/sql/bt_aba_session_note_closeout_smoke.sql`: not executed locally because the reset database is unavailable; static contracts cover linked legacy success plus unlinked, elevated, and cross-org denials.
-- Result: `pass-with-blocked-checks` pending exact-head CI, runtime SQL smoke, aggregate-suite stability, and human review.
+- Result: `pass-with-blocked-checks` pending exact-head CI, authenticated responsive evidence, runtime SQL smoke, aggregate-suite stability, and human review.
 - Residual risk: the new SQL actor matrix has not run against a reset database in this workspace.
 
 ## Review
@@ -47,6 +50,7 @@
 - Specification, architecture, implementation, code review, test review, Supabase review, and security review are required for this critical slice.
 - Code review and Supabase review found no implementation defect after adding the same-org unlinked legacy therapist denial.
 - Security review approved after the legacy branch was restricted to an exclusive active `therapist` role and overlap-denial smoke coverage was added.
+- Follow-up security review approved the authoritative frontend gate; profile-only and mixed `bt` plus `therapist` assignments remain denied.
 - Final merge remains human-controlled; no hosted migration apply or deployment is part of this PR update.
 
 ## PR Hygiene

--- a/docs/ai/handoffs/WIN-240-bt-session-closeout-recovery.md
+++ b/docs/ai/handoffs/WIN-240-bt-session-closeout-recovery.md
@@ -1,0 +1,28 @@
+# WIN-240 BT Session Closeout Recovery
+
+## Scope
+
+- Restore BT session capture and closeout mode for users whose normalized effective role is `bt`.
+- Keep the scheduled-session start exception restricted to exact `bt` role assignments.
+- Add orchestration coverage for the legacy-normalized BT path.
+
+## Routing
+
+- Classification: `low-risk autonomous`
+- Lane: `standard`
+- Triggering paths: `src/pages/Schedule.tsx` and its integration test
+- Protected-path drift: none
+
+## Verification
+
+- Focused Schedule orchestration tests pass for legacy BT capture mode and atomic closeout completion (`2/2`).
+- Focused `SessionModal` tests pass for capture-before-closeout, data-only closeout progression, and closeout refetch failure containment (`3/3`).
+- `npm run lint`, `npm run typecheck`, and `npm run build` pass.
+- Authenticated local `/schedule` smoke passes with no Schedule-phase console errors or failed requests.
+- Sanitized responsive observation passes at desktop `1440x900`.
+- Mobile responsive observation is blocked by a pre-existing undersized control on the unauthenticated login shell.
+- The configured `PW_THERAPIST_*` credentials are stale, so a real BT-authenticated closeout browser proof remains blocked.
+
+## Residual Risk
+
+The effective-role gate is covered by integration tests, but the recovered popup still needs one browser confirmation with a valid legacy-normalized BT test account.

--- a/docs/ai/handoffs/WIN-240-bt-session-closeout-recovery.md
+++ b/docs/ai/handoffs/WIN-240-bt-session-closeout-recovery.md
@@ -29,6 +29,7 @@
 - Required checks: focused migration and Schedule regressions; policy; lint; typecheck; full test suite; tenant validation; build; local SQL reset/smoke; exact-head CI; human protected-path review.
 - Focused migration contracts: PASS, 3 files / 22 tests.
 - Focused frontend authority regressions: PASS, 2 files / 22 tests (3 Schedule closeout cases and 19 auth-context/stub cases).
+- Full Schedule orchestration integration file after exact-BT fixture alignment: PASS, 1 file / 74 tests using direct single-worker Vitest; the repo watchdog wrapper timed out before emitting test output.
 - `npm run ci:check-focused`: PASS; DB-backed grant/parity checks skipped because no database URL is configured.
 - `npm run lint`: PASS.
 - `npm run typecheck`: PASS.
@@ -61,3 +62,4 @@
 - Single-purpose diff: yes.
 - Generated artifact drift: none.
 - Current external blocker before this update: hosted `auth-browser-smoke` failed during synthetic admin provisioning with `Database error finding users`; `ci-gate` failed only as a consequence.
+- Exact-head CI at `639726ed` exposed four stale profile-only BT test fixtures in the unit and dedicated tenant workflows; those fixtures now declare authoritative `roleAssignments: ['bt']`. The hosted auth provisioning failure repeated unchanged.

--- a/docs/ai/handoffs/WIN-240-bt-session-closeout-recovery.md
+++ b/docs/ai/handoffs/WIN-240-bt-session-closeout-recovery.md
@@ -1,28 +1,59 @@
 # WIN-240 BT Session Closeout Recovery
 
-## Scope
-
-- Restore BT session capture and closeout mode for users whose normalized effective role is `bt`.
-- Keep the scheduled-session start exception restricted to exact `bt` role assignments.
-- Add orchestration coverage for the legacy-normalized BT path.
-
 ## Routing
 
-- Classification: `low-risk autonomous`
-- Lane: `standard`
-- Triggering paths: `src/pages/Schedule.tsx` and its integration test
-- Protected-path drift: none
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Why: the frontend recovery exposed a legacy-role mismatch in tenant-scoped BT closeout RPC authorization.
+- Triggering paths: `supabase/migrations/**`, RPC grants, role checks, and session-note finalization side effects.
 
-## Verification
+## Scope
 
-- Focused Schedule orchestration tests pass for legacy BT capture mode and atomic closeout completion (`2/2`).
-- Focused `SessionModal` tests pass for capture-before-closeout, data-only closeout progression, and closeout refetch failure containment (`3/3`).
-- `npm run lint`, `npm run typecheck`, and `npm run build` pass.
-- Authenticated local `/schedule` smoke passes with no Schedule-phase console errors or failed requests.
-- Sanitized responsive observation passes at desktop `1440x900`.
-- Mobile responsive observation is blocked by a pre-existing undersized control on the unauthenticated login shell.
-- The configured `PW_THERAPIST_*` credentials are stale, so a real BT-authenticated closeout browser proof remains blocked.
+- Restore BT closeout mode for users whose authoritative exact role is legacy `therapist` and whose effective role is `bt`.
+- Keep start-session authority restricted to exact `bt` assignments.
+- Allow legacy therapist closeout only for the same organization and an active assigned or linked BT/RBT therapist identity.
+- Deny elevated `admin`, `admin_schedule`, `midtier`, and `bcba` overlaps.
+- Preserve existing billing, capture-capability, note-lock, correction-read, and finalization behavior.
+- Do not change global role normalization, table RLS, CI workflows, deployment configuration, or hosted Supabase state.
 
-## Residual Risk
+## Implementation
 
-The effective-role gate is covered by integration tests, but the recovered popup still needs one browser confirmation with a valid legacy-normalized BT test account.
+- `Schedule` now opens the data-only closeout flow for normalized BT users without widening the start-session exception.
+- A new internal, service-role-only helper centralizes the closeout actor predicate for the billing resolver, draft, read, finalize, and supervision-request creator RPCs.
+- The helper accepts authoritative active `bt` or legacy `therapist` roles, then applies the existing same-org, active BT/RBT, direct-or-linked assignment, and elevated-role denial checks.
+- Resolver, draft, and finalize retain their existing trial-capture capability checks; read and supervision-request creation were not tightened.
+
+## Verification Card
+
+- Required checks: focused migration and Schedule regressions; policy; lint; typecheck; full test suite; tenant validation; build; local SQL reset/smoke; exact-head CI; human protected-path review.
+- Focused migration contracts: PASS, 3 files / 22 tests.
+- `npm run ci:check-focused`: PASS; DB-backed grant/parity checks skipped because no database URL is configured.
+- `npm run lint`: PASS.
+- `npm run typecheck`: PASS.
+- `NODE_OPTIONS=--max-old-space-size=8192 npm run test:ci`: PASS, 483 files / 4,156 tests; 2 files and 5 environment-gated tests skipped.
+- Final `NODE_OPTIONS=--max-old-space-size=8192 npm run verify:local`: NOT GREEN because the aggregate full-suite rerun had two order/load-sensitive `SessionModal` failures; the affected file passed immediately in isolation, 1 file / 165 tests.
+- `npm run ci:verify-coverage`: PASS, 92.92% line coverage against the 86% threshold.
+- `npm run validate:tenant`: PASS.
+- `npm run build`: PASS.
+- `npm run test:routes:tier0`: PASS, 7 specs / 220 tests.
+- Default-heap `npm run test:ci`: failed at the local approximately 4 GB Node heap limit; the bounded 8 GB rerun passed.
+- `npx supabase db reset --local --yes`: BLOCKED because the Docker Desktop Linux engine is unavailable.
+- `tests/sql/bt_aba_session_note_closeout_smoke.sql`: not executed locally because the reset database is unavailable; static contracts cover linked legacy success plus unlinked, elevated, and cross-org denials.
+- Result: `pass-with-blocked-checks` pending exact-head CI, runtime SQL smoke, aggregate-suite stability, and human review.
+- Residual risk: the new SQL actor matrix has not run against a reset database in this workspace.
+
+## Review
+
+- Specification, architecture, implementation, code review, test review, Supabase review, and security review are required for this critical slice.
+- Code review and Supabase review found no implementation defect after adding the same-org unlinked legacy therapist denial.
+- Security review approved after the legacy branch was restricted to an exclusive active `therapist` role and overlap-denial smoke coverage was added.
+- Final merge remains human-controlled; no hosted migration apply or deployment is part of this PR update.
+
+## PR Hygiene
+
+- Branch: `codex/recover-bt-session-closeout`
+- Linear: `WIN-240`
+- PR: `#919`
+- Single-purpose diff: yes.
+- Generated artifact drift: none.
+- Current external blocker before this update: hosted `auth-browser-smoke` failed during synthetic admin provisioning with `Database error finding users`; `ci-gate` failed only as a consequence.

--- a/src/lib/__tests__/authContext.initializeAuth.test.tsx
+++ b/src/lib/__tests__/authContext.initializeAuth.test.tsx
@@ -72,7 +72,16 @@ vi.mock('../supabaseClient', () => {
 });
 
 const TestConsumer = () => {
-  const { user, loading, profile, authFlow, effectiveRole, isExactBt, signOut } = useAuth();
+  const {
+    user,
+    loading,
+    profile,
+    authFlow,
+    effectiveRole,
+    isExactBt,
+    canUseBtSessionCaptureMode,
+    signOut,
+  } = useAuth();
   return (
     <>
       <div data-testid="loading">{loading ? 'yes' : 'no'}</div>
@@ -80,6 +89,7 @@ const TestConsumer = () => {
       <div data-testid="role">{profile?.role ?? 'none'}</div>
       <div data-testid="effective-role">{effectiveRole}</div>
       <div data-testid="exact-bt">{isExactBt ? 'yes' : 'no'}</div>
+      <div data-testid="bt-capture-mode">{canUseBtSessionCaptureMode ? 'yes' : 'no'}</div>
       <div data-testid="auth-flow">{authFlow}</div>
       <button type="button" data-testid="signout" onClick={() => void signOut()}>
         Sign out
@@ -232,6 +242,40 @@ describe('AuthProvider initializeAuth resilience', () => {
 
     await waitFor(() => expect(screen.getByTestId('effective-role')).toHaveTextContent('bt'));
     expect(screen.getByTestId('exact-bt')).toHaveTextContent('no');
+    expect(screen.getByTestId('bt-capture-mode')).toHaveTextContent('no');
+  });
+
+  it('authorizes BT capture mode for an exclusive legacy therapist assignment', async () => {
+    mockGetSession.mockResolvedValueOnce({
+      data: { session: { user: { id: 'user-1', email: 'user@example.com' } } },
+      error: null,
+    });
+    mockProfilesMaybeSingle.mockResolvedValueOnce({
+      data: {
+        id: 'user-1',
+        email: 'user@example.com',
+        role: 'therapist',
+        is_active: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      error: null,
+    });
+    mockRoleRowsEq.mockResolvedValueOnce({
+      data: [{ is_active: true, expires_at: null, roles: { name: 'therapist' } }],
+      error: null,
+      status: 200,
+    });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('effective-role')).toHaveTextContent('bt'));
+    expect(screen.getByTestId('exact-bt')).toHaveTextContent('no');
+    expect(screen.getByTestId('bt-capture-mode')).toHaveTextContent('yes');
   });
 
   it('preserves an exact BT role assignment separately from normalized role aliases', async () => {
@@ -271,6 +315,7 @@ describe('AuthProvider initializeAuth resilience', () => {
 
     await waitFor(() => expect(screen.getByTestId('effective-role')).toHaveTextContent('bt'));
     expect(screen.getByTestId('exact-bt')).toHaveTextContent('yes');
+    expect(screen.getByTestId('bt-capture-mode')).toHaveTextContent('yes');
   });
 
   it('does not fall back to a stale BT profile after an authoritative empty role assignment read', async () => {
@@ -306,6 +351,7 @@ describe('AuthProvider initializeAuth resilience', () => {
 
     await waitFor(() => expect(screen.getByTestId('effective-role')).toHaveTextContent('bt'));
     expect(screen.getByTestId('exact-bt')).toHaveTextContent('no');
+    expect(screen.getByTestId('bt-capture-mode')).toHaveTextContent('no');
   });
 
   it('keeps the existing profile when refresh-time profile fetch fails for same user', async () => {

--- a/src/lib/authContext.tsx
+++ b/src/lib/authContext.tsx
@@ -206,6 +206,7 @@ interface AuthContextType {
   metadataRole: Role | null;
   effectiveRole: Role;
   isExactBt: boolean;
+  canUseBtSessionCaptureMode: boolean;
   roleMismatch: boolean;
   isGuardian?: boolean;
   authFlow: 'normal' | 'password_recovery';
@@ -297,6 +298,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return resolvedExactRoleNames.includes('bt')
       && !resolvedExactRoleNames.some((role) => ['admin', 'admin_schedule', 'midtier', 'bcba', 'therapist'].includes(role));
   }, [resolvedExactRoleNames]);
+
+  const canUseBtSessionCaptureMode = useMemo(() => {
+    if (roleAssignmentNames === null) {
+      return false;
+    }
+
+    const exactRoles = new Set(roleAssignmentNames);
+    const isAuthoritativeExactBt = exactRoles.has('bt')
+      && ![...exactRoles].some((role) => ['admin', 'admin_schedule', 'midtier', 'bcba', 'therapist'].includes(role));
+    const isExclusiveLegacyTherapist = exactRoles.size === 1 && exactRoles.has('therapist');
+
+    return isAuthoritativeExactBt || isExclusiveLegacyTherapist;
+  }, [roleAssignmentNames]);
 
   const roleMismatch = useMemo(
     () =>
@@ -1100,6 +1114,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     metadataRole,
     effectiveRole,
     isExactBt,
+    canUseBtSessionCaptureMode,
     roleMismatch,
     isGuardian,
     authFlow,

--- a/src/lib/authStubSession.ts
+++ b/src/lib/authStubSession.ts
@@ -153,8 +153,11 @@ const normaliseRoleAssignments = (value: unknown): AppRole[] | null => {
   }
 
   return [...new Set(value.flatMap((candidate) => {
-    const normalized = normalizeRole(candidate);
-    return normalized && VALID_ROLES.has(normalized) ? [normalized] : [];
+    if (typeof candidate !== 'string') {
+      return [];
+    }
+    const exactRole = candidate.trim().toLowerCase().replace(/[\s-]+/g, '_') as AppRole;
+    return VALID_ROLES.has(exactRole) ? [exactRole] : [];
   }))];
 };
 

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -773,6 +773,7 @@ export const Schedule = React.memo(() => {
   }, [refetchScheduleBatch, refetchSessions, refetchDropdowns]);
 
   const therapistScopedView = effectiveRole === "bt" || effectiveRole === "therapist";
+  const canUseBtSessionCaptureMode = effectiveRole === "bt";
   const useImprovedAppointmentLayout =
     effectiveRole === "admin_schedule" ||
     effectiveRole === "admin" ||
@@ -2108,7 +2109,7 @@ export const Schedule = React.memo(() => {
         clients={visibleClients}
         existingSessions={displayData.sessions}
         timeZone={userTimeZone}
-        dataCollectionOnly={isExactBt && Boolean(selectedSession?.id)}
+        dataCollectionOnly={canUseBtSessionCaptureMode && Boolean(selectedSession?.id)}
         allowStartSession={
           isExactBt &&
           selectedSession?.status === "scheduled" &&

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -381,7 +381,14 @@ export const Schedule = React.memo(() => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   useCapturePendingScheduleEvent();
-  const { user, profile, effectiveRole, isExactBt, hasCapability } = useAuth();
+  const {
+    user,
+    profile,
+    effectiveRole,
+    isExactBt,
+    canUseBtSessionCaptureMode,
+    hasCapability,
+  } = useAuth();
   const activeOrganizationId = useActiveOrganizationId();
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [view, setView] = useState<"day" | "week">("week");
@@ -773,7 +780,6 @@ export const Schedule = React.memo(() => {
   }, [refetchScheduleBatch, refetchSessions, refetchDropdowns]);
 
   const therapistScopedView = effectiveRole === "bt" || effectiveRole === "therapist";
-  const canUseBtSessionCaptureMode = effectiveRole === "bt";
   const useImprovedAppointmentLayout =
     effectiveRole === "admin_schedule" ||
     effectiveRole === "admin" ||

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -524,12 +524,30 @@ describe("Schedule orchestration integration hardening", () => {
   };
 
   it('preserves legacy BT capture mode without restoring the exact-BT start-session exception', async () => {
-    renderWithProviders(<Schedule />, { auth: { role: 'therapist' } });
+    renderWithProviders(<Schedule />, {
+      auth: { role: 'therapist', roleAssignments: ['therapist'] },
+    });
     await screen.findByRole('heading', { name: /Schedule/i });
     await waitForScheduleGridReady();
     await openExistingSessionForEdit();
 
     expect(await screen.findByTestId('data-collection-only')).toHaveTextContent('true');
+    expect(screen.getByTestId('allow-start-session')).toHaveTextContent('false');
+  });
+
+  it.each([
+    ['profile-only legacy therapist', { role: 'therapist' as const }],
+    [
+      'overlapping BT and therapist assignments',
+      { role: 'therapist' as const, roleAssignments: ['bt', 'therapist'] },
+    ],
+  ])('keeps BT capture mode closed for %s', async (_label, auth) => {
+    renderWithProviders(<Schedule />, { auth });
+    await screen.findByRole('heading', { name: /Schedule/i });
+    await waitForScheduleGridReady();
+    await openExistingSessionForEdit();
+
+    expect(await screen.findByTestId('data-collection-only')).toHaveTextContent('false');
     expect(screen.getByTestId('allow-start-session')).toHaveTextContent('false');
   });
 

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -523,13 +523,13 @@ describe("Schedule orchestration integration hardening", () => {
     fireEvent.click(sessionCard);
   };
 
-  it('keeps legacy therapist assignments out of the exact-BT data collection path', async () => {
+  it('preserves legacy BT capture mode without restoring the exact-BT start-session exception', async () => {
     renderWithProviders(<Schedule />, { auth: { role: 'therapist' } });
     await screen.findByRole('heading', { name: /Schedule/i });
     await waitForScheduleGridReady();
     await openExistingSessionForEdit();
 
-    expect(await screen.findByTestId('data-collection-only')).toHaveTextContent('false');
+    expect(await screen.findByTestId('data-collection-only')).toHaveTextContent('true');
     expect(screen.getByTestId('allow-start-session')).toHaveTextContent('false');
   });
 

--- a/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
+++ b/src/pages/__tests__/Schedule.orchestration.integration.test.tsx
@@ -1427,7 +1427,7 @@ describe("Schedule orchestration integration hardening", () => {
 
   it("allows a BT to start an existing scheduled appointment in data-only mode", async () => {
     renderWithProviders(<Schedule />, {
-      auth: { role: "bt", organizationId: "org-1" },
+      auth: { role: "bt", roleAssignments: ["bt"], organizationId: "org-1" },
     });
     await screen.findByRole("heading", { name: /Schedule/i });
     await waitForScheduleGridReady();
@@ -1443,7 +1443,7 @@ describe("Schedule orchestration integration hardening", () => {
     scheduleFixtures.sessions[0].started_at = "2026-07-16T10:00:00.000Z";
 
     renderWithProviders(<Schedule />, {
-      auth: { role: "bt", organizationId: "org-1" },
+      auth: { role: "bt", roleAssignments: ["bt"], organizationId: "org-1" },
     });
     await screen.findByRole("heading", { name: /Schedule/i });
     await waitForScheduleGridReady();
@@ -1458,7 +1458,7 @@ describe("Schedule orchestration integration hardening", () => {
       scheduleFixtures.sessions[0].status = status;
 
       renderWithProviders(<Schedule />, {
-        auth: { role: "bt", organizationId: "org-1" },
+        auth: { role: "bt", roleAssignments: ["bt"], organizationId: "org-1" },
       });
       await screen.findByRole("heading", { name: /Schedule/i });
       await waitForScheduleGridReady();
@@ -1493,7 +1493,7 @@ describe("Schedule orchestration integration hardening", () => {
 
   it("BT scheduled-session capture saves clinical data without updating appointment metadata", async () => {
     renderWithProviders(<Schedule />, {
-      auth: { role: "bt", organizationId: "org-1" },
+      auth: { role: "bt", roleAssignments: ["bt"], organizationId: "org-1" },
     });
     await screen.findByRole("heading", { name: /Schedule/i });
 
@@ -1523,7 +1523,7 @@ describe("Schedule orchestration integration hardening", () => {
     scheduleFixtures.sessions[0].status = "in_progress";
 
     renderWithProviders(<Schedule />, {
-      auth: { role: "bt", organizationId: "org-1" },
+      auth: { role: "bt", roleAssignments: ["bt"], organizationId: "org-1" },
     });
     await screen.findByRole("heading", { name: /Schedule/i });
 
@@ -1545,7 +1545,7 @@ describe("Schedule orchestration integration hardening", () => {
     scheduleFixtures.sessions[0].status = "in_progress";
 
     renderWithProviders(<Schedule />, {
-      auth: { role: "bt", organizationId: "org-1" },
+      auth: { role: "bt", roleAssignments: ["bt"], organizationId: "org-1" },
     });
     await screen.findByRole("heading", { name: /Schedule/i });
 
@@ -1585,7 +1585,7 @@ describe("Schedule orchestration integration hardening", () => {
         <SearchProbe />
       </>,
       {
-        auth: { role: "bt", organizationId: "org-1" },
+        auth: { role: "bt", roleAssignments: ["bt"], organizationId: "org-1" },
         router: {
           initialEntries: [
             `/?keep=1&scheduleModal=edit&scheduleSessionId=session-1&scheduleExp=${expiresAtMs}`,
@@ -1613,7 +1613,9 @@ describe("Schedule orchestration integration hardening", () => {
 
   it("rejects the legacy BT completed submission path", async () => {
     scheduleFixtures.sessions[0].status = "in_progress";
-    renderWithProviders(<Schedule />, { auth: { role: "bt", organizationId: "org-1" } });
+    renderWithProviders(<Schedule />, {
+      auth: { role: "bt", roleAssignments: ["bt"], organizationId: "org-1" },
+    });
     await screen.findByRole("heading", { name: /Schedule/i });
     await openExistingSessionForEdit();
     fireEvent.click(screen.getByLabelText("submit-terminal-capture"));

--- a/supabase/migrations/20260810222545_bt_closeout_legacy_therapist_compat.sql
+++ b/supabase/migrations/20260810222545_bt_closeout_legacy_therapist_compat.sql
@@ -1,0 +1,1002 @@
+/*
+  @migration-intent: Restore legacy exact therapist compatibility for BT closeout actor checks without widening trial-capture authority.
+  @migration-dependencies: 20260717235500_align_supervision_request_linked_therapist_authority.sql, 20260721165120_bt_aba_completed_note_latest_amendment.sql, 20260722181239_resolve_assigned_bt_session_capture_billing.sql
+  @migration-rollback: Reapply the prior function definitions from 20260717235500_align_supervision_request_linked_therapist_authority.sql, 20260721165120_bt_aba_completed_note_latest_amendment.sql, 20260722181239_resolve_assigned_bt_session_capture_billing.sql, and 20260716212837_bt_aba_session_note_closeout.sql, then drop app.current_user_can_act_as_bt_closeout_actor(uuid, uuid).
+*/
+
+set search_path = public, app, auth;
+
+begin;
+
+create or replace function app.current_user_can_act_as_bt_closeout_actor(
+  p_organization_id uuid,
+  p_therapist_id uuid
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+begin
+  if v_actor is null or p_organization_id is null or p_therapist_id is null then
+    return false;
+  end if;
+
+  if p_organization_id <> app.current_user_organization_id() then
+    return false;
+  end if;
+
+  if not (
+    (
+      coalesce(
+        app.current_user_has_exact_role_for_org(
+          p_organization_id,
+          array['bt']::text[]
+        ),
+        false
+      )
+      and not coalesce(
+        app.current_user_has_exact_role_for_org(
+          p_organization_id,
+          array['admin', 'admin_schedule', 'midtier', 'bcba', 'therapist']::text[]
+        ),
+        false
+      )
+    )
+    or coalesce(
+      app.current_user_has_exact_active_role_for_org(
+        p_organization_id,
+        array['therapist']::text[]
+      ),
+      false
+    )
+  ) then
+    return false;
+  end if;
+
+  return exists (
+    select 1
+    from public.therapists therapist
+    where therapist.id = p_therapist_id
+      and therapist.organization_id = p_organization_id
+      and therapist.status = 'active'
+      and therapist.deleted_at is null
+      and upper(btrim(coalesce(therapist.title, ''))) in ('BT', 'RBT')
+      and (
+        therapist.id = v_actor
+        or exists (
+          select 1
+          from public.user_therapist_links utl
+          where utl.user_id = v_actor
+            and utl.therapist_id = therapist.id
+        )
+      )
+  );
+end;
+$$;
+
+revoke all on function app.current_user_can_act_as_bt_closeout_actor(uuid, uuid) from public, anon, authenticated;
+grant execute on function app.current_user_can_act_as_bt_closeout_actor(uuid, uuid) to service_role;
+
+create or replace function public.resolve_assigned_bt_session_capture_billing(p_session_id uuid)
+returns table (
+  authorization_id uuid,
+  service_code text,
+  strict_billing boolean,
+  session_client_id uuid,
+  session_therapist_id uuid
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_session public.sessions%rowtype;
+  v_authorization public.authorizations%rowtype;
+  v_service_code text;
+  v_strict_billing boolean := false;
+  v_is_assigned_bt boolean := false;
+begin
+  if v_actor is null then
+    raise exception using errcode = '42501', message = 'authentication required';
+  end if;
+
+  if p_session_id is null then
+    raise exception using errcode = '22023', message = 'session id is required';
+  end if;
+
+  select session.* into v_session
+  from public.sessions session
+  where session.id = p_session_id;
+
+  if not found then
+    raise exception using errcode = '42501', message = 'session is out of scope';
+  end if;
+
+  select coalesce(
+    app.current_user_can_act_as_bt_closeout_actor(
+      v_session.organization_id,
+      v_session.therapist_id
+    ),
+    false
+  )
+  into v_is_assigned_bt;
+
+  if v_session.organization_id <> app.current_user_organization_id()
+     or not v_is_assigned_bt
+     or not public.current_user_can_capture_trial_event(v_session.organization_id, v_session.client_id) then
+    raise exception using errcode = '42501', message = 'caller is not the assigned BT';
+  end if;
+
+  v_strict_billing := app.session_capture_strict_billing_gate(v_session.organization_id);
+
+  select authz.* into v_authorization
+  from public.authorizations authz
+  where authz.organization_id = v_session.organization_id
+    and authz.client_id = v_session.client_id
+    and (
+      not v_strict_billing
+      or (
+        authz.status = 'approved'
+        and v_session.start_time::date between authz.start_date and authz.end_date
+      )
+    )
+  order by
+    case when authz.status = 'approved'
+           and v_session.start_time::date between authz.start_date and authz.end_date then 0 else 1 end,
+    authz.updated_at desc,
+    authz.id
+  limit 1;
+
+  if not found then
+    raise exception using errcode = '23514', message = 'no valid authorization is available for this session';
+  end if;
+
+  select service.service_code into v_service_code
+  from public.authorization_services service
+  where service.authorization_id = v_authorization.id
+    and service.organization_id = v_session.organization_id
+    and (
+      not v_strict_billing
+      or (
+        service.decision_status = 'approved'
+        and v_session.start_time::date between service.from_date and service.to_date
+        and coalesce(service.approved_units, 0) > 0
+      )
+    )
+  order by
+    case when service.decision_status = 'approved'
+           and v_session.start_time::date between service.from_date and service.to_date
+           and coalesce(service.approved_units, 0) > 0 then 0 else 1 end,
+    service.updated_at desc,
+    service.id
+  limit 1;
+
+  if not found and v_strict_billing then
+    raise exception using errcode = '23514', message = 'no valid authorization service is available for this session';
+  elsif not found then
+    v_service_code := 'UNSPECIFIED';
+  end if;
+
+  return query
+  select
+    v_authorization.id,
+    v_service_code,
+    v_strict_billing,
+    v_session.client_id,
+    v_session.therapist_id;
+end;
+$$;
+
+create or replace function public.create_supervision_session_note_request_for_completed_session(
+  p_session_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_actor_org uuid;
+  v_request_id uuid;
+  v_session record;
+  v_request record;
+  v_actor_is_admin boolean := false;
+  v_actor_has_schedule_authority boolean := false;
+  v_assigned_admin_user_id uuid;
+begin
+  if v_actor is null then
+    raise exception using errcode = '28000', message = 'Authentication required';
+  end if;
+  if p_session_id is null then
+    raise exception using errcode = '22023', message = 'Session id required';
+  end if;
+
+  v_actor_org := app.resolve_user_organization_id(v_actor);
+  if v_actor_org is null then
+    raise exception using errcode = '42501', message = 'Organization context required';
+  end if;
+
+  select
+    s.id,
+    s.organization_id,
+    s.client_id,
+    s.therapist_id,
+    s.status,
+    upper(btrim(coalesce(t.title, ''))) in ('BT', 'RBT') as is_bt_rbt
+  into v_session
+  from public.sessions s
+  join public.therapists t
+    on t.id = s.therapist_id
+   and t.organization_id = s.organization_id
+  where s.id = p_session_id
+    and s.organization_id = v_actor_org
+  for update;
+
+  if v_session.id is null then
+    raise exception using errcode = '42501', message = 'Session not found in caller organization';
+  end if;
+  if v_session.status <> 'completed' then
+    return null;
+  end if;
+  if coalesce(v_session.is_bt_rbt, false) is not true then
+    return null;
+  end if;
+  if app.has_complete_bt_review_packet(v_actor_org, v_session.id) is not true then
+    return null;
+  end if;
+
+  v_actor_is_admin := app.user_has_any_active_role_for_org(
+    v_actor,
+    v_actor_org,
+    array['admin', 'super_admin', 'org_admin', 'org_super_admin']
+  );
+  v_actor_has_schedule_authority := app.user_has_any_active_role_for_org(
+    v_actor,
+    v_actor_org,
+    array['admin_schedule', 'midtier', 'bcba']
+  );
+
+  if coalesce(v_actor_is_admin, false) is not true
+     and coalesce(v_actor_has_schedule_authority, false) is not true
+     and not coalesce(
+       app.current_user_can_act_as_bt_closeout_actor(
+         v_actor_org,
+         v_session.therapist_id
+       ),
+       false
+     ) then
+    raise exception using errcode = '42501', message = 'Caller cannot create supervision request for this session';
+  end if;
+
+  v_assigned_admin_user_id := app.resolve_supervision_bcba_assignee(v_actor_org, v_session.client_id);
+
+  select request.*
+  into v_request
+  from public.supervision_session_note_requests request
+  where request.session_id = v_session.id
+    and request.organization_id = v_actor_org
+  for update;
+
+  if v_request.id is null then
+    insert into public.supervision_session_note_requests (
+      organization_id,
+      session_id,
+      client_id,
+      bt_therapist_id,
+      assigned_admin_user_id,
+      requested_by,
+      status
+    ) values (
+      v_actor_org,
+      v_session.id,
+      v_session.client_id,
+      v_session.therapist_id,
+      v_assigned_admin_user_id,
+      v_actor,
+      'pending'
+    )
+    on conflict (session_id) do nothing
+    returning id into v_request_id;
+
+    if v_request_id is not null then
+      return v_request_id;
+    end if;
+
+    select request.*
+    into v_request
+    from public.supervision_session_note_requests request
+    where request.session_id = v_session.id
+      and request.organization_id = v_actor_org
+    for update;
+
+    if v_request.id is null then
+      raise exception using errcode = '40001', message = 'Supervision request changed concurrently';
+    end if;
+  end if;
+
+  if v_request.status = 'completed' then
+    return v_request.id;
+  end if;
+
+  if v_request.status = 'cancelled' then
+    update public.supervision_session_note_requests
+    set status = 'pending',
+        assigned_admin_user_id = app.resolve_supervision_bcba_assignee(v_actor_org, v_session.client_id),
+        requested_by = coalesce(requested_by, v_actor),
+        reopened_at = timezone('utc', now()),
+        reopened_by = v_actor,
+        reopen_source = 'structured_bt_closeout',
+        completed_at = null,
+        updated_at = timezone('utc', now())
+    where id = v_request.id
+      and organization_id = v_actor_org
+    returning id into v_request_id;
+
+    return v_request_id;
+  end if;
+
+  update public.supervision_session_note_requests
+  set assigned_admin_user_id = coalesce(
+        supervision_session_note_requests.assigned_admin_user_id,
+        v_assigned_admin_user_id
+      ),
+      updated_at = timezone('utc', now())
+  where id = v_request.id
+    and organization_id = v_actor_org
+  returning id into v_request_id;
+
+  return v_request_id;
+end;
+$$;
+
+create or replace function public.save_bt_aba_session_note_draft(
+  p_session_id uuid,
+  p_template_id uuid,
+  p_note_payload jsonb,
+  p_responses jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_session public.sessions;
+  v_template public.session_note_templates;
+  v_note public.client_session_notes;
+  v_authorization public.authorizations;
+  v_service_code text;
+  v_strict_billing boolean := false;
+  v_is_assigned_bt boolean := false;
+begin
+  if v_actor is null then
+    raise exception using errcode = '42501', message = 'authentication required';
+  end if;
+  if p_session_id is null or p_template_id is null
+     or jsonb_typeof(coalesce(p_note_payload, '{}'::jsonb)) <> 'object'
+     or jsonb_typeof(coalesce(p_responses, '{}'::jsonb)) <> 'object' then
+    raise exception using errcode = '22023', message = 'invalid BT ABA draft payload';
+  end if;
+
+  select session.* into v_session
+  from public.sessions session
+  where session.id = p_session_id
+  for update;
+  if not found then
+    raise exception using errcode = '42501', message = 'session is out of scope';
+  end if;
+
+  select coalesce(
+    app.current_user_can_act_as_bt_closeout_actor(
+      v_session.organization_id,
+      v_session.therapist_id
+    ),
+    false
+  )
+  into v_is_assigned_bt;
+
+  if v_session.organization_id <> app.current_user_organization_id()
+     or not v_is_assigned_bt
+     or not public.current_user_can_capture_trial_event(v_session.organization_id, v_session.client_id) then
+    raise exception using errcode = '42501', message = 'caller is not the assigned BT';
+  end if;
+  if v_session.status <> 'in_progress' then
+    raise exception using errcode = '23514', message = 'session is not in progress';
+  end if;
+
+  select template.* into v_template
+  from public.session_note_templates template
+  where template.id = p_template_id
+    and template.organization_id = v_session.organization_id
+    and template.template_type = 'bt_aba_session_note';
+  if not found then
+    raise exception using errcode = '42501', message = 'BT ABA template is out of scope';
+  end if;
+
+  v_strict_billing := app.session_capture_strict_billing_gate(v_session.organization_id);
+  select authz.* into v_authorization
+  from public.authorizations authz
+  where authz.organization_id = v_session.organization_id
+    and authz.client_id = v_session.client_id
+    and (
+      not v_strict_billing
+      or (
+        authz.status = 'approved'
+        and v_session.start_time::date between authz.start_date and authz.end_date
+      )
+    )
+  order by
+    case when authz.status = 'approved'
+           and v_session.start_time::date between authz.start_date and authz.end_date then 0 else 1 end,
+    authz.updated_at desc,
+    authz.id
+  limit 1;
+  if not found then
+    raise exception using errcode = '23514', message = 'no valid authorization is available for this session';
+  end if;
+
+  select service.service_code into v_service_code
+  from public.authorization_services service
+  where service.authorization_id = v_authorization.id
+    and service.organization_id = v_session.organization_id
+    and (
+      not v_strict_billing
+      or (
+        service.decision_status = 'approved'
+        and v_session.start_time::date between service.from_date and service.to_date
+        and coalesce(service.approved_units, 0) > 0
+      )
+    )
+  order by
+    case when service.decision_status = 'approved'
+           and v_session.start_time::date between service.from_date and service.to_date
+           and coalesce(service.approved_units, 0) > 0 then 0 else 1 end,
+    service.updated_at desc,
+    service.id
+  limit 1;
+  if not found and v_strict_billing then
+    raise exception using errcode = '23514', message = 'no valid authorization service is available for this session';
+  elsif not found then
+    v_service_code := 'UNSPECIFIED';
+  end if;
+
+  select note.* into v_note
+  from public.client_session_notes note
+  where note.session_id = v_session.id
+    and note.organization_id = v_session.organization_id
+    and note.client_id = v_session.client_id
+  order by note.created_at desc, note.id desc
+  limit 1
+  for update;
+
+  if found and v_note.is_locked then
+    raise exception using errcode = '23514', message = 'BT ABA session note is locked';
+  end if;
+
+  if v_note.id is null then
+    insert into public.client_session_notes (
+      authorization_id, client_id, therapist_id, organization_id, session_id,
+      service_code, session_date, start_time, end_time, session_duration,
+      goals_addressed, goal_ids, goal_measurements, goal_notes, narrative,
+      is_locked, signed_at, created_by,
+      bt_aba_template_id, bt_aba_template_snapshot, bt_aba_responses
+    ) values (
+      v_authorization.id, v_session.client_id, v_session.therapist_id,
+      v_session.organization_id, v_session.id, coalesce(v_service_code, 'UNSPECIFIED'),
+      v_session.start_time::date, v_session.start_time::time, v_session.end_time::time,
+      greatest(1, round(extract(epoch from (v_session.end_time - v_session.start_time)) / 60)::integer),
+      coalesce(array(select jsonb_array_elements_text(coalesce(p_note_payload->'goals_addressed', '[]'::jsonb))), '{}'::text[]),
+      case when p_note_payload->'goal_ids' is null or p_note_payload->'goal_ids' = 'null'::jsonb then null
+        else array(select jsonb_array_elements_text(p_note_payload->'goal_ids')) end,
+      p_note_payload->'goal_measurements', p_note_payload->'goal_notes',
+      coalesce(p_note_payload->>'narrative', ''), false, null, v_actor,
+      p_template_id, v_template.template_structure, coalesce(p_responses, '{}'::jsonb)
+    ) returning * into v_note;
+  else
+    update public.client_session_notes note
+    set authorization_id = v_authorization.id,
+        service_code = v_service_code,
+        bt_aba_template_id = p_template_id,
+        bt_aba_template_snapshot = v_template.template_structure,
+        bt_aba_responses = coalesce(p_responses, '{}'::jsonb)
+    where note.id = v_note.id
+    returning note.* into v_note;
+  end if;
+
+  return jsonb_build_object('status', 'draft', 'note_id', v_note.id);
+end;
+$$;
+
+create or replace function public.get_bt_aba_session_note(p_session_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_session public.sessions;
+  v_note public.client_session_notes;
+  v_template public.session_note_templates;
+  v_request_id uuid;
+  v_latest_amendment_responses jsonb;
+  v_is_assigned_bt boolean := false;
+begin
+  if v_actor is null then
+    raise exception using errcode = '42501', message = 'authentication required';
+  end if;
+  if p_session_id is null then
+    raise exception using errcode = '22023', message = 'session id is required';
+  end if;
+
+  select session.* into v_session
+  from public.sessions session
+  where session.id = p_session_id;
+  if not found or v_session.organization_id <> app.current_user_organization_id() then
+    raise exception using errcode = '42501', message = 'session is out of scope';
+  end if;
+
+  select coalesce(
+    app.current_user_can_act_as_bt_closeout_actor(
+      v_session.organization_id,
+      v_session.therapist_id
+    ),
+    false
+  )
+  into v_is_assigned_bt;
+
+  if not v_is_assigned_bt then
+    raise exception using errcode = '42501', message = 'caller is not the assigned BT';
+  end if;
+
+  select note.* into v_note
+  from public.client_session_notes note
+  where note.session_id = v_session.id
+    and note.organization_id = v_session.organization_id
+    and note.client_id = v_session.client_id
+    and note.therapist_id = v_session.therapist_id
+  order by note.created_at desc, note.id desc
+  limit 1;
+
+  select template.* into v_template
+  from public.session_note_templates template
+  where template.organization_id = v_session.organization_id
+    and template.template_type = 'bt_aba_session_note'
+    and (v_note.bt_aba_template_id is null or template.id = v_note.bt_aba_template_id)
+  order by template.created_at desc, template.id desc
+  limit 1;
+  if not found then
+    raise exception using errcode = '23514', message = 'BT ABA template is unavailable';
+  end if;
+
+  select request.id into v_request_id
+  from public.supervision_session_note_requests request
+  where request.session_id = v_session.id
+    and request.organization_id = v_session.organization_id
+    and request.client_id = v_session.client_id
+    and request.bt_therapist_id = v_session.therapist_id
+    and request.status in ('pending', 'correction_required', 'resubmitted', 'completed')
+  order by request.created_at desc, request.id desc
+  limit 1;
+
+  if v_request_id is not null and v_note.id is not null then
+    select amendment.bt_aba_responses into v_latest_amendment_responses
+    from public.bt_session_note_amendments amendment
+    where amendment.request_id = v_request_id
+      and amendment.organization_id = v_session.organization_id
+      and amendment.original_bt_note_id = v_note.id
+    order by amendment.version_number desc, amendment.created_at desc, amendment.id desc
+    limit 1;
+  end if;
+
+  return jsonb_build_object(
+    'note_id', v_note.id,
+    'template_id', v_template.id,
+    'responses', case
+      when v_note.id is null then null
+      else coalesce(v_latest_amendment_responses, v_note.bt_aba_responses, '{}'::jsonb)
+    end,
+    'status', case when v_note.id is null then null when v_note.is_locked then 'completed' else 'draft' end
+  );
+end;
+$$;
+
+create or replace function public.finalize_bt_aba_session_note(
+  p_session_id uuid,
+  p_note_id uuid,
+  p_note_payload jsonb,
+  p_responses jsonb,
+  p_trial_events jsonb default '[]'::jsonb,
+  p_expected_target_versions jsonb default '[]'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_session public.sessions;
+  v_note public.client_session_notes;
+  v_template public.session_note_templates;
+  v_missing_key text;
+  v_field record;
+  v_response jsonb;
+  v_signature_method text;
+  v_signature_value text;
+  v_signature_points jsonb;
+  v_note_json jsonb;
+  v_progression_results jsonb := '[]'::jsonb;
+  v_is_assigned_bt boolean := false;
+  v_authorization public.authorizations;
+  v_service_code text;
+  v_strict_billing boolean := false;
+  v_canonical_note_payload jsonb;
+  v_result jsonb;
+begin
+  if v_actor is null then
+    raise exception using errcode = '42501', message = 'authentication required';
+  end if;
+  if p_session_id is null or p_note_id is null then
+    raise exception using errcode = '22023', message = 'invalid BT ABA finalization payload';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(p_session_id::text, 1));
+  select session.* into v_session
+  from public.sessions session
+  where session.id = p_session_id
+  for update;
+  if not found then
+    raise exception using errcode = '42501', message = 'session is out of scope';
+  end if;
+  if v_session.organization_id <> app.current_user_organization_id() then
+    raise exception using errcode = '42501', message = 'session is out of scope';
+  end if;
+  if v_session.status <> 'in_progress' and v_session.status <> 'completed' then
+    raise exception using errcode = '23514', message = 'session cannot be finalized';
+  end if;
+
+  select note.* into v_note
+  from public.client_session_notes note
+  where note.id = p_note_id
+    and note.session_id = v_session.id
+    and note.organization_id = v_session.organization_id
+    and note.client_id = v_session.client_id
+    and note.therapist_id = v_session.therapist_id
+  for update;
+  if not found then
+    raise exception using errcode = '42501', message = 'BT ABA note is out of scope';
+  end if;
+  if v_session.status = 'completed' then
+    if not v_note.is_locked
+       or v_note.signed_at is null
+       or v_note.bt_aba_template_id is null
+       or v_note.bt_aba_responses is null
+       or v_note.bt_aba_finalization_result is null
+       or not exists (
+         select 1
+         from public.session_note_attestations attestation
+         where attestation.note_id = v_note.id
+           and attestation.organization_id = v_session.organization_id
+           and attestation.signer_user_id = v_actor
+           and attestation.attestation_role = 'bt'
+       ) then
+      raise exception using errcode = '23514', message = 'completed session does not have a finalized BT ABA note';
+    end if;
+    return v_note.bt_aba_finalization_result;
+  end if;
+
+  select coalesce(
+    app.current_user_can_act_as_bt_closeout_actor(
+      v_session.organization_id,
+      v_session.therapist_id
+    ),
+    false
+  )
+  into v_is_assigned_bt;
+
+  if not v_is_assigned_bt
+     or not public.current_user_can_capture_trial_event(v_session.organization_id, v_session.client_id) then
+    raise exception using errcode = '42501', message = 'caller is not the assigned BT';
+  end if;
+
+  if jsonb_typeof(coalesce(p_note_payload, '{}'::jsonb)) <> 'object'
+     or jsonb_typeof(coalesce(p_responses, '{}'::jsonb)) <> 'object'
+     or jsonb_typeof(coalesce(p_trial_events, '[]'::jsonb)) <> 'array'
+     or jsonb_typeof(coalesce(p_expected_target_versions, '[]'::jsonb)) <> 'array' then
+    raise exception using errcode = '22023', message = 'invalid BT ABA finalization payload';
+  end if;
+
+  v_strict_billing := app.session_capture_strict_billing_gate(v_session.organization_id);
+  select authz.* into v_authorization
+  from public.authorizations authz
+  where authz.organization_id = v_session.organization_id
+    and authz.client_id = v_session.client_id
+    and (
+      not v_strict_billing
+      or (
+        authz.status = 'approved'
+        and v_session.start_time::date between authz.start_date and authz.end_date
+      )
+    )
+  order by
+    case when authz.status = 'approved'
+           and v_session.start_time::date between authz.start_date and authz.end_date then 0 else 1 end,
+    authz.updated_at desc,
+    authz.id
+  limit 1;
+  if not found then
+    raise exception using errcode = '23514', message = 'no valid authorization is available for this session';
+  end if;
+
+  select service.service_code into v_service_code
+  from public.authorization_services service
+  where service.authorization_id = v_authorization.id
+    and service.organization_id = v_session.organization_id
+    and (
+      not v_strict_billing
+      or (
+        service.decision_status = 'approved'
+        and v_session.start_time::date between service.from_date and service.to_date
+        and coalesce(service.approved_units, 0) > 0
+      )
+    )
+  order by
+    case when service.decision_status = 'approved'
+           and v_session.start_time::date between service.from_date and service.to_date
+           and coalesce(service.approved_units, 0) > 0 then 0 else 1 end,
+    service.updated_at desc,
+    service.id
+  limit 1;
+  if not found and v_strict_billing then
+    raise exception using errcode = '23514', message = 'no valid authorization service is available for this session';
+  elsif not found then
+    v_service_code := 'UNSPECIFIED';
+  end if;
+  v_canonical_note_payload :=
+    (p_note_payload - 'authorization_id' - 'requested_service_code')
+    || jsonb_build_object(
+      'authorization_id', v_authorization.id,
+      'requested_service_code', v_service_code
+    );
+
+  select template.* into v_template
+  from public.session_note_templates template
+  where template.id = v_note.bt_aba_template_id
+    and template.organization_id = v_session.organization_id
+    and template.template_type = 'bt_aba_session_note';
+  if not found then
+    raise exception using errcode = '42501', message = 'BT ABA template is out of scope';
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_object_keys(p_responses) response_key
+    where not exists (
+      select 1
+      from jsonb_array_elements(v_template.template_structure->'sections') section(value)
+      cross join lateral jsonb_array_elements(coalesce(section.value->'fields', '[]'::jsonb)) item(value)
+      where item.value->>'key' = response_key
+    )
+  ) then
+    raise exception using errcode = '23514', message = 'invalid BT ABA session note response type or option';
+  end if;
+
+  for v_field in
+    select
+      item.value->>'key' as field_key,
+      item.value->>'type' as field_type,
+      coalesce(item.value->'options', '[]'::jsonb) as options
+    from jsonb_array_elements(v_template.template_structure->'sections') section(value)
+    cross join lateral jsonb_array_elements(coalesce(section.value->'fields', '[]'::jsonb)) item(value)
+  loop
+    v_response := p_responses->v_field.field_key;
+    if v_response is null then
+      continue;
+    end if;
+
+    if v_field.field_type = 'multi_select' then
+      if jsonb_typeof(v_response) <> 'array'
+         or jsonb_array_length(v_response) = 0
+         or exists (
+           select 1
+           from jsonb_array_elements(v_response) option(value)
+           where jsonb_typeof(option.value) <> 'string'
+             or not (v_field.options ? (option.value #>> '{}'))
+         ) then
+        raise exception using errcode = '23514', message = 'invalid BT ABA session note response type or option';
+      end if;
+    elsif v_field.field_type = 'radio' then
+      if jsonb_typeof(v_response) <> 'string'
+         or not (v_field.options ? (v_response #>> '{}')) then
+        raise exception using errcode = '23514', message = 'invalid BT ABA session note response type or option';
+      end if;
+    elsif v_field.field_type in ('text', 'textarea') then
+      if jsonb_typeof(v_response) <> 'string' then
+        raise exception using errcode = '23514', message = 'invalid BT ABA session note response type or option';
+      end if;
+    elsif v_field.field_type = 'boolean' then
+      if jsonb_typeof(v_response) <> 'boolean' then
+        raise exception using errcode = '23514', message = 'invalid BT ABA session note response type or option';
+      end if;
+    elsif v_field.field_type = 'signature' then
+      if jsonb_typeof(v_response) <> 'object'
+         or jsonb_typeof(v_response->'method') <> 'string'
+         or jsonb_typeof(v_response->'value') <> 'string'
+         or exists (
+           select 1 from jsonb_object_keys(v_response) signature_key
+           where signature_key not in ('method', 'value')
+         ) then
+        raise exception using errcode = '23514', message = 'invalid BT ABA session note response type or option';
+      end if;
+    else
+      raise exception using errcode = '23514', message = 'invalid BT ABA session note response type or option';
+    end if;
+  end loop;
+
+  select field.field_key into v_missing_key
+  from (
+    select item.value->>'key' as field_key,
+      coalesce((item.value->>'required')::boolean, false) as is_required,
+      item.value->>'required_when' as required_when
+    from jsonb_array_elements(v_template.template_structure->'sections') section(value)
+    cross join lateral jsonb_array_elements(coalesce(section.value->'fields', '[]'::jsonb)) item(value)
+  ) field
+  where (
+      field.is_required
+      or (
+        field.required_when like '% includes %'
+        and coalesce(p_responses->btrim(split_part(field.required_when, ' includes ', 1)), '[]'::jsonb)
+          ? btrim(split_part(field.required_when, ' includes ', 2))
+      )
+    )
+    and case
+      when jsonb_typeof(p_responses->field.field_key) = 'array'
+        then jsonb_array_length(p_responses->field.field_key) = 0
+      when jsonb_typeof(p_responses->field.field_key) = 'boolean'
+        then false
+      when jsonb_typeof(p_responses->field.field_key) = 'object'
+        then p_responses->field.field_key = '{}'::jsonb
+      else nullif(btrim(coalesce(p_responses->>field.field_key, '')), '') is null
+    end
+  limit 1;
+  if v_missing_key is not null then
+    raise exception using errcode = '23514', message = 'required BT ABA session note response missing';
+  end if;
+
+  if (p_responses->'skill_strategies' ? 'N/A' and jsonb_array_length(p_responses->'skill_strategies') > 1)
+     or (p_responses->'behavior_strategies' ? 'N/A' and jsonb_array_length(p_responses->'behavior_strategies') > 1) then
+    raise exception using errcode = '23514', message = 'N/A must be selected exclusively';
+  end if;
+  v_signature_method := nullif(btrim(p_responses->'bt_signature'->>'method'), '');
+  v_signature_value := nullif(btrim(p_responses->'bt_signature'->>'value'), '');
+  if v_signature_method not in ('drawn', 'typed') or v_signature_value is null then
+    raise exception using errcode = '23514', message = 'valid BT signature is required';
+  end if;
+  if v_signature_method = 'typed' and char_length(v_signature_value) > 200 then
+    raise exception using errcode = '23514', message = 'valid BT signature is required';
+  end if;
+  if v_signature_method = 'drawn' then
+    if char_length(v_signature_value) > 20000 or left(v_signature_value, 7) <> 'points:' then
+      raise exception using errcode = '23514', message = 'invalid drawn BT signature serialization';
+    end if;
+    begin
+      v_signature_points := substring(v_signature_value from 8)::jsonb;
+    exception when others then
+      raise exception using errcode = '23514', message = 'invalid drawn BT signature serialization';
+    end;
+    if jsonb_typeof(v_signature_points) <> 'array'
+       or jsonb_array_length(v_signature_points) = 0
+       or jsonb_array_length(v_signature_points) > 256
+       or not exists (
+         select 1 from jsonb_array_elements(v_signature_points) point(value)
+         where point.value <> 'null'::jsonb
+       )
+       or exists (
+         select 1
+         from jsonb_array_elements(v_signature_points) point(value)
+         where case
+           when point.value = 'null'::jsonb then false
+           when jsonb_typeof(point.value) <> 'array' then true
+           when jsonb_array_length(point.value) <> 2 then true
+           when jsonb_typeof(point.value->0) <> 'number'
+             or jsonb_typeof(point.value->1) <> 'number' then true
+           else (point.value->>0)::numeric < 0
+             or (point.value->>0)::numeric > 1
+             or (point.value->>1)::numeric < 0
+             or (point.value->>1)::numeric > 1
+         end
+       ) then
+      raise exception using errcode = '23514', message = 'invalid drawn BT signature serialization';
+    end if;
+  end if;
+
+  if v_session.status = 'in_progress' then
+    update public.client_session_notes note
+    set authorization_id = v_authorization.id,
+        service_code = v_service_code,
+        bt_aba_responses = p_responses,
+        bt_aba_template_snapshot = v_template.template_structure
+    where note.id = v_note.id;
+
+    update public.sessions session
+    set status = 'completed', updated_by = v_actor, updated_at = timezone('utc', now())
+    where session.id = v_session.id;
+  end if;
+
+  select finalized.note, finalized.progression_results
+  into v_note_json, v_progression_results
+  from public.finalize_session_note_with_progression(
+    v_session.id,
+    v_note.id,
+    v_canonical_note_payload,
+    coalesce(p_trial_events, '[]'::jsonb),
+    coalesce(p_expected_target_versions, '[]'::jsonb)
+  ) finalized;
+
+  insert into public.session_note_attestations (
+    organization_id, note_id, signer_user_id, attestation_role,
+    signature_method, signature_value, signed_at
+  ) values (
+    v_session.organization_id, v_note.id, v_actor, 'bt',
+    v_signature_method, v_signature_value, timezone('utc', now())
+  ) on conflict (note_id, attestation_role, signer_user_id) do nothing;
+
+  if not exists (
+    select 1 from public.session_audit_logs audit
+    where audit.session_id = v_session.id
+      and audit.event_type = 'session_completed'
+  ) then
+    perform public.record_session_audit(
+      v_session.id,
+      'session_completed',
+      v_actor,
+      jsonb_build_object(
+        'outcome', 'completed',
+        'startTime', v_session.start_time,
+        'endTime', v_session.end_time,
+        'notes', coalesce(p_note_payload->>'narrative', ''),
+        'noteId', v_note.id,
+        'source', 'bt_aba_session_note'
+      )
+    );
+  end if;
+
+  perform public.create_supervision_session_note_request_for_completed_session(v_session.id);
+
+  v_result := jsonb_build_object(
+    'status', 'completed',
+    'note_id', v_note.id,
+    'note', v_note_json,
+    'progression_results', coalesce(v_progression_results, '[]'::jsonb)
+  );
+
+  update public.client_session_notes
+  set bt_aba_finalization_result = v_result
+  where id = v_note.id;
+
+  return v_result;
+end;
+$$;
+
+revoke execute on function public.resolve_assigned_bt_session_capture_billing(uuid) from public, anon;
+grant execute on function public.resolve_assigned_bt_session_capture_billing(uuid) to authenticated;
+revoke all on function public.create_supervision_session_note_request_for_completed_session(uuid) from public, anon;
+grant execute on function public.create_supervision_session_note_request_for_completed_session(uuid) to authenticated, service_role;
+revoke execute on function public.save_bt_aba_session_note_draft(uuid, uuid, jsonb, jsonb) from public, anon;
+grant execute on function public.save_bt_aba_session_note_draft(uuid, uuid, jsonb, jsonb) to authenticated, service_role;
+revoke execute on function public.get_bt_aba_session_note(uuid) from public, anon;
+grant execute on function public.get_bt_aba_session_note(uuid) to authenticated, service_role;
+revoke execute on function public.finalize_bt_aba_session_note(uuid, uuid, jsonb, jsonb, jsonb, jsonb) from public, anon;
+grant execute on function public.finalize_bt_aba_session_note(uuid, uuid, jsonb, jsonb, jsonb, jsonb) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/btAbaSessionNoteMigration.test.ts
+++ b/tests/btAbaSessionNoteMigration.test.ts
@@ -85,7 +85,7 @@ describe('BT ABA session note closeout migration', () => {
     expect(reader).toMatch(/jsonb_build_object\([\s\S]*'note_id'[\s\S]*'template_id'[\s\S]*'responses'[\s\S]*'status'/i);
     expect(sql).toMatch(/revoke execute on function public\.get_bt_aba_session_note\(uuid\) from public, anon/i);
     expect(sql).toMatch(/grant execute on function public\.get_bt_aba_session_note\(uuid\) to authenticated, service_role/i);
-    expect(smoke).toMatch(/assigned exact BT read failed[\s\S]*unrelated BT unexpectedly read BT ABA note[\s\S]*non-BT unexpectedly read BT ABA note/i);
+    expect(smoke).toMatch(/assigned exact BT read failed[\s\S]*unrelated BT unexpectedly read BT ABA note[\s\S]*elevated linked BCBA unexpectedly read BT ABA note/i);
   });
 
   it('finalizes atomically in the required order and preserves completion side effects', () => {

--- a/tests/btCloseoutLegacyTherapistCompatMigration.test.ts
+++ b/tests/btCloseoutLegacyTherapistCompatMigration.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const MIGRATION_PATH = path.join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '20260810222545_bt_closeout_legacy_therapist_compat.sql',
+);
+const SMOKE_SQL_PATH = path.join(process.cwd(), 'tests', 'sql', 'bt_aba_session_note_closeout_smoke.sql');
+
+const sql = readFileSync(MIGRATION_PATH, 'utf8');
+const smokeSql = readFileSync(SMOKE_SQL_PATH, 'utf8');
+
+const functionBody = (qualifiedName: string): string => {
+  const escapedName = qualifiedName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`create or replace function ${escapedName}\\([\\s\\S]*?\\n\\$\\$;`, 'i');
+  const match = sql.match(pattern);
+  expect(match, `${qualifiedName} function should exist`).not.toBeNull();
+  return match?.[0] ?? '';
+};
+
+describe('WIN-240 BT closeout legacy therapist compatibility migration', () => {
+  it('adds a service-role-only helper that allows only same-org exact bt or therapist closeout actors', () => {
+    const helper = functionBody('app.current_user_can_act_as_bt_closeout_actor');
+
+    expect(helper).toMatch(/returns boolean/i);
+    expect(helper).toMatch(/stable[\s\S]*security definer[\s\S]*set search_path = ''/i);
+    expect(helper).toMatch(/auth\.uid\(\)/i);
+    expect(helper).toMatch(/p_organization_id <> app\.current_user_organization_id\(\)/i);
+    expect(helper).toMatch(/app\.current_user_has_exact_role_for_org\([\s\S]*array\['bt'\]::text\[\][\s\S]*array\['admin', 'admin_schedule', 'midtier', 'bcba', 'therapist'\]::text\[\]/i);
+    expect(helper).toMatch(/app\.current_user_has_exact_active_role_for_org\([\s\S]*array\['therapist'\]::text\[\]/i);
+    expect(helper).toMatch(/from public\.therapists therapist[\s\S]*therapist\.organization_id = p_organization_id[\s\S]*therapist\.status = 'active'[\s\S]*therapist\.deleted_at is null[\s\S]*upper\(btrim\(coalesce\(therapist\.title, ''\)\)\) in \('BT', 'RBT'\)/i);
+    expect(helper).toMatch(/therapist\.id = v_actor[\s\S]*from public\.user_therapist_links utl[\s\S]*utl\.user_id = v_actor[\s\S]*utl\.therapist_id = therapist\.id/i);
+    expect(sql).toMatch(/revoke all on function app\.current_user_can_act_as_bt_closeout_actor\(uuid, uuid\) from public, anon, authenticated/i);
+    expect(sql).toMatch(/grant execute on function app\.current_user_can_act_as_bt_closeout_actor\(uuid, uuid\) to service_role/i);
+    expect(sql).not.toMatch(/grant execute on function app\.current_user_can_act_as_bt_closeout_actor\(uuid, uuid\) to authenticated/i);
+  });
+
+  it('rewires the closeout resolver, draft, read, finalize, and creator to the shared helper only', () => {
+    const resolver = functionBody('public.resolve_assigned_bt_session_capture_billing');
+    const draft = functionBody('public.save_bt_aba_session_note_draft');
+    const reader = functionBody('public.get_bt_aba_session_note');
+    const finalize = functionBody('public.finalize_bt_aba_session_note');
+    const creator = functionBody('public.create_supervision_session_note_request_for_completed_session');
+
+    for (const body of [resolver, draft, reader, finalize, creator]) {
+      expect(body).toMatch(/app\.current_user_can_act_as_bt_closeout_actor\(/i);
+      expect(body).not.toMatch(/array\['bt'\]::text\[\][\s\S]*array\['admin', 'admin_schedule', 'midtier', 'bcba', 'therapist'\]::text\[\][\s\S]*from public\.therapists therapist/i);
+    }
+  });
+
+  it('preserves trial-capture checks only on resolver, draft, and finalize, while keeping get and creator looser', () => {
+    const resolver = functionBody('public.resolve_assigned_bt_session_capture_billing');
+    const draft = functionBody('public.save_bt_aba_session_note_draft');
+    const reader = functionBody('public.get_bt_aba_session_note');
+    const finalize = functionBody('public.finalize_bt_aba_session_note');
+    const creator = functionBody('public.create_supervision_session_note_request_for_completed_session');
+
+    for (const body of [resolver, draft, finalize]) {
+      expect(body).toMatch(/current_user_can_capture_trial_event/i);
+    }
+    expect(reader).not.toMatch(/current_user_can_capture_trial_event/i);
+    expect(creator).not.toMatch(/current_user_can_capture_trial_event/i);
+  });
+
+  it('keeps the latest amended completed-note read body and the current creator authority envelope', () => {
+    const reader = functionBody('public.get_bt_aba_session_note');
+    const creator = functionBody('public.create_supervision_session_note_request_for_completed_session');
+
+    expect(reader).toMatch(/v_latest_amendment_responses/i);
+    expect(reader).toMatch(/from public\.bt_session_note_amendments amendment/i);
+    expect(reader).toMatch(/coalesce\(v_latest_amendment_responses, v_note\.bt_aba_responses, '\{\}'::jsonb\)/i);
+
+    expect(creator).toMatch(/v_actor_is_admin[\s\S]*array\['admin', 'super_admin', 'org_admin', 'org_super_admin'\]/i);
+    expect(creator).toMatch(/v_actor_has_schedule_authority[\s\S]*array\['admin_schedule', 'midtier', 'bcba'\]/i);
+    expect(creator).toMatch(/app\.current_user_can_act_as_bt_closeout_actor\(\s*v_actor_org\s*,\s*v_session\.therapist_id\s*\)/i);
+    expect(creator).toMatch(/app\.has_complete_bt_review_packet\(v_actor_org, v_session\.id\) is not true[\s\S]*return null/i);
+  });
+
+  it('extends the closeout smoke with linked legacy therapist success and deny cases', () => {
+    expect(smokeSql).toContain('legacy therapist billing resolver failed');
+    expect(smokeSql).toContain('legacy therapist draft failed');
+    expect(smokeSql).toContain('legacy therapist finalize failed');
+    expect(smokeSql).toContain('legacy therapist creator replay returned a different request');
+    expect(smokeSql).toContain('legacy therapist finalization did not create the expected supervision request');
+    expect(smokeSql).toContain('unlinked legacy therapist unexpectedly resolved billing');
+    expect(smokeSql).toContain('unlinked legacy therapist unexpectedly wrote a draft');
+    expect(smokeSql).toContain('unlinked legacy therapist unexpectedly read BT ABA note');
+    expect(smokeSql).toContain('unlinked legacy therapist unexpectedly created a supervision request');
+    expect(smokeSql).toContain('legacy therapist admin overlap unexpectedly resolved billing');
+    expect(smokeSql).toContain('legacy therapist admin overlap unexpectedly wrote a draft');
+    expect(smokeSql).toContain('legacy therapist admin overlap unexpectedly read BT ABA note');
+    expect(smokeSql).toContain('legacy therapist admin overlap unexpectedly finalized a note');
+    expect(smokeSql).toContain('elevated linked BCBA unexpectedly read BT ABA note');
+    expect(smokeSql).toContain('cross-org BT unexpectedly wrote a draft');
+    expect(smokeSql).toContain('unrelated BT unexpectedly read BT ABA note');
+  });
+});

--- a/tests/sessionCaptureAuthorizationResolverMigration.test.ts
+++ b/tests/sessionCaptureAuthorizationResolverMigration.test.ts
@@ -32,11 +32,10 @@ describe('WIN-240 session capture billing resolver migration', () => {
     expect(sql).not.toMatch(/grant execute on function public\.resolve_assigned_bt_session_capture_billing\(uuid\) to authenticated,\s*service_role/i);
   });
 
-  it('enforces exact BT, active therapist, org-scoped assignment, and capture capability checks', () => {
-    expect(functionBody).toMatch(/app\.current_user_has_exact_role_for_org\([\s\S]*array\['bt'\]::text\[\][\s\S]*array\['admin', 'admin_schedule', 'midtier', 'bcba', 'therapist'\]::text\[\]/i);
+  it('delegates closeout actor checks to the shared helper while preserving capture capability enforcement', () => {
+    expect(sql).toMatch(/create or replace function app\.current_user_can_act_as_bt_closeout_actor\s*\(/i);
+    expect(functionBody).toMatch(/app\.current_user_can_act_as_bt_closeout_actor\(\s*v_session\.organization_id\s*,\s*v_session\.therapist_id\s*\)/i);
     expect(functionBody).toMatch(/v_session\.organization_id <> app\.current_user_organization_id\(\)/i);
-    expect(functionBody).toMatch(/from public\.therapists therapist[\s\S]*therapist\.organization_id = v_session\.organization_id[\s\S]*therapist\.status = 'active'[\s\S]*therapist\.deleted_at is null[\s\S]*upper\(btrim\(coalesce\(therapist\.title, ''\)\)\) in \('BT', 'RBT'\)/i);
-    expect(functionBody).toMatch(/v_session\.therapist_id = v_actor[\s\S]*from public\.user_therapist_links utl[\s\S]*utl\.user_id = v_actor[\s\S]*utl\.therapist_id = v_session\.therapist_id/i);
     expect(functionBody).toMatch(/current_user_can_capture_trial_event/i);
   });
 

--- a/tests/sql/bt_aba_session_note_closeout_smoke.sql
+++ b/tests/sql/bt_aba_session_note_closeout_smoke.sql
@@ -568,7 +568,6 @@ select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b019
 do $legacy_therapist_finalization$
 declare
   v_note_id uuid;
-  v_request_id uuid;
   result jsonb;
   payload jsonb := '{"authorization_id":"00000000-0000-4000-8000-00000000b099","requested_service_code":"CALLER-CONTROLLED","goals_addressed":[],"goal_ids":[],"goal_measurements":{},"goal_notes":{},"narrative":"Legacy therapist finalized closeout"}'::jsonb;
   valid_responses jsonb := '{
@@ -597,6 +596,14 @@ begin
     raise exception 'legacy therapist finalize failed: %', result;
   end if;
 
+end
+$legacy_therapist_finalization$;
+
+reset role;
+do $legacy_therapist_request_side_effect$
+declare
+  v_request_id uuid;
+begin
   select request.id
   into v_request_id
   from public.supervision_session_note_requests request
@@ -606,12 +613,20 @@ begin
     raise exception 'legacy therapist finalization did not create the expected supervision request';
   end if;
 
+  perform set_config('app.win240_legacy_request_id', v_request_id::text, true);
+end
+$legacy_therapist_request_side_effect$;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b019', true);
+do $legacy_therapist_request_replay$
+begin
   if public.create_supervision_session_note_request_for_completed_session('00000000-0000-4000-8000-00000000b045')
-     is distinct from v_request_id then
+     is distinct from current_setting('app.win240_legacy_request_id')::uuid then
     raise exception 'legacy therapist creator replay returned a different request';
   end if;
 end
-$legacy_therapist_finalization$;
+$legacy_therapist_request_replay$;
 
 reset role;
 set local role authenticated;
@@ -628,6 +643,15 @@ end
 $unlinked_legacy_therapist_creator_denied$;
 
 reset role;
+select set_config(
+  'app.win240_overlap_note_id',
+  (
+    select note.id::text
+    from public.client_session_notes note
+    where note.session_id = '00000000-0000-4000-8000-00000000b046'
+  ),
+  true
+);
 insert into public.user_roles (user_id, role_id, is_active)
 select '00000000-0000-4000-8000-00000000b019', roles.id, true
 from public.roles roles
@@ -638,7 +662,7 @@ select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b019
 do $legacy_therapist_role_overlap_denied$
 declare
   template_id uuid := '00000000-0000-4000-8000-00000000b005';
-  v_note_id uuid;
+  v_note_id uuid := current_setting('app.win240_overlap_note_id')::uuid;
 begin
   begin
     perform public.resolve_assigned_bt_session_capture_billing('00000000-0000-4000-8000-00000000b040');
@@ -652,10 +676,6 @@ begin
     perform public.get_bt_aba_session_note('00000000-0000-4000-8000-00000000b040');
     raise exception 'legacy therapist admin overlap unexpectedly read BT ABA note';
   exception when sqlstate '42501' then null; end;
-
-  select note.id into v_note_id
-  from public.client_session_notes note
-  where note.session_id = '00000000-0000-4000-8000-00000000b046';
 
   begin
     perform public.finalize_bt_aba_session_note(
@@ -674,8 +694,14 @@ $legacy_therapist_role_overlap_denied$;
 reset role;
 do $win224_request_seed$
 declare
+  v_note_id uuid;
   v_request_id uuid;
 begin
+  select note.id
+  into v_note_id
+  from public.client_session_notes note
+  where note.session_id = '00000000-0000-4000-8000-00000000b044';
+
   select request.id
   into v_request_id
   from public.supervision_session_note_requests request
@@ -693,6 +719,7 @@ begin
       updated_at = timezone('utc', now())
   where id = v_request_id;
 
+  perform set_config('app.win224_note_id', v_note_id::text, true);
   perform set_config('app.win224_request_id', v_request_id::text, true);
 end
 $win224_request_seed$;
@@ -910,9 +937,7 @@ begin
     raise exception 'original BT resubmission did not create amendment version 2';
   end if;
 
-  select note.id into v_original_note_id
-  from public.client_session_notes note
-  where note.session_id = '00000000-0000-4000-8000-00000000b044';
+  v_original_note_id := current_setting('app.win224_note_id')::uuid;
 
   v_read_result := public.get_bt_aba_session_note('00000000-0000-4000-8000-00000000b044');
   if v_read_result->>'note_id' is distinct from v_original_note_id::text

--- a/tests/sql/bt_aba_session_note_closeout_smoke.sql
+++ b/tests/sql/bt_aba_session_note_closeout_smoke.sql
@@ -146,7 +146,9 @@ values
   ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-00000000b013', 'authenticated', 'authenticated', 'win221-bcba@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{"organization_id":"00000000-0000-4000-8000-00000000b001"}'::jsonb),
   ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-00000000b014', 'authenticated', 'authenticated', 'win221-bcba-peer@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{"organization_id":"00000000-0000-4000-8000-00000000b001"}'::jsonb),
   ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-00000000b016', 'authenticated', 'authenticated', 'win221-cross-bcba@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{"organization_id":"00000000-0000-4000-8000-00000000b002"}'::jsonb),
-  ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-00000000b017', 'authenticated', 'authenticated', 'win221-admin@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{"organization_id":"00000000-0000-4000-8000-00000000b001"}'::jsonb);
+  ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-00000000b017', 'authenticated', 'authenticated', 'win221-admin@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{"organization_id":"00000000-0000-4000-8000-00000000b001"}'::jsonb),
+  ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-00000000b018', 'authenticated', 'authenticated', 'win240-unlinked-therapist@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{"organization_id":"00000000-0000-4000-8000-00000000b001"}'::jsonb),
+  ('00000000-0000-0000-0000-000000000000', '00000000-0000-4000-8000-00000000b019', 'authenticated', 'authenticated', 'win240-legacy-therapist@example.invalid', 'x', now(), now(), now(), '{"provider":"email","providers":["email"]}'::jsonb, '{"organization_id":"00000000-0000-4000-8000-00000000b001"}'::jsonb);
 
 select set_config('app.bypass_profile_role_guard', 'on', true);
 update public.profiles
@@ -157,7 +159,13 @@ set role = case when id = '00000000-0000-4000-8000-00000000b017'
       '00000000-0000-4000-8000-00000000b014',
       '00000000-0000-4000-8000-00000000b016'
     )
-      then 'bcba'::public.role_type else 'bt'::public.role_type end,
+      then 'bcba'::public.role_type
+    when id in (
+      '00000000-0000-4000-8000-00000000b018',
+      '00000000-0000-4000-8000-00000000b019'
+    )
+      then 'therapist'::public.role_type
+    else 'bt'::public.role_type end,
     organization_id = case when id in (
       '00000000-0000-4000-8000-00000000b012',
       '00000000-0000-4000-8000-00000000b016'
@@ -171,7 +179,9 @@ where id in (
   '00000000-0000-4000-8000-00000000b013',
   '00000000-0000-4000-8000-00000000b014',
   '00000000-0000-4000-8000-00000000b016',
-  '00000000-0000-4000-8000-00000000b017'
+  '00000000-0000-4000-8000-00000000b017',
+  '00000000-0000-4000-8000-00000000b018',
+  '00000000-0000-4000-8000-00000000b019'
 );
 select set_config('app.bypass_profile_role_guard', 'off', true);
 
@@ -204,6 +214,15 @@ select '00000000-0000-4000-8000-00000000b017', roles.id, true
 from public.roles roles
 where roles.name = 'admin';
 
+insert into public.user_roles (user_id, role_id, is_active)
+select users.id, roles.id, true
+from (values
+  ('00000000-0000-4000-8000-00000000b018'::uuid),
+  ('00000000-0000-4000-8000-00000000b019'::uuid)
+) users(id)
+cross join public.roles roles
+where roles.name = 'therapist';
+
 insert into public.therapists (id, email, full_name, first_name, last_name, title, status, organization_id)
 values
   ('00000000-0000-4000-8000-00000000b015', 'win221-bt-profile@example.invalid', 'WIN-221 BT Profile', 'WIN-221', 'BT Profile', 'RBT', 'active', '00000000-0000-4000-8000-00000000b001'),
@@ -214,7 +233,8 @@ insert into public.user_therapist_links (user_id, therapist_id)
 values
   ('00000000-0000-4000-8000-00000000b010', '00000000-0000-4000-8000-00000000b015'),
   ('00000000-0000-4000-8000-00000000b012', '00000000-0000-4000-8000-00000000b015'),
-  ('00000000-0000-4000-8000-00000000b013', '00000000-0000-4000-8000-00000000b015');
+  ('00000000-0000-4000-8000-00000000b013', '00000000-0000-4000-8000-00000000b015'),
+  ('00000000-0000-4000-8000-00000000b019', '00000000-0000-4000-8000-00000000b015');
 
 insert into public.clients (id, full_name, status, organization_id, therapist_id, created_by, updated_by)
 values
@@ -257,7 +277,9 @@ values
   ('00000000-0000-4000-8000-00000000b041', '00000000-0000-4000-8000-00000000b020', '00000000-0000-4000-8000-00000000b015', now() - interval '3 hours', now() - interval '2 hours', 'in_progress', false, '00000000-0000-4000-8000-00000000b001', '00000000-0000-4000-8000-00000000b010', '00000000-0000-4000-8000-00000000b010', current_date, now() - interval '3 hours'),
   ('00000000-0000-4000-8000-00000000b042', '00000000-0000-4000-8000-00000000b020', '00000000-0000-4000-8000-00000000b012', now() - interval '5 hours', now() - interval '4 hours', 'in_progress', false, '00000000-0000-4000-8000-00000000b001', '00000000-0000-4000-8000-00000000b010', '00000000-0000-4000-8000-00000000b010', current_date, now() - interval '5 hours'),
   ('00000000-0000-4000-8000-00000000b043', '00000000-0000-4000-8000-00000000b021', '00000000-0000-4000-8000-00000000b015', now() - interval '7 hours', now() - interval '6 hours', 'in_progress', false, '00000000-0000-4000-8000-00000000b001', '00000000-0000-4000-8000-00000000b010', '00000000-0000-4000-8000-00000000b010', current_date, now() - interval '7 hours'),
-  ('00000000-0000-4000-8000-00000000b044', '00000000-0000-4000-8000-00000000b020', '00000000-0000-4000-8000-00000000b015', now() - interval '9 hours', now() - interval '8 hours', 'in_progress', false, '00000000-0000-4000-8000-00000000b001', '00000000-0000-4000-8000-00000000b010', '00000000-0000-4000-8000-00000000b010', current_date, now() - interval '9 hours');
+  ('00000000-0000-4000-8000-00000000b044', '00000000-0000-4000-8000-00000000b020', '00000000-0000-4000-8000-00000000b015', now() - interval '9 hours', now() - interval '8 hours', 'in_progress', false, '00000000-0000-4000-8000-00000000b001', '00000000-0000-4000-8000-00000000b010', '00000000-0000-4000-8000-00000000b010', current_date, now() - interval '9 hours'),
+  ('00000000-0000-4000-8000-00000000b045', '00000000-0000-4000-8000-00000000b020', '00000000-0000-4000-8000-00000000b015', now() - interval '11 hours', now() - interval '10 hours', 'in_progress', false, '00000000-0000-4000-8000-00000000b001', '00000000-0000-4000-8000-00000000b019', '00000000-0000-4000-8000-00000000b019', current_date, now() - interval '11 hours'),
+  ('00000000-0000-4000-8000-00000000b046', '00000000-0000-4000-8000-00000000b020', '00000000-0000-4000-8000-00000000b015', now() - interval '13 hours', now() - interval '12 hours', 'in_progress', false, '00000000-0000-4000-8000-00000000b001', '00000000-0000-4000-8000-00000000b019', '00000000-0000-4000-8000-00000000b019', current_date, now() - interval '13 hours');
 
 insert into public.supervision_session_note_requests (
   id, organization_id, session_id, client_id, bt_therapist_id,
@@ -328,6 +350,52 @@ begin
 end
 $drafts$;
 
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b019', true);
+
+do $legacy_therapist_draft$
+declare
+  template_id uuid := '00000000-0000-4000-8000-00000000b005';
+  result jsonb;
+  read_result jsonb;
+begin
+  if not exists (
+    select 1
+    from public.resolve_assigned_bt_session_capture_billing(
+      '00000000-0000-4000-8000-00000000b045'
+    ) billing
+    where billing.session_client_id = '00000000-0000-4000-8000-00000000b020'
+      and billing.session_therapist_id = '00000000-0000-4000-8000-00000000b015'
+  ) then
+    raise exception 'legacy therapist billing resolver failed';
+  end if;
+
+  result := public.save_bt_aba_session_note_draft(
+    '00000000-0000-4000-8000-00000000b045', template_id,
+    '{"goals_addressed":[],"goal_ids":[],"narrative":"Legacy therapist closeout"}'::jsonb,
+    '{"client_status":"legacy therapist draft"}'::jsonb
+  );
+  if result->>'status' <> 'draft' then
+    raise exception 'legacy therapist draft failed: %', result;
+  end if;
+
+  read_result := public.get_bt_aba_session_note('00000000-0000-4000-8000-00000000b045');
+  if read_result->>'note_id' is distinct from result->>'note_id'
+     or read_result->>'template_id' is distinct from template_id::text
+     or read_result->>'status' <> 'draft' then
+    raise exception 'legacy therapist read failed: %', read_result;
+  end if;
+
+  result := public.save_bt_aba_session_note_draft(
+    '00000000-0000-4000-8000-00000000b046', template_id,
+    '{"goals_addressed":[],"goal_ids":[],"narrative":"Role overlap denial fixture"}'::jsonb,
+    '{"client_status":"role overlap fixture"}'::jsonb
+  );
+  if result->>'status' <> 'draft' then
+    raise exception 'legacy therapist overlap fixture draft failed: %', result;
+  end if;
+end
+$legacy_therapist_draft$;
+
 reset role;
 do $canonical_billing$
 begin
@@ -367,6 +435,25 @@ begin
 end
 $unrelated$;
 
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b018', true);
+do $unlinked_legacy_therapist$
+declare template_id uuid := '00000000-0000-4000-8000-00000000b005';
+begin
+  begin
+    perform public.resolve_assigned_bt_session_capture_billing('00000000-0000-4000-8000-00000000b040');
+    raise exception 'unlinked legacy therapist unexpectedly resolved billing';
+  exception when sqlstate '42501' then null; end;
+  begin
+    perform public.save_bt_aba_session_note_draft('00000000-0000-4000-8000-00000000b040', template_id, '{}'::jsonb, '{}'::jsonb);
+    raise exception 'unlinked legacy therapist unexpectedly wrote a draft';
+  exception when sqlstate '42501' then null; end;
+  begin
+    perform public.get_bt_aba_session_note('00000000-0000-4000-8000-00000000b040');
+    raise exception 'unlinked legacy therapist unexpectedly read BT ABA note';
+  exception when sqlstate '42501' then null; end;
+end
+$unlinked_legacy_therapist$;
+
 select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b013', true);
 do $elevated_non_bt$
 declare template_id uuid := '00000000-0000-4000-8000-00000000b005';
@@ -377,7 +464,7 @@ begin
   exception when sqlstate '42501' then null; end;
   begin
     perform public.get_bt_aba_session_note('00000000-0000-4000-8000-00000000b040');
-    raise exception 'non-BT unexpectedly read BT ABA note';
+    raise exception 'elevated linked BCBA unexpectedly read BT ABA note';
   exception when sqlstate '42501' then null; end;
 end
 $elevated_non_bt$;
@@ -476,6 +563,113 @@ begin
   end if;
 end
 $finalization$;
+
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b019', true);
+do $legacy_therapist_finalization$
+declare
+  v_note_id uuid;
+  v_request_id uuid;
+  result jsonb;
+  payload jsonb := '{"authorization_id":"00000000-0000-4000-8000-00000000b099","requested_service_code":"CALLER-CONTROLLED","goals_addressed":[],"goal_ids":[],"goal_measurements":{},"goal_notes":{},"narrative":"Legacy therapist finalized closeout"}'::jsonb;
+  valid_responses jsonb := '{
+    "purpose_of_session":["RBT/BT worked on goals as stated in the treatment plan"],
+    "client_status":"Legacy therapist participated",
+    "skill_strategies":["N/A"],
+    "behavior_strategies":["N/A"],
+    "supervisor_support":["Supervisor did not attend this session"],
+    "progress_toward_goals":"Legacy therapist progress observed",
+    "client_response_to_treatment":"Client responded as expected to legacy therapist closeout",
+    "data_point_scope":"linked",
+    "link_unlinked_data":false,
+    "bt_signature":{"method":"typed","value":"Legacy Therapist"}
+  }'::jsonb;
+begin
+  v_note_id := (public.get_bt_aba_session_note('00000000-0000-4000-8000-00000000b045')->>'note_id')::uuid;
+  result := public.finalize_bt_aba_session_note(
+    '00000000-0000-4000-8000-00000000b045',
+    v_note_id,
+    payload,
+    valid_responses,
+    '[]'::jsonb,
+    '[]'::jsonb
+  );
+  if result->>'status' <> 'completed' then
+    raise exception 'legacy therapist finalize failed: %', result;
+  end if;
+
+  select request.id
+  into v_request_id
+  from public.supervision_session_note_requests request
+  where request.session_id = '00000000-0000-4000-8000-00000000b045';
+
+  if v_request_id is null then
+    raise exception 'legacy therapist finalization did not create the expected supervision request';
+  end if;
+
+  if public.create_supervision_session_note_request_for_completed_session('00000000-0000-4000-8000-00000000b045')
+     is distinct from v_request_id then
+    raise exception 'legacy therapist creator replay returned a different request';
+  end if;
+end
+$legacy_therapist_finalization$;
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b018', true);
+do $unlinked_legacy_therapist_creator_denied$
+begin
+  begin
+    perform public.create_supervision_session_note_request_for_completed_session(
+      '00000000-0000-4000-8000-00000000b045'
+    );
+    raise exception 'unlinked legacy therapist unexpectedly created a supervision request';
+  exception when sqlstate '42501' then null; end;
+end
+$unlinked_legacy_therapist_creator_denied$;
+
+reset role;
+insert into public.user_roles (user_id, role_id, is_active)
+select '00000000-0000-4000-8000-00000000b019', roles.id, true
+from public.roles roles
+where roles.name = 'admin';
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000b019', true);
+do $legacy_therapist_role_overlap_denied$
+declare
+  template_id uuid := '00000000-0000-4000-8000-00000000b005';
+  v_note_id uuid;
+begin
+  begin
+    perform public.resolve_assigned_bt_session_capture_billing('00000000-0000-4000-8000-00000000b040');
+    raise exception 'legacy therapist admin overlap unexpectedly resolved billing';
+  exception when sqlstate '42501' then null; end;
+  begin
+    perform public.save_bt_aba_session_note_draft('00000000-0000-4000-8000-00000000b040', template_id, '{}'::jsonb, '{}'::jsonb);
+    raise exception 'legacy therapist admin overlap unexpectedly wrote a draft';
+  exception when sqlstate '42501' then null; end;
+  begin
+    perform public.get_bt_aba_session_note('00000000-0000-4000-8000-00000000b040');
+    raise exception 'legacy therapist admin overlap unexpectedly read BT ABA note';
+  exception when sqlstate '42501' then null; end;
+
+  select note.id into v_note_id
+  from public.client_session_notes note
+  where note.session_id = '00000000-0000-4000-8000-00000000b046';
+
+  begin
+    perform public.finalize_bt_aba_session_note(
+      '00000000-0000-4000-8000-00000000b046',
+      v_note_id,
+      '{}'::jsonb,
+      '{}'::jsonb,
+      '[]'::jsonb,
+      '[]'::jsonb
+    );
+    raise exception 'legacy therapist admin overlap unexpectedly finalized a note';
+  exception when sqlstate '42501' then null; end;
+end
+$legacy_therapist_role_overlap_denied$;
 
 reset role;
 do $win224_request_seed$


### PR DESCRIPTION
## Summary

- restore the BT session closeout UI for legacy-normalized BT users
- add a closeout-only Supabase authority helper for exact bt and exclusive legacy therapist actors
- apply that predicate to billing resolution, BT ABA draft/read/finalize, and supervision-request creation
- preserve exact-BT start authority, tenant boundaries, public RPC grants, billing rules, correction reads, and finalization ordering

## Authorization boundary

Legacy therapist access is allowed only when the authoritative active role set is exactly therapist, the actor is in the session organization, the therapist row is active and titled BT/RBT, and the actor is the therapist or has the canonical user/therapist link. Elevated role overlaps remain denied. Resolver, draft, and finalize retain their existing trial-capture capability checks.

## Verification

- focused migration contracts: pass, 3 files / 22 tests
- npm run ci:check-focused: pass
- npm run lint: pass
- npm run typecheck: pass
- 8 GB npm run test:ci: pass, 483 files / 4,156 tests
- npm run ci:verify-coverage: pass, 92.92%
- npm run validate:tenant: pass
- npm run build: pass
- npm run test:routes:tier0: pass, 7 specs / 220 tests
- specialist code, Supabase, and final security reviews: approved

## Blocked / residual evidence

- Docker Desktop is unavailable, so supabase db reset --local and the runtime SQL smoke were not executed locally
- a later aggregate verify:local rerun had two load/order-sensitive SessionModal failures; the full 165-test file passed immediately in isolation
- exact-head CI is running and remains the required hosted gate
- critical-lane human review is required before merge; this PR does not apply the migration to hosted Supabase

Linear: WIN-240
