### PR TITLE
fix(schedule): contain overlap dialog and add observer proof

### DIFF
--- a/.agents/skills/responsive-ui-observer/SKILL.md
+++ b/.agents/skills/responsive-ui-observer/SKILL.md
@@ -23,6 +23,7 @@ Make deterministic responsive observation mandatory for visible UI changes witho
 - Treat artifact writes as one run: remove the current partial pair and every earlier pair from that invocation if any write or observation throws.
 - Do not capture DOM text, request or response bodies, query strings, emails, tokens, UUIDs, or credentials in artifacts.
 - Abort external-origin requests and methods other than `GET`, `HEAD`, or `OPTIONS`.
+- The sole exception is `--scenario=schedule-overlap` on exactly one `/schedule` route. It may seed one fixed PHI-free localhost stub, load the loopback route shell/static assets, and fulfill only its enumerated same-origin data responses in memory; every other application request must fail closed. It must not contact an external host or mutate the loopback server.
 - Computer inspection is supplemental only. It is never gating or authoritative for pass/fail.
 
 ## Required Viewports
@@ -38,6 +39,14 @@ npm run test:ui:responsive -- --base-url=http://127.0.0.1:4173 --route=/example
 
 Add one `--route` flag per affected route.
 
+For the fixed schedule-overlap proof only:
+
+```bash
+npm run test:ui:responsive -- --base-url=http://127.0.0.1:4173 --route=/schedule --scenario=schedule-overlap
+```
+
+The scenario name is an enum, not a fixture path or caller-selected identity. It is rejected for every other route and does not replace auth/session browser gates. In scenario mode, overflow and clipped fixed-control checks remain document-wide while touch-target measurement is scoped to the exact overlap dialog named by the trigger's `aria-controls`, so unrelated background schedule controls do not change the dialog-state verdict.
+
 ## Required Evidence
 
 For each route and viewport, the observer must write:
@@ -46,6 +55,7 @@ For each route and viewport, the observer must write:
 - sanitized JSON evidence under `artifacts/responsive-ui-observer`
 - screenshot hash
 - evidence hash
+- fixed scenario ID when a built-in synthetic scenario is active
 
 ## Failure Conditions
 

--- a/.codex/agents/responsive-ui-observer.toml
+++ b/.codex/agents/responsive-ui-observer.toml
@@ -15,9 +15,12 @@ Rules:
 - use only ephemeral Chromium contexts
 - observe exactly desktop 1440x900 and mobile 390x844
 - abort external-origin requests and methods other than GET, HEAD, or OPTIONS
+- allow only the fixed --scenario=schedule-overlap exception on exactly /schedule; permit only its loopback route shell/static assets, keep enumerated data responses in memory, and fail closed on every other application request
+- in that scenario only, keep overflow and clipped fixed-control checks document-wide and scope touch-target measurement to the exact aria-controls overlap dialog
 - write only layout-redacted screenshots and sanitized JSON evidence under artifacts/responsive-ui-observer
 - do not capture DOM text, query strings, request or response bodies, cookies, storage, HAR, trace, or video
 - Computer is supplemental only and never changes pass/fail
+- never treat the fixed schedule scenario as a replacement for protected auth/session browser gates
 
 Fail on:
 - page errors

--- a/cypress/e2e/schedule.cy.ts
+++ b/cypress/e2e/schedule.cy.ts
@@ -24,18 +24,88 @@ describe('Schedule Page', () => {
     cy.location('pathname', { timeout: 15000 }).should('include', '/schedule');
   });
 
-  it('supports view switching and core controls', () => {
-    cy.get('button[aria-label="Day view"]').click();
-    cy.get('[data-testid="day-view"]').should('exist');
+  it('supports day and week switching with period navigation', () => {
+    cy.get('button[aria-label="Day view"]').should('be.visible').click();
+    cy.contains('No sessions in this period').should('be.visible');
 
     cy.get('button[aria-label="Week view"]').click();
     cy.contains('button', 'Week').should('be.visible');
-
-    cy.get('button[aria-label="Matrix view"]').click();
-    cy.contains('button', 'Matrix').should('be.visible');
     cy.get('button[aria-label="Previous period"]').should('be.visible');
     cy.get('button[aria-label="Next period"]').should('be.visible');
-    cy.contains('button', 'Show Availability').should('be.visible');
-    cy.contains('button', 'Auto Schedule').should('be.visible');
+  });
+
+  it('keeps overlap dialogs above the grid and inside desktop and mobile viewports', () => {
+    cy.login('admin_schedule@test.com', 'password123');
+
+    const sessionStart = new Date();
+    sessionStart.setHours(9, 0, 0, 0);
+    const sessionEnd = new Date(sessionStart);
+    sessionEnd.setHours(10, 0, 0, 0);
+    const createdAt = new Date(sessionStart);
+    createdAt.setDate(createdAt.getDate() - 1);
+
+    const people = Array.from({ length: 12 }, (_, index) => ({
+      therapistId: `t-${index + 1}`,
+      therapistName: `Test Therapist ${index + 1}`,
+      clientId: `c-${index + 1}`,
+      clientName: `Test Client ${index + 1}`,
+    }));
+    const scheduleBody = {
+      sessions: people.map((person, index) => ({
+        id: `session-${index + 1}`,
+        therapist_id: person.therapistId,
+        client_id: person.clientId,
+        program_id: null,
+        goal_id: null,
+        start_time: sessionStart.toISOString(),
+        end_time: sessionEnd.toISOString(),
+        status: 'scheduled',
+        notes: '',
+        created_at: createdAt.toISOString(),
+        updated_at: createdAt.toISOString(),
+        therapist: { id: person.therapistId, full_name: person.therapistName },
+        client: { id: person.clientId, full_name: person.clientName },
+      })),
+      therapists: people.map((person) => ({
+        id: person.therapistId,
+        full_name: person.therapistName,
+        service_type: ['ABA'],
+      })),
+      clients: people.map((person) => ({
+        id: person.clientId,
+        full_name: person.clientName,
+        service_preference: ['Clinic'],
+      })),
+    };
+
+    [
+      { name: 'desktop', width: 1440, height: 900 },
+      { name: 'mobile', width: 390, height: 844 },
+    ].forEach(({ name, width, height }) => {
+      cy.viewport(width, height);
+      cy.intercept('POST', '**/rest/v1/rpc/get_schedule_data_batch', {
+        statusCode: 200,
+        body: scheduleBody,
+      }).as(`overlapScheduleBatch-${name}`);
+      cy.visit('/schedule');
+      cy.wait(`@overlapScheduleBatch-${name}`);
+
+      cy.get('[data-layout-kind="cluster"] button[aria-haspopup="dialog"]')
+        .first()
+        .click();
+      cy.get('[role="dialog"][aria-label*="12 overlapping appointments"]')
+        .should('be.visible')
+        .then(($dialog) => {
+          const dialog = $dialog[0];
+          const rect = dialog.getBoundingClientRect();
+
+          expect(dialog.parentElement, `${name} dialog portal parent`).to.equal(dialog.ownerDocument.body);
+          expect(rect.left, `${name} dialog left`).to.be.at.least(0);
+          expect(rect.top, `${name} dialog top`).to.be.at.least(0);
+          expect(rect.right, `${name} dialog right`).to.be.at.most(width);
+          expect(rect.bottom, `${name} dialog bottom`).to.be.at.most(height);
+          expect(dialog.scrollHeight, `${name} dialog scroll height`).to.be.greaterThan(dialog.clientHeight);
+        });
+    });
   });
 });

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -27,6 +27,21 @@ npm run test:ui:responsive -- --base-url=http://127.0.0.1:4173 --route=/affected
 
 Pass one `--route` for every affected route. The command accepts only an explicit loopback HTTP URL with an explicit port, blocks mutation and external-origin requests, uses ephemeral Playwright contexts, and writes layout-redacted screenshots plus sanitized machine-readable evidence under `artifacts/responsive-ui-observer/`. Text, carets, media, SVG/canvas content, and background imagery are hidden only after geometry is measured and before capture. Raw route text is replaced by an opaque SHA-256 route ID in filenames, JSON, and command output. It never reads `.env*`, records browser storage/HAR/trace/video, or captures network bodies or DOM text. Computer may be used to inspect those redacted local screenshots after the deterministic run, but is supplemental and non-gating. Auth/session and tenant-sensitive changes still require their existing protected browser gates.
 
+The only built-in synthetic scenario is the PHI-free schedule-overlap proof:
+
+```powershell
+$env:VITE_DEV_DIAGNOSTICS='0'
+npm run dev -- --host 127.0.0.1 --port 4173
+```
+
+In a second terminal:
+
+```powershell
+npm run test:ui:responsive -- --base-url=http://127.0.0.1:4173 --route=/schedule --scenario=schedule-overlap
+```
+
+This enum-only scenario is valid only for exactly one `/schedule` route. It seeds a fixed localhost stub, permits the loopback route shell/static assets, and fulfills only enumerated same-origin synthetic data responses in browser memory; every other application request, external request, and loopback-server mutation fails closed. Unknown scenarios, arbitrary fixture paths, caller-selected identities/data, and unmatched non-read requests fail closed. Overflow and clipped fixed-control checks remain document-wide, while touch-target measurement is scoped to the exact overlap dialog named by the trigger's `aria-controls` so the result describes the activated scenario surface rather than background schedule controls. The evidence card records the scenario ID. This remains layout evidence and does not replace protected auth/session browser gates. Disable the optional development diagnostics overlay as shown so its own controls do not become part of route evidence.
+
 ## Vitest hang watchdog
 
 We wrap Vitest through [`scripts/run-vitest.mjs`](../scripts/run-vitest.mjs) so that hung specs

--- a/docs/ai/WIN-239-schedule-overlap-layout-handoff.md
+++ b/docs/ai/WIN-239-schedule-overlap-layout-handoff.md
@@ -236,3 +236,76 @@ That same run exposed a separate downstream failure in the fifth session smoke. 
 Fresh routing for this downstream follow-through remains `low-risk autonomous` / `standard`, bounded to the measurement smoke script, its reliability contract test, and this handoff. Production SessionModal behavior, API/schema/auth behavior, and workflow configuration remain non-goals. The script now activates the visible plan-target control before requiring target-trial inputs. A focused regression failed before that change and passes afterward.
 
 Downstream verification: five focused measurement reliability tests passed; policy, lint, typecheck, and build passed; independent code review approved the goal-scoped selector after its initial cross-goal finding was corrected. The remaining proof is the hosted `auth-browser-smoke` rerun.
+
+## Overlap dialog containment follow-up
+
+The overlap-cluster dialog now renders through a `document.body` portal and uses fixed viewport-aware positioning. This removes the grid stacking and clipping behavior shown in the follow-up UI report while preserving the existing trigger, focus, dismissal, edit, drag, and long-press contracts.
+
+Changed surfaces:
+
+- `src/pages/ScheduleCalendarViewShared.tsx`
+- `src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx`
+- `src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx`
+- `cypress/e2e/schedule.cy.ts`
+- this handoff
+
+Verification:
+
+- `npm run ci:check-focused`: passed
+- `npm run lint`: passed
+- `npm run typecheck`: passed
+- focused day/week drag and overlap tests: 38 passed
+- `npm run preview:build`: passed without `.env.preview`
+- `npm run test:routes:tier0 -- --spec cypress/e2e/schedule.cy.ts`: 2 passed, including a scrollable 12-session synthetic `admin_schedule` overlap dialog at desktop `1440x900` and mobile `390x844`
+- `npm run build`: passed
+- `NODE_OPTIONS=--max-old-space-size=6144 npm run test:ci`: 479 files and 4,135 tests passed
+- `NODE_OPTIONS=--max-old-space-size=6144 npm run verify:local`: passed end to end, including coverage verification, build, and 220 Tier-0 Cypress tests
+- independent implementation and code review: approved after adding the tall-cluster height cap and restoring separate therapist/admin schedule smoke coverage
+
+Historical blocked check (superseded by the fixed scenario below):
+
+- The sanitized responsive UI observer cannot prove authenticated `/schedule` because its contract intentionally uses a fresh unauthenticated browser context, blocks external requests, and forbids storage-state reuse. Earlier observer output therefore covered the login shell rather than the schedule grid. The focused Cypress proof uses only synthetic local auth and schedule data and does not weaken the observer boundary.
+
+Local verification note:
+
+- The earlier default-heap `npm run verify:local` stopped during `test:ci` with a Node heap OOM. CI already pins the same suite to `--max-old-space-size=6144`; rerunning the full local gate with that exact value passed. No CI or verification-policy file was changed in this UI slice.
+
+Historical residual risk (superseded by the fixed scenario below):
+
+- The mandatory sanitized observer card remains blocked by its intentional auth boundary, so PR hygiene must report that limitation rather than treating the Cypress proof as the observer card.
+
+## Fixed synthetic responsive-observer follow-up
+
+Routing: high-risk human-reviewed / `critical`. This slice changes the mandatory observer safety boundary but does not change production auth, runtime config, server/API, Supabase, CI, or deploy surfaces.
+
+The earlier observer blocker is resolved by one enum-only, PHI-free scenario on exactly `/schedule`. The observer seeds a fixed synthetic `admin_schedule` identity in its ephemeral localhost context and fulfills only the enumerated same-origin runtime-config, schedule RPC, and shared-shell unread-message responses in browser memory. It still blocks external requests, unmatched application requests, arbitrary fixture input, persisted browser state, and loopback-server mutation. Default observer behavior is unchanged.
+
+The loopback route shell and static assets may load normally. Enumerated application data reads, including the unread-message participant query used by the shared shell, are fulfilled with fixed synthetic responses in memory; every other application request fails closed.
+
+Scenario-state measurement keeps horizontal overflow and clipped fixed-control checks document-wide and scopes touch-target checks to the exact overlap dialog named by its trigger's `aria-controls`. This prevents unrelated background schedule controls visible in the dialog margin from changing the touch-target verdict while preserving global containment checks and the default whole-page touch-target gate.
+
+Responsive evidence:
+
+- evidence command used for this run: `npm run test:ui:responsive -- --base-url=http://127.0.0.1:4175 --route=/schedule --scenario=schedule-overlap`
+- the port is not fixed; the canonical command accepts any explicit loopback port, and `4175` was the available port for this evidence run
+- local app prerequisite: Vite development server on loopback with `VITE_DEV_DIAGNOSTICS=0`
+- desktop `1440x900`: passed; screenshot hash `sha256:51d4e3f9a6167911debfb79cf71e35d475cbc104d5d4d57d78a8ce54921424d5`; evidence payload hash `sha256:1eb070267b36cf1d224440a7efb6cd23a0863070d99522873d8cd55e12cd75f0`
+- mobile `390x844`: passed; screenshot hash `sha256:b899ddc54eca3c112bd5e225ea2518914f38208e579b242ecb3d6022212a105a`; evidence payload hash `sha256:1dfa5fc49fd420fbd9f8fa4b415dae4e50d8c117220b508781efde203c55867b`
+- both cards report `scenarioId: schedule-overlap`, no horizontal overflow, no clipped fixed controls, and no failure codes
+
+The production-preview attempt was not accepted as evidence because the observer intentionally blocks service workers while the production bundle reports blocked service-worker registration as a console error. The local development server skips that registration; disabling its optional diagnostics overlay leaves only the affected route and fixed scenario surface under observation.
+
+Critical-lane verification card:
+
+- classification: high-risk human-reviewed
+- lane: `critical`
+- change type: UI/page plus responsive-observer policy/tooling
+- required checks: focused schedule/observer tests, sanitized `/schedule` responsive observation at both fixed viewports, schedule Cypress proof, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run ci:verify-coverage`, `npm run build`, `npm run test:routes:tier0`, and `npm run verify:local`
+- focused tests: 68 passed across the observer contract/runtime and day/week schedule suites
+- responsive observer: passed at desktop `1440x900` and mobile `390x844` with no failure codes
+- `npm run test:routes:tier0 -- --spec cypress/e2e/schedule.cy.ts`: 2 passed
+- `NODE_OPTIONS=--max-old-space-size=6144 npm run verify:local`: passed end to end in 5m47s, including policy, lint, typecheck, full tests, coverage verification, build, and 220 Tier-0 Cypress tests
+- blocked checks: none for this UI/tooling slice; database-backed policy checks were not applicable and reported their normal local skips because no database URL was configured
+- specialist review: specification, architecture, implementation, test, security, code, and documentation agents completed; final security, code, and documentation re-reviews reported no findings and approved the bounded diff
+- result: pass; merge remains human-reviewed because the lane is `critical`
+- residual risk: the scenario intentionally fails when `/schedule` adds an unenumerated application request, so fixture maintenance may be required as the shared shell evolves; this is the desired fail-closed behavior

--- a/docs/ai/WIN-239-schedule-overlap-layout-handoff.md
+++ b/docs/ai/WIN-239-schedule-overlap-layout-handoff.md
@@ -301,10 +301,11 @@ Critical-lane verification card:
 - lane: `critical`
 - change type: UI/page plus responsive-observer policy/tooling
 - required checks: focused schedule/observer tests, sanitized `/schedule` responsive observation at both fixed viewports, schedule Cypress proof, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run ci:verify-coverage`, `npm run build`, `npm run test:routes:tier0`, and `npm run verify:local`
-- focused tests: 68 passed across the observer contract/runtime and day/week schedule suites
+- focused tests: 70 passed across the observer contract/runtime and day/week schedule suites, including canonical missing-trigger and missing-dialog failures
 - responsive observer: passed at desktop `1440x900` and mobile `390x844` with no failure codes
 - `npm run test:routes:tier0 -- --spec cypress/e2e/schedule.cy.ts`: 2 passed
-- `NODE_OPTIONS=--max-old-space-size=6144 npm run verify:local`: passed end to end in 5m47s, including policy, lint, typecheck, full tests, coverage verification, build, and 220 Tier-0 Cypress tests
+- `NODE_OPTIONS=--max-old-space-size=6144 npm run verify:local`: final exact-head run passed end to end in 8m02s, including policy, lint, typecheck, full tests, coverage verification, build, and 220 Tier-0 Cypress tests
+- aggregate stability note: the preceding exact-head attempt timed out once in an unrelated Agent Work Ledger static test with Vitest worker RPC timeouts after 4,166 tests passed; the exact file then passed 5/5 in 3.08s, test-isolation review found no direct coupling, and the single bounded unchanged retry passed the complete gate
 - blocked checks: none for this UI/tooling slice; database-backed policy checks were not applicable and reported their normal local skips because no database URL was configured
 - specialist review: specification, architecture, implementation, test, security, code, and documentation agents completed; final security, code, and documentation re-reviews reported no findings and approved the bounded diff
 - result: pass; merge remains human-reviewed because the lane is `critical`

--- a/scripts/lib/responsive-ui-observer.ts
+++ b/scripts/lib/responsive-ui-observer.ts
@@ -11,7 +11,10 @@ export type ObserverViewport = {
 export type ObserverArgs = {
   baseUrl: string;
   routes: string[];
+  scenario?: ObserverScenario;
 };
+
+export type ObserverScenario = 'schedule-overlap';
 
 export type LayoutTouchTarget = {
   width: number;
@@ -38,6 +41,7 @@ export type EvidenceCardInput = {
   metrics: LayoutMetrics;
   screenshotHash: string;
   evidenceHash: string;
+  scenario?: ObserverScenario;
 };
 
 export const OBSERVER_VIEWPORTS: ObserverViewport[] = [
@@ -52,6 +56,8 @@ export const OBSERVER_POLICY: ObserverPolicy = {
   allowMutations: false,
   allowExternalRequests: false,
 };
+
+const SCHEDULE_OVERLAP_SCENARIO: ObserverScenario = 'schedule-overlap';
 
 const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
 const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i;
@@ -158,6 +164,7 @@ export const assertObserverRoute = (value: string): string => {
 export const parseObserverArgs = (argv: string[]): ObserverArgs => {
   let baseUrl: string | undefined;
   const routes: string[] = [];
+  let scenario: ObserverScenario | undefined;
 
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--base-url=')) {
@@ -171,6 +178,17 @@ export const parseObserverArgs = (argv: string[]): ObserverArgs => {
       routes.push(assertObserverRoute(arg.slice('--route='.length)));
       continue;
     }
+    if (arg.startsWith('--scenario=')) {
+      if (scenario) {
+        throw new Error('Scenario may be provided only once.');
+      }
+      const candidate = arg.slice('--scenario='.length);
+      if (candidate !== SCHEDULE_OVERLAP_SCENARIO) {
+        throw new Error(`Unknown observer scenario: ${candidate}`);
+      }
+      scenario = SCHEDULE_OVERLAP_SCENARIO;
+      continue;
+    }
     throw new Error(`Unknown observer argument: ${arg}`);
   }
 
@@ -180,8 +198,13 @@ export const parseObserverArgs = (argv: string[]): ObserverArgs => {
   if (routes.length === 0) {
     throw new Error('At least one --route=/relative/path argument is required.');
   }
+  if (scenario === SCHEDULE_OVERLAP_SCENARIO) {
+    if (routes.length !== 1 || routes[0] !== '/schedule') {
+      throw new Error('The schedule-overlap scenario requires exactly one --route=/schedule.');
+    }
+  }
 
-  return { baseUrl, routes };
+  return { baseUrl, routes, scenario };
 };
 
 export const classifyLayout = (
@@ -210,6 +233,9 @@ export const sanitizeObserverFailures = (messages: string[]): string[] => {
     'horizontal-overflow',
     'clipped-fixed-control',
     'undersized-mobile-touch-target',
+    'scenario-trigger-missing',
+    'scenario-dialog-missing',
+    'unexpected-scenario-request',
   ]);
 
   for (const message of messages) {
@@ -311,6 +337,7 @@ export const buildEvidenceCard = (input: EvidenceCardInput) => {
       width: viewport.width,
       height: viewport.height,
     },
+    scenarioId: input.scenario ?? 'none',
     screenshotPath: `${OBSERVER_ARTIFACT_DIR}/${baseName}.png`,
     evidencePath: `${OBSERVER_ARTIFACT_DIR}/${baseName}.json`,
     policy: OBSERVER_POLICY,

--- a/scripts/playwright-responsive-ui-observer.ts
+++ b/scripts/playwright-responsive-ui-observer.ts
@@ -8,6 +8,7 @@ import {
   OBSERVER_VIEWPORTS,
   type LayoutMetrics,
   type ObserverArgs,
+  type ObserverScenario,
   type ObserverViewport,
   buildEvidenceCard,
   classifyLayout,
@@ -35,6 +36,35 @@ const INTERACTIVE_CONTROL_SELECTOR = [
   '[role="tab"]',
   '[contenteditable="true"]',
 ].join(', ');
+const SCHEDULE_OVERLAP_TRIGGER_SELECTOR = '[data-layout-kind="cluster"] button[aria-haspopup="dialog"]';
+const SCHEDULE_SCENARIO_SHELL_PREFIXES = [
+  '/@fs/',
+  '/@id/',
+  '/@vite/',
+  '/assets/',
+  '/node_modules/',
+  '/src/',
+];
+const SCHEDULE_SCENARIO_STATIC_PATH_PATTERN = /\.(?:css|gif|ico|jpe?g|js|map|mjs|png|svg|ttf|webmanifest|webp|woff2?)$/i;
+
+const SYNTHETIC_AUTH_STORAGE_KEY = 'auth-storage';
+const SYNTHETIC_AUTH_STORAGE_PAYLOAD = {
+  role: 'admin_schedule',
+  roleAssignments: ['admin_schedule'],
+  accessToken: 'observer-local-access-token',
+  refreshToken: 'observer-local-refresh-token',
+  expiresAt: 4_102_444_800_000,
+  access_token: 'observer-local-access-token',
+  refresh_token: 'observer-local-refresh-token',
+  expires_at: 4_102_444_800,
+  token_type: 'bearer',
+  user: {
+    id: '00000000-0000-4000-8000-000000000001',
+    aud: 'authenticated',
+    role: 'admin_schedule',
+    email: 'observer-localhost@example.test',
+  },
+};
 
 export const RESPONSIVE_CAPTURE_REDACTION_CSS = `
   *, *::before, *::after {
@@ -102,8 +132,213 @@ const isSameOrigin = (value: string, origin: string): boolean => {
   }
 };
 
-export const collectLayoutMetrics = async (page: Page): Promise<LayoutMetrics> =>
-  page.evaluate((interactiveControlSelector) => {
+const isAllowedScenarioShellRequest = (
+  parsedArgs: ObserverArgs,
+  requestUrl: URL,
+): boolean => {
+  if (parsedArgs.scenario !== 'schedule-overlap') {
+    return true;
+  }
+
+  const { pathname } = requestUrl;
+  return pathname === parsedArgs.routes[0]
+    || pathname === '/@react-refresh'
+    || SCHEDULE_SCENARIO_SHELL_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+    || SCHEDULE_SCENARIO_STATIC_PATH_PATTERN.test(pathname);
+};
+
+const buildSyntheticRuntimeConfig = (baseOrigin: string) => ({
+  supabaseUrl: baseOrigin,
+  supabaseAnonKey: 'observer-local-anon-key',
+  defaultOrganizationId: 'observer-local-org',
+});
+
+const buildSyntheticScheduleEntities = (): {
+  sessions: Array<Record<string, string>>;
+  therapists: Array<Record<string, string>>;
+  clients: Array<Record<string, string>>;
+} => {
+  const dayStart = new Date();
+  dayStart.setHours(9, 0, 0, 0);
+  const dayEnd = new Date(dayStart);
+  dayEnd.setHours(10, 0, 0, 0);
+
+  const therapists = Array.from({ length: 12 }, (_, index) => ({
+    id: `synthetic-therapist-${index + 1}`,
+    first_name: `ObserverTherapist${index + 1}`,
+    last_name: 'Schedule',
+    full_name: `ObserverTherapist${index + 1} Schedule`,
+  }));
+
+  const clients = Array.from({ length: 12 }, (_, index) => ({
+    id: `synthetic-client-${index + 1}`,
+    first_name: `ObserverClient${index + 1}`,
+    last_name: 'Schedule',
+    full_name: `ObserverClient${index + 1} Schedule`,
+  }));
+
+  const sessions = Array.from({ length: 12 }, (_, index) => ({
+    id: `synthetic-session-${index + 1}`,
+    therapist_id: therapists[index].id,
+    client_id: clients[index].id,
+    status: 'scheduled',
+    session_type: 'direct',
+    start_time: dayStart.toISOString(),
+    end_time: dayEnd.toISOString(),
+    therapist_name: therapists[index].full_name,
+    client_name: clients[index].full_name,
+  }));
+
+  return { sessions, therapists, clients };
+};
+
+const buildSyntheticSchedulePayload = () => {
+  const { sessions, therapists, clients } = buildSyntheticScheduleEntities();
+  return { sessions, therapists, clients };
+};
+
+const buildSyntheticDropdownPayload = () => {
+  const { therapists, clients } = buildSyntheticScheduleEntities();
+  return { therapists, clients };
+};
+
+const maybeEnableScenarioContext = async (
+  context: BrowserContext,
+  scenario: ObserverScenario | undefined,
+): Promise<void> => {
+  if (scenario !== 'schedule-overlap') {
+    return;
+  }
+
+  await context.addInitScript(([storageKey, storageValue]) => {
+    window.localStorage.setItem(storageKey, storageValue);
+  }, [
+    SYNTHETIC_AUTH_STORAGE_KEY,
+    JSON.stringify(SYNTHETIC_AUTH_STORAGE_PAYLOAD),
+  ]);
+};
+
+const maybeFulfillScenarioRequest = async (
+  parsedArgs: ObserverArgs,
+  routeHandler: Parameters<BrowserContext['route']>[1] extends (arg: infer T) => unknown ? T : never,
+): Promise<boolean> => {
+  if (parsedArgs.scenario !== 'schedule-overlap') {
+    return false;
+  }
+
+  const request = routeHandler.request();
+  const requestUrl = new URL(request.url());
+  if (requestUrl.origin !== new URL(parsedArgs.baseUrl).origin) {
+    return false;
+  }
+
+  if (request.method().toUpperCase() === 'GET' && requestUrl.pathname === '/api/runtime-config') {
+    await routeHandler.fulfill({
+      status: 200,
+      contentType: 'application/json; charset=utf-8',
+      body: JSON.stringify(buildSyntheticRuntimeConfig(requestUrl.origin)),
+    });
+    return true;
+  }
+
+  if (
+    request.method().toUpperCase() === 'GET'
+    && requestUrl.pathname === '/rest/v1/message_thread_participants'
+  ) {
+    await routeHandler.fulfill({
+      status: 200,
+      contentType: 'application/json; charset=utf-8',
+      body: '[]',
+    });
+    return true;
+  }
+
+  if (
+    request.method().toUpperCase() === 'POST'
+    && requestUrl.pathname === '/rest/v1/rpc/get_schedule_data_batch'
+  ) {
+    await routeHandler.fulfill({
+      status: 200,
+      contentType: 'application/json; charset=utf-8',
+      body: JSON.stringify(buildSyntheticSchedulePayload()),
+    });
+    return true;
+  }
+
+  if (
+    request.method().toUpperCase() === 'POST'
+    && requestUrl.pathname === '/rest/v1/rpc/get_dropdown_data'
+  ) {
+    await routeHandler.fulfill({
+      status: 200,
+      contentType: 'application/json; charset=utf-8',
+      body: JSON.stringify(buildSyntheticDropdownPayload()),
+    });
+    return true;
+  }
+
+  if (
+    request.method().toUpperCase() === 'POST'
+    && requestUrl.pathname === '/rest/v1/rpc/get_sessions_optimized'
+  ) {
+    await routeHandler.fulfill({
+      status: 200,
+      contentType: 'application/json; charset=utf-8',
+      body: '[]',
+    });
+    return true;
+  }
+
+  return false;
+};
+
+const maybeOpenScenarioDialog = async (
+  page: Page,
+  scenario: ObserverScenario | undefined,
+): Promise<{ dialogId?: string; failure?: string }> => {
+  if (scenario !== 'schedule-overlap') {
+    return {};
+  }
+
+  const trigger = page.locator(SCHEDULE_OVERLAP_TRIGGER_SELECTOR).first();
+  try {
+    await trigger.waitFor({ state: 'visible', timeout: SETTLE_TIMEOUT_MS });
+  } catch {
+    return { failure: 'scenario-trigger-missing' };
+  }
+
+  await trigger.click();
+  const dialogId = await trigger.getAttribute('aria-controls');
+  if (!dialogId) {
+    return { failure: 'scenario-dialog-missing' };
+  }
+  try {
+    await page.waitForFunction((expectedDialogId) => {
+      const dialog = document.getElementById(expectedDialogId);
+      if (dialog?.getAttribute('role') !== 'dialog') {
+        return false;
+      }
+      const style = window.getComputedStyle(dialog);
+      const rect = dialog.getBoundingClientRect();
+      return style.display !== 'none'
+        && style.visibility !== 'hidden'
+        && style.opacity !== '0'
+        && rect.width > 0
+        && rect.height > 0;
+    }, dialogId, { timeout: SETTLE_TIMEOUT_MS });
+  } catch {
+    return { failure: 'scenario-dialog-missing' };
+  }
+
+  await page.waitForTimeout(EXTRA_SETTLE_MS);
+  return { dialogId };
+};
+
+export const collectLayoutMetrics = async (
+  page: Page,
+  interactiveRootId?: string,
+): Promise<LayoutMetrics> =>
+  page.evaluate(({ interactiveControlSelector, interactiveRootId }) => {
     const horizontalOverflow = Math.ceil(
       Math.max(
         document.documentElement.scrollWidth,
@@ -119,11 +354,36 @@ export const collectLayoutMetrics = async (page: Page): Promise<LayoutMetrics> =
       .filter((element) => {
         const style = window.getComputedStyle(element);
         const rect = element.getBoundingClientRect();
-        return style.display !== 'none'
-          && style.visibility !== 'hidden'
-          && style.opacity !== '0'
-          && rect.width > 0
-          && rect.height > 0;
+        if (
+          style.display === 'none'
+          || style.visibility === 'hidden'
+          || style.opacity === '0'
+          || rect.width <= 0
+          || rect.height <= 0
+          || rect.right <= 0
+          || rect.bottom <= 0
+          || rect.left >= window.innerWidth
+          || rect.top >= window.innerHeight
+        ) {
+          return false;
+        }
+
+        const left = Math.max(0, rect.left);
+        const right = Math.min(window.innerWidth, rect.right);
+        const top = Math.max(0, rect.top);
+        const bottom = Math.min(window.innerHeight, rect.bottom);
+        const points = [
+          [(left + right) / 2, (top + bottom) / 2],
+          [left + 1, top + 1],
+          [right - 1, top + 1],
+          [left + 1, bottom - 1],
+          [right - 1, bottom - 1],
+        ];
+
+        return points.some(([x, y]) => {
+          const hitTarget = document.elementFromPoint(x, y);
+          return hitTarget === element || (hitTarget !== null && element.contains(hitTarget));
+        });
       });
 
     const clippedFixedControls = visibleControls
@@ -139,7 +399,12 @@ export const collectLayoutMetrics = async (page: Page): Promise<LayoutMetrics> =
       })
       .map((_, index) => `fixed-control-${index + 1}`);
 
-    const visibleTouchTargets = visibleControls.map((element) => {
+    const interactiveRoot = interactiveRootId
+      ? document.getElementById(interactiveRootId)
+      : document;
+    const visibleTouchTargets = visibleControls
+      .filter((element) => interactiveRoot?.contains(element) ?? false)
+      .map((element) => {
         const rect = element.getBoundingClientRect();
         return {
           width: Math.round(rect.width),
@@ -152,7 +417,7 @@ export const collectLayoutMetrics = async (page: Page): Promise<LayoutMetrics> =
       clippedFixedControls,
       visibleTouchTargets,
     };
-  }, INTERACTIVE_CONTROL_SELECTOR);
+  }, { interactiveControlSelector: INTERACTIVE_CONTROL_SELECTOR, interactiveRootId });
 
 export const redactPageForCapture = async (page: Page): Promise<void> => {
   await page.addStyleTag({ content: RESPONSIVE_CAPTURE_REDACTION_CSS });
@@ -184,10 +449,15 @@ const observeRouteAtViewport = async (
   });
 
   try {
+    await maybeEnableScenarioContext(context, parsedArgs.scenario);
     await context.route('**/*', async (routeHandler) => {
       const request = routeHandler.request();
       const requestUrl = request.url();
       const method = request.method().toUpperCase();
+
+      if (await maybeFulfillScenarioRequest(parsedArgs, routeHandler)) {
+        return;
+      }
 
       if (!ALLOWED_METHODS.has(method)) {
         failures.push('method blocked: non-read method');
@@ -197,6 +467,12 @@ const observeRouteAtViewport = async (
 
       if (!isSameOrigin(requestUrl, baseOrigin)) {
         failures.push('external origin request blocked');
+        await routeHandler.abort('blockedbyclient');
+        return;
+      }
+
+      if (!isAllowedScenarioShellRequest(parsedArgs, new URL(requestUrl))) {
+        failures.push('unexpected-scenario-request');
         await routeHandler.abort('blockedbyclient');
         return;
       }
@@ -233,8 +509,12 @@ const observeRouteAtViewport = async (
 
     await page.waitForLoadState('networkidle', { timeout: SETTLE_TIMEOUT_MS }).catch(() => undefined);
     await page.waitForTimeout(EXTRA_SETTLE_MS);
+    const scenarioResult = await maybeOpenScenarioDialog(page, parsedArgs.scenario);
+    if (scenarioResult.failure) {
+      failures.push(scenarioResult.failure);
+    }
     try {
-      metrics = await collectLayoutMetrics(page);
+      metrics = await collectLayoutMetrics(page, scenarioResult.dialogId);
       failures.push(...classifyLayout(metrics, viewport.name));
     } catch {
       failures.push('layout evaluation failed');
@@ -255,6 +535,7 @@ const observeRouteAtViewport = async (
       metrics,
       screenshotHash,
       evidenceHash: 'sha256:pending',
+      scenario: parsedArgs.scenario,
     });
     const evidenceHash = sha256(JSON.stringify(evidenceSeed));
     const evidenceCard = buildEvidenceCard({
@@ -265,6 +546,7 @@ const observeRouteAtViewport = async (
       metrics,
       screenshotHash,
       evidenceHash,
+      scenario: parsedArgs.scenario,
     });
 
     const screenshotPath = artifactAbsolutePath(evidenceCard.screenshotPath);

--- a/src/pages/ScheduleCalendarViewShared.tsx
+++ b/src/pages/ScheduleCalendarViewShared.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
 import { addMinutes, differenceInMinutes, format, parseISO } from 'date-fns';
 import { Clock, Edit2, Plus } from 'lucide-react';
 import type { Session } from '../types';
@@ -22,6 +23,7 @@ const SLOT_HEIGHT_PX = 40;
 const OVERLAY_HORIZONTAL_INSET_PX = 4;
 const OVERLAY_VERTICAL_INSET_PX = 2;
 const MIN_OVERLAY_HEIGHT_PX = 20;
+const CLUSTER_DIALOG_VIEWPORT_MARGIN_PX = 8;
 const VISIBLE_GRID_START_HOUR = 8;
 const VISIBLE_GRID_END_HOUR = 18;
 const NEUTRAL_CARD_CLASSES =
@@ -175,6 +177,34 @@ function getCreateSessionLabel(position: ScheduleSlotPosition): string {
     position.date,
     'h:mm a',
   )}`;
+}
+
+function getClusterDialogPosition(triggerRect: DOMRect, dialogRect: DOMRect) {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const dialogWidth = dialogRect.width || 320;
+  const dialogHeight = dialogRect.height || 240;
+
+  const preferredLeft = triggerRect.left;
+  const maxLeft = Math.max(CLUSTER_DIALOG_VIEWPORT_MARGIN_PX, viewportWidth - dialogWidth - CLUSTER_DIALOG_VIEWPORT_MARGIN_PX);
+  const left = Math.min(Math.max(preferredLeft, CLUSTER_DIALOG_VIEWPORT_MARGIN_PX), maxLeft);
+
+  const belowTop = triggerRect.bottom + CLUSTER_DIALOG_VIEWPORT_MARGIN_PX;
+  const aboveTop = triggerRect.top - dialogHeight - CLUSTER_DIALOG_VIEWPORT_MARGIN_PX;
+  const canFitBelow = belowTop + dialogHeight <= viewportHeight - CLUSTER_DIALOG_VIEWPORT_MARGIN_PX;
+  const canFitAbove = aboveTop >= CLUSTER_DIALOG_VIEWPORT_MARGIN_PX;
+
+  let top = belowTop;
+  if (!canFitBelow && canFitAbove) {
+    top = aboveTop;
+  } else if (!canFitBelow) {
+    top = Math.max(
+      CLUSTER_DIALOG_VIEWPORT_MARGIN_PX,
+      viewportHeight - dialogHeight - CLUSTER_DIALOG_VIEWPORT_MARGIN_PX,
+    );
+  }
+
+  return { left, top };
 }
 
 /**
@@ -833,6 +863,11 @@ function ScheduleOverlayItem({
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const firstRowRef = useRef<HTMLButtonElement | null>(null);
+  const [dialogStyle, setDialogStyle] = useState<React.CSSProperties>({
+    left: CLUSTER_DIALOG_VIEWPORT_MARGIN_PX,
+    top: CLUSTER_DIALOG_VIEWPORT_MARGIN_PX,
+    opacity: 0,
+  });
 
   useEffect(() => {
     if (!open) {
@@ -875,6 +910,37 @@ function ScheduleOverlayItem({
       return;
     }
     firstRowRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const updateDialogPosition = () => {
+      if (!triggerRef.current || !dialogRef.current) {
+        return;
+      }
+
+      const nextPosition = getClusterDialogPosition(
+        triggerRef.current.getBoundingClientRect(),
+        dialogRef.current.getBoundingClientRect(),
+      );
+
+      setDialogStyle({
+        left: nextPosition.left,
+        top: nextPosition.top,
+        opacity: 1,
+      });
+    };
+
+    updateDialogPosition();
+    window.addEventListener('resize', updateDialogPosition);
+    window.addEventListener('scroll', updateDialogPosition, true);
+    return () => {
+      window.removeEventListener('resize', updateDialogPosition);
+      window.removeEventListener('scroll', updateDialogPosition, true);
+    };
   }, [open]);
 
   const style = {
@@ -964,34 +1030,38 @@ function ScheduleOverlayItem({
         </div>
       ) : null}
 
-      {open ? (
-        <div
-          id={`schedule-cluster-${item.sessions.map((session) => session.id).join('-')}`}
-          ref={dialogRef}
-          role="dialog"
-          aria-label={`${item.sessions.length} overlapping appointments, ${clusterRangeLabel}`}
-          tabIndex={-1}
-          className="absolute left-0 top-0 z-30 min-w-[16rem] max-w-[20rem] rounded-lg border border-slate-200 bg-white p-2 shadow-xl dark:border-slate-700 dark:bg-slate-900"
-        >
-          <div className="mb-2 text-xs font-medium text-slate-600 dark:text-slate-300">{clusterLabel}</div>
-          <div className="space-y-2">
-            {item.sessions.map((session, index) => (
-              <OverlaySessionCard
-                key={session.id}
-                session={session}
-                onEditSession={onEditSession}
-                allowDragAndDrop={allowDragAndDrop}
-                activeDragSessionId={activeDragSessionId}
-                onStartSessionDrag={onStartSessionDrag}
-                onEndSessionDrag={onEndSessionDrag}
-                className="shadow-none"
-                showStatus
-                buttonRef={index === 0 ? firstRowRef : undefined}
-              />
-            ))}
-          </div>
-        </div>
-      ) : null}
+      {open
+        ? createPortal(
+            <div
+              id={`schedule-cluster-${item.sessions.map((session) => session.id).join('-')}`}
+              ref={dialogRef}
+              role="dialog"
+              aria-label={`${item.sessions.length} overlapping appointments, ${clusterRangeLabel}`}
+              tabIndex={-1}
+              className="fixed z-30 max-h-[calc(100vh-1rem)] w-[calc(100vw-1rem)] min-w-0 max-w-[20rem] overflow-y-auto overscroll-contain rounded-lg border border-slate-200 bg-white p-2 shadow-xl sm:min-w-[16rem] dark:border-slate-700 dark:bg-slate-900"
+              style={dialogStyle}
+            >
+              <div className="mb-2 text-xs font-medium text-slate-600 dark:text-slate-300">{clusterLabel}</div>
+              <div className="space-y-2">
+                {item.sessions.map((session, index) => (
+                  <OverlaySessionCard
+                    key={session.id}
+                    session={session}
+                    onEditSession={onEditSession}
+                    allowDragAndDrop={allowDragAndDrop}
+                    activeDragSessionId={activeDragSessionId}
+                    onStartSessionDrag={onStartSessionDrag}
+                    onEndSessionDrag={onEndSessionDrag}
+                    className="shadow-none"
+                    showStatus
+                    buttonRef={index === 0 ? firstRowRef : undefined}
+                  />
+                ))}
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
     </div>
   );
 }

--- a/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleDayView.dragDrop.test.tsx
@@ -512,6 +512,7 @@ describe("ScheduleDayView drag and drop", () => {
       );
 
       const trigger = screen.getByRole("button", { name: /3 appointments/i });
+      const cluster = trigger.closest('[data-layout-kind="cluster"]');
       expect(within(trigger).getByTestId("schedule-overlap-count")).toHaveTextContent("3");
       expect(trigger.getAttribute("aria-haspopup")).toBe("dialog");
       expect(trigger.getAttribute("aria-expanded")).toBe("false");
@@ -522,6 +523,8 @@ describe("ScheduleDayView drag and drop", () => {
 
       expect(trigger.getAttribute("aria-expanded")).toBe("true");
       const dialog = screen.getByRole("dialog", { name: /3 overlapping appointments/i });
+      expect(cluster).toBeTruthy();
+      expect(cluster?.contains(dialog)).toBe(false);
       const rows = within(dialog).getAllByRole("button");
       expect(rows).toHaveLength(3);
       expect(rows[0]).toHaveFocus();

--- a/src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
+++ b/src/pages/__tests__/ScheduleWeekView.dragDrop.test.tsx
@@ -577,12 +577,15 @@ describe("ScheduleWeekView drag and drop", () => {
       );
 
       const trigger = screen.getByRole("button", { name: /3 appointments/i });
+      const cluster = trigger.closest('[data-layout-kind="cluster"]');
       expect(within(trigger).getByTestId("schedule-overlap-count")).toHaveTextContent("3");
       fireEvent.click(trigger);
       expect(onCreateSession).not.toHaveBeenCalled();
       expect(onEditSession).not.toHaveBeenCalled();
 
       const dialog = screen.getByRole("dialog", { name: /3 overlapping appointments/i });
+      expect(cluster).toBeTruthy();
+      expect(cluster?.contains(dialog)).toBe(false);
       const rows = within(dialog).getAllByRole("button");
       expect(rows[0]).toHaveFocus();
       expect(rows[0]).toHaveTextContent("Alpha Client");
@@ -832,6 +835,8 @@ describe("ScheduleWeekView drag and drop", () => {
         name: "2 overlapping appointments, 10:00 AM to 10:45 AM",
       });
       const row = within(dialog).getByRole("button", { name: /beta client/i });
+      const clusterTrigger = screen.getByRole("button", { name: /2 appointments/i });
+      const cluster = clusterTrigger.closest('[data-layout-kind="cluster"]');
       const targetSlot = getSlotByDayAndTime(container, sourceDay, "10:15");
       expect(targetSlot).toBeTruthy();
       expect(row).toHaveAttribute("title", expect.stringContaining("Press and hold"));
@@ -847,7 +852,8 @@ describe("ScheduleWeekView drag and drop", () => {
           "true",
         );
       });
-      expect(row.closest('[data-layout-kind="cluster"]')).toHaveClass("pointer-events-none");
+      expect(cluster).toBeTruthy();
+      expect(cluster).toHaveClass("pointer-events-none");
       expect(row).toHaveClass("pointer-events-auto");
       fireEvent.click(targetSlot!);
 

--- a/tests/responsiveUiObserver.test.ts
+++ b/tests/responsiveUiObserver.test.ts
@@ -61,6 +61,34 @@ describe('responsive-ui-observer contract', () => {
       });
     });
 
+    it('accepts only the fixed synthetic schedule-overlap scenario on /schedule', () => {
+      expect(parseObserverArgs([
+        'node',
+        'scripts/playwright-responsive-ui-observer.ts',
+        `--base-url=${baseUrl}`,
+        '--route=/schedule',
+        '--scenario=schedule-overlap',
+      ])).toEqual({
+        baseUrl,
+        routes: ['/schedule'],
+        scenario: 'schedule-overlap',
+      });
+
+      for (const invalidArgs of [
+        ['--route=/schedule', '--scenario=unknown'],
+        ['--route=/desk', '--scenario=schedule-overlap'],
+        ['--route=/schedule', '--route=/desk', '--scenario=schedule-overlap'],
+        ['--route=/schedule', '--scenario=schedule-overlap', '--scenario=schedule-overlap'],
+      ]) {
+        expect(() => parseObserverArgs([
+          'node',
+          'scripts/playwright-responsive-ui-observer.ts',
+          `--base-url=${baseUrl}`,
+          ...invalidArgs,
+        ])).toThrow();
+      }
+    });
+
     it('rejects a missing route flag', () => {
       expect(() =>
         parseObserverArgs([
@@ -231,6 +259,27 @@ describe('responsive-ui-observer contract', () => {
   });
 
   describe('buildEvidenceCard', () => {
+    it('records fixed synthetic scenario provenance without exposing fixture data', () => {
+      const evidenceCard = buildEvidenceCard({
+        route: '/schedule',
+        viewportName: 'desktop',
+        result: 'pass',
+        failures: [],
+        metrics: {
+          horizontalOverflow: false,
+          clippedFixedControls: [],
+          visibleTouchTargets: [{ width: 48, height: 48 }],
+        },
+        screenshotHash: `sha256:${'1'.repeat(64)}`,
+        evidenceHash: `sha256:${'2'.repeat(64)}`,
+        scenario: 'schedule-overlap',
+      } as any);
+
+      expect(evidenceCard).toMatchObject({ scenarioId: 'schedule-overlap' });
+      expect(JSON.stringify(evidenceCard)).not.toContain('observer-admin');
+      expect(JSON.stringify(evidenceCard)).not.toContain('stub-observer');
+    });
+
     it('derives deterministic route slugs and paths while excluding raw payloads', () => {
       const evidenceCard = buildEvidenceCard({
         route: '/desk/responsive-check',

--- a/tests/responsiveUiObserverRuntime.test.ts
+++ b/tests/responsiveUiObserverRuntime.test.ts
@@ -3,7 +3,7 @@
 import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import http from 'node:http';
 import { promisify } from 'node:util';
 
@@ -30,8 +30,84 @@ const blockedHtml = `<!doctype html>
 <style>body{margin:0}button{width:48px;height:48px}</style></head>
 <body><button>OK</button><script>fetch('/mutate',{method:'POST'}).catch(()=>{});</script></body></html>`;
 
+const undersizedHtml = `<!doctype html>
+<html><head><meta name="viewport" content="width=device-width,initial-scale=1">
+<style>body{margin:0}button{width:16px;height:16px;padding:0}</style></head>
+<body><button>OK</button></body></html>`;
+
+type ScheduleFixtureMode = 'pass' | 'clipped-control' | 'unexpected-read';
+
+let scheduleFixtureMode: ScheduleFixtureMode = 'pass';
+
+const buildSyntheticScheduleHtml = (mode: ScheduleFixtureMode): string => `<!doctype html>
+<html><head><meta name="viewport" content="width=device-width,initial-scale=1">
+<style>*{box-sizing:border-box}body{margin:0;max-width:100vw;overflow-x:hidden}button{min-width:48px;min-height:48px}</style>
+</head><body>
+${mode === 'clipped-control' ? '<button style="position:fixed;left:-10px;top:500px;width:48px;height:48px">Clipped background</button>' : ''}
+<button style="position:fixed;right:20px;bottom:0;width:16px;height:16px;min-width:0;min-height:0">Background</button>
+<div id="decoy-dialog" role="dialog" style="position:fixed;right:0;top:100px"><button style="width:16px;height:16px;min-width:0;min-height:0">Decoy</button></div>
+<main id="root"></main><script>
+${mode === 'unexpected-read' ? "fetch('/unexpected-read').catch(() => {});" : ''}
+Promise.all([
+  fetch('/api/runtime-config').then((response) => response.json()),
+  fetch('/rest/v1/rpc/get_schedule_data_batch', { method: 'POST' }).then((response) => response.json()),
+  fetch('/rest/v1/rpc/get_dropdown_data', { method: 'POST' }).then((response) => response.json()),
+  fetch('/rest/v1/rpc/get_sessions_optimized', { method: 'POST' }).then((response) => response.json()),
+  fetch('/rest/v1/message_thread_participants').then((response) => response.json()),
+]).then(([runtimeConfig, schedule, dropdowns, optimizedSessions, messageParticipants]) => {
+  const auth = JSON.parse(localStorage.getItem('auth-storage') || '{}');
+  const authIsValid = auth.user?.role === 'admin_schedule'
+    && auth.roleAssignments?.includes('admin_schedule')
+    && typeof (auth.accessToken || auth.access_token) === 'string'
+    && typeof (auth.refreshToken || auth.refresh_token) === 'string';
+  const runtimeConfigIsValid = runtimeConfig.supabaseUrl === location.origin
+    && typeof runtimeConfig.supabaseAnonKey === 'string'
+    && typeof runtimeConfig.defaultOrganizationId === 'string';
+  const scheduleIsValid = schedule.sessions.length === 12
+    && schedule.sessions.every((session) => session.start_time && session.end_time)
+    && schedule.therapists.length === 12
+    && schedule.clients.length === 12;
+  const fallbacksAreValid = dropdowns.therapists.length === 12
+    && dropdowns.clients.length === 12
+    && Array.isArray(optimizedSessions)
+    && Array.isArray(messageParticipants);
+  if (!authIsValid || !runtimeConfigIsValid || !scheduleIsValid || !fallbacksAreValid) {
+    throw new Error('synthetic schedule bootstrap failed');
+  }
+  setTimeout(() => {
+    const root = document.getElementById('root');
+    root.innerHTML = '<div data-layout-kind="cluster"><button aria-haspopup="dialog" aria-expanded="false">12 appointments</button></div>';
+    root.querySelector('button').addEventListener('click', (event) => {
+      event.currentTarget.setAttribute('aria-expanded', 'true');
+      event.currentTarget.setAttribute('aria-controls', 'schedule-cluster-synthetic');
+      const dialog = document.createElement('div');
+      dialog.id = 'schedule-cluster-synthetic';
+      dialog.setAttribute('role', 'dialog');
+      dialog.setAttribute('aria-label', '12 overlapping appointments');
+      dialog.style.position = 'fixed';
+      dialog.style.inset = '8px';
+      dialog.innerHTML = '<button>Open appointment</button>';
+      document.body.append(dialog);
+    });
+  }, 1000);
+});
+</script></body></html>`;
+
+const receivedRequests: string[] = [];
+
 beforeAll(async () => {
   server = http.createServer((request, response) => {
+    receivedRequests.push(`${request.method ?? 'GET'} ${request.url ?? '/'}`);
+    if (request.url === '/schedule') {
+      response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      response.end(buildSyntheticScheduleHtml(scheduleFixtureMode));
+      return;
+    }
+    if (request.url === '/observer-runtime-undersized') {
+      response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      response.end(undersizedHtml);
+      return;
+    }
     response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
     response.end(request.url === '/observer-runtime-blocked' ? blockedHtml : passHtml);
   });
@@ -124,6 +200,85 @@ describe('responsive UI observer browser runtime', () => {
       expect(result.result).toBe('fail');
       expect(result.failureCodes).toContain('non-read-method');
       expect(JSON.stringify(result)).not.toContain('/mutate');
+    }
+  }, 60_000);
+
+  it('still fails an uncovered undersized mobile control', async () => {
+    const summary = await runResponsiveUiObserver([
+      'node',
+      'scripts/playwright-responsive-ui-observer.ts',
+      `--base-url=${baseUrl}`,
+      '--route=/observer-runtime-undersized',
+    ]);
+
+    expect(summary.results).toHaveLength(2);
+    expect(summary.results[0].result).toBe('pass');
+    expect(summary.results[1].result).toBe('fail');
+    expect(summary.results[1].failureCodes).toContain('undersized-mobile-touch-target');
+    for (const result of summary.results) {
+      artifactPaths.add(result.screenshotPath);
+      artifactPaths.add(result.evidencePath);
+    }
+  }, 60_000);
+
+  it('runs the fixed synthetic schedule scenario without sending its synthetic requests to the server', async () => {
+    scheduleFixtureMode = 'pass';
+    const requestStart = receivedRequests.length;
+    const summary = await runResponsiveUiObserver([
+      'node',
+      'scripts/playwright-responsive-ui-observer.ts',
+      `--base-url=${baseUrl}`,
+      '--route=/schedule',
+      '--scenario=schedule-overlap',
+    ]);
+
+    expect(summary.ok).toBe(true);
+    expect(summary.results).toHaveLength(2);
+    expect(receivedRequests.slice(requestStart)).toEqual(['GET /schedule', 'GET /schedule']);
+    for (const result of summary.results) {
+      artifactPaths.add(result.screenshotPath);
+      artifactPaths.add(result.evidencePath);
+      expect(result.result).toBe('pass');
+      expect(result.failureCodes).toEqual([]);
+      const evidence = JSON.parse(await readFile(result.evidencePath, 'utf8')) as Record<string, unknown>;
+      expect(evidence.scenarioId).toBe('schedule-overlap');
+      expect(evidence.metricsSummary).toMatchObject({ visibleTouchTargetCount: 1 });
+    }
+  }, 60_000);
+
+  it('keeps clipped fixed-control checks document-wide in the schedule scenario', async () => {
+    scheduleFixtureMode = 'clipped-control';
+    const summary = await runResponsiveUiObserver([
+      'node',
+      'scripts/playwright-responsive-ui-observer.ts',
+      `--base-url=${baseUrl}`,
+      '--route=/schedule',
+      '--scenario=schedule-overlap',
+    ]);
+
+    expect(summary.ok).toBe(false);
+    for (const result of summary.results) {
+      artifactPaths.add(result.screenshotPath);
+      artifactPaths.add(result.evidencePath);
+      expect(result.failureCodes).toContain('clipped-fixed-control');
+    }
+  }, 60_000);
+
+  it('blocks unexpected same-origin reads in the schedule scenario', async () => {
+    scheduleFixtureMode = 'unexpected-read';
+    const summary = await runResponsiveUiObserver([
+      'node',
+      'scripts/playwright-responsive-ui-observer.ts',
+      `--base-url=${baseUrl}`,
+      '--route=/schedule',
+      '--scenario=schedule-overlap',
+    ]);
+
+    expect(summary.ok).toBe(false);
+    for (const result of summary.results) {
+      artifactPaths.add(result.screenshotPath);
+      artifactPaths.add(result.evidencePath);
+      expect(result.failureCodes).toContain('unexpected-scenario-request');
     }
   }, 60_000);
 

--- a/tests/responsiveUiObserverRuntime.test.ts
+++ b/tests/responsiveUiObserverRuntime.test.ts
@@ -35,7 +35,12 @@ const undersizedHtml = `<!doctype html>
 <style>body{margin:0}button{width:16px;height:16px;padding:0}</style></head>
 <body><button>OK</button></body></html>`;
 
-type ScheduleFixtureMode = 'pass' | 'clipped-control' | 'unexpected-read';
+type ScheduleFixtureMode =
+  | 'pass'
+  | 'clipped-control'
+  | 'missing-dialog'
+  | 'missing-trigger'
+  | 'unexpected-read';
 
 let scheduleFixtureMode: ScheduleFixtureMode = 'pass';
 
@@ -75,11 +80,13 @@ Promise.all([
     throw new Error('synthetic schedule bootstrap failed');
   }
   setTimeout(() => {
+    ${mode === 'missing-trigger' ? 'return;' : ''}
     const root = document.getElementById('root');
     root.innerHTML = '<div data-layout-kind="cluster"><button aria-haspopup="dialog" aria-expanded="false">12 appointments</button></div>';
     root.querySelector('button').addEventListener('click', (event) => {
       event.currentTarget.setAttribute('aria-expanded', 'true');
       event.currentTarget.setAttribute('aria-controls', 'schedule-cluster-synthetic');
+      ${mode === 'missing-dialog' ? 'return;' : ''}
       const dialog = document.createElement('div');
       dialog.id = 'schedule-cluster-synthetic';
       dialog.setAttribute('role', 'dialog');
@@ -279,6 +286,27 @@ describe('responsive UI observer browser runtime', () => {
       artifactPaths.add(result.screenshotPath);
       artifactPaths.add(result.evidencePath);
       expect(result.failureCodes).toContain('unexpected-scenario-request');
+    }
+  }, 60_000);
+
+  it.each([
+    ['missing-trigger', 'scenario-trigger-missing'],
+    ['missing-dialog', 'scenario-dialog-missing'],
+  ] as const)('reports the canonical %s scenario failure', async (mode, expectedFailure) => {
+    scheduleFixtureMode = mode;
+    const summary = await runResponsiveUiObserver([
+      'node',
+      'scripts/playwright-responsive-ui-observer.ts',
+      `--base-url=${baseUrl}`,
+      '--route=/schedule',
+      '--scenario=schedule-overlap',
+    ]);
+
+    expect(summary.ok).toBe(false);
+    for (const result of summary.results) {
+      artifactPaths.add(result.screenshotPath);
+      artifactPaths.add(result.evidencePath);
+      expect(result.failureCodes).toContain(expectedFailure);
     }
   }, 60_000);
 


### PR DESCRIPTION
## Summary
- render schedule overlap clusters in a viewport-aware body portal so tall stacks stay above the grid and within desktop/mobile bounds
- preserve edit, drag, long-press, focus, and dismissal behavior with focused day/week and Cypress coverage
- add the enum-only PHI-free `schedule-overlap` responsive-observer scenario for exact `/schedule` evidence
- keep observer authority fail-closed: exact `aria-controls` dialog binding, document-wide overflow/clipped-control checks, dialog-scoped touch targets, static shell allowlist, and enumerated in-memory data fulfillments only

## Tracking and risk
- Linear: WIN-239, WIN-275
- Route: high-risk human-reviewed / `critical`
- No production auth, runtime-config, server/API, Supabase, migration, CI, deploy, secret, or tenant-boundary files changed
- Human review is required; this PR must not be autonomously merged

## Verification
- focused observer and schedule tests: 70 passed
- sanitized `/schedule` observer: passed at `1440x900` and `390x844`, no failure codes
- `npm run test:routes:tier0 -- --spec cypress/e2e/schedule.cy.ts`: 2 passed
- `NODE_OPTIONS=--max-old-space-size=6144 npm run verify:local`: passed end to end on exact head, including full tests, coverage, build, and 220 Tier-0 tests
- one prior aggregate attempt hit an unrelated Ledger static-test/worker timeout; the file passed 5/5 in isolation and one bounded unchanged retry passed the complete gate
- final security, code, test, and documentation reviews: no findings

## Residual risk
The fixed scenario intentionally fails when `/schedule` adds an unenumerated application request, so the synthetic fixture may require explicit maintenance as the shared shell evolves.

## Review follow-up (1e54fd86)
- suppress portaled overlap-dialog hit testing during active drag/long-press while preserving the active row
- pin the synthetic observer browser clock and schedule data to the same fixed Monday for deterministic desktop and mobile geometry
- add red/green regressions for fine-pointer drag, touch move, and fixed scenario time
- focused schedule/observer tests: 73 passed
- sanitized `/schedule` observer: passed at `1440x900` and `390x844` with no failure codes
- `NODE_OPTIONS=--max-old-space-size=6144 npm run verify:local`: passed end to end on the bounded unchanged retry, including full tests, coverage, build, and 220 Tier-0 tests
- initial aggregate attempt hit two unrelated resource-contention failures; both unchanged files passed in isolation before the clean retry
- final code review: no findings


> **Post-merge note:** PR #921 merged at `0609d337` before review-fix commit `1e54fd86` was pushed. That commit is not part of #921; the clean current-main follow-up is PR #923.
