### PR TITLE
WIN-219: Fix BT session link authorization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Validate secrets policy
         run: npm run ci:secrets
@@ -225,7 +225,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Validate tenant isolation
         run: npm run validate:tenant
@@ -251,7 +251,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Check runtime migration parity
         env:
@@ -276,7 +276,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Check start_session_with_goals runtime contract
         env:
@@ -307,7 +307,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Validate session edge deploy prerequisites
         env:
@@ -349,7 +349,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Validate AI agent edge deploy prerequisites
         env:
@@ -381,7 +381,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Lint
         run: npm run lint
@@ -410,7 +410,7 @@ jobs:
           deno-version: 2.8.3
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Install Playwright browser for runtime contracts
         run: ./node_modules/.bin/playwright install chromium
@@ -449,7 +449,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Build canary
         run: npm run build
@@ -493,7 +493,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.browser_scope.outputs.tier0_required == 'true'
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Download dist artifact
         if: steps.browser_scope.outputs.tier0_required == 'true'
@@ -577,7 +577,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.browser_scope.outputs.auth_smoke_required == 'true'
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Provision auth smoke admin
         if: steps.browser_scope.outputs.auth_smoke_required == 'true'
@@ -752,7 +752,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Select Playwright readiness scope
         id: browser_scope
@@ -840,7 +840,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.browser_scope.outputs.iehp_assessment_import_smoke_required == 'true'
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Provision IEHP smoke admin
         if: steps.browser_scope.outputs.iehp_assessment_import_smoke_required == 'true'
@@ -1009,7 +1009,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.optional_gate.outputs.run_optional == 'true'
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
 
       - name: Install Playwright browser
         if: steps.optional_gate.outputs.run_optional == 'true'

--- a/.github/workflows/tenant-safety.yml
+++ b/.github/workflows/tenant-safety.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 20
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci-with-retry.mjs
       - name: Install Playwright browser for runtime contracts
         run: ./node_modules/.bin/playwright install chromium
       - name: Validate tenant isolation

--- a/docs/ai/WIN-219-bt-session-start-workflow-handoff.md
+++ b/docs/ai/WIN-219-bt-session-start-workflow-handoff.md
@@ -194,3 +194,24 @@ The BT Start Session action is restored only for a valid assigned scheduled appo
 - test review: approved; no must-fix coverage gaps remain after the direct-execution integration test
 - CI architecture review: workflow topology and all 14 substitutions remain intact; a truly stalled install remains governed by the existing job timeout and is outside this fast-failure incident scope
 - pr-ready: yes for critical-lane human review after exact-head required CI; merge-ready remains no until human review completes
+
+### Standalone Tenant-Safety Follow-Up
+
+- exact-head run `31647213679` failed in the standalone `.github/workflows/tenant-safety.yml` before tenant validation, lint, typecheck, or tests ran; its raw `npm ci` hit the same Supabase CLI release `ECONNRESET` / socket hang-up
+- fresh route: `classification: high-risk human-reviewed`, `lane: critical`
+- bounded change: route that workflow's single dependency-install step through the existing retry wrapper and assert the binding in the focused test; retry behavior, tenant checks, secrets, triggers, and all other workflows remain unchanged
+- TDD red: the new standalone-workflow assertion failed on the raw `npm ci` line while the original five tests passed
+- required verification: focused retry/workflow test, direct workflow/policy validation, lint, typecheck, build, exact-head standalone tenant-safety CI, and human review
+- executed verification:
+  - focused retry/workflow test: pass (`6/6`)
+  - `npm run ci:check-focused`: pass; connection-backed checks skipped because no database URL was configured
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+- blocked verification:
+  - `npm run test:ci`: not repeated for the one-line workflow binding; the preceding run was nonzero under aggregate UI contention, and its named failures passed `123/123` in isolation
+  - `npm run verify:local`: not repeated because it includes the same aggregate full-suite condition; required policy, lint, typecheck, focused tests, and build ran directly
+- verify-change result: `pass-with-blocked-checks`; exact-head standalone tenant-safety CI remains required
+- PR hygiene: `pr-ready: yes`, `lane: critical`, branch/Linear/single-purpose/reviewer requirements satisfied; human review remains required before merge
+- delegated review: code review found no workflow correctness defect after this evidence update; test review approved the binding coverage; security review approved unchanged secret handling and fail-closed behavior
+- residual risk: other workflows with raw installs remain outside this incident scope; a failure after all three attempts remains a hard failure

--- a/docs/ai/WIN-219-bt-session-start-workflow-handoff.md
+++ b/docs/ai/WIN-219-bt-session-start-workflow-handoff.md
@@ -149,3 +149,48 @@ The BT Start Session action is restored only for a valid assigned scheduled appo
 - generated artifact drift: none
 - protected-path drift: limited to the two declared `src/server/**` handlers
 - pr-ready: yes for critical-lane human review; exact-head CI must resolve the blocked checks before merge
+
+## CI Install Reliability Follow-Up (2026-08-12)
+
+### Routing And Scope
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- triggering paths: `.github/workflows/ci.yml` and `scripts/ci/npm-ci-with-retry.mjs`
+- allowed files: the main CI workflow, the retry wrapper, its focused test, and this WIN-219 handoff
+- non-goals: no application, auth, Supabase runtime, migration, dependency, lockfile, runner-image, cache, or other workflow changes
+- stop condition: any fix requiring package-manager policy changes or files outside the declared four-file boundary must be re-routed
+
+### Incident And Change
+
+- Required PR jobs repeatedly failed before their checks ran because the Supabase CLI postinstall could not reliably download its GitHub release checksum/archive. Observed failures included `ECONNRESET`, `503 Service Unavailable`, and a corrupt partial archive.
+- All 14 dependency-install steps in the main CI workflow now call one repository-owned wrapper instead of raw `npm ci`.
+- The wrapper performs at most three attempts, waits 10 seconds and then 20 seconds between failures, and preserves the final nonzero exit. It uses the Windows system shell only for the fixed literal `npm ci` command required by the npm command shim; it does not accept command input, skip checks, use `continue-on-error`, change credentials, or alter install arguments.
+- Other workflows remain unchanged; this slice only hardens the required PR workflow where the failures were observed.
+
+### Verification Card
+
+- required checks: focused retry/workflow tests, direct workflow validation, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run build`, and `npm run verify:local` when local prerequisites allow it
+- TDD red: focused test failed because `scripts/ci/npm-ci-with-retry.mjs` did not exist
+- executed checks:
+  - focused retry/workflow test: pass (`5/5`), including real direct execution against a synthetic dependency-free package on Windows
+  - workflow binding: pass (14 guarded installs; zero raw `npm ci` steps)
+  - `npm run ci:check-focused`: pass; connection-backed checks skipped because no database URL was configured
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+  - isolated rerun of the full-suite failures: pass (`123/123` across `ProgramsGoalsTab` and `TherapistOnboarding`)
+- blocked checks:
+  - `npm run test:ci`: nonzero under full local parallel load due UI lookup/timeouts and two Vitest worker `onTaskUpdate` timeouts; the named failing files pass in isolation and the new CI retry test passes independently
+  - `npm run verify:local`: not repeated because it includes the same nonzero full-suite command; its policy, lint, typecheck, focused-test, and build components were executed directly
+- result: `pass-with-blocked-checks`; exact-head GitHub CI is the authoritative runner verification for this workflow-only follow-up
+- residual risk: an upstream outage lasting beyond the bounded retry window still fails closed; human review and exact-head required CI remain mandatory
+
+### Delegated Review And PR Hygiene
+
+- implementation review: approved after replacing the Windows `npm.cmd` launch that reproduced `spawn EINVAL`; the direct-execution regression test now covers the fixed path
+- code review: approved with no remaining findings
+- security review: approved; the Windows shell receives only the fixed literal `npm ci` command, and failure/secret behavior remains fail-closed and unchanged
+- test review: approved; no must-fix coverage gaps remain after the direct-execution integration test
+- CI architecture review: workflow topology and all 14 substitutions remain intact; a truly stalled install remains governed by the existing job timeout and is outside this fast-failure incident scope
+- pr-ready: yes for critical-lane human review after exact-head required CI; merge-ready remains no until human review completes

--- a/docs/ai/WIN-219-bt-session-start-workflow-handoff.md
+++ b/docs/ai/WIN-219-bt-session-start-workflow-handoff.md
@@ -93,3 +93,59 @@
 ## Handoff Summary
 
 The BT Start Session action is restored only for a valid assigned scheduled appointment and remains incapable of editing scheduling or treatment-plan metadata. Scheduled edits now replace stale goal links atomically, while legitimate multi-program goal sets remain canonical and exact at BT start. Local focused, policy, tenant, build, coverage, route, migration, and behavioral SQL checks pass; fresh protected CI and human review are the remaining merge gates.
+
+## Caller-Scoped Link Follow-Up (2026-08-12)
+
+### Routing And Scope
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- issue: [WIN-219](https://linear.app/winningedgeai/issue/WIN-219/restore-start-session-for-scheduled-bt-appointments)
+- branch: `codex/bt-session-link-auth-fix`
+- task intent: stop the app-side session start and completion fallback handlers from preferring a rejected Netlify service credential over the authenticated BT's RLS-scoped therapist-link read
+- production files: `src/server/api/sessions-start.ts`, `src/server/api/sessions-complete.ts`
+- test files: `src/server/__tests__/sessionsStartHandler.test.ts`, `src/server/__tests__/sessionsCompleteHandler.test.ts`
+- non-goals: no edge-function, migration, RLS, role-resolution, session-lifecycle, UI, or credential changes
+- stop condition: any required change outside the two app-side handlers and their focused tests must be re-routed
+
+### Change Summary
+
+- The live Netlify failure executed the app-side legacy start handler: its authenticated org/session reads succeeded, its exact `user_therapist_links` REST read returned `401`, and the Supabase `sessions-start` edge function was not invoked.
+- Both app-side therapist-link checks now use the authenticated caller headers. The user ID remains token-derived, and the therapist ID remains derived from the already org-scoped session row.
+- A successful lookup with no matching row remains a true `403 Forbidden` authorization denial.
+- Any non-OK therapist-link lookup is now reported as `502 upstream_error` instead of being flattened into a false `403`.
+- The change removes the completion fallback's now-unused Netlify service-role header builder and does not alter the Supabase edge authority paths.
+
+### Verification Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- change type: server/API, authz, tenant-scoped session lifecycle
+- required checks: focused handler tests, edge/RLS contract tests, `npm run ci:check-focused`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, `npm run ci:verify-coverage`, `npm run build`, `npm run validate:tenant`, `npm run test:routes:tier0`, `npm run ci:playwright`
+- executed checks:
+  - focused handler tests: pass (`46/46`)
+  - edge/session/RLS contracts: pass (`41/41`)
+  - `npm run ci:check-focused`: pass; connection-backed checks skipped because no database URL was configured
+  - `npm run lint`: pass
+  - `npm run typecheck`: pass
+  - `npm run build`: pass
+  - `npm run validate:tenant`: pass
+  - `npm run ci:verify-coverage`: pass (`92.81%` line coverage; required `86%`)
+  - `npm run test:routes:tier0`: pass (`220/220`)
+  - `npm run test:ci`: all assertions executed successfully (`4229` passed, `5` skipped), but the command exited nonzero after Vitest reported one worker `onTaskUpdate` timeout; an initial run also exceeded the default Node heap
+- blocked checks:
+  - `npm run ci:playwright`: blocked at preflight because local admin/superadmin smoke credentials are unavailable; no hosted mutation ran
+  - `npm run verify:local`: not separately repeatable as a pass because it includes the same nonzero `test:ci` runner condition and credential-independent subset already executed individually
+- result: `pass-with-blocked-checks`; exact-head CI must resolve the Vitest runner result and execute the protected Playwright gate
+- residual risk: hosted behavior still depends on the self-read migration being applied and requires a real linked-BT start/complete smoke after deployment
+
+### Delegated Review And PR Hygiene
+
+- specification, architecture, and implementation engineering: completed for the bounded two-handler slice
+- code review: approved the handler parity and fail-closed response contract after reconciling the live Netlify legacy-path trace; edge-function expansion remains outside this incident scope
+- security review: approved; caller and therapist identities remain server-derived, tenant scoping remains before link lookup, and service-key exposure is reduced
+- test review: approved the focused `403`, caller-header, and `401`/`503` to `502` coverage; exact-head CI must resolve the full-suite runner timeout
+- single-purpose diff: yes
+- generated artifact drift: none
+- protected-path drift: limited to the two declared `src/server/**` handlers
+- pr-ready: yes for critical-lane human review; exact-head CI must resolve the blocked checks before merge

--- a/scripts/ci/npm-ci-with-retry.mjs
+++ b/scripts/ci/npm-ci-with-retry.mjs
@@ -1,0 +1,62 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 10_000;
+const defaultWait = (delayMs) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+
+const defaultRunAttempt = () =>
+  new Promise((resolve, reject) => {
+    const child = spawn("npm", ["ci"], {
+      stdio: "inherit",
+      // Windows command shims require the system shell; the command and arguments are fixed.
+      shell: process.platform === "win32",
+    });
+
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      resolve(code ?? 1);
+    });
+  });
+
+export async function runNpmCiWithRetry({
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  baseDelayMs = DEFAULT_BASE_DELAY_MS,
+  runAttempt = defaultRunAttempt,
+  wait = defaultWait,
+} = {}) {
+  let lastExitCode = 0;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    lastExitCode = await runAttempt();
+    if (lastExitCode === 0) {
+      return;
+    }
+
+    if (attempt < maxAttempts) {
+      await wait(baseDelayMs * attempt);
+    }
+  }
+
+  const error = new Error(`npm ci failed after ${maxAttempts} attempts (last exit code ${lastExitCode})`);
+  error.exitCode = lastExitCode;
+  throw error;
+}
+
+const isDirectExecution = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isDirectExecution) {
+  runNpmCiWithRetry().catch((error) => {
+    if (error instanceof Error) {
+      console.error(error.message);
+      process.exitCode = Number.isInteger(error.exitCode) && error.exitCode > 0 ? error.exitCode : 1;
+      return;
+    }
+
+    console.error(String(error));
+    process.exitCode = 1;
+  });
+}

--- a/src/server/__tests__/sessionsCompleteHandler.test.ts
+++ b/src/server/__tests__/sessionsCompleteHandler.test.ts
@@ -475,7 +475,7 @@ describe("sessionsCompleteHandler", () => {
     }));
   });
 
-  it("runtime REST fallback allows linked therapist users to complete sessions assigned to their therapist row id", async () => {
+  it("runtime REST fallback uses caller-scoped headers for linked therapist completion", async () => {
     vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-key");
     const fetchMock = makeFallbackFetchMock({
       roleName: "no-grant",
@@ -503,12 +503,40 @@ describe("sessionsCompleteHandler", () => {
     expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/rest/v1/user_therapist_links"))).toBe(true);
     const linkCall = fetchMock.mock.calls.find(([input]) => String(input).includes("/rest/v1/user_therapist_links"));
     expect(linkCall?.[1]?.headers).toEqual(expect.objectContaining({
-      apikey: "service-key",
-      Authorization: "Bearer service-key",
+      apikey: "anon-key",
+      Authorization: "Bearer token-123",
     }));
     expect(getFetchBody(fetchMock, "/rest/v1/rpc/record_session_audit")).toEqual(expect.objectContaining({
       p_actor_id: "auth-user-1",
     }));
+  });
+
+  it.each([401, 503])("runtime REST fallback returns 502 when therapist link lookup fails with %i", async (status) => {
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-key");
+    makeFallbackFetchMock({
+      roleName: "therapist",
+      authUserId: "auth-user-1",
+      session: {
+        id: sessionId,
+        status: "scheduled",
+        therapist_id: "therapist-row-1",
+        goal_id: "goal-primary",
+        start_time: "2026-03-31T09:00:00Z",
+        end_time: "2026-03-31T10:00:00Z",
+      },
+      userTherapistLinksStatus: status,
+    });
+
+    const response = await __TESTING__.completeSessionViaRuntimeRest({
+      request: new Request("http://localhost/api/sessions-complete", { method: "POST" }),
+      payload: { session_id: sessionId, outcome: "completed", notes: null },
+      accessToken: "token-123",
+      traceHeaders: {},
+    });
+    const body = await response.json() as { code: string };
+
+    expect(response.status).toBe(502);
+    expect(body.code).toBe("upstream_error");
   });
 
   it("runtime REST fallback still denies unlinked therapist users", async () => {

--- a/src/server/__tests__/sessionsStartHandler.test.ts
+++ b/src/server/__tests__/sessionsStartHandler.test.ts
@@ -181,7 +181,7 @@ describe("sessionsStartHandler", () => {
     expect(vi.mocked(fetchJson).mock.calls[1]?.[0]).toContain("/user_therapist_links");
   });
 
-  it("allows linked therapist users to start sessions assigned to their therapist row id", async () => {
+  it("uses caller-scoped headers when a linked therapist starts an assigned session", async () => {
     vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-key");
     vi.mocked(getAccessToken).mockReturnValue(createAuthToken("auth-user-1"));
     vi.mocked(fetchAuthenticatedUserIdWithStatus).mockResolvedValue({
@@ -249,13 +249,13 @@ describe("sessionsStartHandler", () => {
       "/user_therapist_links?select=therapist_id&user_id=eq.auth-user-1&therapist_id=eq.therapist-row-1",
     );
     expect(vi.mocked(fetchJson).mock.calls[1]?.[1]?.headers).toEqual(expect.objectContaining({
-      apikey: "service-key",
-      Authorization: "Bearer service-key",
+      apikey: "anon",
+      Authorization: `Bearer ${createAuthToken("auth-user-1")}`,
     }));
     expect(vi.mocked(fetchJson).mock.calls[2]?.[0]).toContain("/rpc/start_session_with_goals");
   });
 
-  it("returns 502 when linked therapist lookup fails upstream", async () => {
+  it.each([401, 503])("returns 502 when linked therapist lookup fails with %i", async (status) => {
     vi.mocked(getAccessToken).mockReturnValue(createAuthToken("auth-user-1"));
     vi.mocked(fetchAuthenticatedUserIdWithStatus).mockResolvedValue({
       userId: "auth-user-1",
@@ -290,7 +290,7 @@ describe("sessionsStartHandler", () => {
       })
       .mockResolvedValueOnce({
         ok: false,
-        status: 503,
+        status,
         data: null,
       });
 
@@ -629,6 +629,7 @@ describe("sessionsStartHandler", () => {
     );
 
     expect(response.status).toBe(404);
+    expect(vi.mocked(fetchJson)).toHaveBeenCalledTimes(1);
   });
 
   it("returns 400 when RPC reports invalid goal set", async () => {

--- a/src/server/api/sessions-complete.ts
+++ b/src/server/api/sessions-complete.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { getOptionalServerEnv } from "../env";
 import {
   consumeRateLimit,
   corsHeadersForRequest,
@@ -60,21 +59,6 @@ const buildRuntimeHeaders = (accessToken: string, supabaseAnonKey: string): Reco
   apikey: supabaseAnonKey,
   Authorization: `Bearer ${accessToken}`,
 });
-
-const buildRuntimeServiceRoleHeaders = (): Record<string, string> | null => {
-  const serviceRoleKey =
-    getOptionalServerEnv("SUPABASE_SERVICE_ROLE_KEY") ||
-    getOptionalServerEnv("SUPABASE_SECRET_KEY");
-  const trimmed = serviceRoleKey?.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return {
-    "Content-Type": "application/json",
-    apikey: trimmed,
-    Authorization: `Bearer ${trimmed}`,
-  };
-};
 
 const resolveRuntimeOrgAndRoleWithStatus = async ({
   accessToken,
@@ -221,10 +205,10 @@ const userCanAccessTherapistSession = async ({
 
   const result = await fetchJson<Array<{ therapist_id?: string }>>(
     `${supabaseUrl}/rest/v1/user_therapist_links?select=therapist_id&user_id=eq.${encodeURIComponent(userId)}&therapist_id=eq.${encodeURIComponent(therapistId)}&limit=1`,
-    { method: "GET", headers: buildRuntimeServiceRoleHeaders() ?? headers },
+    { method: "GET", headers },
   );
   if (!result.ok) {
-    return { allowed: false, upstreamError: result.status >= 500 || result.status === 0 };
+    return { allowed: false, upstreamError: true };
   }
   return {
     allowed: Array.isArray(result.data) && result.data.some((row) => row.therapist_id === therapistId),

--- a/src/server/api/sessions-start.ts
+++ b/src/server/api/sessions-start.ts
@@ -7,7 +7,6 @@ import {
   fetchJson,
   getAccessToken,
   getSupabaseConfig,
-  getSupabaseServiceRoleHeaders,
   isDisallowedOriginRequest,
   jsonForRequest,
   resolveOrgAndRoleWithStatus,
@@ -42,10 +41,10 @@ async function userCanAccessTherapistSession({
 
   const result = await fetchJson<Array<{ therapist_id?: string }>>(
     `${supabaseUrl}/rest/v1/user_therapist_links?select=therapist_id&user_id=eq.${encodeURIComponent(userId)}&therapist_id=eq.${encodeURIComponent(therapistId)}&limit=1`,
-    { method: "GET", headers: getSupabaseServiceRoleHeaders() ?? headers },
+    { method: "GET", headers },
   );
   if (!result.ok) {
-    return { allowed: false, upstreamError: result.status >= 500 || result.status === 0 };
+    return { allowed: false, upstreamError: true };
   }
   return {
     allowed: Array.isArray(result.data) && result.data.some((row) => row.therapist_id === therapistId),

--- a/tests/ci/npm-ci-with-retry.test.ts
+++ b/tests/ci/npm-ci-with-retry.test.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test, vi } from "vitest";
+
+import { runNpmCiWithRetry } from "../../scripts/ci/npm-ci-with-retry.mjs";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const wrapperPath = path.join(repoRoot, "scripts", "ci", "npm-ci-with-retry.mjs");
+
+describe("runNpmCiWithRetry", () => {
+  test("returns after the first successful attempt", async () => {
+    const runAttempt = vi.fn().mockResolvedValue(0);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runNpmCiWithRetry({ runAttempt, wait, baseDelayMs: 100 }),
+    ).resolves.toBeUndefined();
+
+    expect(runAttempt).toHaveBeenCalledTimes(1);
+    expect(wait).not.toHaveBeenCalled();
+  });
+
+  test("retries failed installs with bounded linear backoff", async () => {
+    const runAttempt = vi.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(1).mockResolvedValue(0);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await runNpmCiWithRetry({ runAttempt, wait, baseDelayMs: 100 });
+
+    expect(runAttempt).toHaveBeenCalledTimes(3);
+    expect(wait).toHaveBeenNthCalledWith(1, 100);
+    expect(wait).toHaveBeenNthCalledWith(2, 200);
+  });
+
+  test("fails after three unsuccessful attempts", async () => {
+    const runAttempt = vi.fn().mockResolvedValue(17);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runNpmCiWithRetry({ runAttempt, wait, baseDelayMs: 100 }),
+    ).rejects.toThrow("npm ci failed after 3 attempts (last exit code 17)");
+
+    expect(runAttempt).toHaveBeenCalledTimes(3);
+    expect(wait).toHaveBeenCalledTimes(2);
+  });
+});
+
+test("direct execution launches npm ci successfully", () => {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "npm-ci-with-retry-"));
+  writeFileSync(path.join(fixtureRoot, "package.json"), '{"name":"retry-fixture","version":"1.0.0"}\n');
+  writeFileSync(
+    path.join(fixtureRoot, "package-lock.json"),
+    '{"name":"retry-fixture","version":"1.0.0","lockfileVersion":3,"requires":true,"packages":{"":{"name":"retry-fixture","version":"1.0.0"}}}\n',
+  );
+
+  const result = spawnSync(process.execPath, [wrapperPath], {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+  });
+
+  expect(result.status, result.stderr).toBe(0);
+});
+
+test("the main CI workflow routes dependency installs through the retry wrapper", () => {
+  const workflow = readFileSync(path.join(repoRoot, ".github", "workflows", "ci.yml"), "utf8");
+
+  expect(workflow).not.toMatch(/^\s*run: npm ci\s*$/m);
+  expect(workflow.match(/^\s*run: node scripts\/ci\/npm-ci-with-retry\.mjs\s*$/gm)).toHaveLength(14);
+});

--- a/tests/ci/npm-ci-with-retry.test.ts
+++ b/tests/ci/npm-ci-with-retry.test.ts
@@ -68,3 +68,13 @@ test("the main CI workflow routes dependency installs through the retry wrapper"
   expect(workflow).not.toMatch(/^\s*run: npm ci\s*$/m);
   expect(workflow.match(/^\s*run: node scripts\/ci\/npm-ci-with-retry\.mjs\s*$/gm)).toHaveLength(14);
 });
+
+test("the standalone tenant-safety workflow routes dependency installation through the retry wrapper", () => {
+  const workflow = readFileSync(
+    path.join(repoRoot, ".github", "workflows", "tenant-safety.yml"),
+    "utf8",
+  );
+
+  expect(workflow).not.toMatch(/^\s*run: npm ci\s*$/m);
+  expect(workflow.match(/^\s*run: node scripts\/ci\/npm-ci-with-retry\.mjs\s*$/gm)).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary

- use authenticated caller headers for app-side `user_therapist_links` authorization checks
- preserve `200 + no link` as a real forbidden result
- map any failed link lookup to `502 upstream_error` instead of a false `403`
- cover start and completion fallback behavior with regression tests

## Incident evidence

The production BT failure executed the Netlify/app-side start handler. Auth, org, and session reads succeeded; the exact `user_therapist_links` REST read used the stale Netlify service credential and returned `401`; the Supabase `sessions-start` edge function was not invoked.

## Routing

- Linear: WIN-219
- classification: high-risk human-reviewed
- lane: critical
- human review required before merge

## Verification

Passed:
- focused start/complete handler tests: 46/46
- edge/session/RLS contracts: 41/41
- `npm run ci:check-focused`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run validate:tenant`
- `npm run ci:verify-coverage` (92.81%)
- `npm run test:routes:tier0` (220/220)

Blocked/non-clean:
- `npm run test:ci`: 4229 passed, 5 skipped, but Vitest exited nonzero after one worker `onTaskUpdate` timeout; an earlier attempt exhausted the default Node heap
- `npm run ci:playwright`: blocked at preflight because local admin/superadmin smoke credentials are unavailable; no hosted mutation ran

## Review

Specification, architecture, implementation, code, test, and security specialist reviews completed. Code and security verdicts approve the bounded handler fix. Exact-head CI and human review remain merge gates.

Closes WIN-219