### PR TITLE
WIN-154 Harden hosted FBA matrix proof

### DIFF
--- a/.github/workflows/iehp-pdf-mini-matrix-proof.yml
+++ b/.github/workflows/iehp-pdf-mini-matrix-proof.yml
@@ -109,7 +109,7 @@ jobs:
     name: Hosted IEHP PDF mini-matrix proof
     needs: validate
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 75
     permissions:
       checks: read
       contents: read
@@ -273,9 +273,15 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           if [ -f "$PRIVATE_ADMIN_ENV_PATH" ]; then
-            source "$PRIVATE_ADMIN_ENV_PATH"
+            while IFS='=' read -r key value; do
+              case "$key" in
+                CI_SMOKE_ADMIN_EMAIL) CI_SMOKE_ADMIN_EMAIL="$value" ;;
+                PW_SUPERADMIN_USER_ID) PW_SUPERADMIN_USER_ID="$value" ;;
+              esac
+            done < "$PRIVATE_ADMIN_ENV_PATH"
           fi
           export CI_SMOKE_ADMIN_EMAIL
+          export PW_SUPERADMIN_USER_ID
           npx tsx scripts/provision-ci-smoke-admin.ts --cleanup
 
       - name: Finalize redacted run evidence
@@ -286,174 +292,7 @@ jobs:
           VALIDATED_SHA: ${{ needs.validate.outputs.validated_sha }}
           VALIDATED_PR_NUMBER: ${{ needs.validate.outputs.validated_pr_number }}
           PREVIEW_URL: ${{ env.IEHP_PROOF_PREVIEW_URL }}
-        run: |
-          node --input-type=module <<'NODE'
-          import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-          import path from 'node:path';
-
-          const publicDir = path.join(process.env.RUNNER_TEMP, 'iehp-pdf-mini-matrix-public');
-          const logPath = process.env.PRIVATE_MATRIX_LOG_PATH;
-          const workflowSucceeded = process.env.WORKFLOW_STATUS === 'success';
-
-          rmSync(publicDir, { recursive: true, force: true });
-          mkdirSync(publicDir, { recursive: true });
-
-          const runStatus = {
-            ok: workflowSucceeded,
-            status: process.env.WORKFLOW_STATUS ?? 'unknown',
-            workflowRunId: process.env.GITHUB_RUN_ID ?? null,
-            workflowRunAttempt: process.env.GITHUB_RUN_ATTEMPT ?? null,
-            validatedSha: process.env.VALIDATED_SHA ?? null,
-            validatedPrNumber: process.env.VALIDATED_PR_NUMBER ?? null,
-            previewUrl: process.env.PREVIEW_URL ?? null,
-          };
-
-          const writeRunStatus = () => {
-            writeFileSync(path.join(publicDir, 'run-status.json'), `${JSON.stringify(runStatus, null, 2)}\n`, 'utf8');
-          };
-
-          try {
-            if (!logPath || !existsSync(logPath)) {
-              writeRunStatus();
-              if (workflowSucceeded) {
-                throw new Error('PRIVATE_MATRIX_LOG_PATH is missing after a successful matrix run.');
-              }
-              process.exit(0);
-            }
-
-            const source = readFileSync(logPath, 'utf8');
-            const objects = [];
-            let depth = 0;
-            let start = -1;
-            let inString = false;
-            let escaping = false;
-
-            for (let index = 0; index < source.length; index += 1) {
-              const char = source[index];
-              if (inString) {
-                if (escaping) {
-                  escaping = false;
-                } else if (char === '\\') {
-                  escaping = true;
-                } else if (char === '"') {
-                  inString = false;
-                }
-                continue;
-              }
-
-              if (char === '"') {
-                inString = true;
-                continue;
-              }
-
-              if (char === '{') {
-                if (depth === 0) {
-                  start = index;
-                }
-                depth += 1;
-                continue;
-              }
-
-              if (char === '}') {
-                if (depth === 0) continue;
-                depth -= 1;
-                if (depth === 0 && start >= 0) {
-                  const candidate = source.slice(start, index + 1);
-                  try {
-                    objects.push(JSON.parse(candidate));
-                  } catch {
-                    // Ignore non-JSON brace blocks.
-                  }
-                  start = -1;
-                }
-              }
-            }
-
-            const expectedCaseIds = [
-              'clean-single-page',
-              'multi-page-target-content',
-              'alternate-document-phone-format',
-              'scan-300dpi-monochrome',
-              'scan-300dpi-monochrome-rotated-2deg',
-              'scan-150dpi-grayscale-low-quality',
-              'table-structured-fields',
-              'skills-behaviors-proof',
-            ];
-            const matrixCases = objects
-              .filter((entry) => entry?.mode === 'pdf-mini-matrix-case')
-              .map((entry) => {
-                const {
-                  screenshotPath,
-                  screenshot,
-                  ...rest
-                } = entry;
-                return rest;
-              });
-            const aggregate = objects.find((entry) => entry?.mode === 'pdf-mini-matrix');
-
-            if (matrixCases.length !== 8) {
-              throw new Error(`Expected exactly eight case evidence objects but found ${matrixCases.length}.`);
-            }
-            if (!aggregate) {
-              throw new Error('Missing aggregate matrix evidence.');
-            }
-
-            const actualCaseIds = matrixCases.map((entry) => entry.caseId);
-            if (JSON.stringify(actualCaseIds) !== JSON.stringify(expectedCaseIds)) {
-              throw new Error(`Matrix case IDs did not match the expected order. Received: ${JSON.stringify(actualCaseIds)}.`);
-            }
-            const redactedPhonePattern = /^\(\*\*\*\) \*\*\*-\d{4}$/;
-            for (const matrixCase of matrixCases) {
-              const phoneAssertion = matrixCase.assessorPhoneAssertion;
-              if (
-                !phoneAssertion
-                || !redactedPhonePattern.test(phoneAssertion.expectedPhoneRedacted ?? '')
-                || !redactedPhonePattern.test(phoneAssertion.actualPhoneRedacted ?? '')
-              ) {
-                throw new Error(`Matrix case ${matrixCase.caseId} did not contain redacted assessor-phone evidence.`);
-              }
-            }
-            const rawPhonePattern = /(?:\+?1[\s.-]?)?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}/;
-            if (rawPhonePattern.test(JSON.stringify(matrixCases))) {
-              throw new Error('Curated matrix evidence contained a raw phone number.');
-            }
-            if (aggregate.totalCases !== 8) {
-              throw new Error(`Expected aggregate totalCases to equal 8 but received ${aggregate.totalCases}.`);
-            }
-            if (aggregate.passedCases !== 8) {
-              throw new Error(`Expected aggregate passedCases to equal 8 but received ${aggregate.passedCases}.`);
-            }
-            if (aggregate.cleanupVerifiedCases !== 8) {
-              throw new Error(`Expected aggregate cleanupVerifiedCases to equal 8 but received ${aggregate.cleanupVerifiedCases}.`);
-            }
-            if (aggregate.skillsBehaviorsVerifiedCases !== 1) {
-              throw new Error(`Expected aggregate skillsBehaviorsVerifiedCases to equal 1 but received ${aggregate.skillsBehaviorsVerifiedCases}.`);
-            }
-
-            const metadata = {
-              ok: workflowSucceeded,
-              status: process.env.WORKFLOW_STATUS ?? 'unknown',
-              workflowRunId: process.env.GITHUB_RUN_ID ?? null,
-              workflowRunAttempt: process.env.GITHUB_RUN_ATTEMPT ?? null,
-              validatedSha: process.env.VALIDATED_SHA ?? null,
-              validatedPrNumber: process.env.VALIDATED_PR_NUMBER ?? null,
-              previewUrl: process.env.PREVIEW_URL ?? null,
-              caseCount: matrixCases.length,
-            };
-
-            writeFileSync(path.join(publicDir, 'cases.json'), `${JSON.stringify(matrixCases, null, 2)}\n`, 'utf8');
-            writeFileSync(path.join(publicDir, 'aggregate.json'), `${JSON.stringify(aggregate, null, 2)}\n`, 'utf8');
-            writeFileSync(path.join(publicDir, 'run-metadata.json'), `${JSON.stringify(metadata, null, 2)}\n`, 'utf8');
-            writeRunStatus();
-          } catch (error) {
-            runStatus.evidenceError = error instanceof Error ? error.message : String(error);
-            writeRunStatus();
-            if (workflowSucceeded) {
-              throw error;
-            }
-          }
-          NODE
-
+        run: node scripts/finalize-iehp-pdf-mini-matrix-evidence.mjs
       - name: Upload redacted matrix evidence
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/docs/ai/WIN-154-iehp-fba-hosted-proof-reliability-handoff.md
+++ b/docs/ai/WIN-154-iehp-fba-hosted-proof-reliability-handoff.md
@@ -1,0 +1,72 @@
+# WIN-154 IEHP FBA Hosted Proof Reliability Handoff
+
+- Date: August 13, 2026
+- Linear: `WIN-154`
+- Branch: `codex/win-154-fba-hosted-proof-reliability`
+- Classification: `high-risk human-reviewed`
+- Lane: `critical`
+- Triggering paths: `src/server/**` and `.github/workflows/**`
+
+## Hosted Failure Evidence
+
+- Owner-dispatched run: `31673104385`
+- Validated PR: `#940`
+- Validated SHA: `14cfc686ec453632fc2dcd873933dc8cfe9ac249`
+- Immutable PR-head and Netlify preview validation: passed.
+- Passed cases with cleanup: the first five canonical matrix cases through `scan-300dpi-monochrome-rotated-2deg`.
+- Runtime failure: `scan-150dpi-grayscale-low-quality` reached `extraction_failed` because the background extraction workflow aborted at its 55-second application deadline.
+- Coverage shortfall: fail-fast execution skipped `table-structured-fields` and `skills-behaviors-proof`; the finalizer found five of eight evidence objects.
+- Cleanup failure: the workflow sourced but did not export `PW_SUPERADMIN_USER_ID` before invoking the cleanup child process.
+- Public artifact boundary: upload succeeded with only redacted `run-status.json`; no private log, screenshot, or raw phone evidence was published.
+
+## Routed Scope
+
+- Increase the application extraction deadline to five minutes while keeping a separate explicit ten-minute stale-claim threshold.
+- Increase the IEHP smoke polling deadline beyond the application extraction deadline.
+- Continue after case-local matrix failures, emit sanitized failure evidence, and exit nonzero after all cases have run.
+- Export the existing private smoke-admin identity into the cleanup child process.
+- Preserve sanitized partial case and aggregate evidence on failed runs without weakening the exact `8/8/8/1` success gate.
+
+## Implemented Slice
+
+- Raised the application extraction deadline from 55 seconds to five minutes and kept stale-claim recovery as a separate explicit ten-minute boundary.
+- Raised the hosted smoke polling ceiling to six minutes and made matrix execution continue across case-local failures before returning a nonzero result.
+- Extracted evidence finalization into a testable fail-closed module that emits canonical sanitized partial evidence on failed runs and strictly enforces the exact success contract on successful runs.
+- Extended the proof job budget to 75 minutes so all eight bounded case attempts, cleanup, and finalization can complete.
+- Corrected cleanup environment propagation by parsing only the allowlisted smoke-admin email and user ID; the generated password line is never sourced or exported to the cleanup child.
+
+## Non-Goals And Stop Conditions
+
+- No parser or Adobe extraction implementation changes.
+- No Supabase function, schema, migration, RLS, grant, auth, runtime-config, or Netlify configuration changes.
+- No secret changes, `.env*` reads, customer documents, PHI, raw OCR output, screenshots, or private logs in public artifacts.
+- Stop and re-route if the hosted rerun proves the low-quality case fails for extraction quality rather than the bounded runtime deadline.
+
+## Verification Card
+
+- Classification: `high-risk human-reviewed`.
+- Lane: `critical`.
+- Change type: server/API and CI/workflow.
+- Required: `npm ci`; focused server, smoke-runner, finalizer, and workflow tests; workflow YAML parse; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run ci:verify-coverage`; `npm run build`; `npm run verify:local`; exact-head owner-dispatched hosted proof.
+- Executed: `npm ci` passed; `npx vitest run src/server/__tests__/assessmentDocumentsHandler.test.ts tests/scripts/playwright-iehp-assessment-import-smoke.test.ts tests/scripts/finalize-iehp-pdf-mini-matrix-evidence.test.ts tests/workflows/iehp-pdf-mini-matrix-proof.test.ts` passed 126/126; `npm run ci:check-focused` passed; `npm run lint` passed; `npm run typecheck` passed; `NODE_OPTIONS=--max-old-space-size=8192 npm run test:ci` passed 4,290 tests with five skipped; `npm run ci:verify-coverage` passed at 92.81% line coverage; `npm run build` passed; `npm run test:routes:tier0` passed 220/220; `git diff --check` passed.
+- Wrapper diagnostics: the default-heap `npm run test:ci` attempt exhausted the 4 GB Node heap. Two later 8 GB `npm run verify:local` attempts passed policy, lint, and typecheck but stopped in their repeated full-suite phase on unrelated contention: one Schedule batch/worker timeout and one asynchronous AppNavigation assertion. The isolated Schedule suite passed 18/18 and the isolated AppNavigation suite passed 31/31. The earlier standalone 8 GB full suite remains green.
+- Blocked: at this handoff-card capture, this exact uncommitted branch head has no open PR; commit, push, and opening a draft PR on `codex/win-154-fba-hosted-proof-reliability` are the first required steps. Fresh hosted proof then requires that draft's exact immutable Netlify deploy preview, protected credentials, and a separate repository-owner dispatch. PR `#940` is on a different branch and cannot validate this diff.
+- Result: `pass-with-blocked-checks` for the bounded slice; not merge-ready until fresh required CI and the exact-head hosted proof pass.
+- Residual risk: only the hosted Adobe-backed rerun can prove that the five-minute budget is sufficient and all eight evidence objects pass cleanup and redaction gates.
+
+## Specialist Reviews
+
+- Specification, architecture, implementation, test, performance, deploy/CI, code, and security review roles completed.
+- Code review found no implementation correctness defect; its stale-handoff blocker is resolved by this update.
+- Security review identified blanket cleanup auto-export and whole-file sourcing as excessive. The workflow now parses only the allowlisted cleanup identity fields, and its test whitelists the exact cleanup environment while rejecting source-based or password export.
+
+## PR Hygiene
+
+- Branch-ready: yes; dedicated `codex/` branch.
+- Linear-ready: yes; linked to `WIN-154`, status `In Review`.
+- Single-purpose: yes; one hosted FBA proof-reliability slice.
+- Unrelated changes: none.
+- Generated artifact drift: none.
+- Protected-path drift: none beyond the declared critical-lane workflow and server surfaces.
+- PR handoff: pending commit, push, and opening the exact-head draft PR for this branch.
+- PR-ready: no; after the draft exists, its live checks and the owner-dispatched exact-head hosted proof remain required before merge readiness.

--- a/docs/ai/WIN-154-iehp-fba-hosted-proof-reliability-handoff.md
+++ b/docs/ai/WIN-154-iehp-fba-hosted-proof-reliability-handoff.md
@@ -35,7 +35,7 @@
 - Extended the proof job budget to 75 minutes so all eight bounded case attempts, cleanup, and finalization can complete.
 - Corrected cleanup environment propagation by parsing only the allowlisted smoke-admin email and user ID; the generated password line is never sourced or exported to the cleanup child.
 
-## Non-Goals And Stop Conditions
+## Initial Slice Non-Goals And Stop Conditions
 
 - No parser or Adobe extraction implementation changes.
 - No Supabase function, schema, migration, RLS, grant, auth, runtime-config, or Netlify configuration changes.
@@ -50,7 +50,7 @@
 - Required: `npm ci`; focused server, smoke-runner, finalizer, and workflow tests; workflow YAML parse; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run ci:verify-coverage`; `npm run build`; `npm run verify:local`; exact-head owner-dispatched hosted proof.
 - Executed: `npm ci` passed; `npx vitest run src/server/__tests__/assessmentDocumentsHandler.test.ts tests/scripts/playwright-iehp-assessment-import-smoke.test.ts tests/scripts/finalize-iehp-pdf-mini-matrix-evidence.test.ts tests/workflows/iehp-pdf-mini-matrix-proof.test.ts` passed 126/126; `npm run ci:check-focused` passed; `npm run lint` passed; `npm run typecheck` passed; `NODE_OPTIONS=--max-old-space-size=8192 npm run test:ci` passed 4,290 tests with five skipped; `npm run ci:verify-coverage` passed at 92.81% line coverage; `npm run build` passed; `npm run test:routes:tier0` passed 220/220; `git diff --check` passed.
 - Wrapper diagnostics: the default-heap `npm run test:ci` attempt exhausted the 4 GB Node heap. Two later 8 GB `npm run verify:local` attempts passed policy, lint, and typecheck but stopped in their repeated full-suite phase on unrelated contention: one Schedule batch/worker timeout and one asynchronous AppNavigation assertion. The isolated Schedule suite passed 18/18 and the isolated AppNavigation suite passed 31/31. The earlier standalone 8 GB full suite remains green.
-- Blocked: at this handoff-card capture, this exact uncommitted branch head has no open PR; commit, push, and opening a draft PR on `codex/win-154-fba-hosted-proof-reliability` are the first required steps. Fresh hosted proof then requires that draft's exact immutable Netlify deploy preview, protected credentials, and a separate repository-owner dispatch. PR `#940` is on a different branch and cannot validate this diff.
+- Blocked at the initial handoff capture: the branch had not yet been pushed. Draft PR `#941` now tracks this branch; the Adobe diagnostic follow-up below requires a new exact-head CI/deployment/proof cycle.
 - Result: `pass-with-blocked-checks` for the bounded slice; not merge-ready until fresh required CI and the exact-head hosted proof pass.
 - Residual risk: only the hosted Adobe-backed rerun can prove that the five-minute budget is sufficient and all eight evidence objects pass cleanup and redaction gates.
 
@@ -68,5 +68,62 @@
 - Unrelated changes: none.
 - Generated artifact drift: none.
 - Protected-path drift: none beyond the declared critical-lane workflow and server surfaces.
-- PR handoff: pending commit, push, and opening the exact-head draft PR for this branch.
-- PR-ready: no; after the draft exists, its live checks and the owner-dispatched exact-head hosted proof remain required before merge readiness.
+- PR handoff: draft PR `#941` exists and remains intentionally unmerged.
+- PR-ready: no; the diagnostic follow-up requires refreshed review, exact-head checks, reviewed function deployment, and owner-dispatched hosted proof.
+
+## Adobe Failure Diagnostic Follow-up
+
+### Fresh Route And Evidence
+
+- Date: August 13, 2026.
+- Classification: `high-risk human-reviewed`.
+- Lane: `critical`.
+- Triggering paths: `supabase/functions/extract-assessment-fields/**` and `src/server/**`.
+- Failed exact-head hosted run: `31715024657` on SHA `5d617b7355c9aaade24dddc15915722c10e8c5e6`; all eight synthetic cases reached `extract-assessment-fields` version 122 and failed with HTTP 502.
+- Adobe Developer Console showed the PDF Services entitlement, OAuth server-to-server credential, connected product profile, and same-day service activity as active. Adobe Insights has a 24-hour delay and showed historical successful responses only.
+- Adobe usage report showed 103 Extract PDF document transactions, below the 500-transaction monthly free-tier allowance; quota exhaustion is not supported by the evidence.
+- Supabase hosted logs exposed request-level 502 records only, not a sanitized Adobe operation stage. The prior function mapped token, asset, upload, submission, polling, and result failures to the same public code.
+
+### Bounded Scope
+
+- Add a fixed Adobe failure-stage vocabulary and optional numeric upstream HTTP status.
+- Normalize transport, response-body, result-download, and ZIP-parse exceptions into the same sanitized Adobe error boundary.
+- Keep semantic Adobe job failures distinct from HTTP failures by leaving `upstream_status` null when the HTTP response itself succeeded.
+- Return only `stage` and `upstream_status` alongside the existing generic Edge Function error/code.
+- Persist only allowlisted `adobe_stage` and `adobe_upstream_status` fields in the existing tenant-scoped extraction-failure review event so the hosted proof can identify the failing provider boundary.
+- Discard unknown stage names and invalid HTTP status ranges at the server boundary while preserving the generic extraction failure.
+
+Non-goals remain credential rotation, secret access, parser behavior changes, schema/RLS/grant changes, workflow behavior changes, production deployment, or merge. No provider response body, token, signed URL, credential value, document text, screenshot, or PHI may enter the response or audit event.
+
+### Verification Card
+
+- Required: focused Edge Function and server tests; `npm run ci:check-focused`; `npm run lint`; `npm run typecheck`; `npm run test:ci`; `npm run validate:tenant`; `npm run build`; `npm run verify:local` when supported; exact-head CI; exact-head hosted synthetic proof after reviewed deployment.
+- Red-green evidence: token HTTP status and transport-stage tests failed before implementation; server audit propagation failed before implementation; all passed after the bounded changes.
+- Executed: `npm ci` passed; complete `extract-assessment-fields` Deno matrix passed 76/76; `assessmentDocumentsHandler.test.ts` passed 61/61; `deno check` for the Edge Function entrypoint passed; `deno fmt --check` passed for the new Adobe helper and test changes (the legacy entrypoint is not globally Deno-formatted, so its narrow seven-line hunk was reviewed without reformatting unrelated code); `npm run ci:check-focused` passed with its documented credential-dependent skips; `npm run lint` passed; `npm run typecheck` passed; `npm run validate:tenant` passed; `npm run build` passed; `git diff --check` passed.
+- Aggregate verification: the final 8 GB `npm run verify:local` passed in 416.5 seconds, including `npm run test:ci`, coverage verification at 92.81% lines, build, and the Tier-0 browser gate at 220/220. An earlier full-suite attempt hit a Vitest worker timeout in `ProgramsGoalsTab`; that isolated suite passed 116/116, and the final aggregate run cleared the failure.
+- Blocked checks: exact-head CI, reviewed Supabase Edge Function deployment, and the exact-head hosted synthetic matrix require the pushed commit plus the critical-lane human review/deployment action.
+- Result: `pass-with-blocked-checks`; all required local gates pass, while exact-head CI, reviewed deployment, and hosted proof remain required.
+- Residual risk: the diagnostic slice identifies the failing Adobe boundary but does not itself repair a stale secret or Adobe upstream rejection. Any credential rotation remains a separate protected owner action after the stage/status evidence proves it is necessary.
+
+### Follow-up Specialist Reviews
+
+- Code review: approved with no actionable correctness, compatibility, or scope-drift finding.
+- Security review: approved; provider body, tokens, URLs, document content, and PHI remain outside the public and persisted diagnostic boundary.
+- Supabase review: the initial request for explicit malformed-diagnostic behavior was resolved by the pure sanitizer and negative coverage; no migration, RLS, grant, auth, or tenant-scope change was found.
+- Test review: no functional defect found; the focused and aggregate verification package is complete locally, with hosted gates explicitly blocked.
+
+### Follow-up PR Hygiene Verdict
+
+- `pr-ready`: yes for critical-lane human review; not merge-ready.
+- `lane`: `critical`.
+- `branch-ready`: yes; dedicated `codex/win-154-fba-hosted-proof-reliability` branch.
+- `linear-ready`: yes; linked `WIN-154` remains `In Review`.
+- `single-purpose`: yes; the diff only adds sanitized Adobe failure-stage observability for the existing FBA workflow.
+- `unrelated changes`: none.
+- `generated artifact drift`: none; timestamp-only local test-report drift was excluded.
+- `protected-path drift`: none beyond the declared Edge Function and server/API surfaces.
+- `change summary`: present.
+- `verification summary`: present with required, executed, blocked, result, and residual-risk fields.
+- `pr handoff`: draft PR `#941`; exact-head CI, human review, reviewed function deployment, and hosted matrix proof remain required.
+- `reviewer`: code, security, test, architecture, specification, implementation, and Supabase reviews completed.
+- `required follow-up`: push the exact head, require CI success, obtain critical-lane owner review, deploy the reviewed Edge Function, then rerun the eight-case hosted synthetic matrix before merge confirmation.

--- a/scripts/finalize-iehp-pdf-mini-matrix-evidence.mjs
+++ b/scripts/finalize-iehp-pdf-mini-matrix-evidence.mjs
@@ -1,0 +1,345 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const EXPECTED_IEHP_PDF_MINI_MATRIX_CASE_IDS = Object.freeze([
+  'clean-single-page',
+  'multi-page-target-content',
+  'alternate-document-phone-format',
+  'scan-300dpi-monochrome',
+  'scan-300dpi-monochrome-rotated-2deg',
+  'scan-150dpi-grayscale-low-quality',
+  'table-structured-fields',
+  'skills-behaviors-proof',
+]);
+
+const REDACTED_PHONE_PATTERN = /^\(\*\*\*\) \*\*\*-\d{4}$/;
+const RAW_PHONE_PATTERN = /(?:\+?1[\s.-]?)?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}/;
+const SUCCESS_MODE = 'pdf-mini-matrix-case';
+const FAILURE_MODE = 'pdf-mini-matrix-case-failure';
+const AGGREGATE_MODE = 'pdf-mini-matrix';
+
+const isRecord = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+export const extractJsonObjectsFromLog = (source) => {
+  const objects = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaping = false;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === '\\') {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === '{') {
+      if (depth === 0) start = index;
+      depth += 1;
+      continue;
+    }
+
+    if (char !== '}' || depth === 0) continue;
+    depth -= 1;
+    if (depth !== 0 || start < 0) continue;
+
+    try {
+      const candidate = JSON.parse(source.slice(start, index + 1));
+      if (isRecord(candidate)) objects.push(candidate);
+    } catch {
+      // Console output can contain unrelated brace blocks.
+    }
+    start = -1;
+  }
+
+  return objects;
+};
+
+const sanitizeNestedEvidence = (value) => {
+  if (Array.isArray(value)) return value.map((entry) => sanitizeNestedEvidence(entry));
+  if (!isRecord(value)) return value;
+
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, nestedValue]) => {
+      const normalizedKey = key.toLowerCase();
+      if (normalizedKey.includes('screenshot')) return [];
+      if (normalizedKey.includes('error')) return [];
+      if (
+        normalizedKey.includes('phone')
+        && key !== 'expectedPhoneRedacted'
+        && key !== 'actualPhoneRedacted'
+      ) {
+        return [];
+      }
+      return [[key, sanitizeNestedEvidence(nestedValue)]];
+    }),
+  );
+};
+
+const sanitizeAssessorPhoneAssertion = (value) => {
+  if (!isRecord(value)) return null;
+  return {
+    fieldKey: value.fieldKey,
+    rowCount: value.rowCount,
+    nonEmpty: value.nonEmpty,
+    validFormat: value.validFormat,
+    precedenceMatchedExpectedPhone: value.precedenceMatchedExpectedPhone,
+    provenanceRowCount: value.provenanceRowCount,
+    provenanceVerified: value.provenanceVerified,
+    sourceMethod: value.sourceMethod,
+    sourceField: value.sourceField,
+    expectedPhoneRedacted: value.expectedPhoneRedacted,
+    actualPhoneRedacted: value.actualPhoneRedacted,
+  };
+};
+
+const sanitizeSuccessfulCase = (entry) => ({
+  ok: true,
+  mode: SUCCESS_MODE,
+  caseId: entry.caseId,
+  templateType: 'iehp_fba',
+  status: entry.status,
+  draftPrograms: entry.draftPrograms,
+  draftGoals: entry.draftGoals,
+  assessorPhoneAssertion: sanitizeAssessorPhoneAssertion(entry.assessorPhoneAssertion),
+  referralDateAssertion: sanitizeNestedEvidence(entry.referralDateAssertion),
+  skillsBehaviorsProofResult: sanitizeNestedEvidence(entry.skillsBehaviorsProofResult),
+  cleanupVerified: entry.cleanupVerified === true,
+});
+
+const sanitizeFailedCase = (entry) => ({
+  ok: false,
+  mode: FAILURE_MODE,
+  caseId: entry.caseId,
+  templateType: 'iehp_fba',
+  cleanupVerified: false,
+  failureCategory: 'case_execution_failed',
+  errorCategory: 'matrix_failures_detected',
+});
+
+const assertRedactedPhoneEvidence = (successfulCases) => {
+  for (const matrixCase of successfulCases) {
+    const assertion = matrixCase.assessorPhoneAssertion;
+    if (
+      !assertion
+      || !REDACTED_PHONE_PATTERN.test(assertion.expectedPhoneRedacted ?? '')
+      || !REDACTED_PHONE_PATTERN.test(assertion.actualPhoneRedacted ?? '')
+    ) {
+      throw new Error('redacted_phone_evidence_invalid');
+    }
+  }
+};
+
+const assertNoRawPhones = (value) => {
+  if (RAW_PHONE_PATTERN.test(JSON.stringify(value))) {
+    throw new Error('raw_phone_detected');
+  }
+};
+
+const hasExactSuccessfulAggregate = (aggregate) =>
+  aggregate?.ok === true
+  && aggregate?.mode === AGGREGATE_MODE
+  && aggregate?.totalCases === 8
+  && aggregate?.passedCases === 8
+  && aggregate?.cleanupVerifiedCases === 8
+  && aggregate?.skillsBehaviorsVerifiedCases === 1;
+
+const buildMetadataFields = (workflowStatus, metadata, successfulCount, failedCount) => ({
+  ok: workflowStatus === 'success',
+  status: workflowStatus ?? 'unknown',
+  workflowRunId: metadata.workflowRunId ?? null,
+  workflowRunAttempt: metadata.workflowRunAttempt ?? null,
+  validatedSha: metadata.validatedSha ?? null,
+  validatedPrNumber: metadata.validatedPrNumber ?? null,
+  previewUrl: metadata.previewUrl ?? null,
+  caseCount: successfulCount,
+  failedCaseCount: failedCount,
+});
+
+export const buildFinalizedIehpPdfMiniMatrixEvidence = ({
+  logSource,
+  workflowStatus,
+  metadata = {},
+}) => {
+  const workflowSucceeded = workflowStatus === 'success';
+  const objects = extractJsonObjectsFromLog(logSource);
+  const successfulSourceCases = objects.filter((entry) => entry.mode === SUCCESS_MODE);
+  const failedSourceCases = objects.filter((entry) => entry.mode === FAILURE_MODE);
+  const loggedAggregate = objects.filter((entry) => entry.mode === AGGREGATE_MODE).at(-1);
+  const successfulCases = successfulSourceCases.map(sanitizeSuccessfulCase);
+  const failedCases = failedSourceCases.map(sanitizeFailedCase);
+
+  assertRedactedPhoneEvidence(successfulCases);
+
+  const cases = EXPECTED_IEHP_PDF_MINI_MATRIX_CASE_IDS.flatMap((caseId) => {
+    const failedCase = failedCases.find((entry) => entry.caseId === caseId);
+    if (failedCase) return [failedCase];
+    const successfulCase = successfulCases.find((entry) => entry.caseId === caseId);
+    return successfulCase ? [successfulCase] : [];
+  });
+  const cleanupVerifiedSuccessfulCases = cases.filter(
+    (entry) => entry.mode === SUCCESS_MODE && entry.cleanupVerified === true,
+  );
+  const skillsBehaviorsVerifiedCases = cleanupVerifiedSuccessfulCases.filter(
+    (entry) => entry.skillsBehaviorsProofResult != null,
+  ).length;
+  const failedCaseCount = cases.filter((entry) => entry.mode === FAILURE_MODE).length;
+  const aggregate = {
+    ok: workflowSucceeded
+      && cleanupVerifiedSuccessfulCases.length === 8
+      && failedCaseCount === 0
+      && skillsBehaviorsVerifiedCases === 1,
+    mode: AGGREGATE_MODE,
+    totalCases: EXPECTED_IEHP_PDF_MINI_MATRIX_CASE_IDS.length,
+    passedCases: cleanupVerifiedSuccessfulCases.length,
+    cleanupVerifiedCases: cleanupVerifiedSuccessfulCases.length,
+    skillsBehaviorsVerifiedCases,
+  };
+  const runMetadata = buildMetadataFields(
+    workflowStatus,
+    metadata,
+    cleanupVerifiedSuccessfulCases.length,
+    failedCaseCount,
+  );
+  const runStatus = {
+    ok: workflowSucceeded,
+    status: workflowStatus ?? 'unknown',
+    workflowRunId: metadata.workflowRunId ?? null,
+    workflowRunAttempt: metadata.workflowRunAttempt ?? null,
+    validatedSha: metadata.validatedSha ?? null,
+    validatedPrNumber: metadata.validatedPrNumber ?? null,
+    previewUrl: metadata.previewUrl ?? null,
+  };
+
+  if (!workflowSucceeded) {
+    runMetadata.ok = false;
+    if (failedCaseCount > 0) {
+      runStatus.evidenceError = `matrix_case_failures_detected:${failedCaseCount}`;
+    }
+    if (cleanupVerifiedSuccessfulCases.length !== 8) {
+      runStatus.evidenceShortfall = `successful_cleanup_verified_cases:${cleanupVerifiedSuccessfulCases.length}/8`;
+    }
+  }
+
+  assertNoRawPhones({ cases, aggregate, metadata: runMetadata, runStatus });
+
+  if (workflowSucceeded) {
+    const sourceCaseIds = successfulSourceCases.map((entry) => entry.caseId);
+    const exactSourceOrder = JSON.stringify(sourceCaseIds)
+      === JSON.stringify(EXPECTED_IEHP_PDF_MINI_MATRIX_CASE_IDS);
+    if (
+      successfulSourceCases.length !== 8
+      || failedSourceCases.length !== 0
+      || !exactSourceOrder
+      || !hasExactSuccessfulAggregate(loggedAggregate)
+      || !hasExactSuccessfulAggregate(aggregate)
+    ) {
+      throw new Error('successful_contract_failed');
+    }
+  }
+
+  return {
+    cases,
+    aggregate,
+    metadata: runMetadata,
+    runStatus,
+    hasEvidence: cases.length > 0 || Boolean(loggedAggregate),
+  };
+};
+
+const writeJson = (outputDirectory, fileName, value) => {
+  writeFileSync(
+    path.join(outputDirectory, fileName),
+    `${JSON.stringify(value, null, 2)}\n`,
+    'utf8',
+  );
+};
+
+export const finalizeIehpPdfMiniMatrixEvidenceRun = ({
+  logSource,
+  outputDirectory,
+  workflowStatus,
+  metadata = {},
+}) => {
+  rmSync(outputDirectory, { recursive: true, force: true });
+  mkdirSync(outputDirectory, { recursive: true });
+
+  try {
+    const finalized = buildFinalizedIehpPdfMiniMatrixEvidence({
+      logSource,
+      workflowStatus,
+      metadata,
+    });
+    if (finalized.hasEvidence) {
+      writeJson(outputDirectory, 'cases.json', finalized.cases);
+      writeJson(outputDirectory, 'aggregate.json', finalized.aggregate);
+      writeJson(outputDirectory, 'run-metadata.json', finalized.metadata);
+    }
+    writeJson(outputDirectory, 'run-status.json', finalized.runStatus);
+    return finalized;
+  } catch (error) {
+    const evidenceError = error instanceof Error && [
+      'raw_phone_detected',
+      'redacted_phone_evidence_invalid',
+      'successful_contract_failed',
+    ].includes(error.message)
+      ? error.message
+      : 'evidence_finalization_failed';
+    const runStatus = {
+      ok: false,
+      status: workflowStatus ?? 'unknown',
+      workflowRunId: metadata.workflowRunId ?? null,
+      workflowRunAttempt: metadata.workflowRunAttempt ?? null,
+      validatedSha: metadata.validatedSha ?? null,
+      validatedPrNumber: metadata.validatedPrNumber ?? null,
+      previewUrl: metadata.previewUrl ?? null,
+      evidenceError,
+    };
+    writeJson(outputDirectory, 'run-status.json', runStatus);
+    if (workflowStatus === 'success') throw error;
+    return { runStatus, hasEvidence: false };
+  }
+};
+
+export const runIehpPdfMiniMatrixEvidenceFinalizer = (env = process.env) => {
+  const outputDirectory = path.join(env.RUNNER_TEMP, 'iehp-pdf-mini-matrix-public');
+  const logPath = env.PRIVATE_MATRIX_LOG_PATH;
+  const logSource = logPath && existsSync(logPath) ? readFileSync(logPath, 'utf8') : '';
+
+  return finalizeIehpPdfMiniMatrixEvidenceRun({
+    logSource,
+    outputDirectory,
+    workflowStatus: env.WORKFLOW_STATUS ?? 'unknown',
+    metadata: {
+      workflowRunId: env.GITHUB_RUN_ID,
+      workflowRunAttempt: env.GITHUB_RUN_ATTEMPT,
+      validatedSha: env.VALIDATED_SHA,
+      validatedPrNumber: env.VALIDATED_PR_NUMBER,
+      previewUrl: env.PREVIEW_URL,
+    },
+  });
+};
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  try {
+    runIehpPdfMiniMatrixEvidenceFinalizer();
+  } catch {
+    console.error('IEHP PDF mini-matrix evidence finalization failed.');
+    process.exitCode = 1;
+  }
+}

--- a/scripts/playwright-iehp-assessment-import-smoke.ts
+++ b/scripts/playwright-iehp-assessment-import-smoke.ts
@@ -119,6 +119,16 @@ type IehpSmokeCaseEvidence = {
   screenshot: string;
 };
 
+type IehpSmokeCaseFailureEvidence = {
+  ok: false;
+  mode: 'pdf-mini-matrix-case-failure';
+  caseId: string;
+  templateType: 'iehp_fba';
+  cleanupVerified: false;
+  failureCategory: 'case_execution_failed';
+  errorCategory: 'matrix_failures_detected';
+};
+
 type AssessmentPlanPdfBlocker = {
   code?: unknown;
 };
@@ -151,7 +161,7 @@ type ParsedAssessmentPlanPdfPreflight = {
 
 const DEFAULT_BASE_URL = 'https://app.allincompassing.ai';
 const DEFAULT_ASSESSMENT_BUCKET_ID = 'client-documents';
-const EXTRACTION_TIMEOUT_MS = 120_000;
+const EXTRACTION_TIMEOUT_MS = 360_000;
 const IEHP_REFERRAL_DATE_FIELD_KEY = 'IEHP_FBA_REFERRAL_DATE';
 
 type SupabaseClientFactory = typeof createClient;
@@ -178,6 +188,105 @@ const resolveSupabaseAnonKey = (): string =>
 
 const pause = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const buildPublicMatrixCaseFailureEvidence = (caseId: string): IehpSmokeCaseFailureEvidence => ({
+  ok: false,
+  mode: 'pdf-mini-matrix-case-failure',
+  caseId,
+  templateType: 'iehp_fba',
+  cleanupVerified: false,
+  failureCategory: 'case_execution_failed',
+  errorCategory: 'matrix_failures_detected',
+});
+
+export const assertIehpPdfMiniMatrixPreflight = (args: {
+  cases: Array<{ id: string; documentPhone: string }>;
+  expectedAssessorPhone: string;
+}): void => {
+  for (const caseDefinition of args.cases) {
+    if (
+      canonicalizeUsPhoneForComparison(caseDefinition.documentPhone) ===
+      canonicalizeUsPhoneForComparison(args.expectedAssessorPhone)
+    ) {
+      throw new Error(
+        `IEHP PDF mini matrix case ${caseDefinition.id} normalized document phone matched the configured snapshot phone, so precedence proof would be ambiguous.`,
+      );
+    }
+  }
+};
+
+const sanitizePublicMatrixCaseEvidence = (
+  caseEvidence: IehpSmokeCaseEvidence | Record<string, unknown>,
+): Record<string, unknown> => {
+  const {
+    screenshot,
+    errorMessage,
+    assessorPhoneAssertion,
+    ...rest
+  } = caseEvidence as IehpSmokeCaseEvidence & {
+    errorMessage?: unknown;
+  };
+
+  const sanitizedAssessorPhoneAssertion = assessorPhoneAssertion && typeof assessorPhoneAssertion === 'object'
+    ? {
+        fieldKey: assessorPhoneAssertion.fieldKey,
+        rowCount: assessorPhoneAssertion.rowCount,
+        nonEmpty: assessorPhoneAssertion.nonEmpty,
+        validFormat: assessorPhoneAssertion.validFormat,
+        precedenceMatchedExpectedPhone: assessorPhoneAssertion.precedenceMatchedExpectedPhone,
+        provenanceRowCount: assessorPhoneAssertion.provenanceRowCount,
+        provenanceVerified: assessorPhoneAssertion.provenanceVerified,
+        sourceMethod: assessorPhoneAssertion.sourceMethod,
+        sourceField: assessorPhoneAssertion.sourceField,
+        expectedPhoneRedacted: assessorPhoneAssertion.expectedPhoneRedacted,
+        actualPhoneRedacted: assessorPhoneAssertion.actualPhoneRedacted,
+      }
+    : undefined;
+
+  return {
+    ...rest,
+    ...(sanitizedAssessorPhoneAssertion ? { assessorPhoneAssertion: sanitizedAssessorPhoneAssertion } : {}),
+  };
+};
+
+type IehpPdfMiniMatrixTask<T> = {
+  caseId: string;
+  run: () => Promise<T>;
+};
+
+export const runIehpPdfMiniMatrixTasks = async <T>(args: {
+  tasks: Array<IehpPdfMiniMatrixTask<T>>;
+  onSuccess: (evidence: T, caseId: string) => void | Promise<void>;
+  onFailure: (evidence: IehpSmokeCaseFailureEvidence) => void | Promise<void>;
+}): Promise<{ passedCases: T[]; failedCases: IehpSmokeCaseFailureEvidence[] }> => {
+  const passedCases: T[] = [];
+  const failedCases: IehpSmokeCaseFailureEvidence[] = [];
+
+  for (const task of args.tasks) {
+    let evidence: T;
+    try {
+      evidence = await task.run();
+    } catch {
+      const failureEvidence = buildPublicMatrixCaseFailureEvidence(task.caseId);
+      failedCases.push(failureEvidence);
+      await args.onFailure(failureEvidence);
+      continue;
+    }
+
+    passedCases.push(evidence);
+    await args.onSuccess(evidence, task.caseId);
+  }
+
+  return { passedCases, failedCases };
+};
+
+export const assertIehpPdfMiniMatrixTasksSucceeded = (
+  failedCases: IehpSmokeCaseFailureEvidence[],
+): void => {
+  if (failedCases.length > 0) {
+    throw new Error('IEHP PDF mini matrix encountered one or more case-local failures.');
+  }
 };
 
 const buildRasterScanImageDataUrl = async (args: {
@@ -1370,155 +1479,166 @@ async function run() {
     };
 
     if (isPdfMiniMatrixMode) {
-      const passedCases: IehpSmokeCaseEvidence[] = [];
-      for (const caseDefinition of IEHP_PDF_MINI_MATRIX_CASES) {
-        if (
-          canonicalizeUsPhoneForComparison(caseDefinition.documentPhone) ===
-          canonicalizeUsPhoneForComparison(expectedAssessorPhone)
-        ) {
-          throw new Error(
-            `IEHP PDF mini matrix case ${caseDefinition.id} normalized document phone matched the configured snapshot phone, so precedence proof would be ambiguous.`,
-          );
-        }
-        const generatorPage = await context.newPage();
-        try {
-          await generatorPage.setContent(buildIehpPdfMiniMatrixHtml(caseDefinition));
-          let uploadPdfBuffer: Buffer;
-          if (caseDefinition.renderMode === 'raster-scan') {
-            const scanWidth = Math.round(caseDefinition.scan.dpi * 8.5);
-            const scanHeight = caseDefinition.scan.dpi * 11;
-            const scanFontSize = Math.round(54 * (caseDefinition.scan.dpi / 300));
-            const scanPaddingTop = Math.round(240 * (caseDefinition.scan.dpi / 300));
-            const scanPaddingSides = Math.round(220 * (caseDefinition.scan.dpi / 300));
-            await generatorPage.setViewportSize({ width: scanWidth, height: scanHeight });
-            await generatorPage.setContent(`
-              <!doctype html>
-              <html lang="en">
-                <head>
-                  <meta charset="utf-8" />
-                  <title>${caseDefinition.id}</title>
-                  <style>
-                    html, body {
-                      margin: 0;
-                      padding: 0;
-                      width: ${scanWidth}px;
-                      height: ${scanHeight}px;
-                      background: white;
-                    }
-
-                    body {
-                      color: black;
-                      font-family: Arial, sans-serif;
-                      font-size: ${scanFontSize}px;
-                      line-height: 1.4;
-                    }
-
-                    main {
-                      box-sizing: border-box;
-                      width: 100%;
-                      min-height: 100%;
-                      padding: ${scanPaddingTop}px ${scanPaddingSides}px;
-                      transform: rotate(${caseDefinition.scan.rotationDegrees}deg);
-                      transform-origin: center center;
-                    }
-                  </style>
-                </head>
-                <body>
-                  <main>
-                    <p>Referral Date: ${caseDefinition.referralDate}</p>
-                    <p>Assessor's phone number: ${caseDefinition.documentPhone}</p>
-                  </main>
-                </body>
-              </html>
-            `);
-            const rasterScanDataUrl = await buildRasterScanImageDataUrl({
-              page: generatorPage,
-              colorMode: caseDefinition.scan.colorMode,
-              jpegQuality: caseDefinition.scan.jpegQuality,
-            });
-            const rasterPdfPage = await context.newPage();
-            try {
-              await rasterPdfPage.setContent(`
+      assertIehpPdfMiniMatrixPreflight({
+        cases: IEHP_PDF_MINI_MATRIX_CASES,
+        expectedAssessorPhone,
+      });
+      const matrixTasks = IEHP_PDF_MINI_MATRIX_CASES.map((caseDefinition) => ({
+        caseId: caseDefinition.id,
+        run: async (): Promise<IehpSmokeCaseEvidence> => {
+          const generatorPage = await context.newPage();
+          try {
+            await generatorPage.setContent(buildIehpPdfMiniMatrixHtml(caseDefinition));
+            let uploadPdfBuffer: Buffer;
+            if (caseDefinition.renderMode === 'raster-scan') {
+              const scanWidth = Math.round(caseDefinition.scan.dpi * 8.5);
+              const scanHeight = caseDefinition.scan.dpi * 11;
+              const scanFontSize = Math.round(54 * (caseDefinition.scan.dpi / 300));
+              const scanPaddingTop = Math.round(240 * (caseDefinition.scan.dpi / 300));
+              const scanPaddingSides = Math.round(220 * (caseDefinition.scan.dpi / 300));
+              await generatorPage.setViewportSize({ width: scanWidth, height: scanHeight });
+              await generatorPage.setContent(`
                 <!doctype html>
                 <html lang="en">
                   <head>
                     <meta charset="utf-8" />
                     <title>${caseDefinition.id}</title>
                     <style>
-                      @page {
-                        size: Letter;
-                        margin: 0;
-                      }
-
                       html, body {
                         margin: 0;
                         padding: 0;
-                        width: 8.5in;
-                        height: 11in;
+                        width: ${scanWidth}px;
+                        height: ${scanHeight}px;
                         background: white;
                       }
 
-                      img {
-                        display: block;
-                        width: 8.5in;
-                        height: 11in;
+                      body {
+                        color: black;
+                        font-family: Arial, sans-serif;
+                        font-size: ${scanFontSize}px;
+                        line-height: 1.4;
+                      }
+
+                      main {
+                        box-sizing: border-box;
+                        width: 100%;
+                        min-height: 100%;
+                        padding: ${scanPaddingTop}px ${scanPaddingSides}px;
+                        transform: rotate(${caseDefinition.scan.rotationDegrees}deg);
+                        transform-origin: center center;
                       }
                     </style>
                   </head>
                   <body>
-                    <img alt="${caseDefinition.id}" src="${rasterScanDataUrl}" />
+                    <main>
+                      <p>Referral Date: ${caseDefinition.referralDate}</p>
+                      <p>Assessor's phone number: ${caseDefinition.documentPhone}</p>
+                    </main>
                   </body>
                 </html>
               `);
-              uploadPdfBuffer = await rasterPdfPage.pdf({ format: 'Letter', printBackground: true });
-            } finally {
-              if (!rasterPdfPage.isClosed()) {
-                await rasterPdfPage.close().then(() => undefined);
+              const rasterScanDataUrl = await buildRasterScanImageDataUrl({
+                page: generatorPage,
+                colorMode: caseDefinition.scan.colorMode,
+                jpegQuality: caseDefinition.scan.jpegQuality,
+              });
+              const rasterPdfPage = await context.newPage();
+              try {
+                await rasterPdfPage.setContent(`
+                  <!doctype html>
+                  <html lang="en">
+                    <head>
+                      <meta charset="utf-8" />
+                      <title>${caseDefinition.id}</title>
+                      <style>
+                        @page {
+                          size: Letter;
+                          margin: 0;
+                        }
+
+                        html, body {
+                          margin: 0;
+                          padding: 0;
+                          width: 8.5in;
+                          height: 11in;
+                          background: white;
+                        }
+
+                        img {
+                          display: block;
+                          width: 8.5in;
+                          height: 11in;
+                        }
+                      </style>
+                    </head>
+                    <body>
+                      <img alt="${caseDefinition.id}" src="${rasterScanDataUrl}" />
+                    </body>
+                  </html>
+                `);
+                uploadPdfBuffer = await rasterPdfPage.pdf({ format: 'Letter', printBackground: true });
+              } finally {
+                if (!rasterPdfPage.isClosed()) {
+                  await rasterPdfPage.close().then(() => undefined);
+                }
               }
+            } else {
+              const pdfBuffer = await generatorPage.pdf({ format: 'Letter', printBackground: true });
+              uploadPdfBuffer = pdfBuffer;
             }
-          } else {
-            const pdfBuffer = await generatorPage.pdf({ format: 'Letter', printBackground: true });
-            uploadPdfBuffer = pdfBuffer;
+            await generatorPage.close();
+            return await runSmokeCase({
+              caseId: caseDefinition.id,
+              uploadFileName: buildIehpSmokeUploadFileName(Date.now(), 'pdf'),
+              mimeType: 'application/pdf',
+              sourceFileBuffer: uploadPdfBuffer,
+              expectedReferralDate: caseDefinition.referralDate,
+            });
+          } finally {
+            if (!generatorPage.isClosed()) {
+              await generatorPage.close().then(() => undefined);
+            }
           }
-          await generatorPage.close();
-          const caseEvidence = await runSmokeCase({
-            caseId: caseDefinition.id,
-            uploadFileName: buildIehpSmokeUploadFileName(Date.now(), 'pdf'),
-            mimeType: 'application/pdf',
-            sourceFileBuffer: uploadPdfBuffer,
-            expectedReferralDate: caseDefinition.referralDate,
-          });
-          console.log(JSON.stringify(caseEvidence, null, 2));
-          passedCases.push(caseEvidence);
-        } finally {
-          if (!generatorPage.isClosed()) {
-            await generatorPage.close().then(() => undefined);
-          }
-        }
-      }
+        },
+      }));
+      matrixTasks.push({
+        caseId: 'skills-behaviors-proof',
+        run: runSkillsBehaviorsProofCase,
+      });
 
-      const skillsBehaviorsCaseEvidence = await runSkillsBehaviorsProofCase();
-      console.log(JSON.stringify(skillsBehaviorsCaseEvidence, null, 2));
-      passedCases.push(skillsBehaviorsCaseEvidence);
-
-      const skillsBehaviorsVerifiedCases = passedCases.filter(
-        (caseEvidence) => caseEvidence.skillsBehaviorsProofResult !== null,
+      const { passedCases, failedCases } = await runIehpPdfMiniMatrixTasks({
+        tasks: matrixTasks,
+        onSuccess: (caseEvidence) => {
+          console.log(JSON.stringify(sanitizePublicMatrixCaseEvidence(caseEvidence), null, 2));
+        },
+        onFailure: (caseFailureEvidence) => {
+          console.log(JSON.stringify(caseFailureEvidence, null, 2));
+        },
+      });
+      const cleanupVerifiedCases = passedCases.filter(
+        (caseEvidence) => caseEvidence.cleanupVerified === true,
       ).length;
-      if (skillsBehaviorsVerifiedCases !== 1) {
-        throw new Error(
-          `IEHP PDF mini matrix expected exactly one Skills & Behaviors verified case but found ${skillsBehaviorsVerifiedCases}.`,
-        );
-      }
-
+      const skillsBehaviorsVerifiedCases = passedCases.filter(
+        (caseEvidence) => caseEvidence.cleanupVerified === true
+          && caseEvidence.skillsBehaviorsProofResult != null,
+      ).length;
+      const totalCases = IEHP_PDF_MINI_MATRIX_CASES.length + 1;
       const aggregateEvidence = {
-        ok: true,
+        ok: failedCases.length === 0
+          && passedCases.length === totalCases
+          && cleanupVerifiedCases === totalCases
+          && skillsBehaviorsVerifiedCases === 1,
         mode: 'pdf-mini-matrix',
         totalCases: IEHP_PDF_MINI_MATRIX_CASES.length + 1,
-        passedCases: passedCases.length,
-        cleanupVerifiedCases: passedCases.length,
+        passedCases: cleanupVerifiedCases,
+        cleanupVerifiedCases,
         skillsBehaviorsVerifiedCases,
       };
       console.log(JSON.stringify(aggregateEvidence, null, 2));
+      assertIehpPdfMiniMatrixTasksSucceeded(failedCases);
+      if (!aggregateEvidence.ok) {
+        throw new Error('IEHP PDF mini matrix did not satisfy the exact successful evidence contract.');
+      }
       return;
     }
 

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -1287,7 +1287,9 @@ describe("assessmentDocumentsHandler", () => {
     );
   });
 
-  it("skips fresh extraction_running documents but reclaims stale extraction_running documents", async () => {
+  it("skips extraction_running documents until the explicit 10-minute stale reclaim boundary, then reclaims them", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-13T12:00:00.000Z"));
     vi.mocked(getAccessToken).mockReturnValue("token");
     vi.mocked(resolveOrgAndRole).mockResolvedValue({
       organizationId: "org-1",
@@ -1318,7 +1320,9 @@ describe("assessmentDocumentsHandler", () => {
               template_type: "caloptima_fba",
               bucket_id: "client-documents",
               object_path: "clients/22222222-2222-4222-8222-222222222222/assessments/fba.pdf",
-              updated_at: documentLoadCount === 1 ? new Date().toISOString() : "2020-01-01T00:00:00.000Z",
+              updated_at: documentLoadCount === 1
+                ? "2026-08-13T11:50:01.000Z"
+                : "2026-08-13T11:50:00.000Z",
             },
           ],
         };
@@ -1375,6 +1379,10 @@ describe("assessmentDocumentsHandler", () => {
     );
     expect(freshResponse.status).toBe(202);
     await expect(freshResponse.json()).resolves.toMatchObject({ skipped: true, status: "extraction_running" });
+    expect(fetchJson).not.toHaveBeenCalledWith(
+      expect.stringContaining("/functions/v1/extract-assessment-fields"),
+      expect.anything(),
+    );
 
     const staleResponse = await assessmentDocumentsExtractionBackgroundHandler(
       new Request("http://localhost/.netlify/functions/assessment-documents-extract-background", {
@@ -4115,8 +4123,14 @@ describe("assessmentDocumentsHandler", () => {
       extraction_error: null,
     });
     await vi.advanceTimersByTimeAsync(0);
-    await vi.advanceTimersByTimeAsync(55_000);
-    const documentStatusBodies = vi
+    await vi.advanceTimersByTimeAsync(299_999);
+    let documentStatusBodies = vi
+      .mocked(fetchJson)
+      .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-timeout"))
+      .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));
+    expect(documentStatusBodies.some((body) => body.includes("\"status\":\"extraction_failed\""))).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    documentStatusBodies = vi
       .mocked(fetchJson)
       .mock.calls.filter(([url]) => typeof url === "string" && url.includes("/rest/v1/assessment_documents?id=eq.doc-timeout"))
       .map(([, init]) => String((init as RequestInit | undefined)?.body ?? ""));

--- a/src/server/__tests__/assessmentDocumentsHandler.test.ts
+++ b/src/server/__tests__/assessmentDocumentsHandler.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { assessmentDocumentsExtractionBackgroundHandler, assessmentDocumentsHandler } from "../api/assessment-documents";
+import {
+  assessmentDocumentsExtractionBackgroundHandler,
+  assessmentDocumentsHandler,
+  sanitizeAdobeExtractionDiagnostics,
+} from "../api/assessment-documents";
 import { handler as assessmentDocumentsNetlifyHandler } from "../../../netlify/functions/assessment-documents";
 
 vi.mock("../api/shared", async () => {
@@ -33,6 +37,17 @@ const ORIGINAL_SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
 const ORIGINAL_FETCH = globalThis.fetch;
 
 describe("assessmentDocumentsHandler", () => {
+  it("discards unknown Adobe stages and invalid upstream statuses", () => {
+    expect(sanitizeAdobeExtractionDiagnostics({ stage: "provider_body", upstream_status: 99 })).toStrictEqual({
+      stage: null,
+      upstreamStatus: null,
+    });
+    expect(sanitizeAdobeExtractionDiagnostics({ stage: "token", upstream_status: 600 })).toStrictEqual({
+      stage: "token",
+      upstreamStatus: null,
+    });
+  });
+
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(currentUserCanManageProgramsGoals).mockResolvedValue({ allowed: true, upstreamError: false });
@@ -3498,7 +3513,13 @@ describe("assessmentDocumentsHandler", () => {
         return {
           ok: false,
           status: 502,
-          data: { error: "Adobe PDF extraction failed. Review checklist manually." },
+          data: {
+            error: "Adobe PDF extraction failed. Review checklist manually.",
+            code: "adobe_pdf_extract_failed",
+            stage: "token",
+            upstream_status: 401,
+            provider_body: "must-not-be-persisted",
+          },
         };
       }
       if (method === "PATCH" && url.includes("/rest/v1/assessment_documents?id=eq.doc-extract-non-ok")) {
@@ -3589,8 +3610,13 @@ describe("assessmentDocumentsHandler", () => {
       event_payload: {
         reason_code: "edge_extraction_failed",
         status: 502,
+        adobe_stage: "token",
+        adobe_upstream_status: 401,
       },
     });
+    expect(JSON.stringify(extractionFailedReviewEventPayload)).not.toContain(
+      "must-not-be-persisted",
+    );
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("notes");
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("extracted_count");
     expect(extractionFailedReviewEventPayload).not.toHaveProperty("unresolved_count");

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -20,9 +20,9 @@ import { serverLogger } from "../../lib/logger/server";
 
 const SUPPORTED_TEMPLATE_TYPES = ["caloptima_fba", "iehp_fba"] as const;
 const ASSESSMENT_DOCUMENT_BUCKET_ID = "client-documents";
-const EXTRACTION_WORKFLOW_TIMEOUT_MS = 55_000;
+const EXTRACTION_WORKFLOW_TIMEOUT_MS = 5 * 60_000;
 const EXTRACTION_RUNNING_STATUS = "extraction_running";
-const EXTRACTION_RUNNING_STALE_MS = EXTRACTION_WORKFLOW_TIMEOUT_MS * 2;
+const EXTRACTION_RUNNING_STALE_MS = 10 * 60_000;
 const AUTO_DRAFT_STRUCTURED_SECTION_STATUSES = new Set(["drafted", "approved"] as const);
 const PENDING_EXTRACTION_STATUSES = new Set(["uploaded", "extracting", "extraction_running"] as const);
 const RETRYABLE_EDGE_EXTRACTION_STATUSES = new Set([502, 503, 504, 522, 524, 546]);

--- a/src/server/api/assessment-documents.ts
+++ b/src/server/api/assessment-documents.ts
@@ -194,6 +194,9 @@ interface ExtractionFieldResult {
 
 interface ExtractionFunctionResponse {
   error?: string;
+  code?: string;
+  stage?: string;
+  upstream_status?: number | null;
   extraction_provider?: string;
   adobe_element_count?: number | null;
   adobe_table_count?: number | null;
@@ -215,6 +218,32 @@ interface ExtractionFunctionResponse {
   extracted_count: number;
   unresolved_count: number;
 }
+
+const ADOBE_DIAGNOSTIC_STAGES = new Set([
+  "configuration",
+  "token",
+  "asset_creation",
+  "asset_upload",
+  "job_submission",
+  "job_poll",
+  "result_download",
+  "result_parse",
+  "unknown",
+]);
+
+export const sanitizeAdobeExtractionDiagnostics = (
+  response: Pick<ExtractionFunctionResponse, "stage" | "upstream_status"> | null | undefined,
+): { stage: string | null; upstreamStatus: number | null } => ({
+  stage: typeof response?.stage === "string" && ADOBE_DIAGNOSTIC_STAGES.has(response.stage)
+    ? response.stage
+    : null,
+  upstreamStatus: typeof response?.upstream_status === "number" &&
+      Number.isInteger(response.upstream_status) &&
+      response.upstream_status >= 100 &&
+      response.upstream_status <= 599
+    ? response.upstream_status
+    : null,
+});
 
 const extractionFieldResultSchema = z.object({
   placeholder_key: z.string().min(1),
@@ -291,13 +320,23 @@ class ExtractionWorkflowError extends Error {
   readonly reasonCode: string;
   readonly status?: number;
   readonly publicMessage: string;
+  readonly adobeStage: string | null;
+  readonly adobeUpstreamStatus: number | null;
 
-  constructor(reasonCode: string, message = reasonCode, status?: number, publicMessage = "Field extraction failed. Review checklist manually.") {
+  constructor(
+    reasonCode: string,
+    message = reasonCode,
+    status?: number,
+    publicMessage = "Field extraction failed. Review checklist manually.",
+    adobeDiagnostics?: { stage: string | null; upstreamStatus: number | null },
+  ) {
     super(message);
     this.name = "ExtractionWorkflowError";
     this.reasonCode = reasonCode;
     this.status = status;
     this.publicMessage = publicMessage;
+    this.adobeStage = adobeDiagnostics?.stage ?? null;
+    this.adobeUpstreamStatus = adobeDiagnostics?.upstreamStatus ?? null;
   }
 }
 
@@ -623,6 +662,10 @@ const persistExtractionFailure = async (args: {
       event_payload: {
         reason_code: error.reasonCode,
         status: error.status ?? null,
+        ...(error.adobeStage ? { adobe_stage: error.adobeStage } : {}),
+        ...(error.adobeUpstreamStatus !== null
+          ? { adobe_upstream_status: error.adobeUpstreamStatus }
+          : {}),
       },
     }),
   });
@@ -925,7 +968,14 @@ const runCaloptimaExtractionWorkflow = async (args: CaloptimaExtractionWorkflowA
       typeof extractionResult.data?.error === "string" && extractionResult.data.error.trim().length > 0
         ? extractionResult.data.error.trim()
         : "edge_extraction_failed";
-    throw new ExtractionWorkflowError("edge_extraction_failed", edgeError, extractionResult.status);
+    const adobeDiagnostics = sanitizeAdobeExtractionDiagnostics(extractionResult.data);
+    throw new ExtractionWorkflowError(
+      "edge_extraction_failed",
+      edgeError,
+      extractionResult.status,
+      "Field extraction failed. Review checklist manually.",
+      adobeDiagnostics,
+    );
   } catch (error) {
     const workflowError = asExtractionWorkflowError(error, signal);
     serverLogger.error("assessment-documents extraction workflow failed", {

--- a/supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts
+++ b/supabase/functions/extract-assessment-fields/adobe-pdf-extract.test.ts
@@ -28,7 +28,7 @@ const zipStructuredData = async (
 const successfulFetchForDownloadUri = (
   downloadUri: string,
   zipBytes: Uint8Array,
-): ((input: RequestInfo | URL) => Promise<Response>) => {
+): (input: RequestInfo | URL) => Promise<Response> => {
   return async (input: RequestInfo | URL): Promise<Response> => {
     const url = String(input);
     if (url.endsWith("/token")) {
@@ -94,6 +94,223 @@ Deno.test("getAdobePdfExtractCredentials fails closed when Adobe credentials are
   expect(() => getAdobePdfExtractCredentials(envFrom({}))).toThrow(
     AdobePdfExtractError,
   );
+});
+
+Deno.test("extractPdfWithAdobe reports a sanitized token failure stage", async () => {
+  const upstreamBody = "provider-response-must-not-leak";
+
+  try {
+    await extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+      env: envFrom({
+        PDF_SERVICES_CLIENT_ID: "client-id",
+        PDF_SERVICES_CLIENT_SECRET: "client-secret",
+      }),
+      fetchImpl: () =>
+        Promise.resolve(new Response(upstreamBody, { status: 401 })),
+    });
+    throw new Error("Expected Adobe extraction to fail.");
+  } catch (error) {
+    expect(error).toBeInstanceOf(AdobePdfExtractError);
+    const adobeError = error as AdobePdfExtractError & {
+      stage?: string;
+      upstreamStatus?: number | null;
+    };
+    expect(adobeError.stage).toBe("token");
+    expect(adobeError.upstreamStatus).toBe(401);
+    expect(adobeError.message).not.toContain(upstreamBody);
+  }
+});
+
+Deno.test("extractPdfWithAdobe sanitizes transport failures before logging", async () => {
+  const sensitiveTransportDetail =
+    "https://storage.example.test/upload?X-Amz-Signature=must-not-leak";
+
+  try {
+    await extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+      env: envFrom({
+        PDF_SERVICES_CLIENT_ID: "client-id",
+        PDF_SERVICES_CLIENT_SECRET: "client-secret",
+      }),
+      fetchImpl: () => Promise.reject(new Error(sensitiveTransportDetail)),
+    });
+    throw new Error("Expected Adobe extraction to fail.");
+  } catch (error) {
+    expect(error).toBeInstanceOf(AdobePdfExtractError);
+    const adobeError = error as AdobePdfExtractError & {
+      stage?: string;
+      upstreamStatus?: number | null;
+    };
+    expect(adobeError.stage).toBe("token");
+    expect(adobeError.upstreamStatus).toBeNull();
+    expect(adobeError.message).not.toContain(sensitiveTransportDetail);
+  }
+});
+
+Deno.test("AdobePdfExtractError exposes only allowlisted public diagnostics", () => {
+  const sensitiveInternalDetail = "provider-body-must-not-leak";
+  const error = new AdobePdfExtractError(
+    "adobe_pdf_extract_failed",
+    sensitiveInternalDetail,
+    502,
+    "token",
+    401,
+  );
+  const diagnostics = (error as AdobePdfExtractError & {
+    toPublicDiagnostics?: () => Record<string, unknown>;
+  }).toPublicDiagnostics?.();
+
+  expect(diagnostics).toEqual({
+    stage: "token",
+    upstream_status: 401,
+  });
+  expect(JSON.stringify(diagnostics)).not.toContain(sensitiveInternalDetail);
+});
+
+Deno.test("extractPdfWithAdobe sanitizes JSON body read failures", async () => {
+  const sensitiveReadDetail = "token-stream-detail-must-not-leak";
+  const response = Response.json({ access_token: "unused" });
+  Object.defineProperty(response, "text", {
+    value: () => Promise.reject(new Error(sensitiveReadDetail)),
+  });
+
+  try {
+    await extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+      env: envFrom({
+        PDF_SERVICES_CLIENT_ID: "client-id",
+        PDF_SERVICES_CLIENT_SECRET: "client-secret",
+      }),
+      fetchImpl: () => Promise.resolve(response),
+    });
+    throw new Error("Expected Adobe extraction to fail.");
+  } catch (error) {
+    expect(error).toBeInstanceOf(AdobePdfExtractError);
+    const adobeError = error as AdobePdfExtractError;
+    expect(adobeError.stage).toBe("token");
+    expect(adobeError.upstreamStatus).toBe(200);
+    expect(adobeError.message).not.toContain(sensitiveReadDetail);
+  }
+});
+
+Deno.test("extractPdfWithAdobe sanitizes result download body read failures", async () => {
+  const sensitiveReadDetail = "download-stream-detail-must-not-leak";
+  const downloadUri =
+    "https://dcplatformstorageservice-prod-us-east-1.s3-accelerate.amazonaws.com/result.zip?X-Amz-Signature=test";
+  const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    if (url.endsWith("/token")) {
+      return Response.json({ access_token: "token-1" });
+    }
+    if (url.endsWith("/assets")) {
+      return Response.json({
+        uploadUri: ADOBE_US_STORAGE_URL,
+        assetID: "asset-1",
+      });
+    }
+    if (url === ADOBE_US_STORAGE_URL) {
+      return new Response(null, { status: 200 });
+    }
+    if (url.endsWith("/operation/extractpdf")) {
+      return new Response(null, {
+        status: 201,
+        headers: {
+          location:
+            "https://pdf-services.adobe.io/operation/extractpdf/job-1/status",
+        },
+      });
+    }
+    if (url.endsWith("/job-1/status")) {
+      return Response.json({ status: "done", downloadUri });
+    }
+    if (url === downloadUri) {
+      const response = new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+      });
+      Object.defineProperty(response, "arrayBuffer", {
+        value: () => Promise.reject(new Error(sensitiveReadDetail)),
+      });
+      return response;
+    }
+    return new Response("unexpected", { status: 500 });
+  };
+
+  try {
+    await extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+      env: envFrom({
+        PDF_SERVICES_CLIENT_ID: "client-id",
+        PDF_SERVICES_CLIENT_SECRET: "client-secret",
+      }),
+      fetchImpl,
+      sleep: () => Promise.resolve(),
+      maxPollAttempts: 1,
+    });
+    throw new Error("Expected Adobe extraction to fail.");
+  } catch (error) {
+    expect(error).toBeInstanceOf(AdobePdfExtractError);
+    const adobeError = error as AdobePdfExtractError;
+    expect(adobeError.stage).toBe("result_download");
+    expect(adobeError.upstreamStatus).toBe(200);
+    expect(adobeError.message).not.toContain(sensitiveReadDetail);
+  }
+});
+
+Deno.test("extractPdfWithAdobe does not label semantic job failures as HTTP failures", async () => {
+  const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    if (url.endsWith("/token")) {
+      return Response.json({ access_token: "token-1" });
+    }
+    if (url.endsWith("/assets")) {
+      return Response.json({
+        uploadUri: ADOBE_US_STORAGE_URL,
+        assetID: "asset-1",
+      });
+    }
+    if (url === ADOBE_US_STORAGE_URL) {
+      return new Response(null, { status: 200 });
+    }
+    if (url.endsWith("/operation/extractpdf")) {
+      return new Response(null, {
+        status: 201,
+        headers: {
+          location:
+            "https://pdf-services.adobe.io/operation/extractpdf/job-1/status",
+        },
+      });
+    }
+    if (url.endsWith("/job-1/status")) {
+      return Response.json({ status: "failed" });
+    }
+    return new Response("unexpected", { status: 500 });
+  };
+
+  try {
+    await extractPdfWithAdobe(new Uint8Array([1, 2, 3]), {
+      env: envFrom({
+        PDF_SERVICES_CLIENT_ID: "client-id",
+        PDF_SERVICES_CLIENT_SECRET: "client-secret",
+      }),
+      fetchImpl,
+      sleep: () => Promise.resolve(),
+      maxPollAttempts: 1,
+    });
+    throw new Error("Expected Adobe extraction to fail.");
+  } catch (error) {
+    expect(error).toBeInstanceOf(AdobePdfExtractError);
+    const adobeError = error as AdobePdfExtractError;
+    expect(adobeError.stage).toBe("job_poll");
+    expect(adobeError.upstreamStatus).toBeNull();
+  }
+});
+
+Deno.test("normalizeAdobeExtractZip sanitizes invalid ZIP failures", async () => {
+  try {
+    await normalizeAdobeExtractZip(new Uint8Array([1, 2, 3]));
+    throw new Error("Expected Adobe ZIP normalization to fail.");
+  } catch (error) {
+    expect(error).toBeInstanceOf(AdobePdfExtractError);
+    const adobeError = error as AdobePdfExtractError;
+    expect(adobeError.stage).toBe("result_parse");
+  }
 });
 
 Deno.test("normalizeAdobeStructuredData builds ordered text and counts table elements", () => {

--- a/supabase/functions/extract-assessment-fields/adobe-pdf-extract.ts
+++ b/supabase/functions/extract-assessment-fields/adobe-pdf-extract.ts
@@ -28,19 +28,52 @@ export type NormalizedAdobePdfExtract = {
   table_count: number;
 };
 
+export type AdobePdfExtractStage =
+  | "configuration"
+  | "token"
+  | "asset_creation"
+  | "asset_upload"
+  | "job_submission"
+  | "job_poll"
+  | "result_download"
+  | "result_parse"
+  | "unknown";
+
+export type AdobePdfExtractPublicDiagnostics = {
+  stage: AdobePdfExtractStage;
+  upstream_status: number | null;
+};
+
 export class AdobePdfExtractError extends Error {
   readonly code: string;
   readonly status: number;
   readonly publicMessage: string;
+  readonly stage: AdobePdfExtractStage;
+  readonly upstreamStatus: number | null;
 
-  constructor(code: string, message: string, status = 502) {
+  constructor(
+    code: string,
+    message: string,
+    status = 502,
+    stage: AdobePdfExtractStage = "unknown",
+    upstreamStatus: number | null = null,
+  ) {
     super(message);
     this.name = "AdobePdfExtractError";
     this.code = code;
     this.status = status;
+    this.stage = stage;
+    this.upstreamStatus = upstreamStatus;
     this.publicMessage = code === "adobe_pdf_extract_not_configured"
       ? "Adobe PDF extraction is not configured. Review checklist manually."
       : "Adobe PDF extraction failed. Review checklist manually.";
+  }
+
+  toPublicDiagnostics(): AdobePdfExtractPublicDiagnostics {
+    return {
+      stage: this.stage,
+      upstream_status: this.upstreamStatus,
+    };
   }
 }
 
@@ -84,6 +117,7 @@ export const getAdobePdfExtractCredentials = (
       "adobe_pdf_extract_not_configured",
       "Adobe PDF Services credentials are missing.",
       500,
+      "configuration",
     );
   }
 
@@ -93,13 +127,27 @@ export const getAdobePdfExtractCredentials = (
 const parseJsonResponse = async <T>(
   response: Response,
   operation: string,
+  stage: AdobePdfExtractStage,
 ): Promise<T> => {
-  const text = await response.text();
+  let text: string;
+  try {
+    text = await response.text();
+  } catch {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract ${operation} response body could not be read.`,
+      502,
+      stage,
+      response.status,
+    );
+  }
   if (!response.ok) {
     throw new AdobePdfExtractError(
       "adobe_pdf_extract_failed",
       `Adobe PDF Extract ${operation} failed with status ${response.status}.`,
       502,
+      stage,
+      response.status,
     );
   }
   try {
@@ -109,6 +157,26 @@ const parseJsonResponse = async <T>(
       "adobe_pdf_extract_failed",
       `Adobe PDF Extract ${operation} returned invalid JSON.`,
       502,
+      stage,
+      response.status,
+    );
+  }
+};
+
+const fetchAdobe = async (
+  fetchImpl: FetchLike,
+  input: RequestInfo | URL,
+  init: RequestInit,
+  stage: AdobePdfExtractStage,
+): Promise<Response> => {
+  try {
+    return await fetchImpl(input, init);
+  } catch {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      `Adobe PDF Extract ${stage} transport request failed.`,
+      502,
+      stage,
     );
   }
 };
@@ -123,6 +191,11 @@ const parseHttpsUrl = (
   url: string,
   context: "polling" | "upload" | "download",
 ): URL => {
+  const stage: AdobePdfExtractStage = context === "polling"
+    ? "job_poll"
+    : context === "upload"
+    ? "asset_upload"
+    : "result_download";
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -131,6 +204,7 @@ const parseHttpsUrl = (
       "adobe_pdf_extract_failed",
       `Adobe PDF Extract returned an invalid ${context} URL.`,
       502,
+      stage,
     );
   }
 
@@ -139,6 +213,7 @@ const parseHttpsUrl = (
       "adobe_pdf_extract_failed",
       `Adobe PDF Extract returned a non-HTTPS ${context} URL.`,
       502,
+      stage,
     );
   }
 
@@ -147,6 +222,7 @@ const parseHttpsUrl = (
       "adobe_pdf_extract_failed",
       `Adobe PDF Extract returned a ${context} URL with credentials.`,
       502,
+      stage,
     );
   }
 
@@ -161,11 +237,15 @@ const assertAdobePollingUrl = (url: string): void => {
       "adobe_pdf_extract_failed",
       "Adobe PDF Extract returned an unexpected polling host.",
       502,
+      "job_poll",
     );
   }
 };
 
-const assertAdobeStorageUrl = (url: string, context: "upload" | "download"): void => {
+const assertAdobeStorageUrl = (
+  url: string,
+  context: "upload" | "download",
+): void => {
   const parsed = parseHttpsUrl(url, context);
   const hostname = parsed.hostname.toLowerCase();
 
@@ -174,6 +254,7 @@ const assertAdobeStorageUrl = (url: string, context: "upload" | "download"): voi
       "adobe_pdf_extract_failed",
       `Adobe PDF Extract returned an unexpected ${context} host.`,
       502,
+      context === "upload" ? "asset_upload" : "result_download",
     );
   }
 };
@@ -190,6 +271,7 @@ const assertAdobeResultDownloadUrl = (url: string): void => {
       "adobe_pdf_extract_failed",
       "Adobe PDF Extract returned an unexpected download host.",
       502,
+      "result_download",
     );
   }
 };
@@ -198,23 +280,26 @@ const requestAccessToken = async (
   credentials: AdobeCredentials,
   fetchImpl: FetchLike,
 ): Promise<string> => {
-  const response = await fetchImpl(ADOBE_PDF_SERVICES_TOKEN_URL, {
+  const response = await fetchAdobe(fetchImpl, ADOBE_PDF_SERVICES_TOKEN_URL, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
       client_id: credentials.clientId,
       client_secret: credentials.clientSecret,
     }),
-  });
+  }, "token");
   const body = await parseJsonResponse<{ access_token?: unknown }>(
     response,
     "token request",
+    "token",
   );
   if (typeof body.access_token !== "string" || !body.access_token.trim()) {
     throw new AdobePdfExtractError(
       "adobe_pdf_extract_failed",
       "Adobe PDF Extract token response did not include an access token.",
       502,
+      "token",
+      response.status,
     );
   }
   return body.access_token.trim();
@@ -235,20 +320,27 @@ const createAsset = async (
   accessToken: string,
   fetchImpl: FetchLike,
 ): Promise<{ uploadUri: string; assetID: string }> => {
-  const response = await fetchImpl(`${ADOBE_PDF_SERVICES_BASE_URL}/assets`, {
-    method: "POST",
-    headers: buildAdobeHeaders(credentials, accessToken),
-    body: JSON.stringify({ mediaType: "application/pdf" }),
-  });
+  const response = await fetchAdobe(
+    fetchImpl,
+    `${ADOBE_PDF_SERVICES_BASE_URL}/assets`,
+    {
+      method: "POST",
+      headers: buildAdobeHeaders(credentials, accessToken),
+      body: JSON.stringify({ mediaType: "application/pdf" }),
+    },
+    "asset_creation",
+  );
   const body = await parseJsonResponse<{
     uploadUri?: unknown;
     assetID?: unknown;
-  }>(response, "asset creation");
+  }>(response, "asset creation", "asset_creation");
   if (typeof body.uploadUri !== "string" || typeof body.assetID !== "string") {
     throw new AdobePdfExtractError(
       "adobe_pdf_extract_failed",
       "Adobe PDF Extract asset response was incomplete.",
       502,
+      "asset_creation",
+      response.status,
     );
   }
   return { uploadUri: body.uploadUri, assetID: body.assetID };
@@ -265,16 +357,18 @@ const uploadAsset = async (
     pdfBytes.byteOffset,
     pdfBytes.byteOffset + pdfBytes.byteLength,
   ) as ArrayBuffer;
-  const response = await fetchImpl(uploadUri, {
+  const response = await fetchAdobe(fetchImpl, uploadUri, {
     method: "PUT",
     headers: { "Content-Type": "application/pdf" },
     body,
-  });
+  }, "asset_upload");
   if (!response.ok) {
     throw new AdobePdfExtractError(
       "adobe_pdf_extract_failed",
       `Adobe PDF Extract asset upload failed with status ${response.status}.`,
       502,
+      "asset_upload",
+      response.status,
     );
   }
 };
@@ -285,7 +379,8 @@ const submitExtractJob = async (
   assetID: string,
   fetchImpl: FetchLike,
 ): Promise<string> => {
-  const response = await fetchImpl(
+  const response = await fetchAdobe(
+    fetchImpl,
     `${ADOBE_PDF_SERVICES_BASE_URL}/operation/extractpdf`,
     {
       method: "POST",
@@ -295,12 +390,15 @@ const submitExtractJob = async (
         elementsToExtract: ["text", "tables"],
       }),
     },
+    "job_submission",
   );
   if (!response.ok) {
     throw new AdobePdfExtractError(
       "adobe_pdf_extract_failed",
       `Adobe PDF Extract job submission failed with status ${response.status}.`,
       502,
+      "job_submission",
+      response.status,
     );
   }
   const location = response.headers.get("location")?.trim();
@@ -309,6 +407,8 @@ const submitExtractJob = async (
       "adobe_pdf_extract_failed",
       "Adobe PDF Extract job response did not include a polling location.",
       502,
+      "job_submission",
+      response.status,
     );
   }
   return location;
@@ -349,13 +449,14 @@ const pollExtractJob = async (
   assertAdobePollingUrl(pollingUrl);
 
   for (let attempt = 0; attempt < maxPollAttempts; attempt += 1) {
-    const response = await fetchImpl(pollingUrl, {
+    const response = await fetchAdobe(fetchImpl, pollingUrl, {
       method: "GET",
       headers: buildAdobeHeaders(credentials, accessToken),
-    });
+    }, "job_poll");
     const body = await parseJsonResponse<Record<string, unknown>>(
       response,
       "job status",
+      "job_poll",
     );
     const status = typeof body.status === "string"
       ? body.status.toLowerCase()
@@ -367,6 +468,7 @@ const pollExtractJob = async (
           "adobe_pdf_extract_failed",
           "Adobe PDF Extract completed without a download URI.",
           502,
+          "job_poll",
         );
       }
       return downloadUri;
@@ -376,6 +478,7 @@ const pollExtractJob = async (
         "adobe_pdf_extract_failed",
         "Adobe PDF Extract job failed.",
         502,
+        "job_poll",
       );
     }
     await sleep(pollIntervalMs);
@@ -385,6 +488,7 @@ const pollExtractJob = async (
     "adobe_pdf_extract_failed",
     "Adobe PDF Extract job did not complete before polling timed out.",
     504,
+    "job_poll",
   );
 };
 
@@ -394,15 +498,32 @@ const downloadResultZip = async (
 ): Promise<Uint8Array> => {
   assertAdobeResultDownloadUrl(downloadUri);
 
-  const response = await fetchImpl(downloadUri, { method: "GET" });
+  const response = await fetchAdobe(
+    fetchImpl,
+    downloadUri,
+    { method: "GET" },
+    "result_download",
+  );
   if (!response.ok) {
     throw new AdobePdfExtractError(
       "adobe_pdf_extract_failed",
       `Adobe PDF Extract result download failed with status ${response.status}.`,
       502,
+      "result_download",
+      response.status,
     );
   }
-  return new Uint8Array(await response.arrayBuffer());
+  try {
+    return new Uint8Array(await response.arrayBuffer());
+  } catch {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      "Adobe PDF Extract result response body could not be read.",
+      502,
+      "result_download",
+      response.status,
+    );
+  }
 };
 
 const getElementText = (element: AdobeStructuredElement): string => {
@@ -446,16 +567,37 @@ export const normalizeAdobeExtractZip = async (
   zipBytes: Uint8Array,
 ): Promise<NormalizedAdobePdfExtract> => {
   const { default: JSZip } = await import("npm:jszip@3.10.1");
-  const zip = await JSZip.loadAsync(zipBytes);
+  let zip: InstanceType<typeof JSZip>;
+  try {
+    zip = await JSZip.loadAsync(zipBytes);
+  } catch {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      "Adobe PDF Extract result ZIP is invalid.",
+      502,
+      "result_parse",
+    );
+  }
   const structuredDataFile = zip.file("structuredData.json");
   if (!structuredDataFile) {
     throw new AdobePdfExtractError(
       "adobe_pdf_extract_failed",
       "Adobe PDF Extract result is missing structuredData.json.",
       502,
+      "result_parse",
     );
   }
-  const rawStructuredData = await structuredDataFile.async("string");
+  let rawStructuredData: string;
+  try {
+    rawStructuredData = await structuredDataFile.async("string");
+  } catch {
+    throw new AdobePdfExtractError(
+      "adobe_pdf_extract_failed",
+      "Adobe PDF Extract structuredData.json could not be read.",
+      502,
+      "result_parse",
+    );
+  }
   try {
     return normalizeAdobeStructuredData(JSON.parse(rawStructuredData));
   } catch {
@@ -463,6 +605,7 @@ export const normalizeAdobeExtractZip = async (
       "adobe_pdf_extract_failed",
       "Adobe PDF Extract structuredData.json is invalid.",
       502,
+      "result_parse",
     );
   }
 };

--- a/supabase/functions/extract-assessment-fields/index.ts
+++ b/supabase/functions/extract-assessment-fields/index.ts
@@ -3021,9 +3021,14 @@ const handler = async (req: Request): Promise<Response> => {
       console.error("extract-assessment-fields adobe extraction error", {
         code: error.code,
         status: error.status,
+        ...error.toPublicDiagnostics(),
         message: error.message,
       });
-      return json(req, { error: error.publicMessage, code: error.code }, error.status);
+      return json(req, {
+        error: error.publicMessage,
+        code: error.code,
+        ...error.toPublicDiagnostics(),
+      }, error.status);
     }
     console.error("extract-assessment-fields error", error);
     return json(req, { error: "Failed to extract assessment fields." }, 500);

--- a/tests/scripts/finalize-iehp-pdf-mini-matrix-evidence.test.ts
+++ b/tests/scripts/finalize-iehp-pdf-mini-matrix-evidence.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  EXPECTED_IEHP_PDF_MINI_MATRIX_CASE_IDS,
+  buildFinalizedIehpPdfMiniMatrixEvidence,
+  finalizeIehpPdfMiniMatrixEvidenceRun,
+} from '../../scripts/finalize-iehp-pdf-mini-matrix-evidence.mjs';
+
+const temporaryDirectories: string[] = [];
+
+const createTemporaryDirectory = (): string => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'iehp-mini-matrix-finalizer-'));
+  temporaryDirectories.push(directory);
+  return directory;
+};
+
+const phoneAssertion = {
+  fieldKey: 'IEHP_FBA_ASSESSOR_PHONE',
+  rowCount: 1,
+  nonEmpty: true,
+  validFormat: true,
+  precedenceMatchedExpectedPhone: true,
+  provenanceRowCount: 1,
+  provenanceVerified: true,
+  sourceMethod: 'client_snapshot',
+  sourceField: 'primary_therapist_phone',
+  expectedPhoneRedacted: '(***) ***-4242',
+  actualPhoneRedacted: '(***) ***-4242',
+};
+
+const successfulCase = (caseId: string, skillsBehaviorsProofResult: Record<string, unknown> | null = null) => ({
+  ok: true,
+  mode: 'pdf-mini-matrix-case',
+  caseId,
+  templateType: 'iehp_fba',
+  status: 'drafted',
+  draftPrograms: 0,
+  draftGoals: 0,
+  assessorPhoneAssertion: phoneAssertion,
+  referralDateAssertion: { fieldKey: 'IEHP_FBA_REFERRAL_DATE', matched: true },
+  skillsBehaviorsProofResult,
+  cleanupVerified: true,
+});
+
+const failureCase = (caseId: string) => ({
+  ok: false,
+  mode: 'pdf-mini-matrix-case-failure',
+  caseId,
+  templateType: 'iehp_fba',
+  cleanupVerified: true,
+  failureCategory: 'private failure detail',
+  errorCategory: 'private stack detail',
+});
+
+const asLog = (objects: Array<Record<string, unknown>>): string =>
+  objects.map((object, index) => `log line ${index}\n${JSON.stringify(object, null, 2)}`).join('\n');
+
+const readJson = (directory: string, fileName: string): Record<string, unknown> | Array<Record<string, unknown>> =>
+  JSON.parse(readFileSync(path.join(directory, fileName), 'utf8'));
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('IEHP PDF mini-matrix evidence finalizer', () => {
+  it('writes canonically ordered redacted partial evidence after mixed case results without throwing', () => {
+    const outputDirectory = createTemporaryDirectory();
+    const logSource = asLog([
+      {
+        ...successfulCase('table-structured-fields'),
+        screenshot: 'artifacts/private/table-failure.png',
+        errorMessage: 'private table error text',
+        rawPhone: '(951) 555-0101',
+      },
+      successfulCase('clean-single-page'),
+      {
+        ...failureCase('multi-page-target-content'),
+        screenshotPath: 'artifacts/private/multi-page-failure.png',
+        error: 'private rejection text',
+        phone: '951-555-0102',
+      },
+      successfulCase('skills-behaviors-proof', { verified: true }),
+      {
+        ok: false,
+        mode: 'pdf-mini-matrix',
+        totalCases: 8,
+        passedCases: 99,
+        cleanupVerifiedCases: 99,
+        skillsBehaviorsVerifiedCases: 99,
+      },
+    ]);
+
+    expect(() => finalizeIehpPdfMiniMatrixEvidenceRun({
+      logSource,
+      outputDirectory,
+      workflowStatus: 'failure',
+      metadata: {
+        workflowRunId: 'run-1',
+        workflowRunAttempt: '2',
+        validatedSha: 'a'.repeat(40),
+        validatedPrNumber: '154',
+        previewUrl: 'https://example.invalid',
+      },
+    })).not.toThrow();
+
+    const cases = readJson(outputDirectory, 'cases.json') as Array<Record<string, unknown>>;
+    const aggregate = readJson(outputDirectory, 'aggregate.json') as Record<string, unknown>;
+    const metadata = readJson(outputDirectory, 'run-metadata.json') as Record<string, unknown>;
+    const runStatus = readJson(outputDirectory, 'run-status.json') as Record<string, unknown>;
+    const publicEvidence = JSON.stringify({ cases, aggregate, metadata, runStatus });
+
+    expect(cases.map((entry) => entry.caseId)).toEqual([
+      'clean-single-page',
+      'multi-page-target-content',
+      'table-structured-fields',
+      'skills-behaviors-proof',
+    ]);
+    expect(cases.find((entry) => entry.caseId === 'table-structured-fields')).toMatchObject({
+      ok: true,
+      cleanupVerified: true,
+    });
+    expect(cases.find((entry) => entry.caseId === 'multi-page-target-content')).toEqual({
+      ok: false,
+      mode: 'pdf-mini-matrix-case-failure',
+      caseId: 'multi-page-target-content',
+      templateType: 'iehp_fba',
+      cleanupVerified: false,
+      failureCategory: 'case_execution_failed',
+      errorCategory: 'matrix_failures_detected',
+    });
+    expect(aggregate).toEqual({
+      ok: false,
+      mode: 'pdf-mini-matrix',
+      totalCases: 8,
+      passedCases: 3,
+      cleanupVerifiedCases: 3,
+      skillsBehaviorsVerifiedCases: 1,
+    });
+    expect(metadata).toMatchObject({ ok: false, caseCount: 3, failedCaseCount: 1 });
+    expect(runStatus).toMatchObject({
+      ok: false,
+      status: 'failure',
+      evidenceError: 'matrix_case_failures_detected:1',
+      evidenceShortfall: 'successful_cleanup_verified_cases:3/8',
+    });
+    expect(publicEvidence).not.toContain('private table error text');
+    expect(publicEvidence).not.toContain('private rejection text');
+    expect(publicEvidence).not.toContain('failure.png');
+    expect(publicEvidence).not.toContain('(951) 555-0101');
+    expect(publicEvidence).not.toContain('951-555-0102');
+    expect(existsSync(path.join(outputDirectory, 'matrix-output.log'))).toBe(false);
+  });
+
+  it('strictly accepts only the canonical successful 8/8/8/1 contract with no failure objects', () => {
+    const outputDirectory = createTemporaryDirectory();
+    const successfulCases = EXPECTED_IEHP_PDF_MINI_MATRIX_CASE_IDS.map((caseId) =>
+      successfulCase(caseId, caseId === 'skills-behaviors-proof' ? { verified: true } : null));
+    const aggregate = {
+      ok: true,
+      mode: 'pdf-mini-matrix',
+      totalCases: 8,
+      passedCases: 8,
+      cleanupVerifiedCases: 8,
+      skillsBehaviorsVerifiedCases: 1,
+    };
+
+    finalizeIehpPdfMiniMatrixEvidenceRun({
+      logSource: asLog([...successfulCases, aggregate]),
+      outputDirectory,
+      workflowStatus: 'success',
+      metadata: {},
+    });
+
+    expect(readJson(outputDirectory, 'cases.json')).toHaveLength(8);
+    expect(readJson(outputDirectory, 'aggregate.json')).toEqual(aggregate);
+    expect(readJson(outputDirectory, 'run-status.json')).toMatchObject({ ok: true, status: 'success' });
+
+    expect(() => buildFinalizedIehpPdfMiniMatrixEvidence({
+      logSource: asLog([...successfulCases.slice(0, 7), failureCase('skills-behaviors-proof'), aggregate]),
+      workflowStatus: 'success',
+      metadata: {},
+    })).toThrow('successful_contract_failed');
+
+    expect(() => buildFinalizedIehpPdfMiniMatrixEvidence({
+      logSource: asLog([...successfulCases, { ...aggregate, cleanupVerifiedCases: 7 }]),
+      workflowStatus: 'success',
+      metadata: {},
+    })).toThrow('successful_contract_failed');
+  });
+
+  it('fails closed when successful evidence lacks redacted phones or contains a raw phone in an allowed field', () => {
+    expect(() => buildFinalizedIehpPdfMiniMatrixEvidence({
+      logSource: asLog([{
+        ...successfulCase('clean-single-page'),
+        assessorPhoneAssertion: {
+          ...phoneAssertion,
+          actualPhoneRedacted: 'missing-redaction',
+        },
+      }]),
+      workflowStatus: 'failure',
+      metadata: {},
+    })).toThrow('redacted_phone_evidence_invalid');
+
+    expect(() => buildFinalizedIehpPdfMiniMatrixEvidence({
+      logSource: asLog([{
+        ...successfulCase('clean-single-page'),
+        referralDateAssertion: {
+          note: 'unexpected contact 951-555-0199',
+        },
+      }]),
+      workflowStatus: 'failure',
+      metadata: {},
+    })).toThrow('raw_phone_detected');
+  });
+});

--- a/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
+++ b/tests/scripts/playwright-iehp-assessment-import-smoke.test.ts
@@ -20,6 +20,9 @@ import {
   normalizeAssessmentChecklistResponse,
   parseAssessmentPlanPdfPreflight,
   readSyntheticGeneratedDocxText,
+  assertIehpPdfMiniMatrixPreflight,
+  assertIehpPdfMiniMatrixTasksSucceeded,
+  runIehpPdfMiniMatrixTasks,
   restoreIehpGeneratedDocxReviewSelection,
   selectConfiguredSmokeClient,
 } from '../../scripts/playwright-iehp-assessment-import-smoke';
@@ -103,6 +106,71 @@ describe('restoreIehpGeneratedDocxReviewSelection', () => {
         maxPollAttempts: 2,
       }),
     ).rejects.toThrow('IEHP assessment queue did not restore a review or uploaded assessment');
+  });
+});
+
+describe('IEHP PDF mini-matrix task runner', () => {
+  it('hard-stops ambiguous document-phone precedence before any matrix task can run', () => {
+    const runTask = vi.fn();
+
+    expect(() => assertIehpPdfMiniMatrixPreflight({
+      cases: [
+        { id: 'safe-case', documentPhone: '951.555.0101' },
+        { id: 'ambiguous-case', documentPhone: '(909) 555-4242' },
+      ],
+      expectedAssessorPhone: '909-555-4242',
+    })).toThrow(
+      'IEHP PDF mini matrix case ambiguous-case normalized document phone matched the configured snapshot phone, so precedence proof would be ambiguous.',
+    );
+    expect(runTask).not.toHaveBeenCalled();
+  });
+
+  it('attempts later tasks after a rejection and throws only after every task was attempted', async () => {
+    const attempts: string[] = [];
+    const emittedCaseIds: string[] = [];
+    const result = await runIehpPdfMiniMatrixTasks({
+      tasks: [
+        {
+          caseId: 'first-case',
+          run: async () => {
+            attempts.push('first-case');
+            return { caseId: 'first-case', cleanupVerified: true };
+          },
+        },
+        {
+          caseId: 'rejected-case',
+          run: async () => {
+            attempts.push('rejected-case');
+            throw new Error('private rejection text');
+          },
+        },
+        {
+          caseId: 'later-case',
+          run: async () => {
+            attempts.push('later-case');
+            return { caseId: 'later-case', cleanupVerified: true };
+          },
+        },
+      ],
+      onSuccess: (_evidence, caseId) => emittedCaseIds.push(caseId),
+      onFailure: (evidence) => emittedCaseIds.push(evidence.caseId),
+    });
+
+    expect(attempts).toEqual(['first-case', 'rejected-case', 'later-case']);
+    expect(emittedCaseIds).toEqual(['first-case', 'rejected-case', 'later-case']);
+    expect(result.failedCases).toEqual([{
+      ok: false,
+      mode: 'pdf-mini-matrix-case-failure',
+      caseId: 'rejected-case',
+      templateType: 'iehp_fba',
+      cleanupVerified: false,
+      failureCategory: 'case_execution_failed',
+      errorCategory: 'matrix_failures_detected',
+    }]);
+    expect(() => assertIehpPdfMiniMatrixTasksSucceeded(result.failedCases)).toThrow(
+      'IEHP PDF mini matrix encountered one or more case-local failures.',
+    );
+    expect(attempts).toHaveLength(3);
   });
 });
 
@@ -1012,7 +1080,7 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     };
 
     const miniMatrixFlagIndex = script.indexOf("const isPdfMiniMatrixMode = process.argv.includes('--pdf-mini-matrix');");
-    const matrixCaseLoopIndex = script.indexOf('for (const caseDefinition of IEHP_PDF_MINI_MATRIX_CASES)');
+    const matrixTaskBuildIndex = script.indexOf('const matrixTasks = IEHP_PDF_MINI_MATRIX_CASES.map');
     const generatorPageIndex = script.indexOf('const generatorPage = await context.newPage();');
     const setContentIndex = script.indexOf('await generatorPage.setContent(buildIehpPdfMiniMatrixHtml(caseDefinition));');
     const pagePdfIndex = script.indexOf("const pdfBuffer = await generatorPage.pdf({ format: 'Letter', printBackground: true });");
@@ -1036,7 +1104,7 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     const generatorCloseIndex = script.indexOf('await generatorPage.close();');
     const pdfFileNameIndex = script.indexOf(
       "buildIehpSmokeUploadFileName(Date.now(), 'pdf')",
-      matrixCaseLoopIndex,
+      matrixTaskBuildIndex,
     );
     const pdfMimeIndex = script.indexOf("mimeType: 'application/pdf'", pdfFileNameIndex);
     const caseRunnerIndex = script.indexOf('const runSmokeCase = async (');
@@ -1045,10 +1113,10 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     const provenanceFetchIndex = script.indexOf('const provenanceRows = await fetchIehpAssessmentProvenance');
     const assessorPhoneAssertionIndex = script.indexOf('const assessorPhoneAssertion = assertIehpAssessorPhoneChecklist');
     const referralDateAssertionIndex = script.indexOf('const referralDateAssertion = caseInput.expectedReferralDate');
-    const caseEvidenceIndex = script.indexOf('console.log(JSON.stringify(caseEvidence, null, 2));');
+    const caseEvidenceIndex = script.indexOf('console.log(JSON.stringify(sanitizePublicMatrixCaseEvidence(caseEvidence), null, 2));');
     const cleanupCallIndex = script.indexOf('await cleanupAssessmentImportArtifacts({');
     const aggregateEvidenceIndex = script.indexOf('console.log(JSON.stringify(aggregateEvidence, null, 2));');
-    const aggregateCleanupIndex = script.indexOf('cleanupVerifiedCases: passedCases.length,');
+    const aggregateCleanupIndex = script.indexOf('cleanupVerifiedCases,');
 
     expect(packageJson.scripts?.['playwright:iehp-assessment-import-smoke']).toBe(
       'tsx scripts/playwright-iehp-assessment-import-smoke.ts',
@@ -1058,8 +1126,8 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     );
     expect(miniMatrixFlagIndex).toBeGreaterThanOrEqual(0);
     expect(caseRunnerIndex).toBeGreaterThan(miniMatrixFlagIndex);
-    expect(matrixCaseLoopIndex).toBeGreaterThan(miniMatrixFlagIndex);
-    expect(generatorPageIndex).toBeGreaterThan(matrixCaseLoopIndex);
+    expect(matrixTaskBuildIndex).toBeGreaterThan(miniMatrixFlagIndex);
+    expect(generatorPageIndex).toBeGreaterThan(matrixTaskBuildIndex);
     expect(setContentIndex).toBeGreaterThan(generatorPageIndex);
     expect(pagePdfIndex).toBeGreaterThan(setContentIndex);
     expect(scanModeIndex).toBeGreaterThan(setContentIndex);
@@ -1092,28 +1160,26 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     expect(aggregateEvidenceIndex).toBeGreaterThan(aggregateCleanupIndex);
   });
 
-  it('adds the existing skills behaviors proof as one cleaned pdf mini matrix case', () => {
+  it('runs every pdf mini matrix case and the skills behaviors proof through the sequential task runner', () => {
     const script = readFileSync(
       path.join(process.cwd(), 'scripts/playwright-iehp-assessment-import-smoke.ts'),
       'utf8',
     );
 
-    const matrixCaseLoopIndex = script.indexOf('for (const caseDefinition of IEHP_PDF_MINI_MATRIX_CASES)');
+    const matrixTaskBuildIndex = script.indexOf('const matrixTasks = IEHP_PDF_MINI_MATRIX_CASES.map');
+    const matrixPreflightIndex = script.indexOf('assertIehpPdfMiniMatrixPreflight({');
     const reusableProofRunnerIndex = script.indexOf('const runSkillsBehaviorsProofCase = async () =>');
-    const matrixProofCallIndex = script.indexOf(
-      'const skillsBehaviorsCaseEvidence = await runSkillsBehaviorsProofCase();',
-      matrixCaseLoopIndex,
-    );
-    const matrixProofPushIndex = script.indexOf('passedCases.push(skillsBehaviorsCaseEvidence);', matrixProofCallIndex);
+    const matrixProofTaskIndex = script.indexOf("caseId: 'skills-behaviors-proof'", matrixTaskBuildIndex);
+    const runnerCallIndex = script.indexOf('await runIehpPdfMiniMatrixTasks({', matrixProofTaskIndex);
     const evidenceModeIndex = script.indexOf('mode: isSkillsBehaviorsProofMode');
     const matrixEvidenceModeIndex = script.indexOf("? 'pdf-mini-matrix-case'", evidenceModeIndex);
     const aggregateTotalIndex = script.indexOf('totalCases: IEHP_PDF_MINI_MATRIX_CASES.length + 1,');
     const computedSkillsCountIndex = script.indexOf(
       'const skillsBehaviorsVerifiedCases = passedCases.filter(',
-      matrixProofPushIndex,
+      runnerCallIndex,
     );
-    const exactSkillsCountGuardIndex = script.indexOf('if (skillsBehaviorsVerifiedCases !== 1)', computedSkillsCountIndex);
-    const aggregateSkillsIndex = script.indexOf('skillsBehaviorsVerifiedCases,', exactSkillsCountGuardIndex);
+    const aggregateSkillsIndex = script.indexOf('skillsBehaviorsVerifiedCases,', computedSkillsCountIndex);
+    const finalFailureThrowIndex = script.indexOf('assertIehpPdfMiniMatrixTasksSucceeded(failedCases);', aggregateSkillsIndex);
     const standaloneProofCallIndex = script.indexOf(
       'const proofCaseEvidence = await runSkillsBehaviorsProofCase();',
       aggregateSkillsIndex,
@@ -1122,13 +1188,33 @@ describe('playwright-iehp-assessment-import-smoke structure', () => {
     expect(reusableProofRunnerIndex).toBeGreaterThanOrEqual(0);
     expect(evidenceModeIndex).toBeGreaterThanOrEqual(0);
     expect(matrixEvidenceModeIndex).toBeGreaterThan(evidenceModeIndex);
-    expect(matrixProofCallIndex).toBeGreaterThan(matrixCaseLoopIndex);
-    expect(matrixProofPushIndex).toBeGreaterThan(matrixProofCallIndex);
-    expect(computedSkillsCountIndex).toBeGreaterThan(matrixProofPushIndex);
-    expect(exactSkillsCountGuardIndex).toBeGreaterThan(computedSkillsCountIndex);
-    expect(aggregateTotalIndex).toBeGreaterThan(exactSkillsCountGuardIndex);
+    expect(matrixTaskBuildIndex).toBeGreaterThanOrEqual(0);
+    expect(matrixPreflightIndex).toBeGreaterThanOrEqual(0);
+    expect(matrixPreflightIndex).toBeLessThan(matrixTaskBuildIndex);
+    expect(matrixProofTaskIndex).toBeGreaterThan(matrixTaskBuildIndex);
+    expect(runnerCallIndex).toBeGreaterThan(matrixProofTaskIndex);
+    expect(computedSkillsCountIndex).toBeGreaterThan(runnerCallIndex);
+    expect(aggregateTotalIndex).toBeGreaterThan(computedSkillsCountIndex);
     expect(aggregateSkillsIndex).toBeGreaterThan(aggregateTotalIndex);
+    expect(finalFailureThrowIndex).toBeGreaterThan(aggregateSkillsIndex);
     expect(standaloneProofCallIndex).toBeGreaterThan(aggregateSkillsIndex);
+  });
+
+  it('raises the hosted extraction poll ceiling above the server runtime budget and emits sanitized per-case matrix failures', () => {
+    const script = readFileSync(
+      path.join(process.cwd(), 'scripts/playwright-iehp-assessment-import-smoke.ts'),
+      'utf8',
+    );
+
+    expect(script).toContain('const EXTRACTION_TIMEOUT_MS = 360_000;');
+    expect(script).toContain("mode: 'pdf-mini-matrix-case-failure'");
+    expect(script).toContain("failureCategory: 'case_execution_failed'");
+    expect(script).toContain("errorCategory: 'matrix_failures_detected'");
+    expect(script).toContain('const sanitizePublicMatrixCaseEvidence = (');
+    expect(script).toContain('screenshot,');
+    expect(script).toContain('errorMessage,');
+    expect(script).toContain('assessorPhoneAssertion,');
+    expect(script).toContain("cleanupVerified: false");
   });
 
   it('keeps default docx invocation free of referral-date requirements while matrix cases keep them', () => {

--- a/tests/workflows/iehp-pdf-mini-matrix-proof.test.ts
+++ b/tests/workflows/iehp-pdf-mini-matrix-proof.test.ts
@@ -18,6 +18,7 @@ type WorkflowStep = {
 type WorkflowJob = {
   needs?: string;
   if?: string;
+  'timeout-minutes'?: number;
   permissions?: Record<string, string>;
   env?: Record<string, string>;
   outputs?: Record<string, string>;
@@ -92,6 +93,7 @@ describe('protected hosted IEHP PDF mini-matrix workflow', () => {
     const deploy = findStep(proof, 'Verify exact Netlify preview deployment');
 
     expect(proof?.needs).toBe('validate');
+    expect(proof?.['timeout-minutes']).toBe(75);
     expect(proof?.permissions).toEqual({ checks: 'read', contents: 'read', statuses: 'read' });
     expect(findStep(proof, 'Checkout validated commit')?.with).toMatchObject({
       ref: '${{ needs.validate.outputs.validated_sha }}',
@@ -151,24 +153,22 @@ describe('protected hosted IEHP PDF mini-matrix workflow', () => {
     });
     expect(matrix?.run).toContain('set -o pipefail');
     expect(cleanup?.if).toBe('always()');
+    expect(cleanup?.env).toEqual({
+      PRIVATE_ADMIN_ENV_PATH: '${{ runner.temp }}/iehp-pdf-mini-matrix-private/admin.env',
+      SUPABASE_URL: '${{ secrets.SUPABASE_URL }}',
+      SUPABASE_SERVICE_ROLE_KEY: '${{ secrets.SUPABASE_SECRET_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}',
+    });
+    expect(cleanup?.run).not.toContain('source "$PRIVATE_ADMIN_ENV_PATH"');
+    expect(cleanup?.run).not.toContain('set -a');
+    expect(cleanup?.run).not.toContain('export PW_SUPERADMIN_PASSWORD');
+    expect(cleanup?.run).toContain('CI_SMOKE_ADMIN_EMAIL) CI_SMOKE_ADMIN_EMAIL="$value"');
+    expect(cleanup?.run).toContain('PW_SUPERADMIN_USER_ID) PW_SUPERADMIN_USER_ID="$value"');
+    expect(cleanup?.run).toContain('export PW_SUPERADMIN_USER_ID');
     expect(cleanup?.run).toContain('npx tsx scripts/provision-ci-smoke-admin.ts --cleanup');
     expect(finalize?.if).toBe('always()');
-    expect(finalize?.run).toContain('rmSync(publicDir, { recursive: true, force: true })');
-    expect(finalize?.run).toContain("'scan-300dpi-monochrome'");
-    expect(finalize?.run).toContain("'scan-300dpi-monochrome-rotated-2deg'");
-    expect(finalize?.run).toContain("'scan-150dpi-grayscale-low-quality'");
-    expect(finalize?.run).toContain("'table-structured-fields'");
     expect(expectedEvidenceCount).toBe(8);
-    expect(finalize?.run).toContain(`matrixCases.length !== ${expectedEvidenceCount}`);
-    expect(finalize?.run).toContain(`aggregate.totalCases !== ${expectedEvidenceCount}`);
-    expect(finalize?.run).toContain(`aggregate.passedCases !== ${expectedEvidenceCount}`);
-    expect(finalize?.run).toContain(`aggregate.cleanupVerifiedCases !== ${expectedEvidenceCount}`);
-    expect(finalize?.run).toContain('redactedPhonePattern');
-    expect(finalize?.run).toContain('rawPhonePattern');
-    expect(finalize?.run).toContain("'cases.json'");
-    expect(finalize?.run).toContain("'aggregate.json'");
-    expect(finalize?.run).toContain("'run-metadata.json'");
-    expect(finalize?.run).toContain('run-status.json');
+    expect(finalize?.run).toBe('node scripts/finalize-iehp-pdf-mini-matrix-evidence.mjs');
+    expect(finalize?.run).not.toContain("node --input-type=module <<'NODE'");
     expect(finalize?.env).toHaveProperty('WORKFLOW_STATUS', '${{ job.status }}');
     expect(upload?.if).toBe('always()');
     expect(String(upload?.with?.path)).toContain('run-status.json');
@@ -177,6 +177,7 @@ describe('protected hosted IEHP PDF mini-matrix workflow', () => {
     expect(String(upload?.with?.path)).toContain('aggregate.json');
     expect(String(upload?.with?.path)).not.toContain('iehp-pdf-mini-matrix-private');
     expect(String(upload?.with?.path)).not.toContain('matrix-output.log');
+    expect(String(upload?.with?.path)).not.toContain('.png');
     expect(upload?.with?.['if-no-files-found']).toBe('warn');
     expect(upload?.with?.['retention-days']).toBe(7);
     const steps = proof?.steps ?? [];


### PR DESCRIPTION
## Summary
- extend hosted FBA extraction and polling budgets while preserving the stale-claim boundary
- make the eight-case IEHP matrix fail closed after collecting sanitized partial evidence
- add sanitized Adobe failure-stage diagnostics from the Edge Function through the tenant-scoped extraction-failure review event
- discard unknown stages and invalid upstream status values; never persist provider bodies, tokens, URLs, document text, or PHI

Linear: WIN-154

Failure evidence:
- timeout run: https://github.com/Jeduardo622/AllIincompassing/actions/runs/31673104385
- Adobe 502 matrix run: https://github.com/Jeduardo622/AllIincompassing/actions/runs/31715024657

## Verification
- `npm run verify:local`: passed in 416.5s
- complete Deno extraction matrix: 76/76 passed
- assessment document server suite: 61/61 passed
- coverage: 92.81% lines
- Tier-0 browser gate: 220/220 passed
- Deno check and focused Deno formatting: passed
- code, security, test, architecture, specification, implementation, and Supabase reviews completed

## Critical-Lane Gate
- exact head: `2cfe9bcc6d43384a22311c1ada57ad9a3fcd38d9`
- touches `supabase/functions/**` and `src/server/**`
- draft only; do not merge until exact-head CI passes and critical-lane human review is complete
- after review, deploy the exact reviewed Edge Function and rerun the eight-case hosted synthetic matrix
- this patch diagnoses the Adobe boundary; credential rotation or provider remediation remains a separate protected action