### PR TITLE
WIN-154 Expand IEHP FBA PDF upload matrix

### DIFF
--- a/.github/workflows/iehp-pdf-mini-matrix-proof.yml
+++ b/.github/workflows/iehp-pdf-mini-matrix-proof.yml
@@ -375,6 +375,8 @@ jobs:
               'alternate-document-phone-format',
               'scan-300dpi-monochrome',
               'scan-300dpi-monochrome-rotated-2deg',
+              'scan-150dpi-grayscale-low-quality',
+              'table-structured-fields',
               'skills-behaviors-proof',
             ];
             const matrixCases = objects
@@ -389,8 +391,8 @@ jobs:
               });
             const aggregate = objects.find((entry) => entry?.mode === 'pdf-mini-matrix');
 
-            if (matrixCases.length !== 6) {
-              throw new Error(`Expected exactly six case evidence objects but found ${matrixCases.length}.`);
+            if (matrixCases.length !== 8) {
+              throw new Error(`Expected exactly eight case evidence objects but found ${matrixCases.length}.`);
             }
             if (!aggregate) {
               throw new Error('Missing aggregate matrix evidence.');
@@ -415,14 +417,14 @@ jobs:
             if (rawPhonePattern.test(JSON.stringify(matrixCases))) {
               throw new Error('Curated matrix evidence contained a raw phone number.');
             }
-            if (aggregate.totalCases !== 6) {
-              throw new Error(`Expected aggregate totalCases to equal 6 but received ${aggregate.totalCases}.`);
+            if (aggregate.totalCases !== 8) {
+              throw new Error(`Expected aggregate totalCases to equal 8 but received ${aggregate.totalCases}.`);
             }
-            if (aggregate.passedCases !== 6) {
-              throw new Error(`Expected aggregate passedCases to equal 6 but received ${aggregate.passedCases}.`);
+            if (aggregate.passedCases !== 8) {
+              throw new Error(`Expected aggregate passedCases to equal 8 but received ${aggregate.passedCases}.`);
             }
-            if (aggregate.cleanupVerifiedCases !== 6) {
-              throw new Error(`Expected aggregate cleanupVerifiedCases to equal 6 but received ${aggregate.cleanupVerifiedCases}.`);
+            if (aggregate.cleanupVerifiedCases !== 8) {
+              throw new Error(`Expected aggregate cleanupVerifiedCases to equal 8 but received ${aggregate.cleanupVerifiedCases}.`);
             }
             if (aggregate.skillsBehaviorsVerifiedCases !== 1) {
               throw new Error(`Expected aggregate skillsBehaviorsVerifiedCases to equal 1 but received ${aggregate.skillsBehaviorsVerifiedCases}.`);

--- a/docs/ai/WIN-154-iehp-fba-ocr-table-matrix-handoff.md
+++ b/docs/ai/WIN-154-iehp-fba-ocr-table-matrix-handoff.md
@@ -1,0 +1,65 @@
+# WIN-154 IEHP FBA OCR And Table Matrix Handoff
+
+- Date: August 12, 2026
+- Linear: `WIN-154` (new issue creation blocked by the workspace free issue limit)
+- Branch: `codex/win-154-fba-ocr-table-matrix`
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Triggering path: `.github/workflows/iehp-pdf-mini-matrix-proof.yml`
+- Required agents: `specification-engineer` -> `software-architect` -> `implementation-engineer` -> `code-review-engineer` -> `test-engineer` -> `security-engineer`
+
+## Route-task Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- rationale: the existing protected hosted proof workflow hard-codes the matrix case order and evidence counts
+- allowed files: the existing IEHP PDF smoke helper/runner, their focused tests, the dedicated on-demand proof workflow and test, and this handoff
+- non-goals: parser or Adobe configuration changes, server APIs, Supabase functions/migrations, auth, runtime config, production data, PHI, CalOptima, or broad CI changes
+- stop conditions: any requirement to change production extraction behavior, widen secret handling, publish raw OCR/table content, or use a real document fixture
+
+## Scope
+
+- Add one deterministic `150 DPI` grayscale JPEG raster case with actual DPI-derived pixel dimensions and reduced JPEG quality.
+- Add one deterministic digital PDF case whose asserted referral date and assessor phone are rendered in semantic table cells.
+- Keep Adobe as the hosted production extractor by using the existing authenticated upload path and `--pdf-mini-matrix` command.
+- Preserve field-level referral-date extraction, assessor-phone snapshot precedence, provenance, zero-draft assertions, redacted evidence, and fail-closed per-case cleanup.
+- Expand the hosted proof contract from six to eight evidence objects: seven import cases plus the existing Skills & Behaviors proof.
+
+## TDD Evidence
+
+- RED command: `npm test -- --run tests/scripts/iehp-assessment-import-smoke.test.ts tests/scripts/playwright-iehp-assessment-import-smoke.test.ts tests/workflows/iehp-pdf-mini-matrix-proof.test.ts`
+- RED result: expected failure (`7` focused assertions) because the two case definitions, semantic table layout, dynamic raster dimensions/color mode, and eight-case workflow contract did not yet exist.
+- GREEN result: pass (`3` files, `119/119` tests).
+
+## Verification Card
+
+- classification: `high-risk human-reviewed`
+- lane: `critical`
+- change type: protected workflow and synthetic authenticated browser QA harness
+- required checks: workflow YAML parse; focused IEHP matrix tests; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run build`; `npm run verify:local`; hosted `.github/workflows/iehp-pdf-mini-matrix-proof.yml` on the exact PR head
+- executed checks:
+  - workflow YAML parse -> pass
+  - focused IEHP matrix tests -> pass (`3` files, `119/119` tests)
+  - `npm run ci:check-focused` -> pass; environment-gated database, branch-protection, and hosted auth-parity probes skipped as reported
+  - `npm run lint` -> pass
+  - `npm run typecheck` -> pass
+  - `npm run build` -> pass
+  - `npm run test:ci` -> changed IEHP tests passed, but the full run failed on an unrelated `ProgramsGoalsTab` timeout plus a Vitest worker RPC timeout; the file passed `116/116` in isolation
+  - `npm run verify:local` -> policy, lint, and typecheck passed; the wrapper then stopped at `test:ci` on unrelated `ClientSessionTrendsTab` and `TherapistOnboarding` contention failures plus a Vitest worker RPC timeout; both files passed in isolation (`14/14` and `7/7`)
+- blocked checks:
+  - hosted matrix proof -> requires an open same-repository PR, exact preview deployment, and protected GitHub/Supabase credentials
+  - repository-wide `test:ci`/`verify:local` clean completion -> blocked locally by reproducible full-suite worker contention outside the changed files; every surfaced failing file passes in isolation
+- result: `pass-with-blocked-checks`
+- residual risk: the two new fixture shapes require exact-head Adobe-backed hosted proof; local structure and unit tests cannot establish OCR success, and required PR CI must resolve the local full-suite contention result
+
+## Review And PR Hygiene
+
+- specification-engineer: complete; scope limited to exactly two synthetic cases
+- software-architect: complete; approved reuse of the existing upload/Adobe/assertion/cleanup flow
+- implementation-engineer: complete; changed only the bounded helper, runner, and dedicated workflow
+- test-engineer: approved; confirmed seven catalog cases plus the matrix-mode Skills & Behaviors proof produce eight hosted evidence objects
+- security-engineer: approved with unchanged secrets, private log, public evidence, and cleanup boundaries
+- code-review-engineer: approved after the handoff evidence update; no code findings
+- devops-engineer: approved; exact case order/count, immutable PR/preview controls, cleanup, artifact curation, and bounded timeout remain consistent
+- pr-ready: yes for human review; exact-head hosted checks remain required before merge
+- human review: required before merge

--- a/scripts/lib/iehp-assessment-import-smoke.ts
+++ b/scripts/lib/iehp-assessment-import-smoke.ts
@@ -8,19 +8,27 @@ type IehpPdfMiniMatrixBaseCase = {
 };
 
 type IehpDigitalPdfMiniMatrixCase = IehpPdfMiniMatrixBaseCase & {
-  id: 'clean-single-page' | 'multi-page-target-content' | 'alternate-document-phone-format';
+  id:
+    | 'clean-single-page'
+    | 'multi-page-target-content'
+    | 'alternate-document-phone-format'
+    | 'table-structured-fields';
   renderMode: 'digital-pdf';
+  documentLayout: 'plain' | 'table';
 };
 
 type IehpRasterPdfMiniMatrixCase = IehpPdfMiniMatrixBaseCase & {
-  id: 'scan-300dpi-monochrome' | 'scan-300dpi-monochrome-rotated-2deg';
+  id:
+    | 'scan-300dpi-monochrome'
+    | 'scan-300dpi-monochrome-rotated-2deg'
+    | 'scan-150dpi-grayscale-low-quality';
   renderMode: 'raster-scan';
   scan: {
-    dpi: 300;
-    colorMode: 'black-and-white';
+    dpi: 150 | 300;
+    colorMode: 'black-and-white' | 'grayscale';
     rotationDegrees: 0 | 2;
     compression: 'jpeg';
-    jpegQuality: 85;
+    jpegQuality: 45 | 85;
   };
 };
 
@@ -207,6 +215,7 @@ export const IEHP_PDF_MINI_MATRIX_CASES: readonly IehpPdfMiniMatrixCase[] = [
     documentPhone: '(909) 555-0101',
     pageBreakBeforeTarget: false,
     renderMode: 'digital-pdf',
+    documentLayout: 'plain',
   },
   {
     id: 'multi-page-target-content',
@@ -214,6 +223,7 @@ export const IEHP_PDF_MINI_MATRIX_CASES: readonly IehpPdfMiniMatrixCase[] = [
     documentPhone: '909-555-0102',
     pageBreakBeforeTarget: true,
     renderMode: 'digital-pdf',
+    documentLayout: 'plain',
   },
   {
     id: 'alternate-document-phone-format',
@@ -221,6 +231,7 @@ export const IEHP_PDF_MINI_MATRIX_CASES: readonly IehpPdfMiniMatrixCase[] = [
     documentPhone: '+1 909 555 0103',
     pageBreakBeforeTarget: false,
     renderMode: 'digital-pdf',
+    documentLayout: 'plain',
   },
   {
     id: 'scan-300dpi-monochrome',
@@ -249,6 +260,28 @@ export const IEHP_PDF_MINI_MATRIX_CASES: readonly IehpPdfMiniMatrixCase[] = [
       compression: 'jpeg',
       jpegQuality: 85,
     },
+  },
+  {
+    id: 'scan-150dpi-grayscale-low-quality',
+    referralDate: '07/05/2026',
+    documentPhone: '(909) 555-0106',
+    pageBreakBeforeTarget: false,
+    renderMode: 'raster-scan',
+    scan: {
+      dpi: 150,
+      colorMode: 'grayscale',
+      rotationDegrees: 0,
+      compression: 'jpeg',
+      jpegQuality: 45,
+    },
+  },
+  {
+    id: 'table-structured-fields',
+    referralDate: '07/06/2026',
+    documentPhone: '909-555-0107',
+    pageBreakBeforeTarget: false,
+    renderMode: 'digital-pdf',
+    documentLayout: 'table',
   },
 ] as const;
 
@@ -383,12 +416,29 @@ export const buildIehpPdfMiniMatrixHtml = (caseDefinition: IehpPdfMiniMatrixCase
   <head>
     <meta charset="utf-8" />
     <title>${caseDefinition.id}</title>
+    <style>
+      table { border-collapse: collapse; width: 100%; }
+      th, td { border: 1px solid #111; padding: 8px; text-align: left; }
+    </style>
   </head>
   <body>
     <section>
       ${caseDefinition.pageBreakBeforeTarget ? '<p>IEHP FBA PDF mini-matrix page one</p><div style="page-break-before: always;"></div>' : ''}
-      <p>Referral Date: ${caseDefinition.referralDate}</p>
-      <p>Assessor's phone number: ${caseDefinition.documentPhone}</p>
+      ${caseDefinition.renderMode === 'digital-pdf' && caseDefinition.documentLayout === 'table'
+        ? `<table>
+      <tbody>
+        <tr>
+          <th scope="row">Referral Date:</th>
+          <td>${caseDefinition.referralDate}</td>
+        </tr>
+        <tr>
+          <th scope="row">Assessor's phone number:</th>
+          <td>${caseDefinition.documentPhone}</td>
+        </tr>
+      </tbody>
+    </table>`
+        : `<p>Referral Date: ${caseDefinition.referralDate}</p>
+      <p>Assessor's phone number: ${caseDefinition.documentPhone}</p>`}
     </section>
   </body>
 </html>`;

--- a/scripts/playwright-iehp-assessment-import-smoke.ts
+++ b/scripts/playwright-iehp-assessment-import-smoke.ts
@@ -180,15 +180,16 @@ const pause = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms));
 };
 
-const buildMonochromeScanImageDataUrl = async (args: {
+const buildRasterScanImageDataUrl = async (args: {
   page: import('playwright').Page;
+  colorMode: 'black-and-white' | 'grayscale';
   jpegQuality: number;
 }): Promise<string> => {
   const screenshotBuffer = await args.page.screenshot({ type: 'png' });
   const screenshotBase64 = screenshotBuffer.toString('base64');
 
   return args.page.evaluate(
-    async ({ base64, quality }) => {
+    async ({ base64, colorMode, quality }) => {
       const image = new Image();
       image.decoding = 'async';
       image.src = `data:image/png;base64,${base64}`;
@@ -207,17 +208,19 @@ const buildMonochromeScanImageDataUrl = async (args: {
       const { data } = imageData;
       for (let index = 0; index < data.length; index += 4) {
         const luminance = Math.round(data[index] * 0.299 + data[index + 1] * 0.587 + data[index + 2] * 0.114);
-        const monochrome = luminance < 192 ? 0 : 255;
-        data[index] = monochrome;
-        data[index + 1] = monochrome;
-        data[index + 2] = monochrome;
+        const normalized = colorMode === 'black-and-white'
+          ? (luminance < 192 ? 0 : 255)
+          : luminance;
+        data[index] = normalized;
+        data[index + 1] = normalized;
+        data[index + 2] = normalized;
         data[index + 3] = 255;
       }
       context.putImageData(imageData, 0, 0);
 
       return canvas.toDataURL('image/jpeg', quality / 100);
     },
-    { base64: screenshotBase64, quality: args.jpegQuality },
+    { base64: screenshotBase64, colorMode: args.colorMode, quality: args.jpegQuality },
   );
 };
 
@@ -1382,7 +1385,12 @@ async function run() {
           await generatorPage.setContent(buildIehpPdfMiniMatrixHtml(caseDefinition));
           let uploadPdfBuffer: Buffer;
           if (caseDefinition.renderMode === 'raster-scan') {
-            await generatorPage.setViewportSize({ width: 2550, height: 3300 });
+            const scanWidth = Math.round(caseDefinition.scan.dpi * 8.5);
+            const scanHeight = caseDefinition.scan.dpi * 11;
+            const scanFontSize = Math.round(54 * (caseDefinition.scan.dpi / 300));
+            const scanPaddingTop = Math.round(240 * (caseDefinition.scan.dpi / 300));
+            const scanPaddingSides = Math.round(220 * (caseDefinition.scan.dpi / 300));
+            await generatorPage.setViewportSize({ width: scanWidth, height: scanHeight });
             await generatorPage.setContent(`
               <!doctype html>
               <html lang="en">
@@ -1393,15 +1401,15 @@ async function run() {
                     html, body {
                       margin: 0;
                       padding: 0;
-                      width: 2550px;
-                      height: 3300px;
+                      width: ${scanWidth}px;
+                      height: ${scanHeight}px;
                       background: white;
                     }
 
                     body {
                       color: black;
                       font-family: Arial, sans-serif;
-                      font-size: 54px;
+                      font-size: ${scanFontSize}px;
                       line-height: 1.4;
                     }
 
@@ -1409,7 +1417,7 @@ async function run() {
                       box-sizing: border-box;
                       width: 100%;
                       min-height: 100%;
-                      padding: 240px 220px;
+                      padding: ${scanPaddingTop}px ${scanPaddingSides}px;
                       transform: rotate(${caseDefinition.scan.rotationDegrees}deg);
                       transform-origin: center center;
                     }
@@ -1423,8 +1431,9 @@ async function run() {
                 </body>
               </html>
             `);
-            const monochromeScanDataUrl = await buildMonochromeScanImageDataUrl({
+            const rasterScanDataUrl = await buildRasterScanImageDataUrl({
               page: generatorPage,
+              colorMode: caseDefinition.scan.colorMode,
               jpegQuality: caseDefinition.scan.jpegQuality,
             });
             const rasterPdfPage = await context.newPage();
@@ -1457,7 +1466,7 @@ async function run() {
                     </style>
                   </head>
                   <body>
-                    <img alt="${caseDefinition.id}" src="${monochromeScanDataUrl}" />
+                    <img alt="${caseDefinition.id}" src="${rasterScanDataUrl}" />
                   </body>
                 </html>
               `);

--- a/tests/scripts/iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/iehp-assessment-import-smoke.test.ts
@@ -83,6 +83,8 @@ describe('IEHP assessment import smoke helpers', () => {
       'alternate-document-phone-format',
       'scan-300dpi-monochrome',
       'scan-300dpi-monochrome-rotated-2deg',
+      'scan-150dpi-grayscale-low-quality',
+      'table-structured-fields',
     ]);
 
     expect(new Set(IEHP_PDF_MINI_MATRIX_CASES.map((caseDefinition) => caseDefinition.referralDate)).size).toBe(
@@ -97,6 +99,8 @@ describe('IEHP assessment import smoke helpers', () => {
       '+1 909 555 0103',
       '909.555.0104',
       '909 555 0105',
+      '(909) 555-0106',
+      '909-555-0107',
     ]);
   });
 
@@ -107,6 +111,8 @@ describe('IEHP assessment import smoke helpers', () => {
       '+1 909 555 0103',
       '909.555.0104',
       '909 555 0105',
+      '(909) 555-0106',
+      '909-555-0107',
     ]);
 
     for (const caseDefinition of IEHP_PDF_MINI_MATRIX_CASES) {
@@ -152,12 +158,61 @@ describe('IEHP assessment import smoke helpers', () => {
     });
   });
 
+  it('defines one deterministic degraded 150 DPI grayscale JPEG scan', () => {
+    expect(
+      IEHP_PDF_MINI_MATRIX_CASES.find(
+        (caseDefinition) => caseDefinition.id === 'scan-150dpi-grayscale-low-quality',
+      ),
+    ).toMatchObject({
+      referralDate: '07/05/2026',
+      documentPhone: '(909) 555-0106',
+      pageBreakBeforeTarget: false,
+      renderMode: 'raster-scan',
+      scan: {
+        dpi: 150,
+        colorMode: 'grayscale',
+        rotationDegrees: 0,
+        compression: 'jpeg',
+        jpegQuality: 45,
+      },
+    });
+  });
+
+  it('renders the table-structured case as semantic table cells instead of paragraph labels', () => {
+    const tableCase = IEHP_PDF_MINI_MATRIX_CASES.find(
+      (caseDefinition) => caseDefinition.id === 'table-structured-fields',
+    )!;
+    const html = buildIehpPdfMiniMatrixHtml(tableCase);
+
+    expect(tableCase).toMatchObject({
+      referralDate: '07/06/2026',
+      documentPhone: '909-555-0107',
+      renderMode: 'digital-pdf',
+      documentLayout: 'table',
+    });
+    expect(html).toContain('<table>');
+    expect(html).toContain('table { border-collapse: collapse; width: 100%; }');
+    expect(html).toContain('th, td { border: 1px solid #111; padding: 8px; text-align: left; }');
+    expect(html).toContain('<th scope="row">Referral Date:</th>');
+    expect(html).toContain('<th scope="row">Assessor\'s phone number:</th>');
+    expect(html).toContain(`<td>${tableCase.referralDate}</td>`);
+    expect(html).toContain(`<td>${tableCase.documentPhone}</td>`);
+    expect(html).not.toContain(`Referral Date: ${tableCase.referralDate}`);
+  });
+
   it('renders the referral label and document phone into selectable HTML with a page break only for the multi-page case', () => {
     for (const caseDefinition of IEHP_PDF_MINI_MATRIX_CASES) {
       const html = buildIehpPdfMiniMatrixHtml(caseDefinition);
 
-      expect(html).toContain(`Referral Date: ${caseDefinition.referralDate}`);
-      expect(html).toContain(`Assessor's phone number: ${caseDefinition.documentPhone}`);
+      if (caseDefinition.renderMode === 'digital-pdf' && caseDefinition.documentLayout === 'table') {
+        expect(html).toContain('<th scope="row">Referral Date:</th>');
+        expect(html).toContain(`<td>${caseDefinition.referralDate}</td>`);
+        expect(html).toContain('<th scope="row">Assessor\'s phone number:</th>');
+        expect(html).toContain(`<td>${caseDefinition.documentPhone}</td>`);
+      } else {
+        expect(html).toContain(`Referral Date: ${caseDefinition.referralDate}`);
+        expect(html).toContain(`Assessor's phone number: ${caseDefinition.documentPhone}`);
+      }
 
       if (caseDefinition.pageBreakBeforeTarget) {
         expect(html).toContain('page-break-before: always;');
@@ -189,7 +244,7 @@ describe('IEHP assessment import smoke helpers', () => {
   });
 
   it('defines one dedicated opt-in skills behaviors proof case without changing the existing mini matrix cases', () => {
-    expect(IEHP_PDF_MINI_MATRIX_CASES).toHaveLength(5);
+    expect(IEHP_PDF_MINI_MATRIX_CASES).toHaveLength(7);
     expect(IEHP_SKILLS_BEHAVIORS_PROOF_CASE).toMatchObject({
       id: 'skills-behaviors-proof',
       expectedSectionKey: 'IEHP_FBA_BEHAVIOR_SKILL_TARGETS',

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -1017,18 +1017,21 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     const setContentIndex = script.indexOf('await generatorPage.setContent(buildIehpPdfMiniMatrixHtml(caseDefinition));');
     const pagePdfIndex = script.indexOf("const pdfBuffer = await generatorPage.pdf({ format: 'Letter', printBackground: true });");
     const scanModeIndex = script.indexOf("caseDefinition.renderMode === 'raster-scan'", setContentIndex);
-    const scanViewportIndex = script.indexOf('width: 2550, height: 3300', scanModeIndex);
+    const scanWidthIndex = script.indexOf('const scanWidth = Math.round(caseDefinition.scan.dpi * 8.5);', scanModeIndex);
+    const scanHeightIndex = script.indexOf('const scanHeight = caseDefinition.scan.dpi * 11;', scanWidthIndex);
+    const scanViewportIndex = script.indexOf('width: scanWidth, height: scanHeight', scanHeightIndex);
     const rotationIndex = script.indexOf(
       'transform: rotate(${caseDefinition.scan.rotationDegrees}deg);',
       scanViewportIndex,
     );
-    const monochromeHelperIndex = script.indexOf('const buildMonochromeScanImageDataUrl = async');
-    const scanScreenshotIndex = script.indexOf("type: 'png'", monochromeHelperIndex);
+    const rasterHelperIndex = script.indexOf('const buildRasterScanImageDataUrl = async');
+    const scanScreenshotIndex = script.indexOf("type: 'png'", rasterHelperIndex);
     const scanCanvasIndex = script.indexOf('getImageData(0, 0, canvas.width, canvas.height)', scanScreenshotIndex);
     const scanLuminanceIndex = script.indexOf('const luminance = Math.round(', scanCanvasIndex);
+    const scanColorModeIndex = script.indexOf("colorMode === 'black-and-white'", scanLuminanceIndex);
     const scanQualityIndex = script.indexOf("canvas.toDataURL('image/jpeg', quality / 100)", scanLuminanceIndex);
     const rasterPageIndex = script.indexOf('const rasterPdfPage = await context.newPage();', scanQualityIndex);
-    const imageOnlyHtmlIndex = script.indexOf('monochromeScanDataUrl', rasterPageIndex);
+    const imageOnlyHtmlIndex = script.indexOf('rasterScanDataUrl', rasterPageIndex);
     const rasterPdfIndex = script.indexOf("await rasterPdfPage.pdf({ format: 'Letter', printBackground: true })", imageOnlyHtmlIndex);
     const generatorCloseIndex = script.indexOf('await generatorPage.close();');
     const pdfFileNameIndex = script.indexOf(
@@ -1060,13 +1063,16 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     expect(setContentIndex).toBeGreaterThan(generatorPageIndex);
     expect(pagePdfIndex).toBeGreaterThan(setContentIndex);
     expect(scanModeIndex).toBeGreaterThan(setContentIndex);
-    expect(scanViewportIndex).toBeGreaterThan(scanModeIndex);
+    expect(scanWidthIndex).toBeGreaterThan(scanModeIndex);
+    expect(scanHeightIndex).toBeGreaterThan(scanWidthIndex);
+    expect(scanViewportIndex).toBeGreaterThan(scanHeightIndex);
     expect(rotationIndex).toBeGreaterThan(scanViewportIndex);
-    expect(monochromeHelperIndex).toBeLessThan(setContentIndex);
+    expect(rasterHelperIndex).toBeLessThan(setContentIndex);
     expect(script).not.toContain('const loadImage = async');
-    expect(scanScreenshotIndex).toBeGreaterThan(monochromeHelperIndex);
+    expect(scanScreenshotIndex).toBeGreaterThan(rasterHelperIndex);
     expect(scanCanvasIndex).toBeGreaterThan(scanScreenshotIndex);
     expect(scanLuminanceIndex).toBeGreaterThan(scanCanvasIndex);
+    expect(scanColorModeIndex).toBeGreaterThan(scanLuminanceIndex);
     expect(scanQualityIndex).toBeGreaterThan(scanLuminanceIndex);
     expect(rasterPageIndex).toBeGreaterThan(scanQualityIndex);
     expect(imageOnlyHtmlIndex).toBeGreaterThan(rasterPageIndex);
@@ -1099,6 +1105,8 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
       matrixCaseLoopIndex,
     );
     const matrixProofPushIndex = script.indexOf('passedCases.push(skillsBehaviorsCaseEvidence);', matrixProofCallIndex);
+    const evidenceModeIndex = script.indexOf('mode: isSkillsBehaviorsProofMode');
+    const matrixEvidenceModeIndex = script.indexOf("? 'pdf-mini-matrix-case'", evidenceModeIndex);
     const aggregateTotalIndex = script.indexOf('totalCases: IEHP_PDF_MINI_MATRIX_CASES.length + 1,');
     const computedSkillsCountIndex = script.indexOf(
       'const skillsBehaviorsVerifiedCases = passedCases.filter(',
@@ -1112,6 +1120,8 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     );
 
     expect(reusableProofRunnerIndex).toBeGreaterThanOrEqual(0);
+    expect(evidenceModeIndex).toBeGreaterThanOrEqual(0);
+    expect(matrixEvidenceModeIndex).toBeGreaterThan(evidenceModeIndex);
     expect(matrixProofCallIndex).toBeGreaterThan(matrixCaseLoopIndex);
     expect(matrixProofPushIndex).toBeGreaterThan(matrixProofCallIndex);
     expect(computedSkillsCountIndex).toBeGreaterThan(matrixProofPushIndex);

--- a/tests/workflows/iehp-pdf-mini-matrix-proof.test.ts
+++ b/tests/workflows/iehp-pdf-mini-matrix-proof.test.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
 
+import { IEHP_PDF_MINI_MATRIX_CASES } from '../../scripts/lib/iehp-assessment-import-smoke';
+
 type WorkflowStep = {
   name?: string;
   if?: string;
@@ -124,6 +126,7 @@ describe('protected hosted IEHP PDF mini-matrix workflow', () => {
     const cleanup = findStep(proof, 'Clean synthetic smoke admin');
     const finalize = findStep(proof, 'Finalize redacted run evidence');
     const upload = findStep(proof, 'Upload redacted matrix evidence');
+    const expectedEvidenceCount = IEHP_PDF_MINI_MATRIX_CASES.length + 1;
 
     const provision = findStep(proof, 'Provision synthetic smoke admin');
     expect(provision?.env).toMatchObject({
@@ -153,10 +156,13 @@ describe('protected hosted IEHP PDF mini-matrix workflow', () => {
     expect(finalize?.run).toContain('rmSync(publicDir, { recursive: true, force: true })');
     expect(finalize?.run).toContain("'scan-300dpi-monochrome'");
     expect(finalize?.run).toContain("'scan-300dpi-monochrome-rotated-2deg'");
-    expect(finalize?.run).toContain('matrixCases.length !== 6');
-    expect(finalize?.run).toContain('aggregate.totalCases !== 6');
-    expect(finalize?.run).toContain('aggregate.passedCases !== 6');
-    expect(finalize?.run).toContain('aggregate.cleanupVerifiedCases !== 6');
+    expect(finalize?.run).toContain("'scan-150dpi-grayscale-low-quality'");
+    expect(finalize?.run).toContain("'table-structured-fields'");
+    expect(expectedEvidenceCount).toBe(8);
+    expect(finalize?.run).toContain(`matrixCases.length !== ${expectedEvidenceCount}`);
+    expect(finalize?.run).toContain(`aggregate.totalCases !== ${expectedEvidenceCount}`);
+    expect(finalize?.run).toContain(`aggregate.passedCases !== ${expectedEvidenceCount}`);
+    expect(finalize?.run).toContain(`aggregate.cleanupVerifiedCases !== ${expectedEvidenceCount}`);
     expect(finalize?.run).toContain('redactedPhonePattern');
     expect(finalize?.run).toContain('rawPhonePattern');
     expect(finalize?.run).toContain("'cases.json'");


### PR DESCRIPTION
## Summary
- add a deterministic 150 DPI grayscale/JPEG degradation case to the synthetic IEHP FBA PDF matrix
- add a semantic two-column table-layout PDF case
- keep Adobe-backed hosted extraction, field/provenance assertions, redacted evidence, and fail-closed cleanup unchanged
- expand the dedicated hosted proof contract from 6 to 8 evidence objects

## Route and risk
- Linear: WIN-154
- classification: high-risk human-reviewed
- lane: critical
- protected path: `.github/workflows/iehp-pdf-mini-matrix-proof.yml`
- no parser, server, Supabase, auth, runtime, secret, production-data, or PHI changes

## Verification
- focused IEHP matrix tests: 119/119 pass
- workflow YAML parse: pass
- `npm run ci:check-focused`: pass
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run build`: pass
- `npm run test:ci` / `npm run verify:local`: full-suite Vitest worker contention timed out unrelated UI tests; each surfaced file passed in isolation (`ProgramsGoalsTab` 116/116, `ClientSessionTrendsTab` 14/14, `TherapistOnboarding` 7/7)
- code, test, security, and devops specialist reviews: approve

## Required hosted proof
Dispatch `iehp-pdf-mini-matrix-proof.yml` against this exact PR head. Expected redacted aggregate: `totalCases: 8`, `passedCases: 8`, `cleanupVerifiedCases: 8`, `skillsBehaviorsVerifiedCases: 1`.

Human review is required before merge.