### PR TITLE
WIN-203: Restrict BT schedules to linked therapist

### DIFF
--- a/docs/ai/handoffs/WIN-203-bt-schedule-therapist-scope.md
+++ b/docs/ai/handoffs/WIN-203-bt-schedule-therapist-scope.md
@@ -1,0 +1,70 @@
+# WIN-203 BT Schedule Therapist Scope
+
+## Classification
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- trigger: tenant-sensitive schedule authorization in `supabase/migrations/**`
+- merge requirement: human review
+
+## Scope
+
+- Restrict BT and legacy therapist schedule RPC rows to the caller's linked therapist identity.
+- Preserve full-schedule access for `admin`, `admin_schedule`, `midtier`, `bcba`, and super-admin behavior.
+- Keep assigned-client dropdown visibility and direct clinical session reads unchanged.
+- Make the locked mobile schedule summary identify the scoped therapist instead of claiming `All therapists`.
+
+## Non-goals
+
+- No direct-session RLS redesign or clinical caseload capability change.
+- No auth, role-model, session lifecycle, or deployment configuration change.
+- No production migration application or hosted data mutation.
+- Stop and re-route if safe containment requires changing direct clinical session policies.
+
+## Evidence
+
+- Aggregate-only hosted inspection for the reported account and day found one linked therapist, three therapist-owned appointments, and five appointments owned by other therapists among assigned-client schedule rows.
+- The deployed client-scope migrations were present, ruling out a missing production migration as the cause.
+- Root cause: both schedule RPCs authorized assigned clients without also matching `sessions.therapist_id` to the caller's linked therapist identity.
+
+## Change
+
+- Add a fail-closed schedule-session authorization helper.
+- Apply it to `get_sessions_optimized` and `get_schedule_data_batch` without changing their signatures or payloads.
+- Extend synthetic SQL smoke coverage for full-schedule, therapist-owned, BT-owned, and foreign-therapist rows.
+- Correct the locked schedule-options summary and add a focused UI regression assertion.
+
+## Verification Card
+
+- required checks: focused migration/UI contracts; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run validate:tenant`; `npm run build`; `npm run test:routes:tier0`; `npm run ci:playwright`; responsive `/schedule` observer; runtime SQL smoke; `npm run verify:local`
+- executed checks: focused contracts passed (`40/40`); strengthened migration contracts passed (`42/42`); policy checks passed; lint passed; typecheck passed; full test suite passed (`491` files passed, `2` skipped; `4223` tests passed, `5` skipped); tenant validation passed; build passed; Tier-0 route gate passed (`220/220`); responsive observer passed at `1440x900` and `390x844`
+- blocked checks: authenticated Playwright stopped at preflight because no `PW_SUPERADMIN_*` or `PW_ADMIN_*` credentials were available; runtime SQL smoke awaits an isolated Supabase preview containing the new migration
+- aggregate check: `npm run verify:local` passed in 418.7 seconds, including coverage verification and `220/220` Tier-0 routes
+- result: pass locally; preview SQL and credentialed hosted browser checks remain blocked as stated above
+
+## Review
+
+- Specification, architecture, implementation, test, Supabase, security, performance, and code-review agents reviewed the bounded slice.
+- Supabase review found no migration, grant, RLS, or tenant-isolation defect.
+- Security re-review approved the explicit boundary: assigned-client direct session reads remain a separate clinical capability, while schedule loading is RPC-only and now therapist-owned. Human review must confirm that boundary.
+- Performance re-review found no blocker because the therapist lookup remains index-assisted by the existing unique `(user_id, therapist_id)` constraint and both RPCs are date-bounded; representative preview query-plan timing remains residual risk.
+- Final code re-review found no defects and returned `pr-ready: yes` for critical-lane human review after the lane artifacts were added and diagnostic/generated drift was removed.
+
+## Responsive Evidence
+
+- desktop screenshot: `sha256:1aeed981ffec70f8d9592ea95b190db35c9b4dd7efad71c0c972f2e71cc4f473`
+- desktop evidence: `sha256:5896d04ec3f52219e67097a228b121a7b653fb9f02c2413bcf0d65a56af03960`
+- mobile screenshot: `sha256:1344e6e7b69fdab4e21aafc8bbb42d61251c40c0c7db01eddd6d2b45800828e9`
+- mobile evidence: `sha256:655087507cd14ea7db702daade75a24eb2eee117decb5acdd16eb7aef626abed`
+
+## Residual Risk
+
+- The migration and runtime SQL smoke have not run on an isolated Supabase preview yet.
+- Authenticated hosted browser smoke is blocked locally by missing test credentials.
+- Direct assigned-client clinical reads remain broader than the schedule presentation scope by design.
+- Critical-lane human review remains mandatory before merge or production migration.
+
+## Tracking
+
+- Linear: [WIN-203](https://linear.app/winningedgeai/issue/WIN-203)
+- Branch: `codex/bt-owned-schedule-scope`

--- a/docs/ai/handoffs/WIN-203-bt-schedule-therapist-scope.md
+++ b/docs/ai/handoffs/WIN-203-bt-schedule-therapist-scope.md
@@ -68,3 +68,13 @@
 
 - Linear: [WIN-203](https://linear.app/winningedgeai/issue/WIN-203)
 - Branch: `codex/bt-owned-schedule-scope`
+
+## PR Review Follow-up
+
+- Codex P2 `discussion_r3768415295` identified a Schedule edit deep-link fallback that still queried `sessions` directly under the broader clinical policy.
+- Added a forward migration for `get_schedule_session_by_id(uuid)`, which derives organization context and reuses `app.current_user_can_read_schedule_session` before returning a row.
+- Replaced the direct-table deep-link lookup with the scoped RPC without changing direct clinical session RLS.
+- Added BT and therapist owned/foreign runtime SQL probes plus a focused BT deep-link UI regression test.
+- Focused follow-up verification: migration/deep-link/Schedule tests passed (`45/45`); lint, typecheck, policy checks, and production build passed.
+- Independent code, security, and Supabase follow-up reviews found no remaining blocker; the RPC returns only the session row, matching the prior direct lookup payload while enforcing schedule scope.
+- Final review-fixed `npm run verify:local` passed in 430.1 seconds, including full coverage verification and `220/220` Tier-0 routes.

--- a/src/lib/generated/database.types.ts
+++ b/src/lib/generated/database.types.ts
@@ -10537,6 +10537,10 @@ export type Database = {
         Args: { p_end_date: string; p_start_date: string }
         Returns: Json
       }
+      get_schedule_session_by_id: {
+        Args: { p_session_id: string }
+        Returns: Json
+      }
       get_scheduling_efficiency_factor: {
         Args: { p_slot_time: string; p_therapist_id: string }
         Returns: number

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1024,7 +1024,10 @@ export const Schedule = React.memo(() => {
       parts.push("Week-forward on");
     }
     if (therapistScopedView) {
-      parts.push("All therapists");
+      const scopedTherapistName = selectedTherapist
+        ? (visibleTherapists.find((x) => x.id === selectedTherapist)?.full_name ?? "Assigned therapist")
+        : "Assigned therapist";
+      parts.push(scopedTherapistName);
       parts.push(
         selectedClient
           ? (visibleClients.find((x) => x.id === selectedClient)?.full_name ?? "Client")

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -2209,11 +2209,7 @@ export const Schedule = React.memo(() => {
     let cancelled = false;
     void (async () => {
       const { data, error } = await supabase
-        .from("sessions")
-        .select("*")
-        .eq("id", sessionId)
-        .eq("organization_id", activeOrganizationId)
-        .maybeSingle();
+        .rpc("get_schedule_session_by_id", { p_session_id: sessionId });
       if (cancelled) {
         return;
       }

--- a/src/pages/__tests__/Schedule.test.tsx
+++ b/src/pages/__tests__/Schedule.test.tsx
@@ -376,6 +376,11 @@ describe("Schedule", () => {
       await screen.findByRole("heading", { name: /^Schedule$/i }),
     ).toBeInTheDocument();
 
+    expect(
+      await screen.findByText(/^Day view · .* · Dr\. Myles · All clients$/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^Day view · .* · All therapists · All clients$/i)).not.toBeInTheDocument();
+
     await userEvent.click(screen.getByText("Filters & schedule options"));
 
     const myles = await screen.findAllByText("Dr. Myles");

--- a/src/pages/__tests__/Schedule.urlEditDeepLink.test.tsx
+++ b/src/pages/__tests__/Schedule.urlEditDeepLink.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { useLocation } from "react-router-dom";
 import { renderWithProviders, screen, waitFor } from "../../test/utils";
+import { supabase } from "../../lib/supabase";
 import { Schedule } from "../Schedule";
 import type { Client, Session, Therapist } from "../../types";
 
@@ -160,6 +161,41 @@ describe("Schedule URL edit deep links", () => {
       expect(params.has("scheduleModal")).toBe(false);
       expect(params.has("scheduleSessionId")).toBe(false);
       expect(params.has("scheduleExp")).toBe(false);
+    });
+    expect(screen.queryByText(/Edit Session/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps a BT deep link closed when the schedule-scoped RPC denies the session", async () => {
+    const foreignSessionId = "00000000-0000-4000-8000-000000000999";
+    const rpcSpy = vi.spyOn(supabase, "rpc").mockResolvedValue({
+      data: null,
+      error: null,
+      count: null,
+      status: 200,
+      statusText: "OK",
+    });
+    const expiresAtMs = Date.now() + 60_000;
+
+    renderWithProviders(
+      <>
+        <Schedule />
+        <SearchProbe />
+      </>,
+      {
+        auth: { role: "bt", organizationId: "org-1" },
+        router: {
+          initialEntries: [
+            `/?scheduleModal=edit&scheduleSessionId=${foreignSessionId}&scheduleExp=${expiresAtMs}`,
+          ],
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(rpcSpy).toHaveBeenCalledWith("get_schedule_session_by_id", {
+        p_session_id: foreignSessionId,
+      });
+      expect(screen.getByTestId("schedule-search").textContent).toBe("");
     });
     expect(screen.queryByText(/Edit Session/i)).not.toBeInTheDocument();
   });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -904,6 +904,7 @@ export const server = setupServer(
 
     return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }),
+  http.post('*/rest/v1/rpc/get_schedule_session_by_id', () => HttpResponse.json(null)),
   http.post('*/rest/v1/rpc/get_dropdown_data', async ({ request }) => {
     const token = getBearerToken(request.headers);
 

--- a/supabase/migrations/20260812160246_restrict_bt_schedule_to_linked_therapist.sql
+++ b/supabase/migrations/20260812160246_restrict_bt_schedule_to_linked_therapist.sql
@@ -1,0 +1,213 @@
+-- @migration-intent: Restrict BT and legacy therapist scheduling RPC rows to the caller's linked therapist identity while preserving assigned-client clinical session reads.
+-- @migration-dependencies: 20260810171520_restrict_bt_schedule_to_assigned_clients.sql, 20260810190000_enforce_sessions_schedule_read_scope.sql.
+-- @migration-rollback: Restore get_sessions_optimized and get_schedule_data_batch from 20260810171520_restrict_bt_schedule_to_assigned_clients.sql; then DROP FUNCTION app.current_user_can_read_schedule_session(uuid, uuid, uuid).
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION app.current_user_can_read_schedule_session(
+  target_organization_id uuid,
+  target_client_id uuid,
+  target_therapist_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, auth
+AS $$
+  SELECT
+    app.current_user_can_read_full_schedule(target_organization_id)
+    OR (
+      app.current_user_has_exact_role_for_org(
+        target_organization_id,
+        ARRAY['bt', 'therapist']::text[]
+      )
+      AND app.current_user_has_active_schedule_client(
+        target_organization_id,
+        target_client_id
+      )
+      AND target_therapist_id IS NOT DISTINCT FROM app.current_therapist_id()
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_sessions_optimized(
+  p_start_date timestamptz,
+  p_end_date timestamptz,
+  p_therapist_id uuid DEFAULT NULL,
+  p_client_id uuid DEFAULT NULL
+)
+RETURNS TABLE (session_data jsonb)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_org uuid := app.current_user_organization_id();
+BEGIN
+  IF v_org IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Organization context is required';
+  END IF;
+
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'id', s.id,
+    'start_time', s.start_time,
+    'end_time', s.end_time,
+    'status', s.status,
+    'notes', s.notes,
+    'created_at', s.created_at,
+    'created_by', s.created_by,
+    'updated_at', s.updated_at,
+    'updated_by', s.updated_by,
+    'therapist_id', s.therapist_id,
+    'client_id', s.client_id,
+    'program_id', s.program_id,
+    'goal_id', s.goal_id,
+    'started_at', s.started_at,
+    'duration_minutes', s.duration_minutes,
+    'location_type', s.location_type,
+    'session_type', s.session_type,
+    'rate_per_hour', s.rate_per_hour,
+    'total_cost', s.total_cost,
+    'therapist', jsonb_build_object(
+      'id', t.id,
+      'full_name', t.full_name,
+      'email', t.email,
+      'service_type', t.service_type
+    ),
+    'client', jsonb_build_object(
+      'id', c.id,
+      'full_name', c.full_name,
+      'email', c.email,
+      'service_preference', c.service_preference
+    )
+  ) AS session_data
+  FROM public.sessions s
+  JOIN public.therapists t
+    ON s.therapist_id = t.id
+   AND t.organization_id = v_org
+  JOIN public.clients c
+    ON s.client_id = c.id
+   AND c.organization_id = v_org
+  WHERE s.organization_id = v_org
+    AND s.start_time >= p_start_date
+    AND s.start_time <= p_end_date
+    AND (p_therapist_id IS NULL OR s.therapist_id = p_therapist_id)
+    AND (p_client_id IS NULL OR s.client_id = p_client_id)
+    AND app.current_user_can_read_schedule_session(v_org, s.client_id, s.therapist_id)
+  ORDER BY s.start_time;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_schedule_data_batch(
+  p_start_date timestamptz,
+  p_end_date timestamptz
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_org uuid := app.current_user_organization_id();
+  v_sessions jsonb := '[]'::jsonb;
+  v_therapists jsonb := '[]'::jsonb;
+  v_clients jsonb := '[]'::jsonb;
+BEGIN
+  IF v_org IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Organization context is required';
+  END IF;
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', s.id,
+      'start_time', s.start_time,
+      'end_time', s.end_time,
+      'status', s.status,
+      'notes', s.notes,
+      'created_at', s.created_at,
+      'created_by', s.created_by,
+      'updated_at', s.updated_at,
+      'updated_by', s.updated_by,
+      'therapist_id', s.therapist_id,
+      'client_id', s.client_id,
+      'program_id', s.program_id,
+      'goal_id', s.goal_id,
+      'started_at', s.started_at,
+      'duration_minutes', s.duration_minutes,
+      'location_type', s.location_type,
+      'session_type', s.session_type,
+      'rate_per_hour', s.rate_per_hour,
+      'total_cost', s.total_cost,
+      'therapist', jsonb_build_object('id', t.id, 'full_name', t.full_name),
+      'client', jsonb_build_object('id', c.id, 'full_name', c.full_name)
+    )
+    ORDER BY s.start_time
+  )
+  INTO v_sessions
+  FROM public.sessions s
+  JOIN public.therapists t
+    ON s.therapist_id = t.id
+   AND t.organization_id = v_org
+  JOIN public.clients c
+    ON s.client_id = c.id
+   AND c.organization_id = v_org
+  WHERE s.organization_id = v_org
+    AND s.start_time >= p_start_date
+    AND s.start_time <= p_end_date
+    AND app.current_user_can_read_schedule_session(v_org, s.client_id, s.therapist_id);
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', t.id,
+      'full_name', t.full_name,
+      'email', t.email,
+      'service_type', t.service_type,
+      'availability_hours', t.availability_hours
+    )
+    ORDER BY t.full_name
+  )
+  INTO v_therapists
+  FROM public.therapists t
+  WHERE t.status = 'active'
+    AND t.organization_id = v_org
+    AND (
+      app.current_user_can_read_full_schedule(v_org)
+      OR t.id = app.current_therapist_id()
+    );
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', c.id,
+      'full_name', c.full_name,
+      'email', c.email,
+      'service_preference', c.service_preference,
+      'availability_hours', c.availability_hours
+    )
+    ORDER BY c.full_name
+  )
+  INTO v_clients
+  FROM public.clients c
+  WHERE c.organization_id = v_org
+    AND c.deleted_at IS NULL
+    AND app.current_user_can_read_schedule_client(v_org, c.id);
+
+  RETURN jsonb_build_object(
+    'sessions', COALESCE(v_sessions, '[]'::jsonb),
+    'therapists', COALESCE(v_therapists, '[]'::jsonb),
+    'clients', COALESCE(v_clients, '[]'::jsonb)
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION app.current_user_can_read_schedule_session(uuid, uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION app.current_user_can_read_schedule_session(uuid, uuid, uuid) TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.get_sessions_optimized(timestamptz, timestamptz, uuid, uuid) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_schedule_data_batch(timestamptz, timestamptz) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_sessions_optimized(timestamptz, timestamptz, uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_schedule_data_batch(timestamptz, timestamptz) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260812170000_restrict_schedule_deep_link_to_linked_therapist.sql
+++ b/supabase/migrations/20260812170000_restrict_schedule_deep_link_to_linked_therapist.sql
@@ -1,0 +1,44 @@
+-- @migration-intent: Keep Schedule edit deep links inside the same therapist-owned read boundary as schedule batch RPCs.
+-- @migration-dependencies: 20260812160246_restrict_bt_schedule_to_linked_therapist.sql.
+-- @migration-rollback: DROP FUNCTION public.get_schedule_session_by_id(uuid).
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_schedule_session_by_id(p_session_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_org uuid := app.current_user_organization_id();
+  v_session jsonb;
+BEGIN
+  IF v_org IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Organization context is required';
+  END IF;
+
+  SELECT to_jsonb(s)
+  INTO v_session
+  FROM public.sessions s
+  JOIN public.therapists t
+    ON t.id = s.therapist_id
+   AND t.organization_id = v_org
+  JOIN public.clients c
+    ON c.id = s.client_id
+   AND c.organization_id = v_org
+  WHERE s.id = p_session_id
+    AND s.organization_id = v_org
+    AND app.current_user_can_read_schedule_session(v_org, s.client_id, s.therapist_id);
+
+  RETURN v_session;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_schedule_session_by_id(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_schedule_session_by_id(uuid) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/tests/bt-schedule-therapist-owner-scope-migration.test.ts
+++ b/tests/bt-schedule-therapist-owner-scope-migration.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const migrationPath = path.join(
+  process.cwd(),
+  "supabase",
+  "migrations",
+  "20260812160246_restrict_bt_schedule_to_linked_therapist.sql",
+);
+const smokePath = path.join(
+  process.cwd(),
+  "tests",
+  "sql",
+  "employee_role_capability_smoke.sql",
+);
+
+const sql = readFileSync(migrationPath, "utf8");
+const smokeSql = readFileSync(smokePath, "utf8");
+
+const extractFunction = (name: string): string => {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `create or replace function ${escapedName}\\([\\s\\S]*?\\n\\$\\$;`,
+    "i",
+  );
+  const match = sql.match(pattern);
+  expect(match, `${name} function should exist`).not.toBeNull();
+  return match?.[0] ?? "";
+};
+
+describe("BT schedule therapist-owner scope migration", () => {
+  it("requires scoped schedule rows to match the caller therapist identity", () => {
+    const helper = extractFunction("app.current_user_can_read_schedule_session");
+    const normalizedHelper = helper.replace(/\s+/g, " ");
+
+    expect(normalizedHelper).toContain(
+      "app.current_user_can_read_full_schedule(target_organization_id)",
+    );
+    expect(normalizedHelper).toContain("ARRAY['bt', 'therapist']::text[]");
+    expect(normalizedHelper).toContain(
+      "app.current_user_has_active_schedule_client( target_organization_id, target_client_id )",
+    );
+    expect(normalizedHelper).toContain(
+      "target_therapist_id IS NOT DISTINCT FROM app.current_therapist_id()",
+    );
+  });
+
+  it.each([
+    "public.get_sessions_optimized",
+    "public.get_schedule_data_batch",
+  ])("scopes %s by client and therapist ownership", (name) => {
+    const functionSql = extractFunction(name);
+
+    expect(functionSql).toContain(
+      "app.current_user_can_read_schedule_session(v_org, s.client_id, s.therapist_id)",
+    );
+    expect(functionSql).not.toContain(
+      "app.current_user_can_read_schedule_client(v_org, s.client_id)",
+    );
+  });
+
+  it("preserves direct assigned-client session RLS for clinical reads", () => {
+    expect(sql).not.toContain("CREATE POLICY org_read_sessions");
+    expect(sql).not.toContain("CREATE POLICY sessions_schedule_read_scope");
+    expect(sql).not.toContain("DROP POLICY");
+  });
+
+  it("restricts helper and scheduling RPC execution", () => {
+    expect(sql).toContain(
+      "REVOKE EXECUTE ON FUNCTION app.current_user_can_read_schedule_session(uuid, uuid, uuid) FROM PUBLIC, anon;",
+    );
+    expect(sql).toContain(
+      "GRANT EXECUTE ON FUNCTION app.current_user_can_read_schedule_session(uuid, uuid, uuid) TO authenticated, service_role;",
+    );
+    expect(sql).toContain(
+      "REVOKE EXECUTE ON FUNCTION public.get_sessions_optimized(timestamptz, timestamptz, uuid, uuid) FROM PUBLIC, anon;",
+    );
+    expect(sql).toContain(
+      "REVOKE EXECUTE ON FUNCTION public.get_schedule_data_batch(timestamptz, timestamptz) FROM PUBLIC, anon;",
+    );
+  });
+
+  it("adds synthetic matching and foreign therapist probes", () => {
+    expect(smokeSql).toContain("bt_schedule_matching_therapist_allowed");
+    expect(smokeSql).toContain("bt_schedule_foreign_therapist_denied");
+    expect(smokeSql).toContain("therapist_schedule_matching_therapist_allowed");
+    expect(smokeSql).toContain("therapist_schedule_foreign_therapist_denied");
+    expect(smokeSql).toContain("admin_schedule_full_schedule_session_allowed");
+    expect(smokeSql).toContain("admin_schedule_full_schedule_rpc_rows_preserved");
+    expect(smokeSql).toContain("00000000-0000-4000-8000-000000000507");
+  });
+
+  it("documents a bounded rollback", () => {
+    expect(sql).toContain(
+      "DROP FUNCTION app.current_user_can_read_schedule_session(uuid, uuid, uuid)",
+    );
+  });
+});

--- a/tests/bt-schedule-therapist-owner-scope-migration.test.ts
+++ b/tests/bt-schedule-therapist-owner-scope-migration.test.ts
@@ -10,6 +10,13 @@ const migrationPath = path.join(
   "migrations",
   "20260812160246_restrict_bt_schedule_to_linked_therapist.sql",
 );
+const deepLinkMigrationPath = path.join(
+  process.cwd(),
+  "supabase",
+  "migrations",
+  "20260812170000_restrict_schedule_deep_link_to_linked_therapist.sql",
+);
+const schedulePagePath = path.join(process.cwd(), "src", "pages", "Schedule.tsx");
 const smokePath = path.join(
   process.cwd(),
   "tests",
@@ -18,6 +25,8 @@ const smokePath = path.join(
 );
 
 const sql = readFileSync(migrationPath, "utf8");
+const deepLinkSql = readFileSync(deepLinkMigrationPath, "utf8");
+const schedulePage = readFileSync(schedulePagePath, "utf8");
 const smokeSql = readFileSync(smokePath, "utf8");
 
 const extractFunction = (name: string): string => {
@@ -97,5 +106,21 @@ describe("BT schedule therapist-owner scope migration", () => {
     expect(sql).toContain(
       "DROP FUNCTION app.current_user_can_read_schedule_session(uuid, uuid, uuid)",
     );
+  });
+
+  it("routes schedule deep-link lookups through the therapist-owned predicate", () => {
+    expect(deepLinkSql).toContain(
+      "CREATE OR REPLACE FUNCTION public.get_schedule_session_by_id(p_session_id uuid)",
+    );
+    expect(deepLinkSql).toContain(
+      "app.current_user_can_read_schedule_session(v_org, s.client_id, s.therapist_id)",
+    );
+    expect(deepLinkSql).toContain(
+      "REVOKE EXECUTE ON FUNCTION public.get_schedule_session_by_id(uuid) FROM PUBLIC, anon;",
+    );
+    expect(schedulePage).toContain('.rpc("get_schedule_session_by_id"');
+    expect(schedulePage).not.toContain('.from("sessions")\n        .select("*")');
+    expect(smokeSql).toContain("therapist_schedule_deep_link_scope");
+    expect(smokeSql).toContain("bt_schedule_deep_link_scope");
   });
 });

--- a/tests/sql/employee_role_capability_smoke.sql
+++ b/tests/sql/employee_role_capability_smoke.sql
@@ -45,7 +45,8 @@ begin
     '00000000-0000-4000-8000-000000000503',
     '00000000-0000-4000-8000-000000000504',
     '00000000-0000-4000-8000-000000000505',
-    '00000000-0000-4000-8000-000000000506'
+    '00000000-0000-4000-8000-000000000506',
+    '00000000-0000-4000-8000-000000000507'
   );
 
   delete from public.authorization_services
@@ -246,6 +247,7 @@ begin
   insert into public.sessions (id, client_id, therapist_id, start_time, end_time, status, has_transcription_consent, organization_id, created_by, updated_by, session_date, program_id, goal_id)
   values
     ('00000000-0000-4000-8000-000000000501', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000013', now() + interval '7 days', now() + interval '7 days 1 hour', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 7, '00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000301'),
+    ('00000000-0000-4000-8000-000000000507', '00000000-0000-4000-8000-000000000101', '00000000-0000-4000-8000-000000000015', now() + interval '7 days 15 minutes', now() + interval '7 days 1 hour 15 minutes', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 7, '00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000301'),
     ('00000000-0000-4000-8000-000000000502', '00000000-0000-4000-8000-000000000102', '00000000-0000-4000-8000-000000000021', now() + interval '8 days', now() + interval '8 days 1 hour', 'scheduled', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 8, '00000000-0000-4000-8000-000000000202', '00000000-0000-4000-8000-000000000302'),
     ('00000000-0000-4000-8000-000000000506', '00000000-0000-4000-8000-000000000107', '00000000-0000-4000-8000-000000000013', now() + interval '12 days', now() + interval '12 days 1 hour', 'completed', false, '00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000011', current_date + 12, null, null);
 
@@ -273,6 +275,10 @@ select set_config('request.jwt.claim.role', 'authenticated', true);
 
 select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-000000000011', true);
 do $admin_schedule$
+declare
+  optimized_count int;
+  batch_shared_client_count int;
+  batch_data jsonb;
 begin
   insert into role_smoke_results
   values (
@@ -285,6 +291,40 @@ begin
       || ', authz=' || app.current_user_can_manage_authorizations('00000000-0000-4000-8000-000000000001')
       || ', schedule=' || app.current_user_can_manage_schedule('00000000-0000-4000-8000-000000000001')
       || ', programs=' || app.current_user_can_manage_programs_goals('00000000-0000-4000-8000-000000000001'),
+    current_user
+  );
+
+  insert into role_smoke_results
+  values (
+    'admin_schedule_full_schedule_session_allowed',
+    app.current_user_can_read_schedule_session(
+      '00000000-0000-4000-8000-000000000001',
+      '00000000-0000-4000-8000-000000000101',
+      '00000000-0000-4000-8000-000000000015'
+    ),
+    'full schedule role accepted another therapist session',
+    current_user
+  );
+
+  select count(*)
+  into optimized_count
+  from public.get_sessions_optimized(
+    now(),
+    now() + interval '30 days',
+    null,
+    '00000000-0000-4000-8000-000000000101'
+  );
+  batch_data := public.get_schedule_data_batch(now(), now() + interval '30 days');
+  select count(*)
+  into batch_shared_client_count
+  from jsonb_array_elements(batch_data->'sessions') session_row
+  where session_row->>'client_id' = '00000000-0000-4000-8000-000000000101';
+  insert into role_smoke_results
+  values (
+    'admin_schedule_full_schedule_rpc_rows_preserved',
+    optimized_count = 2 and batch_shared_client_count = 2,
+    'optimized_shared_client=' || optimized_count
+      || ', batch_shared_client=' || batch_shared_client_count,
     current_user
   );
 
@@ -417,10 +457,35 @@ declare
   unassigned_note_count int;
   cross_org_note_count int;
   optimized_count int;
+  optimized_therapist_id text;
   affected_rows int;
   batch_data jsonb;
   dropdown_data jsonb;
 begin
+  insert into role_smoke_results
+  values (
+    'therapist_schedule_matching_therapist_allowed',
+    app.current_user_can_read_schedule_session(
+      '00000000-0000-4000-8000-000000000001',
+      '00000000-0000-4000-8000-000000000101',
+      '00000000-0000-4000-8000-000000000015'
+    ),
+    'legacy therapist accepted its own session for a shared client',
+    current_user
+  );
+
+  insert into role_smoke_results
+  values (
+    'therapist_schedule_foreign_therapist_denied',
+    not app.current_user_can_read_schedule_session(
+      '00000000-0000-4000-8000-000000000001',
+      '00000000-0000-4000-8000-000000000101',
+      '00000000-0000-4000-8000-000000000013'
+    ),
+    'legacy therapist rejected another therapist session for a shared client',
+    current_user
+  );
+
   insert into role_smoke_results
   values (
     'therapist_helpers',
@@ -471,8 +536,8 @@ begin
     insert into role_smoke_results values ('therapist_program_note_write_denied', sqlstate = '42501', sqlstate || ': ' || sqlerrm, current_user);
   end;
 
-  select count(*)
-  into optimized_count
+  select count(*), min(session_data->>'therapist_id')
+  into optimized_count, optimized_therapist_id
   from public.get_sessions_optimized(now(), now() + interval '30 days');
   batch_data := public.get_schedule_data_batch(now(), now() + interval '30 days');
   dropdown_data := public.get_dropdown_data();
@@ -483,13 +548,16 @@ begin
     app.current_user_has_active_schedule_client('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000101')
       and not app.current_user_has_active_schedule_client('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000102')
       and optimized_count = 1
+      and optimized_therapist_id = '00000000-0000-4000-8000-000000000015'
       and jsonb_array_length(batch_data->'sessions') = 1
+      and batch_data->'sessions'->0->>'therapist_id' = '00000000-0000-4000-8000-000000000015'
       and jsonb_array_length(batch_data->'clients') = 1
       and batch_data->'clients'->0->>'id' = '00000000-0000-4000-8000-000000000101'
       and jsonb_array_length(dropdown_data->'clients') = 1
       and dropdown_data->'clients'->0->>'id' = '00000000-0000-4000-8000-000000000101'
       and jsonb_array_length(dropdown_data->'locations') = 0,
     'optimized=' || optimized_count
+      || ', optimized_therapist=' || optimized_therapist_id
       || ', batch_sessions=' || jsonb_array_length(batch_data->'sessions')
       || ', batch_clients=' || jsonb_array_length(batch_data->'clients')
       || ', dropdown_clients=' || jsonb_array_length(dropdown_data->'clients'),
@@ -530,9 +598,33 @@ declare
   cross_org_count int;
   historical_count int;
   optimized_count int;
+  optimized_therapist_id text;
   batch_data jsonb;
   dropdown_data jsonb;
 begin
+  insert into role_smoke_results
+  values (
+    'bt_schedule_matching_therapist_allowed',
+    app.current_user_can_read_schedule_session(
+      '00000000-0000-4000-8000-000000000001',
+      '00000000-0000-4000-8000-000000000101',
+      '00000000-0000-4000-8000-000000000013'
+    ),
+    'BT accepted its own session for an assigned client',
+    current_user
+  );
+  insert into role_smoke_results
+  values (
+    'bt_schedule_foreign_therapist_denied',
+    not app.current_user_can_read_schedule_session(
+      '00000000-0000-4000-8000-000000000001',
+      '00000000-0000-4000-8000-000000000101',
+      '00000000-0000-4000-8000-000000000015'
+    ),
+    'BT rejected another therapist session for an assigned client',
+    current_user
+  );
+
   insert into role_smoke_results
   values (
     'bt_helpers',
@@ -583,8 +675,8 @@ begin
   select count(*) into assigned_count from public.sessions where client_id = '00000000-0000-4000-8000-000000000101';
   select count(*) into unassigned_count from public.sessions where client_id = '00000000-0000-4000-8000-000000000102';
   select count(*) into historical_count from public.sessions where client_id = '00000000-0000-4000-8000-000000000107';
-  select count(*)
-  into optimized_count
+  select count(*), min(session_data->>'therapist_id')
+  into optimized_count, optimized_therapist_id
   from public.get_sessions_optimized(now(), now() + interval '30 days');
   batch_data := public.get_schedule_data_batch(now(), now() + interval '30 days');
   dropdown_data := public.get_dropdown_data();
@@ -592,11 +684,13 @@ begin
   insert into role_smoke_results
   values (
     'bt_schedule_rpc_client_scope',
-    assigned_count = 1
+    assigned_count = 2
       and unassigned_count = 0
       and historical_count = 0
       and optimized_count = 1
+      and optimized_therapist_id = '00000000-0000-4000-8000-000000000013'
       and jsonb_array_length(batch_data->'sessions') = 1
+      and batch_data->'sessions'->0->>'therapist_id' = '00000000-0000-4000-8000-000000000013'
       and jsonb_array_length(batch_data->'clients') = 1
       and batch_data->'clients'->0->>'id' = '00000000-0000-4000-8000-000000000101'
       and batch_data->'clients'->0 ? 'availability_hours'
@@ -611,6 +705,7 @@ begin
       || ', direct_unassigned=' || unassigned_count
       || ', direct_historical=' || historical_count
       || ', optimized=' || optimized_count
+      || ', optimized_therapist=' || optimized_therapist_id
       || ', batch_sessions=' || jsonb_array_length(batch_data->'sessions')
       || ', batch_clients=' || jsonb_array_length(batch_data->'clients')
       || ', dropdown_clients=' || jsonb_array_length(dropdown_data->'clients')
@@ -773,7 +868,8 @@ begin
     '00000000-0000-4000-8000-000000000503',
     '00000000-0000-4000-8000-000000000504',
     '00000000-0000-4000-8000-000000000505',
-    '00000000-0000-4000-8000-000000000506'
+    '00000000-0000-4000-8000-000000000506',
+    '00000000-0000-4000-8000-000000000507'
   );
 
   delete from public.authorization_services
@@ -877,7 +973,7 @@ from (
   union all select id from public.programs where id in ('00000000-0000-4000-8000-000000000201', '00000000-0000-4000-8000-000000000202', '00000000-0000-4000-8000-000000000203', '00000000-0000-4000-8000-000000000204', '00000000-0000-4000-8000-000000000205')
   union all select id from public.program_notes where id in ('00000000-0000-4000-8000-000000000801', '00000000-0000-4000-8000-000000000802', '00000000-0000-4000-8000-000000000803', '00000000-0000-4000-8000-000000000804')
   union all select id from public.goals where id in ('00000000-0000-4000-8000-000000000301', '00000000-0000-4000-8000-000000000302', '00000000-0000-4000-8000-000000000303', '00000000-0000-4000-8000-000000000304')
-  union all select id from public.sessions where id in ('00000000-0000-4000-8000-000000000501', '00000000-0000-4000-8000-000000000502', '00000000-0000-4000-8000-000000000503', '00000000-0000-4000-8000-000000000504', '00000000-0000-4000-8000-000000000505', '00000000-0000-4000-8000-000000000506')
+  union all select id from public.sessions where id in ('00000000-0000-4000-8000-000000000501', '00000000-0000-4000-8000-000000000502', '00000000-0000-4000-8000-000000000503', '00000000-0000-4000-8000-000000000504', '00000000-0000-4000-8000-000000000505', '00000000-0000-4000-8000-000000000506', '00000000-0000-4000-8000-000000000507')
   union all select id from public.authorizations where id in ('00000000-0000-4000-8000-000000000401', '00000000-0000-4000-8000-000000000402', '00000000-0000-4000-8000-000000000403', '00000000-0000-4000-8000-000000000404', '00000000-0000-4000-8000-000000000405', '00000000-0000-4000-8000-000000000406')
   union all select id from public.goal_data_points where id in ('00000000-0000-4000-8000-000000000601', '00000000-0000-4000-8000-000000000602')
 ) residue;

--- a/tests/sql/employee_role_capability_smoke.sql
+++ b/tests/sql/employee_role_capability_smoke.sql
@@ -458,6 +458,8 @@ declare
   cross_org_note_count int;
   optimized_count int;
   optimized_therapist_id text;
+  own_deep_link jsonb;
+  foreign_deep_link jsonb;
   affected_rows int;
   batch_data jsonb;
   dropdown_data jsonb;
@@ -483,6 +485,18 @@ begin
       '00000000-0000-4000-8000-000000000013'
     ),
     'legacy therapist rejected another therapist session for a shared client',
+    current_user
+  );
+
+  own_deep_link := public.get_schedule_session_by_id('00000000-0000-4000-8000-000000000507');
+  foreign_deep_link := public.get_schedule_session_by_id('00000000-0000-4000-8000-000000000501');
+  insert into role_smoke_results
+  values (
+    'therapist_schedule_deep_link_scope',
+    own_deep_link->>'id' = '00000000-0000-4000-8000-000000000507'
+      and foreign_deep_link is null,
+    'own=' || coalesce(own_deep_link->>'id', 'null')
+      || ', foreign=' || coalesce(foreign_deep_link->>'id', 'null'),
     current_user
   );
 
@@ -599,6 +613,8 @@ declare
   historical_count int;
   optimized_count int;
   optimized_therapist_id text;
+  own_deep_link jsonb;
+  foreign_deep_link jsonb;
   batch_data jsonb;
   dropdown_data jsonb;
 begin
@@ -622,6 +638,18 @@ begin
       '00000000-0000-4000-8000-000000000015'
     ),
     'BT rejected another therapist session for an assigned client',
+    current_user
+  );
+
+  own_deep_link := public.get_schedule_session_by_id('00000000-0000-4000-8000-000000000501');
+  foreign_deep_link := public.get_schedule_session_by_id('00000000-0000-4000-8000-000000000507');
+  insert into role_smoke_results
+  values (
+    'bt_schedule_deep_link_scope',
+    own_deep_link->>'id' = '00000000-0000-4000-8000-000000000501'
+      and foreign_deep_link is null,
+    'own=' || coalesce(own_deep_link->>'id', 'null')
+      || ', foreign=' || coalesce(foreign_deep_link->>'id', 'null'),
     current_user
   );
 


### PR DESCRIPTION
## Summary
- restrict BT and legacy therapist schedule RPC rows to the caller's linked therapist identity
- preserve full-schedule roles and assigned-client clinical session access
- correct the locked mobile schedule summary so it identifies the scoped therapist
- add synthetic multi-therapist authorization coverage and a critical-lane handoff

## Root cause
The deployed schedule RPCs checked assigned-client scope but did not also match `sessions.therapist_id` to the caller's linked therapist identity. Aggregate hosted inspection found foreign-therapist rows in the reported account's assigned-client result set.

## Verification
- `npm run verify:local` (pass, 418.7s)
- focused migration/UI contracts: 40/40 pass
- strengthened migration contracts: 42/42 pass
- responsive `/schedule` observer: pass at 1440x900 and 390x844
- independent code, security, Supabase, and performance reviews: no remaining in-scope blocker

## Blocked / human review
- `npm run ci:playwright` stopped at credential preflight; no test credentials were available locally
- runtime SQL smoke awaits the isolated Supabase PR preview containing this migration
- direct assigned-client session reads remain the separate clinical capability established by PR #918; this PR narrows Schedule RPC presentation only
- critical-lane human review is required before merge or production migration

Linear: WIN-203