### PR TITLE
fix(session): preserve rapid incorrect trial clicks

### DIFF
--- a/docs/ai/handoffs/WIN-110-live-session-incorrect-trial-race.md
+++ b/docs/ai/handoffs/WIN-110-live-session-incorrect-trial-race.md
@@ -1,0 +1,33 @@
+# WIN-110 Live Session Incorrect Trial Race
+
+- `classification`: low-risk autonomous
+- `lane`: standard
+- `files touched`: `src/components/SessionModal.tsx`, `src/components/__tests__/SessionModal.test.tsx`, this handoff
+- `scope`: keep pending trial-event reads synchronized across same-task rapid clicks and immediate save so visual counts, generated trial numbers, and submitted events include every click
+- `non-goals`: server/API behavior, auth or routing, Supabase schema/RLS, CI/workflows, deployment
+- `required agents`: specification-engineer, implementation-engineer, code-review-engineer, test-engineer
+- `required checks`: `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; focused SessionModal regression; `npm run test:ci`; `npm run ci:verify-coverage`; `npm run build`; `npm run test:routes:tier0`; `npm run ci:playwright`; `npm run verify:local`; `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4173 --route=/schedule`; local browser proof at `390x844`
+- `executed checks`: focused SessionModal regression -> pass (7 selected tests); `npm run ci:check-focused` -> pass; `npm run lint` -> pass; `npm run typecheck` -> pass; `NODE_OPTIONS=--max-old-space-size=8192 npm run test:ci` -> pass (483 files, 4,159 tests, 5 skipped); `npm run ci:verify-coverage` -> pass (92.81% lines); `npm run build` -> pass; `PREVIEW_PORT=4174 npm run test:routes:tier0` -> pass (7 specs, 220 tests); `NODE_OPTIONS=--max-old-space-size=8192 PREVIEW_PORT=4174 npm run verify:local` -> pass; local production-preview browser proof at `390x844` -> pass (`dialogMounted=true`, two same-task Incorrect clicks rendered count `2`)
+- `blocked checks`: `npm run ci:playwright` reached the hosted app but stopped on preexisting hosted state: `playwright:therapist-authorization` rejected the configured therapist credential, and a direct remaining-session run found no eligible therapist/client/program/goal fixture before reaching the changed UI. Responsive observer desktop `1440x900` passed; mobile `390x844` flags the unchanged unauthenticated login page's forgot-password link as a 28x19 undersized touch target. Evidence: `artifacts/responsive-ui-observer/route-b8269c2977ef848259bf5694da1ebe4e7a041d55cb00a9e9fd3689b0c23f675f.desktop.1440x900.json` and `.mobile.390x844.json`.
+- `result`: pass-with-blocked-checks
+- `reviewer`: specification, implementation, test, and code-review agents completed; final re-review found no findings or protected-path drift
+- `residual risk`: browser proof covers the exact rapid-click rendering failure; same-task immediate-save payload numbering is covered by the focused component regression
+- `pr handoff`: ready for a draft PR; merge readiness remains blocked by the unrelated responsive-observer mobile baseline and hosted Playwright credential/fixture drift
+
+## PR Hygiene
+
+- `pr-ready`: no (draft PR is ready; merge-ready is blocked by required external/baseline checks)
+- `branch-ready`: yes (`codex/fix-live-session-incorrect-trial`)
+- `linear-ready`: yes (`WIN-110`)
+- `single-purpose`: yes
+- `unrelated changes`: none
+- `generated artifact drift`: none
+- `protected-path drift`: none
+- `change summary`: present
+- `verification summary`: present
+- `reviewer`: completed with no findings
+- `required follow-up`: repair or explicitly resolve the hosted therapist credential/lifecycle fixture and the unchanged login-page mobile touch-target baseline, then rerun the blocked checks
+
+## Root Cause
+
+Rapid click handlers and submission read render-time `pendingTrialEvents`. React can batch multiple clicks and an immediate save before a render, causing each handler to derive the same count/trial number and submit to omit the newest events. A synchronized ref now supplies immediate reads while React state continues to trigger rendering.

--- a/src/components/SessionModal.tsx
+++ b/src/components/SessionModal.tsx
@@ -779,7 +779,19 @@ export function SessionModal({
   const [conflicts, setConflicts] = useState<Conflict[]>([]);
   const [alternativeTimes, setAlternativeTimes] = useState<AlternativeTime[]>([]);
   const [isLoadingAlternatives, setIsLoadingAlternatives] = useState(false);
-  const [pendingTrialEvents, setPendingTrialEvents] = useState<SessionCaptureTrialEventInput[]>([]);
+  const [pendingTrialEvents, setPendingTrialEventsState] = useState<SessionCaptureTrialEventInput[]>([]);
+  const pendingTrialEventsRef = useRef<SessionCaptureTrialEventInput[]>([]);
+  const setPendingTrialEvents = useCallback((
+    update:
+      | SessionCaptureTrialEventInput[]
+      | ((current: SessionCaptureTrialEventInput[]) => SessionCaptureTrialEventInput[]),
+  ) => {
+    const next = typeof update === 'function'
+      ? update(pendingTrialEventsRef.current)
+      : update;
+    pendingTrialEventsRef.current = next;
+    setPendingTrialEventsState(next);
+  }, []);
   const [promptOutcomeByTargetId, setPromptOutcomeByTargetId] = useState<Record<string, PromptOutcome>>({});
   const [pendingNumericTrialValues, setPendingNumericTrialValues] = useState<Record<string, string>>({});
   const [progressionNotices, setProgressionNotices] = useState<string[]>([]);
@@ -1950,7 +1962,7 @@ export function SessionModal({
       const mergeGoalIds = options?.captureMergeGoalIds?.filter((id) => id.trim().length > 0) ?? [];
       const isPartialCaptureSave = mergeGoalIds.length > 0;
       const discardedTargetIds = new Set(options?.discardTrialTargetIds ?? []);
-      const trialEventsForSubmit = pendingTrialEvents.filter((event) => {
+      const trialEventsForSubmit = pendingTrialEventsRef.current.filter((event) => {
         if (discardedTargetIds.has(event.target_id)) return false;
         if (!isPartialCaptureSave) {
           return true;
@@ -2704,9 +2716,10 @@ export function SessionModal({
       field: 'metric_value' | 'incorrect_trials',
       scope: 'all' | 'pending' = 'all',
     ) => {
+      const currentPendingTrialEvents = pendingTrialEventsRef.current;
       const sourceEvents = scope === 'pending'
-        ? pendingTrialEvents
-        : [...existingTrialEvents, ...pendingTrialEvents];
+        ? currentPendingTrialEvents
+        : [...existingTrialEvents, ...currentPendingTrialEvents];
       return sourceEvents.filter((event) => {
         if (event.target_id !== targetId) {
           return false;
@@ -2721,14 +2734,15 @@ export function SessionModal({
           : event.value === 0;
       }).length;
     },
-    [existingTrialEvents, pendingTrialEvents],
+    [existingTrialEvents],
   );
 
   const getRawTrialNumericSummary = useCallback(
     (targetId: string, scope: 'all' | 'pending' = 'all') => {
+      const currentPendingTrialEvents = pendingTrialEventsRef.current;
       const sourceEvents = scope === 'pending'
-        ? pendingTrialEvents
-        : [...existingTrialEvents, ...pendingTrialEvents];
+        ? currentPendingTrialEvents
+        : [...existingTrialEvents, ...currentPendingTrialEvents];
       return sourceEvents
         .filter((event) => event.target_id === targetId && typeof event.value === 'number')
         .reduce(
@@ -2739,17 +2753,17 @@ export function SessionModal({
           { count: 0, total: 0 },
         );
     },
-    [existingTrialEvents, pendingTrialEvents],
+    [existingTrialEvents],
   );
 
   const getNextRawTrialNumber = useCallback(
     (targetId: string): number => {
-      const maxTrialNumber = [...existingTrialEvents, ...pendingTrialEvents]
+      const maxTrialNumber = [...existingTrialEvents, ...pendingTrialEventsRef.current]
         .filter((event) => event.target_id === targetId)
         .reduce((max, event) => Math.max(max, Number(event.trial_number) || 0), 0);
       return maxTrialNumber + 1;
     },
-    [existingTrialEvents, pendingTrialEvents],
+    [existingTrialEvents],
   );
 
   const bumpTrialCount = useCallback(

--- a/src/components/__tests__/SessionModal.test.tsx
+++ b/src/components/__tests__/SessionModal.test.tsx
@@ -5290,7 +5290,7 @@ describe('SessionModal', () => {
     });
   }, 15000);
 
-  it('submits configured plan target trials as raw trial events', async () => {
+  it('submits rapid configured-target trial clicks with unique sequential trial numbers', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const targetId = '88888888-8888-4888-8888-888888888888';
     const buildChain = (rows: unknown[], singleRow: unknown = null) => {
@@ -5406,8 +5406,19 @@ describe('SessionModal', () => {
     fireEvent.change(screen.getByLabelText(/^Per-goal note$/i), {
       target: { value: 'Observed steady progress' },
     });
-    await userEvent.click(screen.getByRole('button', { name: /Increase incorrect or no-response trials for target 1/i }));
-    await userEvent.click(screen.getByRole('button', { name: /Save skills/i }));
+    const incorrectButton = screen.getByRole('button', {
+      name: /Increase incorrect or no-response trials for target 1/i,
+    });
+    const saveSkillsButton = screen.getByRole('button', { name: /Save skills/i });
+    await act(async () => {
+      incorrectButton.click();
+      incorrectButton.click();
+    });
+    expect(incorrectButton.parentElement).toHaveTextContent('+2 · −2');
+    await act(async () => {
+      incorrectButton.click();
+      saveSkillsButton.click();
+    });
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
@@ -5422,6 +5433,18 @@ describe('SessionModal', () => {
           expect.objectContaining({
             target_id: targetId,
             trial_number: 4,
+            response: 'incorrect',
+            expected_progression_version: 7,
+          }),
+          expect.objectContaining({
+            target_id: targetId,
+            trial_number: 5,
+            response: 'incorrect',
+            expected_progression_version: 7,
+          }),
+          expect.objectContaining({
+            target_id: targetId,
+            trial_number: 6,
             response: 'incorrect',
             expected_progression_version: 7,
           }),


### PR DESCRIPTION
## Summary
- keep pending trial-event reads synchronized across rapid same-task clicks
- preserve unique sequential trial numbers and include the newest click in immediate Save skills submissions
- add regression coverage for visible Incorrect counts and the immediate-save payload

Linear: WIN-110

## Verification
- `npm run verify:local` (pass with `NODE_OPTIONS=--max-old-space-size=8192`, `PREVIEW_PORT=4174`)
- focused SessionModal regression (pass)
- 483 test files / 4,159 tests passed; 5 skipped
- coverage 92.81%
- tier-0 routes: 7 specs / 220 tests passed
- local production-preview browser proof at 390x844: two same-task Incorrect clicks rendered count 2
- independent code review: no findings

## Blocked external checks
- hosted `npm run ci:playwright` stops before the changed UI because the configured therapist credential is rejected and hosted lifecycle data has no eligible therapist/client/program/goal combination
- responsive observer desktop passes; mobile reaches the unchanged login page and flags its existing forgot-password link as a 28x19 touch target

This PR is intentionally draft until those external/baseline checks are repaired or resolved. No production deployment is included.