### PR TITLE
WIN-154 Add IEHP generated DOCX parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,6 +887,7 @@ jobs:
 
           npm run playwright:iehp-assessment-import-smoke
           npm run playwright:iehp-assessment-import-skills-behaviors
+          npm run playwright:iehp-assessment-import-generated-docx-parity
 
       - name: Cleanup IEHP smoke admin
         if: always() && steps.browser_scope.outputs.iehp_assessment_import_smoke_required == 'true'

--- a/docs/ai/win-154-iehp-generated-docx-parity-handoff.md
+++ b/docs/ai/win-154-iehp-generated-docx-parity-handoff.md
@@ -55,7 +55,9 @@
 - The runner now waits on the restored review when it is already visible and selects the uploaded assessment only when restoration did not occur.
 - Exact-head CI run `31654537699` confirmed the immediate branch was still too early because the assessment queue could remain in its loading state after reload.
 - The runner now waits for either the restored review or the specific uploaded assessment before branching, and fails closed if neither appears within the bounded wait.
-- Focused regression coverage executes both restoration branches, delayed queue readiness, and the fail-closed timeout; `109/109` focused tests pass.
+- Exact-head CI run `31655791717` reached generated DOCX comparison and exposed stale literal heading matching: Word formatting splits text across XML runs, auto-numbering is not literal, and several generated-template labels differ from the source PDF headings.
+- Parity now requires paragraph-level exact semantic matches against the generated IEHP template headings while tolerating Word-run fragmentation and non-literal numbering. Parsed skill/behavior names and source narratives remain independently mandatory.
+- Focused regression coverage executes both restoration branches, delayed queue readiness, fail-closed timeout, Word-run fragmentation, non-literal numbering, and heading/name/narrative cross-paragraph collision negatives; `114/114` focused tests pass. The committed IEHP output template matches all `26/26` representative headings under the corrected contract.
 - The next exact-head hosted run remains the decisive Adobe-backed verification for this fix.
 
 ## Review and PR Hygiene

--- a/docs/ai/win-154-iehp-generated-docx-parity-handoff.md
+++ b/docs/ai/win-154-iehp-generated-docx-parity-handoff.md
@@ -53,7 +53,9 @@
 - Exact-head CI run `31653029750` on commit `3abf5c5fd40e09397bf9ccc786d83312c6b375ab` cleared the prior checklist approval HTTP `400` and passed the default DOCX and skills/behaviors modes.
 - Generated DOCX parity then reached the post-approval reload and failed because the smoke unconditionally clicked the uploaded filename after the app had already restored the IEHP FBA review.
 - The runner now waits on the restored review when it is already visible and selects the uploaded assessment only when restoration did not occur.
-- Focused regression coverage executes both restoration branches; `107/107` focused tests pass.
+- Exact-head CI run `31654537699` confirmed the immediate branch was still too early because the assessment queue could remain in its loading state after reload.
+- The runner now waits for either the restored review or the specific uploaded assessment before branching, and fails closed if neither appears within the bounded wait.
+- Focused regression coverage executes both restoration branches, delayed queue readiness, and the fail-closed timeout; `109/109` focused tests pass.
 - The next exact-head hosted run remains the decisive Adobe-backed verification for this fix.
 
 ## Review and PR Hygiene

--- a/docs/ai/win-154-iehp-generated-docx-parity-handoff.md
+++ b/docs/ai/win-154-iehp-generated-docx-parity-handoff.md
@@ -1,0 +1,68 @@
+# WIN-154 IEHP Generated DOCX Parity Handoff
+
+- Date: August 12, 2026
+- Linear: `WIN-154`
+- Branch: `codex/win-154-fba-output-parity`
+- PR: pending
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Triggering path: `.github/workflows/ci.yml`
+- Required agents: `specification-engineer` -> `software-architect` -> `implementation-engineer` -> `code-review-engineer` -> `test-engineer` -> `security-engineer`
+
+## Route-task Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- rationale: the slice adds a hosted Adobe-backed browser command to the required CI workflow
+- allowed files: the existing IEHP assessment-import smoke runner/helpers/tests, `package.json`, one CI command, and this handoff
+- non-goals: parser behavior, Adobe functions, server APIs, Supabase/schema changes, production data, secrets, and publish semantics
+- stop conditions: any fix requiring parser/server semantics or a broader protected surface
+
+## Scope
+
+- Generate a complete synthetic IEHP FBA PDF in memory and upload it through the existing authenticated Programs & Goals workflow.
+- Require Adobe-backed extraction to finish at `extracted`, with zero draft programs/goals and a complete required checklist/structured-section set.
+- Derive behavior/skill expectations from `IEHP_FBA_BEHAVIOR_SKILL_TARGETS`, reject unresolved reconciliation, approve only reviewable synthetic required rows, generate the IEHP DOCX, and compare output text against all parsed names plus representative headings and narratives.
+- Require an explicitly marked smoke/synthetic/test client, exact assessment response identity, exact private generated-object scope, redacted evidence, and fail-closed source/generated cleanup.
+- Parse the downloaded synthetic DOCX only from an auto-deleted OS temp directory; do not retain it in uploaded CI artifacts.
+
+## Verification Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- change type: CI/workflow policy and authenticated synthetic browser verification harness
+- required checks: workflow YAML parse; focused IEHP/parity tests; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run ci:verify-coverage`; `npm run build`; `npm run test:routes:tier0`; `npm run verify:local`; hosted `npm run playwright:iehp-assessment-import-generated-docx-parity`
+- executed checks:
+  - workflow YAML parse -> pass
+  - focused IEHP/parity suite -> pass (`132/132`)
+  - `npm run ci:check-focused` -> pass; environment-dependent DB, preview-drift, branch-protection, and auth-parity probes skipped as reported
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `NODE_OPTIONS=--max-old-space-size=8192 npm run test:ci` -> pass (`492` files, `4261` tests; `5` environment-gated tests skipped)
+  - `npm run ci:verify-coverage` -> pass (`92.81%` line coverage; all module thresholds pass)
+  - `npm run build` -> pass
+  - `npm run test:routes:tier0` -> pass (`220/220`)
+  - `npm run verify:local` -> first attempt exhausted the default Node heap; later attempts reached two different unrelated async UI timeouts, while the scheduling timeout passed `4/4` in isolation and one separate full `test:ci` run passed all `4261` tests; all remaining constituent gates passed independently
+- blocked checks:
+  - hosted `npm run playwright:iehp-assessment-import-generated-docx-parity` -> local process has no Playwright/Supabase credentials; the command is wired into required PR CI for decisive Adobe-backed proof
+- result: `pass-with-blocked-checks`
+- residual risk: hosted extraction/template latency and contract drift can only be resolved by the required PR CI run; the expanded job retains its existing 25-minute timeout
+
+## Review and PR Hygiene
+
+- `code-review-engineer`: approve after requested output-parity and assessment-binding fixes; no findings
+- `security-engineer`: approve after smoke-client, temp-artifact, storage-scope, and review-state containment fixes; no findings
+- `devops-engineer`: approve; the command remains inside the IEHP smoke job required by `ci-gate`; no findings
+- `test-engineer`: required focused, full-suite, hosted, and cleanup evidence identified before implementation
+- `pr-ready`: yes, pending commit/push and live hosted checks
+- `branch-ready`: yes
+- `linear-ready`: yes (`WIN-154`)
+- `single-purpose`: yes
+- `unrelated changes`: none
+- `generated artifact drift`: none; the test reliability timestamp-only output was restored
+- `protected-path drift`: `.github/workflows/ci.yml` only, already routed `critical`
+- `change summary`: present
+- `verification summary`: present
+- `pr handoff`: ready; human review remains required before merge
+- `reviewer`: completed
+- `required follow-up`: open the PR, run the hosted Adobe-backed parity command through required CI, and fix only slice-related failures

--- a/docs/ai/win-154-iehp-generated-docx-parity-handoff.md
+++ b/docs/ai/win-154-iehp-generated-docx-parity-handoff.md
@@ -3,7 +3,7 @@
 - Date: August 12, 2026
 - Linear: `WIN-154`
 - Branch: `codex/win-154-fba-output-parity`
-- PR: pending
+- PR: `#930`
 - Classification: `high-risk human-reviewed`
 - Lane: `critical`
 - Triggering path: `.github/workflows/ci.yml`
@@ -48,13 +48,21 @@
 - result: `pass-with-blocked-checks`
 - residual risk: hosted extraction/template latency and contract drift can only be resolved by the required PR CI run; the expanded job retains its existing 25-minute timeout
 
+## Hosted Failure Triage
+
+- Exact-head CI run `31653029750` on commit `3abf5c5fd40e09397bf9ccc786d83312c6b375ab` cleared the prior checklist approval HTTP `400` and passed the default DOCX and skills/behaviors modes.
+- Generated DOCX parity then reached the post-approval reload and failed because the smoke unconditionally clicked the uploaded filename after the app had already restored the IEHP FBA review.
+- The runner now waits on the restored review when it is already visible and selects the uploaded assessment only when restoration did not occur.
+- Focused regression coverage executes both restoration branches; `107/107` focused tests pass.
+- The next exact-head hosted run remains the decisive Adobe-backed verification for this fix.
+
 ## Review and PR Hygiene
 
 - `code-review-engineer`: approve after requested output-parity and assessment-binding fixes; no findings
 - `security-engineer`: approve after smoke-client, temp-artifact, storage-scope, and review-state containment fixes; no findings
 - `devops-engineer`: approve; the command remains inside the IEHP smoke job required by `ci-gate`; no findings
 - `test-engineer`: required focused, full-suite, hosted, and cleanup evidence identified before implementation
-- `pr-ready`: yes, pending commit/push and live hosted checks
+- `pr-ready`: yes, pending the next exact-head live hosted checks
 - `branch-ready`: yes
 - `linear-ready`: yes (`WIN-154`)
 - `single-purpose`: yes

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "playwright:iehp-assessment-import-smoke": "tsx scripts/playwright-iehp-assessment-import-smoke.ts",
     "playwright:iehp-assessment-import-pdf-mini-matrix": "tsx scripts/playwright-iehp-assessment-import-smoke.ts --pdf-mini-matrix",
     "playwright:iehp-assessment-import-skills-behaviors": "tsx scripts/playwright-iehp-assessment-import-smoke.ts --skills-behaviors-proof",
+    "playwright:iehp-assessment-import-generated-docx-parity": "tsx scripts/playwright-iehp-assessment-import-smoke.ts --generated-docx-parity",
     "playwright:assessment-upload-promote-smoke": "tsx scripts/playwright-assessment-upload-promote-smoke.ts",
     "playwright:assessment-pdf-smoke": "tsx scripts/playwright-assessment-pdf-smoke.ts",
     "playwright:clinical-data-parity-agent": "tsx scripts/clinical-data-parity-agent.ts",

--- a/scripts/lib/iehp-assessment-import-smoke.ts
+++ b/scripts/lib/iehp-assessment-import-smoke.ts
@@ -171,7 +171,6 @@ type IehpStructuredSectionApprovalPatch = {
   structured_section_id: string;
   status: 'approved';
   review_notes: string;
-  payload: Record<string, unknown>;
 };
 
 export type IehpRequiredFinalOutputApprovals = {
@@ -653,14 +652,25 @@ const NON_MEANINGFUL_METADATA_KEYS = new Set([
   'section_key',
   'section_index',
   'field_key',
+  'page_number',
+  'field_type',
+  'mode',
   'label',
   'status',
   'required',
+  'source',
+  'layout_json',
+  'template_placeholder',
+  'entered_value_present',
+  'options',
 ]);
 
 const hasMeaningfulValue = (value: unknown): boolean => {
   if (value === null || value === undefined) return false;
-  if (typeof value === 'string') return value.trim().length > 0;
+  if (typeof value === 'string') {
+    const normalized = value.trim();
+    return normalized.length > 0 && normalized.toLowerCase() !== 'unknown';
+  }
   if (typeof value === 'number') return Number.isFinite(value);
   if (typeof value === 'boolean') return value;
   if (Array.isArray(value)) return value.some((entry) => hasMeaningfulValue(entry));
@@ -1057,7 +1067,13 @@ export const selectIehpRequiredFinalOutputApprovals = (args: {
     if (!isObjectRecord(section) || !isRequiredForIehpFinalOutput(section.field_key, section.required === true)) {
       continue;
     }
-    if (!isObjectRecord(section.payload) || !hasMeaningfulValue(section.payload)) {
+    if (!isObjectRecord(section.payload)) {
+      throw new Error(`IEHP smoke required structured row ${section.field_key} was blank or malformed.`);
+    }
+    const approvalPayload = section.field_key === 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS'
+      ? Object.fromEntries(Object.entries(section.payload).filter(([key]) => key !== 'skills_behaviors'))
+      : section.payload;
+    if (!hasMeaningfulValue(approvalPayload)) {
       throw new Error(`IEHP smoke required structured row ${section.field_key} was blank or malformed.`);
     }
     assertSyntheticAutoApprovalStatus(
@@ -1075,7 +1091,6 @@ export const selectIehpRequiredFinalOutputApprovals = (args: {
       structured_section_id: sectionId,
       status: 'approved',
       review_notes: 'IEHP generated DOCX parity auto-approved required structured row from synthetic smoke fixture.',
-      payload: section.payload,
     });
   }
 

--- a/scripts/lib/iehp-assessment-import-smoke.ts
+++ b/scripts/lib/iehp-assessment-import-smoke.ts
@@ -283,32 +283,32 @@ export const IEHP_SKILLS_BEHAVIORS_PROOF_CASE: IehpSkillsBehaviorsProofCase = {
 export const IEHP_GENERATED_DOCX_PARITY_PROOF_CASE: IehpGeneratedDocxParityProofCase = {
   id: 'generated-docx-parity',
   expectedSectionHeadings: [
-    'I. IDENTIFICATION',
+    'Functional Behavioral Assessment Report',
     'Referral Date:',
     'Assessor/Certification:',
-    'II. BEHAVIORS',
-    'III. BACKGROUND INFORMATION',
-    'IV. BHT SCHOOL HOURS',
-    'HEALTH AND MEDICAL',
-    'CURRENT SERVICES AND ACTIVITIES',
-    'INTERVENTION HISTORY',
-    'V. BHT AVAILABILITY',
-    "VI. MEMBER'S ENVIRONMENTAL ANALYSIS:",
-    'VII. DESCRIPTION OF ASSESSMENT PROCEDURES:',
-    'PREFERENCE ASSESSMENT',
-    'Preference Areas: Potential Reinforcers:',
-    'VIII. ADAPTIVE AND FUNCTIONAL MEASURE SUMMARIES',
-    'TARGET BEHAVIORS:',
-    'REPLACEMENT BEHAVIORS:',
-    'SAFETY/CRISIS PROCEDURE',
-    'XI. PARENT EDUCATION',
-    'COORDINATION OF CARE:',
-    'XIII. DISCHARGE CRITERIA:',
-    'TRANSITION OF CARE:',
-    'TEACHING INTERVENTION STRATEGIES',
-    'FAMILY INVOLVEMENT',
-    'XIV. RECOMMENDATIONS:',
-    'REPORT COMPLETED BY:',
+    'BEHAVIORS:',
+    'BACKGROUND INFORMATION:',
+    'BHT (School Hours)',
+    'Health and Medical -',
+    'Current Services and Activities-',
+    'Intervention History -',
+    'BHT Availability',
+    "MEMBER'S ENVIRONMENTAL ANALYSIS:",
+    'DESCRIPTION OF ASSESSMENT PROCEDURES:',
+    'Preference Assessment- Within this section the assessor will state the preference assessment administered to the Member during the assessment.',
+    'Preference Areas:',
+    'ASSESSMENT MEAURES:',
+    'Target Behaviors',
+    'Replacement Behavior(s):',
+    'Safety Procedure/Crisis Plan-',
+    'Parent Education:',
+    'Coordination of Care:',
+    'Discharge, Transition and Exit Plans:',
+    'Transition Planning:',
+    'Teaching Intervention Strategies - Within this section list all teaching procedures and methodologies used to the teach skill deficits and replacement behaviors. Include strategies on generalization, maintenance, thinning schedules of reinforcement, transition to natural mediators, and relapse prevention.',
+    "Family Involvement: Within this section of the report provider will outline parent involvement and participation within the therapy session. Provider will include a statement on the expected level of participation as outlined within the BHT IEHP Policy. Provider will outline the parent training and education approach for teaching the parent goals. Providers will include a plan on how the provider will address parental involvement within therapy sessions. Parent education goals will be listed below. Parent Participation is not an educational goal; it is an expectation. A Parent should have AT LEAST 2 Parent Education Goals.",
+    'Clinical Recommendations',
+    'Report completed by: The Health plan requires the treatment plan to be developed by a BCBA per APL 23-010',
   ],
   expectedBehaviorSkillTerms: [
     'Functional Communication',
@@ -985,7 +985,9 @@ export const deriveIehpGeneratedDocxParityManifest = (args: {
   };
 };
 
-const normalizeParityText = (value: string): string => value.toLowerCase().replace(/\s+/g, ' ').trim();
+const normalizeParityText = (value: string): string => value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+const normalizeParitySectionHeading = (value: string): string =>
+  normalizeParityText(value.replace(/^\s*[ivxlcdm]+\.\s*/i, ''));
 
 export const assertIehpGeneratedDocxTextParity = (args: {
   generatedDocxText: string;
@@ -993,12 +995,20 @@ export const assertIehpGeneratedDocxTextParity = (args: {
   proofCase?: IehpGeneratedDocxParityProofCase;
 }): IehpGeneratedDocxParityAssertion => {
   const proofCase = args.proofCase ?? IEHP_GENERATED_DOCX_PARITY_PROOF_CASE;
-  const normalizedOutput = normalizeParityText(args.generatedDocxText);
-  const countMatches = (values: readonly string[]): number =>
-    values.filter((value) => normalizedOutput.includes(normalizeParityText(value))).length;
+  const normalizedOutputParagraphs = args.generatedDocxText
+    .split(/\r?\n+/)
+    .map(normalizeParitySectionHeading)
+    .filter((value) => value.length > 0);
+  const countMatches = (values: readonly string[], normalizeExpected = normalizeParityText): number =>
+    values.filter((value) => {
+      const normalizedExpected = normalizeExpected(value);
+      return normalizedOutputParagraphs.some((paragraph) => paragraph.includes(normalizedExpected));
+    }).length;
 
   const matchedNameCount = countMatches(args.sourceManifest.names);
-  const matchedSectionHeadingCount = countMatches(proofCase.expectedSectionHeadings);
+  const matchedSectionHeadingCount = proofCase.expectedSectionHeadings.filter((heading) =>
+    normalizedOutputParagraphs.includes(normalizeParitySectionHeading(heading)),
+  ).length;
   const matchedNarrativeTermCount = countMatches(proofCase.expectedNarrativeTerms);
 
   if (matchedNameCount !== args.sourceManifest.totalNames) {

--- a/scripts/lib/iehp-assessment-import-smoke.ts
+++ b/scripts/lib/iehp-assessment-import-smoke.ts
@@ -27,13 +27,28 @@ type IehpRasterPdfMiniMatrixCase = IehpPdfMiniMatrixBaseCase & {
 export type IehpPdfMiniMatrixCase = IehpDigitalPdfMiniMatrixCase | IehpRasterPdfMiniMatrixCase;
 
 type DocumentChecklistItem = {
+  id?: string;
+  label?: string | null;
   placeholder_key: string;
+  required?: boolean;
+  status?: string;
   value_text?: string | null;
+  value_json?: unknown;
+};
+
+type DocumentChecklistStructuredSection = {
+  id?: string;
+  field_key?: string;
+  section_key?: string;
+  section_index?: number;
+  payload?: unknown;
+  required?: boolean;
+  status?: string;
 };
 
 type DocumentChecklistResponse = {
   items: DocumentChecklistItem[];
-  structured_sections?: unknown[];
+  structured_sections?: DocumentChecklistStructuredSection[] | unknown[];
 };
 
 type AssessmentExtractionProvenanceRow = {
@@ -72,6 +87,10 @@ type SkillsBehaviorsCounts = {
 type SkillsBehaviorsClinicalGoalType = 'behavior' | 'skill' | null;
 
 type SkillsBehaviorsReconciliationStatus = 'matched' | 'summary_only' | 'detailed_only' | 'ambiguous';
+
+type IehpPreflightBlocker = {
+  code?: unknown;
+};
 
 export type IehpSkillsBehaviorsProofCase = {
   id: 'skills-behaviors-proof';
@@ -119,6 +138,67 @@ export type IehpDocumentFieldAssertion = {
   valueMatched: true;
   provenanceRowCount: number;
   documentProvenanceVerified: true;
+};
+
+export type IehpGeneratedDocxParityManifest = {
+  sectionCount: 1;
+  version: 1;
+  names: string[];
+  totalNames: number;
+  behaviorCount: number;
+  skillCount: number;
+  matchedCount: number;
+  detailedOnlyCount: number;
+  summaryOnlyOrAmbiguousCount: number;
+};
+
+export type IehpRedactedPreflightBlockerEvidence = {
+  ready: boolean;
+  blockerCount: number;
+  blockerCodes: string[];
+  hasUnapprovedRequiredBlocker: boolean;
+};
+
+type IehpChecklistApprovalPatch = {
+  item_id: string;
+  status: 'approved';
+  review_notes: string;
+  value_text?: string;
+  value_json?: unknown;
+};
+
+type IehpStructuredSectionApprovalPatch = {
+  structured_section_id: string;
+  status: 'approved';
+  review_notes: string;
+  payload: Record<string, unknown>;
+};
+
+export type IehpRequiredFinalOutputApprovals = {
+  checklistApprovals: IehpChecklistApprovalPatch[];
+  structuredSectionApprovals: IehpStructuredSectionApprovalPatch[];
+  summary: {
+    checklistCount: number;
+    structuredCount: number;
+    allRequiredRowsApproved: boolean;
+  };
+};
+
+export type IehpGeneratedDocxParityProofCase = {
+  id: 'generated-docx-parity';
+  expectedSectionHeadings: readonly string[];
+  expectedBehaviorSkillTerms: readonly [string, string, string, string];
+  expectedNarrativeTerms: readonly string[];
+};
+
+export type IehpGeneratedDocxParityAssertion = {
+  expectedNameCount: number;
+  matchedNameCount: number;
+  expectedSectionHeadingCount: number;
+  matchedSectionHeadingCount: number;
+  expectedNarrativeTermCount: number;
+  matchedNarrativeTermCount: number;
+  allExpectedContentPresent: true;
 };
 
 export const IEHP_PDF_MINI_MATRIX_CASES: readonly IehpPdfMiniMatrixCase[] = [
@@ -199,6 +279,51 @@ export const IEHP_SKILLS_BEHAVIORS_PROOF_CASE: IehpSkillsBehaviorsProofCase = {
     detailedOnly: 'Waiting',
     excludedParent: 'Parent Coaching',
   },
+};
+
+export const IEHP_GENERATED_DOCX_PARITY_PROOF_CASE: IehpGeneratedDocxParityProofCase = {
+  id: 'generated-docx-parity',
+  expectedSectionHeadings: [
+    'I. IDENTIFICATION',
+    'Referral Date:',
+    'Assessor/Certification:',
+    'II. BEHAVIORS',
+    'III. BACKGROUND INFORMATION',
+    'IV. BHT SCHOOL HOURS',
+    'HEALTH AND MEDICAL',
+    'CURRENT SERVICES AND ACTIVITIES',
+    'INTERVENTION HISTORY',
+    'V. BHT AVAILABILITY',
+    "VI. MEMBER'S ENVIRONMENTAL ANALYSIS:",
+    'VII. DESCRIPTION OF ASSESSMENT PROCEDURES:',
+    'PREFERENCE ASSESSMENT',
+    'Preference Areas: Potential Reinforcers:',
+    'VIII. ADAPTIVE AND FUNCTIONAL MEASURE SUMMARIES',
+    'TARGET BEHAVIORS:',
+    'REPLACEMENT BEHAVIORS:',
+    'SAFETY/CRISIS PROCEDURE',
+    'XI. PARENT EDUCATION',
+    'COORDINATION OF CARE:',
+    'XIII. DISCHARGE CRITERIA:',
+    'TRANSITION OF CARE:',
+    'TEACHING INTERVENTION STRATEGIES',
+    'FAMILY INVOLVEMENT',
+    'XIV. RECOMMENDATIONS:',
+    'REPORT COMPLETED BY:',
+  ],
+  expectedBehaviorSkillTerms: [
+    'Functional Communication',
+    'Community Safety',
+    'Transition Tolerance',
+    'Waiting',
+  ],
+  expectedNarrativeTerms: [
+    'Records reviewed included synthetic diagnostic',
+    'visual schedule, transition warnings',
+    'caregivers will secure the environment',
+    'Home, school, and community',
+    'Caregiver will implement prompting and reinforcement strategies',
+  ],
 };
 
 type ResolveIehpSmokeSampleFileArgs = {
@@ -317,6 +442,139 @@ export const buildIehpSkillsBehaviorsProofPdfHtml = (
   </body>
 </html>`;
 
+export const buildIehpGeneratedDocxParityPdfHtml = (
+  proofCase: IehpGeneratedDocxParityProofCase = IEHP_GENERATED_DOCX_PARITY_PROOF_CASE,
+): string => `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>${proofCase.id}</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        color: #111;
+        margin: 32px;
+        line-height: 1.35;
+        font-size: 12px;
+      }
+      h1, h2, h3 {
+        margin: 18px 0 8px;
+      }
+      p {
+        margin: 0 0 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Inland Empire Health Plan Functional Behavioral Assessment Report</h1>
+    <p>Header: synthetic IEHP generated DOCX parity fixture.</p>
+    <h2>I. IDENTIFICATION</h2>
+    <p>First Name: Synthetic</p>
+    <p>Last Name: Member</p>
+    <p>Birth Date: 01/01/2018</p>
+    <p>Report Date: 08/12/2026</p>
+    <p>Referral Date: 08/01/2026</p>
+    <p>IEHP Member ID#: SYNTH-0001</p>
+    <p>Present Address: 100 Synthetic Way, Test City, CA 90000</p>
+    <p>Parent/Guardian: Synthetic Caregiver</p>
+    <p>Phone: (909) 555-0199</p>
+    <p>Language: English</p>
+    <p>Assessor/Certification: Synthetic BCBA, BCBA 1-00-00000</p>
+    <p>Assessor's phone number: (909) 555-0188</p>
+    <p>Reason for Referral: Synthetic caregiver request for ABA treatment focused on communication, safety, and transitions.</p>
+    <h2>II. BEHAVIORS</h2>
+    <p>The behaviors and functional skills to be addressed are:</p>
+    <p>${proofCase.expectedBehaviorSkillTerms.join('; ')}</p>
+    <h2>III. BACKGROUND INFORMATION</h2>
+    <p>Persons in Household and Relationship to IEHP Member</p>
+    <p>Member lives with two caregivers and one sibling in a synthetic household.</p>
+    <p>School Information</p>
+    <p>Member attends a synthetic public school classroom with speech and behavior support.</p>
+    <h2>IV. BHT SCHOOL HOURS</h2>
+    <p>Monday through Friday: 8:00 AM to 3:00 PM.</p>
+    <h2>HEALTH AND MEDICAL</h2>
+    <p>Medical summary narrative for synthetic QA fixture. No acute medical concerns were documented.</p>
+    <h2>CURRENT SERVICES AND ACTIVITIES</h2>
+    <p>School-based services, caregiver coaching, and recreational community routines were reviewed.</p>
+    <h2>INTERVENTION HISTORY</h2>
+    <p>Prior ABA ended last year and resumed in a synthetic continuity-of-care scenario.</p>
+    <h2>V. BHT AVAILABILITY</h2>
+    <p>After-school weekday availability and weekend daytime availability were documented.</p>
+    <h2>VI. MEMBER'S ENVIRONMENTAL ANALYSIS:</h2>
+    <p>Availability and access to reinforcers: Yes. Level of noise/environmental distractions: Fair.</p>
+    <h2>VII. DESCRIPTION OF ASSESSMENT PROCEDURES:</h2>
+    <p>Records Reviewed: 08/01/2026 Telehealth BCBA</p>
+    <p>Clinical Interview: 08/02/2026 Home BCBA</p>
+    <p>1st Member Observation: 08/03/2026 home observation narrative.</p>
+    <p>2nd Member Observation: 08/04/2026 school observation narrative.</p>
+    <p>Records reviewed included synthetic diagnostic, school, and service coordination documents.</p>
+    <h2>PREFERENCE ASSESSMENT</h2>
+    <p>Caregiver reported interests and reinforcers including praise, sensory tools, breaks, and music.</p>
+    <p>Preference Areas: Potential Reinforcers:</p>
+    <p>Social: praise and shared activities.</p>
+    <p>Sensory: fidgets and music.</p>
+    <h2>VIII. ADAPTIVE AND FUNCTIONAL MEASURE SUMMARIES</h2>
+    <p>VB-MAPP Assessment Summary: Preserve as assessment block.</p>
+    <p>Vineland Adaptive Behavior Scales, 3rd Edition Date Administered: 08/01/2026 Name of Interviewer: Synthetic BCBA Name of Respondent: Synthetic Caregiver Assessment Summary: Synthetic adaptive summary.</p>
+    <p>AFLS Assessment Summary: Preserve as assessment block.</p>
+    <p>ABAS-3 Assessment Summary: Preserve as assessment block.</p>
+    <h2>IX. TARGET BEHAVIORS</h2>
+    <h3>TARGET BEHAVIORS:</h3>
+    <p>Program Name: Transition Tolerance</p>
+    <p>Instrumental Goal: Member will transition between tasks without aggression across home and school routines.</p>
+    <p>Data Collection: Frequency</p>
+    <p>Mastery Criteria: Zero events across four consecutive weeks.</p>
+    <p>Baseline: Three events per hour.</p>
+    <h3>REPLACEMENT BEHAVIORS:</h3>
+    <p>Program Name: Functional Communication</p>
+    <p>Instrumental Goal: Member will request help across five targets in home and school contexts.</p>
+    <p>Data Collection: Percent opportunities</p>
+    <p>Mastery Criteria: Eighty percent across four consecutive weeks.</p>
+    <p>Baseline: Zero percent independent.</p>
+    <p>Program Name: Waiting</p>
+    <p>Instrumental Goal: Member will wait safely before accessing preferred activities in the community.</p>
+    <p>Data Collection: Percent opportunities</p>
+    <p>Mastery Criteria: Eighty percent across four consecutive weeks.</p>
+    <p>Baseline: Zero percent independent.</p>
+    <p>Program Name: Community Safety</p>
+    <p>Instrumental Goal: Member will remain with caregiver and stop at safety cues across public settings.</p>
+    <p>Data Collection: Percent opportunities</p>
+    <p>Mastery Criteria: Eighty percent across four consecutive weeks.</p>
+    <p>Baseline: Twenty percent independent.</p>
+    <h2>X. BEHAVIOR INTERVENTION PLAN</h2>
+    <p>Antecedent Strategies: visual schedule, transition warnings, and first-then supports.</p>
+    <p>Replacement Behavior: request break and request help.</p>
+    <p>Consequence Strategies: differential reinforcement and planned response blocking for safety.</p>
+    <h2>SAFETY/CRISIS PROCEDURE</h2>
+    <p>Safety Procedure: caregivers will secure the environment, follow the synthetic crisis response, and contact emergency services for immediate danger.</p>
+    <h2>XI. PARENT EDUCATION</h2>
+    <p>Program Name: Parent Coaching</p>
+    <p>Instrumental Goal: Caregiver will implement prompting and reinforcement strategies with fidelity.</p>
+    <p>Data Collection: Percent opportunities</p>
+    <p>Mastery Criteria: Ninety percent across four consecutive weeks.</p>
+    <p>Baseline: Zero percent independent.</p>
+    <h2>XII. LOCATION OF SERVICE</h2>
+    <p>Home, school, and community.</p>
+    <h2>COORDINATION OF CARE:</h2>
+    <p>Coordinate with parent, school, PCP, and current service providers.</p>
+    <h2>XIII. DISCHARGE CRITERIA:</h2>
+    <p>Exit plan criteria placeholder covering sustained performance and caregiver implementation.</p>
+    <h2>TRANSITION OF CARE:</h2>
+    <p>Transition planning includes fading service intensity, handoff to natural supports, and school coordination.</p>
+    <h2>TEACHING INTERVENTION STRATEGIES</h2>
+    <p>Modeling, least-to-most prompting, visual supports, and reinforcement thinning were documented.</p>
+    <h2>FAMILY INVOLVEMENT</h2>
+    <p>Caregiver participation, consent, and agreement with the synthetic treatment plan were documented.</p>
+    <h2>XIV. RECOMMENDATIONS:</h2>
+    <p>H2019 Therapeutic Behavioral Services, per 15 minutes 10 units</p>
+    <p>H0032 Mental Health Service Plan Development by Non-Physician, per 15 minutes 4 units</p>
+    <p>Recommendation notes: synthetic HCPCS recommendation summary.</p>
+    <h2>REPORT COMPLETED BY:</h2>
+    <p>Synthetic BCBA MM/DD/YYYY</p>
+    <p>Signature placeholder: synthetic parity fixture only.</p>
+  </body>
+</html>`;
+
 export const assertIehpDocumentChecklistField = (args: {
   checklist: DocumentChecklistResponse;
   expectedValue: string;
@@ -381,6 +639,41 @@ const hasValidSkillsBehaviorsClinicalGoalType = (value: unknown): value is Skill
 
 const hasValidSkillsBehaviorsReconciliationStatus = (value: unknown): value is SkillsBehaviorsReconciliationStatus =>
   value === 'matched' || value === 'summary_only' || value === 'detailed_only' || value === 'ambiguous';
+
+const IEHP_OPTIONAL_FINAL_OUTPUT_KEYS = new Set([
+  'IEHP_FBA_ADAPTIVE_MEASURE_SUMMARIES',
+  'IEHP_FBA_ASSESSOR_PHONE',
+  'IEHP_FBA_REFERRING_PROVIDER',
+]);
+
+const NON_MEANINGFUL_METADATA_KEYS = new Set([
+  'id',
+  'created_at',
+  'updated_at',
+  'section_key',
+  'section_index',
+  'field_key',
+  'label',
+  'status',
+  'required',
+]);
+
+const hasMeaningfulValue = (value: unknown): boolean => {
+  if (value === null || value === undefined) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value === 'boolean') return value;
+  if (Array.isArray(value)) return value.some((entry) => hasMeaningfulValue(entry));
+  if (isObjectRecord(value)) {
+    return Object.entries(value).some(([key, entry]) =>
+      !NON_MEANINGFUL_METADATA_KEYS.has(key) && hasMeaningfulValue(entry)
+    );
+  }
+  return false;
+};
+
+const isRequiredForIehpFinalOutput = (fieldKey: string | undefined, required: boolean | undefined): boolean =>
+  Boolean(required) && typeof fieldKey === 'string' && !IEHP_OPTIONAL_FINAL_OUTPUT_KEYS.has(fieldKey);
 
 const hasValidSkillsBehaviorsStatusTypePairing = (
   clinicalGoalType: SkillsBehaviorsClinicalGoalType,
@@ -566,6 +859,235 @@ export const assertIehpSkillsBehaviorsChecklistSection = (args: {
     detailedOnlyPreserved: true,
     parentExcluded: true,
     provenanceVerified: true,
+  };
+};
+
+export const buildRedactedIehpPreflightBlockerEvidence = (args: {
+  ready: boolean;
+  blockers: IehpPreflightBlocker[];
+}): IehpRedactedPreflightBlockerEvidence => {
+  const blockerCodes: string[] = [];
+  for (const blocker of args.blockers) {
+    const code = typeof blocker?.code === 'string' && blocker.code.trim() ? blocker.code.trim() : 'unknown_blocker';
+    if (!blockerCodes.includes(code)) {
+      blockerCodes.push(code);
+    }
+  }
+
+  return {
+    ready: args.ready,
+    blockerCount: args.blockers.length,
+    blockerCodes,
+    hasUnapprovedRequiredBlocker: blockerCodes.some((code) => /(required|unapproved)/i.test(code)),
+  };
+};
+
+export const deriveIehpGeneratedDocxParityManifest = (args: {
+  checklist: DocumentChecklistResponse;
+}): IehpGeneratedDocxParityManifest => {
+  const sections = Array.isArray(args.checklist.structured_sections) ? args.checklist.structured_sections : [];
+  const matchingRows = sections.filter((section) =>
+    isObjectRecord(section) && section.field_key === 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS'
+  );
+
+  if (matchingRows.length === 0) {
+    throw new Error('IEHP smoke could not find IEHP_FBA_BEHAVIOR_SKILL_TARGETS in structured sections.');
+  }
+  if (matchingRows.length !== 1) {
+    throw new Error(
+      `IEHP smoke expected exactly one IEHP_FBA_BEHAVIOR_SKILL_TARGETS structured section row but found ${matchingRows.length}.`,
+    );
+  }
+
+  const payload = matchingRows[0]?.payload;
+  const skillsBehaviors = isObjectRecord(payload) ? payload.skills_behaviors : null;
+  if (!isObjectRecord(skillsBehaviors) || !Array.isArray(skillsBehaviors.items)) {
+    throw new Error('IEHP smoke found IEHP_FBA_BEHAVIOR_SKILL_TARGETS but payload.skills_behaviors was missing or malformed.');
+  }
+  if (skillsBehaviors.version !== 1) {
+    throw new Error('IEHP smoke expected IEHP_FBA_BEHAVIOR_SKILL_TARGETS skills_behaviors.version to equal 1.');
+  }
+
+  let behaviorCount = 0;
+  let skillCount = 0;
+  let matchedCount = 0;
+  let detailedOnlyCount = 0;
+  let summaryOnlyOrAmbiguousCount = 0;
+  const names: string[] = [];
+
+  for (const item of skillsBehaviors.items) {
+    if (!isObjectRecord(item)) {
+      throw new Error(
+        'IEHP smoke found IEHP_FBA_BEHAVIOR_SKILL_TARGETS but payload.skills_behaviors.items contained a malformed entry.',
+      );
+    }
+    const name = typeof item.name === 'string' ? item.name.trim() : '';
+    if (!name) {
+      throw new Error(
+        'IEHP smoke found IEHP_FBA_BEHAVIOR_SKILL_TARGETS but payload.skills_behaviors.items contained a blank name.',
+      );
+    }
+    const clinicalGoalType = item.clinical_goal_type;
+    const reconciliationStatus = item.reconciliation_status;
+    if (!hasValidSkillsBehaviorsClinicalGoalType(clinicalGoalType)) {
+      throw new Error(
+        'IEHP smoke found IEHP_FBA_BEHAVIOR_SKILL_TARGETS but payload.skills_behaviors.items contained an invalid clinical_goal_type.',
+      );
+    }
+    if (
+      !hasValidSkillsBehaviorsReconciliationStatus(reconciliationStatus) ||
+      !hasValidSkillsBehaviorsStatusTypePairing(clinicalGoalType, reconciliationStatus)
+    ) {
+      throw new Error(
+        'IEHP smoke found IEHP_FBA_BEHAVIOR_SKILL_TARGETS but payload.skills_behaviors.items contained an invalid reconciliation_status for its clinical_goal_type.',
+      );
+    }
+
+    names.push(name);
+    if (clinicalGoalType === 'behavior') behaviorCount += 1;
+    if (clinicalGoalType === 'skill') skillCount += 1;
+    if (reconciliationStatus === 'matched') matchedCount += 1;
+    if (reconciliationStatus === 'detailed_only') detailedOnlyCount += 1;
+    if (reconciliationStatus === 'summary_only' || reconciliationStatus === 'ambiguous') {
+      summaryOnlyOrAmbiguousCount += 1;
+    }
+  }
+
+  if (behaviorCount === 0 || skillCount === 0) {
+    throw new Error('IEHP smoke expected at least one behavior and one skill in IEHP_FBA_BEHAVIOR_SKILL_TARGETS.');
+  }
+  if (summaryOnlyOrAmbiguousCount > 0) {
+    throw new Error(
+      'IEHP generated DOCX parity refuses to auto-approve summary-only or ambiguous skills_behaviors items.',
+    );
+  }
+
+  return {
+    sectionCount: 1,
+    version: 1,
+    names,
+    totalNames: names.length,
+    behaviorCount,
+    skillCount,
+    matchedCount,
+    detailedOnlyCount,
+    summaryOnlyOrAmbiguousCount,
+  };
+};
+
+const normalizeParityText = (value: string): string => value.toLowerCase().replace(/\s+/g, ' ').trim();
+
+export const assertIehpGeneratedDocxTextParity = (args: {
+  generatedDocxText: string;
+  sourceManifest: IehpGeneratedDocxParityManifest;
+  proofCase?: IehpGeneratedDocxParityProofCase;
+}): IehpGeneratedDocxParityAssertion => {
+  const proofCase = args.proofCase ?? IEHP_GENERATED_DOCX_PARITY_PROOF_CASE;
+  const normalizedOutput = normalizeParityText(args.generatedDocxText);
+  const countMatches = (values: readonly string[]): number =>
+    values.filter((value) => normalizedOutput.includes(normalizeParityText(value))).length;
+
+  const matchedNameCount = countMatches(args.sourceManifest.names);
+  const matchedSectionHeadingCount = countMatches(proofCase.expectedSectionHeadings);
+  const matchedNarrativeTermCount = countMatches(proofCase.expectedNarrativeTerms);
+
+  if (matchedNameCount !== args.sourceManifest.totalNames) {
+    throw new Error('IEHP generated DOCX parity expected every in-memory skills_behaviors name to appear in the generated DOCX.');
+  }
+  if (matchedSectionHeadingCount !== proofCase.expectedSectionHeadings.length) {
+    throw new Error('IEHP generated DOCX parity expected every representative IEHP section heading to appear in the generated DOCX.');
+  }
+  if (matchedNarrativeTermCount !== proofCase.expectedNarrativeTerms.length) {
+    throw new Error('IEHP generated DOCX parity expected every representative source narrative to appear in the generated DOCX.');
+  }
+
+  return {
+    expectedNameCount: args.sourceManifest.totalNames,
+    matchedNameCount,
+    expectedSectionHeadingCount: proofCase.expectedSectionHeadings.length,
+    matchedSectionHeadingCount,
+    expectedNarrativeTermCount: proofCase.expectedNarrativeTerms.length,
+    matchedNarrativeTermCount,
+    allExpectedContentPresent: true,
+  };
+};
+
+const assertSyntheticAutoApprovalStatus = (status: string | undefined, fieldKey: string): void => {
+  const normalizedStatus = status?.trim() ?? '';
+  if (normalizedStatus !== 'drafted' && normalizedStatus !== 'verified' && normalizedStatus !== 'approved') {
+    throw new Error(`IEHP smoke required row ${fieldKey} was not in a reviewable status for synthetic auto-approval.`);
+  }
+};
+
+export const selectIehpRequiredFinalOutputApprovals = (args: {
+  checklist: DocumentChecklistResponse;
+}): IehpRequiredFinalOutputApprovals => {
+  const checklistApprovals: IehpChecklistApprovalPatch[] = [];
+  const structuredSectionApprovals: IehpStructuredSectionApprovalPatch[] = [];
+
+  for (const item of args.checklist.items) {
+    if (!isRequiredForIehpFinalOutput(item.placeholder_key, item.required)) {
+      continue;
+    }
+    const hasMeaningfulTextValue = typeof item.value_text === 'string' && hasMeaningfulValue(item.value_text);
+    const hasMeaningfulJsonValue = hasMeaningfulValue(item.value_json);
+    if (!hasMeaningfulTextValue && !hasMeaningfulJsonValue) {
+      throw new Error(`IEHP smoke required checklist row ${item.placeholder_key} was blank or malformed.`);
+    }
+    assertSyntheticAutoApprovalStatus(item.status, item.placeholder_key);
+    if ((item.status ?? '').trim() === 'approved') {
+      continue;
+    }
+    const itemId = typeof item.id === 'string' ? item.id.trim() : '';
+    if (!itemId) {
+      throw new Error(`IEHP smoke required checklist row ${item.placeholder_key} was blank or malformed.`);
+    }
+    checklistApprovals.push({
+      item_id: itemId,
+      status: 'approved',
+      review_notes: 'IEHP generated DOCX parity auto-approved required checklist row from synthetic smoke fixture.',
+      ...(hasMeaningfulTextValue
+        ? { value_text: item.value_text.trim() }
+        : { value_json: item.value_json }),
+    });
+  }
+
+  const sections = Array.isArray(args.checklist.structured_sections) ? args.checklist.structured_sections : [];
+  for (const section of sections) {
+    if (!isObjectRecord(section) || !isRequiredForIehpFinalOutput(section.field_key, section.required === true)) {
+      continue;
+    }
+    if (!isObjectRecord(section.payload) || !hasMeaningfulValue(section.payload)) {
+      throw new Error(`IEHP smoke required structured row ${section.field_key} was blank or malformed.`);
+    }
+    assertSyntheticAutoApprovalStatus(
+      typeof section.status === 'string' ? section.status : undefined,
+      section.field_key ?? 'unknown',
+    );
+    if ((typeof section.status === 'string' ? section.status.trim() : '') === 'approved') {
+      continue;
+    }
+    const sectionId = typeof section.id === 'string' ? section.id.trim() : '';
+    if (!sectionId) {
+      throw new Error(`IEHP smoke required structured row ${section.field_key} was blank or malformed.`);
+    }
+    structuredSectionApprovals.push({
+      structured_section_id: sectionId,
+      status: 'approved',
+      review_notes: 'IEHP generated DOCX parity auto-approved required structured row from synthetic smoke fixture.',
+      payload: section.payload,
+    });
+  }
+
+  const allRequiredRowsApproved = checklistApprovals.length === 0 && structuredSectionApprovals.length === 0;
+  return {
+    checklistApprovals,
+    structuredSectionApprovals,
+    summary: {
+      checklistCount: checklistApprovals.length,
+      structuredCount: structuredSectionApprovals.length,
+      allRequiredRowsApproved,
+    },
   };
 };
 

--- a/scripts/playwright-iehp-assessment-import-smoke.ts
+++ b/scripts/playwright-iehp-assessment-import-smoke.ts
@@ -1,21 +1,30 @@
 import { createClient } from '@supabase/supabase-js';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { chromium } from 'playwright';
 import { isValidPhone, sanitizePhone } from '../src/lib/validation';
 import * as iehpAssessmentImportSmoke from './lib/iehp-assessment-import-smoke';
 
-import { cleanupAssessmentImportArtifacts } from './lib/assessment-import-cleanup';
+import { cleanupAssessmentImportArtifacts, deleteAssessmentStorageObject } from './lib/assessment-import-cleanup';
+import { assertSmokeClientMarker } from './lib/assessment-upload-promote-smoke-guards';
+import { readClinicalQaOutputFixtureText } from './lib/clinical-data-parity-agent';
 import {
+  IEHP_GENERATED_DOCX_PARITY_PROOF_CASE,
   IEHP_PDF_MINI_MATRIX_CASES,
   assertIehpDocumentChecklistField,
+  assertIehpGeneratedDocxTextParity,
+  buildRedactedIehpPreflightBlockerEvidence,
+  buildIehpGeneratedDocxParityPdfHtml,
   buildIehpPdfMiniMatrixHtml,
   canonicalizeUsPhoneForComparison,
+  deriveIehpGeneratedDocxParityManifest,
   buildIehpSmokeCleanupFailureMessage,
   buildIehpSmokeCleanupFailureManifestPayload,
   buildIehpSmokeUploadFileName,
   resolveIehpSmokeSampleFile,
+  selectIehpRequiredFinalOutputApprovals,
 } from './lib/iehp-assessment-import-smoke';
 import { loadPlaywrightEnv } from './lib/load-playwright-env';
 import {
@@ -45,9 +54,20 @@ type ChecklistResponse = {
     id: string;
     placeholder_key: string;
     label?: string | null;
+    required?: boolean;
+    status?: string;
     value_text?: string | null;
+    value_json?: unknown;
   }>;
-  structured_sections?: unknown[];
+  structured_sections?: Array<{
+    id?: string;
+    field_key?: string;
+    section_key?: string;
+    section_index?: number;
+    payload?: unknown;
+    required?: boolean;
+    status?: string;
+  }> | unknown[];
 };
 
 type ChecklistResponsePayload =
@@ -99,7 +119,38 @@ type IehpSmokeCaseEvidence = {
   screenshot: string;
 };
 
+type AssessmentPlanPdfBlocker = {
+  code?: unknown;
+};
+
+type AssessmentPlanPdfPreflightResponse = {
+  assessment_document_id?: unknown;
+  generated_file_type?: unknown;
+  preflight?: {
+    ready?: unknown;
+    blockers?: unknown;
+    warnings?: unknown;
+  };
+};
+
+type AssessmentPlanPdfGenerateResponse = {
+  assessment_document_id?: string;
+  generated_file_type?: 'docx' | 'pdf';
+  signed_url?: string;
+  object_path?: string;
+  bucket_id?: string | null;
+  filename?: string | null;
+};
+
+type ParsedAssessmentPlanPdfPreflight = {
+  assessmentDocumentId: string;
+  generatedFileType: 'docx' | 'pdf';
+  ready: boolean;
+  blockers: AssessmentPlanPdfBlocker[];
+};
+
 const DEFAULT_BASE_URL = 'https://app.allincompassing.ai';
+const DEFAULT_ASSESSMENT_BUCKET_ID = 'client-documents';
 const EXTRACTION_TIMEOUT_MS = 120_000;
 const IEHP_REFERRAL_DATE_FIELD_KEY = 'IEHP_FBA_REFERRAL_DATE';
 
@@ -347,6 +398,173 @@ const fetchAssessmentChecklist = async (
   return normalizeAssessmentChecklistResponse((await response.json()) as ChecklistResponsePayload);
 };
 
+const callAppJson = async <T>(
+  baseUrl: string,
+  accessToken: string,
+  pathValue: string,
+  init: RequestInit = {},
+): Promise<T> => {
+  const response = await fetchWithRetry(
+    `${baseUrl}${pathValue}`,
+    {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        ...(init.body ? { 'Content-Type': 'application/json' } : {}),
+        ...init.headers,
+      },
+    },
+    `Request for ${pathValue}`,
+  );
+
+  if (!response.ok) {
+    throw new Error(`Request for ${pathValue} failed with status ${response.status}.`);
+  }
+
+  const text = await response.text();
+  return text ? JSON.parse(text) as T : {} as T;
+};
+
+const postAssessmentPlanPdfPreflight = async (args: {
+  baseUrl: string;
+  accessToken: string;
+  assessmentDocumentId: string;
+}): Promise<AssessmentPlanPdfPreflightResponse> =>
+  callAppJson<AssessmentPlanPdfPreflightResponse>(
+    args.baseUrl,
+    args.accessToken,
+    '/api/assessment-plan-pdf',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        assessment_document_id: args.assessmentDocumentId,
+        preflight_only: true,
+      }),
+    },
+  );
+
+export const parseAssessmentPlanPdfPreflight = (
+  payload: AssessmentPlanPdfPreflightResponse,
+): ParsedAssessmentPlanPdfPreflight => {
+  const assessmentDocumentId =
+    typeof payload.assessment_document_id === 'string' ? payload.assessment_document_id.trim() : '';
+  if (!assessmentDocumentId) {
+    throw new Error('IEHP generated DOCX parity expected assessment-plan-pdf preflight to include assessment_document_id.');
+  }
+
+  const generatedFileType = payload.generated_file_type;
+  if (generatedFileType !== 'docx' && generatedFileType !== 'pdf') {
+    throw new Error('IEHP generated DOCX parity expected assessment-plan-pdf preflight to include generated_file_type.');
+  }
+
+  if (!payload.preflight || typeof payload.preflight !== 'object') {
+    throw new Error('IEHP generated DOCX parity expected assessment-plan-pdf preflight payload.preflight.');
+  }
+
+  if (typeof payload.preflight.ready !== 'boolean') {
+    throw new Error('IEHP generated DOCX parity expected assessment-plan-pdf preflight ready boolean.');
+  }
+
+  if (!Array.isArray(payload.preflight.blockers)) {
+    throw new Error('IEHP generated DOCX parity expected assessment-plan-pdf preflight blockers array.');
+  }
+
+  return {
+    assessmentDocumentId,
+    generatedFileType,
+    ready: payload.preflight.ready,
+    blockers: payload.preflight.blockers as AssessmentPlanPdfBlocker[],
+  };
+};
+
+export const cleanupGeneratedDocxParityArtifacts = async (args: {
+  generatedArtifact?:
+    | {
+        bucketId: string;
+        objectPath: string;
+      }
+    | null;
+  sourceAssessment?:
+    | {
+        assessmentDocumentId: string;
+        bucketId: string;
+        objectPath: string;
+      }
+    | null;
+  deleteGeneratedArtifact?: () => Promise<void>;
+  deleteSourceAssessment?: () => Promise<void>;
+}): Promise<void> => {
+  const operations: Array<Promise<void>> = [];
+
+  if (args.generatedArtifact || args.deleteGeneratedArtifact) {
+    operations.push((args.deleteGeneratedArtifact ?? (async () => undefined))());
+  }
+  if (args.sourceAssessment || args.deleteSourceAssessment) {
+    operations.push((args.deleteSourceAssessment ?? (async () => undefined))());
+  }
+
+  const results = await Promise.allSettled(operations);
+  const failedCount = results.filter((result) => result.status === 'rejected').length;
+  if (failedCount > 0) {
+    throw new Error(`IEHP generated DOCX parity cleanup did not complete for ${failedCount} cleanup target(s).`);
+  }
+};
+
+export const assertIehpGeneratedDocxStorageTarget = (args: {
+  bucketId: string | null | undefined;
+  objectPath: string | null | undefined;
+  clientId: string;
+  assessmentDocumentId: string;
+}): { bucketId: typeof DEFAULT_ASSESSMENT_BUCKET_ID; objectPath: string } => {
+  const bucketId = args.bucketId?.trim() ?? '';
+  const objectPath = args.objectPath?.trim() ?? '';
+  const expectedPrefix = `clients/${args.clientId}/assessments/generated-iehp-fba-${args.assessmentDocumentId}-`;
+  const timestampAndExtension = objectPath.slice(expectedPrefix.length);
+
+  if (bucketId !== DEFAULT_ASSESSMENT_BUCKET_ID) {
+    throw new Error('IEHP generated DOCX parity rejected an unexpected generated artifact bucket.');
+  }
+  if (!objectPath.startsWith(expectedPrefix) || !/^\d+\.docx$/.test(timestampAndExtension)) {
+    throw new Error('IEHP generated DOCX parity rejected an unexpected generated artifact object path.');
+  }
+
+  return { bucketId: DEFAULT_ASSESSMENT_BUCKET_ID, objectPath };
+};
+
+export const readSyntheticGeneratedDocxText = async (
+  artifactBuffer: Buffer,
+  options: {
+    tempRoot?: string;
+    reader?: (filePath: string) => Promise<string>;
+  } = {},
+): Promise<string> => {
+  const tempDirectory = mkdtempSync(path.join(options.tempRoot ?? tmpdir(), 'synthetic-iehp-docx-parity-'));
+  const tempArtifactPath = path.join(tempDirectory, 'generated.docx');
+
+  try {
+    writeFileSync(tempArtifactPath, artifactBuffer);
+    return await (options.reader ?? readClinicalQaOutputFixtureText)(tempArtifactPath);
+  } finally {
+    rmSync(tempDirectory, { recursive: true, force: true });
+  }
+};
+
+const patchAssessmentChecklist = async (args: {
+  baseUrl: string;
+  accessToken: string;
+  body: Record<string, unknown>;
+}): Promise<void> => {
+  await callAppJson(
+    args.baseUrl,
+    args.accessToken,
+    '/api/assessment-checklist',
+    {
+      method: 'PATCH',
+      body: JSON.stringify(args.body),
+    },
+  );
+};
+
 export const fetchIehpAssessorPhoneProvenance = async (args: {
   accessToken: string;
   assessmentDocumentId: string;
@@ -561,7 +779,7 @@ export const selectConfiguredSmokeClient = async (
       const authResult = await signInSmokeUser(supabase, email, password);
       const { data: client, error } = await supabase
         .from('clients')
-        .select('id, therapist_id, organization_id')
+        .select('id, therapist_id, organization_id, full_name')
         .eq('id', configuredClientId)
         .maybeSingle();
 
@@ -611,6 +829,11 @@ export const selectConfiguredSmokeClient = async (
         );
       }
 
+      assertSmokeClientMarker(
+        typeof client.full_name === 'string' ? client.full_name : null,
+        'configured-client',
+      );
+
       return {
         accessToken: authResult.accessToken,
         clientId: client.id,
@@ -642,10 +865,13 @@ async function run() {
   const supabaseAnonKey = resolveSupabaseAnonKey();
   const isPdfMiniMatrixMode = process.argv.includes('--pdf-mini-matrix');
   const isSkillsBehaviorsProofMode = process.argv.includes('--skills-behaviors-proof');
+  const isGeneratedDocxParityMode = process.argv.includes('--generated-docx-parity');
   const IEHP_SKILLS_BEHAVIORS_PROOF_CASE = iehpAssessmentImportSmoke.IEHP_SKILLS_BEHAVIORS_PROOF_CASE;
   // buildIehpSkillsBehaviorsProofPdfHtml
   const sampleFilePath =
-    isPdfMiniMatrixMode || isSkillsBehaviorsProofMode ? null : resolveIehpSmokeSampleFile({ cwd: process.cwd() });
+    isPdfMiniMatrixMode || isSkillsBehaviorsProofMode || isGeneratedDocxParityMode
+      ? null
+      : resolveIehpSmokeSampleFile({ cwd: process.cwd() });
   const defaultSourceFileBuffer = sampleFilePath ? readFileSync(sampleFilePath) : null;
   const credentialCandidates = [
     {
@@ -837,6 +1063,276 @@ async function run() {
       }
     };
 
+    const runGeneratedDocxParityCase = async () => {
+      let createdAssessment: AssessmentDocumentRecord | null = null;
+      let generatedDocxObjectPath: string | null = null;
+      let generatedDocxBucketId: string | null = null;
+
+      return executeIehpSmokeCaseWithCleanup({
+        caseId: 'generated-docx-parity',
+        latestDir,
+        executeCase: async () => {
+          const uploadFileName = buildIehpSmokeUploadFileName(Date.now(), 'pdf');
+          const generatedPdfPage = await context.newPage();
+          let generatedPdfBuffer: Buffer;
+          try {
+            await generatedPdfPage.setContent(
+              buildIehpGeneratedDocxParityPdfHtml(IEHP_GENERATED_DOCX_PARITY_PROOF_CASE),
+            );
+            generatedPdfBuffer = await generatedPdfPage.pdf({ format: 'Letter', printBackground: true });
+          } finally {
+            if (!generatedPdfPage.isClosed()) {
+              await generatedPdfPage.close().then(() => undefined);
+            }
+          }
+          await page.goto(`${baseUrl}/clients/${clientId}?tab=programs-goals`, {
+            waitUntil: 'domcontentloaded',
+            timeout: 60_000,
+          });
+          await page.waitForLoadState('networkidle').catch(() => undefined);
+
+          await page.locator('#programs-goals-fba-template').selectOption('iehp_fba');
+          await page.getByText('IEHP FBA Upload Workflow').waitFor({ timeout: 20_000 });
+          await page.locator('#programs-goals-fba-file-upload').setInputFiles({
+            name: uploadFileName,
+            mimeType: 'application/pdf',
+            buffer: generatedPdfBuffer,
+          });
+          await page.getByRole('button', { name: /Upload IEHP FBA/i }).click();
+          await page.getByText('Uploading and processing your FBA. This can take a moment.').waitFor({ timeout: 20_000 });
+
+          const deadline = Date.now() + EXTRACTION_TIMEOUT_MS;
+          while (Date.now() < deadline) {
+            const documents = await fetchAssessmentDocuments(baseUrl, accessToken, clientId);
+            createdAssessment =
+              documents.find(
+                (document) => document.file_name === uploadFileName && document.template_type === 'iehp_fba',
+              ) ?? null;
+            if (createdAssessment && !['uploaded', 'extracting', 'extraction_running'].includes(createdAssessment.status)) {
+              break;
+            }
+            await pause(2_000);
+          }
+
+          if (!createdAssessment) {
+            throw new Error('Uploaded IEHP assessment document was not found in the queue.');
+          }
+          if (createdAssessment.status === 'drafted') {
+            throw new Error('IEHP import smoke unexpectedly created draft records and moved to drafted status.');
+          }
+          if (createdAssessment.status !== 'extracted') {
+            throw new Error(
+              `IEHP import smoke ended with ${createdAssessment.status}${
+                createdAssessment.extraction_error ? `: ${createdAssessment.extraction_error}` : ''
+              }`,
+            );
+          }
+
+          const { programCount, goalCount } = await fetchAssessmentDraftCounts(baseUrl, accessToken, createdAssessment.id);
+          if (programCount !== 0 || goalCount !== 0) {
+            throw new Error(
+              `IEHP import smoke expected zero drafts but found ${programCount} program(s) and ${goalCount} goal(s).`,
+            );
+          }
+
+          const checklist = await fetchAssessmentChecklist(baseUrl, accessToken, createdAssessment.id);
+          const provenanceRows = await fetchIehpAssessmentProvenance({
+            accessToken,
+            assessmentDocumentId: createdAssessment.id,
+            organizationId,
+            supabaseAnonKey,
+            supabaseUrl,
+            fieldKeys: [IEHP_ASSESSOR_PHONE_FIELD_KEY],
+          });
+          const assessorPhoneAssertion = assertIehpAssessorPhoneChecklist({
+            checklist,
+            expectedPhone: expectedAssessorPhone,
+            provenanceRows,
+          });
+
+          const preflightBeforeApprovalResponse = await postAssessmentPlanPdfPreflight({
+            baseUrl,
+            accessToken,
+            assessmentDocumentId: createdAssessment.id,
+          });
+          const parsedPreflightBeforeApproval = parseAssessmentPlanPdfPreflight(preflightBeforeApprovalResponse);
+          const preflightBeforeApproval = buildRedactedIehpPreflightBlockerEvidence({
+            ready: parsedPreflightBeforeApproval.ready,
+            blockers: parsedPreflightBeforeApproval.blockers,
+          });
+          if (preflightBeforeApproval.ready || !preflightBeforeApproval.hasUnapprovedRequiredBlocker) {
+            throw new Error('IEHP generated DOCX parity expected preflight_only to report unapproved required blockers.');
+          }
+
+          const sourceManifest = deriveIehpGeneratedDocxParityManifest({ checklist });
+          const approvalSelection = selectIehpRequiredFinalOutputApprovals({ checklist });
+          for (const approval of approvalSelection.checklistApprovals) {
+            await patchAssessmentChecklist({
+              baseUrl,
+              accessToken,
+              body: approval,
+            });
+          }
+          for (const approval of approvalSelection.structuredSectionApprovals) {
+            await patchAssessmentChecklist({
+              baseUrl,
+              accessToken,
+              body: approval,
+            });
+          }
+
+          const approvedChecklist = await fetchAssessmentChecklist(baseUrl, accessToken, createdAssessment.id);
+          const approvalVerification = selectIehpRequiredFinalOutputApprovals({ checklist: approvedChecklist });
+          if (!approvalVerification.summary.allRequiredRowsApproved) {
+            throw new Error('IEHP generated DOCX parity expected all required final-output rows to be approved after PATCH.');
+          }
+
+          const preflightAfterApprovalResponse = await postAssessmentPlanPdfPreflight({
+            baseUrl,
+            accessToken,
+            assessmentDocumentId: createdAssessment.id,
+          });
+          const parsedPreflightAfterApproval = parseAssessmentPlanPdfPreflight(preflightAfterApprovalResponse);
+          const preflightAfterApproval = buildRedactedIehpPreflightBlockerEvidence({
+            ready: parsedPreflightAfterApproval.ready,
+            blockers: parsedPreflightAfterApproval.blockers,
+          });
+          if (!preflightAfterApproval.ready) {
+            throw new Error('IEHP generated DOCX parity expected preflight_only to become ready after required approvals.');
+          }
+
+          await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
+          await page.waitForLoadState('networkidle').catch(() => undefined);
+          await page.getByRole('button', { name: uploadFileName, exact: true }).click({ timeout: 20_000 });
+          await page.getByRole('heading', { name: 'IEHP FBA Checklist Review' }).waitFor({ timeout: 20_000 });
+          const generatedDocxResponsePromise = page.waitForResponse(
+            (response) => {
+              const url = new URL(response.url());
+              return url.pathname === '/api/assessment-plan-pdf' && response.request().method() === 'POST';
+            },
+            { timeout: 45_000 },
+          );
+          const popupPromise = page.waitForEvent('popup', { timeout: 5_000 }).catch(() => null);
+          await page.getByRole('button', { name: /Generate completed IEHP DOCX/i }).click({ timeout: 10_000 });
+
+          const generatedDocxResponse = await generatedDocxResponsePromise;
+          if (!generatedDocxResponse.ok()) {
+            throw new Error('IEHP generated DOCX parity request failed before artifact download.');
+          }
+
+          const generatedDocxPayload = (await generatedDocxResponse.json()) as AssessmentPlanPdfGenerateResponse;
+          if (generatedDocxPayload.assessment_document_id !== createdAssessment.id) {
+            throw new Error('IEHP generated DOCX parity received a generation response for the wrong assessment document.');
+          }
+          if (generatedDocxPayload.generated_file_type !== 'docx') {
+            throw new Error('IEHP generated DOCX parity expected a DOCX response.');
+          }
+          const signedUrl = typeof generatedDocxPayload.signed_url === 'string' ? generatedDocxPayload.signed_url.trim() : '';
+          if (!signedUrl) {
+            throw new Error('IEHP generated DOCX parity expected a non-empty signed_url.');
+          }
+          const generatedStorageTarget = assertIehpGeneratedDocxStorageTarget({
+            bucketId: generatedDocxPayload.bucket_id,
+            objectPath: generatedDocxPayload.object_path,
+            clientId,
+            assessmentDocumentId: createdAssessment.id,
+          });
+          generatedDocxObjectPath = generatedStorageTarget.objectPath;
+          generatedDocxBucketId = generatedStorageTarget.bucketId;
+
+          const generatedDocxArtifactResponse = await page.context().request.get(signedUrl);
+          if (!generatedDocxArtifactResponse.ok()) {
+            throw new Error(`IEHP generated DOCX parity artifact download failed with HTTP ${generatedDocxArtifactResponse.status()}.`);
+          }
+          const generatedDocxArtifactBuffer = await generatedDocxArtifactResponse.body();
+          const popup = await popupPromise;
+          await popup?.close().catch(() => undefined);
+
+          const generatedDocxText = await readSyntheticGeneratedDocxText(generatedDocxArtifactBuffer);
+          const generatedDocxParity = assertIehpGeneratedDocxTextParity({
+            generatedDocxText,
+            sourceManifest,
+            proofCase: IEHP_GENERATED_DOCX_PARITY_PROOF_CASE,
+          });
+
+          return {
+            ok: true,
+            mode: 'generated-docx-parity',
+            caseId: 'generated-docx-parity',
+            templateType: 'iehp_fba',
+            status: createdAssessment.status,
+            draftPrograms: programCount,
+            draftGoals: goalCount,
+            assessorPhoneAssertion,
+            preflightBeforeApproval,
+            preflightAfterApproval,
+            sourceManifest: {
+              sectionCount: sourceManifest.sectionCount,
+              version: sourceManifest.version,
+              totalNames: sourceManifest.totalNames,
+              behaviorCount: sourceManifest.behaviorCount,
+              skillCount: sourceManifest.skillCount,
+              matchedCount: sourceManifest.matchedCount,
+              detailedOnlyCount: sourceManifest.detailedOnlyCount,
+              summaryOnlyOrAmbiguousCount: sourceManifest.summaryOnlyOrAmbiguousCount,
+            },
+            approvalSummary: approvalSelection.summary,
+            generatedDocxParity,
+            cleanupVerified: true,
+          };
+        },
+        cleanupCase: async () => {
+          await cleanupGeneratedDocxParityArtifacts({
+            generatedArtifact: generatedDocxObjectPath
+              ? {
+                  bucketId: generatedDocxBucketId || DEFAULT_ASSESSMENT_BUCKET_ID,
+                  objectPath: generatedDocxObjectPath,
+                }
+              : null,
+            sourceAssessment: createdAssessment
+              ? {
+                  assessmentDocumentId: createdAssessment.id,
+                  bucketId: createdAssessment.bucket_id?.trim() || DEFAULT_ASSESSMENT_BUCKET_ID,
+                  objectPath: createdAssessment.object_path,
+                }
+              : null,
+            deleteGeneratedArtifact: generatedDocxObjectPath
+              ? () =>
+                  deleteAssessmentStorageObject(fetch, {
+                    supabaseUrl,
+                    supabaseAnonKey,
+                    accessToken,
+                    bucketId: generatedDocxBucketId || DEFAULT_ASSESSMENT_BUCKET_ID,
+                    objectPath: generatedDocxObjectPath,
+                  })
+              : undefined,
+            deleteSourceAssessment: createdAssessment
+              ? () =>
+                  cleanupAssessmentImportArtifacts({
+                    accessToken,
+                    baseUrl,
+                    supabaseAnonKey,
+                    supabaseUrl,
+                    target: {
+                      assessmentDocumentId: createdAssessment.id,
+                      bucketId: createdAssessment.bucket_id?.trim() || DEFAULT_ASSESSMENT_BUCKET_ID,
+                      objectPath: createdAssessment.object_path,
+                    },
+                  })
+              : undefined,
+          });
+        },
+        cleanupTargetKnown: () => Boolean(createdAssessment),
+        onRunFailure: async () => {
+          const screenshot = await captureFailureScreenshot(
+            page,
+            'playwright-iehp-assessment-import-smoke-generated-docx-parity-failure',
+          );
+          console.error(`IEHP assessment import smoke failed for generated-docx-parity. Screenshot: ${screenshot}`);
+        },
+      });
+    };
+
     if (isPdfMiniMatrixMode) {
       const passedCases: IehpSmokeCaseEvidence[] = [];
       for (const caseDefinition of IEHP_PDF_MINI_MATRIX_CASES) {
@@ -1003,6 +1499,12 @@ async function run() {
           2,
         ),
       );
+      return;
+    }
+
+    if (isGeneratedDocxParityMode) {
+      const generatedDocxParityEvidence = await runGeneratedDocxParityCase();
+      console.log(JSON.stringify(generatedDocxParityEvidence, null, 2));
       return;
     }
 

--- a/scripts/playwright-iehp-assessment-import-smoke.ts
+++ b/scripts/playwright-iehp-assessment-import-smoke.ts
@@ -859,13 +859,28 @@ export const selectConfiguredSmokeClient = async (
 
 export const restoreIehpGeneratedDocxReviewSelection = async (args: {
   isReviewVisible: () => Promise<boolean>;
+  isUploadedAssessmentVisible: () => Promise<boolean>;
+  waitForNextPoll: () => Promise<void>;
   selectUploadedAssessment: () => Promise<void>;
   waitForReview: () => Promise<void>;
+  maxPollAttempts?: number;
 }): Promise<void> => {
-  if (!(await args.isReviewVisible())) {
-    await args.selectUploadedAssessment();
+  const maxPollAttempts = args.maxPollAttempts ?? 120;
+  for (let attempt = 0; attempt < maxPollAttempts; attempt += 1) {
+    if (await args.isReviewVisible()) {
+      await args.waitForReview();
+      return;
+    }
+    if (await args.isUploadedAssessmentVisible()) {
+      await args.selectUploadedAssessment();
+      await args.waitForReview();
+      return;
+    }
+    if (attempt < maxPollAttempts - 1) {
+      await args.waitForNextPoll();
+    }
   }
-  await args.waitForReview();
+  throw new Error('IEHP assessment queue did not restore a review or uploaded assessment.');
 };
 
 async function run() {
@@ -1215,10 +1230,12 @@ async function run() {
           await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
           await page.waitForLoadState('networkidle').catch(() => undefined);
           const reviewHeading = page.getByRole('heading', { name: 'IEHP FBA Checklist Review' });
+          const uploadedAssessmentButton = page.getByRole('button', { name: uploadFileName, exact: true });
           await restoreIehpGeneratedDocxReviewSelection({
             isReviewVisible: () => reviewHeading.isVisible().catch(() => false),
-            selectUploadedAssessment: () =>
-              page.getByRole('button', { name: uploadFileName, exact: true }).click({ timeout: 20_000 }),
+            isUploadedAssessmentVisible: () => uploadedAssessmentButton.isVisible().catch(() => false),
+            waitForNextPoll: () => page.waitForTimeout(500),
+            selectUploadedAssessment: () => uploadedAssessmentButton.click({ timeout: 20_000 }),
             waitForReview: () => reviewHeading.waitFor({ timeout: 20_000 }),
           });
           const generatedDocxResponsePromise = page.waitForResponse(

--- a/scripts/playwright-iehp-assessment-import-smoke.ts
+++ b/scripts/playwright-iehp-assessment-import-smoke.ts
@@ -857,6 +857,17 @@ export const selectConfiguredSmokeClient = async (
   throw new Error('Could not authenticate any configured IEHP assessment import smoke credential.');
 };
 
+export const restoreIehpGeneratedDocxReviewSelection = async (args: {
+  isReviewVisible: () => Promise<boolean>;
+  selectUploadedAssessment: () => Promise<void>;
+  waitForReview: () => Promise<void>;
+}): Promise<void> => {
+  if (!(await args.isReviewVisible())) {
+    await args.selectUploadedAssessment();
+  }
+  await args.waitForReview();
+};
+
 async function run() {
   loadPlaywrightEnv();
 
@@ -1203,8 +1214,13 @@ async function run() {
 
           await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
           await page.waitForLoadState('networkidle').catch(() => undefined);
-          await page.getByRole('button', { name: uploadFileName, exact: true }).click({ timeout: 20_000 });
-          await page.getByRole('heading', { name: 'IEHP FBA Checklist Review' }).waitFor({ timeout: 20_000 });
+          const reviewHeading = page.getByRole('heading', { name: 'IEHP FBA Checklist Review' });
+          await restoreIehpGeneratedDocxReviewSelection({
+            isReviewVisible: () => reviewHeading.isVisible().catch(() => false),
+            selectUploadedAssessment: () =>
+              page.getByRole('button', { name: uploadFileName, exact: true }).click({ timeout: 20_000 }),
+            waitForReview: () => reviewHeading.waitFor({ timeout: 20_000 }),
+          });
           const generatedDocxResponsePromise = page.waitForResponse(
             (response) => {
               const url = new URL(response.url());

--- a/tests/scripts/iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/iehp-assessment-import-smoke.test.ts
@@ -293,9 +293,6 @@ describe('IEHP assessment import smoke helpers', () => {
   it('renders a dedicated synthetic IEHP generated-docx parity PDF fixture with full extraction headings and deterministic terms', () => {
     const html = buildIehpGeneratedDocxParityPdfHtml(IEHP_GENERATED_DOCX_PARITY_PROOF_CASE);
 
-    for (const heading of IEHP_GENERATED_DOCX_PARITY_PROOF_CASE.expectedSectionHeadings) {
-      expect(html).toContain(heading);
-    }
     for (const term of IEHP_GENERATED_DOCX_PARITY_PROOF_CASE.expectedBehaviorSkillTerms) {
       expect(html).toContain(term);
     }
@@ -734,6 +731,79 @@ describe('assertIehpGeneratedDocxTextParity', () => {
       matchedNarrativeTermCount: 2,
       allExpectedContentPresent: true,
     });
+  });
+
+  it('matches section headings across Word run fragmentation and non-literal numbering', () => {
+    const fragmentedProofCase = {
+      ...proofCase,
+      expectedSectionHeadings: ['II. BEHAVIORS', 'Assessor/Certification:', 'Safety Procedure/Crisis Plan'],
+    };
+    const fragmentedText = [
+      'BEHAVIORS :',
+      'Assessor /C ertification :',
+      'Safety Procedure/Crisis Plan-',
+      ...proofCase.expectedNarrativeTerms,
+      ...sourceManifest.names,
+    ].join('\n');
+
+    expect(
+      assertIehpGeneratedDocxTextParity({
+        generatedDocxText: fragmentedText,
+        sourceManifest,
+        proofCase: fragmentedProofCase,
+      }),
+    ).toMatchObject({
+      matchedSectionHeadingCount: 3,
+      allExpectedContentPresent: true,
+    });
+  });
+
+  it('does not satisfy missing headings with related body text or later behavior headings', () => {
+    const collisionProofCase = {
+      ...proofCase,
+      expectedSectionHeadings: [
+        'II. BEHAVIORS',
+        'ASSESSMENT MEAURES:',
+        'Discharge, Transition and Exit Plans:',
+        'Transition Planning:',
+      ],
+    };
+    const collisionText = [
+      'TARGET BEHAVIORS:',
+      'REPLACEMENT BEHAVIORS:',
+      'Assessment Summary:',
+      'Discharge criteria are described in this body paragraph.',
+      'Transition planning includes fading service intensity.',
+      ...proofCase.expectedNarrativeTerms,
+      ...sourceManifest.names,
+    ].join('\n');
+
+    expect(() =>
+      assertIehpGeneratedDocxTextParity({
+        generatedDocxText: collisionText,
+        sourceManifest,
+        proofCase: collisionProofCase,
+      }),
+    ).toThrow('representative IEHP section heading');
+  });
+
+  it.each([
+    {
+      label: 'skill or behavior name',
+      text: completeText.replace('Behavior One', 'Behavior\nOne'),
+    },
+    {
+      label: 'source narrative',
+      text: completeText.replace('Synthetic narrative two', 'Synthetic narrative\ntwo'),
+    },
+  ])('does not join adjacent paragraphs to satisfy a missing $label', ({ text }) => {
+    expect(() =>
+      assertIehpGeneratedDocxTextParity({
+        generatedDocxText: text,
+        sourceManifest,
+        proofCase,
+      }),
+    ).toThrow('IEHP generated DOCX parity expected');
   });
 
   it.each([

--- a/tests/scripts/iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/iehp-assessment-import-smoke.test.ts
@@ -2,16 +2,22 @@ import { describe, expect, it } from 'vitest';
 import { isValidPhone } from '../../src/lib/validation';
 
 import {
+  IEHP_GENERATED_DOCX_PARITY_PROOF_CASE,
   IEHP_PDF_MINI_MATRIX_CASES,
   IEHP_SKILLS_BEHAVIORS_PROOF_CASE,
+  assertIehpGeneratedDocxTextParity,
   assertIehpSkillsBehaviorsChecklistSection,
+  buildRedactedIehpPreflightBlockerEvidence,
+  buildIehpGeneratedDocxParityPdfHtml,
   buildIehpPdfMiniMatrixHtml,
   buildIehpSkillsBehaviorsProofPdfHtml,
   canonicalizeUsPhoneForComparison,
   buildIehpSmokeUploadFileName,
   buildIehpSmokeCleanupFailureMessage,
   buildIehpSmokeCleanupFailureManifestPayload,
+  deriveIehpGeneratedDocxParityManifest,
   resolveIehpSmokeSampleFile,
+  selectIehpRequiredFinalOutputApprovals,
 } from '../../scripts/lib/iehp-assessment-import-smoke';
 
 describe('IEHP assessment import smoke helpers', () => {
@@ -64,6 +70,10 @@ describe('IEHP assessment import smoke helpers', () => {
   it('keeps the default DOCX upload name and supports PDF uploads explicitly', () => {
     expect(buildIehpSmokeUploadFileName(12345)).toBe('iehp-fba-smoke-12345.docx');
     expect(buildIehpSmokeUploadFileName(12345, 'pdf')).toBe('iehp-fba-smoke-12345.pdf');
+  });
+
+  it('supports a dedicated generated docx parity smoke command name', () => {
+    expect(buildIehpSmokeUploadFileName(12345, 'docx')).toBe('iehp-fba-smoke-12345.docx');
   });
 
   it('defines exactly the approved IEHP PDF mini matrix cases with unique synthetic values', () => {
@@ -260,6 +270,47 @@ describe('IEHP assessment import smoke helpers', () => {
     expect(message).toContain('artifacts/latest/manifest.json');
     expect(message).not.toContain('client-documents');
     expect(message).not.toContain('doc-1');
+  });
+
+  it('redacts preflight blocker evidence down to code and count only', () => {
+    expect(
+      buildRedactedIehpPreflightBlockerEvidence({
+        ready: false,
+        blockers: [
+          { code: 'required_checklist_pending', message: 'Synthetic detail that must stay private.' },
+          { code: 'required_checklist_pending', message: 'Second private detail.' },
+          { code: 'required_structured_sections_pending', message: 'Another private detail.' },
+        ],
+      }),
+    ).toEqual({
+      ready: false,
+      blockerCount: 3,
+      blockerCodes: ['required_checklist_pending', 'required_structured_sections_pending'],
+      hasUnapprovedRequiredBlocker: true,
+    });
+  });
+
+  it('renders a dedicated synthetic IEHP generated-docx parity PDF fixture with full extraction headings and deterministic terms', () => {
+    const html = buildIehpGeneratedDocxParityPdfHtml(IEHP_GENERATED_DOCX_PARITY_PROOF_CASE);
+
+    for (const heading of IEHP_GENERATED_DOCX_PARITY_PROOF_CASE.expectedSectionHeadings) {
+      expect(html).toContain(heading);
+    }
+    for (const term of IEHP_GENERATED_DOCX_PARITY_PROOF_CASE.expectedBehaviorSkillTerms) {
+      expect(html).toContain(term);
+    }
+    for (const term of IEHP_GENERATED_DOCX_PARITY_PROOF_CASE.expectedNarrativeTerms) {
+      expect(html).toContain(term);
+    }
+
+    expect(html).toContain('Report Date: 08/12/2026');
+    expect(html).toContain('IEHP Member ID#: SYNTH-0001');
+    expect(html).toContain('Records Reviewed: 08/01/2026 Telehealth BCBA');
+    expect(html).toContain('Clinical Interview: 08/02/2026 Home BCBA');
+    expect(html).toContain('1st Member Observation: 08/03/2026 home observation narrative.');
+    expect(html).toContain('2nd Member Observation: 08/04/2026 school observation narrative.');
+    expect(html).toContain('H2019 Therapeutic Behavioral Services, per 15 minutes 10 units');
+    expect(html).toContain('H0032 Mental Health Service Plan Development by Non-Physician, per 15 minutes 4 units');
   });
 });
 
@@ -533,5 +584,415 @@ describe('assertIehpSkillsBehaviorsChecklistSection', () => {
         proofCase: IEHP_SKILLS_BEHAVIORS_PROOF_CASE,
       }),
     ).toThrow(message);
+  });
+});
+
+describe('deriveIehpGeneratedDocxParityManifest', () => {
+  const checklist = {
+    items: [],
+    structured_sections: [
+      {
+        field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+        payload: {
+          skills_behaviors: {
+            version: 1,
+            items: [
+              {
+                name: 'Behavior One',
+                clinical_goal_type: 'behavior',
+                reconciliation_status: 'matched',
+              },
+              {
+                name: 'Skill One',
+                clinical_goal_type: 'skill',
+                reconciliation_status: 'matched',
+              },
+              {
+                name: 'Skill Two',
+                clinical_goal_type: 'skill',
+                reconciliation_status: 'detailed_only',
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+
+  it('derives a v1 generated-docx parity manifest from skills_behaviors without producing log-ready names', () => {
+    expect(deriveIehpGeneratedDocxParityManifest({ checklist })).toEqual({
+      sectionCount: 1,
+      version: 1,
+      names: ['Behavior One', 'Skill One', 'Skill Two'],
+      totalNames: 3,
+      behaviorCount: 1,
+      skillCount: 2,
+      matchedCount: 2,
+      detailedOnlyCount: 1,
+      summaryOnlyOrAmbiguousCount: 0,
+    });
+  });
+
+  it.each(['summary_only', 'ambiguous'] as const)(
+    'refuses to build an auto-approval manifest with a %s skills_behaviors item',
+    (reconciliationStatus) => {
+      const unresolvedChecklist = structuredClone(checklist);
+      const section = unresolvedChecklist.structured_sections[0];
+      section.payload.skills_behaviors.items.push({
+        name: 'Needs Review',
+        clinical_goal_type: null,
+        reconciliation_status: reconciliationStatus,
+      });
+
+      expect(() => deriveIehpGeneratedDocxParityManifest({ checklist: unresolvedChecklist })).toThrow(
+        'IEHP generated DOCX parity refuses to auto-approve summary-only or ambiguous skills_behaviors items.',
+      );
+    },
+  );
+
+  it.each([
+    {
+      name: 'missing section',
+      input: { items: [], structured_sections: [] },
+      message: 'IEHP smoke could not find IEHP_FBA_BEHAVIOR_SKILL_TARGETS in structured sections.',
+    },
+    {
+      name: 'wrong version',
+      input: {
+        items: [],
+        structured_sections: [
+          {
+            field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+            payload: { skills_behaviors: { version: 2, items: [{ name: 'Behavior One', clinical_goal_type: 'behavior', reconciliation_status: 'matched' }, { name: 'Skill One', clinical_goal_type: 'skill', reconciliation_status: 'matched' }] } },
+          },
+        ],
+      },
+      message: 'IEHP smoke expected IEHP_FBA_BEHAVIOR_SKILL_TARGETS skills_behaviors.version to equal 1.',
+    },
+    {
+      name: 'missing behavior',
+      input: {
+        items: [],
+        structured_sections: [
+          {
+            field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+            payload: { skills_behaviors: { version: 1, items: [{ name: 'Skill One', clinical_goal_type: 'skill', reconciliation_status: 'matched' }] } },
+          },
+        ],
+      },
+      message: 'IEHP smoke expected at least one behavior and one skill in IEHP_FBA_BEHAVIOR_SKILL_TARGETS.',
+    },
+    {
+      name: 'blank item name',
+      input: {
+        items: [],
+        structured_sections: [
+          {
+            field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+            payload: { skills_behaviors: { version: 1, items: [{ name: 'Behavior One', clinical_goal_type: 'behavior', reconciliation_status: 'matched' }, { name: '   ', clinical_goal_type: 'skill', reconciliation_status: 'matched' }] } },
+          },
+        ],
+      },
+      message: 'IEHP smoke found IEHP_FBA_BEHAVIOR_SKILL_TARGETS but payload.skills_behaviors.items contained a blank name.',
+    },
+  ])('fails clearly for $name', ({ input, message }) => {
+    expect(() => deriveIehpGeneratedDocxParityManifest({ checklist: input })).toThrow(message);
+  });
+});
+
+describe('assertIehpGeneratedDocxTextParity', () => {
+  const proofCase = {
+    id: 'generated-docx-parity' as const,
+    expectedSectionHeadings: ['I. IDENTIFICATION', 'IX. TARGET BEHAVIORS'],
+    expectedBehaviorSkillTerms: ['Behavior One', 'Skill One', 'Skill Two', 'Skill Three'] as const,
+    expectedNarrativeTerms: ['Synthetic narrative one', 'Synthetic narrative two'],
+  };
+  const sourceManifest = {
+    sectionCount: 1 as const,
+    version: 1 as const,
+    names: ['Behavior One', 'Skill One'],
+    totalNames: 2,
+    behaviorCount: 1,
+    skillCount: 1,
+    matchedCount: 2,
+    detailedOnlyCount: 0,
+    summaryOnlyOrAmbiguousCount: 0,
+  };
+  const completeText = [
+    ...proofCase.expectedSectionHeadings,
+    ...proofCase.expectedNarrativeTerms,
+    ...sourceManifest.names,
+  ].join('\n');
+
+  it('requires names, representative section headings, and representative source narratives', () => {
+    expect(assertIehpGeneratedDocxTextParity({ generatedDocxText: completeText, sourceManifest, proofCase })).toEqual({
+      expectedNameCount: 2,
+      matchedNameCount: 2,
+      expectedSectionHeadingCount: 2,
+      matchedSectionHeadingCount: 2,
+      expectedNarrativeTermCount: 2,
+      matchedNarrativeTermCount: 2,
+      allExpectedContentPresent: true,
+    });
+  });
+
+  it.each([
+    ['skill or behavior name', 'Behavior One'],
+    ['section heading', 'IX. TARGET BEHAVIORS'],
+    ['source narrative', 'Synthetic narrative two'],
+  ])('fails closed when the generated DOCX omits a representative %s', (_label, missingTerm) => {
+    expect(() =>
+      assertIehpGeneratedDocxTextParity({
+        generatedDocxText: completeText.replace(missingTerm, ''),
+        sourceManifest,
+        proofCase,
+      }),
+    ).toThrow('IEHP generated DOCX parity expected');
+  });
+});
+
+describe('selectIehpRequiredFinalOutputApprovals', () => {
+  const baseChecklist = {
+    items: [
+      {
+        id: 'required-checklist',
+        label: 'Required text field',
+        placeholder_key: 'IEHP_REQUIRED_TEXT',
+        required: true,
+        status: 'verified',
+        value_text: 'Approved text',
+      },
+      {
+        id: 'optional-phone',
+        label: 'Optional phone',
+        placeholder_key: 'IEHP_FBA_ASSESSOR_PHONE',
+        required: true,
+        status: 'verified',
+        value_text: '(951) 555-0101',
+      },
+    ],
+    structured_sections: [
+      {
+        id: 'required-structured',
+        field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+        section_key: 'behavior-skill-targets',
+        section_index: 0,
+        required: true,
+        status: 'verified',
+        payload: {
+          skills_behaviors: {
+            version: 1,
+            items: [{ name: 'Behavior One', clinical_goal_type: 'behavior', reconciliation_status: 'matched' }],
+          },
+          keep_server_side: true,
+        },
+      },
+      {
+        id: 'optional-provider',
+        field_key: 'IEHP_FBA_REFERRING_PROVIDER',
+        section_key: 'provider',
+        section_index: 1,
+        required: true,
+        status: 'verified',
+        payload: { provider: 'Synthetic Provider' },
+      },
+    ],
+  };
+
+  it('selects only final-output-required checklist and structured approvals and preserves original payloads', () => {
+    const result = selectIehpRequiredFinalOutputApprovals({ checklist: baseChecklist });
+
+    expect(result.summary).toEqual({
+      checklistCount: 1,
+      structuredCount: 1,
+      allRequiredRowsApproved: false,
+    });
+    expect(result.checklistApprovals).toEqual([
+      {
+        item_id: 'required-checklist',
+        status: 'approved',
+        review_notes: 'IEHP generated DOCX parity auto-approved required checklist row from synthetic smoke fixture.',
+        value_text: 'Approved text',
+      },
+    ]);
+    expect(result.structuredSectionApprovals).toEqual([
+      {
+        structured_section_id: 'required-structured',
+        status: 'approved',
+        review_notes: 'IEHP generated DOCX parity auto-approved required structured row from synthetic smoke fixture.',
+        payload: baseChecklist.structured_sections[0]?.payload,
+      },
+    ]);
+  });
+
+  it('reports all required rows approved after already-approved required rows are filtered out', () => {
+    const result = selectIehpRequiredFinalOutputApprovals({
+      checklist: {
+        items: [
+          {
+            id: 'required-checklist',
+            label: 'Required text field',
+            placeholder_key: 'IEHP_REQUIRED_TEXT',
+            required: true,
+            status: 'approved',
+            value_text: 'Approved text',
+          },
+        ],
+        structured_sections: [
+          {
+            id: 'required-structured',
+            field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+            section_key: 'behavior-skill-targets',
+            section_index: 0,
+            required: true,
+            status: 'approved',
+            payload: { skills_behaviors: { version: 1, items: [{ name: 'Behavior One', clinical_goal_type: 'behavior', reconciliation_status: 'matched' }] } },
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toEqual({
+      checklistCount: 0,
+      structuredCount: 0,
+      allRequiredRowsApproved: true,
+    });
+  });
+
+  it('preserves value_json on checklist approvals instead of stringifying it into value_text', () => {
+    const valueJson = { narrative: 'Structured review value', selected: 'yes' };
+    const result = selectIehpRequiredFinalOutputApprovals({
+      checklist: {
+        items: [
+          {
+            id: 'required-checklist',
+            label: 'Required json field',
+            placeholder_key: 'IEHP_REQUIRED_JSON',
+            required: true,
+            status: 'verified',
+            value_text: '   ',
+            value_json: valueJson,
+          },
+        ],
+        structured_sections: [],
+      },
+    });
+
+    expect(result.checklistApprovals).toEqual([
+      {
+        item_id: 'required-checklist',
+        status: 'approved',
+        review_notes: 'IEHP generated DOCX parity auto-approved required checklist row from synthetic smoke fixture.',
+        value_json: valueJson,
+      },
+    ]);
+  });
+
+  it.each([
+    {
+      name: 'blank required checklist value',
+      checklist: {
+        items: [
+          {
+            id: 'required-checklist',
+            label: 'Required text field',
+            placeholder_key: 'IEHP_REQUIRED_TEXT',
+            required: true,
+            status: 'verified',
+            value_text: '   ',
+          },
+        ],
+        structured_sections: [],
+      },
+      message: 'IEHP smoke required checklist row IEHP_REQUIRED_TEXT was blank or malformed.',
+    },
+    {
+      name: 'missing required structured payload',
+      checklist: {
+        items: [],
+        structured_sections: [
+          {
+            id: 'required-structured',
+            field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+            section_key: 'behavior-skill-targets',
+            section_index: 0,
+            required: true,
+            status: 'verified',
+            payload: null,
+          },
+        ],
+      },
+      message: 'IEHP smoke required structured row IEHP_FBA_BEHAVIOR_SKILL_TARGETS was blank or malformed.',
+    },
+    {
+      name: 'false-only checklist value',
+      checklist: {
+        items: [
+          {
+            id: 'required-checklist',
+            label: 'Required boolean field',
+            placeholder_key: 'IEHP_REQUIRED_BOOLEAN',
+            required: true,
+            status: 'verified',
+            value_json: false,
+          },
+        ],
+        structured_sections: [],
+      },
+      message: 'IEHP smoke required checklist row IEHP_REQUIRED_BOOLEAN was blank or malformed.',
+    },
+    {
+      name: 'metadata-only structured payload',
+      checklist: {
+        items: [],
+        structured_sections: [
+          {
+            id: 'required-structured',
+            field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+            section_key: 'behavior-skill-targets',
+            section_index: 0,
+            required: true,
+            status: 'verified',
+            payload: { field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS', section_index: 0, required: true },
+          },
+        ],
+      },
+      message: 'IEHP smoke required structured row IEHP_FBA_BEHAVIOR_SKILL_TARGETS was blank or malformed.',
+    },
+    {
+      name: 'unreviewable checklist status',
+      checklist: {
+        items: [
+          {
+            id: 'required-checklist',
+            placeholder_key: 'IEHP_REQUIRED_TEXT',
+            required: true,
+            status: 'not_started',
+            value_text: 'Synthetic value',
+          },
+        ],
+        structured_sections: [],
+      },
+      message: 'IEHP smoke required row IEHP_REQUIRED_TEXT was not in a reviewable status for synthetic auto-approval.',
+    },
+    {
+      name: 'rejected structured status',
+      checklist: {
+        items: [],
+        structured_sections: [
+          {
+            id: 'required-structured',
+            field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+            required: true,
+            status: 'rejected',
+            payload: { narrative: 'Synthetic value' },
+          },
+        ],
+      },
+      message:
+        'IEHP smoke required row IEHP_FBA_BEHAVIOR_SKILL_TARGETS was not in a reviewable status for synthetic auto-approval.',
+    },
+  ])('fails closed for $name', ({ checklist, message }) => {
+    expect(() => selectIehpRequiredFinalOutputApprovals({ checklist })).toThrow(message);
   });
 });

--- a/tests/scripts/iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/iehp-assessment-import-smoke.test.ts
@@ -799,7 +799,7 @@ describe('selectIehpRequiredFinalOutputApprovals', () => {
     ],
   };
 
-  it('selects only final-output-required checklist and structured approvals and preserves original payloads', () => {
+  it('selects only final-output-required approvals and keeps structured approvals status-only', () => {
     const result = selectIehpRequiredFinalOutputApprovals({ checklist: baseChecklist });
 
     expect(result.summary).toEqual({
@@ -820,7 +820,6 @@ describe('selectIehpRequiredFinalOutputApprovals', () => {
         structured_section_id: 'required-structured',
         status: 'approved',
         review_notes: 'IEHP generated DOCX parity auto-approved required structured row from synthetic smoke fixture.',
-        payload: baseChecklist.structured_sections[0]?.payload,
       },
     ]);
   });
@@ -846,7 +845,13 @@ describe('selectIehpRequiredFinalOutputApprovals', () => {
             section_index: 0,
             required: true,
             status: 'approved',
-            payload: { skills_behaviors: { version: 1, items: [{ name: 'Behavior One', clinical_goal_type: 'behavior', reconciliation_status: 'matched' }] } },
+            payload: {
+              targets: ['Behavior One'],
+              skills_behaviors: {
+                version: 1,
+                items: [{ name: 'Behavior One', clinical_goal_type: 'behavior', reconciliation_status: 'matched' }],
+              },
+            },
           },
         ],
       },
@@ -953,11 +958,69 @@ describe('selectIehpRequiredFinalOutputApprovals', () => {
             section_index: 0,
             required: true,
             status: 'verified',
-            payload: { field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS', section_index: 0, required: true },
+            payload: {
+              field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+              section_index: 0,
+              required: true,
+              source: 'adobe',
+            },
           },
         ],
       },
       message: 'IEHP smoke required structured row IEHP_FBA_BEHAVIOR_SKILL_TARGETS was blank or malformed.',
+    },
+    {
+      name: 'derived-only skills behaviors payload',
+      checklist: {
+        items: [],
+        structured_sections: [
+          {
+            id: 'required-structured',
+            field_key: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',
+            required: true,
+            status: 'verified',
+            payload: {
+              skills_behaviors: {
+                version: 1,
+                items: [{ name: 'Derived Only', clinical_goal_type: 'skill', reconciliation_status: 'matched' }],
+              },
+            },
+          },
+        ],
+      },
+      message: 'IEHP smoke required structured row IEHP_FBA_BEHAVIOR_SKILL_TARGETS was blank or malformed.',
+    },
+    {
+      name: 'approved metadata-only structured payload',
+      checklist: {
+        items: [],
+        structured_sections: [
+          {
+            id: 'required-structured',
+            field_key: 'IEHP_FBA_REASON_FOR_REFERRAL',
+            required: true,
+            status: 'approved',
+            payload: { source: 'adobe', template_placeholder: true, entered_value_present: false },
+          },
+        ],
+      },
+      message: 'IEHP smoke required structured row IEHP_FBA_REASON_FOR_REFERRAL was blank or malformed.',
+    },
+    {
+      name: 'unknown-only structured payload',
+      checklist: {
+        items: [],
+        structured_sections: [
+          {
+            id: 'required-structured',
+            field_key: 'IEHP_FBA_REASON_FOR_REFERRAL',
+            required: true,
+            status: 'verified',
+            payload: { clinical_value: 'unknown' },
+          },
+        ],
+      },
+      message: 'IEHP smoke required structured row IEHP_FBA_REASON_FOR_REFERRAL was blank or malformed.',
     },
     {
       name: 'unreviewable checklist status',

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { assertIehpDocumentChecklistField } from '../../scripts/lib/iehp-assessment-import-smoke';
+import {
+  IEHP_GENERATED_DOCX_PARITY_PROOF_CASE,
+  assertIehpDocumentChecklistField,
+  assertIehpGeneratedDocxTextParity,
+} from '../../scripts/lib/iehp-assessment-import-smoke';
 
 import {
   assertIehpAssessorPhoneChecklist,
@@ -1373,6 +1377,38 @@ describe('generated DOCX artifact containment', () => {
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  it('matches every representative heading against the bundled generated IEHP DOCX template', async () => {
+    const templateBuffer = readFileSync(
+      path.resolve('supabase/functions/generate-assessment-plan-docx/fill_docs/Updated FBA -IEHP.docx'),
+    );
+    const generatedDocxText = await readSyntheticGeneratedDocxText(templateBuffer);
+
+    expect(
+      assertIehpGeneratedDocxTextParity({
+        generatedDocxText,
+        sourceManifest: {
+          sectionCount: 1,
+          version: 1,
+          names: [],
+          totalNames: 0,
+          behaviorCount: 0,
+          skillCount: 0,
+          matchedCount: 0,
+          detailedOnlyCount: 0,
+          summaryOnlyOrAmbiguousCount: 0,
+        },
+        proofCase: {
+          ...IEHP_GENERATED_DOCX_PARITY_PROOF_CASE,
+          expectedNarrativeTerms: [],
+        },
+      }),
+    ).toMatchObject({
+      expectedSectionHeadingCount: 26,
+      matchedSectionHeadingCount: 26,
+      allExpectedContentPresent: true,
+    });
   });
 });
 

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -41,6 +41,8 @@ describe('restoreIehpGeneratedDocxReviewSelection', () => {
 
     await restoreIehpGeneratedDocxReviewSelection({
       isReviewVisible: vi.fn().mockResolvedValue(true),
+      isUploadedAssessmentVisible: vi.fn().mockResolvedValue(false),
+      waitForNextPoll: vi.fn().mockResolvedValue(undefined),
       selectUploadedAssessment,
       waitForReview,
     });
@@ -55,6 +57,8 @@ describe('restoreIehpGeneratedDocxReviewSelection', () => {
 
     await restoreIehpGeneratedDocxReviewSelection({
       isReviewVisible: vi.fn().mockResolvedValue(false),
+      isUploadedAssessmentVisible: vi.fn().mockResolvedValue(true),
+      waitForNextPoll: vi.fn().mockResolvedValue(undefined),
       selectUploadedAssessment,
       waitForReview,
     });
@@ -62,6 +66,39 @@ describe('restoreIehpGeneratedDocxReviewSelection', () => {
     expect(selectUploadedAssessment).toHaveBeenCalledOnce();
     expect(waitForReview).toHaveBeenCalledOnce();
     expect(selectUploadedAssessment.mock.invocationCallOrder[0]).toBeLessThan(waitForReview.mock.invocationCallOrder[0]);
+  });
+
+  it('waits for the assessment queue before choosing a restoration path', async () => {
+    const isReviewVisible = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const isUploadedAssessmentVisible = vi.fn().mockResolvedValue(false);
+    const waitForNextPoll = vi.fn().mockResolvedValue(undefined);
+    const selectUploadedAssessment = vi.fn();
+    const waitForReview = vi.fn().mockResolvedValue(undefined);
+
+    await restoreIehpGeneratedDocxReviewSelection({
+      isReviewVisible,
+      isUploadedAssessmentVisible,
+      waitForNextPoll,
+      selectUploadedAssessment,
+      waitForReview,
+    });
+
+    expect(waitForNextPoll).toHaveBeenCalledOnce();
+    expect(selectUploadedAssessment).not.toHaveBeenCalled();
+    expect(waitForReview).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed when neither restoration target becomes visible', async () => {
+    await expect(
+      restoreIehpGeneratedDocxReviewSelection({
+        isReviewVisible: vi.fn().mockResolvedValue(false),
+        isUploadedAssessmentVisible: vi.fn().mockResolvedValue(false),
+        waitForNextPoll: vi.fn().mockResolvedValue(undefined),
+        selectUploadedAssessment: vi.fn(),
+        waitForReview: vi.fn(),
+        maxPollAttempts: 2,
+      }),
+    ).rejects.toThrow('IEHP assessment queue did not restore a review or uploaded assessment');
   });
 });
 
@@ -1197,8 +1234,9 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     expect(approvalSelectionIndex).toBeGreaterThan(manifestDerivationIndex);
     expect(approvedRefetchIndex).toBeGreaterThan(approvalSelectionIndex);
     expect(reviewHeadingIndex).toBeGreaterThan(approvedRefetchIndex);
+    expect(uploadFileButtonIndex).toBeGreaterThan(reviewHeadingIndex);
     expect(restoredSelectionCallIndex).toBeGreaterThan(reviewHeadingIndex);
-    expect(uploadFileButtonIndex).toBeGreaterThan(restoredSelectionCallIndex);
+    expect(restoredSelectionCallIndex).toBeGreaterThan(uploadFileButtonIndex);
     expect(generateButtonIndex).toBeGreaterThan(approvedRefetchIndex);
     expect(outputFixtureReaderIndex).toBeGreaterThan(generateButtonIndex);
     expect(storageCleanupIndex).toBeGreaterThan(outputFixtureReaderIndex);

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -2,15 +2,20 @@
  * @vitest-environment node
  */
 import { describe, expect, it, vi } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { assertIehpDocumentChecklistField } from '../../scripts/lib/iehp-assessment-import-smoke';
 
 import {
   assertIehpAssessorPhoneChecklist,
+  assertIehpGeneratedDocxStorageTarget,
+  cleanupGeneratedDocxParityArtifacts,
   executeIehpSmokeCaseWithCleanup,
   fetchIehpAssessorPhoneProvenance,
   normalizeAssessmentChecklistResponse,
+  parseAssessmentPlanPdfPreflight,
+  readSyntheticGeneratedDocxText,
   selectConfiguredSmokeClient,
 } from '../../scripts/playwright-iehp-assessment-import-smoke';
 import { assertIehpSkillsBehaviorsChecklistSection } from '../../scripts/lib/iehp-assessment-import-smoke';
@@ -48,7 +53,12 @@ describe('selectConfiguredSmokeClient', () => {
       error: null,
     });
     const maybeSingle = vi.fn().mockResolvedValue({
-      data: { id: 'client-123', therapist_id: 'therapist-123', organization_id: 'org-123' },
+      data: {
+        id: 'client-123',
+        therapist_id: 'therapist-123',
+        organization_id: 'org-123',
+        full_name: 'Synthetic Smoke Client',
+      },
       error: null,
     });
     const anonClient = {
@@ -116,6 +126,48 @@ describe('selectConfiguredSmokeClient', () => {
       email: 'admin@test.com',
       password: 'valid-secret',
     });
+  });
+
+  it('rejects a configured client that is not explicitly marked as smoke, synthetic, or test', async () => {
+    const signInWithPassword = vi.fn().mockResolvedValue({
+      data: { session: { access_token: 'admin-token' }, user: { id: 'admin-user' } },
+      error: null,
+    });
+    const clientMaybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'client-123',
+        therapist_id: 'therapist-123',
+        organization_id: 'org-123',
+        full_name: 'Production Client',
+      },
+      error: null,
+    });
+    const therapistMaybeSingle = vi.fn().mockResolvedValue({
+      data: { id: 'therapist-123', phone: '(951) 555-0101' },
+      error: null,
+    });
+    const anonClient = {
+      auth: { signInWithPassword },
+      from: vi.fn((table: string) => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: table === 'clients' ? clientMaybeSingle : therapistMaybeSingle,
+          })),
+        })),
+      })),
+    };
+
+    await expect(
+      selectConfiguredSmokeClient(
+        'https://example.supabase.co',
+        'anon-key',
+        [{ email: 'admin@test.com', password: 'valid-secret', label: 'synthetic credential' }],
+        {
+          clientFactory: vi.fn(() => anonClient) as never,
+          env: { PW_ASSESSMENT_CLIENT_ID: 'client-123' } as NodeJS.ProcessEnv,
+        },
+      ),
+    ).rejects.toThrow('PW_ASSESSMENT_CLIENT_ID must point at a clearly marked smoke client.');
   });
 
   it('does not try the next credential for generic auth 400 errors', async () => {
@@ -220,7 +272,12 @@ describe('selectConfiguredSmokeClient', () => {
       error: null,
     });
     const clientMaybeSingle = vi.fn().mockResolvedValue({
-      data: { id: 'client-123', therapist_id: 'therapist-123', organization_id: 'org-123' },
+      data: {
+        id: 'client-123',
+        therapist_id: 'therapist-123',
+        organization_id: 'org-123',
+        full_name: 'Synthetic Smoke Client',
+      },
       error: null,
     });
     const from = vi.fn((table: string) => {
@@ -371,7 +428,12 @@ describe('selectConfiguredSmokeClient', () => {
       error: null,
     });
     const clientMaybeSingle = vi.fn().mockResolvedValue({
-      data: { id: 'client-123', therapist_id: 'therapist-123', organization_id: 'org-123' },
+      data: {
+        id: 'client-123',
+        therapist_id: 'therapist-123',
+        organization_id: 'org-123',
+        full_name: 'Synthetic Smoke Client',
+      },
       error: null,
     });
     const therapistMaybeSingle = vi.fn().mockResolvedValue({
@@ -448,10 +510,14 @@ describe('selectConfiguredSmokeClient', () => {
     expect(iehpJob).not.toMatch(/^\s+PW_ADMIN_PASSWORD/m);
     expect(iehpJob).toContain('npm run playwright:iehp-assessment-import-smoke');
     expect(iehpJob).toContain('npm run playwright:iehp-assessment-import-skills-behaviors');
+    expect(iehpJob).toContain('npm run playwright:iehp-assessment-import-generated-docx-parity');
     expect(iehpJob.indexOf('npm run playwright:iehp-assessment-import-smoke')).toBeLessThan(
       iehpJob.indexOf('npm run playwright:iehp-assessment-import-skills-behaviors'),
     );
     expect(iehpJob.indexOf('npm run playwright:iehp-assessment-import-skills-behaviors')).toBeLessThan(
+      iehpJob.indexOf('npm run playwright:iehp-assessment-import-generated-docx-parity'),
+    );
+    expect(iehpJob.indexOf('npm run playwright:iehp-assessment-import-generated-docx-parity')).toBeLessThan(
       iehpJob.indexOf('name: Cleanup IEHP smoke admin'),
     );
     expect(cleanupStepStart).toBeGreaterThanOrEqual(0);
@@ -1047,6 +1113,190 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     expect(checklistAssertionIndex).toBeGreaterThan(checklistFetchIndex);
     expect(proofEvidenceIndex).toBeGreaterThan(checklistAssertionIndex);
     expect(proofModeIndex).toBeGreaterThan(proofCaseRunnerIndex);
+  });
+
+  it('adds an opt-in generated docx parity mode and command after the skills behaviors smoke', () => {
+    const script = readFileSync(
+      path.join(process.cwd(), 'scripts/playwright-iehp-assessment-import-smoke.ts'),
+      'utf8',
+    );
+    const packageJson = JSON.parse(
+      readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'),
+    ) as {
+      scripts?: Record<string, string>;
+    };
+
+    const generatedDocxFlagIndex = script.indexOf(
+      "const isGeneratedDocxParityMode = process.argv.includes('--generated-docx-parity');",
+    );
+    const generatedRunnerIndex = script.indexOf('const runGeneratedDocxParityCase = async () =>');
+    const generatedPdfPageIndex = script.indexOf('const generatedPdfPage = await context.newPage();', generatedRunnerIndex);
+    const generatedPdfHtmlIndex = script.indexOf('buildIehpGeneratedDocxParityPdfHtml', generatedRunnerIndex);
+    const generatedPdfBufferIndex = script.indexOf(
+      "generatedPdfBuffer = await generatedPdfPage.pdf({ format: 'Letter', printBackground: true });",
+      generatedRunnerIndex,
+    );
+    const generatedPdfUploadNameIndex = script.indexOf("const uploadFileName = buildIehpSmokeUploadFileName(Date.now(), 'pdf');", generatedRunnerIndex);
+    const generatedPdfMimeIndex = script.indexOf("mimeType: 'application/pdf'", generatedRunnerIndex);
+    const preflightCallIndex = script.indexOf('const preflightBeforeApprovalResponse = await postAssessmentPlanPdfPreflight', generatedRunnerIndex);
+    const manifestDerivationIndex = script.indexOf('deriveIehpGeneratedDocxParityManifest', generatedRunnerIndex);
+    const approvalSelectionIndex = script.indexOf('selectIehpRequiredFinalOutputApprovals', generatedRunnerIndex);
+    const approvedRefetchIndex = script.indexOf('const approvedChecklist = await fetchAssessmentChecklist', generatedRunnerIndex);
+    const generateButtonIndex = script.indexOf("name: /Generate completed IEHP DOCX/i", generatedRunnerIndex);
+    const outputFixtureReaderIndex = script.indexOf('readSyntheticGeneratedDocxText', generatedRunnerIndex);
+    const storageCleanupIndex = script.indexOf('deleteAssessmentStorageObject', generatedRunnerIndex);
+    const generatedModeIndex = script.indexOf("mode: 'generated-docx-parity'", generatedRunnerIndex);
+
+    expect(packageJson.scripts?.['playwright:iehp-assessment-import-generated-docx-parity']).toBe(
+      'tsx scripts/playwright-iehp-assessment-import-smoke.ts --generated-docx-parity',
+    );
+    expect(generatedDocxFlagIndex).toBeGreaterThanOrEqual(0);
+    expect(generatedRunnerIndex).toBeGreaterThan(generatedDocxFlagIndex);
+    expect(generatedPdfPageIndex).toBeGreaterThan(generatedRunnerIndex);
+    expect(generatedPdfHtmlIndex).toBeGreaterThan(generatedPdfPageIndex);
+    expect(generatedPdfBufferIndex).toBeGreaterThan(generatedPdfHtmlIndex);
+    expect(generatedPdfUploadNameIndex).toBeGreaterThan(generatedRunnerIndex);
+    expect(generatedPdfMimeIndex).toBeGreaterThan(generatedPdfUploadNameIndex);
+    expect(preflightCallIndex).toBeGreaterThan(generatedDocxFlagIndex);
+    expect(manifestDerivationIndex).toBeGreaterThan(preflightCallIndex);
+    expect(approvalSelectionIndex).toBeGreaterThan(manifestDerivationIndex);
+    expect(approvedRefetchIndex).toBeGreaterThan(approvalSelectionIndex);
+    expect(generateButtonIndex).toBeGreaterThan(approvedRefetchIndex);
+    expect(outputFixtureReaderIndex).toBeGreaterThan(generateButtonIndex);
+    expect(storageCleanupIndex).toBeGreaterThan(outputFixtureReaderIndex);
+    expect(generatedModeIndex).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('parseAssessmentPlanPdfPreflight', () => {
+  it('reads the hosted preflight payload shape and fails closed if it drifts', () => {
+    expect(
+      parseAssessmentPlanPdfPreflight({
+        assessment_document_id: 'assessment-123',
+        generated_file_type: 'docx',
+        preflight: {
+          ready: false,
+          blockers: [{ code: 'required_checklist_pending' }],
+          warnings: [],
+        },
+      }),
+    ).toEqual({
+      assessmentDocumentId: 'assessment-123',
+      generatedFileType: 'docx',
+      ready: false,
+      blockers: [{ code: 'required_checklist_pending' }],
+    });
+  });
+
+  it.each([
+    {
+      name: 'missing preflight object',
+      payload: { assessment_document_id: 'assessment-123', generated_file_type: 'docx' },
+      message: 'payload.preflight',
+    },
+    {
+      name: 'missing ready boolean',
+      payload: { assessment_document_id: 'assessment-123', generated_file_type: 'docx', preflight: { blockers: [] } },
+      message: 'ready boolean',
+    },
+    {
+      name: 'missing blockers array',
+      payload: { assessment_document_id: 'assessment-123', generated_file_type: 'docx', preflight: { ready: true } },
+      message: 'blockers array',
+    },
+  ])('fails clearly for $name', ({ payload, message }) => {
+    expect(() => parseAssessmentPlanPdfPreflight(payload)).toThrow(message);
+  });
+});
+
+describe('cleanupGeneratedDocxParityArtifacts', () => {
+  it('attempts both generated-object and source cleanup even when the first one fails', async () => {
+    const deleteGeneratedArtifact = vi.fn().mockRejectedValue(new Error('generated delete failed'));
+    const deleteSourceAssessment = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      cleanupGeneratedDocxParityArtifacts({
+        generatedArtifact: { bucketId: 'generated-bucket', objectPath: 'generated/path.docx' },
+        sourceAssessment: {
+          assessmentDocumentId: 'assessment-123',
+          bucketId: 'client-documents',
+          objectPath: 'clients/source.pdf',
+        },
+        deleteGeneratedArtifact,
+        deleteSourceAssessment,
+      }),
+    ).rejects.toThrow('IEHP generated DOCX parity cleanup did not complete for 1 cleanup target(s).');
+
+    expect(deleteGeneratedArtifact).toHaveBeenCalledTimes(1);
+    expect(deleteSourceAssessment).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('generated DOCX artifact containment', () => {
+  it('accepts only the exact private bucket and assessment-scoped generated object path', () => {
+    expect(
+      assertIehpGeneratedDocxStorageTarget({
+        bucketId: 'client-documents',
+        objectPath: 'clients/client-123/assessments/generated-iehp-fba-assessment-123-1786560000000.docx',
+        clientId: 'client-123',
+        assessmentDocumentId: 'assessment-123',
+      }),
+    ).toEqual({
+      bucketId: 'client-documents',
+      objectPath: 'clients/client-123/assessments/generated-iehp-fba-assessment-123-1786560000000.docx',
+    });
+  });
+
+  it.each([
+    {
+      name: 'wrong bucket',
+      bucketId: 'public-documents',
+      objectPath: 'clients/client-123/assessments/generated-iehp-fba-assessment-123-1786560000000.docx',
+      message: 'unexpected generated artifact bucket',
+    },
+    {
+      name: 'wrong client',
+      bucketId: 'client-documents',
+      objectPath: 'clients/other-client/assessments/generated-iehp-fba-assessment-123-1786560000000.docx',
+      message: 'unexpected generated artifact object path',
+    },
+    {
+      name: 'wrong assessment',
+      bucketId: 'client-documents',
+      objectPath: 'clients/client-123/assessments/generated-iehp-fba-other-assessment-1786560000000.docx',
+      message: 'unexpected generated artifact object path',
+    },
+  ])('rejects $name before cleanup can delete it', ({ bucketId, objectPath, message }) => {
+    expect(() =>
+      assertIehpGeneratedDocxStorageTarget({
+        bucketId,
+        objectPath,
+        clientId: 'client-123',
+        assessmentDocumentId: 'assessment-123',
+      }),
+    ).toThrow(message);
+  });
+
+  it('uses a non-artifact temp directory and removes the DOCX after extracting text', async () => {
+    const tempRoot = mkdtempSync(path.join(tmpdir(), 'iehp-docx-parity-test-'));
+    let capturedPath = '';
+
+    try {
+      const text = await readSyntheticGeneratedDocxText(Buffer.from('synthetic-docx'), {
+        tempRoot,
+        reader: async (filePath) => {
+          capturedPath = filePath;
+          expect(existsSync(filePath)).toBe(true);
+          expect(filePath).not.toContain(path.join('artifacts', 'latest'));
+          return 'synthetic extracted text';
+        },
+      });
+
+      expect(text).toBe('synthetic extracted text');
+      expect(existsSync(capturedPath)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeAssessmentChecklistResponse,
   parseAssessmentPlanPdfPreflight,
   readSyntheticGeneratedDocxText,
+  restoreIehpGeneratedDocxReviewSelection,
   selectConfiguredSmokeClient,
 } from '../../scripts/playwright-iehp-assessment-import-smoke';
 import { assertIehpSkillsBehaviorsChecklistSection } from '../../scripts/lib/iehp-assessment-import-smoke';
@@ -32,6 +33,37 @@ const sliceWorkflowJob = (workflow: string, jobName: string): string => {
 
   return nextJob === -1 ? workflow.slice(start) : workflow.slice(start, afterJobName + nextJob);
 };
+
+describe('restoreIehpGeneratedDocxReviewSelection', () => {
+  it('does not click the uploaded assessment when its review is already visible', async () => {
+    const selectUploadedAssessment = vi.fn();
+    const waitForReview = vi.fn().mockResolvedValue(undefined);
+
+    await restoreIehpGeneratedDocxReviewSelection({
+      isReviewVisible: vi.fn().mockResolvedValue(true),
+      selectUploadedAssessment,
+      waitForReview,
+    });
+
+    expect(selectUploadedAssessment).not.toHaveBeenCalled();
+    expect(waitForReview).toHaveBeenCalledOnce();
+  });
+
+  it('selects the uploaded assessment before waiting when its review is not visible', async () => {
+    const selectUploadedAssessment = vi.fn().mockResolvedValue(undefined);
+    const waitForReview = vi.fn().mockResolvedValue(undefined);
+
+    await restoreIehpGeneratedDocxReviewSelection({
+      isReviewVisible: vi.fn().mockResolvedValue(false),
+      selectUploadedAssessment,
+      waitForReview,
+    });
+
+    expect(selectUploadedAssessment).toHaveBeenCalledOnce();
+    expect(waitForReview).toHaveBeenCalledOnce();
+    expect(selectUploadedAssessment.mock.invocationCallOrder[0]).toBeLessThan(waitForReview.mock.invocationCallOrder[0]);
+  });
+});
 
 describe('selectConfiguredSmokeClient', () => {
   it('falls back to the next configured credential when the first seed password drifted', async () => {
@@ -1142,6 +1174,9 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     const manifestDerivationIndex = script.indexOf('deriveIehpGeneratedDocxParityManifest', generatedRunnerIndex);
     const approvalSelectionIndex = script.indexOf('selectIehpRequiredFinalOutputApprovals', generatedRunnerIndex);
     const approvedRefetchIndex = script.indexOf('const approvedChecklist = await fetchAssessmentChecklist', generatedRunnerIndex);
+    const reviewHeadingIndex = script.indexOf("const reviewHeading = page.getByRole('heading', { name: 'IEHP FBA Checklist Review' });", generatedRunnerIndex);
+    const restoredSelectionCallIndex = script.indexOf('await restoreIehpGeneratedDocxReviewSelection({', generatedRunnerIndex);
+    const uploadFileButtonIndex = script.indexOf("name: uploadFileName, exact: true", generatedRunnerIndex);
     const generateButtonIndex = script.indexOf("name: /Generate completed IEHP DOCX/i", generatedRunnerIndex);
     const outputFixtureReaderIndex = script.indexOf('readSyntheticGeneratedDocxText', generatedRunnerIndex);
     const storageCleanupIndex = script.indexOf('deleteAssessmentStorageObject', generatedRunnerIndex);
@@ -1161,6 +1196,9 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     expect(manifestDerivationIndex).toBeGreaterThan(preflightCallIndex);
     expect(approvalSelectionIndex).toBeGreaterThan(manifestDerivationIndex);
     expect(approvedRefetchIndex).toBeGreaterThan(approvalSelectionIndex);
+    expect(reviewHeadingIndex).toBeGreaterThan(approvedRefetchIndex);
+    expect(restoredSelectionCallIndex).toBeGreaterThan(reviewHeadingIndex);
+    expect(uploadFileButtonIndex).toBeGreaterThan(restoredSelectionCallIndex);
     expect(generateButtonIndex).toBeGreaterThan(approvedRefetchIndex);
     expect(outputFixtureReaderIndex).toBeGreaterThan(generateButtonIndex);
     expect(storageCleanupIndex).toBeGreaterThan(outputFixtureReaderIndex);


### PR DESCRIPTION
## Summary
- add a self-contained synthetic IEHP FBA PDF upload-to-generated-DOCX parity mode
- verify Adobe-backed extraction preserves skills, behaviors, representative sections, and narratives
- fail closed on non-smoke clients, unresolved reconciliation, mismatched assessment/storage scope, and cleanup failures
- run the new proof inside the required IEHP assessment import CI job

## Safety
- critical / high-risk human-reviewed lane because `.github/workflows/ci.yml` changes
- no production parser, Adobe function, server API, Supabase, schema, auth, or UI changes
- generated DOCX is parsed only from an auto-deleted OS temp directory and is not retained in CI artifacts
- human review is required before merge

## Verification
- focused IEHP/parity suite: 132 passed
- lint: passed
- typecheck: passed
- test:ci: 492 files / 4,261 tests passed; 5 environment-gated skipped
- coverage: 92.81%, all module thresholds passed
- build: passed
- Tier-0 routes: 220 passed
- workflow YAML parse: passed
- code, security, and devops specialist reviews: approved, no findings
- verify:local wrapper remains locally flaky on unrelated async UI timeouts; every constituent gate passed independently
- hosted Adobe-backed parity command: pending in this PR's required CI

Linear: WIN-154
Handoff: docs/ai/win-154-iehp-generated-docx-parity-handoff.md