### PR TITLE
WIN-135: harden IEHP FBA collapsed target parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,11 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
+        with:
+          deno-version: 2.8.3
+
       - name: Install dependencies
         run: npm ci
 
@@ -424,6 +429,9 @@ jobs:
 
       - name: Verify coverage thresholds
         run: npm run ci:verify-coverage
+
+      - name: Run extractor Deno tests
+        run: deno test --no-lock --node-modules-dir=none --no-prompt --allow-env --allow-read supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts supabase/functions/extract-assessment-fields/index.test.ts supabase/functions/extract-assessment-fields/iehp-skills-behaviors.test.ts supabase/functions/extract-assessment-fields/structured-goals.test.ts
 
   build:
     name: build

--- a/docs/ai/WIN-135-iehp-fba-collapsed-parser-handoff.md
+++ b/docs/ai/WIN-135-iehp-fba-collapsed-parser-handoff.md
@@ -1,0 +1,68 @@
+# WIN-135 IEHP FBA Collapsed Target Parser Handoff
+
+## Route And Scope
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- triggering paths: `supabase/functions/**`, `.github/workflows/**`
+- tracking: `WIN-135`
+- human review: required before merge
+
+A dedicated child issue could not be created because the Linear workspace reached its free issue limit. The bounded execution is recorded on the existing open FBA follow-up queue with explicit critical-lane scope.
+
+## Problem And Root Cause
+
+Adobe PDF Extract already supplies ordered text to the IEHP parser. When several checkbox labels are returned in one text element, the summary can look like:
+
+```text
+[U+2610] Physical Aggression [U+2610] Functional Communication [U+2610] Community Safety
+```
+
+The IEHP summary tokenizer split newlines, semicolons, and bullets, but not checkbox/square markers. It therefore emitted one combined `payload.targets` value, and the conservative Skills & Behaviors reconciliation could not match the individual behavior and skill goal blocks.
+
+## Bounded Change
+
+- Treat common checkbox and square glyphs as delimiters in the existing IEHP target-list tokenizer.
+- Add a synthetic regression that proves three collapsed targets remain distinct and reconcile as behavior, skill, and summary-only review data.
+- Add required, secret-free extractor Deno suites to the existing `unit_tests` CI job, which is already a governed prerequisite for the main-branch Supabase deployment.
+- Guard the pre-deploy test ordering with a focused workflow contract and prevent Deno from rewriting `deno.lock`.
+
+No schema, migration, auth, RLS, grant, tenant filter, API response shape, runtime configuration, provider credential, deployment, or production-data behavior changed.
+
+## Tenant And Clinical Safety
+
+- Organization and tenant read/write boundaries are unchanged.
+- Cross-tenant access remains impossible through this change because no database access, authorization, or persistence path changed.
+- All new parser evidence is synthetic and contains no customer data or PHI.
+- Extracted Skills & Behaviors remain review data; existing clinician approval and publish controls are unchanged.
+
+## Verification Evidence
+
+- RED: the synthetic Deno regression returned one combined checkbox target instead of three distinct targets.
+- GREEN: focused collapsed-target regression passed.
+- GREEN: all four extractor-native Deno suites passed, `67 passed`, `0 failed`.
+- GREEN: workflow contract test passed, `1 passed`, `0 failed`.
+- GREEN: `npm run validate:tenant` passed.
+- GREEN: final `npm run verify:local` passed in 456 seconds, including policy checks, lint, typecheck, `4,217` Vitest tests (`5` skipped), coverage verification, production build, and `220` Tier-0 browser route tests.
+
+### Verification Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- files touched: `.github/workflows/ci.yml`; `supabase/functions/extract-assessment-fields/index.ts`; `supabase/functions/extract-assessment-fields/index.test.ts`; `tests/workflows/iehp-fba-parser-ci.test.ts`; `docs/ai/WIN-135-iehp-fba-collapsed-parser-handoff.md`
+- required agents: `specification-engineer` -> `software-architect` -> `implementation-engineer` -> `test-engineer` + `devops-engineer` -> `code-review-engineer` + `security-engineer` + `supabase-reviewer` + `documentation-engineer`
+- required checks: focused parser regression; extractor-native Deno suites; CI workflow contract; `npm run validate:tenant`; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run ci:verify-coverage`; `npm run build`; `npm run test:routes:tier0`; `npm run verify:local`
+- executed checks: focused parser RED -> failed as expected; focused parser GREEN -> pass; extractor-native Deno suites -> pass (`67/67`); workflow contract -> pass (`1/1`); `npm run validate:tenant` -> pass; post-review workflow contract -> pass (`1/1`); post-review `npm run ci:check-focused` -> pass; final `npm run verify:local` -> pass in 456 seconds
+- blocked checks: live branch protection -> CI only; privileged function database grants -> missing protected database URL; Supabase preview drift -> missing `SUPABASE_DB_URL`; hosted function auth parity -> CI-only configuration; no credentials or hosted systems were accessed
+- reviewer: completed; initial code/security findings were corrected, and final code, security, Supabase, and documentation reviews found no unresolved implementation defect
+- residual risk: the change is proven against synthetic Adobe-collapsed text but has not been deployed or exercised with customer documents; production activation remains outside this slice
+- pr handoff: local branch is review-ready; PR identifier and live checks will be appended immediately after publication
+
+## Specialist Review
+
+- Specification and architecture reviewers confirmed the existing tokenizer is the smallest safe seam and no payload-schema change is required.
+- Implementation and test reviewers confirmed the synthetic reconciliation coverage and the pre-existing CI coverage gap.
+- Supabase review found no schema, auth, tenant, persistence, RLS, grant, or RPC drift.
+- Documentation review found the handoff accurate before the final CI-order correction.
+- Code review identified ambiguous checkbox wording in this handoff; the example now states the tested `U+2610` marker explicitly rather than implying a literal word token.
+- Security review identified that a standalone parser job could finish after the main-branch function deployment. The Deno suites now run inside the already-required `unit_tests` job, and the workflow contract proves that deployment depends on that job.

--- a/docs/ai/WIN-135-iehp-fba-collapsed-parser-handoff.md
+++ b/docs/ai/WIN-135-iehp-fba-collapsed-parser-handoff.md
@@ -56,7 +56,7 @@ No schema, migration, auth, RLS, grant, tenant filter, API response shape, runti
 - blocked checks: live branch protection -> CI only; privileged function database grants -> missing protected database URL; Supabase preview drift -> missing `SUPABASE_DB_URL`; hosted function auth parity -> CI-only configuration; no credentials or hosted systems were accessed
 - reviewer: completed; initial code/security findings were corrected, and final code, security, Supabase, and documentation reviews found no unresolved implementation defect
 - residual risk: the change is proven against synthetic Adobe-collapsed text but has not been deployed or exercised with customer documents; production activation remains outside this slice
-- pr handoff: local branch is review-ready; PR identifier and live checks will be appended immediately after publication
+- pr handoff: ready at PR `#927` (`https://github.com/Jeduardo622/AllIincompassing/pull/927`); live checks are pending and human review remains required
 
 ## Specialist Review
 
@@ -66,3 +66,12 @@ No schema, migration, auth, RLS, grant, tenant filter, API response shape, runti
 - Documentation review found the handoff accurate before the final CI-order correction.
 - Code review identified ambiguous checkbox wording in this handoff; the example now states the tested `U+2610` marker explicitly rather than implying a literal word token.
 - Security review identified that a standalone parser job could finish after the main-branch function deployment. The Deno suites now run inside the already-required `unit_tests` job, and the workflow contract proves that deployment depends on that job.
+
+## Pull Request State
+
+- PR: `#927` (`https://github.com/Jeduardo622/AllIincompassing/pull/927`)
+- publication head: `07a5001b3c446d945101c506a8b1ff6988381846`
+- live checks at publication: CI `change-scope`, `tenant-safety`, Lighthouse, and Netlify deploy preview pending; Supabase Preview skipped
+- review decision: no GitHub human review submitted
+- merge state: `BLOCKED`
+- merge result: not merged; critical-lane human review and exact-head required checks remain mandatory

--- a/supabase/functions/extract-assessment-fields/index.test.ts
+++ b/supabase/functions/extract-assessment-fields/index.test.ts
@@ -781,6 +781,73 @@ Deno.test("extractStructuredSections reconciles IEHP summary targets", () => {
   );
 });
 
+Deno.test("extractStructuredSections splits Adobe-collapsed IEHP checkbox targets", () => {
+  const sections = asSections(
+    "iehp_fba",
+    `
+      BEHAVIORS
+      The behaviors and functional skills to be addressed are:
+      \u2610 Physical Aggression \u2610 Functional Communication \u2610 Community Safety
+      BACKGROUND INFORMATION:
+      Living Situation
+      Caregiver One Parent
+      Target Behaviors
+      TARGET BEHAVIORS:
+      Program Name: Physical Aggression
+      Instrumental Goal: By December 2027, member will reduce aggression from 3x per hour to 0x per hour.
+      Data Collection: Rate.
+      Mastery Criteria: 0x per hour across 4 consecutive weeks.
+      Baseline: 3x per hour.
+      REPLACEMENT BEHAVIORS:
+      Program Name: Functional Communication
+      Instrumental Goal: By December 2027, member will request help across 5 targets.
+      Data Collection: Percentage of opportunities.
+      Mastery Criteria: 80% across 4 consecutive weeks.
+      Baseline: 0% independent.
+      Safety/Crisis Procedure
+      Crisis safety narrative.
+    `,
+  );
+
+  const summary = sections.find((section) => section.field_key === "IEHP_FBA_BEHAVIOR_SKILL_TARGETS");
+  const skillsBehaviors = summary?.payload.skills_behaviors as
+    | { items?: Array<Record<string, unknown>>; counts?: Record<string, unknown> }
+    | undefined;
+
+  expect(summary?.payload.targets).toEqual([
+    "Physical Aggression",
+    "Functional Communication",
+    "Community Safety",
+  ]);
+  expect(skillsBehaviors).toMatchObject({
+    counts: {
+      total: 3,
+      behavior: 1,
+      skill: 1,
+      summary_only: 1,
+      detailed_only: 0,
+      ambiguous: 0,
+    },
+    items: [
+      expect.objectContaining({
+        name: "Physical Aggression",
+        clinical_goal_type: "behavior",
+        reconciliation_status: "matched",
+      }),
+      expect.objectContaining({
+        name: "Functional Communication",
+        clinical_goal_type: "skill",
+        reconciliation_status: "matched",
+      }),
+      expect.objectContaining({
+        name: "Community Safety",
+        clinical_goal_type: null,
+        reconciliation_status: "summary_only",
+      }),
+    ],
+  });
+});
+
 Deno.test("extractStructuredSections preserves IEHP adaptive measure block slots when source content is missing", () => {
   const sections = asSections(
     "iehp_fba",

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -781,7 +781,7 @@ const appendMissingIeHpTemplatePlaceholders = (
 
 const splitListText = (value: string): string[] =>
   value
-    .split(/\s*(?:\n+|;|•|\u2022)\s*/g)
+    .split(/\s*(?:\n+|;|[\u2022\u25a0\u25a1\u2610\u2611\u2612])\s*/g)
     .map((entry) => normalizeExtractedValue(entry))
     .filter((entry) => entry.length > 0);
 

--- a/tests/workflows/iehp-fba-parser-ci.test.ts
+++ b/tests/workflows/iehp-fba-parser-ci.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync('.github/workflows/ci.yml', 'utf8').replace(/\r\n/g, '\n');
+const unitTestsStart = workflow.indexOf('\n  unit_tests:');
+const buildStart = workflow.indexOf('\n  build:', unitTestsStart);
+const unitTestsJob = workflow.slice(unitTestsStart, buildStart);
+const deployStart = workflow.indexOf('\n  deploy_session_edge:');
+const deployEnd = workflow.indexOf('\n  deploy_ai_agent_edge:', deployStart);
+const deployJob = workflow.slice(deployStart, deployEnd);
+const ciGateStart = workflow.indexOf('\n  ci_gate:');
+const ciGateJob = workflow.slice(ciGateStart);
+
+describe('IEHP FBA parser CI gate', () => {
+  it('runs the protected extractor suites before deployment without changing deno.lock', () => {
+    expect(unitTestsStart).toBeGreaterThanOrEqual(0);
+    expect(buildStart).toBeGreaterThan(unitTestsStart);
+    expect(workflow).not.toContain('\n  iehp_fba_parser_tests:');
+    expect(unitTestsJob).toContain(
+      'uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5',
+    );
+    expect(unitTestsJob).toContain('deno-version: 2.8.3');
+    expect(unitTestsJob).toContain(
+      'deno test --no-lock --node-modules-dir=none --no-prompt --allow-env --allow-read supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts supabase/functions/extract-assessment-fields/index.test.ts supabase/functions/extract-assessment-fields/iehp-skills-behaviors.test.ts supabase/functions/extract-assessment-fields/structured-goals.test.ts',
+    );
+    expect(deployJob).toContain('- unit_tests');
+    expect(ciGateJob).toContain('- unit_tests');
+    expect(ciGateJob).toContain('UNIT_RESULT: ${{ needs.unit_tests.result }}');
+    expect(ciGateJob).toContain('[ "${UNIT_RESULT}" = "success" ] || failed+=("unit-tests=${UNIT_RESULT}")');
+  });
+});


### PR DESCRIPTION
## Summary
- split Adobe-collapsed IEHP FBA checkbox targets before Skills & Behaviors reconciliation
- add synthetic behavior, skill, and summary-only regression coverage
- run all extractor-native Deno suites inside the deployment-blocking unit_tests CI job

## Routing
- Linear: WIN-135
- classification: high-risk human-reviewed
- lane: critical
- protected paths: supabase/functions/**, .github/workflows/**
- human review is required before merge

## Verification
- extractor-native Deno suites: 67 passed, 0 failed
- workflow contract: 1 passed, 0 failed
- npm run validate:tenant: passed
- npm run verify:local: passed
  - policy, lint, typecheck, 4,217 Vitest tests, coverage, build
  - 220 Tier-0 browser route tests
- code, security, Supabase, and documentation specialist reviews completed
- initial fail-open deployment-order finding was corrected by placing Deno suites inside the existing deployment-blocking unit_tests job

## Risk
No schema, auth, tenant, RLS, grant, RPC, persistence, provider credential, or deployment action changed. Proof uses synthetic data only. Hosted/customer-document validation and deployment remain outside this PR.