### PR TITLE
WIN-275: Close domain terminology review gaps

### DIFF
--- a/docs/ai/handoffs/WIN-275-clinical-domain-terminology-successor.md
+++ b/docs/ai/handoffs/WIN-275-clinical-domain-terminology-successor.md
@@ -63,9 +63,9 @@ The current terminology branch changes `src/components/ClientDetails/ProgramsGoa
 
 - rolling manifest path: `docs/ai/reviews/WIN-275-solo-maintainer-attestation.json`
 - manifest hash recorded there for `src/components/ClientDetails/ProgramsGoalsTab.tsx`: `fbc032c2dddca32dd846ce1a89e80fdd0cb45500bb31f21c773cc2c33dd74fa4`
-- current canonical terminology-branch hash for that file: `b35c8c719a68cdba9be9183b99a5a690da26d097bb12915c354243102b4bdea6`
+- current canonical review-fix hash for that file: `093d2287e9c2e9b01b40f00b93cfaa7b35d4f1dcc2037408f83b5cba1c0de859`
 - canonicalization: UTF-8 text with CRLF normalized to LF, matching `tests/agentWorkLedgerHostedShadowProof.test.ts`
-- raw Windows workspace-byte SHA-256 from `Get-FileHash`: `88ac7775906c914364b54b4b70223ee39df9f76949c3a134485628ed1cfcb76f`
+- raw Windows workspace-byte SHA-256 from `Get-FileHash`: `422875b62142c14564a43001230e29854a05a59ab13d6179c298b6fb07aa0988`
 
 ## Rolling Manifest Decision
 
@@ -115,3 +115,17 @@ Specialist results:
 - result: `pass-with-blocked-checks`
 - residual risk: the four post-merge UI review findings remain for the stacked follow-up PR; critical-lane owner review and exact-head CI are mandatory
 - pr handoff: ready after Linear linkage, commit, push, and `pr-hygiene`
+
+## 2026-08-12 UI Review-Fix Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical` because `ProgramsGoalsTab.tsx` remains hash-bound review evidence
+- affected routes: `/clients/test-client` and `/schedule`
+- changes: distinguish care-plan and goal-domain creation actions, present legacy API program errors as domain errors, and separate query failure from empty-domain state while blocking save until retry
+- immutable UI implementation head: `2fb23276af27355d14e98a8d202e21cbc9b01ff9`
+- focused tests: `AddSessionNoteModal.test.tsx` and `ProgramsGoalsTab.test.tsx` passed `142/142`; hosted-proof contract passed `38/38`
+- standard checks: lint, typecheck, and production build passed
+- full local union: policy, lint, and typecheck passed before `test:ci` hit a Vitest worker RPC timeout in the pre-existing progression integration; that integration immediately passed `10/10` in isolation, while the parent evidence branch full suite passed `4236/4236`
+- responsive observer: `4/4` passed at desktop `1440x900` and mobile `390x844`; sanitized evidence is under `artifacts/responsive-ui-observer/route-e1da5b24224600e4b86f943f21a449b421da6772c554c840aecbaab450cb8fcf.*` and `artifacts/responsive-ui-observer/route-b8269c2977ef848259bf5694da1ebe4e7a041d55cb00a9e9fd3689b0c23f675f.*`
+- blocked checks: local full-suite coverage worker stability and credential-backed `npm run ci:playwright`; exact-head CI remains required
+- residual risk: stacked PR must merge only after evidence PR `#934`, exact-head CI, and owner review

--- a/docs/ai/reviews/WIN-275-clinical-domain-terminology-successor-attestation.json
+++ b/docs/ai/reviews/WIN-275-clinical-domain-terminology-successor-attestation.json
@@ -50,9 +50,11 @@
     ]
   },
   "branchContext": {
-    "branch": "codex/win-275-terminology-successor",
+    "branch": "codex/win-275-terminology-ui-review-fixes",
+    "originalBranch": "codex/win-275-terminology-successor",
     "baseMergeCommit": "37e7cbfa888ebb3b33cf895cb9638f6b6590bd5f",
-    "implementationHeadCommit": "e5f9e0843149df6260838d75df66feebb11a979c",
+    "originalImplementationHeadCommit": "e5f9e0843149df6260838d75df66feebb11a979c",
+    "implementationHeadCommit": "2fb23276af27355d14e98a8d202e21cbc9b01ff9",
     "mergedVerificationHeadCommit": "f3be4aaf558c6331724f1ba1439ad7d98e4000ad"
   },
   "successorAgents": {
@@ -110,6 +112,18 @@
     },
     "responsive-closure-security-engineer": {
       "agentId": "019ff29d-0687-7e60-a659-535a66c25a49",
+      "status": "APPROVE"
+    },
+    "review-fix-code-review-engineer": {
+      "agentId": "019ff8d8-5a76-70a2-8117-2f84f6f436ea",
+      "status": "APPROVE"
+    },
+    "review-fix-test-engineer": {
+      "agentId": "019ff8d8-5c33-78f1-a833-b13bc1bb2747",
+      "status": "PASS_WITH_LOCAL_FULL_SUITE_RESOURCE_BLOCKER"
+    },
+    "review-fix-security-engineer": {
+      "agentId": "019ff8d8-5fc5-7321-b98e-134d07008c90",
       "status": "APPROVE"
     }
   },
@@ -207,7 +221,7 @@
       "path": "src/components/ClientDetails/ProgramsGoalsTab.tsx",
       "algorithm": "sha256",
       "canonicalization": "UTF-8 text with CRLF normalized to LF, matching tests/agentWorkLedgerHostedShadowProof.test.ts",
-      "canonicalSha256": "b35c8c719a68cdba9be9183b99a5a690da26d097bb12915c354243102b4bdea6"
+      "canonicalSha256": "093d2287e9c2e9b01b40f00b93cfaa7b35d4f1dcc2037408f83b5cba1c0de859"
     }
   },
   "expectedHashDrift": {
@@ -217,7 +231,7 @@
       {
         "path": "src/components/ClientDetails/ProgramsGoalsTab.tsx",
         "manifestSha256": "fbc032c2dddca32dd846ce1a89e80fdd0cb45500bb31f21c773cc2c33dd74fa4",
-        "currentBranchCanonicalSha256": "b35c8c719a68cdba9be9183b99a5a690da26d097bb12915c354243102b4bdea6"
+        "currentBranchCanonicalSha256": "093d2287e9c2e9b01b40f00b93cfaa7b35d4f1dcc2037408f83b5cba1c0de859"
       }
     ],
     "noManifestUpdatePerformed": false

--- a/docs/ai/reviews/WIN-275-solo-maintainer-attestation.json
+++ b/docs/ai/reviews/WIN-275-solo-maintainer-attestation.json
@@ -64,8 +64,9 @@
   },
   "terminologySuccessorAttestation": {
     "path": "docs/ai/reviews/WIN-275-clinical-domain-terminology-successor-attestation.json",
-    "sha256": "3a33d47fad2749990aaf9201b23efc2cb552fecef034bfd37ac1710846be8635",
-    "implementationHeadCommit": "e5f9e0843149df6260838d75df66feebb11a979c",
+    "sha256": "c93bb25e09c1f7f80b2a952a8b1c3f1e0c416e1cdbf4d02896b0aa3b55a934f9",
+    "originalImplementationHeadCommit": "e5f9e0843149df6260838d75df66feebb11a979c",
+    "implementationHeadCommit": "2fb23276af27355d14e98a8d202e21cbc9b01ff9",
     "mergedVerificationHeadCommit": "f3be4aaf558c6331724f1ba1439ad7d98e4000ad",
     "hostedActionAuthorized": false
   },
@@ -129,7 +130,7 @@
     "docs/ai/handoffs/agent-work-ledger-adoption-contract.md": "d200e34d9516117ea21c10a950de30bc8e3c8870552dff9382ab8fb38664fe62",
     "docs/ops/agent-work-ledger-caller-adoption.md": "85a23906a650b0f8929dbae58096e3d688780fe27c6f25dbe5b3f49b68984a1e",
     "src/components/ClientDetails/IehpFbaLayoutReview.tsx": "8fe6c210cc1719efce43fad12b2af38815dd75a92b17e4878da12211f0394209",
-    "src/components/ClientDetails/ProgramsGoalsTab.tsx": "b35c8c719a68cdba9be9183b99a5a690da26d097bb12915c354243102b4bdea6",
+    "src/components/ClientDetails/ProgramsGoalsTab.tsx": "093d2287e9c2e9b01b40f00b93cfaa7b35d4f1dcc2037408f83b5cba1c0de859",
     "src/components/__tests__/IehpFbaLayoutReview.test.tsx": "06f5a04b356347fe75bc3bf7f389017f46b381a09af3b4702a440414c759ef2e",
     "src/lib/__tests__/agent-work-ledger.test.ts": "20850c876406328c2f8a09ee78f70ed83f379e7130b3e30dede8f50af5972814",
     "src/lib/agent-work-ledger.ts": "77f4eb775c6744bc55588ee3ab126978796470bfae1691ff06fe762aa29ad0a6",

--- a/src/components/AddSessionNoteModal.tsx
+++ b/src/components/AddSessionNoteModal.tsx
@@ -112,7 +112,12 @@ export function AddSessionNoteModal({
   // Programs — still loaded for goal group headers (display only).
   // The program <select> has been removed; goals are now fetched client-wide.
   // ---------------------------------------------------------------------------
-  const { data: programs = [], isLoading: isLoadingPrograms } = useQuery({
+  const {
+    data: programs = [],
+    isLoading: isLoadingPrograms,
+    isError: isProgramsError,
+    refetch: refetchPrograms,
+  } = useQuery({
     queryKey: ['client-programs', clientId, organizationId ?? 'MISSING_ORG'],
     queryFn: async () => {
       if (!clientId || !organizationId) {
@@ -134,7 +139,12 @@ export function AddSessionNoteModal({
   });
 
   // Client-scoped goals query — fetches all goals regardless of program.
-  const { data: goals = [], isLoading: isLoadingGoals } = useQuery({
+  const {
+    data: goals = [],
+    isLoading: isLoadingGoals,
+    isError: isGoalsError,
+    refetch: refetchGoals,
+  } = useQuery({
     queryKey: ['client-goals', clientId, organizationId ?? 'MISSING_ORG'],
     queryFn: async () => {
       if (!clientId || !organizationId) {
@@ -552,6 +562,11 @@ export function AddSessionNoteModal({
 
     if (hasSessions && !selectedSessionId && !isEditingUnlinkedNote) {
       showError('Select a scheduled session to link this note.');
+      return;
+    }
+
+    if (isProgramsError || isGoalsError) {
+      showError('Retry loading domains and goals before logging this note.');
       return;
     }
 
@@ -1206,6 +1221,17 @@ export function AddSessionNoteModal({
             <p className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Domains &amp; Goals</p>
             {isLoadingGoals || isLoadingPrograms ? (
               <div className="text-sm text-gray-500 dark:text-gray-400">Loading goals…</div>
+            ) : isProgramsError || isGoalsError ? (
+              <div className="space-y-2 text-sm text-red-700 dark:text-red-300" role="alert">
+                <p>Unable to load domains and goals.</p>
+                <button
+                  type="button"
+                  onClick={() => void Promise.all([refetchPrograms(), refetchGoals()])}
+                  className="rounded-md border border-red-300 px-3 py-2 text-sm font-medium hover:bg-red-50 dark:border-red-700 dark:hover:bg-red-950/30"
+                >
+                  Retry loading domains and goals
+                </button>
+              </div>
             ) : availableGoals.length === 0 ? (
               <div className="space-y-1 text-sm text-gray-500 dark:text-gray-400">
                 <p>
@@ -1280,7 +1306,7 @@ export function AddSessionNoteModal({
           <button
             type="button"
             onClick={handleSubmit}
-            disabled={isSaving}
+            disabled={isSaving || isProgramsError || isGoalsError}
             className="flex min-h-11 w-full items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:min-w-[10rem]"
           >
             {isSaving ? 'Saving…' : 'Save Note'}

--- a/src/components/ClientDetails/ProgramsGoalsTab.tsx
+++ b/src/components/ClientDetails/ProgramsGoalsTab.tsx
@@ -619,6 +619,13 @@ const callEdgeWithSupabaseFallback = async (params: {
   }
 };
 
+const presentCarePlanDomainError = (message: string) =>
+  message
+    .replace(/\bPrograms\b/g, "Domains")
+    .replace(/\bProgram\b/g, "Domain")
+    .replace(/\bprograms\b/g, "domains")
+    .replace(/\bprogram\b/g, "domain");
+
 const isSupportedAssessmentFile = (file: File): boolean => {
   const lowerFileName = file.name.trim().toLowerCase();
   return SUPPORTED_ASSESSMENT_FILE_EXTENSIONS.some((extension) => lowerFileName.endsWith(extension));
@@ -2756,7 +2763,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         timeoutMessage: "Create domain request timed out. Please retry.",
       });
       if (!response.ok) {
-        throw new Error(await parseApiErrorMessage(response, "Failed to create domain."));
+        throw new Error(presentCarePlanDomainError(await parseApiErrorMessage(response, "Failed to create domain.")));
       }
       return parseJson<Program>(response);
     },
@@ -2808,7 +2815,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
         timeoutMessage: "Update domain request timed out. Please retry.",
       });
       if (!response.ok) {
-        throw new Error(await parseApiErrorMessage(response, "Failed to update domain."));
+        throw new Error(presentCarePlanDomainError(await parseApiErrorMessage(response, "Failed to update domain.")));
       }
       return parseJson<Program>(response);
     },
@@ -3736,7 +3743,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                   disabled={!programNameValue || createProgram.isLoading}
                   className="w-full px-3 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
                 >
-                  {createProgram.isLoading ? "Creating..." : "Create Domain"}
+                  {createProgram.isLoading ? "Creating..." : "Create Care Plan Domain"}
                 </button>
                 {programsQueryError instanceof Error && (
                   <p className="text-xs text-amber-700 dark:text-amber-300">
@@ -4810,7 +4817,7 @@ export function ProgramsGoalsTab({ client }: ProgramsGoalsTabProps) {
                     disabled={!newGoalDomainNameValue || createGoalDomain.isLoading}
                     className="mt-2 w-full rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
                   >
-                    {createGoalDomain.isLoading ? "Creating domain..." : "Create Domain"}
+                    {createGoalDomain.isLoading ? "Creating domain..." : "Create Goal Domain"}
                   </button>
                 </div>
               )}

--- a/src/components/__tests__/AddSessionNoteModal.test.tsx
+++ b/src/components/__tests__/AddSessionNoteModal.test.tsx
@@ -87,6 +87,12 @@ function buildChain(rows: unknown[] = []): QueryChain {
   return chain;
 }
 
+function buildErrorChain(message: string): QueryChain {
+  const chain = buildChain();
+  chain.order.mockResolvedValue({ data: null, error: new Error(message) });
+  return chain;
+}
+
 // Sessions query ends with .order(...).limit(50) — order must return the chain
 // so that .limit() can be called on it as the actual terminal method.
 function buildChainWithLimit(rows: unknown[] = []): QueryChain {
@@ -391,6 +397,23 @@ describe('AddSessionNoteModal — per-goal note textareas', () => {
 
     expect(await screen.findByText('No active goals found for this client.')).toBeInTheDocument();
     expect(screen.queryByText('No active domains found for this client.')).not.toBeInTheDocument();
+  });
+
+  it('shows a retryable load error instead of an empty-domain message when domain data fails', async () => {
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'programs') return buildErrorChain('domain query failed') as any;
+      if (table === 'goals') return buildChain([]) as any;
+      if (table === 'sessions') return buildChainWithLimit([mockSession]) as any;
+      if (table === 'session_goals') return buildChain([]) as any;
+      return buildChain([]) as any;
+    });
+
+    renderWithProviders(<AddSessionNoteModal {...defaultProps} clientId="client-load-error" />);
+
+    expect(await screen.findByText('Unable to load domains and goals.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry loading domains and goals' })).toBeInTheDocument();
+    expect(screen.queryByText('No active domains found for this client.')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save Note' })).toBeDisabled();
   });
 
   it('does not treat an inactive domain as active', async () => {

--- a/src/components/__tests__/ProgramsGoalsTab.test.tsx
+++ b/src/components/__tests__/ProgramsGoalsTab.test.tsx
@@ -984,7 +984,35 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
 
     expect(await screen.findByRole("heading", { name: /Add Domain/i })).toBeInTheDocument();
     expect(screen.getByText("Loading existing domains. You can still add a new domain below.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Create Domain" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create Care Plan Domain" })).toBeInTheDocument();
+  });
+
+  it("presents legacy program API errors using domain terminology", async () => {
+    vi.mocked(callApi).mockImplementation(async (path: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "POST" && path === "/api/programs") {
+        return new Response(JSON.stringify({ error: "Failed to create program" }), { status: 500 });
+      }
+      if (method === "GET" && path.startsWith("/api/programs?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/goals?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/program-notes?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-documents?")) return new Response(JSON.stringify([]), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-checklist?")) return new Response(JSON.stringify({ items: [], structured_sections: [] }), { status: 200 });
+      if (method === "GET" && path.startsWith("/api/assessment-drafts?")) return new Response(JSON.stringify({ programs: [], goals: [] }), { status: 200 });
+      return new Response(JSON.stringify({ error: "Not handled in test" }), { status: 500 });
+    });
+
+    renderWithProviders(<ProgramsGoalsTab client={buildClient()} />, {
+      auth: { role: "midtier", organizationId: ORG_ID, accessToken: "test-access-token" },
+    });
+
+    fireEvent.change(await screen.findByPlaceholderText("Domain name"), { target: { value: "Communication" } });
+    await user.click(screen.getByRole("button", { name: "Create Care Plan Domain" }));
+
+    await waitFor(() => expect(showError).toHaveBeenCalled());
+    expect(vi.mocked(showError).mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({ message: "Failed to create domain" }),
+    );
   });
 
   it("unlocks goal and note creation after creating a program while the programs query is still loading", async () => {
@@ -1031,7 +1059,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     fireEvent.change(await screen.findByPlaceholderText("Domain name"), {
       target: { value: "Communication Program" },
     });
-    await user.click(screen.getAllByRole("button", { name: "Create Domain" })[0]);
+    await user.click(screen.getByRole("button", { name: "Create Care Plan Domain" }));
 
     await waitFor(() => {
       expect(showSuccess).toHaveBeenCalledWith("Domain created");
@@ -1804,7 +1832,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
 
     const programNameInput = await screen.findByPlaceholderText("Domain name");
     fireEvent.change(programNameInput, { target: { value: "Communication Program" } });
-    await user.click(screen.getAllByRole("button", { name: "Create Domain" })[0]);
+    await user.click(screen.getByRole("button", { name: "Create Care Plan Domain" }));
 
     await waitFor(() => {
       expect(showSuccess).toHaveBeenCalledWith("Domain created");
@@ -1818,7 +1846,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     });
     await user.selectOptions(screen.getByLabelText("Domain"), "__create_new_domain__");
     await user.type(screen.getByLabelText("New domain name *"), "Social Communication");
-    await user.click(screen.getAllByRole("button", { name: "Create Domain" })[1]);
+    await user.click(screen.getByRole("button", { name: "Create Goal Domain" }));
 
     await waitFor(() => {
       expect(goalDomainInsert).toHaveBeenCalledWith([
@@ -3050,7 +3078,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
     fireEvent.change(await screen.findByPlaceholderText("Domain name"), {
       target: { value: "Communication Program" },
     });
-    await user.click(screen.getAllByRole("button", { name: "Create Domain" })[0]);
+    await user.click(screen.getByRole("button", { name: "Create Care Plan Domain" }));
 
     await waitFor(() => {
       expect(showSuccess).toHaveBeenCalledWith("Domain created");
@@ -3626,7 +3654,7 @@ describe("ProgramsGoalsTab", { timeout: 15_000 }, () => {
 
     const programNameInput = await screen.findByPlaceholderText("Domain name");
     await user.type(programNameInput, "Fallback Program");
-    await user.click(screen.getAllByRole("button", { name: "Create Domain" })[0]);
+    await user.click(screen.getByRole("button", { name: "Create Care Plan Domain" }));
 
     await waitFor(() => {
       expect(showSuccess).toHaveBeenCalledWith("Domain created");


### PR DESCRIPTION
## Summary
- show a retryable load failure instead of an empty-domain state in Add Session Note and block save until data is available
- distinguish `Create Care Plan Domain` from `Create Goal Domain`
- normalize legacy program wording only in user-visible care-plan mutation errors
- refresh the protected-surface evidence against immutable implementation commit `2fb23276`

## Verification
- focused component + contract tests: 180/180
- component tests: 142/142
- progression integration isolation: 10/10
- lint, typecheck, build: pass
- responsive observer: 4/4 for `/clients/test-client` and `/schedule` at 1440x900 and 390x844
- full local verify union reached test:ci but hit a Vitest worker RPC timeout in the pre-existing progression integration; that integration immediately passed in isolation. Exact-head CI is required.
- local `ci:playwright` remains blocked by missing PW admin credentials

## Stack
Depends on #934. Merge #934 first, then retarget this PR to `main` if GitHub does not do so automatically.

Linear: WIN-275